### PR TITLE
Remove comments in production build

### DIFF
--- a/client/webpack.production.config.js
+++ b/client/webpack.production.config.js
@@ -43,7 +43,9 @@ var config = {
         new webpack.optimize.UglifyJsPlugin({
             compress: {
                 warnings: true
-            }
+            },
+
+            comments: false
         }),
 
         new HTMLPlugin({


### PR DESCRIPTION
Add `comments: false` to Uglify configuration. This should slightly reduce bundle size.