### PR TITLE
V2.1.3

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -4,9 +4,7 @@
     "document": true,
     "dispatcher": true,
     "console": true,
-    "fetch": true,
-    "XMLSerializer": true,
-    "Blob": true
+    "fetch": true
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/client/src/js/base/InputSave.js
+++ b/client/src/js/base/InputSave.js
@@ -97,7 +97,6 @@ export class InputSave extends React.Component {
     };
 
     blur = () => {
-        this.inputNode.blur();
         this.buttonNode.blur();
     };
 

--- a/client/src/js/base/RelativeTime.js
+++ b/client/src/js/base/RelativeTime.js
@@ -1,16 +1,10 @@
 import React from "react";
 import Moment from "moment";
 import PropTypes from "prop-types";
-import { forEach, includes } from "lodash-es";
-
-window.relativeTimeCallbacks = [];
-
-window.setInterval(1000, () => {
-    forEach(window.relativeTimeCallbacks, callback => callback());
-});
+import { includes } from "lodash-es";
 
 /**
- * Shows the passed time prop relative to the current time (eg. 3 days ago). The relative time string is updates
+ * Shows the passed time prop relative to the current time (eg. 3 days ago). The relative time string is updated
  * automatically as time passes.
  */
 export class RelativeTime extends React.Component {
@@ -26,8 +20,8 @@ export class RelativeTime extends React.Component {
         time: PropTypes.string.isRequired
     };
 
-    componentWillMount () {
-        window.relativeTimeCallbacks.push(this.update);
+    componentDidMount () {
+        this.interval = window.setInterval(this.update, 8000);
     }
 
     componentWillReceiveProps (nextProps) {
@@ -49,11 +43,7 @@ export class RelativeTime extends React.Component {
     }
 
     componentWillUnmount () {
-        const index = window.relativeTimeCallbacks.indexOf(this.update);
-
-        if (index !== -1) {
-            window.relativeTimeCallbacks.splice(index, 1);
-        }
+        window.clearInterval(this.interval);
     }
 
     getTimeString = () => {

--- a/client/src/js/samples/components/Analyses/Pathoscope/Download.js
+++ b/client/src/js/samples/components/Analyses/Pathoscope/Download.js
@@ -5,8 +5,8 @@ export const createBlob = (svgNode) => {
     const doctype = "<?xml version='1.0' standalone='no'?>"
     + "<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>";
 
-    const svg = (new XMLSerializer()).serializeToString(svgNode);
-    const blob = new Blob([ doctype + svg ], { type: "image/svg+xml;charset=utf-8" });
+    const svg = (new window.XMLSerializer()).serializeToString(svgNode);
+    const blob = new window.Blob([ doctype + svg ], { type: "image/svg+xml;charset=utf-8" });
     const url = window.URL.createObjectURL(blob);
 
     return url;

--- a/client/src/js/settings/components/Jobs/Task.js
+++ b/client/src/js/settings/components/Jobs/Task.js
@@ -11,8 +11,8 @@ const readOnlyFields = ["create_subtraction", "rebuild_index"];
 
 class Task extends React.Component {
 
-    handleChangeLimit = (value) => {
-        this.props.onChangeLimit(this.props.taskPrefix, "proc", value);
+    handleChangeLimit = (name, value) => {
+        this.props.onChangeLimit(this.props.taskPrefix, name, value);
     };
 
     render () {
@@ -27,6 +27,7 @@ class Task extends React.Component {
                 <Row>
                     <Col md={4}>
                         <TaskField
+                            name="proc"
                             value={proc}
                             readOnly={readOnly}
                             onChange={this.handleChangeLimit}
@@ -34,6 +35,7 @@ class Task extends React.Component {
                     </Col>
                     <Col md={4}>
                         <TaskField
+                            name="mem"
                             value={mem}
                             readOnly={readOnly}
                             onChange={this.handleChangeLimit}
@@ -41,6 +43,7 @@ class Task extends React.Component {
                     </Col>
                     <Col md={4}>
                         <TaskField
+                            name="inst"
                             value={inst}
                             readOnly={taskPrefix === "rebuild_index"}
                             onChange={this.handleChangeLimit}

--- a/client/src/js/settings/components/Jobs/TaskField.js
+++ b/client/src/js/settings/components/Jobs/TaskField.js
@@ -15,13 +15,14 @@ export default class TaskField extends React.PureComponent {
     }
 
     static propTypes = {
+        name: PropTypes.string,
         value: PropTypes.number,
         onChange: PropTypes.func,
         readOnly: PropTypes.bool
     };
 
     componentWillReceiveProps (nextProps) {
-        if (nextProps.value !== this.props.value) {
+        if (nextProps.value !== this.state.value) {
             this.setState({
                 value: nextProps.value,
                 pending: false
@@ -44,7 +45,7 @@ export default class TaskField extends React.PureComponent {
     handleSubmit = (e) => {
         e.preventDefault();
         this.setState({pending: true}, () => {
-            this.props.onChange(this.state.value);
+            this.props.onChange(this.props.name, this.state.value);
             this.inputNode.blur();
         });
 

--- a/client/src/js/settings/components/Jobs/Tasks.js
+++ b/client/src/js/settings/components/Jobs/Tasks.js
@@ -97,6 +97,4 @@ const mapDispatchToProps = (dispatch) => ({
 
 });
 
-const Container = connect(mapStateToProps, mapDispatchToProps)(TaskLimits);
-
-export default Container;
+export default connect(mapStateToProps, mapDispatchToProps)(TaskLimits);

--- a/client/src/style/style.less
+++ b/client/src/style/style.less
@@ -45,8 +45,8 @@
 @input-group-addon-bg: #fff;
 @input-border-focus: lighten(@brand-primary, 8%);
 
-@state-danger-bg: lighten(@brand-danger, 8%);
-@state-danger-text: @brand-danger;
+@state-danger-bg: lighten(@brand-danger, 30%);
+@state-danger-text: darken(@brand-danger, 12%);
 @state-danger-border: @brand-danger;
 
 body {


### PR DESCRIPTION
- use per-component interval to update RelativeTime (fixes #464)
- improve danger colors (fixes #465)
- fix job settings inputs (#467)
- fix `TypeError: n.inputNode.blur is not a function` (resolves #467)