### PR TITLE
Reference source types

### DIFF
--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -260,7 +260,10 @@ async def create(req):
         "type": "string"
     },
     "source_types": {
-        "type": "list"
+        "type": "list",
+        "schema": {
+            "type": "string"
+        }
     }
 })
 async def edit(req):

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -258,8 +258,10 @@ async def create(req):
     },
     "internal_control": {
         "type": "string"
+    },
+    "source_types": {
+        "type": "list"
     }
-
 })
 async def edit(req):
     db = req.app["db"]


### PR DESCRIPTION
- resolves #619 
- allow `source_types` to be passed to `PATCH /api/refs/:ref_id`
- restrict `source_types` value to an array of strings
- update `source_types` reference field on `PATCH` request