### PR TITLE
Fix dev-only references to client files

### DIFF
--- a/virtool/app_routes.py
+++ b/virtool/app_routes.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 async def index_handler(req):
-    static_hash = get_static_hash()
+    static_hash = get_static_hash(req.app["client_path"])
 
     if not req["session"].user_id:
         keys = generate_verification_keys()

--- a/virtool/error_pages.py
+++ b/virtool/error_pages.py
@@ -15,20 +15,20 @@ async def middleware_factory(app, handler):
 
             if not is_api_call:
                 if response.status == 404:
-                    return handle_404()
+                    return handle_404(app["client_path"])
 
             return response
 
         except web.HTTPException as ex:
             if not is_api_call and ex.status == 404:
-                return handle_404()
+                return handle_404(app["client_path"])
 
             raise
 
     return middleware_handler
 
 
-def handle_404():
+def handle_404(client_path):
     path = os.path.join(sys.path[0], "templates", "error_404.html")
-    html = Template(filename=path).render(hash=get_static_hash())
+    html = Template(filename=path).render(hash=get_static_hash(client_path))
     return web.Response(body=html, content_type="text/html", status=404)

--- a/virtool/setup.py
+++ b/virtool/setup.py
@@ -26,12 +26,7 @@ def setup_routes(app):
     app.router.add_post(r"/setup/watch", setup_watch)
     app.router.add_get(r"/setup/clear", clear)
     app.router.add_get(r"/setup/save", save_and_reload)
-
-    static_path = os.path.join(sys.path[0], "client", "dist")
-
-    if os.path.isdir(static_path):
-        app.router.add_static("/static", static_path)
-
+    app.router.add_static("/static", app["client_path"])
     app.router.add_get(r"/{suffix:.*}", setup_redirect)
 
 
@@ -54,7 +49,7 @@ async def setup_get(req):
     if setup["first_user_password"]:
         setup["first_user_password"] = "dummy password"
 
-    html = template.render(hash=virtool.utils.get_static_hash(), setup=setup)
+    html = template.render(hash=virtool.utils.get_static_hash(req.app["client_path"]), setup=setup)
 
     return web.Response(body=html, content_type="text/html")
 

--- a/virtool/utils.py
+++ b/virtool/utils.py
@@ -213,10 +213,8 @@ def to_bool(obj):
     return str(obj).lower() in ["1", "true"]
 
 
-def get_static_hash():
-    client_files = os.listdir(os.path.join(sys.path[0], "client", "dist"))
-
-    for file_name in client_files:
+def get_static_hash(client_path):
+    for file_name in os.listdir(client_path):
         if "style." in file_name:
             return file_name.split(".")[1]
 


### PR DESCRIPTION
There are more references in the server code to ``client/dist`` paths.

Use the app-level ``client_path`` value to flexibly handle dev and production client path locations.