### PR TITLE
Remove reference API endpoint and import improvements

### DIFF
--- a/tests/db/test_references.py
+++ b/tests/db/test_references.py
@@ -34,10 +34,3 @@ async def test_import(mocker, tmpdir, test_motor, test_dispatch, static_time):
         "foo",
         "bob"
     )
-
-    m.assert_has_calls([
-        mocker.call(test_motor, test_dispatch, "foo", 0.2, "validate_documents"),
-        mocker.call(test_motor, test_dispatch, "foo", 0.4, "import_documents"),
-        mocker.call(test_motor, test_dispatch, "foo", 0.7, "create_history"),
-        mocker.call(test_motor, test_dispatch, "foo", 1)
-    ])

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -11,7 +11,7 @@ import virtool.db.utils
 import virtool.http.routes
 import virtool.kinds
 import virtool.utils
-from virtool.api.utils import compose_regex_query, json_response, no_content, not_found, paginate
+from virtool.api.utils import compose_regex_query, json_response, not_found, paginate
 
 routes = virtool.http.routes.Routes()
 

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -275,12 +275,10 @@ async def remove(req):
 
     process = await virtool.db.processes.register(db, dispatch, "delete_reference")
 
-    process = virtool.utils.base_processor(process)
-
     await aiojobs.aiohttp.spawn(req, virtool.db.references.cleanup_removed(
         db,
         dispatch,
-        process_id,
+        process["id"],
         ref_id,
         user_id
     ))

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 
 import aiojobs.aiohttp
@@ -12,7 +11,7 @@ import virtool.db.utils
 import virtool.http.routes
 import virtool.kinds
 import virtool.utils
-from virtool.api.utils import compose_regex_query, json_response, not_found, paginate
+from virtool.api.utils import compose_regex_query, json_response, no_content, not_found, paginate
 
 routes = virtool.http.routes.Routes()
 
@@ -132,8 +131,26 @@ async def find_indexes(req):
         "allowed": ["genome", "barcode"],
         "default": "genome"
     },
+    "clone_from": {
+        "type": "string",
+        "excludes": [
+            "import_from",
+            "remote_from"
+        ]
+    },
     "import_from": {
-        "type": "string"
+        "type": "string",
+        "excludes": [
+            "clone_from",
+            "remote_from"
+        ]
+    },
+    "remote_from": {
+        "type": "string",
+        "excludes": [
+            "clone_from",
+            "import_from"
+        ]
     },
     "organism": {
         "type": "string",
@@ -234,3 +251,44 @@ async def get_unbuilt_changes(req):
     return json_response({
         "history": [virtool.utils.base_processor(c) for c in history]
     })
+
+
+@routes.delete("/api/refs/{ref_id}")
+async def remove(req):
+    """
+    Remove a reference and its kinds, history, and indexes.
+
+    """
+    db = req.app["db"]
+    dispatch = req.app["dispatch"]
+
+    ref_id = req.match_info["ref_id"]
+
+    user_id = req["client"].user_id
+
+    delete_result = await db.refs.delete_one({
+        "_id": ref_id
+    })
+
+    if not delete_result.deleted_count:
+        return not_found()
+
+    process = await virtool.db.processes.register(db, dispatch, "delete_reference")
+
+    process = virtool.utils.base_processor(process)
+
+    await aiojobs.aiohttp.spawn(req, virtool.db.references.cleanup_removed(
+        db,
+        dispatch,
+        process_id,
+        ref_id,
+        user_id
+    ))
+
+    headers = {
+        "Content-Location": "/api/processes/" + process["id"]
+    }
+
+    return json_response(process, 202, headers)
+
+

--- a/virtool/db/kinds.py
+++ b/virtool/db/kinds.py
@@ -187,10 +187,10 @@ async def join_and_format(db, kind_id, joined=None, issues=False):
     return joined
 
 
-async def remove(db, dispatch, kind_id, user_id):
+async def remove(db, dispatch, kind_id, user_id, document=None):
 
     # Join the kind.
-    joined = await join(db, kind_id)
+    joined = await join(db, kind_id, document=document)
 
     if not joined:
         return None

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -429,7 +429,7 @@ async def import_file(app, path, ref_id, created_at, process_id, user_id):
 
     await virtool.db.processes.update(db, dispatch, process_id, 0.4, "import_documents")
 
-    used_kind_ids = set()
+    used_kind_ids = set(await db.history.distinct("kind.id"))
     used_isolate_ids = set()
     used_sequence_ids = set()
 

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -470,9 +470,11 @@ async def import_file(app, path, ref_id, created_at, process_id, user_id):
 
                 sequence.update({
                     "_id": sequence_id,
-                    "ref_id": ref_id,
                     "kind_id": kind_id,
-                    "isolate_id": isolate_id
+                    "isolate_id": isolate_id,
+                    "ref": {
+                        "id": ref_id
+                    }
                 })
 
                 await db.sequences.insert_one(sequence)

--- a/virtool/processes.py
+++ b/virtool/processes.py
@@ -1,4 +1,5 @@
 STEP_COUNTS = {
+    "delete_reference": 2,
     "import_reference": 0,
     "setup_remote_reference": 0,
     "update_remote_reference": 0,
@@ -7,6 +8,7 @@ STEP_COUNTS = {
 }
 
 FIRST_STEPS = {
+    "delete_reference": "delete_indexes",
     "import_reference": "load_file",
     "setup_remote_reference": "",
     "update_remote_reference": "",

--- a/virtool/processes.py
+++ b/virtool/processes.py
@@ -18,3 +18,32 @@ UNIQUES = [
     "update_software",
     "install_hmms"
 ]
+
+
+class ProgressTracker:
+
+    def __init__(self, total, db=None, increment=0.05, factor=1):
+        self.total = total
+        self.db = db
+        self.increment = increment
+        self.factor = factor
+
+        self.count = 0
+        self.last_reported = 0
+
+    def add(self, value):
+        count = self.count + value
+
+        if count > self.total:
+            raise ValueError("Count cannot exceed total")
+
+        self.count = count
+
+        return self.progress
+
+    async def reported(self):
+        self.last_reported = self.progress
+
+    @property
+    def progress(self):
+        return round(self.count / self.total, 2)

--- a/virtool/processes.py
+++ b/virtool/processes.py
@@ -48,4 +48,4 @@ class ProgressTracker:
 
     @property
     def progress(self):
-        return round(self.count / self.total, 2)
+        return round(self.count / self.total * self.factor, 2)


### PR DESCRIPTION
- add _delete\_reference_ process type
- add debug logging for database checks so it is obvious which ones are lagging
- add `ProgressTracker` class on server to simplify tracking progress of complex _processes_
- add reference removal endpoint
- implement finer progress tracking for reference import process
- make sure `id`s for previously removed kinds are reserved when importing by checking the history
- use subdocument structure for `ref.id` in newly imported sequences
