### PR TITLE
Index improvements and more fixes

### DIFF
--- a/client/src/js/base/InputSave.js
+++ b/client/src/js/base/InputSave.js
@@ -53,10 +53,6 @@ export class InputSave extends React.Component {
         autoComplete: true
     };
 
-    componentDidMount () {
-        this.focus();
-    }
-
     componentWillReceiveProps (nextProps) {
         // If the initialValue has changed. Remove the pending state on the component. This will remove the spinner on
         // the save button and enable the Input component again.

--- a/client/src/js/indexes/components/Entry.js
+++ b/client/src/js/indexes/components/Entry.js
@@ -12,12 +12,13 @@
 
 import React from "react";
 import PropTypes from "prop-types";
+import { ClipLoader } from "halogenium";
 import { LinkContainer } from "react-router-bootstrap";
 import { Row, Col, Label } from "react-bootstrap";
 import { Icon, RelativeTime, ListGroupItem } from "../../base";
 
 export default class IndexEntry extends React.PureComponent {
-    
+
     static propTypes = {
         ready: PropTypes.bool,
         showReady: PropTypes.bool,
@@ -35,12 +36,20 @@ export default class IndexEntry extends React.PureComponent {
         // spinner with "Building" is shown, if the index is the active index a green check is shown. Otherwise, no
         // content is shown at the right.
         if (this.props.showReady) {
-            ready = (
-                <span className="pull-right">
-                    <Icon name="checkmark" bsStyle="success" pending={!this.props.ready} />
-                    <span> {this.props.ready ? "Active": "Building"}</span>
-                </span>
-            );
+            if (this.props.ready) {
+                ready = (
+                    <span className="pull-right">
+                        <Icon name="checkmark" bsStyle="success"/> <strong>Active</strong>
+                    </span>
+                );
+            } else {
+                ready = (
+                    <div className="pull-right" >
+                        <ClipLoader size="14px" color="#3c8786" style={{display: "inline"}} />
+                        <strong> Building</strong>
+                    </div>
+                );
+            }
         }
 
         // The description of

--- a/client/src/js/indexes/components/List.js
+++ b/client/src/js/indexes/components/List.js
@@ -11,9 +11,9 @@
 
 import React from "react";
 import { connect } from "react-redux";
-import { Alert } from "react-bootstrap";
+import { Alert, Badge } from "react-bootstrap";
 
-import { Button, Flex, FlexItem, Icon, ListGroupItem } from "../../base";
+import { Button, Flex, FlexItem, Icon, ListGroupItem, PageHint } from "../../base";
 import { findIndexes, showRebuild } from "../actions";
 import IndexEntry from "./Entry";
 import RebuildIndex from "./Rebuild";
@@ -32,7 +32,7 @@ class IndexesList extends React.Component {
 
         let content;
 
-        if (this.props.totalCount > 0) {
+        if (this.props.totalVirusCount > 0) {
             // Set to true when a ready index has been seen when mapping through the index documents. Used to mark only
             // the newest ready index with a checkmark in the index list.
             let haveSeenReady = false;
@@ -113,7 +113,18 @@ class IndexesList extends React.Component {
         return (
             <div>
                 <h3 className="view-header">
-                    <strong>Virus Indexes</strong>
+                    <Flex alignItems="flex-end">
+                        <FlexItem grow={0} shrink={0}>
+                            <strong>Virus Indexes</strong> <Badge>{this.props.totalCount}</Badge>
+                        </FlexItem>
+                        <FlexItem grow={1} shrink={0}>
+                            <PageHint
+                                page={this.props.page}
+                                count={this.props.foundCount}
+                                totalCount={this.props.totalCount}
+                            />
+                        </FlexItem>
+                    </Flex>
                 </h3>
 
                 {content}
@@ -124,9 +135,7 @@ class IndexesList extends React.Component {
 
 const mapStateToProps = (state) => {
     return {
-        documents: state.indexes.documents,
-        modifiedCount: state.indexes.modifiedCount,
-        totalCount: state.indexes.totalCount,
+        ...state.indexes,
         canRebuild: state.account.permissions.rebuild_index
     };
 };

--- a/client/src/js/indexes/components/List.js
+++ b/client/src/js/indexes/components/List.js
@@ -21,9 +21,7 @@ import RebuildIndex from "./Rebuild";
 class IndexesList extends React.Component {
 
     componentDidMount () {
-        if (this.props.documents === null) {
-            this.props.onFind();
-        }
+        this.props.onFind();
     }
 
     render () {

--- a/client/src/js/indexes/components/Rebuild.js
+++ b/client/src/js/indexes/components/Rebuild.js
@@ -11,7 +11,8 @@
 
 import React from "react";
 import { connect } from "react-redux";
-import { Modal, Panel } from "react-bootstrap";
+import { ClipLoader } from "halogenium";
+import { Modal } from "react-bootstrap";
 
 import { getUnbuilt, createIndex, hideRebuild } from "../actions";
 import { Button } from "../../base";
@@ -33,6 +34,18 @@ class RebuildIndex extends React.Component {
     };
 
     render () {
+        let history;
+
+        if (this.props.unbuilt) {
+            history = <RebuildHistory unbuilt={this.props.unbuilt} />;
+        } else {
+            history = (
+                <div className="text-center" style={{padding: "70px 0"}}>
+                    <ClipLoader color="#3c8786" size={16} />
+                </div>
+            );
+        }
+
         return (
             <Modal bsSize="large" onEntered={this.modalEntered} show={this.props.show} onHide={this.props.onHide}>
                 <Modal.Header>
@@ -40,11 +53,7 @@ class RebuildIndex extends React.Component {
                 </Modal.Header>
                 <form onSubmit={this.save}>
                     <Modal.Body>
-                        <Panel>
-                            Build the changes described below into a new index.
-                        </Panel>
-
-                        <RebuildHistory unbuilt={this.props.unbuilt} />
+                        {history}
                     </Modal.Body>
                     <Modal.Footer>
                         <Button type="submit" bsStyle="primary" icon="hammer">

--- a/client/src/js/indexes/reducers.js
+++ b/client/src/js/indexes/reducers.js
@@ -22,7 +22,7 @@ import {
 const initialState = {
     documents: null,
     modifiedCount: 0,
-    totalCount: 0,
+    totalVirusCount: 0,
     error: false,
 
     detail: null,
@@ -45,10 +45,14 @@ const indexesReducer = (state = initialState, action) => {
             });
 
         case FIND_INDEXES.SUCCEEDED:
+            console.log(action);
             return assign({}, state, {
                 documents: action.data.documents,
+                page: action.data.page,
+                foundCount: action.data.found_count,
+                totalCount: action.data.total_count,
                 modifiedCount: action.data.modified_virus_count,
-                totalCount: action.data.total_virus_count
+                totalVirusCount: action.data.total_virus_count
             });
 
         case GET_INDEX.REQUESTED:

--- a/client/src/js/indexes/reducers.js
+++ b/client/src/js/indexes/reducers.js
@@ -45,7 +45,6 @@ const indexesReducer = (state = initialState, action) => {
             });
 
         case FIND_INDEXES.SUCCEEDED:
-            console.log(action);
             return assign({}, state, {
                 documents: action.data.documents,
                 page: action.data.page,

--- a/client/src/js/indexes/sagas.js
+++ b/client/src/js/indexes/sagas.js
@@ -58,6 +58,7 @@ export function* createIndex (action) {
     yield setPending(function* () {
         try {
             const response = yield indexesAPI.create();
+            yield put({type: FIND_INDEXES.REQUESTED});
             yield put({type: CREATE_INDEX.SUCCEEDED, data: response.body});
         } catch (error) {
             yield put({type: CREATE_INDEX.FAILED, error: error});

--- a/client/src/js/sagas.js
+++ b/client/src/js/sagas.js
@@ -7,8 +7,6 @@
  *
  */
 
-import { fork } from "redux-saga/effects"
-
 import { watchAccount } from "./account/sagas"
 import { watchFiles } from "./files/sagas";
 import { watchGroups } from "./groups/sagas";
@@ -24,18 +22,17 @@ import { watchViruses } from "./viruses/sagas"
 
 export default function* rootSaga () {
     yield [
-        fork(watchAccount),
-        fork(watchFiles),
-        fork(watchSubtraction),
-        fork(watchHmms),
-        fork(watchIndexes),
-        fork(watchJobs),
-        fork(watchSamples),
-        fork(watchSettings),
-        fork(watchSubtraction),
-        fork(watchGroups),
-        fork(watchUpdates),
-        fork(watchUsers),
-        fork(watchViruses)
+        watchAccount(),
+        watchFiles(),
+        watchSubtraction(),
+        watchHmms(),
+        watchIndexes(),
+        watchJobs(),
+        watchSamples(),
+        watchSettings(),
+        watchGroups(),
+        watchUpdates(),
+        watchUsers(),
+        watchViruses()
     ];
 }

--- a/client/src/js/subtraction/actions.js
+++ b/client/src/js/subtraction/actions.js
@@ -14,8 +14,7 @@ import {
     LIST_SUBTRACTION_IDS,
     GET_SUBTRACTION,
     CREATE_SUBTRACTION,
-    SHOW_CREATE_SUBTRACTION,
-    HIDE_SUBTRACTION_MODAL
+    SHOW_CREATE_SUBTRACTION
 } from "../actionTypes";
 
 export const wsUpdateSubtraction = (data) => {
@@ -69,11 +68,5 @@ export const removeSubtraction = (hostId) => {
 export const showCreateSubtraction = () => {
     return {
         type: SHOW_CREATE_SUBTRACTION
-    };
-};
-
-export const hideSubtractionModal = () => {
-    return {
-        type: HIDE_SUBTRACTION_MODAL
     };
 };

--- a/client/src/js/viruses/components/Detail/Editor.js
+++ b/client/src/js/viruses/components/Detail/Editor.js
@@ -83,7 +83,7 @@ const IsolateEditor = (props) => {
                     </ListGroup>
                 </Col>
                 <Col md={9}>
-                    <IsolateDetail />
+                    {noIsolatesFound ? null: <IsolateDetail />}
                 </Col>
             </Row>
         </div>

--- a/client/src/js/viruses/reducers.js
+++ b/client/src/js/viruses/reducers.js
@@ -7,12 +7,8 @@
  *
  */
 
-import { assign, concat, find, reject } from "lodash";
 import {
-    WS_UPDATE_VIRUS,
-    WS_REMOVE_VIRUS,
     WS_UPDATE_STATUS,
-
     FIND_VIRUSES,
     GET_VIRUS,
     CREATE_VIRUS,
@@ -66,7 +62,8 @@ const virusesInitialState = {
 };
 
 const hideVirusModal = (state) => {
-    return assign({}, state, {
+    return {
+        ...state,
         edit: false,
         remove: false,
         addIsolate: false,
@@ -75,13 +72,14 @@ const hideVirusModal = (state) => {
         addSequence: false,
         editSequence: false,
         removeSequence: false
-    });
+    };
 };
 
 const receivedDetailAfterChange = (state, action) => {
-    return assign({}, hideVirusModal(state), {
+    return {
+        ...hideVirusModal(state),
         detail: action.data
-    })
+    };
 };
 
 export default function virusesReducer (state = virusesInitialState, action) {
@@ -90,81 +88,51 @@ export default function virusesReducer (state = virusesInitialState, action) {
 
         case WS_UPDATE_STATUS:
             if (action.data.id === "virus_import") {
-                return assign({}, state, {
-                    importData: assign({}, state.importData, action.data, {in_progress: true})
-                });
+                return {...state, importData: {...state.importData, ...action.data, in_progress: true}};
             }
 
             return state;
 
-        case WS_UPDATE_VIRUS:
-            return assign({}, state, {
-                viruses: concat(
-                    reject(state.viruses, {id: action.virus_id}),
-                    assign({}, find(state.viruses, {id: action.virus_id}), action.data)
-                )
-            });
-
-        case WS_REMOVE_VIRUS:
-            return assign({}, state, {
-                viruses: reject(state.viruses, {id: action.virus_id})
-            });
-
         case FIND_VIRUSES.REQUESTED:
-            return assign({}, state, action.terms);
+            return {...state, ...action.terms};
 
         case FIND_VIRUSES.SUCCEEDED:
-            return assign({}, state, {
+            return {
+                ...state,
                 documents: action.data.documents,
                 page: action.data.page,
                 pageCount: action.data.page_count,
                 totalCount: action.data.total_count,
                 foundCount: action.data.found_count,
                 modifiedCount: action.data.modified_count
-            });
-
-        case FIND_VIRUSES.FAILED:
-            return assign({}, state, {
-                viruses: []
-            });
+            };
 
         case GET_VIRUS.REQUESTED:
-            return assign({}, state, {
-                detail: null,
-                activeIsolateId: null,
-                activeSequenceId: null
-            });
+            return {...state, detail: null, activeIsolateId: null, activeSequenceId: null};
 
         case GET_VIRUS.SUCCEEDED:
-            return assign({}, state, {
+            return {
+                ...state,
                 detail: action.data,
                 activeIsolateId: action.data.isolates.length ? action.data.isolates[0].id: null
-            });
-
-        case CREATE_VIRUS.REQUESTED:
-            return assign({}, state, {
-                pending: true
-            });
+            };
 
         case CREATE_VIRUS.FAILED:
-            return assign({}, state, {
-                createError: action.error
-            });
+            return {...state, createError: action.error};
 
         case REMOVE_VIRUS.SUCCEEDED:
-            return assign({}, state, {
-                detail: null,
-                actionIsolateId: null,
-                remove: false
-            });
+            return {...state, detail: null, actionIsolateId: null, remove: false};
 
         case EDIT_VIRUS.FAILED:
-            return assign({}, state, {
-                editError: action.message
-            });
+            return {...state, editError: action.message};
+
+        case ADD_ISOLATE.SUCCEEDED:
+            return {
+                ...receivedDetailAfterChange(state, action),
+                activeIsolateId: action.data.isolates[action.data.isolates.length - 1].id
+            };
 
         case EDIT_VIRUS.SUCCEEDED:
-        case ADD_ISOLATE.SUCCEEDED:
         case EDIT_ISOLATE.SUCCEEDED:
         case SET_ISOLATE_AS_DEFAULT.SUCCEEDED:
         case REMOVE_ISOLATE.SUCCEEDED:
@@ -174,76 +142,46 @@ export default function virusesReducer (state = virusesInitialState, action) {
             return receivedDetailAfterChange(state, action);
 
         case GET_VIRUS_HISTORY.REQUESTED:
-            return assign({}, state, {
-                detailHistory: null
-            });
+            return {...state, detailHistory: null};
 
         case GET_VIRUS_HISTORY.SUCCEEDED:
-            return assign({}, state, {
-                detailHistory: action.data
-            });
+            return {...state, detailHistory: action.data};
 
         case REVERT.SUCCEEDED:
-            return assign({}, state, {
-                detail: action.detail,
-                detailHistory: action.history
-            });
+            return {...state, detail: action.detail, detailHistory: action.history};
 
         case UPLOAD_IMPORT.SUCCEEDED:
-            return assign({}, state, {
-                importData: assign({}, action.data, {in_progress: false})
-            });
+            return {...state, importData: {...action.data, in_progress: false}};
 
         case SELECT_ISOLATE:
-            return assign({}, state, {
-               activeIsolateId: action.isolateId
-            });
+            return {...state, activeIsolateId: action.isolateId};
 
         case SELECT_SEQUENCE:
-            return assign({}, state, {
-               activeSequenceId: action.sequenceId
-            });
+            return {...state, activeSequenceId: action.sequenceId};
 
         case SHOW_EDIT_VIRUS:
-            return assign({}, state, {
-                edit: true,
-                editError: ""
-            });
+            return {...state, edit: true, editError: ""};
 
         case SHOW_REMOVE_VIRUS:
-            return assign({}, state, {
-                remove: true
-            });
+            return {...state, remove: true};
 
         case SHOW_ADD_ISOLATE:
-            return assign({}, state, {
-                addIsolate: true
-            });
+            return {...state, addIsolate: true};
 
         case SHOW_EDIT_ISOLATE:
-            return assign({}, state, {
-                editIsolate: true
-            });
+            return {...state, editIsolate: true};
 
         case SHOW_REMOVE_ISOLATE:
-            return assign({}, state, {
-                removeIsolate: true
-            });
+            return {...state, removeIsolate: true};
 
         case SHOW_ADD_SEQUENCE:
-            return assign({}, state, {
-                addSequence: true
-            });
+            return {...state, addSequence: true};
 
         case SHOW_EDIT_SEQUENCE:
-            return assign({}, state, {
-                editSequence: action.sequenceId
-            });
+            return {...state, editSequence: action.sequenceId};
 
         case SHOW_REMOVE_SEQUENCE:
-            return assign({}, state, {
-                removeSequence: action.sequenceId
-            });
+            return {...state, removeSequence: action.sequenceId};
 
         case HIDE_VIRUS_MODAL:
             return hideVirusModal(state);

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,5 @@ setproctitle==1.1.10
 six==1.11.0
 svgwrite==1.1.11
 urllib3==1.21.1
-uvloop==0.8.1
+uvloop==0.9.0
 yarl==0.15.0

--- a/tests/handlers/test_indexes.py
+++ b/tests/handlers/test_indexes.py
@@ -72,6 +72,11 @@ class TestFind:
                     "virus_count": 231
                 }
             ],
+            "total_count": 2,
+            "found_count": 2,
+            "page": 1,
+            "page_count": 1,
+            "per_page": 15,
             "modified_virus_count": 0,
             "total_virus_count": 0
         }

--- a/virtool/handlers/indexes.py
+++ b/virtool/handlers/indexes.py
@@ -12,17 +12,25 @@ async def find(req):
     """
     db = req.app["db"]
 
-    documents = await db.indexes.find({}, virtool.virus_index.PROJECTION, sort=[("version", -1)]).to_list(None)
-
     modified_virus_count = len(await db.history.find({"index.id": "unbuilt"}, ["virus"]).distinct("virus.name"))
 
     total_virus_count = await db.viruses.count()
 
-    return json_response({
-        "documents": [virtool.utils.base_processor(d) for d in documents],
+    data = await paginate(
+        db.indexes,
+        {},
+        req.query,
+        projection=virtool.virus_index.PROJECTION,
+        sort_by="version",
+        reverse=True
+    )
+
+    data.update({
         "modified_virus_count": modified_virus_count,
         "total_virus_count": total_virus_count
     })
+
+    return json_response(data)
 
 
 async def get(req):

--- a/virtool/handlers/utils.py
+++ b/virtool/handlers/utils.py
@@ -55,6 +55,8 @@ def compose_regex_query(term, fields):
     # Stringify fields.
     fields = [str(field) for field in virtool.utils.coerce_list(fields)]
 
+    term = re.escape(term)
+
     # Compile regex, making is case-insensitive.
     regex = re.compile(str(term), re.IGNORECASE)
 

--- a/virtool/virus_hmm.py
+++ b/virtool/virus_hmm.py
@@ -1,6 +1,7 @@
 import aiofiles
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 
@@ -39,7 +40,7 @@ async def hmmstat(loop, path):
     output = await loop.run_in_executor(None, subprocess.check_output, command)
 
     result = [line.split() for line in output.decode("utf-8").split("\n") if line and line[0] != "#"]
-
+a
     return [{
         "cluster": int(line[1].replace("vFam_", "")),
         "count": int(line[3]),
@@ -181,7 +182,7 @@ async def install_official(loop, db, settings, dispatch, server_version, usernam
 
         decompressed_path = os.path.join(temp_path, "hmm")
         install_path = os.path.join(settings.get("data_path"), "hmm", "profiles.hmm")
-        await loop.run_in_executor(None, os.rename, os.path.join(decompressed_path, "profiles.hmm"), install_path)
+        await loop.run_in_executor(None, shutil.move, os.path.join(decompressed_path, "profiles.hmm"), install_path)
 
         await update_process(db, dispatch, 0, step="import_annotations")
 

--- a/virtool/virus_hmm.py
+++ b/virtool/virus_hmm.py
@@ -40,7 +40,7 @@ async def hmmstat(loop, path):
     output = await loop.run_in_executor(None, subprocess.check_output, command)
 
     result = [line.split() for line in output.decode("utf-8").split("\n") if line and line[0] != "#"]
-a
+
     return [{
         "cluster": int(line[1].replace("vFam_", "")),
         "count": int(line[3]),


### PR DESCRIPTION
- use pagination in indexes API and client views
- show loading icon for building indexes
- show loading icon when fetching unbuilt history for new build
- select new isolate after it has been created
- fix unwanted autofocus on settings ``InputSave`` components
- fix duplicate call to ``POST /api/subtraction`` caused by saga bug
- fix render error for empty viruses
- upgrade uvloop (fixes #262)
- use shutil.move rather than os.rename during HMM install (fixes #263)
- escape regex patterns before using (fixes #264)
