### PR TITLE
UI reorganization and submenu

### DIFF
--- a/client/src/js/App.js
+++ b/client/src/js/App.js
@@ -6,6 +6,7 @@ import { ConnectedRouter } from "react-router-redux";
 import { Switch, Route, withRouter } from "react-router-dom";
 
 import NavBar from "./nav/components/Bar";
+import Sidebar from "./nav/components/Sidebar";
 import Welcome from "./home/components/Welcome";
 import Jobs from "./jobs/components/Jobs";
 import Samples from "./samples/components/Samples";
@@ -24,6 +25,7 @@ const Inner = (props) => {
                 <Helmet titleTemplate="Virtool - %s" defaultTitle="Virtool" />
 
                 <NavBar />
+                <Sidebar />
 
                 <Switch>
                     <Route path="/" component={Welcome} exact />
@@ -33,7 +35,7 @@ const Inner = (props) => {
                     <Route path="/viruses" component={Viruses} />
                     <Route path="/hmm" component={HMM} />
                     <Route path="/subtraction" component={Subtraction} />
-                    <Route path="/settings" component={Settings} />
+                    <Route path="/administration" component={Settings} />
                     <Route path="/account" component={Account} />
                 </Switch>
 

--- a/client/src/js/account/components/Account.js
+++ b/client/src/js/account/components/Account.js
@@ -16,12 +16,12 @@ class Account extends React.Component {
     }
 
     render () {
+
         return (
             <div className="container">
                 <h3 className="view-header">
                     <strong>Account</strong>
                 </h3>
-
                 <Nav bsStyle="tabs">
                     <LinkContainer to="/account/general">
                         <NavItem>General</NavItem>

--- a/client/src/js/jobs/components/Jobs.js
+++ b/client/src/js/jobs/components/Jobs.js
@@ -23,24 +23,20 @@ const JobsSettings = () => (
 );
 
 const Jobs = (props) => {
-    let content;
-
     if (props.settings === null) {
-        content = <LoadingPlaceholder />;
-    } else {
-        content = (
-            <div className="container">
-                <Switch>
-                    <Route path="/jobs" component={JobsList} exact />
-                    <Route path="/jobs/resources" component={JobsResources} />
-                    <Route path="/jobs/settings" component={JobsSettings} />
-                    <Route path="/jobs/:jobId" component={JobDetail} />
-                </Switch>
-            </div>
-        );
+        return <LoadingPlaceholder />;
     }
-
-    return content;
+    
+    return (
+        <div className="container">
+            <Switch>
+                <Route path="/jobs" component={JobsList} exact />
+                <Route path="/jobs/resources" component={JobsResources} />
+                <Route path="/jobs/settings" component={JobsSettings} />
+                <Route path="/jobs/:jobId" component={JobDetail} />
+            </Switch>
+        </div>
+    );
 };
 
 const mapStateToProps = (state) => ({

--- a/client/src/js/jobs/components/Jobs.js
+++ b/client/src/js/jobs/components/Jobs.js
@@ -6,19 +6,46 @@ import { findJobs } from "../actions";
 import JobsList from "./List";
 import JobDetail from "./Detail";
 import JobsResources from "./Resources";
+import Resources from "../../settings/components/Jobs/Resources";
+import Tasks from "../../settings/components/Jobs/Tasks";
+import { LoadingPlaceholder } from "../../base";
 
-const Jobs = () => (
-    <div className="container">
-        <Switch>
-            <Route path="/jobs" component={JobsList} exact />
-            <Route path="/jobs/resources" component={JobsResources} />
-            <Route path="/jobs/:jobId" component={JobDetail} />
-        </Switch>
+const JobsSettings = () => (
+    <div>
+        <h3 className="view-header">
+            <strong>
+                Job Settings
+            </strong>
+        </h3>
+        <Resources />
+        <Tasks />
     </div>
 );
 
+const Jobs = (props) => {
+    let content;
+
+    if (props.settings === null) {
+        content = <LoadingPlaceholder />;
+    } else {
+        content = (
+            <div className="container">
+                <Switch>
+                    <Route path="/jobs" component={JobsList} exact />
+                    <Route path="/jobs/resources" component={JobsResources} />
+                    <Route path="/jobs/settings" component={JobsSettings} />
+                    <Route path="/jobs/:jobId" component={JobDetail} />
+                </Switch>
+            </div>
+        );
+    }
+
+    return content;
+};
+
 const mapStateToProps = (state) => ({
-    documents: state.jobs.list
+    documents: state.jobs.list,
+    settings: state.settings.data
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/src/js/jobs/components/Toolbar.js
+++ b/client/src/js/jobs/components/Toolbar.js
@@ -4,7 +4,6 @@
  */
 import React from "react";
 import { connect } from "react-redux";
-import { LinkContainer } from "react-router-bootstrap";
 import { InputGroup, FormGroup, FormControl, Dropdown, MenuItem } from "react-bootstrap";
 
 import { clearJobs } from "../actions";
@@ -50,10 +49,6 @@ const JobsToolbar = (props) => {
                     <FormControl value={props.term} onChange={(e) => props.onFind(e.target.value)} />
                 </InputGroup>
             </FormGroup>
-
-            <LinkContainer to="/jobs/resources">
-                <Button icon="meter" tip="Resources" />
-            </LinkContainer>
 
             {removalDropdown}
         </div>

--- a/client/src/js/nav/components/Bar.js
+++ b/client/src/js/nav/components/Bar.js
@@ -8,7 +8,6 @@ import NotificationIcon from "./Icon";
 import { logout } from "../../account/actions";
 import { Icon, AutoProgressBar } from "../../base";
 
-
 const isHomeActive = (match, location) => location.pathname === "/" || startsWith(location.pathname, "/home");
 
 const Bar = (props) => {
@@ -67,14 +66,6 @@ const Bar = (props) => {
                                 Subtraction
                             </NavItem>
                         </LinkContainer>
-
-                        {props.permissions.modify_settings ? (
-                            <LinkContainer to="/settings">
-                                <NavItem>
-                                    Settings
-                                </NavItem>
-                            </LinkContainer>
-                        ) : null}
                     </Nav>
 
                     <Nav pullRight>
@@ -97,6 +88,9 @@ const Bar = (props) => {
                         <NavDropdown id="account-dropdown" title={dropdownTitle}>
                             <LinkContainer to="/account" activeClassName="">
                                 <MenuItem>Account</MenuItem>
+                            </LinkContainer>
+                            <LinkContainer to="/administration">
+                                <MenuItem>Administration</MenuItem>
                             </LinkContainer>
                             <MenuItem href="https://gitreports.com/issue/virtool/virtool" target="_blank">
                                 Report Issue

--- a/client/src/js/nav/components/Icon.js
+++ b/client/src/js/nav/components/Icon.js
@@ -57,7 +57,9 @@ class NotificationIcon extends React.Component {
     render () {
 
         const availableUpdates = this.props.updates ? this.props.updates.releases.length : null;
-        const unbuiltIndex = this.props.unbuilt ? this.props.unbuilt.history.length : null;
+        const unbuiltIndex = ((this.props.modifiedVirusCount || this.props.modifiedCount) && this.props.unbuilt)
+            ? this.props.unbuilt.history.length
+            : null;
 
         const iconStyle = (availableUpdates || unbuiltIndex) ? "icon-pulse" : "icon";
 
@@ -86,7 +88,9 @@ class NotificationIcon extends React.Component {
 
 const mapStateToProps = (state) => ({
     updates: state.updates.software,
-    unbuilt: state.indexes.unbuilt
+    unbuilt: state.indexes.unbuilt,
+    modifiedVirusCount: state.indexes.modified_virus_count,
+    modifiedCount: state.viruses.modified_count
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/src/js/nav/components/Notifications.js
+++ b/client/src/js/nav/components/Notifications.js
@@ -17,7 +17,7 @@ const getInitialState = (props) => {
 
     }
 
-    if (props.modifiedCount || props.modifiedVirusCount) {
+    if ((props.modifiedCount || props.modifiedVirusCount) && props.unbuilt) {
         notifArray.push({
             message: "Rebuild Index",
             link: "/viruses/indexes"
@@ -96,6 +96,7 @@ class Notifications extends React.Component {
 
 const mapStateToProps = (state) => ({
     updates: state.updates.software,
+    unbuilt: state.indexes.unbuilt,
     modifiedVirusCount: state.indexes.modified_virus_count,
     modifiedCount: state.viruses.modified_count,
     canUpdate: state.account.permissions.modify_settings

--- a/client/src/js/nav/components/Sidebar.js
+++ b/client/src/js/nav/components/Sidebar.js
@@ -20,6 +20,8 @@ const isHomeActive = (location) => {
         activeTab = "Subtraction";
     } else if (startsWith(location.pathname, "/administration")) {
         activeTab = "Administration";
+    } else if (startsWith(location.pathname, "/hmm")) {
+        activeTab = "HMM";
     }
 
     return activeTab;
@@ -38,7 +40,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/jobs">
                         <NavItem className="sidebar-item">
                             <Icon name="menu" />
-                            <div>Jobs List</div>
+                            <div>List</div>
                         </NavItem>
                     </LinkContainer>
                     <LinkContainer to="/jobs/resources">
@@ -50,7 +52,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/jobs/settings">
                         <NavItem className="sidebar-item">
                             <Icon name="cog" />
-                            <div>Limit Settings</div>
+                            <div>Settings</div>
                         </NavItem>
                     </LinkContainer>
                 </Nav>
@@ -62,7 +64,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/samples">
                         <NavItem className="sidebar-item">
                             <Icon name="menu" />
-                            <div>Samples List</div>
+                            <div>List</div>
                         </NavItem>
                     </LinkContainer>
                     <LinkContainer to="/samples/files">
@@ -74,7 +76,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/samples/settings">
                         <NavItem className="sidebar-item">
                             <Icon name="cog" />
-                            <div>Sample Settings</div>
+                            <div>Settings</div>
                         </NavItem>
                     </LinkContainer>
                 </Nav>
@@ -86,7 +88,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/viruses">
                         <NavItem className="sidebar-item">
                             <Icon name="menu" />
-                            <div>Viruses List</div>
+                            <div>List</div>
                         </NavItem>
                     </LinkContainer>
                     <LinkContainer to="/viruses/indexes">
@@ -98,7 +100,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/viruses/settings">
                         <NavItem className="sidebar-item">
                             <Icon name="cog" />
-                            <div>Virus Settings</div>
+                            <div>Settings</div>
                         </NavItem>
                     </LinkContainer>
                 </Nav>
@@ -110,7 +112,7 @@ const Sidebar = (props) => {
                     <LinkContainer to="/subtraction">
                         <NavItem className="sidebar-item">
                             <Icon name="menu" />
-                            <div>Subtraction List</div>
+                            <div>List</div>
                         </NavItem>
                     </LinkContainer>
                     <LinkContainer to="/subtraction/files">
@@ -156,6 +158,18 @@ const Sidebar = (props) => {
                     </Nav>
                 ) : <Nav className="sidebar" />;
             break;
+        case "HMM":
+            sidebarComponents = (             
+                <Nav className="sidebar">
+                    <LinkContainer to="/hmm">
+                        <NavItem className="sidebar-item">
+                            <Icon name="menu" />
+                            <div>List</div>
+                        </NavItem>
+                    </LinkContainer>
+                </Nav>
+            );
+    break;
         default:
             sidebarComponents = <Nav className="sidebar" />;
     }

--- a/client/src/js/nav/components/Sidebar.js
+++ b/client/src/js/nav/components/Sidebar.js
@@ -1,180 +1,81 @@
 import React from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-import { LinkContainer } from "react-router-bootstrap";
-import { Nav, NavItem } from "react-bootstrap";
-import { Icon } from "../../base";
+import { Nav } from "react-bootstrap";
+import { SidebarItem } from "./SidebarItem";
 import { startsWith } from "lodash-es";
 
 const isHomeActive = (location) => {
-
-    let activeTab;
-
     if (startsWith(location.pathname, "/jobs")) {
-        activeTab = "Jobs";
+        return "Jobs";
     } else if (startsWith(location.pathname, "/samples")) {
-        activeTab = "Samples";
+        return "Samples";
     } else if (startsWith(location.pathname, "/viruses")) {
-        activeTab = "Viruses";
+        return "Viruses";
     } else if (startsWith(location.pathname, "/subtraction")) {
-        activeTab = "Subtraction";
+        return "Subtraction";
     } else if (startsWith(location.pathname, "/administration")) {
-        activeTab = "Administration";
+        return "Administration";
     } else if (startsWith(location.pathname, "/hmm")) {
-        activeTab = "HMM";
+        return "HMM";
     }
-
-    return activeTab;
 };
 
 const Sidebar = (props) => {
 
     const activeTab = isHomeActive(props.location);
-    let sidebarComponents;
 
     switch (activeTab) {
-
         case "Jobs":
-            sidebarComponents = (
+            return (
                 <Nav className="sidebar">
-                    <LinkContainer to="/jobs">
-                        <NavItem className="sidebar-item">
-                            <Icon name="menu" />
-                            <div>List</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/jobs/resources">
-                        <NavItem className="sidebar-item">
-                            <Icon name="meter" />
-                            <div>Resources</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/jobs/settings">
-                        <NavItem className="sidebar-item">
-                            <Icon name="cog" />
-                            <div>Settings</div>
-                        </NavItem>
-                    </LinkContainer>
+                    <SidebarItem title="List" link="/jobs" icon="menu" />
+                    <SidebarItem title="Resources" link="/jobs/resources" icon="meter" />
+                    <SidebarItem title="Settings" link="/jobs/settings" icon="cog" />
                 </Nav>
             );
-            break;
         case "Samples":
-            sidebarComponents = (
+            return (
                 <Nav className="sidebar">
-                    <LinkContainer to="/samples">
-                        <NavItem className="sidebar-item">
-                            <Icon name="menu" />
-                            <div>List</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/samples/files">
-                        <NavItem className="sidebar-item">
-                            <Icon name="folder-open" />
-                            <div>Files</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/samples/settings">
-                        <NavItem className="sidebar-item">
-                            <Icon name="cog" />
-                            <div>Settings</div>
-                        </NavItem>
-                    </LinkContainer>
+                    <SidebarItem title="List" link="/samples" icon="menu" />
+                    <SidebarItem title="Files" link="/samples/files" icon="folder-open" />
+                    <SidebarItem title="Settings" link="/samples/settings" icon="cog" />
                 </Nav>
             );
-            break;
         case "Viruses":
-            sidebarComponents = (
+            return (
                 <Nav className="sidebar">
-                    <LinkContainer to="/viruses">
-                        <NavItem className="sidebar-item">
-                            <Icon name="menu" />
-                            <div>List</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/viruses/indexes">
-                        <NavItem className="sidebar-item">
-                            <Icon name="filing" />
-                            <div>Indexes</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/viruses/settings">
-                        <NavItem className="sidebar-item">
-                            <Icon name="cog" />
-                            <div>Settings</div>
-                        </NavItem>
-                    </LinkContainer>
+                    <SidebarItem title="List" link="/viruses" icon="menu" />
+                    <SidebarItem title="Indexes" link="/viruses/indexes" icon="filing" />
+                    <SidebarItem title="Settings" link="/viruses/settings" icon="cog" />
                 </Nav>
             );
-            break;
         case "Subtraction":
-            sidebarComponents = (
+            return (
                 <Nav className="sidebar">
-                    <LinkContainer to="/subtraction">
-                        <NavItem className="sidebar-item">
-                            <Icon name="menu" />
-                            <div>List</div>
-                        </NavItem>
-                    </LinkContainer>
-                    <LinkContainer to="/subtraction/files">
-                        <NavItem className="sidebar-item">
-                            <Icon name="folder-open" />
-                            <div>Files</div>
-                        </NavItem>
-                    </LinkContainer>
+                    <SidebarItem title="List" link="/subtraction" icon="menu" />
+                    <SidebarItem title="Files" link="/subtraction/files" icon="folder-open" />
                 </Nav>
             );
-            break;
         case "Administration":
-            sidebarComponents = props.permissions.modify_settings
+            return props.permissions.modify_settings
                 ? (
                     <Nav className="sidebar">
-                        <LinkContainer to="/administration/server">
-                            <NavItem className="sidebar-item">
-                                <Icon name="cloud" />
-                                <div>Server</div>
-                            </NavItem>
-                        </LinkContainer>
-
-                        <LinkContainer to="/administration/data">
-                            <NavItem className="sidebar-item">
-                                <Icon name="database" />
-                                <div>Data</div>
-                            </NavItem>
-                        </LinkContainer>
-
-                        <LinkContainer to="/administration/users">
-                            <NavItem className="sidebar-item">
-                                <Icon name="users" />
-                                <div>Users</div>
-                            </NavItem>
-                        </LinkContainer>
-
-                        <LinkContainer to="/administration/updates">
-                            <NavItem className="sidebar-item">
-                                <Icon name="plus-square" />
-                                <div>Updates</div>
-                            </NavItem>
-                        </LinkContainer>
+                        <SidebarItem title="Server" link="/administration/server" icon="cloud" />
+                        <SidebarItem title="Data" link="/administration/data" icon="database" />
+                        <SidebarItem title="Users" link="/administration/users" icon="users" />
+                        <SidebarItem title="Updates" link="/administration/updates" icon="plus-square" />
                     </Nav>
                 ) : <Nav className="sidebar" />;
-            break;
         case "HMM":
-            sidebarComponents = (             
+            return (
                 <Nav className="sidebar">
-                    <LinkContainer to="/hmm">
-                        <NavItem className="sidebar-item">
-                            <Icon name="menu" />
-                            <div>List</div>
-                        </NavItem>
-                    </LinkContainer>
+                    <SidebarItem title="List" link="/hmm" icon="menu" />
                 </Nav>
             );
-    break;
         default:
-            sidebarComponents = <Nav className="sidebar" />;
+            return <Nav className="sidebar" />;
     }
-
-    return sidebarComponents;
 };
 
 const mapStateToProps = (state) => ({

--- a/client/src/js/nav/components/Sidebar.js
+++ b/client/src/js/nav/components/Sidebar.js
@@ -1,0 +1,170 @@
+import React from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { LinkContainer } from "react-router-bootstrap";
+import { Nav, NavItem } from "react-bootstrap";
+import { Icon } from "../../base";
+import { startsWith } from "lodash-es";
+
+const isHomeActive = (location) => {
+
+    let activeTab;
+
+    if (startsWith(location.pathname, "/jobs")) {
+        activeTab = "Jobs";
+    } else if (startsWith(location.pathname, "/samples")) {
+        activeTab = "Samples";
+    } else if (startsWith(location.pathname, "/viruses")) {
+        activeTab = "Viruses";
+    } else if (startsWith(location.pathname, "/subtraction")) {
+        activeTab = "Subtraction";
+    } else if (startsWith(location.pathname, "/administration")) {
+        activeTab = "Administration";
+    }
+
+    return activeTab;
+};
+
+const Sidebar = (props) => {
+
+    const activeTab = isHomeActive(props.location);
+    let sidebarComponents;
+
+    switch (activeTab) {
+
+        case "Jobs":
+            sidebarComponents = (
+                <Nav className="sidebar">
+                    <LinkContainer to="/jobs">
+                        <NavItem className="sidebar-item">
+                            <Icon name="menu" />
+                            <div>Jobs List</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/jobs/resources">
+                        <NavItem className="sidebar-item">
+                            <Icon name="meter" />
+                            <div>Resources</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/jobs/settings">
+                        <NavItem className="sidebar-item">
+                            <Icon name="cog" />
+                            <div>Limit Settings</div>
+                        </NavItem>
+                    </LinkContainer>
+                </Nav>
+            );
+            break;
+        case "Samples":
+            sidebarComponents = (
+                <Nav className="sidebar">
+                    <LinkContainer to="/samples">
+                        <NavItem className="sidebar-item">
+                            <Icon name="menu" />
+                            <div>Samples List</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/samples/files">
+                        <NavItem className="sidebar-item">
+                            <Icon name="folder-open" />
+                            <div>Files</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/samples/settings">
+                        <NavItem className="sidebar-item">
+                            <Icon name="cog" />
+                            <div>Sample Settings</div>
+                        </NavItem>
+                    </LinkContainer>
+                </Nav>
+            );
+            break;
+        case "Viruses":
+            sidebarComponents = (
+                <Nav className="sidebar">
+                    <LinkContainer to="/viruses">
+                        <NavItem className="sidebar-item">
+                            <Icon name="menu" />
+                            <div>Viruses List</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/viruses/indexes">
+                        <NavItem className="sidebar-item">
+                            <Icon name="filing" />
+                            <div>Indexes</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/viruses/settings">
+                        <NavItem className="sidebar-item">
+                            <Icon name="cog" />
+                            <div>Virus Settings</div>
+                        </NavItem>
+                    </LinkContainer>
+                </Nav>
+            );
+            break;
+        case "Subtraction":
+            sidebarComponents = (
+                <Nav className="sidebar">
+                    <LinkContainer to="/subtraction">
+                        <NavItem className="sidebar-item">
+                            <Icon name="menu" />
+                            <div>Subtraction List</div>
+                        </NavItem>
+                    </LinkContainer>
+                    <LinkContainer to="/subtraction/files">
+                        <NavItem className="sidebar-item">
+                            <Icon name="folder-open" />
+                            <div>Files</div>
+                        </NavItem>
+                    </LinkContainer>
+                </Nav>
+            );
+            break;
+        case "Administration":
+            sidebarComponents = props.permissions.modify_settings
+                ? (
+                    <Nav className="sidebar">
+                        <LinkContainer to="/administration/server">
+                            <NavItem className="sidebar-item">
+                                <Icon name="cloud" />
+                                <div>Server</div>
+                            </NavItem>
+                        </LinkContainer>
+
+                        <LinkContainer to="/administration/data">
+                            <NavItem className="sidebar-item">
+                                <Icon name="database" />
+                                <div>Data</div>
+                            </NavItem>
+                        </LinkContainer>
+
+                        <LinkContainer to="/administration/users">
+                            <NavItem className="sidebar-item">
+                                <Icon name="users" />
+                                <div>Users</div>
+                            </NavItem>
+                        </LinkContainer>
+
+                        <LinkContainer to="/administration/updates">
+                            <NavItem className="sidebar-item">
+                                <Icon name="plus-square" />
+                                <div>Updates</div>
+                            </NavItem>
+                        </LinkContainer>
+                    </Nav>
+                ) : <Nav className="sidebar" />;
+            break;
+        default:
+            sidebarComponents = <Nav className="sidebar" />;
+    }
+
+    return sidebarComponents;
+};
+
+const mapStateToProps = (state) => ({
+    ...state.account
+});
+
+export default withRouter(connect(mapStateToProps, null)(Sidebar));

--- a/client/src/js/nav/components/SidebarItem.js
+++ b/client/src/js/nav/components/SidebarItem.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { NavItem } from "react-bootstrap";
+import { LinkContainer } from "react-router-bootstrap";
+import { Icon } from "../../base";
+
+export const SidebarItem = (props) => (
+
+    <LinkContainer to={props.link}>
+        <NavItem className="sidebar-item">
+            <Icon name={props.icon} />
+            <div>{props.title}</div>
+        </NavItem>
+    </LinkContainer>
+    
+);

--- a/client/src/js/samples/components/Samples.js
+++ b/client/src/js/samples/components/Samples.js
@@ -26,24 +26,20 @@ const SampleSettings = () => (
 );
 
 const Samples = (props) => {
-    let content;
-
     if (props.settings === null) {
-        content = <LoadingPlaceholder />;
-    } else {
-        content = (
-            <div className="container">
-                <Switch>
-                    <Route path="/samples" component={SamplesList} exact />
-                    <Route path="/samples/files" component={SampleFileManager} exact />
-                    <Route path="/samples/settings" component={SampleSettings} />
-                    <Route path="/samples/:sampleId" component={SampleDetail} />
-                </Switch>
-            </div>
-        );
+        return <LoadingPlaceholder />;
     }
-
-    return content;
+    
+    return (
+        <div className="container">
+            <Switch>
+                <Route path="/samples" component={SamplesList} exact />
+                <Route path="/samples/files" component={SampleFileManager} exact />
+                <Route path="/samples/settings" component={SampleSettings} />
+                <Route path="/samples/:sampleId" component={SampleDetail} />
+            </Switch>
+        </div>
+    );
 };
 
 const mapStateToProps = (state) => ({

--- a/client/src/js/samples/components/Samples.js
+++ b/client/src/js/samples/components/Samples.js
@@ -1,22 +1,53 @@
 import React from "react";
 import { Switch, Route } from "react-router-dom";
+import { connect } from "react-redux";
 
 import FileManager from "../../files/components/Manager";
 import SamplesList from "./List";
 import SampleDetail from "./Detail";
+import UniqueNames from "../../settings/components/General/UniqueNames";
+import SampleRights from "../../settings/components/General/SampleRights";
+import { LoadingPlaceholder } from "../../base";
 
 const SampleFileManager = () => (
     <FileManager fileType="reads" />
 );
 
-const Samples = () => (
-    <div className="container">
-        <Switch>
-            <Route path="/samples" component={SamplesList} exact />
-            <Route path="/samples/files" component={SampleFileManager} exact />
-            <Route path="/samples/:sampleId" component={SampleDetail} />
-        </Switch>
+const SampleSettings = () => (
+    <div>
+        <h3 className="view-header">
+            <strong>
+                Sample Settings
+            </strong>
+        </h3>
+        <UniqueNames />
+        <SampleRights />
     </div>
 );
 
-export default Samples;
+const Samples = (props) => {
+    let content;
+
+    if (props.settings === null) {
+        content = <LoadingPlaceholder />;
+    } else {
+        content = (
+            <div className="container">
+                <Switch>
+                    <Route path="/samples" component={SamplesList} exact />
+                    <Route path="/samples/files" component={SampleFileManager} exact />
+                    <Route path="/samples/settings" component={SampleSettings} />
+                    <Route path="/samples/:sampleId" component={SampleDetail} />
+                </Switch>
+            </div>
+        );
+    }
+
+    return content;
+};
+
+const mapStateToProps = (state) => ({
+    settings: state.settings.data
+});
+
+export default connect(mapStateToProps)(Samples);

--- a/client/src/js/samples/components/Toolbar.js
+++ b/client/src/js/samples/components/Toolbar.js
@@ -23,10 +23,6 @@ const SampleToolbar = ({canCreate, onFind, term}) => (
             </InputGroup>
         </FormGroup>
 
-        <LinkContainer to="/samples/files">
-            <Button tip="Read Files" icon="folder-open" />
-        </LinkContainer>
-
         {canCreate ? (
             <LinkContainer to={{state: {create: true}}}>
                 <Button

--- a/client/src/js/settings/components/Settings.js
+++ b/client/src/js/settings/components/Settings.js
@@ -1,32 +1,15 @@
 import React from "react";
 import { connect } from "react-redux";
 import { Switch, Redirect, Route } from "react-router-dom";
-import { Nav, NavItem } from "react-bootstrap";
-import { LinkContainer } from "react-router-bootstrap";
 
-import SourceTypes from "./General/SourceTypes";
-import InternalControl from "./General/InternalControl";
-import UniqueNames from "./General/UniqueNames";
-import SampleRights from "./General/SampleRights";
 import HTTP from "./Server/HTTP";
 import Proxy from "./Server/Proxy";
 import Sentry from "./Server/Sentry";
 import SSL from "./Server/SSL";
 import Data from "./Data";
-import Resources from "./Jobs/Resources";
-import Tasks from "./Jobs/Tasks";
 import Users from "../../users/components/Users";
 import Updates from "../../updates/components/Viewer";
 import { LoadingPlaceholder } from "../../base";
-
-const General = () => (
-    <div>
-        <SourceTypes />
-        <InternalControl />
-        <UniqueNames />
-        <SampleRights />
-    </div>
-);
 
 const Server = () => (
     <div>
@@ -34,13 +17,6 @@ const Server = () => (
         <Proxy />
         <Sentry />
         <SSL />
-    </div>
-);
-
-const Jobs = () => (
-    <div>
-        <Resources />
-        <Tasks />
     </div>
 );
 
@@ -52,13 +28,11 @@ const Settings = ({ settings }) => {
     } else {
         content = (
             <Switch>
-                <Redirect from="/settings" to="/settings/general" exact />
-                <Route path="/settings/general" component={General} />
-                <Route path="/settings/server" component={Server} />
-                <Route path="/settings/data" component={Data} />
-                <Route path="/settings/jobs" component={Jobs} />
-                <Route path="/settings/users" component={Users} />
-                <Route path="/settings/updates" component={Updates} />
+                <Redirect from="/administration" to="/administration/server" exact />
+                <Route path="/administration/server" component={Server} />
+                <Route path="/administration/data" component={Data} />
+                <Route path="/administration/users" component={Users} />
+                <Route path="/administration/updates" component={Updates} />
             </Switch>
         );
     }
@@ -67,35 +41,9 @@ const Settings = ({ settings }) => {
         <div className="container">
             <h3 className="view-header">
                 <strong>
-                    Settings
+                    Administration
                 </strong>
             </h3>
-
-            <Nav bsStyle="tabs">
-                <LinkContainer to="/settings/general">
-                    <NavItem>General</NavItem>
-                </LinkContainer>
-
-                <LinkContainer to="/settings/server">
-                    <NavItem>Server</NavItem>
-                </LinkContainer>
-
-                <LinkContainer to="/settings/data">
-                    <NavItem>Data</NavItem>
-                </LinkContainer>
-
-                <LinkContainer to="/settings/jobs">
-                    <NavItem>Jobs</NavItem>
-                </LinkContainer>
-
-                <LinkContainer to="/settings/users">
-                    <NavItem>Users</NavItem>
-                </LinkContainer>
-
-                <LinkContainer to="/settings/updates">
-                    <NavItem>Updates</NavItem>
-                </LinkContainer>
-            </Nav>
 
             {content}
         </div>

--- a/client/src/js/subtraction/components/List.js
+++ b/client/src/js/subtraction/components/List.js
@@ -103,10 +103,6 @@ const SubtractionList = (props) => {
                     </InputGroup>
                 </FormGroup>
 
-                <LinkContainer to="/subtraction/files">
-                    <Button icon="folder-open" tip="Files" />
-                </LinkContainer>
-
                 {props.canModify ? (
                     <LinkContainer to={{state: {createSubtraction: true}}}>
                         <Button bsStyle="primary" icon="new-entry" tip="Create" />

--- a/client/src/js/viruses/components/Toolbar.js
+++ b/client/src/js/viruses/components/Toolbar.js
@@ -23,13 +23,6 @@ const VirusToolbar = ({ canModify, onFind, term, onFilter, search }) => (
             </div>
         </div>
 
-        <LinkContainer to="/viruses/indexes">
-            <Button
-                icon="filing"
-                tip="Indexes"
-            />
-        </LinkContainer>
-
         <Button
             tip="Filter Unverified"
             onClick={() => onFilter("/viruses?verified=false")}

--- a/client/src/js/viruses/components/Viruses.js
+++ b/client/src/js/viruses/components/Viruses.js
@@ -1,19 +1,50 @@
 import React from "react";
 import { Switch, Route } from "react-router-dom";
+import { connect } from "react-redux";
 
 import VirusesList from "./List";
 import VirusDetail from "./Detail/Detail";
 import Indexes from "../../indexes/components/Indexes";
+import { LoadingPlaceholder } from "../../base";
+import SourceTypes from "../../settings/components/General/SourceTypes";
+import InternalControl from "../../settings/components/General/InternalControl";
 
-const Viruses = () => (
-    <div className="container">
-        <Switch>
-            <Route path="/viruses" component={VirusesList} exact />
-            <Route path="/viruses/create" component={VirusesList} />
-            <Route path="/viruses/indexes" component={Indexes} />
-            <Route path="/viruses/:virusId" component={VirusDetail} />
-        </Switch>
+const VirusSettings = () => (
+    <div>
+        <h3 className="view-header">
+            <strong>
+                Viruses Settings
+            </strong>
+        </h3>
+        <SourceTypes />
+        <InternalControl />
     </div>
 );
 
-export default Viruses;
+const Viruses = (props) => {
+    let content;
+
+    if (props.settings === null) {
+        content = <LoadingPlaceholder />;
+    } else {
+        content = (
+            <div className="container">
+                <Switch>
+                    <Route path="/viruses" component={VirusesList} exact />
+                    <Route path="/viruses/create" component={VirusesList} />
+                    <Route path="/viruses/settings" component={VirusSettings} />
+                    <Route path="/viruses/indexes" component={Indexes} />
+                    <Route path="/viruses/:virusId" component={VirusDetail} />
+                </Switch>
+            </div>
+        );
+    }
+
+    return content;
+};
+
+const mapStateToProps = (state) => ({
+    settings: state.settings.data
+});
+
+export default connect(mapStateToProps)(Viruses);

--- a/client/src/js/viruses/components/Viruses.js
+++ b/client/src/js/viruses/components/Viruses.js
@@ -22,25 +22,21 @@ const VirusSettings = () => (
 );
 
 const Viruses = (props) => {
-    let content;
-
     if (props.settings === null) {
-        content = <LoadingPlaceholder />;
-    } else {
-        content = (
-            <div className="container">
-                <Switch>
-                    <Route path="/viruses" component={VirusesList} exact />
-                    <Route path="/viruses/create" component={VirusesList} />
-                    <Route path="/viruses/settings" component={VirusSettings} />
-                    <Route path="/viruses/indexes" component={Indexes} />
-                    <Route path="/viruses/:virusId" component={VirusDetail} />
-                </Switch>
-            </div>
-        );
+        return <LoadingPlaceholder />;
     }
-
-    return content;
+    
+    return (
+        <div className="container">
+            <Switch>
+                <Route path="/viruses" component={VirusesList} exact />
+                <Route path="/viruses/create" component={VirusesList} />
+                <Route path="/viruses/settings" component={VirusSettings} />
+                <Route path="/viruses/indexes" component={Indexes} />
+                <Route path="/viruses/:virusId" component={VirusDetail} />
+            </Switch>
+        </div>
+    );
 };
 
 const mapStateToProps = (state) => ({

--- a/client/src/style/style.less
+++ b/client/src/style/style.less
@@ -131,7 +131,7 @@ td.sequence-cell > textarea {
   max-width: 5vw; 
   min-height: 100%; 
   max-height: 100%; 
-  border: 1px solid #3c87865d; 
+  border-right: 1px solid #3c87865d; 
   background-color: #c1e4db50; 
   z-index: 1000; 
   margin: -@navbar-margin-bottom 0 0 0; 

--- a/client/src/style/style.less
+++ b/client/src/style/style.less
@@ -32,6 +32,17 @@
 // Bootstrap small-screen breakpoint variable
 @screen-sm: 992px;
 
+// Bootstrap container sizes 
+@container-sm: 88vw; 
+@container-md: 88vw; 
+@container-lg: 88vw; 
+
+// Bootstrap collapse menu button color 
+@navbar-default-toggle-hover-bg: #60af98;
+
+// Sidebar menu button hover color
+@nav-link-hover-bg: #c1e4db; 
+
 // Bootstrap border-radius variable
 @border-radius-base: 0;
 @border-radius-large: 0;
@@ -75,9 +86,72 @@ td.sequence-cell > textarea {
   border: none;
 }
 
-.navbar {
-  box-shadow: 0px 2px 2px 0 #d5d5d5;
+.container {
+  position: absolute;
+  left: 110px;
+  right: 20px;
+  max-width: 100vw - 130px;
 }
+
+.navbar {
+  //box-shadow: 0px 2px 2px 0 #d5d5d5;
+}
+
+.navbar-fixed-top > .container {
+  left: 0;
+  right: 0;
+  width: 100vw;
+  padding: 0 35px;
+}
+
+.navbar-default .navbar-toggle { 
+  border-color: transparent; 
+} 
+ 
+.navbar-default .navbar-toggle .icon-bar { 
+  background-color: #edf7f6; 
+} 
+
+@media (max-width: @grid-float-breakpoint) { 
+  .navbar-collapse {
+    position: absolute;
+    right: 0;
+    margin-top: 0 !important;
+    background-color: #60af98; 
+    max-width: 150px;
+    min-width: 150px;
+  } 
+} 
+
+.sidebar {  
+  position: fixed; 
+  right: 0; 
+  left: 0; 
+  min-width: 95px; 
+  max-width: 5vw; 
+  min-height: 100%; 
+  max-height: 100%; 
+  border: 1px solid #3c87865d; 
+  background-color: #c1e4db50; 
+  z-index: 1000; 
+  margin: -@navbar-margin-bottom 0 0 0; 
+  padding: @navbar-margin-bottom 0 0 0; 
+} 
+ 
+.sidebar-item { 
+  max-width: 5vw; 
+  min-width: 96px; 
+  width: 100%; 
+  height: 100%; 
+  text-align: center; 
+  padding: 0 0; 
+  margin-left: -1px; 
+}
+
+.sidebar-item > a { 
+  color: #05486c; 
+  padding: 10px 0 !important; 
+} 
 
 .text-em {
   font-style: italic;

--- a/templates/login.html
+++ b/templates/login.html
@@ -10,7 +10,7 @@
     <title>Virtool - Login</title>
 </head>
 <body style="background-color: #3c8786">
-<div class="container">
+<div class="container-login">
     <div class="row" style="margin-top: 25px;">
         <div class="col-md-4 col-md-offset-4">
             <div class="text-center" style="margin-bottom: 15px; color: white">


### PR DESCRIPTION
- resolves #531 
- added a fixed column to the left-hand side for domain-specific sidebar
- modified css container size to take up more of the viewport width
- settings tab has been moved to drop down menu in top left corner and renamed to "Administration"
- settings sub tabs are moved to sidebar 

- one problem is that when in the "/administration" tab, reloading the page results in a 404 error, but not when navigating from a different page. 