### PR TITLE
Reference users and groups

### DIFF
--- a/tests/api/test_references.py
+++ b/tests/api/test_references.py
@@ -1,3 +1,7 @@
+import pytest
+from aiohttp.test_utils import make_mocked_coro
+
+
 async def test_create(spawn_client, test_random_alphanumeric, static_time):
     client = await spawn_client(authorize=True, permissions=["create_ref"])
 
@@ -38,9 +42,46 @@ async def test_create(spawn_client, test_random_alphanumeric, static_time):
             "modify_otu": True,
             "remove": True
         }],
+        groups=[],
         contributors=[],
         internal_control=None,
         restrict_source_types=False,
         source_types=default_source_type,
         latest_build=None
     )
+
+
+@pytest.mark.parametrize("error", [None, 404, 409])
+@pytest.mark.parametrize("field", ["group", "user"])
+async def test_add_group_or_user(error, field, mocker, spawn_client, resp_is):
+    client = await spawn_client(authorize=True, permissions=["create_ref"])
+
+    expected = {"id": "test"}
+
+    if error == 404:
+        expected = None
+
+    m_add_group_or_user = mocker.patch("virtool.db.references.add_group_or_user", make_mocked_coro(expected))
+
+    url = "/api/refs/foobar/{}s".format(field)
+
+    resp = await client.post(url, {
+        field + "_id": "baz",
+        "modify": True
+    })
+
+    if exists:
+        assert resp.status == 201
+
+        assert await resp.json() == expected
+
+        m_add_group_or_user.assert_called_with(client.db, "foobar", field + "s", {
+            "build": False,
+            "modify": True,
+            "modify_otu": False,
+            "remove": False,
+            field + "_id": "baz"
+        })
+
+    else:
+        assert await resp_is.not_found(resp)

--- a/tests/api/test_references.py
+++ b/tests/api/test_references.py
@@ -51,7 +51,7 @@ async def test_create(spawn_client, test_random_alphanumeric, static_time):
     )
 
 
-@pytest.mark.parametrize("error", [None, 404, 409])
+@pytest.mark.parametrize("error", [None, 404])
 @pytest.mark.parametrize("field", ["group", "user"])
 async def test_add_group_or_user(error, field, mocker, spawn_client, resp_is):
     client = await spawn_client(authorize=True, permissions=["create_ref"])
@@ -70,7 +70,10 @@ async def test_add_group_or_user(error, field, mocker, spawn_client, resp_is):
         "modify": True
     })
 
-    if exists:
+    if error == 404:
+        assert await resp_is.not_found(resp)
+
+    else:
         assert resp.status == 201
 
         assert await resp.json() == expected
@@ -83,5 +86,61 @@ async def test_add_group_or_user(error, field, mocker, spawn_client, resp_is):
             field + "_id": "baz"
         })
 
-    else:
+
+@pytest.mark.parametrize("error", [None, 404])
+@pytest.mark.parametrize("field", ["group", "user"])
+async def test_edit_group_or_user(error, field, mocker, spawn_client, resp_is):
+    client = await spawn_client(authorize=True, permissions=["create_ref"])
+
+    expected = {"id": "test"}
+
+    if error == 404:
+        expected = None
+
+    m_edit_group_or_user = mocker.patch("virtool.db.references.edit_group_or_user", make_mocked_coro(expected))
+
+    url = "/api/refs/foobar/{}s/baz".format(field)
+
+    resp = await client.patch(url, {
+        "remove": True
+    })
+
+    if error == 404:
         assert await resp_is.not_found(resp)
+
+    else:
+        assert resp.status == 200
+
+        assert await resp.json() == expected
+
+        m_edit_group_or_user.assert_called_with(client.db, "foobar", "baz", field + "s", {
+            "build": False,
+            "modify": False,
+            "modify_otu": False,
+            "remove": True
+        })
+
+
+@pytest.mark.parametrize("error", [None, 404])
+@pytest.mark.parametrize("field", ["group", "user"])
+async def test_delete_group_or_user(error, field, mocker, spawn_client, resp_is):
+    client = await spawn_client(authorize=True, permissions=["create_ref"])
+
+    expected = "test"
+
+    if error == 404:
+        expected = None
+
+    m_edit_group_or_user = mocker.patch("virtool.db.references.delete_group_or_user", make_mocked_coro(expected))
+
+    url = "/api/refs/foobar/{}s/baz".format(field)
+
+    resp = await client.delete(url)
+
+    if error == 404:
+        assert await resp_is.not_found(resp)
+
+    else:
+        assert resp.status == 204
+
+        m_edit_group_or_user.assert_called_with(client.db, "foobar", "baz", field + "s")

--- a/tests/db/test_references.py
+++ b/tests/db/test_references.py
@@ -4,11 +4,182 @@ import os
 import shutil
 import sys
 
+import pytest
 from aiohttp.test_utils import make_mocked_coro
 
 import virtool.db.references
+import virtool.errors
 
 TEST_IMPORT_FILE_PATH = os.path.join(sys.path[0], "tests", "test_files", "files", "import.json.gz")
+
+
+async def add_group_or_user(db, ref_id, field, data):
+
+    document = await db.references.find_one({"_id": ref_id}, [field])
+
+    if not document:
+        return None
+
+    subdocument_id = data.get("group_id", None) or data["user_id"]
+
+    if subdocument_id in [s["id"] for s in document[field]]:
+        raise virtool.errors.DatabaseError(field + " already exists")
+
+    rights = {key: data.get(key, False) for key in virtool.references.RIGHTS}
+
+    subdocument = {
+        "id": subdocument_id,
+        "created_at": virtool.utils.timestamp(),
+        **rights
+    }
+
+    await db.references.update_one({"_id": ref_id}, {
+        "$push": {
+            field: subdocument
+        }
+    })
+
+    return subdocument
+
+
+@pytest.mark.parametrize("error", [None, "duplicate", "missing"])
+@pytest.mark.parametrize("field", ["group", "user"])
+@pytest.mark.parametrize("rights", [True, False])
+async def test_add_group_or_user(error, field, rights, test_dbi, static_time):
+
+    ref_id = "foo"
+
+    subdocuments = [
+        {
+            "id": "bar"
+        },
+        {
+            "id": "baz"
+        }
+    ]
+
+    if error != "missing":
+        await test_dbi.references.insert_one({
+
+            "_id": ref_id,
+            "groups": subdocuments,
+            "users": subdocuments
+        })
+
+    subdocument_id = "bar" if error == "duplicate" else "buzz"
+
+    payload = {
+        field + "_id": subdocument_id
+    }
+
+    if rights:
+        payload["build"] = True
+
+    task = virtool.db.references.add_group_or_user(test_dbi, ref_id, field + "s", payload)
+
+    if error == "duplicate":
+        with pytest.raises(virtool.errors.DatabaseError) as err:
+            await task
+
+        assert field + " already exists" in str(err)
+
+    elif error == "missing":
+        assert await task is None
+
+    else:
+        await task
+
+        expected = {
+            "id": subdocument_id,
+            "created_at": static_time,
+            "build": rights,
+            "modify": False,
+            "modify_otu": False,
+            "remove": False
+        }
+
+        assert await test_dbi.references.find_one() == {
+            "_id": ref_id,
+            "groups": subdocuments + ([expected] if field == "group" else []),
+            "users": subdocuments + ([expected] if field == "user" else [])
+        }
+
+
+@pytest.mark.parametrize("missing", [None, "reference", "subdocument"])
+@pytest.mark.parametrize("field", ["group", "user"])
+async def test_edit_group_or_user(field, missing, test_dbi, static_time):
+
+    ref_id = "foo"
+
+    subdocuments = [
+        {
+            "id": "bar"
+        },
+        {
+            "id": "baz"
+        }
+    ]
+
+    if missing != "reference":
+        await test_dbi.references.insert_one({
+            "_id": ref_id,
+            "groups": subdocuments,
+            "users": subdocuments
+        })
+
+    subdocument_id = "buzz" if missing == "subdocument" else "baz"
+
+    subdocument = await virtool.db.references.edit_group_or_user(test_dbi, ref_id, subdocument_id, field + "s", {
+        "build": True,
+        "remove": True
+    })
+
+    if missing:
+        assert subdocument is None
+
+    else:
+        expected = {
+            "id": subdocument_id,
+            "build": True,
+            "modify": False,
+            "modify_otu": False,
+            "remove": True
+        }
+
+        assert await test_dbi.references.find_one() == {
+            "_id": ref_id,
+            "groups": (subdocuments[:1] + [expected]) if field == "group" else subdocuments,
+            "users": (subdocuments[:1] + [expected]) if field == "user" else subdocuments
+        }
+
+
+@pytest.mark.parametrize("field", ["groups", "users"])
+async def test_delete_group_or_user(field, test_dbi):
+
+    ref_id = "foo"
+
+    subdocuments = [
+        {
+            "id": "bar"
+        },
+        {
+            "id": "baz"
+        }
+    ]
+
+    await test_dbi.references.insert_one({
+        "_id": ref_id,
+        "groups": subdocuments,
+        "users": subdocuments
+    })
+
+    await virtool.db.references.delete_group_or_user(test_dbi, "foo", "bar", field)
+
+    assert await test_dbi.references.find_one() == {
+        "_id": ref_id,
+        "groups": [subdocuments[1]] if field == "groups" else subdocuments,
+        "users": [subdocuments[1]] if field == "users" else subdocuments
+    }
 
 
 async def test_import(mocker, tmpdir, test_motor, static_time):

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -335,6 +335,7 @@ async def create_document(db, settings, name, organism, description, data_type, 
         "public": public,
         "restrict_source_types": False,
         "source_types": settings["default_source_types"],
+        "groups": list(),
         "users": users,
         "user": user
     }

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -138,15 +138,15 @@ async def get_latest_build(db, ref_id):
     :rtype: Union[None, dict]
 
     """
-    last_build = await db.indexes.find_one({
+    latest_build = await db.indexes.find_one({
         "reference.id": ref_id,
         "ready": True
     }, projection=["created_at", "version", "user"], sort=[("index.version", pymongo.DESCENDING)])
 
-    if last_build is None:
+    if latest_build is None:
         return None
 
-    return virtool.utils.base_processor(last_build)
+    return virtool.utils.base_processor(latest_build)
 
 
 async def get_internal_control(db, internal_control_id):

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -66,7 +66,7 @@ async def check_source_type(db, ref_id, source_type):
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
 
-    :param ref_id: the id of the ref to get contributors for
+    :param ref_id: the reference context
     :type ref_id: str
 
     :param source_type: the source type to check

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -46,6 +46,16 @@ async def organize(db, settings, server_version):
 
     await organize_paths(db, settings)
 
+    await organize_dev(db)
+
+
+async def organize_dev(db):
+    await db.references.update_many({"groups": {"$exists": False}}, {
+        "$set": {
+            "groups": []
+        }
+    })
+
 
 async def organize_analyses(db):
     """

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -36,13 +36,13 @@ async def organize(db, settings, server_version):
     await organize_files(db)
     await organize_history(db)
     await organize_indexes(db)
-    await organize_references(db, settings)
+    await organize_users(db)
     await organize_groups(db)
+    await organize_references(db, settings)
     await organize_otus(db)
     await organize_sequences(db)
     await organize_status(db, server_version)
     await organize_subtraction(db)
-    await organize_users(db)
 
     await organize_paths(db, settings)
 

--- a/virtool/references.py
+++ b/virtool/references.py
@@ -1,6 +1,13 @@
 import gzip
 import json
 
+RIGHTS = [
+    "build",
+    "modify",
+    "modify_otu",
+    "remove"
+]
+
 
 def get_owner_user(user_id):
     return {


### PR DESCRIPTION
- add API endpoints for managing reference groups and users
- add `organize_dev` function
- include empty `groups` array when creating a new reference document
- update tests

