### PR TITLE
Include libcrypto in build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ build_exe_options = {
         "numpy"
     ],
     "bin_includes": [
+        "libcrypto.so.1.0.0",
         "libssl.so.1.0.0"
     ],
     "packages": [


### PR DESCRIPTION
- fix missing libcrypto.so.1.0.0 on CentOS
- explicitly include shared lib in cx_freeze build