### PR TITLE
Unbuilt changes

### DIFF
--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -95,6 +95,16 @@ async def find_history(req):
         "reference.id": ref_id
     }
 
+    unbuilt = req.query.get("unbuilt", None)
+
+    if unbuilt == "true":
+        base_query["index.id"] = "unbuilt"
+
+    elif unbuilt == "false":
+        base_query["index.id"] = {
+            "$ne": "unbuilt"
+        }
+
     data = await virtool.db.history.find(
         db,
         req.query,

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -311,26 +311,6 @@ async def edit(req):
     return json_response(document)
 
 
-@routes.get("/api/refs/{ref_id}/unbuilt")
-async def get_unbuilt_changes(req):
-    """
-    Get a JSON document describing the unbuilt changes that could be used to create a new index.
-
-    """
-    db = req.app["db"]
-
-    ref_id = req.match_info["ref_id"]
-
-    history = await db.history.find({
-        "reference.id": ref_id,
-        "index.id": "unbuilt"
-    }, virtool.db.history.LIST_PROJECTION).to_list(None)
-
-    return json_response({
-        "history": [virtool.utils.base_processor(c) for c in history]
-    })
-
-
 @routes.delete("/api/refs/{ref_id}")
 async def remove(req):
     """

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -196,6 +196,7 @@ async def create(req):
 
         document = await virtool.db.references.create_for_import(
             db,
+            settings,
             data["name"],
             data["description"],
             data["public"],

--- a/virtool/db/history.py
+++ b/virtool/db/history.py
@@ -116,7 +116,7 @@ async def add(db, method_name, old, new, description, user_id):
     return document
 
 
-async def find(db, req_query, base_query=None):
+async def find(db, req_query, base_query=None, unbuilt=False):
     data = await paginate(
         db.history,
         {},


### PR DESCRIPTION
- resolves #649
- allow searching unbuilt changes for the all or specific references
- endpoints:
  - `GET /api/history?unbuilt=true`
  - `GET /api/refs/:ref_id/history?unbuilt=true`
- fix missing `user_id` arg for reference creation
- support pagination (old unbuilt GET returned all data)