### PR TITLE
Use Python 3.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: python
-python: '3.6'
+python: '3.5'
 services: mongodb
 cache: pip
+
 install:
 - pip install -r requirements.txt
+
 script: pytest --cov
+
 before_install:
 - pip install codecov
+
 after_success:
 - codecov
+
 before_deploy:
 - mkdir build
 - mkdir build/virtool


### PR DESCRIPTION
Pyinstaller encounters an errors when running Python 3.6.