### PR TITLE
Group edit API

### DIFF
--- a/client/src/js/groups/api.js
+++ b/client/src/js/groups/api.js
@@ -9,13 +9,14 @@ export const create = ({ groupId }) => (
         .send({group_id: groupId})
 );
 
-export const setPermission = ({ groupId, permission, value }) => {
-    const update = {};
-    update[permission] = value;
-
-    return Request.patch(`/api/groups/${groupId}`)
-        .send(update);
-};
+export const setPermission = ({ groupId, permission, value }) => (
+    Request.patch(`/api/groups/${groupId}`)
+        .send({
+            permissions: {
+                [permission]: value
+            }
+        })
+);
 
 export const remove = ({ groupId }) => (
     Request.delete(`/api/groups/${groupId}`)

--- a/client/src/js/groups/components/Groups.js
+++ b/client/src/js/groups/components/Groups.js
@@ -7,7 +7,7 @@ import { push } from "react-router-redux";
 import { listGroups, createGroup, setGroupPermission, removeGroup } from "../actions";
 import { clearError } from "../../errors/actions";
 import { AutoProgressBar, Button, Icon, InputError, ListGroupItem, LoadingPlaceholder } from "../../base";
-import {routerLocationHasState} from "../../utils";
+import { routerLocationHasState } from "../../utils";
 
 class Group extends React.Component {
 
@@ -188,7 +188,7 @@ class Groups extends React.Component {
                         key={key}
                         onClick={() => this.props.onSetPermission(activeGroup.id, key, !value)}
                     >
-                        <code>{key}</code> <Icon name={`checkbox-${value ? "checked" : "unchecked"}`} pullRight />
+                        <code>{key}</code> <Icon faStyle="far" name={value ? "check-square" : "square"} pullRight />
                     </ListGroupItem>
                 );
 
@@ -228,11 +228,9 @@ class Groups extends React.Component {
                         <Col md={7}>
                             <Panel>
                                 <Panel.Heading>Permissions</Panel.Heading>
-                                <Panel.Body>
-                                    <ListGroup style={{marginBottom: "10px"}}>
-                                        {permissionComponents}
-                                    </ListGroup>
-                                </Panel.Body>
+                                <ListGroup>
+                                    {permissionComponents}
+                                </ListGroup>
                             </Panel>
 
                             <Panel>

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -155,7 +155,9 @@ class TestUpdatePermissions:
         })
 
         resp = await client.patch("/api/groups/test", data={
-            "create_sample": True
+            "permissions": {
+                "create_sample": True
+            }
         })
 
         assert resp.status == 200
@@ -185,11 +187,13 @@ class TestUpdatePermissions:
         })
 
         resp = await client.patch("/api/groups/test", data={
-            "foo_bar": True
+            "permissions": {
+                "foo_bar": True
+            }
         })
 
         assert await resp_is.invalid_input(resp, {
-            "foo_bar": ["unknown field"]
+            "permissions": ["Keys must be valid permissions"]
         })
 
     async def test_not_found(self, spawn_client, resp_is):
@@ -200,7 +204,9 @@ class TestUpdatePermissions:
         client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])
 
         resp = await client.patch("/api/groups/test", data={
-            "create_sample": True
+            "permissions": {
+                "create_sample": True
+            }
         })
 
         assert await resp_is.not_found(resp)

--- a/virtool/api/groups.py
+++ b/virtool/api/groups.py
@@ -6,6 +6,7 @@ import virtool.db.users
 import virtool.http.routes
 import virtool.users
 import virtool.utils
+import virtool.validators
 from virtool.api.utils import conflict, json_response, not_found, no_content
 
 routes = virtool.http.routes.Routes()
@@ -68,14 +69,19 @@ async def get(req):
 
 
 @routes.patch("/api/groups/{group_id}", admin=True, schema={
-    key: {"type": "boolean"} for key in virtool.users.PERMISSIONS
+    "permissions": {
+        "type": dict,
+        "default": {},
+        "validator": virtool.validators.is_permission_dict
+    }
 })
 async def update_permissions(req):
     """
     Updates the permissions of a given group.
 
     """
-    db, data = req.app["db"], req["data"]
+    db = req.app["db"]
+    data = req["data"]
 
     group_id = req.match_info["group_id"]
 
@@ -84,7 +90,7 @@ async def update_permissions(req):
     if not old_document:
         return not_found()
 
-    old_document["permissions"].update(data)
+    old_document["permissions"].update(data["permissions"])
 
     # Get the current permissions dict for the passed group id.
     document = await db.groups.find_one_and_update({"_id": group_id}, {

--- a/virtool/api/groups.py
+++ b/virtool/api/groups.py
@@ -70,7 +70,7 @@ async def get(req):
 
 @routes.patch("/api/groups/{group_id}", admin=True, schema={
     "permissions": {
-        "type": dict,
+        "type": "dict",
         "default": {},
         "validator": virtool.validators.is_permission_dict
     }


### PR DESCRIPTION
Make group edit endpoint make more semantic sense. Use `permissions` field over per-permission fields:
```json
{
    "permissions": {}
}
```
Instead of:
```json
{
    "create_sample": true
}
```

- update endpoint
- update validation
- update dependent client code