### PR TITLE
Indexes API fixes

### DIFF
--- a/tests/handlers/test_indexes.py
+++ b/tests/handlers/test_indexes.py
@@ -11,7 +11,6 @@ class TestFind:
                 "_id": "foo",
                 "version": 0,
                 "created_at": static_time,
-                "virus_count": 231,
                 "ready": True,
                 "has_files": True,
                 "user": {
@@ -25,7 +24,6 @@ class TestFind:
                 "_id": "bar",
                 "version": 1,
                 "created_at": static_time,
-                "virus_count": 232,
                 "ready": False,
                 "has_files": True,
                 "user": {
@@ -47,6 +45,8 @@ class TestFind:
                     "created_at": "2015-10-06T20:00:00Z",
                     "has_files": True,
                     "id": "bar",
+                    "modification_count": 0,
+                    "modified_virus_count": 0,
                     "job": {
                         "id": "sj82la"
                     },
@@ -55,12 +55,13 @@ class TestFind:
                         "id": "test"
                     },
                     "version": 1,
-                    "virus_count": 232
                 },
                 {
                     "created_at": "2015-10-06T20:00:00Z",
                     "has_files": True,
                     "id": "foo",
+                    "modification_count": 0,
+                    "modified_virus_count": 0,
                     "job": {
                         "id": "abh675"
                     },
@@ -69,7 +70,6 @@ class TestFind:
                         "id": "test"
                     },
                     "version": 0,
-                    "virus_count": 231
                 }
             ],
             "total_count": 2,
@@ -91,7 +91,6 @@ class TestGet:
             "_id": "foobar",
             "version": 0,
             "created_at": static_time,
-            "virus_count": 232,
             "ready": False,
             "has_files": True,
             "user": {
@@ -190,7 +189,6 @@ class TestGet:
             "has_files": True,
             "id": "foobar",
             "version": 0,
-            "virus_count": 232,
             "change_count": 4,
             "viruses": [
                 {
@@ -293,7 +291,6 @@ class TestCreate:
             "_id": expected_id,
             "version": 1,
             "created_at": static_time,
-            "virus_count": None,
             "ready": False,
             "has_files": True,
             "manifest": {},
@@ -318,7 +315,6 @@ class TestCreate:
                 "id": "test"
             },
             "version": 1,
-            "virus_count": None
         }
 
         # Check that ``job_manager.new`` is called with the expected args and kwargs.

--- a/virtool/handlers/indexes.py
+++ b/virtool/handlers/indexes.py
@@ -12,7 +12,7 @@ async def find(req):
     """
     db = req.app["db"]
 
-    modified_virus_count = len(await db.history.distinct("virus.id", {"index.id": "unbuilt"}))
+    unbuilt_modified_virus_count = len(await db.history.distinct("virus.id", {"index.id": "unbuilt"}))
 
     total_virus_count = await db.viruses.count()
 
@@ -25,8 +25,14 @@ async def find(req):
         reverse=True
     )
 
+    for document in data["documents"]:
+        document.update({
+            "modified_virus_count": len(await db.history.distinct("virus.id", {"index.id": document["id"]})),
+            "modification_count": await db.history.count({"index.id": document["id"]})
+        })
+
     data.update({
-        "modified_virus_count": modified_virus_count,
+        "modified_virus_count": unbuilt_modified_virus_count,
         "total_virus_count": total_virus_count
     })
 

--- a/virtool/handlers/indexes.py
+++ b/virtool/handlers/indexes.py
@@ -12,7 +12,7 @@ async def find(req):
     """
     db = req.app["db"]
 
-    modified_virus_count = len(await db.history.find({"index.id": "unbuilt"}, ["virus"]).distinct("virus.name"))
+    modified_virus_count = len(await db.history.distinct("virus.id", {"index.id": "unbuilt"}))
 
     total_virus_count = await db.viruses.count()
 
@@ -142,7 +142,6 @@ async def create(req):
         "_id": index_id,
         "version": index_version,
         "created_at": virtool.utils.timestamp(),
-        "virus_count": None,
         "manifest": virus_manifest,
         "ready": False,
         "has_files": True,

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -195,7 +195,8 @@ async def organize_hmms(db):
 async def organize_indexes(db):
     await db.indexes.update_many({}, {
         "$unset": {
-            "_version": ""
+            "_version": "",
+            "virus_count": ""
         },
         "$rename": {
             "index_version": "version",

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -196,7 +196,9 @@ async def organize_indexes(db):
     await db.indexes.update_many({}, {
         "$unset": {
             "_version": "",
-            "virus_count": ""
+            "virus_count": "",
+            "modified_virus_count": "",
+            "modification_count": ""
         },
         "$rename": {
             "index_version": "version",


### PR DESCRIPTION
- eliminate index document fields: `virus_count`, `modified_virus_count`, and `modification_count`
- fix #410 