### PR TITLE
Hotfix 2

### DIFF
--- a/virtool/pathoscope.py
+++ b/virtool/pathoscope.py
@@ -60,7 +60,7 @@ def find_sam_align_score(fields):
     raise ValueError("Could not find alignment score")
 
 
-def build_matrix(analysis_path, vta_path, p_score_cutoff=0.01):
+def build_matrix(vta_path, p_score_cutoff=0.01):
     u = dict()
     nu = dict()
 
@@ -133,18 +133,7 @@ def build_matrix(analysis_path, vta_path, p_score_cutoff=0.01):
         # Normalize p_score.
         nu[read_index][2] = [k / p_score_sum for k in nu[read_index][1]]
 
-    try:
-        return u, nu, refs, reads
-    except struct.error as err:
-        if "format requires -2147483648" in str(err):
-            for obj in [u, nu, refs, reads]:
-                filename = "{}.json".format(obj.__name__)
-                with open(os.path.join(analysis_path, filename), "w") as f:
-                    json.dump(obj, f)
-
-            return None
-
-        raise
+    return u, nu, refs, reads
 
 
 def em(u, nu, genomes, max_iter, epsilon, pi_prior, theta_prior):

--- a/virtool/sample_analysis.py
+++ b/virtool/sample_analysis.py
@@ -3,6 +3,7 @@ Functions and job classes for sample analysis.
 
 """
 import collections
+import json
 import os
 import shlex
 import shutil
@@ -534,7 +535,20 @@ class Pathoscope(Base):
         """
         vta_path = os.path.join(self.analysis_path, "to_isolates.vta")
 
-        u, nu, refs, reads = await self.run_in_executor(virtool.pathoscope.build_matrix, vta_path)
+        matrix = await self.run_in_executor(virtool.pathoscope.build_matrix, self.analysis_path, vta_path)
+
+        if matrix is None:
+            u = None
+            nu = None
+            refs = None
+            reads = None
+
+            for obj in [u, nu, refs, reads]:
+                filename = "{}.json".format(obj.__name__)
+                with open(os.path.join(self.analysis_path, filename), "r") as f:
+                    obj = json.load(f)
+        else:
+            u, nu, refs, reads = matrix
 
         best_hit_initial_reads, best_hit_initial, level_1_initial, level_2_initial = await self.run_in_executor(
             virtool.pathoscope.compute_best_hit,

--- a/virtool/sample_analysis.py
+++ b/virtool/sample_analysis.py
@@ -1095,7 +1095,7 @@ class NuVs(Base):
 
 def run_patho(analysis_path, vta_path, reassigned_path):
 
-    u, nu, refs, reads = virtool.pathoscope.build_matrix(analysis_path, vta_path)
+    u, nu, refs, reads = virtool.pathoscope.build_matrix(vta_path)
 
     best_hit_initial_reads, best_hit_initial, level_1_initial, level_2_initial = virtool.pathoscope.compute_best_hit(
         u,


### PR DESCRIPTION
- prevent ``struct.error`` during PathoscopeBowtie (resolves #314)
- error is due to pickling a dict that is to large when communicating between processes
- fixed by calling all ``virtool.pathoscope`` functions in a separate process and only returning the results (*not* matrix)