### PR TITLE
Validate API user inputs for length where necessary

### DIFF
--- a/tests/handlers/test_account.py
+++ b/tests/handlers/test_account.py
@@ -138,6 +138,8 @@ class TestChangePassword:
         """
         client = await spawn_client(authorize=True)
 
+        client.app["settings"]["minimum_password_length"] = 8
+
         resp = await client.put("/api/account/password", {"old_password": "hello_world", "new_password": "foo_bar_1"})
 
         assert resp.status == 200
@@ -153,12 +155,14 @@ class TestChangePassword:
         """
         client = await spawn_client(authorize=True)
 
+        client.app["settings"]["minimum_password_length"] = 8
+
         resp = await client.put("/api/account/password", {
             "old_password": "not_right",
             "new_password": "foo_bar"
         })
 
-        assert await resp_is.bad_request(resp, "Password is to short. Must be at least 8 characters.")
+        assert await resp_is.invalid_input(resp, {'new_password': ['min length is 8']})
 
     async def test_invalid_old(self, spawn_client, resp_is):
         """
@@ -166,6 +170,8 @@ class TestChangePassword:
 
         """
         client = await spawn_client(authorize=True)
+
+        client.app["settings"]["minimum_password_length"] = 8
 
         resp = await client.put("/api/account/password", {
             "old_password": "not_right",
@@ -180,6 +186,8 @@ class TestChangePassword:
 
         """
         client = await spawn_client(authorize=True)
+
+        client.app["settings"]["minimum_password_length"] = 8
 
         resp = await client.put("/api/account/password", {"new_password": 1234})
 
@@ -265,8 +273,6 @@ class TestCreateAPIKey:
             body["permissions"] = req_permissions
 
         resp = await client.post("/api/account/keys", body)
-
-        print(await resp.json())
 
         assert resp.status == 201
 

--- a/tests/handlers/test_users.py
+++ b/tests/handlers/test_users.py
@@ -86,6 +86,8 @@ class TestCreate:
         """
         client = await spawn_client(authorize=True, permissions=["manage_users"])
 
+        client.app["settings"]["minimum_password_length"] = 8
+
         data = {
             "user_id": "bob",
             "password": "hello_world",
@@ -128,6 +130,8 @@ class TestCreate:
         """
         client = await spawn_client(authorize=True, permissions=["manage_users"])
 
+        client.app["settings"]["minimum_password_length"] = 8
+
         data = {
             "username": "bob",
             "password": 1234,
@@ -151,6 +155,8 @@ class TestCreate:
         """
         client = await spawn_client(authorize=True, permissions=["manage_users"])
 
+        client.app["settings"]["minimum_password_length"] = 8
+
         data = {
             "user_id": "test",
             "password": "hello_world",
@@ -163,11 +169,11 @@ class TestCreate:
 
 
 @pytest.mark.parametrize("data", [
-    {"password": "foo_bar", "force_reset": True, "primary_group": "tech"},
-    {"password": "foo_bar", "force_reset": True},
+    {"password": "hello_world", "force_reset": True, "primary_group": "tech"},
+    {"password": "hello_world", "force_reset": True},
     {"force_reset": True, "primary_group": "tech"},
-    {"password": "foo_bar", "primary_group": "tech"},
-    {"password": "foo_bar"},
+    {"password": "hello_world", "primary_group": "tech"},
+    {"password": "hello_world"},
     {"force_reset": True},
     {"primary_group": "tech"}
 ])
@@ -176,13 +182,13 @@ async def test_edit(data, error, spawn_client, resp_is, static_time, create_user
 
     client = await spawn_client(authorize=True, permissions=["manage_users"])
 
+    client.app["settings"]["minimum_password_length"] = 8
+
     bob = None
 
     if error != "user_dne":
         groups = [] if error == "not_group_member" else ["tech"]
         bob = dict(create_user("bob", groups=groups))
-        import pprint
-        pprint.pprint(bob)
         await client.db.users.insert_one(bob)
 
     groups_to_insert = [{


### PR DESCRIPTION
- resolves #412 
- ensure sure new usernames are at least one character in length
- take minimum length from settings value `minimum_password_length`
- validate password length for user create and edit endpoints
- validate password length for account change password requests
- return `422` responses for passwords that do not meet the requirement
