### PR TITLE
Force remote name and description

### DIFF
--- a/virtool/api/genbank.py
+++ b/virtool/api/genbank.py
@@ -25,8 +25,6 @@ async def get(req):
     async with aiohttp.ClientSession() as session:
         gi = await virtool.genbank.search(settings, session, accession)
 
-        print(gi)
-
         if not gi:
             return not_found()
 

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -286,9 +286,7 @@ async def create(req):
         document = await virtool.db.references.create_remote(
             db,
             settings,
-            data["name"],
-            data["description"],
-            data["public"],
+            True,
             remote_from,
             user_id
         )

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -169,7 +169,7 @@ async def find_indexes(req):
 @routes.post("/api/refs", permission="create_ref", schema={
     "name": {
         "type": "string",
-        "required": True
+        "default": ""
     },
     "description": {
         "type": "string",
@@ -177,7 +177,9 @@ async def find_indexes(req):
     },
     "data_type": {
         "type": "string",
-        "allowed": ["genome", "barcode"],
+        "allowed": [
+            "genome"
+        ],
         "default": "genome"
     },
     "clone_from": {
@@ -210,7 +212,6 @@ async def find_indexes(req):
         "type": "boolean",
         "default": False
     }
-
 })
 async def create(req):
     db = req.app["db"]

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -196,6 +196,7 @@ async def find_indexes(req):
     },
     "remote_from": {
         "type": "string",
+        "allowed": ["virtool/virtool-database"],
         "excludes": [
             "clone_from",
             "import_from"

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -648,9 +648,6 @@ async def finish_import(app, path, ref_id, created_at, process_id, user_id):
 async def finish_remote(app, release, ref_id, created_at, process_id, user_id):
     db = app["db"]
 
-    import pprint
-    pprint.pprint(release)
-
     progress_tracker = virtool.processes.ProgressTracker(
         db,
         process_id,

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -367,6 +367,8 @@ async def create_clone(db, settings, name, clone_from, description, public, user
 
     source = await db.references.find_one(clone_from)
 
+    name = name or "Clone of " + source["name"]
+
     document = await create_document(
         db,
         settings,
@@ -458,7 +460,7 @@ async def create_import(db, settings, name, description, public, import_from, us
     document = await create_document(
         db,
         settings,
-        name,
+        name or "Unnamed Import",
         None,
         description,
         None,

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -706,6 +706,12 @@ async def finish_remote(app, release, ref_id, created_at, process_id, user_id):
         await insert_change(db, otu_id, "remote", user_id)
         await progress_tracker.add(1)
 
+    await db.references.update_one({"_id": ref_id}, {
+        "$set": {
+            "remotes_from.version": release["name"]
+        }
+    })
+
     await virtool.db.processes.update(db, process_id, progress=1)
 
 

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -509,15 +509,15 @@ async def create_original(db, settings):
     return document
 
 
-async def create_remote(db, settings, name, description, public, remote_from, user_id):
+async def create_remote(db, settings, public, remote_from, user_id):
     created_at = virtool.utils.timestamp()
 
     document = await create_document(
         db,
         settings,
-        name,
+        "Plant Viruses",
         None,
-        description,
+        "The official plant virus reference from the Virtool developers",
         None,
         public,
         created_at=created_at,

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -60,7 +60,6 @@ async def get_latest_release(settings, session, slug, etag=None):
             return dict(data, etag=resp.headers["etag"])
 
         elif resp.status == 404 or resp.status == 304:
-            print(resp.status)
             return None
 
         else:


### PR DESCRIPTION

- add to `remotes_from.version` when `finish_remote()` completes
- don't require `name` for any reference creation requests (defaults will apply)
- force `name` and `description` for remote reference (the official reference)