### PR TITLE
Edit reference API endpoint

### DIFF
--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -50,7 +50,12 @@ async def get(req):
     if not document:
         return not_found()
 
-    document.update(await virtool.db.references.get_computed(db, ref_id))
+    try:
+        internal_control_id = document["internal_control"]["id"]
+    except KeyError:
+        internal_control_id = None
+
+    document.update(await virtool.db.references.get_computed(db, ref_id, internal_control_id))
 
     return json_response(virtool.utils.base_processor(document))
 
@@ -228,7 +233,7 @@ async def create(req):
         "Location": "/api/refs/" + document["_id"]
     }
 
-    document.update(await virtool.db.references.get_computed(db, document["_id"]))
+    document.update(await virtool.db.references.get_computed(db, document["_id"], None))
 
     return json_response(virtool.utils.base_processor(document), headers=headers, status=201)
 

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -1,4 +1,5 @@
 import os
+import pymongo
 
 import aiojobs.aiohttp
 
@@ -236,6 +237,60 @@ async def create(req):
     document.update(await virtool.db.references.get_computed(db, document["_id"], None))
 
     return json_response(virtool.utils.base_processor(document), headers=headers, status=201)
+
+
+@routes.patch("/api/refs/{ref_id}", schema={
+    "name": {
+        "type": "string"
+    },
+    "description": {
+        "type": "string"
+    },
+    "data_type": {
+        "type": "string",
+        "allowed": ["genome", "barcode"]
+    },
+    "organism": {
+        "type": "string"
+    },
+    "public": {
+        "type": "boolean"
+    },
+    "internal_control": {
+        "type": "string"
+    }
+
+})
+async def edit(req):
+    db = req.app["db"]
+    data = req["data"]
+
+    ref_id = req.match_info["ref_id"]
+
+    if not await db.refs.count({"_id": ref_id}):
+        return not_found()
+
+    update = data
+
+    internal_control_id = data.get("internal_control", None)
+
+    if internal_control_id:
+        if not await db.kinds.find_one({"_id": internal_control_id, "ref.id": ref_id}):
+            return not_found("Internal control not found")
+
+        update["internal_control"] = {
+            "id": update["internal_control"]
+        }
+
+    document = await db.refs.find_one_and_update({"_id": ref_id}, {
+        "$set": update
+    }, return_document=pymongo.ReturnDocument.AFTER, projection=virtool.db.references.PROJECTION)
+
+    document["internal_control"] = await virtool.db.references.get_internal_control(db, internal_control_id)
+
+    document = virtool.utils.base_processor(document)
+
+    return json_response(document)
 
 
 @routes.get("/api/refs/{ref_id}/unbuilt")

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -22,6 +22,7 @@ PROJECTION = [
     "organism",
     "public",
     "user",
+    "internal_control",
     "cloned_from",
     "imported_from",
     "remoted_from",
@@ -61,10 +62,10 @@ async def cleanup_removed(db, dispatch, process_id, ref_id, user_id):
     await virtool.db.processes.update(db, dispatch, process_id, progress=1)
 
 
-async def get_computed(db, ref_id):
+async def get_computed(db, ref_id, internal_control_id):
     contributors, internal_control, latest_build = await asyncio.gather(
         get_contributors(db, ref_id),
-        get_internal_control(db, ref_id),
+        get_internal_control(db, internal_control_id),
         get_latest_build(db, ref_id)
     )
 
@@ -117,28 +118,31 @@ async def get_latest_build(db, ref_id):
     return virtool.utils.base_processor(last_build)
 
 
-async def get_internal_control(db, kind_id):
+async def get_internal_control(db, internal_control_id):
     """
     Return a minimal dict describing the ref internal control given a `kind_id`.
 
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
 
-    :param kind_id: the id of the kind to create a minimal dict for
-    :type kind_id: str
+    :param internal_control_id: the id of the kind to create a minimal dict for
+    :type internal_control_id: str
 
     :return: a minimal dict describing the ref internal control
     :rtype: Union[None, dict]
 
     """
-    name = await virtool.db.utils.get_one_field(db.kinds, "name", kind_id)
+    if internal_control_id is None:
+        return None
+
+    name = await virtool.db.utils.get_one_field(db.kinds, "name", internal_control_id)
 
     if name is None:
         return None
 
     return {
-        "id": kind_id,
-        "name": await virtool.db.utils.get_one_field(db.kinds, "name", kind_id)
+        "id": internal_control_id,
+        "name": await virtool.db.utils.get_one_field(db.kinds, "name", internal_control_id)
     }
 
 


### PR DESCRIPTION
- add endpoint at `PATCH /api/refs/:ref_id` for editing references
- edit internal controls for references by passing a kind id as a value for the  `internal_control` field
- internal controls are returned from the API as subdocuments including a `name` field:
  ```json
  "internal_control": {
      "id": "ah4m5jqz",
      "name": "Thingy"
  }
  ```