### PR TITLE
Merge handle-large-nuvs

### DIFF
--- a/client/src/js/actionTypes.js
+++ b/client/src/js/actionTypes.js
@@ -51,6 +51,7 @@ export const UPDATE_SAMPLE_RIGHTS = createRequestActionType("UPDATE_SAMPLE_RIGHT
 export const REMOVE_SAMPLE = createRequestActionType("REMOVE_SAMPLE");
 export const FIND_ANALYSES = createRequestActionType("FIND_ANALYSES");
 export const GET_ANALYSIS = createRequestActionType("GET_ANALYSIS");
+export const GET_ANALYSIS_PROGRESS = "GET_ANALYSIS_PROGRESS";
 export const ANALYZE = createRequestActionType("ANALYZE");
 export const BLAST_NUVS = createRequestActionType("BLAST_NUVS");
 export const REMOVE_ANALYSIS = createRequestActionType("REMOVE_ANALYSIS");

--- a/client/src/js/samples/actions.js
+++ b/client/src/js/samples/actions.js
@@ -17,7 +17,7 @@ import {
     BLAST_NUVS,
     REMOVE_ANALYSIS,
     SHOW_REMOVE_SAMPLE,
-    HIDE_SAMPLE_MODAL
+    HIDE_SAMPLE_MODAL, GET_ANALYSIS_PROGRESS
 } from "../actionTypes";
 
 export const wsUpdateSample = (update) => ({
@@ -92,6 +92,11 @@ export const findAnalyses = (sampleId) => ({
 export const getAnalysis = (analysisId) => ({
     type: GET_ANALYSIS.REQUESTED,
     analysisId
+});
+
+export const getAnalysisProgress = (progress) => ({
+    type: GET_ANALYSIS_PROGRESS,
+    progress
 });
 
 export const analyze = (sampleId, algorithm) => ({

--- a/client/src/js/samples/api.js
+++ b/client/src/js/samples/api.js
@@ -53,8 +53,11 @@ export const findAnalyses = ({ sampleId }) => (
     Request.get(`/api/samples/${sampleId}/analyses`)
 );
 
-export const getAnalysis = ({ analysisId }) => (
+export const getAnalysis = (analysisId, onProgress, onSuccess, onFailure) => (
     Request.get(`/api/analyses/${analysisId}`)
+        .on("progress", onProgress)
+        .then(res => onSuccess(res))
+        .catch(err => onFailure(err))
 );
 
 export const analyze = ({ sampleId, algorithm }) => (

--- a/client/src/js/samples/components/Analyses/Detail.js
+++ b/client/src/js/samples/components/Analyses/Detail.js
@@ -2,8 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import Numeral from "numeral";
 import { connect } from "react-redux";
-import { Label, Table } from "react-bootstrap";
-import { IDRow, LoadingPlaceholder, RelativeTime } from "../../../base";
+import { Col, Label, ProgressBar, Row, Table } from "react-bootstrap";
+import {IDRow, RelativeTime} from "../../../base";
 
 import { getAnalysis } from "../../actions";
 import { getTaskDisplayName } from "../../../utils";
@@ -29,7 +29,17 @@ class AnalysisDetail extends React.Component {
     render () {
 
         if (this.props.detail === null) {
-            return <LoadingPlaceholder />;
+            return (
+                <div style={{paddingTop: "130px"}}>
+                    <Row>
+                        <Col xs={12} md={4} mdOffset={4}>
+                            <div className="progress-small">
+                                <ProgressBar now={this.props.progress || 15} active/>
+                            </div>
+                        </Col>
+                    </Row>
+                </div>
+            );
         }
 
         const detail = this.props.detail;
@@ -88,6 +98,7 @@ class AnalysisDetail extends React.Component {
 
 const mapStateToProps = (state) => ({
     detail: state.samples.analysisDetail,
+    progress: state.samples.getAnalysisProgress,
     quality: state.samples.detail.quality
 });
 

--- a/client/src/js/samples/components/Analyses/Item.js
+++ b/client/src/js/samples/components/Analyses/Item.js
@@ -1,6 +1,8 @@
 import React from "react";
 import CX from "classnames";
+import { get } from "lodash";
 import { connect } from "react-redux";
+import { LinkContainer } from "react-router-bootstrap";
 import { ClipLoader } from "halogenium";
 import { Row, Col, Label } from "react-bootstrap";
 
@@ -9,56 +11,56 @@ import { Icon, RelativeTime } from "../../../base";
 import { removeAnalysis } from "../../actions";
 import { getCanModify } from "../../selectors";
 
-export class AnalysisItem extends React.Component {
+export const AnalysisItem = (props) => {
 
-    render () {
+    const itemClass = CX("list-group-item spaced", {hoverable: props.ready});
 
-        const itemClass = CX("list-group-item spaced", {hoverable: this.props.ready});
+    let end;
 
-        let end;
-
-        if (this.props.ready) {
-            if (this.props.canModify) {
-                end = (
-                    <Icon
-                        name="remove"
-                        bsStyle="danger"
-                        onClick={() => this.props.onRemove(this.props.id)}
-                        style={{fontSize: "17px"}}
-                        pullRight
-                    />
-                );
-            }
-        } else {
+    if (props.ready) {
+        if (props.canModify) {
             end = (
-                <strong className="pull-right">
-                    <ClipLoader size="14px" color="#3c8786" style={{display: "inline"}}/> In Progress
-                </strong>
+                <Icon
+                    name="remove"
+                    bsStyle="danger"
+                    onClick={() => props.onRemove(props.id)}
+                    style={{fontSize: "17px"}}
+                    pullRight
+                />
             );
         }
+    } else {
+        end = (
+            <strong className="pull-right">
+                <ClipLoader size="14px" color="#3c8786" style={{display: "inline"}}/> In Progress
+            </strong>
+        );
+    }
 
-        return (
-            <div className={itemClass} onClick={this.props.ready ? this.props.onRemove : null}>
+    return (
+        <LinkContainer to={`/samples/${props.sampleId}/analyses/${props.id}`}>
+            <div className={itemClass}>
                 <Row>
                     <Col md={3}>
-                        <strong>{getTaskDisplayName(this.props.algorithm)}</strong>
+                        <strong>{getTaskDisplayName(props.algorithm)}</strong>
                     </Col>
                     <Col md={4}>
-                        Started <RelativeTime time={this.props.created_at}/> by {this.props.user.id}
+                        Started <RelativeTime time={props.created_at}/> by {props.user.id}
                     </Col>
                     <Col md={1}>
-                        <Label>{this.props.index.version}</Label>
+                        <Label>{props.index.version}</Label>
                     </Col>
                     <Col md={4}>
                         {end}
                     </Col>
                 </Row>
             </div>
-        );
-    }
-}
+        </LinkContainer>
+    );
+};
 
 const mapStateToProps = (state) => ({
+    sampleId: get(state.samples.detail, "id"),
     canModify: getCanModify(state)
 });
 

--- a/client/src/js/samples/components/Analyses/List.js
+++ b/client/src/js/samples/components/Analyses/List.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { LinkContainer } from "react-router-bootstrap";
 import { sortBy } from "lodash";
 import { connect } from "react-redux";
 import { ListGroup, FormGroup, InputGroup, FormControl } from "react-bootstrap";
@@ -53,11 +52,7 @@ class AnalysesList extends React.Component {
 
             // The components that detail individual analyses.
             listContent = sorted.map((document) =>
-                <LinkContainer key={document.id} to={`/samples/${this.props.detail.id}/analyses/${document.id}`}>
-                    <AnalysisItem
-                        {...document}
-                    />
-                </LinkContainer>
+                <AnalysisItem key={document.id} {...document} />
             );
         } else {
             listContent = <NoneFound noun="analyses" noListGroup />;

--- a/client/src/js/samples/reducer.js
+++ b/client/src/js/samples/reducer.js
@@ -11,7 +11,7 @@ import {
     GET_ANALYSIS,
     ANALYZE,
     BLAST_NUVS,
-    REMOVE_ANALYSIS
+    REMOVE_ANALYSIS, GET_ANALYSIS_PROGRESS
 } from "../actionTypes";
 
 const initialState = {
@@ -19,6 +19,7 @@ const initialState = {
     detail: null,
     analyses: null,
     analysisDetail: null,
+    getAnalysisProgress: 0,
     showEdit: false,
     showRemove: false,
     editError: false,
@@ -87,10 +88,13 @@ export default function samplesReducer (state = initialState, action) {
             return {...state, analyses: action.data.documents};
 
         case GET_ANALYSIS.REQUESTED:
-            return {...state, analysisDetail: null};
+            return {...state, analysisDetail: null, getAnalysisProgress: 0};
 
         case GET_ANALYSIS.SUCCEEDED:
             return {...state, analysisDetail: action.data};
+
+        case GET_ANALYSIS_PROGRESS:
+            return {...state, getAnalysisProgress: action.progress};
 
         case ANALYZE.SUCCEEDED:
             return {...state, analyses: state.analyses === null ? null : state.analyses.concat([action.data])};

--- a/client/src/style/progress.less
+++ b/client/src/style/progress.less
@@ -74,3 +74,7 @@
     margin-bottom: 0;
   }
 }
+
+.progress-small .progress {
+  height: 10px;
+}

--- a/tests/handlers/test_analyses.py
+++ b/tests/handlers/test_analyses.py
@@ -9,7 +9,9 @@ async def test_get(mocker, not_found, spawn_client):
 
     document = {
         "_id": "foobar",
-        "formatted": False
+        "formatted": False,
+        "algorithm": "pathoscope_bowtie",
+        "results": {}
     }
 
     if not not_found:
@@ -34,7 +36,9 @@ async def test_get(mocker, not_found, spawn_client):
 
         assert await resp.json() == {
             "id": "foobar",
-            "formatted": True
+            "formatted": True,
+            "algorithm": "pathoscope_bowtie",
+            "results": {}
         }
 
         assert m.call_args[0] == (

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -90,7 +90,7 @@ class TestAdd:
     async def test_remove(self, test_motor, static_time, test_virus_edit, test_change):
         """
         Test that the addition of a change due to virus removal inserts the expected change document.
-        
+
         """
         # There is no new document because this is a change document for a virus removal operation.
         new = None
@@ -132,7 +132,7 @@ class TestCalculateDiff:
         """
         Test that a diff is correctly calculated. Should work since the tested function is a very light wrapper for the
         dictdiffer function.
-         
+
         """
         old, new = test_virus_edit
 
@@ -192,7 +192,7 @@ class TestGetMostRecentChange:
         ])
 
         most_recent = await virtool.virus_history.get_most_recent_change(test_motor, "6116cba1")
-        
+
         assert most_recent == {
             "_id": "6116cba1.2",
             "description": "Description number 2",
@@ -211,7 +211,7 @@ class TestGetMostRecentChange:
     async def test_none(self, test_motor, static_time):
         """
         Test that ``None`` is returned if no change documents exist for the given ``virus_id``.
-         
+
         """
         most_recent = await virtool.virus_history.get_most_recent_change(test_motor, "6116cba1.1")
         assert most_recent is None

--- a/tests/test_virus_hmm.py
+++ b/tests/test_virus_hmm.py
@@ -1,5 +1,4 @@
 import concurrent.futures
-import filecmp
 import gzip
 import json
 import operator

--- a/virtool/bio.py
+++ b/virtool/bio.py
@@ -1,5 +1,4 @@
 import aiohttp
-from aiohttp.client_exceptions import ServerTimeoutError
 import asyncio
 import io
 import json

--- a/virtool/handlers/analyses.py
+++ b/virtool/handlers/analyses.py
@@ -1,4 +1,7 @@
+import aiofiles
 import asyncio
+import json
+import os
 
 import virtool.bio
 import virtool.errors
@@ -19,12 +22,29 @@ async def get(req):
 
     document = await db.analyses.find_one(analysis_id)
 
+    if document is None:
+        return not_found()
+
+    if document["algorithm"] == "nuvs" and document["results"] == "file":
+
+        sample_id = document["sample"]["id"]
+
+        path = os.path.join(
+            req.app["settings"].get("data_path"),
+            "samples",
+            sample_id,
+            "analysis",
+            analysis_id,
+            "nuvs.json"
+        )
+
+        async with aiofiles.open(path, "r") as f:
+            json_string = await f.read()
+            document["results"] = json.loads(json_string)
+
     formatted = await virtool.sample_analysis.format_analysis(db, document)
 
-    if document:
-        return json_response(virtool.utils.base_processor(formatted))
-
-    return not_found()
+    return json_response(virtool.utils.base_processor(formatted))
 
 
 async def remove(req):

--- a/virtool/handlers/history.py
+++ b/virtool/handlers/history.py
@@ -44,7 +44,7 @@ async def get(req):
 async def revert(req):
     """
     Remove the change document with the given ``change_id`` and any subsequent changes.
-     
+
     """
     db = req.app["db"]
 

--- a/virtool/handlers/updates.py
+++ b/virtool/handlers/updates.py
@@ -31,6 +31,8 @@ async def upgrade(req):
     db = req.app["db"]
     dispatch = req.app["dispatcher"].dispatch
 
+    channel = req.app["settings"].get("software_channel")
+
     await req.app["job_manager"].close()
 
     document = await db.status.find_one("software_update")
@@ -48,7 +50,7 @@ async def upgrade(req):
         document = await db.status.find_one_and_update({"_id": "software_update"}, {
             "$set": {
                 "current_version": req.app["version"],
-                "releases": await virtool.updates.get_releases(db, req.app["version"])
+                "releases": await virtool.updates.get_releases(db, channel, req.app["version"])
             }
         }, return_document=pymongo.ReturnDocument)
 

--- a/virtool/sample.py
+++ b/virtool/sample.py
@@ -124,10 +124,10 @@ async def remove_samples(db, settings, id_list):
     - removes all analyses associated with the sample from the analyses collection
     - removes the sample from the samples collection
     - removes the sample directory from the file system
-    
+
     :param db: a Motor client
     :type db: :class:`.motor.motor_asyncio.AsyncIOMotorClient``
-    
+
     :param settings: a Virtool settings object
     :type settings: :class:`.Settings`
 

--- a/virtool/sample_create.py
+++ b/virtool/sample_create.py
@@ -271,7 +271,7 @@ class CreateSample(virtool.job.Job):
             await virtool.file.remove(self.loop, self.db, self.settings, self.dispatch, file_id)
 
     async def cleanup(self):
-        await virtool.file.release_reservations(self.db, self.task_args["files"])
+        await virtool.file.release_reservations(self.db, self.dispatch, self.task_args["files"])
 
         try:
             await self.loop.run_in_executor(None, shutil.rmtree, self.sample_path)

--- a/virtool/virus.py
+++ b/virtool/virus.py
@@ -33,12 +33,12 @@ SEQUENCE_PROJECTION = [
 async def dispatch_version_only(req, new):
     """
     Dispatch a virus update. Should be called when the document itself is not being modified.
-    
+
     :param req: the request object
-    
+
     :param new: the virus document
     :type new: Coroutine[dict]
-    
+
     """
     await req.app["dispatcher"].dispatch(
         "viruses",
@@ -51,7 +51,7 @@ async def join(db, virus_id, document=None):
     """
     Join the virus associated with the supplied virus id with its sequences. If a virus entry is also passed, the
     database will not be queried for the virus based on its id.
-    
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
 
@@ -136,16 +136,16 @@ async def check_name_and_abbreviation(db, name=None, abbreviation=None):
     """
     Check is a virus name and abbreviation are already in use in the database. Returns a message if the ``name`` or
     ``abbreviation`` are already in use. Returns ``False`` if they are not in use.
-    
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param name: a virus name
     :type name: str
-    
+
     :param abbreviation: a virus abbreviation
     :type abbreviation: str
-    
+
     """
     name_count = 0
 
@@ -180,13 +180,13 @@ def check_virus(joined):
     * empty_isolate - isolates that have no sequences associated with them.
     * empty_sequence - sequences that have a zero length sequence field.
     * isolate_inconsistency - virus has isolates containing different numbers of sequences.
-    
+
     :param joined: a joined virus
     :type joined: dict
-    
+
     :return: return any errors or False if there are no errors.
     :rtype: Union[dict, None]
-    
+
     """
     errors = {
         "empty_virus": len(joined["isolates"]) == 0,
@@ -252,16 +252,16 @@ async def update_last_indexed_version(db, virus_ids, version):
     """
     Called from a index rebuild job. Updates the last indexed version and _version fields
     of all viruses involved in the rebuild when the build completes.
-    
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param virus_ids: a list the ``virus_id`` of each virus to update
     :type virus_ids: list
-    
+
     :param version: the value to set for the viruses ``version`` and ``last_indexed_version`` fields
     :type: int
-    
+
     :return: the Pymongo update result
     :rtype: :class:`~pymongo.results.UpdateResult`
 
@@ -282,10 +282,10 @@ def get_default_isolate(virus, isolate_processor=None):
 
     :param virus: a virus document.
     :type virus: dict
-    
+
     :param isolate_processor: a function to process the default isolate into a desired format.
     :type: func
-    
+
     :return: the default isolate dict.
     :rtype: dict
 
@@ -319,7 +319,7 @@ async def get_new_isolate_id(db, excluded=None):
 
     :return: a new unique isolate id
     :rtype: Coroutine[str]
-    
+
     """
     used_isolate_ids = excluded or list()
 
@@ -386,16 +386,16 @@ def extract_isolate_ids(virus):
 def find_isolate(isolates, isolate_id):
     """
     Return the isolate identified by ``isolate_id`` from a list of isolates.
-    
+
     :param isolates: a list of isolate dicts
     :type isolates: list
-    
+
     :param isolate_id: the isolate_id of the isolate to return
     :type isolate_id: str
-    
+
     :return: an isolate
     :rtype: dict
-    
+
     """
     return next((isolate for isolate in isolates if isolate["id"] == isolate_id), None)
 
@@ -436,7 +436,7 @@ def get_default_sequences(joined_virus):
 
     :param joined_virus: the joined virus document.
     :type joined_virus: dict
-    
+
     :return: a list of sequences associated with the default isolate.
     :rtype: list
 
@@ -449,13 +449,13 @@ def get_default_sequences(joined_virus):
 def format_isolate_name(isolate):
     """
     Take a complete or partial isolate ``dict`` and return a readable isolate name.
-    
+
     :param isolate: a complete or partial isolate ``dict`` containing ``source_type`` and ``source_name`` fields.
     :type isolate: dict
-    
+
     :return: an isolate name
     :rtype: str
-     
+
     """
     if not isolate["source_type"] or not isolate["source_name"]:
         return "Unnamed Isolate"

--- a/virtool/virus_history.py
+++ b/virtool/virus_history.py
@@ -34,25 +34,25 @@ async def add(db, method_name, old, new, description, user_id):
 
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param method_name: the name of the handler method that executed the change
     :type method_name: str
-    
+
     :param old: the virus document prior to the change
     :type new: Union[dict, None]
-    
+
     :param new: the virus document after the change
     :type new: Union[dict, None]
-    
+
     :param description: a human readable description of the change
     :type description: str
-    
+
     :param user_id: the id of the requesting user
     :type user_id: str
-    
+
     :return: the change document
     :rtype: Coroutine[dict]
-    
+
     """
     try:
         virus_id = old["_id"]
@@ -105,16 +105,16 @@ async def add(db, method_name, old, new, description, user_id):
 def calculate_diff(old, new):
     """
     Calculate the diff for a joined virus document before and after modification.
-    
+
     :param old: the joined virus document before modification
     :type old: dict
-    
+
     :param new: the joined virus document after modification
     :type new: dict
-    
+
     :return: the diff
     :rtype: list
-    
+
     """
     return list(dictdiffer.diff(old, new))
 
@@ -122,16 +122,16 @@ def calculate_diff(old, new):
 async def get_most_recent_change(db, virus_id):
     """
     Get the most recent change for the virus identified by the passed ``virus_id``.
-    
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param virus_id: the target virus_id
     :type virus_id: str
-    
+
     :return: the most recent change document
     :rtype: Coroutine[dict]
-    
+
     """
     return await db.history.find_one({
         "virus.id": virus_id,
@@ -142,20 +142,20 @@ async def get_most_recent_change(db, virus_id):
 async def patch_virus_to_version(db, virus_id, version):
     """
     Take a joined virus back in time to the passed ``version``. Uses the diffs in the change documents associated with
-    the virus.    
-    
+    the virus.
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-     
+
     :param virus_id: the id of the virus to patch
     :type virus_id: str
-    
+
     :param version: the version to patch to
     :type version: str or int
-    
+
     :return: the current joined virus, patched virus, and the ids of changes reverted in the process
     :rtype: Coroutine[tuple]
-    
+
     """
     # A list of history_ids reverted to produce the patched entry.
     reverted_history_ids = list()

--- a/virtool/virus_import.py
+++ b/virtool/virus_import.py
@@ -74,7 +74,7 @@ async def import_data(db, dispatch, data, user_id):
     for virus in viruses:
         isolates = virus["isolates"]
         isolate_counts.append(len(isolates))
-        
+
         for isolate in isolates:
             sequence_counts.append(len(isolate["sequences"]))
 
@@ -233,16 +233,16 @@ async def check_import_abbreviation(db, virus_document, lower_name=None):
     Check if the abbreviation for a virus document to be imported already exists in the database. If the abbreviation
     exists, set the ``abbreviation`` field in the virus document to an empty string and return warning text to
     send to the client.
-    
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param virus_document: the virus document that is being imported
     :type virus_document: dict
-    
+
     :param lower_name: the name of the virus coerced to lowercase
     :type lower_name: str
-     
+
     """
     lower_name = lower_name or virus_document["name"].lower()
 
@@ -269,19 +269,19 @@ async def send_import_dispatches(dispatch, insertions, replacements, flush=False
     """
     Dispatch all possible insertion and replacement messages for a running virus reference import. Called many times
     during an import process.
-    
+
     :param dispatch: the dispatch function
     :type dispatch: func
-    
+
     :param insertions: a list of tuples describing insertions
     :type insertions: list
-    
+
     :param replacements: a list of tuples describing replacements and their component removals and an insertions
     :type replacements: list
-    
+
     :param flush: override the length check and flush all data to the dispatcher
     :type flush: bool
-     
+
     """
 
     if len(insertions) == 30 or (flush and insertions):
@@ -306,13 +306,13 @@ async def insert_from_import(db, virus_document, user_id):
     """
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param virus_document: the virus document to add
     :type virus_document: dict
-    
+
     :param user_id: the requesting ``user_id``
     :type user_id: str
-    
+
     """
     # Modified is set to ``False`` so the user does not have to verify every single imported virus.
     virus_document.update({
@@ -360,16 +360,16 @@ async def insert_from_import(db, virus_document, user_id):
 async def delete_for_import(db, virus_id, user_id):
     """
     Delete a virus document and its sequences as part of an import process.
-    
+
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-    
+
     :param virus_id: the ``virus_id`` to remove
     :type virus_id: str
-    
+
     :param user_id: the requesting ``user_id``
     :type user_id: str
-     
+
     """
     joined = await virtool.virus.join(db, virus_id)
 


### PR DESCRIPTION
- when nuvs output exceed MongoDB documents size, write to file
- show progress bar for long-loading sample details
- discard nuvs sequences with no annotated ORFs
- fix unwanted analysis removal on list item click
- resolves #320 