### PR TITLE
Build index

### DIFF
--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -46,6 +46,9 @@ async def test_find(spawn_client, test_changes):
                     "id": "6116cba1",
                     "name": "Prunus virus F",
                     "version": 1
+                },
+                "ref": {
+                    "id": "hxn167"
                 }
             },
             {
@@ -64,6 +67,9 @@ async def test_find(spawn_client, test_changes):
                     "id": "6116cba1",
                     "name": "Prunus virus F",
                     "version": 1
+                },
+                "ref": {
+                    "id": "hxn167"
                 }
             },
             {
@@ -82,6 +88,9 @@ async def test_find(spawn_client, test_changes):
                     "id": "6116cba1",
                     "name": "Prunus virus F",
                     "version": 1
+                },
+                "ref": {
+                    "id": "hxn167"
                 }
             }
         ], key=itemgetter("id"))
@@ -129,6 +138,9 @@ async def test_get(not_found, resp_is, spawn_client, test_changes):
                 "id": "6116cba1",
                 "name": "Prunus virus F",
                 "version": 1
+            },
+            "ref": {
+                "id": "hxn167"
             }
         }
 

--- a/virtool/api/indexes.py
+++ b/virtool/api/indexes.py
@@ -97,6 +97,15 @@ async def create(req):
 
     await db.indexes.insert_one(document)
 
+    await db.history.update_many({"index.id": "unbuilt", "ref.id": ref_id}, {
+        "$set": {
+            "index": {
+                "id": index_id,
+                "version": index_version
+            }
+        }
+    })
+
     # A dict of task_args for the rebuild job.
     task_args = {
         "ref_id": ref_id,

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -136,7 +136,8 @@ async def find_indexes(req):
         "type": "string"
     },
     "organism": {
-        "type": "string"
+        "type": "string",
+        "default": ""
     },
     "public": {
         "type": "boolean",

--- a/virtool/db/history.py
+++ b/virtool/db/history.py
@@ -23,8 +23,9 @@ LIST_PROJECTION = [
     "description",
     "method_name",
     "created_at",
-    "kind",
     "index",
+    "kind",
+    "ref",
     "user"
 ]
 


### PR DESCRIPTION
- bring back missing update of history `index` field when building index
- return `ref` field at `GET /api/indexes`
- update `BuildIndex` class and manually test
- use empty string as default ref `organism` field value
