### PR TITLE
Accession fix

### DIFF
--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -511,6 +511,7 @@ async def import_file(app, path, ref_id, created_at, process_id, user_id):
 
                 sequence.update({
                     "_id": sequence_id,
+                    "accession": sequence.get("_id", None) or sequence["accession"],
                     "otu_id": otu_id,
                     "isolate_id": isolate_id,
                     "reference": {

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -525,8 +525,9 @@ async def import_file(app, path, ref_id, created_at, process_id, user_id):
 
         progress = progress_tracker.add(1)
 
-        if progress - progress_tracker.last_reported >= 0.05:
+        if progress_tracker.progress - progress_tracker.last_reported >= 0.05:
             await virtool.db.processes.update(db, process_id, progress=(0.2 + progress))
+            progress_tracker.reported()
 
     await virtool.db.processes.update(db, process_id, 0.6, "create_history")
 
@@ -556,7 +557,8 @@ async def import_file(app, path, ref_id, created_at, process_id, user_id):
 
         progress = progress_tracker.add(1)
 
-        if progress - progress_tracker.last_reported >= 0.05:
+        if progress_tracker.progress - progress_tracker.last_reported >= 0.05:
             await virtool.db.processes.update(db, process_id, progress=(0.6 + progress))
+            progress_tracker.reported()
 
     await virtool.db.processes.update(db, process_id, 1)

--- a/virtool/processes.py
+++ b/virtool/processes.py
@@ -43,7 +43,7 @@ class ProgressTracker:
 
         return self.progress
 
-    async def reported(self):
+    def reported(self):
         self.last_reported = self.progress
 
     @property


### PR DESCRIPTION
- resolves #663 
- assign `accession` field during reference import
- reduce frequency of reference import process updates
- update create sequence endpoint to take `accession` input and create sequence with `accession` field and unique `id` field