### PR TITLE
Add reservations to files and hide read files that are reserved during import

### DIFF
--- a/client/src/js/components/Samples/Manage/Create/ReadSelector.js
+++ b/client/src/js/components/Samples/Manage/Create/ReadSelector.js
@@ -19,7 +19,14 @@ import ReadItem from "./ReadItem";
 
 const suffixes = [".fastq", ".fq", ".fastq.gz", ".fq.gz"];
 
-const getReadyFiles = () => dispatcher.db.files.find({file_type: "reads", "ready": true});
+const getAvailableFiles = () => {
+    let files = dispatcher.db.files.find({
+        file_type: "reads",
+        ready: true
+    });
+
+    return filter(files, {reserved: false});
+};
 
 /**
  * A main view for importing samples from FASTQ files. Importing starts an import job on the server.
@@ -31,7 +38,7 @@ export default class ReadSelector extends React.PureComponent {
     constructor (props) {
         super(props);
         this.state = {
-            files: getReadyFiles(),
+            files: getAvailableFiles(),
             filter: "",
             showAll: false
         };
@@ -71,7 +78,7 @@ export default class ReadSelector extends React.PureComponent {
     toggleShowAll = () => this.setState({showAll: !this.state.showAll});
 
     update = () => {
-        const files = getReadyFiles();
+        const files = getAvailableFiles();
 
         this.setState({files: files}, () => {
             this.props.select(intersection(this.props.selected, files.map(f => f["_id"])));

--- a/virtool/analyses.py
+++ b/virtool/analyses.py
@@ -249,7 +249,8 @@ class Collection(virtool.database.Collection):
             }
         })
 
-        yield self.collections["samples"].recalculate_algorithm_tags(data["sample_id"])
+        for sample_id in id_list:
+            yield self.collections["samples"].recalculate_algorithm_tags(sample_id)
 
     @virtool.gen.exposed_method([])
     def detail(self, transaction):

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -284,3 +284,11 @@ def organize_samples(database):
             "$set": calculate_algorithm_tags(analyses),
             "$inc": {"_version": 1}
         })
+
+
+def organize_files(database):
+    database.files.update({"reserved": {"$exists": False}}, {
+        "$set": {
+            "reserved": False
+        }
+    }, multi=True)

--- a/virtool/samples.py
+++ b/virtool/samples.py
@@ -141,12 +141,9 @@ class Collection(virtool.database.Collection):
         data.update({
             "added": virtool.utils.timestamp(),
             "format": "fastq",
-
             "imported": "ip",
             "quality": None,
-
             "analyzed": False,
-
             "hold": True,
             "archived": False
         })
@@ -155,6 +152,8 @@ class Collection(virtool.database.Collection):
 
         # Start the import job
         proc, mem = 2, 6
+
+        yield self.collections["files"].reserve_files(data["files"])
 
         self.collections["jobs"].new("import_reads", task_args, proc, mem, data["username"])
 
@@ -709,6 +708,7 @@ class ImportReads(virtool.job.Job):
 
         """
         # Delete database entry
+        self.collection_operation("files", "reserve_files_cop", {"file_ids": self.files, "reserved": False})
         self.collection_operation("samples", "_remove_samples", [self.sample_id])
 
 

--- a/virtool/tests/test_organize_files.py
+++ b/virtool/tests/test_organize_files.py
@@ -1,0 +1,33 @@
+import pytest
+
+from virtool.organize import organize_files
+
+
+@pytest.fixture
+def file_documents():
+    return [
+        {"_id": 1},
+        {"_id": 2},
+        {"_id": 3, "reserved": False},
+        {"_id": 4, "reserved": False}
+    ]
+
+
+class TestOrganizeFiles:
+
+    def test_add_reserved(self, mock_pymongo, file_documents):
+        mock_pymongo.files.insert_many(file_documents)
+
+        organize_files(mock_pymongo)
+
+        assert all([document["reserved"] is False for document in mock_pymongo.files.find()])
+
+    def test_retain_existing(self, mock_pymongo, file_documents):
+        file_documents[0]["reserved"] = True
+        file_documents[1]["reserved"] = True
+
+        mock_pymongo.files.insert_many(file_documents)
+
+        organize_files(mock_pymongo)
+
+        assert [document["reserved"] for document in mock_pymongo.files.find()] == [True, True, False, False]


### PR DESCRIPTION
Fixes #40.

- add `reserved` field to file document and synchronize it
- add code to organize module for file documents
- add tests for `organize_files()`
- fix` remove_by_sample_id` bug in 5f3ac23
