### PR TITLE
Upgrade cx-freeze to 6.0b1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ chardet==3.0.4
 codacy-coverage==1.3.10
 coloredlogs==9.0
 coverage==4.4.2
-cx-Freeze==5.1.1
+cx-Freeze==6.0b1
 dictdiffer==0.7.0
 execnet==1.5.0
 humanfriendly==4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,10 @@ attrs==17.4.0
 bcrypt==3.1.4
 cchardet==2.1.1
 Cerberus==1.1
+certifi==2018.1.18
 cffi==1.11.4
 chardet==3.0.4
+codacy-coverage==1.3.10
 coloredlogs==9.0
 coverage==4.4.2
 cx-Freeze==5.1.1
@@ -41,8 +43,10 @@ pytest-xdist==1.20.1
 python-dateutil==2.6.1
 raven==6.5.0
 raven-aiohttp==0.6.0
+requests==2.18.4
 semver==2.7.9
 setproctitle==1.1.10
 six==1.11.0
+urllib3==1.22
 uvloop==0.9.1
 yarl==1.0.0


### PR DESCRIPTION
- resolves issue with missing `libffi`