### PR TITLE
Update remote references

### DIFF
--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -51,7 +51,14 @@ async def find(req):
     if term:
         db_query.update(compose_regex_query(term, ["name", "data_type"]))
 
-    data = await paginate(db.references, db_query, req.query, sort="name", projection=virtool.db.references.PROJECTION)
+    data = await paginate(
+        db.references,
+        db_query,
+        req.query,
+        sort="name",
+        processor=virtool.db.references.processor,
+        projection=virtool.db.references.PROJECTION
+    )
 
     for d in data["documents"]:
         latest_build, otu_count, unbuilt_count = await asyncio.gather(

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -300,13 +300,13 @@ async def create(req):
             user_id
         )
 
-        latest_release = await virtool.github.get_latest_release(
+        release = await virtool.github.get_release(
             settings,
             req.app["client"],
             remote_from
         )
 
-        latest_release = virtool.github.format_release(latest_release)
+        release = virtool.github.format_release(release)
 
         process = await virtool.db.processes.register(db, "remote_reference")
 

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -103,6 +103,16 @@ async def get(req):
 
 @routes.get("/api/refs/{ref_id}/update")
 async def get_update(req):
+    """
+    Get the latest update from GitHub and return it. Also updates the reference document. This is the only way of doing
+    so without waiting for an automatic refresh every 10 minutes.
+
+    """
+    ref_id = req.match_info["ref_id"]
+
+    release = await virtool.db.references.check_for_remote_update(req.app, ref_id)
+
+    return json_response(release)
     ref_id = req.match_info["ref_id"]
 
     update = await virtool.db.references.check_for_remote_update(req.app, ref_id)

--- a/virtool/db/otus.py
+++ b/virtool/db/otus.py
@@ -157,7 +157,7 @@ async def find(db, names, term, req_query, verified, ref_id=None):
     return data
 
 
-async def join(db, otu_id, document=None):
+async def join(db, query, document=None):
     """
     Join the otu associated with the supplied ``otu_id`` with its sequences. If a otu entry is also passed,
     the database will not be queried for the otu based on its id.
@@ -165,8 +165,8 @@ async def join(db, otu_id, document=None):
     :param db: the application database client
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
 
-    :param otu_id: the id of the otu to join.
-    :type otu_id: str
+    :param query: the id of the otu to join or a Mongo query.
+    :type query: Union[dict,str]
 
     :param document: use this otu document as a basis for the join instead finding it using the otu id.
     :type document: dict
@@ -176,13 +176,13 @@ async def join(db, otu_id, document=None):
 
     """
     # Get the otu entry if a ``document`` parameter was not passed.
-    document = document or await db.otus.find_one(otu_id)
+    document = document or await db.otus.find_one(query)
 
     if document is None:
         return None
 
     # Get the sequence entries associated with the isolate ids.
-    sequences = await db.sequences.find({"otu_id": otu_id}).to_list(None) or list()
+    sequences = await db.sequences.find({"otu_id": document["_id"]}).to_list(None) or list()
 
     # Merge the sequence entries into the otu entry.
     return virtool.otus.merge_otu(document, sequences)

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -85,7 +85,7 @@ async def check_for_remote_update(app, ref_id):
     etag = remotes_from.get("etag", None)
 
     try:
-        latest_release = await virtool.github.get_latest_release(
+        latest_release = await virtool.github.get_release(
             app["settings"],
             app["client"],
             remotes_from["slug"],

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -18,24 +18,34 @@ import virtool.utils
 
 PROJECTION = [
     "_id",
+    "remotes_from",
     "created_at",
     "data_type",
+    "imported_from",
+    "internal_control",
+    "latest_build",
     "name",
     "organism",
-    "public",
-    "user",
-    "internal_control",
-    "cloned_from",
-    "imported_from",
-    "remotes_from",
     "process",
-    "latest_build",
-    "unbuilt_count"
+    "public",
+    "release",
+    "remotes_from",
+    "unbuilt_count",
+    "updates",
+    "user"
 ]
 
 
-async def add_group_or_user(db, ref_id, field, data):
+def processor(document):
+    try:
+        document["installed"] = document.pop("updates")[-1]
+    except (KeyError, IndexError):
+        pass
 
+    return virtool.utils.base_processor(document)
+
+
+async def add_group_or_user(db, ref_id, field, data):
     document = await db.references.find_one({"_id": ref_id}, [field])
 
     if not document:

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -283,6 +283,16 @@ async def edit_group_or_user(db, ref_id, subdocument_id, field, data):
 
 
 async def get_computed(db, ref_id, internal_control_id):
+    """
+    Get all computed data for the specified reference.
+
+    :param db: the application database client
+    :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
+
+    :param ref_id:
+    :param internal_control_id:
+    :return:
+    """
     contributors, internal_control, latest_build, otu_count, unbuilt_count = await asyncio.gather(
         get_contributors(db, ref_id),
         get_internal_control(db, internal_control_id),

--- a/virtool/db/status.py
+++ b/virtool/db/status.py
@@ -30,7 +30,7 @@ async def fetch_and_update_hmm_release(app):
     if existing:
         etag = existing.get("etag", None)
 
-    release = await virtool.github.get_latest_release(settings, session, "virtool/virtool-hmm", etag)
+    release = await virtool.github.get_release(settings, session, "virtool/virtool-hmm", etag)
 
     if release:
         return await db.status.find_one_and_update({"_id": "hmm"}, {

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -25,7 +25,7 @@ def format_release(release):
     }
 
 
-async def get_release(settings, session, slug, etag=None, version=None):
+async def get_release(settings, session, slug, etag=None, release_id="latest"):
     """
     GET data from a GitHub API url.
 
@@ -41,16 +41,14 @@ async def get_release(settings, session, slug, etag=None, version=None):
     :param etag: an ETag for the resource to be used with the `If-None-Match` header
     :type etag: str
 
-    :param version: the release name to get
-    :type version: str
+    :param release_id: the id of the GitHub release to get
+    :type release_id: Union[int,str]
 
     :return: the latest release
     :rtype: Coroutine[dict]
 
     """
-    specifier = "tags/" + version if version else "latest"
-
-    url = "{}/{}/releases/{}".format(BASE_URL, slug, specifier)
+    url = "{}/{}/releases/{}".format(BASE_URL, slug, release_id)
 
     headers = dict(HEADERS)
 

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -24,7 +24,7 @@ def format_release(release):
     }
 
 
-async def get_latest_release(settings, session, slug, etag=None):
+async def get_release(settings, session, slug, etag=None, version=None):
     """
     GET data from a GitHub API url.
 
@@ -40,11 +40,16 @@ async def get_latest_release(settings, session, slug, etag=None):
     :param etag: an ETag for the resource to be used with the `If-None-Match` header
     :type etag: str
 
+    :param version: the release name to get
+    :type version: str
+
     :return: the latest release
     :rtype: Coroutine[dict]
 
     """
-    url = "{}/{}/releases/latest".format(BASE_URL, slug)
+    specifier = "tags/" + version if version else "latest"
+
+    url = "{}/{}/releases/{}".format(BASE_URL, slug, specifier)
 
     headers = dict(HEADERS)
 

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -12,6 +12,7 @@ def format_release(release):
     asset = release["assets"][0]
 
     return {
+        "id": release["id"],
         "name": release["name"],
         "body": release["body"],
         "etag": release["etag"],

--- a/virtool/processes.py
+++ b/virtool/processes.py
@@ -5,6 +5,7 @@ FIRST_STEPS = {
     "clone_reference": "copy_otus",
     "import_reference": "load_file",
     "remote_reference": "download",
+    "update_remote_reference": "download",
     "update_software": "",
     "install_hmms": ""
 }
@@ -17,7 +18,7 @@ UNIQUES = [
 
 class ProgressTracker:
 
-    def __init__(self, db, process_id, total, factor=1, increment=0.05, initial=0):
+    def __init__(self, db, process_id, total, factor=1, increment=0.03, initial=0):
         self.db = db
         self.process_id = process_id
         self.total = total


### PR DESCRIPTION
- allow `virtool.db.otus.join()` to take a Mongo query in addition to the existing `id` functionality
- include new fields in remote reference API responses
  - `installed`: the most recently installed remote update
  - `release`: the latest available release
  - `updates`: a history of updates applied to the references
- includes `id` fields in formatted releases
- rename `get_latest_release()` to `get_release` and allow it to get releases by `id`
- store `remote.id` in OTU documents for use during updates

