### PR TITLE
Deprecate admin group

### DIFF
--- a/client/src/js/App.js
+++ b/client/src/js/App.js
@@ -13,7 +13,7 @@ import Samples from "./samples/components/Samples";
 import References from "./references/components/References";
 import HMM from "./hmm/components/HMM";
 import Subtraction from "./subtraction/components/Subtraction";
-import Settings from "./settings/components/Settings";
+import Administration from "./administration/components/Settings";
 import Account from "./account/components/Account";
 import UploadOverlay from "./files/components/UploadOverlay";
 import { LoadingPlaceholder } from "./base";
@@ -34,7 +34,7 @@ const Inner = (props) => {
                     <Route path="/refs" component={References} />
                     <Route path="/hmm" component={HMM} />
                     <Route path="/subtraction" component={Subtraction} />
-                    <Route path="/administration" component={Settings} />
+                    <Route path="/administration" component={Administration} />
                     <Route path="/account" component={Account} />
                 </Switch>
 

--- a/client/src/js/actionTypes.js
+++ b/client/src/js/actionTypes.js
@@ -157,8 +157,6 @@ export const LIST_USERS = createRequestActionType("LIST_USERS");
 export const FILTER_USERS = "FILTER_USERS";
 export const CREATE_USER = createRequestActionType("CREATE_USER");
 export const EDIT_USER = createRequestActionType("EDIT_USER");
-export const ADD_USER_TO_GROUP = createRequestActionType("ADD_USER_TO_GROUP");
-export const REMOVE_USER_FROM_GROUP = createRequestActionType("REMOVE_USER_FROM_GROUP");
 
 // Groups
 export const LIST_GROUPS = createRequestActionType("LIST_GROUPS");

--- a/client/src/js/administration/actions.js
+++ b/client/src/js/administration/actions.js
@@ -1,0 +1,61 @@
+import { simpleActionCreator } from "../utils";
+import {
+    GET_SETTINGS,
+    UPDATE_SETTINGS,
+    GET_CONTROL_READAHEAD,
+    TEST_PROXY
+} from "../actionTypes";
+
+/**
+ * Returns action that can trigger an API call for retrieving settings.
+ *
+ * @func
+ * @returns {object}
+ */
+export const getSettings = simpleActionCreator(GET_SETTINGS.REQUESTED);
+
+/**
+ * Returns action that can trigger an API call for matching search term results.
+ *
+ * @func
+ * @param term {string} user input search term
+ * @returns {object}
+ */
+export const getControlReadahead = (term) => ({
+    type: GET_CONTROL_READAHEAD.REQUESTED,
+    term
+});
+
+/**
+ * Returns action that can trigger an API call for testing proxy.
+ *
+ * @func
+ * @returns {object}
+ */
+export const testProxy = simpleActionCreator(TEST_PROXY.REQUESTED);
+
+/**
+ * Returns action that can trigger an API call to update a specific setting.
+ *
+ * @func
+ * @param key {string} property name to update
+ * @param value {any} new value to replace old value
+ * @returns {object}
+ */
+export const updateSetting = (key, value) => {
+    const update = {};
+    update[key] = value;
+    return updateSettings(update);
+};
+
+/**
+ * Returns action that can trigger an API call for updating multiple settings fields.
+ *
+ * @func
+ * @param update {object} update data of key-value pairs
+ * @returns {object}
+ */
+export const updateSettings = (update) => ({
+    type: UPDATE_SETTINGS.REQUESTED,
+    update
+});

--- a/client/src/js/administration/api.js
+++ b/client/src/js/administration/api.js
@@ -1,0 +1,14 @@
+import Request from "superagent";
+
+export const get = () => (
+    Request.get("/api/settings")
+);
+
+export const update = ({ update }) => (
+    Request.patch("/api/settings")
+        .send(update)
+);
+
+export const proxy = () => (
+    Request.get("/api/settings/proxy")
+);

--- a/client/src/js/administration/components/Data.js
+++ b/client/src/js/administration/components/Data.js
@@ -1,0 +1,109 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Row, Col, Panel } from "react-bootstrap";
+
+import { updateSetting } from "../actions";
+import { Icon, InputError } from "../../base";
+
+const WarningFooter = () => (
+    <small className="text-danger">
+        <Icon name="warning" /> Changing these settings can make Virtool non-functional
+    </small>
+);
+
+const DataOptions = ({ db_name, db_host, db_port, data_path, watch_path, onSave }) => (
+    <div>
+        <Row>
+            <Col md={12}>
+                <h5><strong>Database</strong></h5>
+            </Col>
+            <Col xs={12} md={6} mdPush={6}>
+                <Panel>
+                    <Panel.Body>
+                        Change the parameters for connecting to MongoDB.
+                    </Panel.Body>
+                    <Panel.Footer>
+                        <WarningFooter />
+                    </Panel.Footer>
+                </Panel>
+            </Col>
+            <Col xs={12} md={6} mdPull={6}>
+                <Panel>
+                    <Panel.Body>
+                        <InputError
+                            label="Database Name"
+                            onSave={(e) => onSave("db_name", e.value)}
+                            initialValue={db_name}
+                            noMargin
+                            withButton
+                        />
+                        <InputError
+                            label="MongoDB Host"
+                            onSave={(e) => onSave("db_host", e.value)}
+                            initialValue={db_host}
+                            noMargin
+                            withButton
+                        />
+                        <InputError
+                            label="MongoDB Port"
+                            type="number"
+                            onSave={(e) => onSave("db_port", Number(e.value))}
+                            initialValue={db_port}
+                            noMargin
+                            withButton
+                        />
+                    </Panel.Body>
+                </Panel>
+            </Col>
+        </Row>
+        <Row>
+            <Col xs={12}>
+                <h5><strong>Paths</strong></h5>
+            </Col>
+            <Col xs={12} md={6} mdPush={6}>
+                <Panel>
+                    <Panel.Body>
+                        Set the paths where Virtool looks for its data files and for FASTQ files to import.
+                    </Panel.Body>
+                    <Panel.Footer>
+                        <WarningFooter />
+                    </Panel.Footer>
+                </Panel>
+            </Col>
+            <Col xs={12} md={6} mdPull={6}>
+                <Panel>
+                    <Panel.Body>
+                        <InputError
+                            label="Virtool Data"
+                            onSave={(e) => onSave("watch_path", e.value)}
+                            initialValue={data_path}
+                            noMargin
+                            withButton
+                        />
+                        <InputError
+                            label="Watch Folder"
+                            onSave={(e) => onSave("watch_path", e.value)}
+                            initialValue={watch_path}
+                            noMargin
+                            withButton
+                        />
+                    </Panel.Body>
+                </Panel>
+            </Col>
+        </Row>
+    </div>
+);
+
+const mapStateToProps = (state) => ({
+    ...state.settings.data
+});
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onSave: (key, value) => {
+        dispatch(updateSetting(key, value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DataOptions);

--- a/client/src/js/administration/components/General/InternalControl.js
+++ b/client/src/js/administration/components/General/InternalControl.js
@@ -1,0 +1,90 @@
+import React from "react";
+import { connect } from "react-redux";
+import { AsyncTypeahead } from "react-bootstrap-typeahead";
+import { Row, Col, Panel } from "react-bootstrap";
+import { Flex, FlexItem, Checkbox } from "../../../base";
+import { updateSetting, getControlReadahead } from "../../actions";
+
+class InternalControl extends React.Component {
+
+    render () {
+
+        const useInternalControl = this.props.settings.use_internal_control;
+
+        const internalControlId = this.props.settings.internal_control_id;
+
+        const selected = internalControlId.id ? [internalControlId] : [];
+
+        return (
+            <div>
+                <Row>
+                    <Col xs={12} md={6}>
+                        <Flex alignItems="center" style={{marginBottom: "10px"}}>
+                            <FlexItem grow={1} >
+                                <strong>Internal Control</strong>
+                            </FlexItem>
+                            <FlexItem grow={0} shrink={0}>
+                                <Checkbox
+                                    label="Enable"
+                                    checked={useInternalControl}
+                                    onClick={() => this.props.onToggle(!useInternalControl)}
+                                />
+                            </FlexItem>
+                        </Flex>
+                    </Col>
+                    <Col smHidden md={6} />
+                </Row>
+                <Row>
+                    <Col xs={12} mdPush={6} md={6}>
+                        <Panel>
+                            <Panel.Body>
+                                Set a virus that is spiked into samples to be used as a positive control.
+                                Viral abundances in a sample can be calculated as proportions relative to the control.
+                            </Panel.Body>
+                        </Panel>
+                    </Col>
+                    <Col xs={12} mdPull={6} md={6}>
+                        <Panel>
+                            <Panel.Body>
+                                <AsyncTypeahead
+                                    labelKey="name"
+                                    allowNew={false}
+                                    isLoading={this.props.readaheadPending}
+                                    onSearch={this.props.onGetReadahead}
+                                    onChange={this.props.onUpdate}
+                                    selected={selected}
+                                    options={this.props.readahead || []}
+                                    renderMenuItemChildren={option => <option key={option.id}>{option.name}</option>}
+                                />
+                            </Panel.Body>
+                        </Panel>
+                    </Col>
+                </Row>
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = (state) => ({
+    settings: state.settings.data,
+    readahead: state.settings.readahead,
+    readaheadPending: state.settings.readaheadPending
+});
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onGetReadahead: (term) => {
+        dispatch(getControlReadahead(term));
+    },
+
+    onUpdate: (selected) => {
+        dispatch(updateSetting("internal_control_id", selected.length ? selected[0].id : ""));
+    },
+
+    onToggle: (value) => {
+        dispatch(updateSetting("use_internal_control", value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(InternalControl);

--- a/client/src/js/administration/components/General/SampleRights.js
+++ b/client/src/js/administration/components/General/SampleRights.js
@@ -1,0 +1,105 @@
+import React from "react";
+import { includes } from "lodash-es";
+import { connect } from "react-redux";
+import { Row, Col, Panel } from "react-bootstrap";
+import { updateSetting, updateSettings } from "../../actions";
+import { Help, InputError } from "../../../base";
+
+const SampleRights = (props) => (
+    <Row>
+        <Col md={12}>
+            <h5><strong>Default Sample Rights</strong></h5>
+        </Col>
+        <Col md={6}>
+            <Panel>
+                <Panel.Body>
+                    <label className="control-label" style={{width: "100%"}}>
+                        <span>Sample Group</span>
+                        <Help pullRight>
+                            <p>
+                                <strong>None</strong>: samples are assigned no group and only
+                                <em> all {"users'"}</em> rights apply
+                            </p>
+                            <p>
+                                <strong>{"User's"} primary group</strong>: samples are automatically assigned the
+                                creating {"user's"} primary group
+                            </p>
+                            <p>
+                                <strong>Choose</strong>: samples are assigned by the user in the creation form
+                            </p>
+                        </Help>
+                    </label>
+
+                    <InputError
+                        type="select"
+                        value={props.sampleGroup}
+                        onChange={(e) => props.onChangeSampleGroup(e.target.value)}
+                    >
+                        <option value="none">None</option>
+                        <option value="force_choice">Force choice</option>
+                        <option value="users_primary_group">{"User's"} primary group</option>
+                    </InputError>
+
+                    <InputError
+                        type="select"
+                        label="Group Rights"
+                        value={props.group}
+                        onChange={(e) => props.onChangeRights("group", e.target.value)}
+                    >
+                        <option value="">None</option>
+                        <option value="r">Read</option>
+                        <option value="rw">Read & write</option>
+                    </InputError>
+
+                    <InputError
+                        name="all"
+                        type="select"
+                        label="All Users' Rights"
+                        value={props.all}
+                        onChange={(e) => props.onChangeRights("all", e.target.value)}
+                    >
+                        <option value="">None</option>
+                        <option value="r">Read</option>
+                        <option value="rw">Read & write</option>
+                    </InputError>
+                </Panel.Body>
+            </Panel>
+        </Col>
+        <Col md={6}>
+            <Panel>
+                <Panel.Body>
+                    Set the method used to assign groups to new samples and the default rights.
+                </Panel.Body>
+            </Panel>
+        </Col>
+    </Row>
+);
+
+const mapStateToProps = state => {
+    const settings = state.settings.data;
+
+    return {
+        sampleGroup: settings.sample_group,
+        group: (settings.sample_group_read ? "r" : "") + (settings.sample_group_write ? "w" : ""),
+        all: (settings.sample_all_read ? "r" : "") + (settings.sample_all_write ? "w" : "")
+    };
+};
+
+const mapDispatchToProps = dispatch => ({
+
+    onChangeSampleGroup: (value) => {
+        dispatch(updateSetting("sample_group", value));
+    },
+
+    onChangeRights: (level, value) => {
+        const update = {};
+
+        update[`sample_${level}_read`] = includes(value, "r");
+        update[`sample_${level}_write`] = includes(value, "w");
+
+        dispatch(updateSettings(update));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SampleRights);

--- a/client/src/js/administration/components/General/SourceTypes.js
+++ b/client/src/js/administration/components/General/SourceTypes.js
@@ -1,0 +1,173 @@
+import React from "react";
+import { includes, map, toLower, without } from "lodash-es";
+import { connect } from "react-redux";
+import { Row, Col, Panel, Overlay, Popover, FormGroup, InputGroup, FormControl } from "react-bootstrap";
+
+import { Flex, FlexItem, Icon, Button, Checkbox, ListGroupItem } from "../../../base";
+import { updateSetting } from "../../actions";
+
+const getInitialState = () => ({
+    value: "",
+    error: null
+});
+
+const SourceTypeItem = ({ onRemove, sourceType, restrictSourceTypes }) => (
+    <ListGroupItem key={sourceType} disabled={!restrictSourceTypes}>
+        <span className="text-capitalize">{sourceType}</span>
+        {restrictSourceTypes ? <Icon name="remove" onClick={() => onRemove(sourceType)} pullRight /> : null}
+    </ListGroupItem>
+);
+
+class SourceTypes extends React.Component {
+
+    constructor (props) {
+        super(props);
+        this.state = getInitialState();
+    }
+
+    remove = (sourceType) => {
+        this.props.onUpdate(without(this.props.allowed_source_types, sourceType));
+    };
+
+    handleEnable = () => {
+        this.props.onToggle(!this.props.restrict_source_types);
+    };
+
+    handleSubmit = (e) => {
+        e.preventDefault();
+
+        // Do nothing if the sourceType is an empty string.
+        if (this.state.value !== "") {
+            // Convert source type to lowercase. All source types are single words stored in lowercase. They are
+            // capitalized when rendered in the application.
+            const newSourceType = toLower(this.state.value);
+
+            if (includes(this.props.allowed_source_types, newSourceType)) {
+                // Show error if the source type already exists in the list.
+                this.setState({
+                    error: "Source type already exists."
+                });
+            } else if (includes(newSourceType, " ")) {
+                // Show error if the input string includes a space character.
+                this.setState({
+                    error: "Source types may not contain spaces."
+                });
+            } else {
+                const newSourceTypes = this.props.allowed_source_types.concat([newSourceType]);
+                this.props.onUpdate(newSourceTypes);
+                this.setState(getInitialState());
+            }
+        }
+    };
+
+    render () {
+
+        const restrictSourceTypes = this.props.restrict_source_types;
+
+        const listComponents = map(this.props.allowed_source_types.sort(), sourceType =>
+            <SourceTypeItem
+                key={sourceType}
+                onRemove={this.remove}
+                sourceType={sourceType}
+                restrictSourceTypes={restrictSourceTypes}
+            />
+        );
+
+        return (
+            <div>
+                <Row>
+                    <Col xs={12} md={6}>
+                        <Flex alignItems="center">
+                            <FlexItem grow={1} >
+                                <h5><strong>Source Types</strong></h5>
+                            </FlexItem>
+                            <FlexItem>
+                                <Checkbox
+                                    label="Enable"
+                                    checked={restrictSourceTypes}
+                                    onClick={this.handleEnable}
+                                />
+                            </FlexItem>
+                        </Flex>
+                    </Col>
+
+                    <Col smHidden md={6} />
+                </Row>
+                <Row>
+                    <Col xs={12} md={6} mdPush={6}>
+                        <Panel>
+                            <Panel.Body>
+                                Configure a list of allowable source types. When a user creates a new isolate they will
+                                only be able to select a source type from this list. If this feature is disabled, users
+                                will be able to enter any string as a source type.
+                            </Panel.Body>
+                        </Panel>
+                    </Col>
+                    <Col xs={12} md={6} mdPull={6}>
+                        <Panel>
+                            <Panel.Body>
+                                <form onSubmit={this.handleSubmit}>
+                                    <FormGroup>
+                                        <InputGroup ref={(node) => this.containerNode = node}>
+                                            <FormControl
+                                                type="text"
+                                                inputRef={(node) => this.inputNode = node}
+                                                disabled={!restrictSourceTypes}
+                                                onChange={(e) => this.setState({value: e.target.value, error: null})}
+                                                value={this.state.value}
+                                            />
+                                            <InputGroup.Button>
+                                                <Button type="submit" bsStyle="primary" disabled={!restrictSourceTypes}>
+                                                    <Icon name="plus-square" style={{paddingLeft: "3px"}} />
+                                                </Button>
+                                            </InputGroup.Button>
+                                        </InputGroup>
+                                    </FormGroup>
+                                </form>
+
+                                <div>
+                                    {listComponents}
+                                </div>
+
+                                <Overlay
+                                    show={!!this.state.error}
+                                    target={() => this.inputNode}
+                                    container={() => this.containerNode}
+                                    placement="top"
+                                    animation={false}
+                                >
+                                    <Popover id="source-type-error-popover" className="text-danger">
+                                        {this.state.error}
+                                    </Popover>
+                                </Overlay>
+                            </Panel.Body>
+                        </Panel>
+                    </Col>
+                </Row>
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = (state) => {
+    const { allowed_source_types, restrict_source_types } = state.settings.data;
+
+    return {
+        allowed_source_types,
+        restrict_source_types
+    };
+};
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onUpdate: (value) => {
+        dispatch(updateSetting("allowed_source_types", value));
+    },
+
+    onToggle: (value) => {
+        dispatch(updateSetting("restrict_source_types", value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SourceTypes);

--- a/client/src/js/administration/components/General/UniqueNames.js
+++ b/client/src/js/administration/components/General/UniqueNames.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Row, Col, Panel } from "react-bootstrap";
+
+import { updateSetting } from "../../actions";
+import { Checkbox, Button } from "../../../base";
+
+const UniqueNames = ({ enabled, onToggle }) => (
+    <div>
+        <Row>
+            <Col md={12}>
+                <h5><strong>Unique Sample Names</strong></h5>
+            </Col>
+            <Col xs={12} md={6} mdPush={6}>
+                <Panel>
+                    <Panel.Body>
+                        Enable this feature to ensure that every created sample has a unique name. If a user
+                        attempts to assign an existing name to a new sample an error will be displayed.
+                    </Panel.Body>
+                </Panel>
+            </Col>
+            <Col xs={12} md={6} mdPull={6}>
+                <Panel>
+                    <Panel.Body>
+                        <Button onClick={() => {onToggle(!enabled)}} block>
+                            <Checkbox checked={enabled} /> Enable
+                        </Button>
+                    </Panel.Body>
+                </Panel>
+            </Col>
+        </Row>
+    </div>
+);
+
+const mapStateToProps = (state) => ({
+    enabled: state.settings.data.sample_unique_names
+});
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onToggle: (value) => {
+        dispatch(updateSetting("sample_unique_names", value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(UniqueNames);

--- a/client/src/js/administration/components/Jobs/Resources.js
+++ b/client/src/js/administration/components/Jobs/Resources.js
@@ -1,0 +1,195 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Col, Panel, Row } from "react-bootstrap";
+import { toNumber, upperFirst } from "lodash-es";
+
+import { Alert, Flex, FlexItem, InputError, LoadingPlaceholder } from "../../../base";
+import { getResources } from "../../../jobs/actions";
+import { maxResourcesSelector, minResourcesSelector } from "../../selectors";
+import { updateSetting } from "../../actions";
+
+const getErrorMessage = (isError, min, max) => (
+    isError ? `Value must be between ${min} and ${max}` : null
+);
+
+const LimitLabel = ({ label, available, unit }) => (
+    <h5>
+        <Flex alignItems="center">
+            <FlexItem grow={1} shrink={0}>
+                <strong>{label}</strong>
+            </FlexItem>
+            <FlexItem grow={0} shrink={0}>
+                <small className="text-info">
+                    {available} {unit} available
+                </small>
+            </FlexItem>
+        </Flex>
+    </h5>
+);
+
+class Resources extends React.Component {
+
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            errorProc: false,
+            errorMem: false,
+            showAlert: false
+        };
+    }
+
+    componentDidMount () {
+        this.props.onGet();
+    }
+
+    componentWillReceiveProps (nextProps) {
+        if (nextProps.mem !== this.props.mem) {
+            this.setState({errorMem: false});
+        }
+
+        if (nextProps.proc !== this.props.proc) {
+            this.setState({errorProc: false});
+        }
+    }
+
+    handleChange = (e) => {
+        this.setError(e, false);
+    };
+
+    handleInvalid = (e) => {
+        this.setError(e, true);
+    };
+
+    handleSave = (e) => {
+        const name = e.name;
+        const value = toNumber(e.value);
+        const error = `error${upperFirst(name)}`;
+
+        if (value <= e.max && value >= e.min) {
+            this.props.onUpdate(e);
+        } else {
+            this.setState({ [error]: true });
+        }
+    };
+
+    setError = (e, value) => {
+        e.preventDefault();
+
+        this.setState({
+            [`error${upperFirst(e.target.name)}`]: value
+        });
+    };
+
+    render () {
+
+        if (this.props.resources === null) {
+            return <LoadingPlaceholder />;
+        }
+
+        const errorMessageProc = getErrorMessage(
+            this.state.errorProc,
+            this.props.minProc,
+            this.props.maxProc
+        );
+
+        const errorMessageMem = getErrorMessage(
+            this.state.errorMem,
+            this.props.minMem,
+            this.props.maxMem
+        );
+
+        let alert;
+
+        if (this.props.error) {
+            alert = (
+                <Alert bsStyle="danger" icon="warning">
+                    Resource Limit values cannot be lower than corresponding Task-specific Limits.
+                </Alert>
+            );
+        }
+
+        return (
+            <div>
+                {alert}
+                <Row>
+                    <Col md={12}>
+                        <h5><strong>Resource Limits</strong></h5>
+                    </Col>
+                    <Col xs={12} md={6} mdPush={6}>
+                        <Panel>
+                            <Panel.Body>
+                                Set limits on the computing resources Virtool can use on the host server.
+                            </Panel.Body>
+                        </Panel>
+                    </Col>
+                    <Col xs={12} md={6} mdPull={6}>
+                        <Panel>
+                            <Panel.Body>
+                                <LimitLabel label="CPU Limit" available={this.props.maxProc} unit="cores" />
+                                <InputError
+                                    type="number"
+                                    name="proc"
+                                    min={this.props.minProc}
+                                    max={this.props.maxProc}
+                                    onSave={this.handleSave}
+                                    onInvalid={this.handleInvalid}
+                                    onChange={this.handleChange}
+                                    initialValue={this.props.proc}
+                                    error={errorMessageProc}
+                                    noMargin
+                                    withButton
+                                />
+
+                                <LimitLabel label="Memory Limit (GB)" available={this.props.maxMem} unit="GB" />
+                                <InputError
+                                    type="number"
+                                    name="mem"
+                                    min={this.props.minMem}
+                                    max={this.props.maxMem}
+                                    onSave={this.handleSave}
+                                    onInvalid={this.handleInvalid}
+                                    onChange={this.handleChange}
+                                    initialValue={this.props.mem}
+                                    error={errorMessageMem}
+                                    noMargin
+                                    withButton
+                                />
+                            </Panel.Body>
+                        </Panel>
+                    </Col>
+                </Row>
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = (state) => {
+    const { maxProc, maxMem } = maxResourcesSelector(state);
+    const { minProc, minMem } = minResourcesSelector(state);
+
+    return {
+        proc: state.settings.data.proc,
+        mem: state.settings.data.mem,
+        minProc,
+        minMem,
+        maxProc,
+        maxMem,
+        resources: state.jobs.resources,
+        error: state.settings.data.updateError
+    };
+};
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onUpdate: (e) => {
+        dispatch(updateSetting(e.name, toNumber(e.value)));
+    },
+
+    onGet: () => {
+        dispatch(getResources());
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Resources);

--- a/client/src/js/administration/components/Jobs/Task.js
+++ b/client/src/js/administration/components/Jobs/Task.js
@@ -1,0 +1,134 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { includes } from "lodash-es";
+import { Row, Col } from "react-bootstrap";
+import { ListGroupItem } from "../../../base";
+import { getTaskDisplayName } from "../../../utils";
+
+import TaskField from "./TaskField";
+
+const getInitialState = () => ({
+    exceedsError: false,
+    zeroError: false
+});
+
+const readOnlyFields = ["create_subtraction", "rebuild_index"];
+
+class Task extends React.Component {
+
+    constructor (props) {
+        super(props);
+        this.state = getInitialState();
+    }
+
+    componentWillReceiveProps (nextProps) {
+        const { proc, mem, inst } = this.props;
+
+        if (proc === nextProps.proc && mem === nextProps.mem && inst === nextProps.inst) {
+            this.handleClearError();
+        }
+    }
+
+    handleChangeLimit = (name, value) => {
+        this.handleClearError();
+        this.props.onChangeLimit(this.props.taskPrefix, name, value);
+    };
+
+    handleClearError = () => {
+        this.setState(getInitialState());
+    };
+
+    handleInvalid = (e) => {
+        const zeroError = e.target.value === "0";
+
+        this.setState({
+            exceedsError: !zeroError,
+            zeroError
+        });
+    };
+
+    render () {
+
+        const { inst, mem, proc, taskPrefix, currentLimitProc, currentLimitMem } = this.props;
+
+        const readOnly = includes(readOnlyFields, taskPrefix);
+
+        let error;
+
+        if (this.state.zeroError) {
+            error = "Value cannot be 0";
+        }
+
+        if (this.state.exceedsError) {
+            error = "Value cannot exceed system resource limits";
+        }
+
+        const errorComponent = (
+            <div className={error ? "input-form-error" : "input-form-error-none"}>
+                <span className="input-error-message">
+                    {error || "None"}
+                </span>
+            </div>
+        );
+
+        return (
+            <ListGroupItem allowFocus bsStyle={this.state.error ? "danger" : null}>
+                <h5><strong>{getTaskDisplayName(taskPrefix)}</strong></h5>
+                <Row>
+                    <Col md={4}>
+                        <TaskField
+                            name="proc"
+                            value={currentLimitProc < proc ? currentLimitProc : proc}
+                            readOnly={readOnly}
+                            onChange={this.handleChangeLimit}
+                            clear={this.handleClearError}
+                            lowerLimit={this.props.procLowerLimit}
+                            upperLimit={currentLimitProc}
+                            onInvalid={this.handleInvalid}
+                        />
+                    </Col>
+                    <Col md={4}>
+                        <TaskField
+                            name="mem"
+                            value={currentLimitMem < mem ? currentLimitMem : mem}
+                            readOnly={readOnly}
+                            onChange={this.handleChangeLimit}
+                            clear={this.handleClearError}
+                            lowerLimit={this.props.memLowerLimit}
+                            upperLimit={currentLimitMem}
+                            onInvalid={this.handleInvalid}
+                        />
+                    </Col>
+                    <Col md={4}>
+                        <TaskField
+                            name="inst"
+                            value={inst}
+                            readOnly={taskPrefix === "rebuild_index"}
+                            onChange={this.handleChangeLimit}
+                            clear={this.handleClearError}
+                            lowerLimit={1}
+                            upperLimit={10}
+                            onInvalid={this.handleInvalid}
+                        />
+                    </Col>
+
+                    {errorComponent}
+                </Row>
+            </ListGroupItem>
+        );
+    }
+}
+
+Task.propTypes = {
+    taskPrefix: PropTypes.string.isRequired,
+    proc: PropTypes.number,
+    mem: PropTypes.number,
+    inst: PropTypes.number,
+    onChangeLimit: PropTypes.func,
+    procLowerLimit: PropTypes.number,
+    memLowerLimit: PropTypes.number,
+    currentLimitProc: PropTypes.number,
+    currentLimitMem: PropTypes.number
+};
+
+export default Task;

--- a/client/src/js/administration/components/Jobs/TaskField.js
+++ b/client/src/js/administration/components/Jobs/TaskField.js
@@ -1,0 +1,106 @@
+import CX from "classnames";
+import React from "react";
+import PropTypes from "prop-types";
+import { toInteger } from "lodash-es";
+
+import { Icon, InputError } from "../../../base";
+
+export default class TaskField extends React.PureComponent {
+
+    constructor (props) {
+        super(props);
+        this.state = {
+            value: this.props.value,
+            pending: false
+        };
+    }
+
+    static propTypes = {
+        name: PropTypes.string,
+        value: PropTypes.number,
+        onChange: PropTypes.func,
+        clear: PropTypes.func,
+        readOnly: PropTypes.bool,
+        lowerLimit: PropTypes.number,
+        upperLimit: PropTypes.number,
+        onInvalid: PropTypes.func
+    };
+
+    componentWillReceiveProps (nextProps) {
+        if (nextProps.value !== this.state.value) {
+            this.setState({
+                value: nextProps.value,
+                pending: false
+            });
+        }
+    }
+
+    handleBlur = () => {
+        if (!this.state.pending) {
+            this.setState({value: this.props.value});
+        }
+        this.props.clear();
+    };
+
+    handleChange = (e) => {
+        this.setState({
+            value: e.target.value
+        });
+    };
+
+    handleInvalid = (e) => {
+        e.preventDefault();
+        this.props.onInvalid(e);
+    };
+
+    handleSubmit = (e) => {
+        e.preventDefault();
+
+        if (this.state.value) {
+            this.setState({pending: true}, () => {
+                this.props.onChange(this.props.name, toInteger(this.state.value));
+            });
+        } else {
+            this.props.onInvalid();
+        }
+    };
+
+    render () {
+
+        const hasFeedback = this.state.pending || this.props.readOnly;
+
+        // Apply the "has-feedback" Bootstrap class to the input element if a setting save is pending.
+        const groupClass = CX("form-group", {"has-feedback": hasFeedback});
+
+        let feedbackIcon;
+
+        // If a settings save is pending show a spinner in the input element.
+        if (hasFeedback) {
+            feedbackIcon = (
+                <span className="form-control-feedback">
+                    <Icon name="lock" pending={this.state.pending} />
+                </span>
+            );
+        }
+
+        return (
+            <form onSubmit={this.handleSubmit}>
+                <div className={groupClass}>
+                    <InputError
+                        type="number"
+                        value={this.state.value}
+                        min={this.props.lowerLimit}
+                        max={this.props.upperLimit}
+                        onBlur={this.handleBlur}
+                        onChange={this.handleChange}
+                        onInvalid={this.handleInvalid}
+                        disabled={this.props.readOnly}
+                        noError
+                        noMargin
+                    />
+                    {feedbackIcon}
+                </div>
+            </form>
+        );
+    }
+}

--- a/client/src/js/administration/components/Jobs/Tasks.js
+++ b/client/src/js/administration/components/Jobs/Tasks.js
@@ -1,0 +1,108 @@
+import React from "react";
+import { forEach, map } from "lodash-es";
+import { connect } from "react-redux";
+import { Row, Col, ListGroup, Panel } from "react-bootstrap";
+
+import { updateSetting } from "../../actions";
+import { Flex, FlexItem, ListGroupItem, Icon } from "../../../base";
+import Task from "./Task";
+
+const taskNames = [
+    "create_sample",
+    "rebuild_index",
+    "create_subtraction",
+    "pathoscope_bowtie",
+    "nuvs"
+];
+
+const TasksFooter = () => (
+    <small>
+        <Flex className="text-warning">
+            <FlexItem grow={0} shrink={0}>
+                <Icon name="warning" />
+            </FlexItem>
+            <FlexItem grow={1} pad>
+                Changing CPU and memory settings will not affect jobs that have already been initialized.
+            </FlexItem>
+        </Flex>
+    </small>
+);
+
+const TaskLimits = (props) => {
+
+    const taskComponents = map(taskNames, taskPrefix =>
+        <Task
+            key={taskPrefix}
+            taskPrefix={taskPrefix}
+            proc={props.limits[taskPrefix].proc}
+            mem={props.limits[taskPrefix].mem}
+            inst={props.limits[taskPrefix].inst}
+            onChangeLimit={props.onChangeLimit}
+            procLowerLimit={1}
+            memLowerLimit={1}
+            currentLimitProc={props.resourceProc}
+            currentLimitMem={props.resourceMem}
+        />
+    );
+
+    return (
+        <Row>
+            <Col md={12}>
+                <h5><strong>Task-specific Limits</strong></h5>
+            </Col>
+            <Col md={6}>
+                <ListGroup>
+                    <ListGroupItem key="title">
+                        <Row>
+                            <Col md={4}>CPU</Col>
+                            <Col md={4}>Memory (GB)</Col>
+                            <Col md={4}>Instances</Col>
+                        </Row>
+                    </ListGroupItem>
+                    {taskComponents}
+                </ListGroup>
+            </Col>
+            <Col md={6}>
+                <Panel>
+                    <Panel.Body>
+                        Set limits on specific tasks.
+                    </Panel.Body>
+                    <Panel.Footer>
+                        <TasksFooter />
+                    </Panel.Footer>
+                </Panel>
+            </Col>
+        </Row>
+    );
+};
+
+const mapStateToProps = (state) => {
+    const limits = {};
+
+    forEach(taskNames, taskName => {
+        limits[taskName] = {
+            proc: state.settings.data[`${taskName}_proc`],
+            mem: state.settings.data[`${taskName}_mem`],
+            inst: state.settings.data[`${taskName}_inst`]
+        };
+    });
+
+    const settings = {
+        procLowerLimit: state.settings.data.rebuild_index_proc,
+        memLowerLimit: state.settings.data.rebuild_index_mem,
+        resourceProc: state.settings.data.proc,
+        resourceMem: state.settings.data.mem
+    };
+
+    return {limits, ...settings};
+};
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onChangeLimit: (taskPrefix, key, value) => {
+        dispatch(updateSetting(`${taskPrefix}_${key}`, value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TaskLimits);

--- a/client/src/js/administration/components/Server/HTTP.js
+++ b/client/src/js/administration/components/Server/HTTP.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { toNumber } from "lodash-es";
+import { connect } from "react-redux";
+import { Row, Col, Panel } from "react-bootstrap";
+
+import { updateSetting } from "../../actions";
+import { Checkbox, Icon, InputError } from "../../../base";
+
+const HTTPCheckboxLabel = () => (
+    <span>
+        Enable <a rel="noopener noreferrer" href="https://docs.virtool.ca/web-api.html" target="_blank">API</a>
+    </span>
+);
+
+const HTTPFooter = () => (
+    <small className="text-warning">
+        <Icon name="warning" /> Changes to these settings will only take effect when the server is reloaded.
+    </small>
+);
+
+const HTTPOptions = (props) => (
+    <Row>
+        <Col xs={12}>
+            <h5><strong>HTTP Server</strong></h5>
+        </Col>
+        <Col xs={12} md={6} mdPush={6}>
+            <Panel>
+                <Panel.Body>
+                    Change the address and port the the web server listens on.
+                </Panel.Body>
+                <Panel.Footer>
+                    <HTTPFooter />
+                </Panel.Footer>
+            </Panel>
+        </Col>
+        <Col xs={12} md={6} mdPull={6}>
+            <Panel>
+                <Panel.Body>
+                    <InputError
+                        label="Host"
+                        autoComplete={false}
+                        onSave={props.onUpdateHost}
+                        initialValue={props.host}
+                        noMargin
+                        withButton
+                    />
+                    <InputError
+                        label="Port"
+                        type="number"
+                        autoComplete={false}
+                        onSave={props.onUpdatePort}
+                        initialValue={props.port}
+                        noMargin
+                        withButton
+                    />
+                    <Checkbox
+                        label={<HTTPCheckboxLabel />}
+                        checked={props.enableApi}
+                        onClick={() => props.onUpdateAPI(!props.enableApi)}
+                    />
+                </Panel.Body>
+            </Panel>
+        </Col>
+    </Row>
+);
+
+const mapStateToProps = (state) => ({
+    host: state.settings.data.server_host,
+    port: state.settings.data.server_port,
+    enableApi: state.settings.data.enable_api
+});
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onUpdateHost: (e) => {
+        dispatch(updateSetting("server_host", e.value));
+    },
+
+    onUpdatePort: (e) => {
+        dispatch(updateSetting("server_port", toNumber(e.value)));
+    },
+
+    onUpdateAPI: (value) => {
+        dispatch(updateSetting("enable_api", value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(HTTPOptions);

--- a/client/src/js/administration/components/Server/Proxy.js
+++ b/client/src/js/administration/components/Server/Proxy.js
@@ -1,0 +1,186 @@
+import React from "react";
+import { ClipLoader } from "halogenium";
+import { connect } from "react-redux";
+import { Col, Panel, Row } from "react-bootstrap";
+
+import { testProxy, updateSetting } from "../../actions";
+import { Button, Checkbox, Flex, FlexItem, Icon, InputError } from "../../../base";
+
+const ProxyFooter = () => (
+    <small className="text-danger">
+        <Icon name="warning" /> Proxy authentication is stored in plain text in the settings file.
+    </small>
+);
+
+const ProxyTestIcon = ({ proxyTestPending, proxyTestSucceeded, proxyTestFailed }) => {
+
+    if (proxyTestPending) {
+        return (
+            <div style={{padding: "0 1px"}}>
+                <ClipLoader size="12px" color="#333" />
+            </div>
+        );
+    }
+
+    let iconName = "cloud";
+    let iconStyle;
+
+    if (proxyTestSucceeded) {
+        iconName = "checkmark";
+        iconStyle = "success";
+    }
+
+    if (proxyTestFailed) {
+        iconName = "blocked";
+        iconStyle = "danger";
+    }
+
+    return <Icon name={iconName} bsStyle={iconStyle} />;
+
+};
+
+const ProxyOptions = (props) => {
+
+    const disableInputs = !props.enabled || props.trust;
+
+    const errorProxyAddress = props.proxyTestFailed || null;
+
+    return (
+        <Row>
+            <Col xs={12}>
+                <Row>
+                    <Col xs={12} md={6}>
+                        <Flex alignItems="center" style={{marginBottom: "10px"}}>
+                            <FlexItem grow={1}>
+                                <strong>Proxy</strong>
+                            </FlexItem>
+                            <FlexItem>
+                                <Checkbox
+                                    label="Enable"
+                                    checked={props.enabled}
+                                    onClick={() => props.onToggle(!props.enabled)}
+                                />
+                            </FlexItem>
+                        </Flex>
+                    </Col>
+                    <Col smHidden md={6} />
+                </Row>
+            </Col>
+
+            <Col xs={12} md={6} mdPush={6}>
+                <Panel>
+                    <Panel.Body>
+                        Configure the server to use a proxy for outgoing requests.
+                    </Panel.Body>
+                    <Panel.Footer>
+                        <ProxyFooter />
+                    </Panel.Footer>
+                </Panel>
+            </Col>
+            <Col xs={12} md={6} mdPull={6}>
+                <Panel>
+                    <Panel.Body>
+                        <InputError
+                            label="Address"
+                            autoComplete={false}
+                            onSave={props.onUpdateAddress}
+                            initialValue={props.address}
+                            disabled={disableInputs}
+                            error={errorProxyAddress}
+                            noMargin
+                            withButton
+                        />
+                        <InputError
+                            label="Username"
+                            autoComplete={false}
+                            onSave={props.onUpdateUsername}
+                            initialValue={props.username}
+                            disabled={disableInputs}
+                            noMargin
+                            withButton
+                        />
+                        <InputError
+                            label="Password"
+                            type="password"
+                            autoComplete={false}
+                            onSave={props.onUpdatePassword}
+                            initialValue={props.password}
+                            disabled={disableInputs}
+                            noMargin
+                            withButton
+                        />
+                        <Flex alignItems="center">
+                            <FlexItem grow={1} shrink={0}>
+                                <Checkbox
+                                    label="Trust Environmental Variables"
+                                    checked={props.trust}
+                                    onClick={() => props.onUpdateTrust(!props.trust)}
+                                    disabled={!props.enabled}
+                                />
+                            </FlexItem>
+                            <FlexItem grow={0} shrink={0}>
+                                <Button onClick={props.onTest} disabled={!props.enabled} pullRight>
+                                    <Flex>
+                                        <FlexItem>
+                                            <ProxyTestIcon {...props} />
+                                        </FlexItem>
+                                        <FlexItem pad>
+                                            Test
+                                        </FlexItem>
+                                    </Flex>
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    </Panel.Body>
+                </Panel>
+            </Col>
+        </Row>
+    );
+};
+
+const mapStateToProps = (state) => {
+
+    const { data, proxyTestPending, proxyTestSucceeded, proxyTestFailed } = state.settings;
+
+    return {
+        address: data.proxy_address,
+        enabled: data.proxy_enable,
+        username: data.proxy_username,
+        password: data.proxy_password,
+        trust: data.proxy_trust,
+
+        proxyTestPending,
+        proxyTestSucceeded,
+        proxyTestFailed
+    };
+};
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onTest: () => {
+        dispatch(testProxy());
+    },
+
+    onToggle: (value) => {
+        dispatch(updateSetting("proxy_enable", value));
+    },
+
+    onUpdateAddress: (e) => {
+        dispatch(updateSetting("proxy_address", e.value));
+    },
+
+    onUpdateUsername: (e) => {
+        dispatch(updateSetting("proxy_username", e.value));
+    },
+
+    onUpdatePassword: (e) => {
+        dispatch(updateSetting("proxy_password", e.value));
+    },
+
+    onUpdateTrust: (value) => {
+        dispatch(updateSetting("proxy_trust", value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProxyOptions);

--- a/client/src/js/administration/components/Server/Sentry.js
+++ b/client/src/js/administration/components/Server/Sentry.js
@@ -1,0 +1,58 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Row, Col, Panel } from "react-bootstrap";
+
+import { updateSetting } from "../../actions";
+import { Button, Icon, Checkbox } from "../../../base";
+
+const SentryFooter = () => (
+    <small className="text-warning">
+        <Icon name="warning" /> Changes to these settings will only take effect when the server is reloaded.
+    </small>
+);
+
+const SentryOptions = ({ enabled, onToggle }) => (
+    <div>
+        <Row>
+            <Col xs={12}>
+                <label>Sentry</label>
+            </Col>
+        </Row>
+        <Row>
+            <Col xs={12} md={6} mdPush={6}>
+                <Panel>
+                    <Panel.Body>
+                        Enable or disable Sentry error reporting.
+                         Error reporting allows the developers to prevent future errors.
+                    </Panel.Body>
+                    <Panel.Footer>
+                        <SentryFooter />
+                    </Panel.Footer>
+                </Panel>
+            </Col>
+            <Col xs={12} md={6} mdPull={6}>
+                <Panel>
+                    <Panel.Body>
+                        <Button onClick={() => {onToggle(!enabled)}} block>
+                            <Checkbox checked={enabled} /> Enable
+                        </Button>
+                    </Panel.Body>
+                </Panel>
+            </Col>
+        </Row>
+    </div>
+);
+
+const mapStateToProps = (state) => ({
+    enabled: state.settings.data.enable_sentry
+});
+
+const mapDispatchToProps = (dispatch) => ({
+
+    onToggle: (value) => {
+        dispatch(updateSetting("enable_sentry", value));
+    }
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SentryOptions);

--- a/client/src/js/administration/components/Settings.js
+++ b/client/src/js/administration/components/Settings.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Switch, Redirect, Route } from "react-router-dom";
+import { Nav, NavItem } from "react-bootstrap";
+import { LinkContainer } from "react-router-bootstrap";
+
+import HTTP from "./Server/HTTP";
+import Proxy from "./Server/Proxy";
+import Sentry from "./Server/Sentry";
+import Data from "./Data";
+import Users from "../../users/components/Users";
+import Updates from "../../updates/components/Viewer";
+import { LoadingPlaceholder } from "../../base";
+
+const Server = () => (
+    <div>
+        <HTTP />
+        <Proxy />
+        <Sentry />
+    </div>
+);
+
+const Settings = ({ settings }) => {
+    let content;
+
+    if (settings === null) {
+        content = <LoadingPlaceholder />;
+    } else {
+        content = (
+            <Switch>
+                <Redirect from="/administration" to="/administration/server" exact />
+                <Route path="/administration/server" component={Server} />
+                <Route path="/administration/data" component={Data} />
+                <Route path="/administration/users" component={Users} />
+                <Route path="/administration/updates" component={Updates} />
+            </Switch>
+        );
+    }
+
+    return (
+        <div className="container-noside">
+            <h3 className="view-header">
+                <strong>
+                    Administration
+                </strong>
+            </h3>
+
+            <Nav bsStyle="tabs">
+                <LinkContainer to="/administration/server">
+                    <NavItem>Server</NavItem>
+                </LinkContainer>
+                <LinkContainer to="/administration/data">
+                    <NavItem>Data</NavItem>
+                </LinkContainer>
+                <LinkContainer to="/administration/users">
+                    <NavItem>Users</NavItem>
+                </LinkContainer>
+                <LinkContainer to="/administration/updates">
+                    <NavItem>Updates</NavItem>
+                </LinkContainer>
+            </Nav>
+
+            {content}
+        </div>
+    );
+};
+
+const mapStateToProps = (state) => ({
+    settings: state.settings.data
+});
+
+export default connect(mapStateToProps)(Settings);

--- a/client/src/js/administration/reducer.js
+++ b/client/src/js/administration/reducer.js
@@ -1,0 +1,60 @@
+import { GET_CONTROL_READAHEAD, GET_SETTINGS, TEST_PROXY, UPDATE_SETTINGS } from "../actionTypes";
+
+export const initialState = {
+    data: null,
+    readahead: null,
+    readaheadPending: false,
+    proxyTestPending: false,
+    proxyTestSucceeded: false,
+    proxyTestFailed: false
+};
+
+export const proxyTestClear = {
+    proxyTestPending: false,
+    proxyTestSucceeded: false,
+    proxyTestFailed: false
+};
+
+export default function settingsReducer (state = initialState, action) {
+
+    switch (action.type) {
+
+        case GET_SETTINGS.SUCCEEDED:
+            return {...state, data: action.data, ...proxyTestClear};
+
+        case UPDATE_SETTINGS.SUCCEEDED:
+            return {...state, data: {...state.data, ...action.update}, ...proxyTestClear};
+
+        case UPDATE_SETTINGS.FAILED:
+            return {
+                ...state,
+                data: {
+                    ...state.data,
+                    updateError: {status: action.status, message: action.message}
+                },
+                ...proxyTestClear
+            };
+
+        case GET_CONTROL_READAHEAD.REQUESTED:
+            return {...state, readaheadPending: true};
+
+        case GET_CONTROL_READAHEAD.SUCCEEDED:
+            return {...state, readahead: action.data, readaheadPending: false};
+
+        case GET_CONTROL_READAHEAD.FAILED:
+            return {...state, readaheadPending: false};
+
+        case TEST_PROXY.REQUESTED:
+            return {...state, ...proxyTestClear, proxyTestPending: true};
+
+        case TEST_PROXY.SUCCEEDED:
+            return {...state, ...proxyTestClear, proxyTestSucceeded: true};
+
+        case TEST_PROXY.FAILED:
+            return {...state, ...proxyTestClear, proxyTestFailed: action.message};
+
+        default:
+            return state;
+    }
+
+}

--- a/client/src/js/administration/sagas.js
+++ b/client/src/js/administration/sagas.js
@@ -1,0 +1,41 @@
+import { put, takeEvery, takeLatest, throttle } from "redux-saga/effects";
+
+import * as settingsAPI from "./api";
+import * as virusesAPI from "../references/api";
+import { apiCall, setPending, putGenericError } from "../sagaUtils";
+import {GET_SETTINGS, UPDATE_SETTINGS, GET_CONTROL_READAHEAD, TEST_PROXY} from "../actionTypes";
+
+export function* watchSettings () {
+    yield throttle(120, GET_CONTROL_READAHEAD.REQUESTED, getControlReadahead);
+    yield takeLatest(GET_SETTINGS.REQUESTED, getSettings);
+    yield takeLatest(TEST_PROXY.REQUESTED, testProxy);
+    yield takeEvery(UPDATE_SETTINGS.REQUESTED, updateSettings);
+}
+
+function* getSettings (action) {
+    yield apiCall(settingsAPI.get, action, GET_SETTINGS);
+}
+
+function* updateSettings (action) {
+    yield setPending(function* (action) {
+        try {
+            const response = yield settingsAPI.update(action);
+            yield put({
+                type: UPDATE_SETTINGS.SUCCEEDED,
+                settings: response.body,
+                key: action.key,
+                update: action.update
+            });
+        } catch (error) {
+            yield putGenericError(UPDATE_SETTINGS, error);
+        }
+    }(action));
+}
+
+function* testProxy () {
+    yield apiCall(settingsAPI.proxy, {}, TEST_PROXY);
+}
+
+function* getControlReadahead (action) {
+    yield setPending(apiCall(virusesAPI.listNames, action, GET_CONTROL_READAHEAD));
+}

--- a/client/src/js/administration/selectors.js
+++ b/client/src/js/administration/selectors.js
@@ -1,0 +1,41 @@
+import { createSelector } from "reselect";
+import { endsWith, flatMap, keys, map, max, pick } from "lodash-es";
+
+import { taskDisplayNames } from "../utils";
+
+const getMaximumTaskLimit = (limits, type) => (
+    max(map(limits, (value, key) =>
+        endsWith(key, type) ? value : 0
+    ))
+);
+
+const taskLimitKeys = flatMap(keys(taskDisplayNames), name => [`${name}_proc`, `${name}_mem`]);
+
+const taskSpecificLimitSelector = state => pick(state.settings.data, taskLimitKeys);
+
+const resourcesSelector = state => state.jobs.resources;
+
+export const maxResourcesSelector = createSelector(
+    [resourcesSelector],
+    resources => {
+        if (resources === null) {
+            return {
+                maxProc: 1,
+                maxMem: 1
+            };
+        }
+
+        const maxProc = resources.proc.length;
+        const maxMem = Math.floor(resources.mem.total / Math.pow(1024, 3));
+
+        return { maxProc, maxMem };
+    }
+);
+
+export const minResourcesSelector = createSelector(
+    [taskSpecificLimitSelector],
+    (limits) => ({
+        minProc: getMaximumTaskLimit(limits, "proc"),
+        minMem: getMaximumTaskLimit(limits, "mem")
+    })
+);

--- a/client/src/js/administration/settings-actions.test.js
+++ b/client/src/js/administration/settings-actions.test.js
@@ -1,0 +1,71 @@
+import {
+    getSettings,
+    getControlReadahead,
+    testProxy,
+    updateSetting,
+    updateSettings
+} from "./actions";
+import {
+    GET_SETTINGS,
+    UPDATE_SETTINGS,
+    GET_CONTROL_READAHEAD,
+    TEST_PROXY
+} from "../actionTypes";
+
+describe("Settings Action Creators:", () => {
+
+    it("getSettings: returns simple action", () => {
+        const result = getSettings();
+        const expected = {
+            type: "GET_SETTINGS_REQUESTED"
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("getControlReadahead: returns action to get search term matches", () => {
+        const term = "searchterm";
+        const result = getControlReadahead(term);
+        const expected = {
+            type: "GET_CONTROL_READAHEAD_REQUESTED",
+            term
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("testProxy: returns simple action", () => {
+        const result = testProxy();
+        const expected = {
+            type: "TEST_PROXY_REQUESTED"
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("updateSetting: returns action to update one setting via updateSettings()", () => {
+        const key = "test_setting";
+        const value = 1;
+        const result = updateSetting(key, value);
+        const expected = {
+            type: "UPDATE_SETTINGS_REQUESTED",
+            update: {
+                [key]: value
+            }
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("updateSettings: returns action to update multiple settings", () => {
+        const update = {};
+        const result = updateSettings(update);
+        const expected = {
+            type: "UPDATE_SETTINGS_REQUESTED",
+            update
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+});

--- a/client/src/js/administration/settings-reducer.test.js
+++ b/client/src/js/administration/settings-reducer.test.js
@@ -1,0 +1,167 @@
+import reducer, {
+    initialState as reducerInitialState,
+    proxyTestClear
+} from "./reducer";
+import {
+    GET_CONTROL_READAHEAD,
+    GET_SETTINGS,
+    TEST_PROXY,
+    UPDATE_SETTINGS
+} from "../actionTypes";
+
+describe("Settings Reducer", () => {
+
+    const initialState = reducerInitialState;
+    let state;
+    let action;
+    let result;
+    let expected;
+
+    it("should return the initial state on first pass", () => {
+        result = reducer(undefined, {});
+        expected = initialState;
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should return the given state on other action types", () => {
+        action = {
+            type: "UNHANDLED_ACTION"
+        };
+        result = reducer(initialState, action);
+        expected = initialState;
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle GET_SETTINGS_SUCCEEDED", () => {
+        state = {};
+        action = {
+            type: "GET_SETTINGS_SUCCEEDED",
+            data: {},
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            data: action.data,
+            ...proxyTestClear
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle UPDATE_SETTINGS_SUCCEEDED", () => {
+        state = {
+            data: {
+                test: "target"
+            }
+        };
+        action = {
+            type: "UPDATE_SETTINGS_SUCCEEDED",
+            update: {
+                test: "target_updated"
+            }
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            data: {
+                ...state.data,
+                ...action.update
+            },
+            ...proxyTestClear
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle GET_CONTROL_READAHEAD_REQUESTED", () => {
+        state = {};
+        action = {
+            type: "GET_CONTROL_READAHEAD_REQUESTED"
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            readaheadPending: true
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle GET_CONTROL_READAHEAD_SUCCEEDED", () => {
+        state = {};
+        action = {
+            type: "GET_CONTROL_READAHEAD_SUCCEEDED",
+            data: {}
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            readahead: action.data,
+            readaheadPending: false
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle GET_CONTROL_READAHEAD_FAILED", () => {
+        state = {};
+        action = {
+            type: "GET_CONTROL_READAHEAD_FAILED"
+        };
+        result = reducer(state, action);
+        expected = {
+            readaheadPending: false
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle TEST_PROXY_REQUESTED", () => {
+        state = {};
+        action = {
+            type: "TEST_PROXY_REQUESTED"
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            ...proxyTestClear,
+            proxyTestPending: true
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle TEST_PROXY_SUCCEEDED", () => {
+        state = {};
+        action = {
+            type: "TEST_PROXY_SUCCEEDED"
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            ...proxyTestClear,
+            proxyTestSucceeded: true
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle TEST_PROXY_FAILED", () => {
+        state = {};
+        action = {
+            type: "TEST_PROXY_FAILED",
+            message: "test_failed"
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            ...proxyTestClear,
+            proxyTestFailed: action.message
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+});

--- a/client/src/js/files/components/Manager.js
+++ b/client/src/js/files/components/Manager.js
@@ -8,7 +8,7 @@ import { push } from "react-router-redux";
 import File from "./File";
 import { findFiles, removeFile, upload, uploadProgress } from "../actions";
 import { Alert, Button, LoadingPlaceholder, NoneFound, Pagination, ViewHeader } from "../../base";
-import { createRandomString } from "../../utils";
+import { createRandomString, checkAdminOrPermission } from "../../utils";
 
 class FileManager extends React.Component {
 
@@ -50,7 +50,7 @@ class FileManager extends React.Component {
 
         let toolbar;
 
-        if (this.props.canUpload) {
+        if (checkAdminOrPermission(this.props.isAdmin, this.props.permissions, "upload_file")) {
             toolbar = (
                 <div className="toolbar">
                     <Dropzone
@@ -111,7 +111,8 @@ const mapStateToProps = (state) => {
         page,
         page_count,
         total_count,
-        canUpload: state.account.permissions.upload_file
+        permissions: state.account.permissions,
+        isAdmin: state.account.administrator
     };
 };
 

--- a/client/src/js/index.js
+++ b/client/src/js/index.js
@@ -6,7 +6,7 @@ import App from "./App";
 import WSConnection from "./websocket";
 import createHistory from "history/createBrowserHistory";
 import { getAccount } from "./account/actions";
-import { getSettings } from "./settings/actions";
+import { getSettings } from "./administration/actions";
 import { createStore, combineReducers, applyMiddleware } from "redux";
 import createSagaMiddleware from "redux-saga";
 import { routerReducer, routerMiddleware } from "react-router-redux";
@@ -23,7 +23,7 @@ import jobsReducer from "./jobs/reducer";
 import subtractionReducer from "./subtraction/reducer";
 import referencesReducer from "./references/reducer";
 import samplesReducer from "./samples/reducer";
-import settingsReducer from "./settings/reducer";
+import settingsReducer from "./administration/reducer";
 import updatesReducer from "./updates/reducer";
 import usersReducer from "./users/reducer";
 

--- a/client/src/js/jobs/components/Jobs.js
+++ b/client/src/js/jobs/components/Jobs.js
@@ -6,8 +6,8 @@ import { findJobs } from "../actions";
 import JobsList from "./List";
 import JobDetail from "./Detail";
 import JobsResources from "./Resources";
-import Resources from "../../settings/components/Jobs/Resources";
-import Tasks from "../../settings/components/Jobs/Tasks";
+import Resources from "../../administration/components/Jobs/Resources";
+import Tasks from "../../administration/components/Jobs/Tasks";
 import { LoadingPlaceholder } from "../../base";
 
 const JobsSettings = () => (

--- a/client/src/js/nav/components/Icon.js
+++ b/client/src/js/nav/components/Icon.js
@@ -42,22 +42,26 @@ class NotificationIcon extends React.Component {
 
         const iconStyle = availableUpdates ? "icon-pulse" : "icon";
 
-        return (
-            <div>
-                <div ref={node => this.target = node} onClick={this.state.show ? null : this.handleToggle}>
-                    <Icon
-                        className={iconStyle}
-                        name="notification"
-                        tip="Click to see notifications"
-                        tipPlacement="left"
-                    />
-                </div>
+        if (this.props.isAdmin) {
+            return (
+                <div>
+                    <div ref={node => this.target = node} onClick={this.state.show ? null : this.handleToggle}>
+                        <Icon
+                            className={iconStyle}
+                            name="notification"
+                            tip="Click to see notifications"
+                            tipPlacement="left"
+                        />
+                    </div>
 
-                <Overlay show={this.state.show} placement="bottom" target={this.target}>
-                    <Notifications onClick={this.handleToggle} />
-                </Overlay>
-            </div>
-        );
+                    <Overlay show={this.state.show} placement="bottom" target={this.target}>
+                        <Notifications onClick={this.handleToggle} />
+                    </Overlay>
+                </div>
+            );
+        }
+
+        return <div />;
     }
 }
 

--- a/client/src/js/samples/selectors.js
+++ b/client/src/js/samples/selectors.js
@@ -13,7 +13,7 @@ export const getCanModify = createSelector(
 
         return (
             sample.all_write ||
-            includes(account.groups, "administrator") ||
+            account.administrator ||
             sample.group_write && includes(account.groups, sample.group)
         );
     }

--- a/client/src/js/users/actions.js
+++ b/client/src/js/users/actions.js
@@ -8,8 +8,7 @@ import {
     LIST_USERS,
     FILTER_USERS,
     CREATE_USER,
-    ADD_USER_TO_GROUP,
-    REMOVE_USER_FROM_GROUP, EDIT_USER
+    EDIT_USER
 } from "../actionTypes";
 
 /**
@@ -58,32 +57,4 @@ export const editUser = (userId, update) => ({
     type: EDIT_USER.REQUESTED,
     userId,
     update
-});
-
-/**
- * Returns action that can trigger an API call for adding a user to a group.
- *
- * @func
- * @param userId {string} unique user id
- * @param groupId {string} unique group id
- * @returns {object}
- */
-export const addUserToGroup = (userId, groupId) => ({
-    type: ADD_USER_TO_GROUP.REQUESTED,
-    userId,
-    groupId
-});
-
-/**
- * Returns action that can trigger an API call for removing a user from a group.
- *
- * @func
- * @param userId {string} unique user id
- * @param groupId {string} unique group id
- * @returns {object}
- */
-export const removeUserFromGroup = (userId, groupId) => ({
-    type: REMOVE_USER_FROM_GROUP.REQUESTED,
-    userId,
-    groupId
 });

--- a/client/src/js/users/api.js
+++ b/client/src/js/users/api.js
@@ -21,13 +21,3 @@ export const edit = ({ userId, update }) => (
     Request.patch(`/api/users/${userId}`)
         .send(update)
 );
-
-export const addUserToGroup = ({ userId, groupId }) => (
-    Request.post(`/api/users/${userId}/groups`, {
-        group_id: groupId
-    })
-);
-
-export const removeUserFromGroup = ({ userId, groupId }) => (
-    Request.delete(`/api/users/${userId}/groups/${groupId}`)
-);

--- a/client/src/js/users/components/Groups.js
+++ b/client/src/js/users/components/Groups.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { includes, map } from "lodash-es";
+import { includes, map, remove } from "lodash-es";
 import { connect } from "react-redux";
 import { Row, Col, Panel } from "react-bootstrap";
 import { ListGroupItem, Checkbox } from "../../base";
 
-import { addUserToGroup, removeUserFromGroup, listUsers } from "../actions";
+import { editUser, listUsers } from "../actions";
 
 class UserGroup extends React.Component {
 
@@ -15,14 +15,19 @@ class UserGroup extends React.Component {
     }
 
     handleClick = () => {
-        const { groupId, userId } = this.props;
+        const { userGroups, groupId, userId } = this.props;
+        let newGroups;
 
         if (this.props.toggled) {
-            return this.props.onRemoveFromGroup(userId, groupId);
+            newGroups = remove(userGroups, (group) =>
+                group !== groupId
+            );
+            return this.props.onEditGroup(userId, newGroups);
         }
 
-        this.props.onAddToGroup(userId, groupId);
-
+        newGroups = userGroups.slice();
+        newGroups.push(groupId);
+        this.props.onEditGroup(userId, newGroups);
     };
 
     render () {
@@ -41,18 +46,17 @@ class UserGroup extends React.Component {
     }
 }
 
-const UserGroups = ({ accountUserId, addToGroup, allGroups, memberGroups, removeFromGroup, userId, list }) => {
+const UserGroups = ({ accountUserId, allGroups, memberGroups, EditGroup, userId, list }) => {
 
     const groupComponents = map(allGroups, groupId =>
         <UserGroup
             key={groupId}
             groupId={groupId}
+            userGroups={memberGroups}
             accountUserId={accountUserId}
             userId={userId}
-            disabled={groupId === "administrator" && userId === accountUserId}
             toggled={includes(memberGroups, groupId)}
-            onAddToGroup={addToGroup}
-            onRemoveFromGroup={removeFromGroup}
+            onEditGroup={EditGroup}
             onListUsers={list}
         />
     );
@@ -75,12 +79,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
 
-    addToGroup: (userId, groupId) => {
-        dispatch(addUserToGroup(userId, groupId));
-    },
-
-    removeFromGroup: (userId, groupId) => {
-        dispatch(removeUserFromGroup(userId, groupId));
+    EditGroup: (userId, groups) => {
+        dispatch(editUser(userId, { groups }));
     },
 
     list: () => {

--- a/client/src/js/users/components/User.js
+++ b/client/src/js/users/components/User.js
@@ -93,7 +93,7 @@ export class UserItem extends React.Component {
         }
 
         return (
-            <LinkContainer to={`/settings/users/${this.props.id}`} style={{paddingLeft: "10px"}}>
+            <LinkContainer to={`/administration/users/${this.props.id}`} style={{paddingLeft: "10px"}}>
                 <ListGroupItem className="spaced">
                     {identifier}
                 </ListGroupItem>
@@ -109,7 +109,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
 
     onClose: () => {
-        dispatch(push("/settings/users"));
+        dispatch(push("/administration/users"));
     },
 
     onSetPrimaryGroup: (userId, groupId) => {

--- a/client/src/js/users/components/Users.js
+++ b/client/src/js/users/components/Users.js
@@ -85,8 +85,8 @@ export class ManageUsers extends React.Component {
                     </Col>
                     <Col xs={12}>
                         <Switch>
-                            <Route path="/settings/users" component={UsersList} exact />
-                            <Route path="/settings/users/:activeId" component={UsersList} />
+                            <Route path="/administration/users" component={UsersList} exact />
+                            <Route path="/administration/users/:activeId" component={UsersList} />
                         </Switch>
                     </Col>
                 </Row>

--- a/client/src/js/users/reducer.js
+++ b/client/src/js/users/reducer.js
@@ -4,9 +4,7 @@ import {
     LIST_USERS,
     FILTER_USERS,
     CREATE_USER,
-    EDIT_USER,
-    ADD_USER_TO_GROUP,
-    REMOVE_USER_FROM_GROUP
+    EDIT_USER
 } from "../actionTypes";
 
 export const initialState = {
@@ -43,10 +41,6 @@ const reducer = (state = initialState, action) => {
 
         case EDIT_USER.SUCCEEDED:
             return updateUser(state, action.data);
-
-        case ADD_USER_TO_GROUP.SUCCEEDED:
-        case REMOVE_USER_FROM_GROUP.SUCCEEDED:
-            return updateUser(state, {groups: action.data, id: action.id});
 
         case CREATE_USER.REQUESTED:
             return {...state, createPending: true};

--- a/client/src/js/users/sagas.js
+++ b/client/src/js/users/sagas.js
@@ -6,9 +6,7 @@ import * as usersAPI from "./api";
 import {
     LIST_USERS,
     CREATE_USER,
-    EDIT_USER,
-    ADD_USER_TO_GROUP,
-    REMOVE_USER_FROM_GROUP
+    EDIT_USER
 } from "../actionTypes";
 
 function* listUsers (action) {
@@ -24,7 +22,7 @@ function* createUser (action) {
             yield put({type: actionType.SUCCEEDED, data: response.body, ...extra});
 
             // Close the create user modal and navigate to the new user.
-            yield put(push(`/settings/users/${action.userId}`, {state: {createUser: false}}));
+            yield put(push(`/administration/users/${action.userId}`, {state: {createUser: false}}));
         } catch (error) {
             yield putGenericError(actionType, error);
         }
@@ -35,18 +33,8 @@ function* editUser (action) {
     yield setPending(apiCall(usersAPI.edit, action, EDIT_USER));
 }
 
-function* addToGroup (action) {
-    yield setPending(apiCall(usersAPI.addUserToGroup, action, ADD_USER_TO_GROUP, {id: action.userId}));
-}
-
-function* removeFromGroup (action) {
-    yield setPending(apiCall(usersAPI.removeUserFromGroup, action, REMOVE_USER_FROM_GROUP, {id: action.userId}));
-}
-
 export function* watchUsers () {
     yield takeLatest(LIST_USERS.REQUESTED, listUsers);
     yield throttle(200, CREATE_USER.REQUESTED, createUser);
     yield takeEvery(EDIT_USER.REQUESTED, editUser);
-    yield takeEvery(ADD_USER_TO_GROUP.REQUESTED, addToGroup);
-    yield takeEvery(REMOVE_USER_FROM_GROUP.REQUESTED, removeFromGroup);
 }

--- a/client/src/js/users/users-actions.test.js
+++ b/client/src/js/users/users-actions.test.js
@@ -59,30 +59,4 @@ describe("Users Action Creators:", () => {
         expect(result).toEqual(expected);
     });
 
-    it("addUserToGroup: returns action to add user to a group", () => {
-        const userId = "testid";
-        const groupId = "groupid";
-        const result = addUserToGroup(userId, groupId);
-        const expected = {
-            type: "ADD_USER_TO_GROUP_REQUESTED",
-            userId,
-            groupId
-        };
-
-        expect(result).toEqual(expected);
-    });
-
-    it("removeUserFromGroup: returns action to remove user from group", () => {
-        const userId = "testid";
-        const groupId = "groupId";
-        const result = removeUserFromGroup(userId, groupId);
-        const expected = {
-            type: "REMOVE_USER_FROM_GROUP_REQUESTED",
-            userId,
-            groupId
-        };
-
-        expect(result).toEqual(expected);
-    });
-
 });

--- a/client/src/js/users/users-reducer.test.js
+++ b/client/src/js/users/users-reducer.test.js
@@ -122,52 +122,6 @@ describe("Users Reducer", () => {
         expect(result).toEqual(expected);
     });
 
-    it("should handle ADD_USER_TO_GROUP_SUCCEEDED", () => {
-        state = {
-            list: [
-                { id: "admin", groups: [] },
-                { id: "user", groups: [] }
-            ]
-        };
-        action = {
-            type: "ADD_USER_TO_GROUP_SUCCEEDED",
-            id: "user",
-            data: [ "test_group" ]
-        };
-        result = reducer(state, action);
-        expected = {
-            list: [
-                { id: "admin", groups: [] },
-                { id: "user", groups: [ "test_group" ] }
-            ]
-        };
-
-        expect(result).toEqual(expected);
-    });
-    
-    it("should handle REMOVE_USER_FROM_GROUP_SUCCEEDED", () => {
-        state = {
-            list: [
-                { id: "admin", groups: [] },
-                { id: "user", groups: [ "test_group" ] }
-            ]
-        };
-        action = {
-            type: "REMOVE_USER_FROM_GROUP_SUCCEEDED",
-            id: "user",
-            data: []
-        };
-        result = reducer(state, action);
-        expected = {
-            list: [
-                { id: "admin", groups: [] },
-                { id: "user", groups: [] }
-            ]
-        };
-
-        expect(result).toEqual(expected);
-    });
-
     it("should handle CREATE_USER_REQUESTED", () => {
         state = {};
         action = {

--- a/client/src/js/utils.js
+++ b/client/src/js/utils.js
@@ -184,3 +184,7 @@ export const toScientificNotation = (number) => {
 
     return Numeral(number).format("0.000");
 };
+
+export const checkAdminOrPermission = (isAdmin, permissions, permission) => (
+    isAdmin || permissions[permission]
+);


### PR DESCRIPTION
- resolves #548 
- removed `addUserToGroup` and `removeUserFromGroup` actions and related methods, instead group membership is updated through `editUser`
- software update Icon in navbar only shows for administrators
- added function to check administrator and permission settings in utils.js
- deprecated settings directory files moved to administration (but settings directory not removed yet)