### PR TITLE
Source types update

### DIFF
--- a/tests/api/test_otus.py
+++ b/tests/api/test_otus.py
@@ -122,7 +122,6 @@ class TestCreate:
 
         m_add_history = mocker.patch("virtool.db.history.add", make_mocked_coro({"_id": "change.1"}))
 
-        #
         m_compose = mocker.patch("virtool.history.compose_create_description", return_value="Test description")
 
         m_create = mocker.patch("virtool.db.otus.create", make_mocked_coro(test_merged_otu))
@@ -723,9 +722,6 @@ class TestAddIsolate:
         """
         client = await spawn_client(authorize=True, permissions=["modify_otu"])
 
-        client.app["settings"]["restrict_source_types"] = True
-        client.app["settings"]["allowed_source_types"] = ["isolate"]
-
         await client.db.otus.insert_one(test_otu)
 
         data = {
@@ -735,6 +731,7 @@ class TestAddIsolate:
         }
 
         mocker.patch("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.references.check_source_type", make_mocked_coro(True))
 
         resp = await client.post("/api/otus/6116cba1/isolates", data)
 
@@ -780,15 +777,12 @@ class TestAddIsolate:
             "test"
         )
 
-    async def test_not_default(self, monkeypatch, spawn_client, test_otu, test_add_history):
+    async def test_not_default(self, mocker, spawn_client, test_otu, test_add_history):
         """
         Test that a non-default isolate can be properly added
 
         """
         client = await spawn_client(authorize=True, permissions=["modify_otu"])
-
-        client.app["settings"]["restrict_source_types"] = True
-        client.app["settings"]["allowed_source_types"] = ["isolate"]
 
         await client.db.otus.insert_one(test_otu)
 
@@ -798,7 +792,8 @@ class TestAddIsolate:
             "default": False
         }
 
-        monkeypatch.setattr("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.references.check_source_type", make_mocked_coro(True))
 
         resp = await client.post("/api/otus/6116cba1/isolates", data)
 
@@ -844,16 +839,13 @@ class TestAddIsolate:
             "test"
         )
 
-    async def test_first(self, monkeypatch, spawn_client, test_otu, test_add_history):
+    async def test_first(self, mocker, spawn_client, test_otu, test_add_history):
         """
         Test that the first isolate for a otu is set as the ``default`` otu even if ``default`` is set to ``False``
         in the POST input.
 
         """
         client = await spawn_client(authorize=True, permissions=["modify_otu"])
-
-        client.app["settings"]["restrict_source_types"] = True
-        client.app["settings"]["allowed_source_types"] = ["isolate"]
 
         test_otu["isolates"] = []
 
@@ -865,7 +857,8 @@ class TestAddIsolate:
             "default": False
         }
 
-        monkeypatch.setattr("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.references.check_source_type", make_mocked_coro(True))
 
         resp = await client.post("/api/otus/6116cba1/isolates", data)
 
@@ -900,15 +893,12 @@ class TestAddIsolate:
             "test"
         )
 
-    async def test_force_case(self, monkeypatch, spawn_client, test_otu):
+    async def test_force_case(self, mocker, spawn_client, test_otu):
         """
         Test that the ``source_type`` value is forced to lower case.
 
         """
         client = await spawn_client(authorize=True, permissions=["modify_otu"])
-
-        client.app["settings"]["restrict_source_types"] = True
-        client.app["settings"]["allowed_source_types"] = ["isolate"]
 
         await client.db.otus.insert_one(test_otu)
 
@@ -918,7 +908,8 @@ class TestAddIsolate:
             "default": False
         }
 
-        monkeypatch.setattr("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.references.check_source_type", make_mocked_coro(True))
 
         resp = await client.post("/api/otus/6116cba1/isolates", data)
 
@@ -962,6 +953,7 @@ class TestAddIsolate:
         await client.db.otus.insert_one(test_otu)
 
         mocker.patch("virtool.db.otus.get_new_isolate_id", make_mocked_coro("test"))
+        mocker.patch("virtool.db.references.check_source_type", make_mocked_coro(True))
 
         resp = await client.post("/api/otus/6116cba1/isolates", {})
 

--- a/tests/api/test_references.py
+++ b/tests/api/test_references.py
@@ -1,6 +1,15 @@
 async def test_create(spawn_client, test_random_alphanumeric, static_time):
     client = await spawn_client(authorize=True, permissions=["create_ref"])
 
+    default_source_type = [
+        "strain",
+        "isolate"
+    ]
+
+    client.app["settings"] = {
+        "default_source_types": default_source_type
+    }
+
     data = {
         "name": "Test Viruses",
         "description": "A bunch of viruses used for testing",
@@ -31,5 +40,7 @@ async def test_create(spawn_client, test_random_alphanumeric, static_time):
         }],
         contributors=[],
         internal_control=None,
+        restrict_source_types=False,
+        source_types=default_source_type,
         latest_build=None
     )

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -174,13 +174,20 @@ async def test_organize_references(has_references, has_otu, mocker, test_motor):
 
     m = mocker.patch("virtool.db.references.create_original", new=make_mocked_coro())
 
-    await virtool.organize.organize_references(test_motor)
+    settings = {
+        "default_source_types": [
+            "culture",
+            "strain"
+        ]
+    }
+
+    await virtool.organize.organize_references(test_motor, settings)
 
     document = await test_motor.refs.find_one()
 
     if has_otu and not has_references:
         assert document is None
-        m.assert_called_with(test_motor,)
+        m.assert_called_with(test_motor, settings)
 
     else:
         assert not m.called

--- a/virtool/api/otus.py
+++ b/virtool/api/otus.py
@@ -292,7 +292,7 @@ async def add_isolate(req):
     # All source types are stored in lower case.
     data["source_type"] = data["source_type"].lower()
 
-    if not virtool.db.references.check_source_type(db, settings, document["ref"]["id"], data["source_type"]):
+    if not await virtool.db.references.check_source_type(db, document["ref"]["id"], data["source_type"]):
         return conflict("Source type is not allowed")
 
     # Get a unique isolate_id for the new isolate.

--- a/virtool/api/otus.py
+++ b/virtool/api/otus.py
@@ -292,7 +292,7 @@ async def add_isolate(req):
     # All source types are stored in lower case.
     data["source_type"] = data["source_type"].lower()
 
-    if not virtool.otus.check_source_type(settings, data["source_type"]):
+    if not virtool.db.references.check_source_type(db, settings, document["ref"]["id"], data["source_type"]):
         return conflict("Source type is not allowed")
 
     # Get a unique isolate_id for the new isolate.

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -170,6 +170,7 @@ async def find_indexes(req):
 async def create(req):
     db = req.app["db"]
     data = req["data"]
+    settings = req.app["settings"]
 
     user_id = req["client"].user_id
 
@@ -179,6 +180,7 @@ async def create(req):
     if clone_from:
         document = await virtool.db.references.clone(
             db,
+            settings,
             data["name"],
             clone_from,
             data["description"],
@@ -219,6 +221,7 @@ async def create(req):
     else:
         document = await virtool.db.references.create_document(
             db,
+            settings,
             data["name"],
             data["organism"],
             data["description"],

--- a/virtool/app_settings.py
+++ b/virtool/app_settings.py
@@ -88,9 +88,8 @@ SCHEMA = {
     # Accounts
     "minimum_password_length": {"type": "integer", "default": 8},
 
-    # otu settings
-    "restrict_source_types": get_default_boolean(True),
-    "allowed_source_types": {"type": "list", "default": ["isolate", "strain"]}
+    # Reference settings
+    "default_source_types": {"type": "list", "default": ["isolate", "strain"]}
 }
 
 TASK_SPECIFIC_LIMIT_KEYS = [

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -30,6 +30,38 @@ PROJECTION = [
 ]
 
 
+async def check_source_type(db, ref_id, source_type):
+    """
+    Check if the provided `source_type` is valid based on the current reference source type configuration.
+
+    :param db: the application database client
+    :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
+
+    :param ref_id: the id of the ref to get contributors for
+    :type ref_id: str
+
+    :param source_type: the source type to check
+    :type source_type: str
+
+    :return: source type is valid
+    :rtype: bool
+
+    """
+    document = await db.refs.find_one(ref_id, ["restrict_source_types", "source_types"])
+
+    restrict_source_types = document.get("restrict_source_types", False)
+    source_types = document.get("source_types", list())
+
+    # Return `False` when source_types are restricted and source_type is not allowed.
+    if source_type and restrict_source_types:
+        return source_type in source_types
+
+    # Return `True` when:
+    # - source_type is empty string (unknown)
+    # - source_types are not restricted
+    # - source_type is an allowed source_type
+    return True
+
 async def cleanup_removed(db, process_id, ref_id, user_id):
     await virtool.db.processes.update(db, process_id, 0, step="delete_indexes")
 

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -36,14 +36,13 @@ async def organize(db, settings, server_version):
     await organize_files(db)
     await organize_history(db)
     await organize_indexes(db)
-    await organize_references(db)
+    await organize_references(db, settings)
     await organize_groups(db)
     await organize_otus(db)
     await organize_sequences(db)
     await organize_status(db, server_version)
     await organize_subtraction(db)
     await organize_users(db)
-    await organize_references(db)
 
     await organize_paths(db, settings)
 
@@ -154,11 +153,11 @@ async def organize_paths(db, settings):
         shutil.rmtree(old_reference_path)
 
 
-async def organize_references(db):
+async def organize_references(db, settings):
     logger.info(" • references")
 
     if await db.otus.count() and not await db.refs.count():
-        await virtool.db.references.create_original(db)
+        await virtool.db.references.create_original(db, settings)
 
 
 async def organize_sequences(db):

--- a/virtool/otus.py
+++ b/virtool/otus.py
@@ -12,30 +12,6 @@ import virtool.utils
 logger = logging.getLogger(__name__)
 
 
-def check_source_type(settings, source_type):
-    """
-    Check if the provided `source_type` is valid based on the current server `settings`.
-
-    :param settings: the application settings object
-    :type settings: :class:`virtool.app_settings.Settings`
-
-    :param source_type: the source type to check
-    :type source_type: str
-
-    :return: source type is valid
-    :rtype: bool
-
-    """
-    # Return `False` when source_types are restricted and source_type is not allowed.
-    if source_type and settings["restrict_source_types"]:
-        return source_type in settings["allowed_source_types"]
-
-    # Return `True` when:
-    # - source_type is empty string (unknown)
-    # - source_types are not restricted
-    # - source_type is an allowed source_type
-    return True
-
 
 def evaluate_changes(data, document):
     name = data.get("name", None)


### PR DESCRIPTION
- related to #640 
- add new setting `default_source_types` whose value will be assigned to new references
- add `restrict_source_types` settings to each reference (`False` by default)
- remove source type settings `restrict_source_types` and `allowed_source_types`
- check source type inputs based on reference-specific settings

