### PR TITLE
cx_Freeze

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,15 +78,16 @@ script:
 
 after_success:
 - python-codacy-coverage -r coverage.xml
-- mkdir build
-- mkdir build/virtool
-- pyinstaller -F --hidden-import=tkinter --hidden-import=tkinter.filedialog --distpath build/virtool run.py
-- cp -rv assets build/virtool
-- cp -rv client/dist build/virtool/client
-- cp -v LICENSE build/virtool
-- cp -v readme.md build/virtool
-- echo $TRAVIS_TAG > build/virtool/VERSION
-- cd build
+- mkdir gh_build
+- mkdir gh_build/virtool
+- python setup.py build
+- cp -rv build/exe.linux-x86_64-3.6/* gh_build/virtool
+- cp -rv assets gh_build/virtool
+- cp -rv client/dist gh_build/virtool/client
+- cp -v LICENSE gh_build/virtool
+- cp -v readme.md gh_build/virtool
+- echo $TRAVIS_TAG > gh_build/virtool/VERSION
+- cd gh_build
 - tar -cvzf virtool.tar.gz virtool
 - tar -tvf virtool.tar.gz
 - cd ..

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiofiles==0.3.1
 aiohttp==2.2.5
+appdirs==1.4.3
 arrow==0.10.0
 async-timeout==1.3.0
 bcrypt==3.1.3
@@ -11,6 +12,7 @@ cffi==1.10.0
 chardet==3.0.4
 coloredlogs==7.3
 coverage==4.4.1
+cx-Freeze==5.0.2
 dictdiffer==0.6.1
 humanfriendly==4.4.1
 idna==2.5
@@ -20,11 +22,13 @@ MarkupSafe==1.0
 motor==1.1
 multidict==3.1.3
 numpy==1.13.1
+packaging==16.8
 psutil==5.3.0
 py==1.4.34
 pycparser==2.18
 PyInstaller==3.2.1
 pymongo==3.5.1
+pyparsing==2.2.0
 pytest==3.2.1
 pytest-aiohttp==0.1.3
 pytest-asyncio==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from cx_Freeze import setup, Executable
+
+packages = [
+    "encodings",
+    "uvloop",
+    "motor",
+    "appdirs",
+    "packaging",
+    "packaging.version",
+    "_cffi_backend",
+    "asyncio",
+    "asyncio.base_events",
+    "asyncio.compat"
+]
+
+# Dependencies are automatically detected, but it might need
+# fine tuning.
+buildOptions = dict(packages=packages, excludes=[])
+
+base = 'Console'
+
+executables = [
+    Executable('run.py', base=base)
+]
+
+setup(name='virtool',
+      version='3.0.0',
+      description='',
+      options=dict(build_exe=buildOptions),
+      executables=executables)


### PR DESCRIPTION
Swith to ``cx_Freeze`` because ``pyinstaller`` doesn't support Python3.6

- add ``setup.py`` file
- update ``.travis.yml``
- update ``requirements.txt``