### PR TITLE
Exclude numpy from cx_freeze

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ from cx_Freeze import setup, Executable
 # Dependencies are automatically detected, but it might need
 # fine tuning.
 build_exe_options = {
+    "excludes": [
+        "numpy"
+    ],
     "packages": [
         "_cffi_backend",
         "appdirs",


### PR DESCRIPTION
- reduce build size