### PR TITLE
Include libssl in build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ build_exe_options = {
     "excludes": [
         "numpy"
     ],
+    "bin_includes": [
+        "libssl.so.1.0.0"
+    ],
     "packages": [
         "_cffi_backend",
         "appdirs",


### PR DESCRIPTION
- fix missing `libssl.so.1.0.0` on CentOS
- explicitly include shared lib in cx_freeze build