### PR TITLE
Change job resources url to /api/resources

### DIFF
--- a/virtool/api/jobs.py
+++ b/virtool/api/jobs.py
@@ -133,7 +133,7 @@ async def clear(req):
     })
 
 
-@routes.get("/api/jobs/resources")
+@routes.get("/api/resources")
 async def get_resources(req):
     """
     Get a object describing compute resource usage on the server.


### PR DESCRIPTION
- resolves #642 
- `404` bug for `/api/jobs/resources` was due to URL clash in API routing
- resource handler belongs at its own (non-`jobs`) endpoint because it is not a job resources