### PR TITLE
Administrator Update

### DIFF
--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -44,7 +44,7 @@ class TestCreate:
         Test that a group can be added to the database at ``POST /api/groups/:group_id``.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         resp = await client.post("/api/groups", data={
             "group_id": "test"
@@ -70,7 +70,7 @@ class TestCreate:
         ``group_id`` already exists.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         await client.db.groups.insert_one({
             "_id": "test",
@@ -84,7 +84,7 @@ class TestCreate:
         assert await resp_is.conflict(resp, "Group already exists")
 
     async def test_missing(self, spawn_client, resp_is):
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         resp = await client.post("/api/groups", data={
             "test": "test"
@@ -96,7 +96,7 @@ class TestCreate:
         })
 
     async def test_wrong_type(self, spawn_client, resp_is):
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         resp = await client.post("/api/groups", data={
             "group_id": 1
@@ -147,7 +147,7 @@ class TestUpdatePermissions:
         Test that a valid request results in permission changes.
 
         """
-        client = await spawn_client(authorize=True)
+        client = await spawn_client(authorize=True, administrator=True)
 
         await client.db.groups.insert_one({
             "_id": "test",
@@ -177,7 +177,7 @@ class TestUpdatePermissions:
         Test that an invalid permission key results in a ``422`` response.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         await client.db.groups.insert_one({
             "_id": "test",
@@ -197,7 +197,7 @@ class TestUpdatePermissions:
         Test that updating an non-existent group results in a ``404`` response.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         resp = await client.patch("/api/groups/test", data={
             "create_sample": True
@@ -213,7 +213,7 @@ class TestRemove:
         Test that an existing document can be removed at ``DELETE /api/groups/:group_id``.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         await client.db.groups.insert_one({
             "_id": "test",
@@ -240,7 +240,7 @@ class TestRemove:
         Test that 404 is returned for non-existent group.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         resp = await client.delete("/api/groups/test")
 

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -9,7 +9,7 @@ async def test_find(spawn_client, create_user):
     Test that a ``GET /users`` returns a list of users.
 
     """
-    client = await spawn_client(authorize=True, permissions=["create_sample"])
+    client = await spawn_client(authorize=True, administrator=True, permissions=["create_sample"])
 
     user_ids = ["bob", "fred", "john"]
 
@@ -31,7 +31,10 @@ async def test_find(spawn_client, create_user):
 
     expected = [dict(base_dict, id=user_id) for user_id in user_ids + ["test"]]
 
-    expected[3]["permissions"] = dict(base_dict["permissions"], create_sample=True)
+    expected[3].update({
+        "administrator": True,
+        "permissions": dict(base_dict["permissions"], create_sample=True)
+    })
 
     assert sorted(await resp.json(), key=itemgetter("id")) == sorted(expected, key=itemgetter("id"))
 
@@ -42,7 +45,7 @@ async def test_get(not_found, spawn_client, create_user, resp_is, no_permissions
     Test that a ``GET /api/users`` returns a list of users.
 
     """
-    client = await spawn_client(authorize=True, permissions=["manage_users"])
+    client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
     users = [create_user("bob")]
 
@@ -82,7 +85,7 @@ class TestCreate:
         - check password
 
         """
-        client = await spawn_client(authorize=True)
+        client = await spawn_client(authorize=True, administrator=True)
 
         client.app["settings"]["minimum_password_length"] = 8
 
@@ -126,7 +129,7 @@ class TestCreate:
         Test that invalid and missing input data result in a ``422`` response with detailed error data.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         client.app["settings"]["minimum_password_length"] = 8
 
@@ -151,7 +154,7 @@ class TestCreate:
         Test that an input ``user_id`` that already exists results in a ``400`` response with informative error message.
 
         """
-        client = await spawn_client(authorize=True, permissions=["manage_users"])
+        client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         client.app["settings"]["minimum_password_length"] = 8
 
@@ -178,7 +181,7 @@ class TestCreate:
 @pytest.mark.parametrize("error", [None, "invalid_input", "user_dne", "group_dne", "not_group_member"])
 async def test_edit(data, error, spawn_client, resp_is, static_time, create_user, no_permissions):
 
-    client = await spawn_client(authorize=True)
+    client = await spawn_client(authorize=True, administrator=True)
 
     client.app["settings"]["minimum_password_length"] = 8
 
@@ -255,7 +258,7 @@ async def test_remove(exists, spawn_client, resp_is, create_user):
     Test that a group is removed from the user for a valid request.
 
     """
-    client = await spawn_client(authorize=True)
+    client = await spawn_client(authorize=True, administrator=True)
 
     if exists:
         await client.db.users.insert_one(create_user("bob"))

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -47,6 +47,12 @@ def protect(route_decorator, admin, permission, public, schema):
                     "message": "Requires authorization"
                 }, status=401)
 
+            if admin and not req["client"].administrator:
+                return json_response({
+                    "id": "not_permitted",
+                    "message": "Requires administrative privilege"
+                }, status=403)
+
             if permission and not req["client"].permissions[permission]:
                 return json_response({
                     "id": "not_permitted",


### PR DESCRIPTION
- perform administrator checks on applicable endpoints and return `403` for failure
- update tests to use administrator test user where necessary