### PR TITLE
Return OTU count in reference API responses

### DIFF
--- a/tests/api/test_references.py
+++ b/tests/api/test_references.py
@@ -22,7 +22,8 @@ async def test_create(mocker, spawn_client, test_random_alphanumeric, static_tim
         "public": True
     }
 
-    m = mocker.patch("virtool.db.references.get_unbuilt_count", make_mocked_coro(5))
+    m_get_otu_count = mocker.patch("virtool.db.references.get_otu_count", make_mocked_coro(22))
+    m_get_unbuilt_count = mocker.patch("virtool.db.references.get_unbuilt_count", make_mocked_coro(5))
 
     resp = await client.post("/api/refs", data)
 
@@ -48,12 +49,18 @@ async def test_create(mocker, spawn_client, test_random_alphanumeric, static_tim
         contributors=[],
         internal_control=None,
         restrict_source_types=False,
+        otu_count=22,
         unbuilt_change_count=5,
         source_types=default_source_type,
         latest_build=None
     )
 
-    m.assert_called_with(
+    m_get_otu_count.assert_called_with(
+        client.db,
+        test_random_alphanumeric.history[0]
+    )
+
+    m_get_unbuilt_count.assert_called_with(
         client.db,
         test_random_alphanumeric.history[0]
     )

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -53,13 +53,15 @@ async def find(req):
     data = await paginate(db.references, db_query, req.query, sort="name", projection=virtool.db.references.PROJECTION)
 
     for d in data["documents"]:
-        latest_build, unbuilt_count = await asyncio.gather(
+        latest_build, otu_count, unbuilt_count = await asyncio.gather(
             virtool.db.references.get_latest_build(db, d["id"]),
+            virtool.db.references.get_otu_count(db, d["id"]),
             virtool.db.references.get_unbuilt_count(db, d["id"])
         )
 
         d.update({
             "latest_build": latest_build,
+            "otu_count": otu_count,
             "unbuilt_change_count": unbuilt_count
         })
 


### PR DESCRIPTION
- resolves #593 
- add `otu_count` reference document field assigned the number of OTUs associated with the given reference
- return `otu_count` field in reference API responses