### PR TITLE
Reset internal control when OTU is removed

### DIFF
--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -355,9 +355,9 @@ async def edit(req):
         "$set": update
     }, projection=virtool.db.references.PROJECTION)
 
-    document["internal_control"] = await virtool.db.references.get_internal_control(db, internal_control_id)
-
     document = virtool.utils.base_processor(document)
+
+    document.update(await virtool.db.references.get_computed(db, document["_id"], internal_control_id))
 
     return json_response(document)
 

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -69,7 +69,7 @@ async def find(req):
 @routes.get("/api/refs/{ref_id}")
 async def get(req):
     """
-    Get the complete representation of a specfic reference.
+    Get the complete representation of a specific reference.
 
     """
     db = req.app["db"]

--- a/virtool/db/otus.py
+++ b/virtool/db/otus.py
@@ -236,6 +236,12 @@ async def remove(db, otu_id, user_id, document=None):
     # Remove the otu document itself.
     await db.otus.delete_one({"_id": otu_id})
 
+    await db.references.update_one({"_id": joined["reference"]["id"], "internal_control.id": joined["_id"]}, {
+        "$set": {
+            "internal_control": None
+        }
+    })
+
     description = virtool.history.compose_remove_description(joined)
 
     await virtool.db.history.add(


### PR DESCRIPTION
- resolves #596 
- return all computed data in response when reference is edited
- set reference `internal control` field to `null` when associated OTU is removed