### PR TITLE
HMM fixes and tweaks

### DIFF
--- a/client/src/js/hmm/components/Installer.js
+++ b/client/src/js/hmm/components/Installer.js
@@ -17,6 +17,7 @@
  */
 
 import React from "react";
+import Numeral from "numeral";
 import { connect } from "react-redux";
 import { Alert, Col, Panel, ProgressBar, Row } from "react-bootstrap";
 
@@ -38,6 +39,14 @@ class HMMInstall extends React.Component {
 
             const progress = 20 * (steps.indexOf(this.props.process.step) + this.props.process.progress);
 
+            let step = this.props.process.step.replace("_", " ");
+
+            if (step === "download") {
+                const size = this.props.size;
+                const part = this.props.size * this.props.process.progress;
+                step += ` (${Numeral(part).format("0.0 b")}/${Numeral(size).format("0.0 b")})`;
+            }
+
             return (
                 <Panel>
                     <Row>
@@ -47,7 +56,7 @@ class HMMInstall extends React.Component {
                                 <ProgressBar now={progress} />
                                 <p>
                                     <small className="text-muted text-capitalize">
-                                        {this.props.process.step.replace("_", " ")}
+                                        {step}
                                     </small>
                                 </p>
                             </div>
@@ -60,7 +69,7 @@ class HMMInstall extends React.Component {
                 <Alert bsStyle="warning" className="text-center">
                     <h5 className="text-warning">
                         <strong>
-                            <Icon name="warning"/> No HMM data found.
+                            <Icon name="warning"/> No HMM file found.
                         </strong>
                     </h5>
 
@@ -75,6 +84,7 @@ class HMMInstall extends React.Component {
 
 const mapStateToProps = (state) => {
     return {
+        size: state.hmms.size,
         ready: state.hmms.ready,
         process: state.hmms.process
     };

--- a/client/src/js/hmm/components/List.js
+++ b/client/src/js/hmm/components/List.js
@@ -70,10 +70,10 @@ class HMMList extends React.Component {
             );
         }
 
-        let noFilePanel;
+        let installer;
 
         if (!this.props.fileExists) {
-            noFilePanel = <HMMInstaller />;
+            installer = <HMMInstaller />;
         }
 
         let rowComponents = this.props.list.map(document => {
@@ -125,7 +125,7 @@ class HMMList extends React.Component {
                     />
                 </h3>
 
-                {noFilePanel}
+                {installer}
 
                 <FormGroup>
                     <InputGroup>

--- a/client/src/js/hmm/reducer.js
+++ b/client/src/js/hmm/reducer.js
@@ -25,7 +25,7 @@ const hmmsReducer = (state = initialState, action) => {
                     ...state,
                     process: action.data.process,
                     ready: action.data.ready,
-                    size: action.data.size
+                    size: action.data.download_size
                 };
             }
 

--- a/client/src/js/samples/components/Analyses/NuVs/ORF.js
+++ b/client/src/js/samples/components/Analyses/NuVs/ORF.js
@@ -5,12 +5,6 @@ import { scaleLinear } from "d3-scale";
 import { capitalize } from "lodash";
 import { Flex, FlexItem } from "../../../../base";
 
-const DEFAULT_HMM = {
-    label: "Unannotated",
-    best_e: "N/A",
-    family: "N/A"
-};
-
 const HEIGHT = 8;
 
 export default class NuVsORF extends React.Component {
@@ -69,16 +63,30 @@ export default class NuVsORF extends React.Component {
 
     render () {
 
-        const hmm = this.props.hits[0] || DEFAULT_HMM;
+        const hmm = this.props.hits[0];
+
+        let label;
+
+        if (hmm) {
+            label = (
+                <a target="_blank" href={`/hmm/${hmm.hit}`}>
+                    {capitalize(hmm.names[0])}
+                </a>
+            );
+        } else {
+            label = (
+                <span>
+                    Unannotated
+                </span>
+            );
+        }
 
         return (
             <div className="nuvs-item">
                 <div className="nuvs-item-header">
                     <Flex>
                         <FlexItem>
-                            <a target="_blank" href={`/hmm/${hmm.hit}`}>
-                                {capitalize(hmm.names[0])}
-                            </a>
+                            {label}
                         </FlexItem>
                         <FlexItem pad={5}>
                             <small className="text-primary text-strong">
@@ -87,7 +95,7 @@ export default class NuVsORF extends React.Component {
                         </FlexItem>
                         <FlexItem pad={5}>
                             <small className="text-danger text-strong">
-                                {hmm.best_e}
+                                {hmm ? hmm.best_e: null}
                             </small>
                         </FlexItem>
                     </Flex>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles==0.3.2
-aiohttp==2.2.5
+aiohttp==2.3.3
 apipkg==1.4
 appdirs==1.4.3
 arrow==0.10.0
@@ -22,7 +22,7 @@ inotify==0.2.8
 Mako==1.0.7
 MarkupSafe==1.0
 motor==1.1
-multidict==3.3.0
+multidict==3.3.2
 olefile==0.44
 packaging==16.8
 Pillow==4.2.1
@@ -50,4 +50,4 @@ six==1.11.0
 svgwrite==1.1.11
 urllib3==1.21.1
 uvloop==0.8.1
-yarl==0.13.0
+yarl==0.14.2

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -44,7 +44,7 @@ class VTClient:
             await self.db.sessions.insert_one({
                 "_id": "foobar",
                 "ip": "127.0.0.1",
-                "user_agent": "Python/3.6 aiohttp/2.2.5",
+                "user_agent": "Python/3.6 aiohttp/2.3.3",
                 "user": {
                     "id": "test"
                 },

--- a/tests/handlers/test_hmm.py
+++ b/tests/handlers/test_hmm.py
@@ -65,6 +65,8 @@ class TestFind:
 
         tmpdir.mkdir("hmm")
 
+        hmm_document["hidden"] = False
+
         await client.db.hmm.insert(hmm_document)
 
         resp = await client.get("/api/hmms")

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -99,6 +99,9 @@ async def init_db(app):
     logger.info("Checking viruses...")
     await virtool.organize.organize_viruses(db, logger.info)
 
+    logger.info("Checking hmms...")
+    await virtool.organize.organize_hmms(db)
+
     logger.info("Checking jobs...")
     await virtool.organize.organize_jobs(db)
 

--- a/virtool/handlers/groups.py
+++ b/virtool/handlers/groups.py
@@ -16,7 +16,7 @@ async def find(req):
     Get a list of all existing group documents.
 
     """
-    documents = await req.app["db"].groups.find({}).to_list(None)
+    documents = await req.app["db"].groups.find().to_list(None)
 
     return json_response([virtool.utils.base_processor(d) for d in documents])
 

--- a/virtool/handlers/hmm.py
+++ b/virtool/handlers/hmm.py
@@ -22,7 +22,14 @@ async def find(req):
     if term:
         db_query.update(compose_regex_query(term, ["label"]))
 
-    data = await paginate(db.hmm, db_query, req.query, "cluster", projection=virtool.virus_hmm.PROJECTION)
+    data = await paginate(
+        db.hmm,
+        db_query,
+        req.query,
+        "cluster",
+        projection=virtool.virus_hmm.PROJECTION,
+        filter={"hidden": False}
+    )
 
     profiles_path = os.path.join(req.app["settings"].get("data_path"), "hmm", "profiles.hmm")
 

--- a/virtool/handlers/jobs.py
+++ b/virtool/handlers/jobs.py
@@ -36,10 +36,11 @@ async def find(req):
         db.jobs,
         db_query,
         req.query,
-        "name",
         projection=virtool.job.LIST_PROJECTION,
         processor=virtool.job.processor
     )
+
+    data["documents"].sort(key=lambda d: d["created_at"])
 
     return json_response(data)
 

--- a/virtool/handlers/users.py
+++ b/virtool/handlers/users.py
@@ -16,7 +16,7 @@ async def find(req):
     Get a list of all user documents in the database.
 
     """
-    users = await req.app["db"].users.find({}, virtool.user.PROJECTION).to_list(length=None)
+    users = await req.app["db"].users.find({}, virtool.user.PROJECTION).to_list(None)
 
     return json_response([virtool.utils.base_processor(user) for user in users])
 

--- a/virtool/handlers/utils.py
+++ b/virtool/handlers/utils.py
@@ -254,7 +254,7 @@ async def paginate(collection, db_query, url_query, sort_by, projection=None, pr
     if page > 1:
         cursor.skip((page - 1) * per_page)
 
-    documents = [processor(d) for d in await cursor.to_list(length=per_page)]
+    documents = [processor(d) for d in await cursor.to_list(per_page)]
 
     return {
         "documents": documents,

--- a/virtool/handlers/utils.py
+++ b/virtool/handlers/utils.py
@@ -233,18 +233,27 @@ def validation(schema):
     return decorator
 
 
-async def paginate(collection, db_query, url_query, sort_by, projection=None, processor=virtool.utils.base_processor,
-                   reverse=False):
+async def paginate(collection, db_query, url_query, sort_by=None, projection=None, filter=None,
+                   processor=virtool.utils.base_processor, reverse=False):
 
     page = int(url_query.get("page", 1))
     per_page = int(url_query.get("per_page", 15))
 
-    total_count = await collection.count()
+    filter = filter or {}
+
+    total_count = await collection.count(filter)
+
+    sort = None
+
+    if sort_by:
+        sort = [(sort_by, -1 if reverse else 1)]
+
+    db_query.update(filter)
 
     cursor = collection.find(
         db_query,
         projection,
-        sort=[(sort_by, -1 if reverse else 1)]
+        sort=sort
     )
 
     found_count = await cursor.count()

--- a/virtool/job_manager.py
+++ b/virtool/job_manager.py
@@ -138,6 +138,8 @@ class Manager:
         for job in self._jobs_dict.values():
             await job.cancel()
 
+        self.executor.shutdown(wait=True)
+
     def reserve_resources(self, job):
         """
         Reserve resources for the given job. Throws an :class:`InsufficientResourceError` if the required resources are

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -107,6 +107,18 @@ async def organize_samples(db, settings):
             })
 
 
+async def organize_hmms(db):
+    await virtool.organize_utils.unset_version_field(db.hmm)
+    await db.hmm.update_many({}, {
+        "$rename": {
+            "definition": "names"
+        },
+        "$unset": {
+            "label"
+        }
+    })
+
+
 async def organize_analyses(db, logger_cb=None):
     """
     Bring analysis documents up-to-date by doing the following:

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -109,12 +109,19 @@ async def organize_samples(db, settings):
 
 async def organize_hmms(db):
     await virtool.organize_utils.unset_version_field(db.hmm)
+
+    await db.hmm.update_many({"hidden": {"$exists": False}}, {
+        "$set": {
+            "hidden": False
+        }
+    })
+
     await db.hmm.update_many({}, {
         "$rename": {
             "definition": "names"
         },
         "$unset": {
-            "label"
+            "label": ""
         }
     })
 

--- a/virtool/user_groups.py
+++ b/virtool/user_groups.py
@@ -28,7 +28,7 @@ def merge_group_permissions(groups):
 
 
 async def update_member_users(db, group_id, remove=False):
-    groups = await db.groups.find().to_list(length=None)
+    groups = await db.groups.find().to_list(None)
 
     async for user in db.users.find({"groups": group_id}, ["groups", "permissions", "primary_group"]):
         if remove:


### PR DESCRIPTION
- update aiohttp to 2.3.3
- shutdown job manager ``ProcessPoolExecutor on close``
- update HMM collection documents in ``organize.py`` (resolves #251)
- delete unreferenced HMM annotations when installing new ones from GitHub repo
- hide old, reference HMM documents in find results
- show download size progress during HMM install
- sort jobs find results by ``created_at`` time
