### PR TITLE
Create sample files

### DIFF
--- a/client/src/js/actionTypes.js
+++ b/client/src/js/actionTypes.js
@@ -43,6 +43,7 @@ export const WS_REMOVE_SAMPLE = "WS_REMOVE_SAMPLE";
 export const WS_UPDATE_ANALYSIS = "WS_UPDATE_ANALYSIS";
 export const WS_REMOVE_ANALYSIS = "WS_REMOVE_ANALYSIS";
 export const FIND_SAMPLES = createRequestActionType("FIND_SAMPLES");
+export const FIND_READ_FILES = createRequestActionType("FIND_READ_FILES");
 export const FIND_READY_HOSTS = createRequestActionType("FIND_READY_HOSTS");
 export const GET_SAMPLE = createRequestActionType("GET_SAMPLE");
 export const REFRESH_SAMPLE = createRequestActionType("REFRESH_SAMPLE");

--- a/client/src/js/files/api.js
+++ b/client/src/js/files/api.js
@@ -13,10 +13,11 @@ import Request from "superagent";
  * @param page {number} the page of results to get
  * @returns {promise}
  */
-export const find = ({ fileType, page }) => (
+export const find = ({ fileType, page, perPage }) => (
     Request.get("/api/files")
         .query({
             type: fileType,
+            per_page: perPage,
             page
         })
 );

--- a/client/src/js/samples/actions.js
+++ b/client/src/js/samples/actions.js
@@ -1,9 +1,10 @@
-import { simpleActionCreator } from "../utils";
+import {simpleActionCreator} from "../utils";
 import {
     WS_UPDATE_SAMPLE,
     WS_REMOVE_SAMPLE,
     WS_UPDATE_ANALYSIS,
     WS_REMOVE_ANALYSIS,
+    FIND_READ_FILES,
     FIND_READY_HOSTS,
     GET_SAMPLE,
     CREATE_SAMPLE,
@@ -38,6 +39,8 @@ export const wsRemoveAnalysis = (removed) => ({
     type: WS_REMOVE_ANALYSIS,
     removed
 });
+
+export const findReadFiles = simpleActionCreator(FIND_READ_FILES.REQUESTED);
 
 export const findReadyHosts = simpleActionCreator(FIND_READY_HOSTS.REQUESTED);
 

--- a/client/src/js/samples/components/Create/Create.js
+++ b/client/src/js/samples/components/Create/Create.js
@@ -11,10 +11,9 @@ import {
 import { push } from "react-router-redux";
 
 import ReadSelector from "./ReadSelector";
-import { findReadyHosts, createSample } from "../../actions";
+import { findReadFiles, findReadyHosts, createSample } from "../../actions";
 import { clearError } from "../../../errors/actions";
 import { Button, Icon, InputError, LoadingPlaceholder } from "../../../base";
-import { findFiles } from "../../../files/actions";
 import { routerLocationHasState } from "../../../utils";
 
 const getReadyHosts = (props) => (
@@ -290,7 +289,7 @@ const mapStateToProps = (state) => {
         show,
         groups: state.account.groups,
         readyHosts: state.samples.readyHosts,
-        readyReads: filter(state.files.documents, {type: "reads", reserved: false}),
+        readyReads: filter(state.samples.readFiles, {reserved: false}),
         forceGroupChoice: state.settings.sample_group === "force_choice",
         error: get(state, "errors.CREATE_SAMPLE_ERROR.message", "")
     };
@@ -303,7 +302,7 @@ const mapDispatchToProps = (dispatch) => ({
     },
 
     onFindFiles: () => {
-        dispatch(findFiles("reads", 1));
+        dispatch(findReadFiles());
     },
 
     onCreate: ({ name, isolate, host, locale, subtraction, files }) => {

--- a/client/src/js/samples/components/Create/ReadSelector.js
+++ b/client/src/js/samples/components/Create/ReadSelector.js
@@ -126,11 +126,12 @@ export default class ReadSelector extends React.PureComponent {
                             </FormGroup>
                         </div>
 
-                        <div className="panel panel-default">
-                            <div className="list-group">
+                        <div style={{maxHeight: "400px", overflowY: "auto"}}>
+                            <div className="list-group" style={{border: "none", marginBottom: 0}}>
                                 {fileComponents}
                             </div>
                         </div>
+
                         {errorMessage}
                     </Panel.Body>
                 </Panel>

--- a/client/src/js/samples/reducer.js
+++ b/client/src/js/samples/reducer.js
@@ -7,6 +7,7 @@ import {
     SHOW_REMOVE_SAMPLE,
     HIDE_SAMPLE_MODAL,
     FIND_ANALYSES,
+    FIND_READ_FILES,
     FIND_READY_HOSTS,
     GET_ANALYSIS,
     ANALYZE,
@@ -19,6 +20,7 @@ const initialState = {
     detail: null,
     analyses: null,
     analysisDetail: null,
+    readFiles: null,
     getAnalysisProgress: 0,
     showEdit: false,
     showRemove: false,
@@ -52,6 +54,9 @@ export default function samplesReducer (state = initialState, action) {
 
         case FIND_SAMPLES.SUCCEEDED:
             return {...state, ...action.data};
+
+        case FIND_READ_FILES.SUCCEEDED:
+            return {...state, readFiles: action.data.documents};
 
         case FIND_READY_HOSTS.SUCCEEDED:
             return {...state, readyHosts: action.data.documents};

--- a/client/src/js/samples/sagas.js
+++ b/client/src/js/samples/sagas.js
@@ -4,6 +4,7 @@ import { buffers, END, eventChannel } from "redux-saga";
 import { call, put, select, take, takeEvery, takeLatest, throttle } from "redux-saga/effects";
 
 import * as samplesAPI from "./api";
+import * as filesAPI from "../files/api";
 import { getAnalysisProgress } from "./actions";
 import { apiCall, apiFind, pushHistoryState, putGenericError, setPending } from "../sagaUtils";
 import {
@@ -11,6 +12,7 @@ import {
     WS_REMOVE_SAMPLE,
     WS_UPDATE_ANALYSIS,
     FIND_SAMPLES,
+    FIND_READ_FILES,
     FIND_READY_HOSTS,
     GET_SAMPLE,
     REFRESH_SAMPLE,
@@ -31,6 +33,7 @@ export function* watchSamples () {
     yield takeEvery(WS_REMOVE_SAMPLE, wsSample);
     yield takeEvery(WS_UPDATE_ANALYSIS, wsUpdateAnalysis);
     yield takeLatest(FIND_READY_HOSTS.REQUESTED, findReadyHosts);
+    yield takeLatest(FIND_READ_FILES.REQUESTED, findReadFiles);
     yield takeLatest(REFRESH_SAMPLE.REQUESTED, getSample);
     yield takeLatest(GET_SAMPLE.REQUESTED, getSample);
     yield takeLatest(CREATE_SAMPLE.REQUESTED, createSample);
@@ -54,6 +57,14 @@ export function* wsUpdateAnalysis (action) {
 
 export function* findSamples (action) {
     yield apiFind("/samples", samplesAPI.find, action, FIND_SAMPLES);
+}
+
+export function* findReadFiles () {
+    yield apiCall(filesAPI.find, {
+        fileType: "reads",
+        page: 1,
+        perPage: 500
+    }, FIND_READ_FILES);
 }
 
 export function* findReadyHosts () {


### PR DESCRIPTION
- retrieve up to 500 files when populating the `<ReadSelector />` component in the `<CreateSample />` modal
- scroll file overflow in `<ReadSelector />`
- fixes issue where most recently uploaded files couldn't be used to create samples