### PR TITLE
Reference-specific source types API

### DIFF
--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -133,8 +133,7 @@ async def test_update_settings(invalid_input, spawn_client, resp_is):
 
     if invalid_input:
         assert await resp_is.invalid_input(resp, {
-            "show_ids": ["must be of boolean type"],
-            "foo_bar": ["unknown field"]
+            "show_ids": ["must be of boolean type"]
         })
     else:
         assert resp.status == 200

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -91,7 +91,6 @@ class TestCreate:
         })
 
         assert await resp_is.invalid_input(resp, {
-            "test": ["unknown field"],
             "group_id": ["required field"]
         })
 

--- a/tests/api/test_otus.py
+++ b/tests/api/test_otus.py
@@ -184,7 +184,6 @@ class TestCreate:
         assert resp.status == 422
 
         assert await resp_is.invalid_input(resp, {
-            "otu_name": ["unknown field"],
             "abbreviation": ["must be of string type"],
             "name": ["required field"]
         })
@@ -396,7 +395,6 @@ class TestEdit:
         assert resp.status == 422
 
         assert await resp_is.invalid_input(resp, {
-            "otu_name": ["unknown field"],
             "abbreviation": ["must be of string type"]
         })
 
@@ -1621,8 +1619,7 @@ class TestCreateSequence:
 
         assert await resp_is.invalid_input(resp, {
             "accession": ["must be of string type"],
-            "sequence": ["required field"],
-            "seq": ["unknown field"]
+            "sequence": ["required field"]
         })
 
     @pytest.mark.parametrize("otu_id, isolate_id", [
@@ -1749,8 +1746,7 @@ class TestEditSequence:
         assert resp.status == 422
 
         assert await resp_is.invalid_input(resp, {
-            "definition": ["must be of string type"],
-            "plant": ["unknown field"]
+            "definition": ["must be of string type"]
         })
 
     @pytest.mark.parametrize("foobar", ["otu_id", "isolate_id", "sequence_id"])

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -717,5 +717,5 @@ class TestAnalyze:
         })
 
         assert await resp_is.invalid_input(resp, {
-            "algorithm": ["required field"], "foobar": ["unknown field"], "ref_id": ["required field"]
+            "algorithm": ["required field"], "ref_id": ["required field"]
         })

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -141,10 +141,9 @@ class TestCreate:
 
         resp = await client.post("/api/users", data)
 
-        assert resp.status == 422
+        print(await resp.json())
 
         assert await resp_is.invalid_input(resp, {
-            "username": ["unknown field"],
             "password": ["must be of string type"],
             "user_id": ["required field"]
         })
@@ -208,7 +207,7 @@ async def test_edit(data, error, spawn_client, resp_is, static_time, create_user
     payload = dict(data)
 
     if error == "invalid_input":
-        payload["foobar"] = "baz"
+        payload["force_reset"] = "baz"
 
     resp = await client.patch("/api/users/bob", payload)
 
@@ -221,7 +220,7 @@ async def test_edit(data, error, spawn_client, resp_is, static_time, create_user
 
     elif error == "invalid_input":
         assert await resp_is.invalid_input(resp, {
-            "foobar": ["unknown field"]
+            "force_reset": ["must be of boolean type"]
         })
 
     elif error == "user_dne":

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -294,6 +294,9 @@ async def create(req):
     "internal_control": {
         "type": "string"
     },
+    "restrict_source_types": {
+        "type": "boolean"
+    },
     "source_types": {
         "type": "list",
         "schema": {

--- a/virtool/api/users.py
+++ b/virtool/api/users.py
@@ -51,7 +51,7 @@ async def create(req):
         "user_id": {"type": "string", "minlength": 1, "required": True},
         "password": {"type": "string", "minlength": req.app["settings"]["minimum_password_length"], "required": True},
         "force_reset": {"type": "boolean", "default": True}
-    })
+    }, purge_unknown=True)
 
     if not v.validate(data):
         return invalid_input(v.errors)
@@ -87,7 +87,7 @@ async def edit(req):
         "groups": {"type": "list", "allowed": groups},
         "password": {"type": "string", "minlength": req.app["settings"]["minimum_password_length"]},
         "primary_group": {"type": "string"}
-    })
+    }, purge_unknown=True)
 
     if not v.validate(data):
         return invalid_input(v.errors)

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -69,7 +69,7 @@ def protect(route_decorator, admin, permission, public, schema):
                     data = None
 
                 if schema and data is not None:
-                    v = Validator(schema)
+                    v = Validator(schema, purge_unknown=True)
 
                     if not v.validate(data):
                         return invalid_input(v.errors)


### PR DESCRIPTION
- fixes #670
- accept restrict_source_types at ref edit endpoint
- ignore and purge unknown API inputs be default