### PR TITLE
Return all computed data for index find requests

### DIFF
--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -4,12 +4,22 @@ import pytest
 import shutil
 import sys
 import types
+import multidict
 from aiohttp.test_utils import make_mocked_coro
 
 import virtool.app_dispatcher
 
 SAM_PATH = os.path.join(sys.path[0], "tests", "test_files", "test_al.sam")
 SAM_50_PATH = os.path.join(sys.path[0], "tests", "test_files", "sam_50.sam")
+
+
+@pytest.fixture(scope="session")
+def md_proxy():
+    def func(data_dict=None):
+        md = multidict.MultiDict(data_dict or dict())
+        return multidict.MultiDictProxy(md)
+
+    return func
 
 
 @pytest.fixture


### PR DESCRIPTION
- resolves #636
- add `md_proxy()` testing fixture
- applies to endpoints:
  - `GET /api/indexes`
  - `GET /api/refs/:ref_id/indexes`
- return fields `total_otu_count`, `modified_out_count`, `change_count`
- update tests
