### PR TITLE
Don't error on API when page outside range requested

### DIFF
--- a/virtool/handlers/utils.py
+++ b/virtool/handlers/utils.py
@@ -265,10 +265,6 @@ async def paginate(collection, db_query, url_query, sort=None, projection=None, 
     documents = list()
 
     if found_count:
-
-        if page > page_count:
-            return not_found("Page outside range: {}".format(page))
-
         if page > 1:
             cursor.skip((page - 1) * per_page)
 


### PR DESCRIPTION
Finally fix this stupid bug.

- resolves #429
- resolves #397 