### PR TITLE
Read file reservation

### DIFF
--- a/client/src/js/samples/actions.js
+++ b/client/src/js/samples/actions.js
@@ -8,9 +8,10 @@
  */
 
 import {
+    WS_UPDATE_SAMPLE,
+    WS_REMOVE_SAMPLE,
     WS_UPDATE_ANALYSIS,
     WS_REMOVE_ANALYSIS,
-
     FIND_SAMPLES,
     FIND_READY_HOSTS,
     GET_SAMPLE,
@@ -22,10 +23,23 @@ import {
     ANALYZE,
     BLAST_NUVS,
     REMOVE_ANALYSIS,
-
     SHOW_REMOVE_SAMPLE,
     HIDE_SAMPLE_MODAL
 } from "../actionTypes";
+
+export const wsUpdateSample = (update) => {
+    return {
+        type: WS_UPDATE_SAMPLE,
+        update
+    };
+};
+
+export const wsRemoveSample = (removed) => {
+    return {
+        type: WS_REMOVE_SAMPLE,
+        removed
+    };
+};
 
 export const wsUpdateAnalysis = (update) => {
     return {

--- a/client/src/js/samples/components/Create/Create.js
+++ b/client/src/js/samples/components/Create/Create.js
@@ -12,9 +12,8 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { filter } from "lodash";
+import { capitalize, filter, includes } from "lodash";
 import { connect } from "react-redux";
-import { capitalize } from "lodash";
 import {
     Alert,
     Modal,
@@ -311,7 +310,7 @@ const mapStateToProps = (state) => {
     return {
         groups: state.account.groups,
         readyHosts: state.samples.readyHosts,
-        readyReads: filter(state.files.documents, {type: "reads"}),
+        readyReads: filter(state.files.documents, {type: "reads", reserved: false}),
         forceGroupChoice: state.settings.sample_group === "force_choice"
     };
 };

--- a/client/src/js/samples/components/Create/Create.js
+++ b/client/src/js/samples/components/Create/Create.js
@@ -12,7 +12,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { capitalize, filter, includes } from "lodash";
+import { capitalize, filter } from "lodash";
 import { connect } from "react-redux";
 import {
     Alert,

--- a/client/src/js/samples/reducers.js
+++ b/client/src/js/samples/reducers.js
@@ -7,7 +7,7 @@
  *
  */
 
-import { assign, concat, find, reject } from "lodash";
+import { assign, concat, find, includes, reject, union } from "lodash";
 import {
     WS_UPDATE_SAMPLE,
     FIND_SAMPLES,
@@ -23,6 +23,7 @@ import {
     BLAST_NUVS,
     REMOVE_ANALYSIS
 } from "../actionTypes";
+import {CREATE_SAMPLE} from "../actionTypes";
 
 const setNuvsBLAST = (state, analysisId, sequenceIndex, data = "ip") => {
     const analysisDetail = state.analysisDetail;
@@ -56,6 +57,7 @@ const initialState = {
 
     editError: false,
 
+    reservedFiles: [],
     readyHosts: null
 };
 
@@ -81,9 +83,7 @@ export default function reducer (state = initialState, action) {
             });
 
         case FIND_READY_HOSTS.SUCCEEDED:
-            return assign({}, state, {
-                readyHosts: action.data.documents
-            });
+            return {...state, readyHosts: action.data.documents};
 
         case GET_SAMPLE.REQUESTED:
             return assign({}, state, {
@@ -93,9 +93,13 @@ export default function reducer (state = initialState, action) {
             });
 
         case GET_SAMPLE.SUCCEEDED:
-            return assign({}, state, {
-                detail: action.data
-            });
+            return {...state, detail: action.data};
+
+        case CREATE_SAMPLE.REQUESTED:
+            return {...state, reservedFiles: union(state.reservedFiles, action.files)};
+
+        case CREATE_SAMPLE.FAILED:
+            return {...state, reservedFiles: reject(state.reservedFiles, fileId => includes(action.files, fileId))};
 
         case UPDATE_SAMPLE.SUCCEEDED: {
             if (state.list === null) {

--- a/client/src/js/samples/reducers.js
+++ b/client/src/js/samples/reducers.js
@@ -7,9 +7,8 @@
  *
  */
 
-import { assign, concat, find, includes, reject, union } from "lodash";
+import { assign, reject } from "lodash";
 import {
-    WS_UPDATE_SAMPLE,
     FIND_SAMPLES,
     GET_SAMPLE,
     UPDATE_SAMPLE,
@@ -23,7 +22,6 @@ import {
     BLAST_NUVS,
     REMOVE_ANALYSIS
 } from "../actionTypes";
-import {CREATE_SAMPLE} from "../actionTypes";
 
 const setNuvsBLAST = (state, analysisId, sequenceIndex, data = "ip") => {
     const analysisDetail = state.analysisDetail;
@@ -65,14 +63,6 @@ export default function reducer (state = initialState, action) {
 
     switch (action.type) {
 
-        case WS_UPDATE_SAMPLE:
-            return assign({}, state, {
-                viruses: concat(
-                    reject(state.viruses, {id: action.virus_id}),
-                    assign({}, find(state.viruses, {id: action.virus_id}), action.data)
-                )
-            });
-
         case FIND_SAMPLES.SUCCEEDED:
             return assign({}, state, {
                 documents: action.data.documents,
@@ -95,12 +85,6 @@ export default function reducer (state = initialState, action) {
         case GET_SAMPLE.SUCCEEDED:
             return {...state, detail: action.data};
 
-        case CREATE_SAMPLE.REQUESTED:
-            return {...state, reservedFiles: union(state.reservedFiles, action.files)};
-
-        case CREATE_SAMPLE.FAILED:
-            return {...state, reservedFiles: reject(state.reservedFiles, fileId => includes(action.files, fileId))};
-
         case UPDATE_SAMPLE.SUCCEEDED: {
             if (state.list === null) {
                 return state;
@@ -112,11 +96,7 @@ export default function reducer (state = initialState, action) {
         }
 
         case REMOVE_SAMPLE.SUCCEEDED:
-            return assign({}, state, {
-                detail: null,
-                analyses: null,
-                analysisDetail: null
-            });
+            return {...state, detail: null, analyses: null, analysisDetail: null};
 
         case SHOW_REMOVE_SAMPLE:
             return assign({}, state, {

--- a/client/src/js/samples/sagas.js
+++ b/client/src/js/samples/sagas.js
@@ -12,6 +12,8 @@ import { push } from "react-router-redux";
 import samplesAPI from "./api";
 import { setPending } from "../wrappers";
 import {
+    WS_UPDATE_SAMPLE,
+    WS_REMOVE_SAMPLE,
     WS_UPDATE_ANALYSIS,
     FIND_SAMPLES,
     FIND_READY_HOSTS,
@@ -28,6 +30,8 @@ import {
 }  from "../actionTypes";
 
 export function* watchSamples () {
+    yield takeEvery(WS_UPDATE_SAMPLE, findSamples);
+    yield takeEvery(WS_REMOVE_SAMPLE, findSamples);
     yield takeEvery(WS_UPDATE_ANALYSIS, wsUpdateAnalysis);
     yield takeLatest(FIND_SAMPLES.REQUESTED, findSamples);
     yield takeLatest(FIND_READY_HOSTS.REQUESTED, findReadyHosts);

--- a/client/src/js/websocket.js
+++ b/client/src/js/websocket.js
@@ -1,20 +1,23 @@
 import { WS_CLOSED } from "./actionTypes";
-import { wsUpdateJob, wsRemoveJob } from "./jobs/actions";
 import { wsUpdateFile, wsRemoveFile } from "./files/actions";
-import { wsUpdateAnalysis, wsRemoveAnalysis } from "./samples/actions";
+import { wsUpdateJob, wsRemoveJob } from "./jobs/actions";
+import { wsUpdateSample, wsRemoveSample, wsUpdateAnalysis, wsRemoveAnalysis } from "./samples/actions";
 import { wsUpdateStatus } from "./status/actions";
 
+
 const documentUpdaters = {
-    jobs: wsUpdateJob,
+    analyses: wsUpdateAnalysis,
     files: wsUpdateFile,
-    status: wsUpdateStatus,
-    analyses: wsUpdateAnalysis
+    jobs: wsUpdateJob,
+    samples: wsUpdateSample,
+    status: wsUpdateStatus
 };
 
 const documentRemovers = {
-    jobs: wsRemoveJob,
+    analyses: wsRemoveAnalysis,
     files: wsRemoveFile,
-    analyses: wsRemoveAnalysis
+    jobs: wsRemoveJob,
+    samples: wsRemoveSample
 };
 
 export default function WSConnection (dispatch) {

--- a/tests/handlers/test_samples.py
+++ b/tests/handlers/test_samples.py
@@ -213,7 +213,9 @@ class TestGet:
 class TestCreate:
 
     @pytest.mark.parametrize("group_setting", ["none", "users_primary_group", "force_choice"])
-    async def test(self, group_setting, monkeypatch, spawn_client, test_motor, static_time, test_random_alphanumeric):
+    async def test(self, group_setting, monkeypatch, spawn_client, test_motor, test_dispatch, static_time,
+                   test_random_alphanumeric):
+
         client = await spawn_client(authorize=True, permissions=["create_sample"], job_manager=True)
 
         await client.db.subtraction.insert_one({
@@ -299,6 +301,7 @@ class TestCreate:
         # Check call to file.reserve.
         assert m_reserve.call_args[0] == (
             test_motor,
+            test_dispatch,
             ["test.fq"]
         )
 

--- a/tests/handlers/test_uploads.py
+++ b/tests/handlers/test_uploads.py
@@ -39,6 +39,7 @@ class TestUpload:
             "name": "Test.fq.gz",
             "type": "reads",
             "ready": False,
+            "reserved": False,
             "uploaded_at": "2017-10-06T20:00:00Z",
             "id": "{}-Test.fq.gz".format(test_random_alphanumeric.last_choice),
             "user": {
@@ -53,6 +54,7 @@ class TestUpload:
                 "name": "Test.fq.gz",
                 "type": "reads",
                 "ready": False,
+                "reserved": False,
                 "uploaded_at": static_time,
                 "id": "{}-Test.fq.gz".format(test_random_alphanumeric.last_choice),
                 "user": {

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -288,6 +288,7 @@ class TestManager:
             "expires_at": None,
             "created": False,
             "uploaded_at": static_time,
+            "reserved": False,
             "ready": False,
             "user": None
         }

--- a/virtool/file.py
+++ b/virtool/file.py
@@ -103,4 +103,4 @@ async def remove(loop, db, settings, dispatch, file_id):
 
     file_path = os.path.join(settings.get("data_path"), "files", file_id)
 
-    virtool.utils.rm(file_path)
+    await loop.run_in_executor(None, virtool.utils.rm, file_path)

--- a/virtool/file.py
+++ b/virtool/file.py
@@ -14,13 +14,12 @@ PROJECTION = [
     "user",
     "uploaded_at",
     "type",
-    "ready"
+    "ready",
+    "reserved"
 ]
 
 
 async def create(db, dispatch, filename, file_type, user_id=None):
-    print(user_id)
-
     file_id = None
 
     while file_id is None or file_id in await db.files.distinct("_id"):
@@ -70,7 +69,7 @@ async def create(db, dispatch, filename, file_type, user_id=None):
 async def reserve(db, file_ids):
     await db.files.update_many({"_id": {"$in": file_ids}}, {
         "$set": {
-            "reserve": True
+            "reserved": True
         }
     })
 

--- a/virtool/file.py
+++ b/virtool/file.py
@@ -47,6 +47,7 @@ async def create(db, dispatch, filename, file_type, user_id=None):
         "uploaded_at": uploaded_at,
         "expires_at": expires_at,
         "created": False,
+        "reserved": False,
         "ready": False
     }
 

--- a/virtool/handlers/files.py
+++ b/virtool/handlers/files.py
@@ -9,7 +9,8 @@ async def find(req):
     db = req.app["db"]
 
     query = {
-        "ready": True
+        "ready": True,
+        "reserved": False
     }
 
     file_type = req.query.get("type", None)

--- a/virtool/handlers/genbank.py
+++ b/virtool/handlers/genbank.py
@@ -14,7 +14,7 @@ async def get(req):
     accession = req.match_info["accession"]
 
     tool = "Virtool"
-    email = "dev@virtool.ca"
+    email = "igboyes@virtool.ca"
 
     params = {
         "db": "nucleotide",

--- a/virtool/handlers/samples.py
+++ b/virtool/handlers/samples.py
@@ -134,7 +134,7 @@ async def create(req):
 
     await db.samples.insert_one(document)
 
-    await virtool.file.reserve(db, data["files"])
+    await virtool.file.reserve(db, req.app["dispatcher"].dispatch, data["files"])
 
     task_args = {
         "sample_id": sample_id,


### PR DESCRIPTION
- while samples are being created, prevent associated read files from being used (resolves #281)
- run file removal in ``ThreadPoolExecutor``
- refresh samples in client on websocket update