### PR TITLE
Miscellaneous fixes

### DIFF
--- a/client/src/js/updates/components/Viewer.js
+++ b/client/src/js/updates/components/Viewer.js
@@ -31,7 +31,9 @@ class SoftwareUpdateViewer extends React.Component {
             );
         }
 
-        const currentVersion = "v1.8.3"; // this.props.updates.current_version;
+        console.log(this.props.updates);
+
+        const currentVersion = this.props.updates.current_version;
 
         const releases = filter(this.props.updates.releases, release => {
             return versionComparator(release.name, currentVersion) === 1;

--- a/client/src/js/viruses/components/Detail/IsolateDetail.js
+++ b/client/src/js/viruses/components/Detail/IsolateDetail.js
@@ -190,7 +190,8 @@ const mapStateToProps = (state) => {
         editing: state.viruses.editingIsolate,
         editingSequence: state.viruses.editSequence,
         allowedSourceTypes: state.settings.data.allowed_source_types,
-        restrictSourceTypes: state.settings.data.restrict_source_types
+        restrictSourceTypes: state.settings.data.restrict_source_types,
+        canModify: state.account.permissions.modify_virus
     };
 };
 

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -303,9 +303,9 @@ def find_server_version(install_path="."):
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
 
-    if output is None or "Not a git repository" not in output:
+    if output and "Not a git repository" not in output:
         return output
-
+    
     try:
         version_file_path = os.path.join(install_path, "VERSION")
 

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -296,15 +296,22 @@ def configure_ssl(cert_path, key_path):
 
 
 def find_server_version(install_path="."):
+    output = None
+
     try:
-        return subprocess.check_output(["git", "describe", "--tags"]).decode().rstrip()
+        output = subprocess.check_output(["git", "describe", "--tags"]).decode().rstrip()
     except (subprocess.CalledProcessError, FileNotFoundError):
-        try:
-            version_file_path = os.path.join(install_path, "VERSION")
+        pass
 
-            with open(version_file_path, "r") as version_file:
-                return version_file.read().rstrip()
+    if output is None or "Not a git repository" not in output:
+        return output
 
-        except FileNotFoundError:
-            logger.critical("Could not determine software version.")
-            return "Unknown"
+    try:
+        version_file_path = os.path.join(install_path, "VERSION")
+
+        with open(version_file_path, "r") as version_file:
+            return version_file.read().rstrip()
+
+    except FileNotFoundError:
+        logger.critical("Could not determine software version.")
+        return "Unknown"

--- a/virtool/handlers/samples.py
+++ b/virtool/handlers/samples.py
@@ -33,7 +33,14 @@ async def find(req):
     if query["term"]:
         db_query.update(compose_regex_query(query["term"], ["name", "user.id"]))
 
-    data = await paginate(db.samples, db_query, req.query, "name", projection=virtool.sample.LIST_PROJECTION)
+    data = await paginate(
+        db.samples,
+        db_query,
+        req.query,
+        "created_at",
+        projection=virtool.sample.LIST_PROJECTION,
+        reverse=True
+    )
 
     return json_response(data)
 

--- a/virtool/handlers/updates.py
+++ b/virtool/handlers/updates.py
@@ -22,6 +22,8 @@ async def get(req):
         }
     })
 
+    document["current_version"] = virtool.app.find_server_version()
+
     return json_response(virtool.utils.base_processor(document))
 
 

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -264,6 +264,9 @@ async def organize_subtraction(db):
     await db.subtraction.update_many({}, {
         "$unset": {
             "lengths": ""
+        },
+        "$rename": {
+            "nucleotides": "gc"
         }
     })
 


### PR DESCRIPTION
- show available updates correctly
- send current software version in ``GET`` requests to ``/api/updates/software``
- sort sample entries by ``created_at`` datetime in descending order (applies to client and API)
- in organize.py, ``$rename`` ``nucleotides`` field to ``gc`` subtraction collection
- fix issues with permission-dependent rendering of virus views in client
- fix ``find_server_version`` function