### PR TITLE
Update ViewHeader and use for major views

### DIFF
--- a/client/src/js/account/components/Account.js
+++ b/client/src/js/account/components/Account.js
@@ -1,10 +1,10 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { connect } from "react-redux";
 import { LinkContainer } from "react-router-bootstrap";
 import { Switch, Redirect, Route } from "react-router-dom";
 import { Nav, NavItem } from "react-bootstrap";
 
+import { ViewHeader } from "../../base";
 import { getAccount } from "../actions";
 import AccountGeneral from "./General";
 import AccountSettings from "./Settings";
@@ -20,12 +20,9 @@ class Account extends React.Component {
 
         return (
             <div className="container-noside">
-                <Helmet>
-                    <title>Account</title>
-                </Helmet>
-                <h3 className="view-header">
+                <ViewHeader title="Account">
                     <strong>Account</strong>
-                </h3>
+                </ViewHeader>
                 <Nav bsStyle="tabs">
                     <LinkContainer to="/account/general">
                         <NavItem>General</NavItem>

--- a/client/src/js/administration/components/Settings.js
+++ b/client/src/js/administration/components/Settings.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { connect } from "react-redux";
 import { Switch, Redirect, Route } from "react-router-dom";
 import { Nav, NavItem } from "react-bootstrap";
@@ -11,7 +10,7 @@ import Sentry from "./Server/Sentry";
 import Data from "./Data";
 import Users from "../../users/components/Users";
 import Updates from "../../updates/components/Viewer";
-import { LoadingPlaceholder } from "../../base";
+import { LoadingPlaceholder, ViewHeader } from "../../base";
 
 const Server = () => (
     <div className="settings-container">
@@ -40,14 +39,9 @@ const Settings = ({ settings }) => {
 
     return (
         <div className="container-noside">
-            <Helmet>
-                <title>Administration</title>
-            </Helmet>
-            <h3 className="view-header">
-                <strong>
-                    Administration
-                </strong>
-            </h3>
+            <ViewHeader title="Administration">
+                <strong>Administration</strong>
+            </ViewHeader>
 
             <Nav bsStyle="tabs">
                 <LinkContainer to="/administration/server">

--- a/client/src/js/base/ViewHeader.js
+++ b/client/src/js/base/ViewHeader.js
@@ -44,30 +44,34 @@ export const PageHint = ({ page, count, totalCount, perPage = 15, pullRight = tr
  * @param foundCount {count} the number of documents found by the current query
  * @param totalCount {count} the total number of documents
  */
-export const ViewHeader = ({ title, page, count, foundCount, totalCount }) => (
+export const ViewHeader = ({ title, page, count, foundCount, totalCount, children }) => (
     <h3 className="view-header">
         <Helmet>
             <title>{title}</title>
         </Helmet>
-        <Flex alignItems="flex-end">
-            <FlexItem grow={0} shrink={0}>
-                <strong>{title}</strong> <Badge>{totalCount}</Badge>
-            </FlexItem>
-            <FlexItem grow={1} shrink={0}>
-                <PageHint
-                    page={page}
-                    count={count}
-                    totalCount={foundCount}
-                />
-            </FlexItem>
-        </Flex>
+        {foundCount ? (
+            <Flex alignItems="flex-end">
+                <FlexItem grow={0} shrink={0}>
+                    <strong>{title}</strong> <Badge>{totalCount}</Badge>
+                </FlexItem>
+                <FlexItem grow={1} shrink={0}>
+                    <PageHint
+                        page={page}
+                        count={count}
+                        totalCount={foundCount}
+                    />
+                </FlexItem>
+            </Flex>
+        ) : null}
+        {children}
     </h3>
 );
 
 ViewHeader.propTypes = {
     title: PropTypes.string,
-    page: PropTypes.number.isRequired,
-    count: PropTypes.number.isRequired,
-    foundCount: PropTypes.number.isRequired,
-    totalCount: PropTypes.number
+    page: PropTypes.number,
+    count: PropTypes.number,
+    foundCount: PropTypes.number,
+    totalCount: PropTypes.number,
+    children: PropTypes.node
 };

--- a/client/src/js/hmm/components/Detail.js
+++ b/client/src/js/hmm/components/Detail.js
@@ -1,10 +1,9 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { map, sortBy } from "lodash-es";
 import { Row, Col, Table, Badge, Label, Panel, ListGroup } from "react-bootstrap";
 import { connect } from "react-redux";
 
-import { IDRow, ListGroupItem, LoadingPlaceholder } from "../../base";
+import { IDRow, ListGroupItem, LoadingPlaceholder, ViewHeader } from "../../base";
 import { getHmm } from "../actions";
 
 const HMMTaxonomy = ({ counts }) => {
@@ -56,12 +55,9 @@ class HMMDetail extends React.Component {
 
         return (
             <div>
-                <Helmet>
-                    <title>{`${this.props.detail.names[0]} - HMMs`}</title>
-                </Helmet>
-                <h3 className="view-header">
+                <ViewHeader title={`${this.props.detail.names[0]} - HMMs`}>
                     <strong>{this.props.detail.names[0]}</strong>
-                </h3>
+                </ViewHeader>
 
                 <Table bordered>
                     <tbody>

--- a/client/src/js/indexes/components/Detail.js
+++ b/client/src/js/indexes/components/Detail.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import { connect } from "react-redux";
 import { Switch, Redirect, Route } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
@@ -8,7 +7,7 @@ import { Badge, Nav, NavItem, Breadcrumb } from "react-bootstrap";
 import IndexGeneral from "./General";
 import IndexChanges from "./Changes";
 import { getIndex } from "../actions";
-import { LoadingPlaceholder } from "../../base";
+import { LoadingPlaceholder, ViewHeader } from "../../base";
 
 class IndexDetail extends React.Component {
 
@@ -29,9 +28,7 @@ class IndexDetail extends React.Component {
 
         return (
             <div>
-                <Helmet>
-                    <title>{`Index ${version} - Indexes - Virtool`}</title>
-                </Helmet>
+                <ViewHeader title={`Index ${version} - Indexes - Virtool`} />
 
                 <Breadcrumb>
                     <Breadcrumb.Item>

--- a/client/src/js/jobs/components/Detail.js
+++ b/client/src/js/jobs/components/Detail.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import Moment from "moment";
 import { connect } from "react-redux";
 import { Table } from "react-bootstrap";
@@ -7,7 +6,7 @@ import { push } from "react-router-redux";
 
 import { getJob, removeJob } from "../actions";
 import { getTaskDisplayName } from "../../utils";
-import { Flex, FlexItem, Icon, LoadingPlaceholder, ProgressBar } from "../../base";
+import { Flex, FlexItem, Icon, LoadingPlaceholder, ProgressBar, ViewHeader } from "../../base";
 import TaskArgs from "./TaskArgs";
 import JobError from "./Error";
 
@@ -72,10 +71,7 @@ class JobDetail extends React.Component {
 
         return (
             <div>
-                <Helmet>
-                    <title>{`${taskName} - Jobs`}</title>
-                </Helmet>
-                <h3 style={{marginBottom: "20px"}}>
+                <ViewHeader title={`${taskName} - Jobs`}>
                     <Flex alignItems="flex-end">
                         <FlexItem grow={1}>
                             <Flex alignItems="center">
@@ -97,7 +93,7 @@ class JobDetail extends React.Component {
                             onClick={this.handleClick}
                         />
                     </Flex>
-                </h3>
+                </ViewHeader>
 
                 <ProgressBar bsStyle={progressStyle} now={latest.progress * 100} />
 

--- a/client/src/js/otus/components/Detail/Detail.js
+++ b/client/src/js/otus/components/Detail/Detail.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { Switch, Route, Redirect } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
@@ -14,7 +13,7 @@ import RemoveOTU from "./RemoveOTU";
 import Schema from "./Schema";
 import { getReference } from "../../../references/actions";
 import { getOTU, showEditOTU, showRemoveOTU } from "../../actions";
-import { Flex, FlexItem, Icon, LoadingPlaceholder } from "../../../base";
+import { Flex, FlexItem, Icon, LoadingPlaceholder, ViewHeader } from "../../../base";
 
 const OTUSection = ({ match }) => (
     <div>
@@ -80,9 +79,7 @@ class OTUDetail extends React.Component {
 
         return (
             <div>
-                <Helmet>
-                    <title>{`${name} - OTU`}</title>
-                </Helmet>
+                <ViewHeader title={`${name} - OTU`} />
 
                 <Breadcrumb>
                     <Breadcrumb.Item>

--- a/client/src/js/references/components/Detail/Detail.js
+++ b/client/src/js/references/components/Detail/Detail.js
@@ -1,12 +1,12 @@
 import React from "react";
+import Moment from "moment";
 import { connect } from "react-redux";
-import Helmet from "react-helmet";
 import { Switch, Route, Redirect } from "react-router-dom";
 import { push } from "react-router-redux";
 import { LinkContainer } from "react-router-bootstrap";
 import { Nav, NavItem, Badge } from "react-bootstrap";
 import { getReference } from "../../actions";
-import { LoadingPlaceholder, Icon, RelativeTime } from "../../../base";
+import { LoadingPlaceholder, Icon, ViewHeader, Flex, FlexItem } from "../../../base";
 
 import EditReference from "./Edit";
 import ReferenceManage from "./Manage";
@@ -62,16 +62,18 @@ class ReferenceDetail extends React.Component {
 
         return (
             <div>
-                <Helmet>
-                    <title>{`${name} - References`}</title>
-                </Helmet>
-                <h3 className="view-header">
-                    <strong>{name}</strong>
-                    {headerIcon}
+                <ViewHeader title={`${name} - References`}>
+                    <Flex alignItems="flex-end">
+                        <FlexItem grow={1}>
+                            <strong>{name}</strong>
+                        </FlexItem>
+                        {headerIcon}
+                    </Flex>
                     <div className="text-muted" style={{fontSize: "12px"}}>
-                        Created <RelativeTime time={created_at} /> by {user.id}
+                        Created {Moment(created_at).calendar()} by {user.id}
                     </div>
-                </h3>
+                </ViewHeader>
+
                 <Nav bsStyle="tabs">
                     <LinkContainer to={`/refs/${id}/manage`}>
                         <NavItem>Manage</NavItem>

--- a/client/src/js/samples/components/Detail.js
+++ b/client/src/js/samples/components/Detail.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Helmet from "react-helmet";
+import Moment from "moment";
 import { includes } from "lodash-es";
 import { Nav, NavItem } from "react-bootstrap";
 import { connect } from "react-redux";
@@ -13,7 +13,7 @@ import Quality from "./Quality/Quality";
 import RemoveSample from "./Remove";
 import Rights from "./Rights";
 import { getSample, showRemoveSample, hideSampleModal } from "../actions";
-import { Flex, FlexItem, Icon, LoadingPlaceholder } from "../../base";
+import { Flex, FlexItem, Icon, LoadingPlaceholder, ViewHeader } from "../../base";
 import { getCanModify } from "../selectors";
 
 class SampleDetail extends React.Component {
@@ -53,7 +53,7 @@ class SampleDetail extends React.Component {
                     <small style={{paddingLeft: "5px"}}>
                         <Icon
                             bsStyle="warning"
-                            name="pencil"
+                            name="pencil-alt"
                             tip="Edit Sample"
                             onClick={this.props.showEdit}
                         />
@@ -73,12 +73,11 @@ class SampleDetail extends React.Component {
             );
         }
 
+        const { created_at, user } = this.props.detail;
+
         return (
             <div>
-                <Helmet>
-                    <title>{`${detail.name} - Samples`}</title>
-                </Helmet>
-                <h3 style={{marginBottom: "20px"}}>
+                <ViewHeader title={`${detail.name} - Samples`}>
                     <Flex alignItems="flex-end">
                         <FlexItem grow={1}>
                             <strong>
@@ -89,7 +88,10 @@ class SampleDetail extends React.Component {
                         {editIcon}
                         {removeIcon}
                     </Flex>
-                </h3>
+                    <div className="text-muted" style={{fontSize: "12px"}}>
+                        Created {Moment(created_at).calendar()} by {user.id}
+                    </div>
+                </ViewHeader>
 
                 <Nav bsStyle="tabs">
                     <LinkContainer to={`/samples/${sampleId}/general`}>

--- a/client/src/js/samples/components/General.js
+++ b/client/src/js/samples/components/General.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Moment from "moment";
 import Numeral from "numeral";
 import { map } from "lodash-es";
 import { Panel, Table } from "react-bootstrap";
@@ -22,15 +21,6 @@ const SampleDetailGeneral = (props) => (
                 )}
 
                 <IDRow id={props.id} />
-
-                <tr>
-                    <th>Created</th>
-                    <td>{Moment(props.created_at).calendar()}</td>
-                </tr>
-                <tr>
-                    <th>Created By</th>
-                    <td>{props.userId}</td>
-                </tr>
             </tbody>
         </table>
 

--- a/client/src/js/subtraction/components/Detail.js
+++ b/client/src/js/subtraction/components/Detail.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Helmet from "react-helmet";
 import Numeral from "numeral";
 import { map } from "lodash-es";
 import { connect } from "react-redux";
@@ -8,7 +7,7 @@ import { LinkContainer } from "react-router-bootstrap";
 import { Badge, Col, Row, Table } from "react-bootstrap";
 
 import { getSubtraction } from "../actions";
-import { Button, Flex, FlexItem, Icon, LoadingPlaceholder, NoneFound } from "../../base";
+import { Button, Flex, FlexItem, Icon, LoadingPlaceholder, NoneFound, ViewHeader } from "../../base";
 import EditSubtraction from "./Edit";
 import RemoveSubtraction from "./Remove";
 
@@ -79,7 +78,7 @@ class SubtractionDetail extends React.Component {
 
             const editIcon = (
                 <Icon
-                    name="pencil"
+                    name="pencil-alt"
                     bsStyle="warning"
                     onClick={() => this.setState({showEdit: true})}
                     pullRight
@@ -88,10 +87,7 @@ class SubtractionDetail extends React.Component {
 
             return (
                 <div>
-                    <Helmet>
-                        <title>{`${data.id} - Subtraction`}</title>
-                    </Helmet>
-                    <h3 className="view-header">
+                    <ViewHeader title={`${data.id} - Subtraction`}>
                         <Flex alignItems="flex-end">
                             <FlexItem grow={0} shrink={0}>
                                 <strong>{data.id}</strong>
@@ -107,7 +103,7 @@ class SubtractionDetail extends React.Component {
                                 </small>
                             </FlexItem>
                         </Flex>
-                    </h3>
+                    </ViewHeader>
 
                     <Table bordered>
                         <tbody>


### PR DESCRIPTION
- resolves #735 
- Updated `<ViewHeader />` component so that `<PageHint />` is only used if optional `foundCount` is supplied; and also accepts `children` props for customized headers
- Updated several Detail pages to use `<ViewHeader />` rather than custom solutions