### PR TITLE
Remote ref update checks

### DIFF
--- a/client/src/js/otus/components/Detail/History.js
+++ b/client/src/js/otus/components/Detail/History.js
@@ -8,53 +8,71 @@
  */
 import React from "react";
 import PropTypes from "prop-types";
-import { groupBy, map, reverse, sortBy } from "lodash-es";
+import { get, groupBy, map, reverse, sortBy } from "lodash-es";
 import { connect } from "react-redux";
 import { Row, Col, ListGroup, Label } from "react-bootstrap";
 
 import { getOTUHistory, revert } from "../../actions";
 import { Flex, FlexItem, ListGroupItem, RelativeTime, Icon } from "../../../base";
 
-
-const getMethodIcon = (change) => {
-
-    switch (change.method_name) {
-        case "create":
-            return <Icon name="new-entry" bsStyle="primary" />;
-
-        case "edit":
-            return <Icon name="pencil" bsStyle="warning" />;
-
-        case "verify":
-            return <Icon name="checkmark" bsStyle="success" />;
-
-        case "remove":
-            return <Icon name="remove" bsStyle="danger" />;
-
-        case "add_isolate":
-            return <Icon name="lab" bsStyle="primary" />;
-
-        case "edit_isolate":
-            return <Icon name="lab" bsStyle="warning" />;
-
-        case "set_as_default":
-            return <Icon name="star" bsStyle="warning" />;
-
-        case "remove_isolate":
-            return <Icon name="lab" bsStyle="danger" />;
-
-        case "create_sequence":
-            return <Icon name="dna" bsStyle="primary" />;
-
-        case "edit_sequence":
-            return <Icon name="dna" bsStyle="warning" />;
-
-        case "remove_sequence":
-            return <Icon name="dna" bsStyle="danger" />;
-
-        default:
-            return <Icon name="warning" bsStyle="danger" />;
+const methodIconProps = {
+    add_isolate: {
+        name: "flask",
+        bsStyle: "primary"
+    },
+    create: {
+        name: "plus-square",
+        bsStyle: "primary"
+    },
+    create_sequence: {
+        name: "dna",
+        bsStyle: "primary"
+    },
+    edit: {
+        name: "pencil",
+        bsStyle: "warning"
+    },
+    edit_isolate: {
+        name: "flask",
+        bsStyle: "warning"
+    },
+    edit_sequence: {
+        name: "dna",
+        bsStyle: "warning"
+    },
+    remote: {
+        name: "link",
+        bsStyle: "primary"
+    },
+    remove: {
+        name: "trash",
+        bsStyle: "danger"
+    },
+    remove_isolate: {
+        name: "flask",
+        bsStyle: "danger"
+    },
+    remove_sequence: {
+        name: "dna",
+        bsStyle: "danger"
+    },
+    set_as_default: {
+        name: "star",
+        bsStyle: "warning"
+    },
+    update: {
+        name: "arrow-alt-circle-up",
+        bsStyle: "warning"
     }
+};
+
+const getMethodIcon = ({ method_name }) => {
+    const props = get(methodIconProps, method_name, {
+        name: "exclamation-triangle",
+        bsStyle: "danger"
+    });
+
+    return <Icon {...props} />;
 };
 
 export class Change extends React.Component {

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -94,6 +94,14 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
+@routes.get("/api/refs/{ref_id}/update")
+async def get_update(req):
+    ref_id = req.match_info["ref_id"]
+
+    update = await virtool.db.references.check_for_remote_update(req.app, ref_id)
+
+    return json_response(update)
+
 @routes.get("/api/refs/{ref_id}/otus")
 async def find_otus(req):
     db = req.app["db"]

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 
 import pymongo
+import semver
 
 import virtool.db.history
 import virtool.db.otus
@@ -60,6 +61,69 @@ async def add_group_or_user(db, ref_id, field, data):
     })
 
     return subdocument
+
+
+async def check_for_remote_update(app, ref_id):
+    """
+    Check the the GitHub repository identified by the passed `slug` for a release newer than the provided `version`. If
+    a newer release is found, update the reference identified by the passed `ref_id` and return the release.
+
+    :param app: the application object
+    :type app: :class:`aiohttp.Application`
+
+    :param ref_id: the id of the reference to update
+    :type ref_id: str
+
+    :return: the latest release if newer than the passed version
+    :rtype: Coroutine[dict]
+
+    """
+    db = app["db"]
+
+    remotes_from = await virtool.db.utils.get_one_field(db.references, "remotes_from", ref_id)
+
+    etag = remotes_from.get("etag", None)
+
+    try:
+        latest_release = await virtool.github.get_latest_release(
+            app["settings"],
+            app["client"],
+            remotes_from["slug"],
+            etag
+        )
+    except virtool.errors.GitHubError as err:
+        await db.references.update_one({"_id": ref_id}, {
+            "$set": {
+                "remotes_from.etag": None,
+                "remotes_from.last_checked": virtool.utils.timestamp(),
+                "remotes_from.update": None,
+                "remotes_from.errors": [str(err)]
+            }
+        })
+
+        return None
+
+    update = remotes_from["update"]
+
+    if latest_release:
+        etag = latest_release["etag"]
+
+        latest_version = latest_release["name"].lstrip("v")
+        installed_version = remotes_from["version"].lstrip("v")
+
+        if semver.compare(latest_version, installed_version) == 1:
+            update = virtool.github.format_release(latest_release)
+
+    await db.references.update_one({"_id": ref_id}, {
+        "$set": {
+            "remotes_from.etag": etag,
+            "remotes_from.last_checked": virtool.utils.timestamp(),
+            "remotes_from.update": update,
+            "remotes_from.errors": None
+        }
+    })
+
+    return update
 
 
 async def check_source_type(db, ref_id, source_type):

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -41,7 +41,7 @@ async def get_latest_release(settings, session, slug, etag=None):
     :type etag: str
 
     :return: the latest release
-    :rtype: dict
+    :rtype: Coroutine[dict]
 
     """
     url = "{}/{}/releases/latest".format(BASE_URL, slug)

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -60,7 +60,7 @@ async def get_latest_release(settings, session, slug, etag=None):
 
             return dict(data, etag=resp.headers["etag"])
 
-        elif resp.status == 404 or resp.status == 304:
+        elif resp.status == 304:
             return None
 
         else:

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -14,6 +14,7 @@ def format_release(release):
     return {
         "name": release["name"],
         "body": release["body"],
+        "etag": release["etag"],
         "filename": asset["name"],
         "size": asset["size"],
         "browser_url": release["url"],


### PR DESCRIPTION
- allow forcing update checks at `GET /api/refs/:ref_id/update`
- automatically check for remote reference updates every 10 minutes
- implement remote reference update checking
- include `etag` field in formatted GitHub releases
- update OTU history icons