### PR TITLE
Close multiple issues

### DIFF
--- a/client/src/js/hmm/components/List.js
+++ b/client/src/js/hmm/components/List.js
@@ -29,7 +29,7 @@ import {
 } from "react-bootstrap";
 
 import { findHMMs } from "../actions";
-import { Icon, ListGroupItem, PageHint } from "../../base"
+import { Icon, Flex, FlexItem, ListGroupItem, PageHint } from "../../base"
 import HMMInstaller from "./Installer";
 
 /**
@@ -115,14 +115,19 @@ class HMMList extends React.Component {
         return (
             <div>
                 <h3 className="view-header">
-                    <strong>HMMs</strong> <Badge>{this.props.totalCount}</Badge>
-
-                    <PageHint
-                        count={this.props.list.length}
-                        totalCount={this.props.totalCount}
-                        page={this.props.page}
-                        pullRight
-                    />
+                    <Flex alignItems="flex-end">
+                        <FlexItem grow={0} shrink={0}>
+                            <strong>HMMs</strong> <Badge>{this.props.totalCount}</Badge>
+                        </FlexItem>
+                        <FlexItem grow={1} shrink={0}>
+                            <PageHint
+                                count={this.props.list.length}
+                                totalCount={this.props.totalCount}
+                                page={this.props.page}
+                                pullRight
+                            />
+                        </FlexItem>
+                    </Flex>
                 </h3>
 
                 {installer}

--- a/client/src/js/nav/components/Bar.js
+++ b/client/src/js/nav/components/Bar.js
@@ -102,9 +102,12 @@ const Bar = (props) => {
                         </NavItem>
 
                         <NavDropdown id="account-dropdown" title={dropdownTitle}>
-                            <LinkContainer to="/account">
+                            <LinkContainer to="/account" activeClassName="">
                                 <MenuItem>Account</MenuItem>
                             </LinkContainer>
+                            <MenuItem href="https://gitreports.com/issue/virtool/virtool" target="_blank">
+                                Report Issue
+                            </MenuItem>
                             <MenuItem onClick={props.logout}>Logout</MenuItem>
                         </NavDropdown>
                     </Nav>

--- a/client/src/js/samples/api.js
+++ b/client/src/js/samples/api.js
@@ -50,6 +50,10 @@ const samplesAPI = {
             })
     },
 
+    remove: (sampleId) => {
+        return Request.delete(`/api/samples/${sampleId}`);
+    },
+
     findAnalyses: (sampleId) => {
         return Request.get(`/api/samples/${sampleId}/analyses`)
     },

--- a/client/src/js/samples/components/Detail.js
+++ b/client/src/js/samples/components/Detail.js
@@ -94,7 +94,7 @@ class SampleDetail extends React.Component {
                     <Route path="/samples/:sampleId/analyses" component={Analyses}/>
                 </Switch>
 
-                <RemoveSample name={detail.name} />
+                <RemoveSample id={detail.id} name={detail.name} />
             </div>
         );
     }

--- a/client/src/js/samples/components/Remove.js
+++ b/client/src/js/samples/components/Remove.js
@@ -29,7 +29,7 @@ const RemoveSample = (props) => (
             <Button
                 bsStyle="danger"
                 icon="checkmark"
-                onClick={() => props.onConfirm(props.id, props.onSuccess)}
+                onClick={() => props.onConfirm(props.id)}
             >
                 Confirm
             </Button>
@@ -42,8 +42,7 @@ RemoveSample.propTypes = {
     name: PropTypes.string,
     show: PropTypes.bool,
     onHide: PropTypes.func,
-    onConfirm: PropTypes.func,
-    onSuccess: PropTypes.func
+    onConfirm: PropTypes.func
 };
 
 const mapStateToProps = (state) => {
@@ -58,8 +57,8 @@ const mapDispatchToProps = (dispatch) => {
             dispatch(hideSampleModal());
         },
 
-        onConfirm: (sampleId, onSuccess) => {
-            dispatch(removeSample(sampleId, onSuccess));
+        onConfirm: (sampleId) => {
+            dispatch(removeSample(sampleId));
         }
     };
 };

--- a/client/src/js/samples/reducers.js
+++ b/client/src/js/samples/reducers.js
@@ -10,8 +10,6 @@
 import { assign, concat, find, reject } from "lodash";
 import {
     WS_UPDATE_SAMPLE,
-    WS_REMOVE_SAMPLE,
-    WS_REMOVE_ANALYSIS,
     FIND_SAMPLES,
     GET_SAMPLE,
     UPDATE_SAMPLE,
@@ -73,14 +71,6 @@ export default function reducer (state = initialState, action) {
                 )
             });
 
-        case WS_REMOVE_SAMPLE:
-            return assign({}, state, {
-                viruses: reject(state.viruses, {id: action.virus_id})
-            });
-
-        case WS_REMOVE_ANALYSIS:
-            return state;
-
         case FIND_SAMPLES.SUCCEEDED:
             return assign({}, state, {
                 documents: action.data.documents,
@@ -119,8 +109,9 @@ export default function reducer (state = initialState, action) {
 
         case REMOVE_SAMPLE.SUCCEEDED:
             return assign({}, state, {
-                analyses: reject(state.analyses, {id: action.id}),
-                analysisDetail: state.analysisDetail.id === action.id ? null: state.analysisDetail
+                detail: null,
+                analyses: null,
+                analysisDetail: null
             });
 
         case SHOW_REMOVE_SAMPLE:

--- a/client/src/js/samples/sagas.js
+++ b/client/src/js/samples/sagas.js
@@ -6,8 +6,7 @@
  * @author igboyes
  *
  */
-
-import { takeEvery, takeLatest, throttle, put } from "redux-saga/effects";
+import { put, takeEvery, takeLatest, throttle } from "redux-saga/effects";
 import { push } from "react-router-redux";
 
 import samplesAPI from "./api";
@@ -20,6 +19,7 @@ import {
     REFRESH_SAMPLE,
     CREATE_SAMPLE,
     UPDATE_SAMPLE,
+    REMOVE_SAMPLE,
     FIND_ANALYSES,
     GET_ANALYSIS,
     ANALYZE,
@@ -35,6 +35,7 @@ export function* watchSamples () {
     yield takeLatest(GET_SAMPLE.REQUESTED, getSample);
     yield takeLatest(CREATE_SAMPLE.REQUESTED, createSample);
     yield takeEvery(UPDATE_SAMPLE.REQUESTED, updateSample);
+    yield throttle(300, REMOVE_SAMPLE.REQUESTED, removeSample);
     yield takeLatest(FIND_ANALYSES.REQUESTED, findAnalyses);
     yield takeLatest(GET_ANALYSIS.REQUESTED, getAnalysis);
     yield takeEvery(ANALYZE.REQUESTED, analyze);
@@ -97,6 +98,19 @@ export function* updateSample (action) {
             yield samplesAPI.update(action.sampleId, action.update);
             yield put(push({state: {editSample: false}}));
             yield put({type: REFRESH_SAMPLE.REQUESTED, sampleId: action.sampleId});
+        } catch (error) {
+            yield put({type: UPDATE_SAMPLE.FAILED, error});
+        }
+    }, action);
+}
+
+export function* removeSample (action) {
+    yield setPending(function* (action) {
+        try {
+            yield samplesAPI.remove(action.sampleId);
+            yield put({type: FIND_SAMPLES.REQUESTED});
+
+            yield put(push("/samples"));
         } catch (error) {
             yield put({type: UPDATE_SAMPLE.FAILED, error});
         }

--- a/client/src/js/viruses/components/Create.js
+++ b/client/src/js/viruses/components/Create.js
@@ -11,6 +11,7 @@
 
 import React from "react";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 import { withRouter } from "react-router-dom";
 import { Row, Col, Modal, Alert, ButtonToolbar } from "react-bootstrap";
 
@@ -67,7 +68,7 @@ class CreateVirus extends React.Component {
         };
 
         return (
-            <Modal show={true} onHide={this.props.onHide} onExited={this.modalExited}>
+            <Modal show={this.props.show} onHide={() => this.props.onHide(this.props)} onExited={this.modalExited}>
                 <Modal.Header onHide={this.props.onHide} closeButton>
                     Create Virus
                 </Modal.Header>
@@ -117,15 +118,15 @@ const mapStateToProps = (state) => {
     };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (dispatch) => {
     return {
 
         onSubmit: (name, abbreviation) => {
             dispatch(createVirus(name, abbreviation))
         },
 
-        onHide: () => {
-            ownProps.history.push("/viruses");
+        onHide: ({ location }) => {
+            dispatch(push({...location, state: {createVirus: false}}));
         }
     };
 };

--- a/client/src/js/viruses/components/Create.js
+++ b/client/src/js/viruses/components/Create.js
@@ -30,10 +30,6 @@ class CreateVirus extends React.Component {
         };
     }
 
-    componentDidMount () {
-        this.inputNode.focus();
-    }
-
     modalExited = () => {
         this.setState({
             name: "",
@@ -82,7 +78,6 @@ class CreateVirus extends React.Component {
                             <Col md={9}>
                                 <Input
                                     {...inputProps}
-                                    ref={(node) => this.inputNode = node}
                                     label="Name"
                                     value={this.state.name}
                                     onChange={(e) => this.setState({name: e.target.value})}

--- a/client/src/js/viruses/components/Import.js
+++ b/client/src/js/viruses/components/Import.js
@@ -37,8 +37,8 @@ class VirusImport extends React.Component {
         onCommit: PropTypes.func
     };
 
-    handleProgress = (progress) => {
-        this.setState({uploadProgress: progress});
+    handleProgress = (progressEvent) => {
+        this.setState({uploadProgress: progressEvent.loaded / progressEvent.total});
     };
 
     handleCommit = () => {

--- a/client/src/js/viruses/components/List.js
+++ b/client/src/js/viruses/components/List.js
@@ -10,6 +10,7 @@
 import React from "react";
 import URI from "urijs";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 import { Link, Route } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
 import { Alert, Badge, Row, Col, ListGroup, Pagination } from "react-bootstrap";
@@ -93,7 +94,7 @@ class VirusesList extends React.Component {
                     <span>
                         <Icon name="info"/> No viruses found. <Link to={{state: {virusImport: true}}}>Import</Link> or
                     </span>
-                    <span> <Link to="/viruses/create">Create</Link> some</span>
+                    <span> <Link to={{state: {createVirus: true}}}>Create</Link> some</span>
                 </ListGroupItem>
             );
         }
@@ -139,6 +140,7 @@ class VirusesList extends React.Component {
                 <VirusToolbar
                     canModify={this.props.account.permissions.modify_virus}
                     onChangeTerm={this.handleChangeTerm}
+                    location={this.props.location}
                 />
 
                 <ListGroup>
@@ -158,9 +160,9 @@ class VirusesList extends React.Component {
                     />
                 </div>
 
-                <Route path="/viruses/create">
-                    <CreateVirus {...this.props} />
-                </Route>
+                <Route children={({ location }) => {
+                    return <CreateVirus {...this.props} show={!!location.state && location.state.createVirus} />;
+                }} />
             </div>
         );
 
@@ -191,6 +193,10 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
         onToggleModifiedOnly: () => {
             dispatch(findViruses({modified: !ownProps.modified}));
+        },
+
+        onHide: () => {
+            dispatch(push({state: {createVirus: false}}));
         }
     };
 };

--- a/client/src/js/viruses/components/Toolbar.js
+++ b/client/src/js/viruses/components/Toolbar.js
@@ -44,7 +44,7 @@ const VirusToolbar = (props) => (
         </LinkContainer>
 
         {props.canModify ? (
-            <LinkContainer to="/viruses/create">
+            <LinkContainer to={{...props.location, state: {createVirus: true}}} replace>
                 <Button bsStyle="primary" tip="Create">
                     <Icon name="new-entry" />
                 </Button>

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -103,6 +103,10 @@ async def test_install(download_release_error, loop, tmpdir, monkeypatch, mocker
             "index.html"
         }
 
+        document = await test_motor.status.find_one("software_update", ["process"])
+
+        assert document["process"]["complete"] is True
+
         assert m_reload.called
 
     else:

--- a/virtool/handlers/updates.py
+++ b/virtool/handlers/updates.py
@@ -28,7 +28,6 @@ async def get(req):
 async def upgrade(req):
 
     db = req.app["db"]
-    settings = req.app["settings"]
     dispatch = req.app["dispatcher"].dispatch
 
     await req.app["job_manager"].close()

--- a/virtool/handlers/users.py
+++ b/virtool/handlers/users.py
@@ -231,6 +231,8 @@ async def add_group(req):
         }
     }, return_document=ReturnDocument.AFTER, projection=virtool.user.PROJECTION)
 
+    await virtool.user.update_users_keys(db, user_id, document["groups"], document["permissions"])
+
     return json_response(virtool.utils.base_processor(document))
 
 
@@ -271,6 +273,8 @@ async def remove_group(req):
     document = await db.users.find_one_and_update({"_id": user_id}, {
         "$set": update
     }, return_document=ReturnDocument.AFTER, projection=virtool.user.PROJECTION)
+
+    await virtool.user.update_users_keys(db, user_id, document["groups"], document["permissions"])
 
     return json_response(virtool.utils.base_processor(document))
 

--- a/virtool/handlers/users.py
+++ b/virtool/handlers/users.py
@@ -231,7 +231,7 @@ async def add_group(req):
         }
     }, return_document=ReturnDocument.AFTER, projection=virtool.user.PROJECTION)
 
-    await virtool.user.update_users_keys(db, user_id, document["groups"], document["permissions"])
+    await virtool.user.update_sessions_and_keys(db, user_id, document["groups"], document["permissions"])
 
     return json_response(virtool.utils.base_processor(document))
 
@@ -274,7 +274,7 @@ async def remove_group(req):
         "$set": update
     }, return_document=ReturnDocument.AFTER, projection=virtool.user.PROJECTION)
 
-    await virtool.user.update_users_keys(db, user_id, document["groups"], document["permissions"])
+    await virtool.user.update_sessions_and_keys(db, user_id, document["groups"], document["permissions"])
 
     return json_response(virtool.utils.base_processor(document))
 

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -435,11 +435,8 @@ def organize_files(db):
 
 
 async def organize_status(db):
-    document = await db.status.find_one("software_update")
-
-    if document and "process" not in document:
-        await db.status.update_one({"_id": "software_update"}, {
-            "$set": {
-                "process": None
-            }
-        })
+    await db.status.update_one({"_id": "software_update"}, {
+        "$set": {
+            "process": None
+        }
+    }, upsert=True)

--- a/virtool/updates.py
+++ b/virtool/updates.py
@@ -179,7 +179,7 @@ async def install(db, dispatch, loop, download_url, size):
 
         document = await db.status.find_one_and_update({"_id": "software_update"}, {
             "$set": {
-                "process": None
+                "process.complete": True
             }
         }, return_document=pymongo.ReturnDocument.AFTER)
 

--- a/virtool/user.py
+++ b/virtool/user.py
@@ -170,3 +170,11 @@ def check_api_key(key, hashed):
     return hash_api_key(key) == hashed
 
 
+async def update_users_keys(db, user_id, groups, permissions):
+    async for api_key in db.keys.find({"user.id": user_id}, ["permissions"]):
+        await db.keys.update_one({"_id": api_key["_id"]}, {
+            "$set": {
+                "groups": groups,
+                "permissions": {p: (api_key["permissions"][p] and permissions[p]) for p in permissions}
+            }
+        })

--- a/virtool/user_groups.py
+++ b/virtool/user_groups.py
@@ -64,4 +64,4 @@ async def update_member_users(db, group_id, remove=False):
             projection=["groups", "permissions"]
         )
 
-        await virtool.user.update_users_keys(db, user["_id"], document["groups"], document["permissions"])
+        await virtool.user.update_sessions_and_keys(db, user["_id"], document["groups"], document["permissions"])


### PR DESCRIPTION
- implement sample removal in client (resolves #223)
- update sessions and API keys when user account groups or permissions changes (resolves #159)
- fix virus import progress calculation (resolves #238)
- fix show and hide issues with virus creation modal (resolves #224)
- align HMM page counter consistenly with other views
- update organization of status collection on app init
- add issue reporting link in user drop down (refers user to [gitreports.com](gitreports.com))

