### PR TITLE
Clean up orphaned job documents

### DIFF
--- a/tests/handlers/test_jobs.py
+++ b/tests/handlers/test_jobs.py
@@ -1,12 +1,20 @@
-class TestGet:
+import pytest
 
-    async def test(self, spawn_client, test_job):
-        client = await spawn_client()
 
+@pytest.mark.parametrize("status", [200, 404])
+async def test_get(status, spawn_client, test_job, resp_is):
+    client = await spawn_client()
+
+    if status == 200:
         await client.db.jobs.insert_one(test_job)
 
-        resp = await client.get("/api/jobs/4c530449")
+    resp = await client.get("/api/jobs/4c530449")
 
+    assert resp.status == status
+
+    if status == 404:
+        assert await resp_is.not_found(resp)
+    else:
         assert await resp.json() == {
             "task": "rebuild_index",
             "mem": 16,
@@ -55,9 +63,6 @@ class TestGet:
             ]
         }
 
-    async def test_not_found(self, spawn_client, resp_is):
-        client = await spawn_client()
 
-        resp = await client.get("/api/jobs/4c530449")
-
-        assert await resp_is.not_found(resp)
+async def test_cancel(spawn_client):
+    pass

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,35 +3,33 @@ import datetime
 import virtool.job
 
 
-class TestDispatchProcessor:
+def test_processor(test_db, test_job):
+    """
+    Test that the dispatch processor properly formats a raw job document into a dispatchable format.
 
-    def test(self, test_db, test_job):
-        """
-        Test that the dispatch processor properly formats a raw job document into a dispatchable format.
-         
-        """
-        test_db.jobs.insert_one(test_job)
+    """
+    test_db.jobs.insert_one(test_job)
 
-        document = test_db.jobs.find_one()
+    document = test_db.jobs.find_one()
 
-        assert virtool.job.dispatch_processor(document) == {
-            "id": "4c530449",
-            "created_at": datetime.datetime(2017, 10, 6, 20, 0),
-            "args": {
-                "algorithm": "nuvs",
-                "analysis_id": "e410429b",
-                "index_id": "465428b0",
-                "name": None,
-                "sample_id": "1e01a382",
-                "username": "igboyes"
-            },
-            "mem": 16,
-            "proc": 10,
-            "progress": 1.0,
-            "stage": "import_results",
-            "state": "complete",
-            "task": "rebuild_index",
-            "user": {
-                "id": "igboyes"
-            }
+    assert virtool.job.processor(document) == {
+        "id": "4c530449",
+        "created_at": datetime.datetime(2017, 10, 6, 20, 0),
+        "args": {
+            "algorithm": "nuvs",
+            "analysis_id": "e410429b",
+            "index_id": "465428b0",
+            "name": None,
+            "sample_id": "1e01a382",
+            "username": "igboyes"
+        },
+        "mem": 16,
+        "proc": 10,
+        "progress": 1.0,
+        "stage": "import_results",
+        "state": "complete",
+        "task": "rebuild_index",
+        "user": {
+            "id": "igboyes"
         }
+    }

--- a/virtool/handlers/jobs.py
+++ b/virtool/handlers/jobs.py
@@ -41,6 +41,7 @@ async def find(req):
         db_query,
         virtool.job.LIST_PROJECTION,
         sort=[("name", 1)]
+        processor=virtool.job.processor
     )
 
     found_count = await cursor.count()

--- a/virtool/job.py
+++ b/virtool/job.py
@@ -46,6 +46,29 @@ def processor(document):
     return document
 
 
+async def get_waiting_and_running_ids(db):
+    agg = await db.jobs.aggregate([
+        {"$project": {
+            "status": {
+                "$arrayElemAt": ["$status", -1]
+            }
+        }},
+
+        {"$match": {
+            "$or": [
+                {"status.state": "waiting"},
+                {"status.state": "running"},
+            ]
+        }},
+
+        {"$project": {
+            "_id": True
+        }}
+    ]).to_list(None)
+
+    return [a["_id"] for a in agg]
+
+
 class Job:
 
     def __init__(self, loop, executor, db, settings, dispatch, job_id, task_name, task_args, proc, mem):

--- a/virtool/job.py
+++ b/virtool/job.py
@@ -19,7 +19,7 @@ LIST_PROJECTION = [
 ]
 
 
-def dispatch_processor(document):
+def processor(document):
     """
     Removes the ``status`` and ``args`` fields from the job document.
     Adds a ``username`` field, an ``added`` date taken from the first status entry in the job document, and
@@ -197,7 +197,7 @@ class Job:
             }
         }, return_document=pymongo.ReturnDocument.AFTER, projection=LIST_PROJECTION)
 
-        await self.dispatch("jobs", "update", dispatch_processor(document))
+        await self.dispatch("jobs", "update", processor(document))
 
     async def add_log(self, line, indent=0):
         timestamp = virtool.utils.timestamp().isoformat()

--- a/virtool/job_manager.py
+++ b/virtool/job_manager.py
@@ -108,7 +108,7 @@ class Manager:
 
         document = await self.db.jobs.find_one(job_id, virtool.job.LIST_PROJECTION)
 
-        await self.dispatch("jobs", "update", virtool.job.dispatch_processor(document))
+        await self.dispatch("jobs", "update", virtool.job.processor(document))
 
         return virtool.utils.base_processor(document)
 

--- a/virtool/job_manager.py
+++ b/virtool/job_manager.py
@@ -31,6 +31,8 @@ class Manager:
         #: A dict to store all the tracked job objects in.
         self._jobs_dict = dict()
 
+        self._run_task = None
+
         #: The main loop
         self._stop = False
         self.started = False
@@ -40,9 +42,11 @@ class Manager:
 
     def start(self):
         self.started = True
-        asyncio.ensure_future(self.run(), loop=self.loop)
+        self._run_task = asyncio.ensure_future(self.run(), loop=self.loop)
 
     async def run(self):
+        iteration = 0
+
         while True:
             to_delete = list()
 
@@ -60,6 +64,19 @@ class Manager:
 
             for job_id in to_delete:
                 del self._jobs_dict[job_id]
+
+            iteration += 1
+
+            if iteration == 100:
+                iteration = 0
+
+                ids = await virtool.job.get_waiting_and_running_ids(self.db)
+
+                await self.db.jobs.delete_many({
+                    "_id": {
+                        "$in": [job_id for job_id in ids if job_id not in self._jobs_dict]
+                    }
+                })
 
             await asyncio.sleep(0.1, loop=self.loop)
 


### PR DESCRIPTION
- rename ``job.dispatch_processor()`` to ``processor()``
- use ``paginate()`` in find jobs endpoint
- add ``get_running_and_waiting_ids()`` job utility function
- check for and remove orphaned documents every 100 iterations of the main ``run()`` method
- resolves #237 