### PR TITLE
Potential fix for Travis CI timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_script:
 - sleep 15
 
 script:
-- pytest --faulthandler-timeout=30 --cov --cov-report xml -vv
+- pytest --cov --cov-report xml -vv
 
 after_success:
 - python-codacy-coverage -r coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,11 +39,9 @@ pytest-aiohttp==0.1.3
 pytest-asyncio==0.6.0
 pytest-cov==2.5.1
 pytest-datafiles==1.0
-pytest-faulthandler==1.3.1
 pytest-forked==0.2
 pytest-mock==1.6.2
 pytest-repeat==0.4.1
-pytest-timeout==1.2.0
 pytest-xdist==1.20.0
 python-dateutil==2.6.1
 setproctitle==1.1.10


### PR DESCRIPTION
Remove pytest timeout plugins.

I originally used these to figure out why long running subprocesses were hanging during builds and also local testing. This issue was fixed a while ago and now ``pytest-faulthandler`` is not necessary and is actually failing long-running tests.

The plugins ``pytest-faulthandler`` and ``pytest-timeout`` have been removed from ``requirements.txt`` and the ``pytest`` call is updated in ``.travis.yml``.