### PR TITLE
Fix 742

### DIFF
--- a/client/src/js/actionTypes.js
+++ b/client/src/js/actionTypes.js
@@ -55,6 +55,7 @@ export const REMOVE_SAMPLE = createRequestActionType("REMOVE_SAMPLE");
 export const FIND_ANALYSES = createRequestActionType("FIND_ANALYSES");
 export const GET_ANALYSIS = createRequestActionType("GET_ANALYSIS");
 export const GET_ANALYSIS_PROGRESS = "GET_ANALYSIS_PROGRESS";
+export const CLEAR_ANALYSIS = "CLEAR_ANALYSIS";
 export const ANALYZE = createRequestActionType("ANALYZE");
 export const BLAST_NUVS = createRequestActionType("BLAST_NUVS");
 export const REMOVE_ANALYSIS = createRequestActionType("REMOVE_ANALYSIS");

--- a/client/src/js/samples/actions.js
+++ b/client/src/js/samples/actions.js
@@ -13,6 +13,7 @@ import {
     REMOVE_SAMPLE,
     FIND_ANALYSES,
     GET_ANALYSIS,
+    CLEAR_ANALYSIS,
     ANALYZE,
     BLAST_NUVS,
     REMOVE_ANALYSIS,
@@ -89,6 +90,8 @@ export const getAnalysis = (analysisId) => ({
     type: GET_ANALYSIS.REQUESTED,
     analysisId
 });
+
+export const clearAnalysis = simpleActionCreator(CLEAR_ANALYSIS);
 
 export const getAnalysisProgress = (progress) => ({
     type: GET_ANALYSIS_PROGRESS,

--- a/client/src/js/samples/components/Analyses/Detail.js
+++ b/client/src/js/samples/components/Analyses/Detail.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { Col, Label, Panel, ProgressBar, Row, Table } from "react-bootstrap";
 import {IDRow, LoadingPlaceholder, RelativeTime} from "../../../base";
 
-import { getAnalysis } from "../../actions";
+import { getAnalysis, clearAnalysis } from "../../actions";
 import { getTaskDisplayName } from "../../../utils";
 import PathoscopeViewer from "./Pathoscope/Viewer";
 import NuVsViewer from "./NuVs/Viewer";
@@ -13,6 +13,10 @@ class AnalysisDetail extends React.Component {
 
     componentDidMount () {
         this.props.getAnalysis(this.props.match.params.analysisId);
+    }
+
+    componentWillUnmount () {
+        this.props.clearAnalysis();
     }
 
     render () {
@@ -108,6 +112,10 @@ const mapDispatchToProps = (dispatch) => ({
 
     getAnalysis: (analysisId) => {
         dispatch(getAnalysis(analysisId));
+    },
+
+    clearAnalysis: () => {
+        dispatch(clearAnalysis());
     }
 
 });

--- a/client/src/js/samples/reducer.js
+++ b/client/src/js/samples/reducer.js
@@ -33,7 +33,7 @@ const initialState = {
 const setNuvsBLAST = (state, analysisId, sequenceIndex, data = "ip") => {
     const analysisDetail = state.analysisDetail;
 
-    if (analysisDetail.id === analysisId) {
+    if (analysisDetail && analysisDetail.id === analysisId) {
         return {...state, analysisDetail: {
             ...analysisDetail,
             results: map(analysisDetail.results, sequence => {

--- a/client/src/js/samples/reducer.js
+++ b/client/src/js/samples/reducer.js
@@ -10,6 +10,7 @@ import {
     FIND_READ_FILES,
     FIND_READY_HOSTS,
     GET_ANALYSIS,
+    CLEAR_ANALYSIS,
     ANALYZE,
     BLAST_NUVS,
     REMOVE_ANALYSIS, GET_ANALYSIS_PROGRESS
@@ -100,6 +101,9 @@ export default function samplesReducer (state = initialState, action) {
 
         case GET_ANALYSIS_PROGRESS:
             return {...state, getAnalysisProgress: action.progress};
+
+        case CLEAR_ANALYSIS:
+            return {...state, getAnalysisProgress: 0, analysisDetail: null};
 
         case ANALYZE.REQUESTED:
             return {

--- a/client/src/js/samples/sagas.js
+++ b/client/src/js/samples/sagas.js
@@ -1,4 +1,4 @@
-import { includes, noop } from "lodash-es";
+import { get, includes, noop } from "lodash-es";
 import { LOCATION_CHANGE, push } from "react-router-redux";
 import { buffers, END, eventChannel } from "redux-saga";
 import { call, put, select, take, takeEvery, takeLatest, throttle } from "redux-saga/effects";
@@ -27,6 +27,8 @@ import {
     REMOVE_ANALYSIS
 } from "../actionTypes";
 
+export const getAnalysisDetailId = (state) => get(state, "samples.analysisDetail.id", null);
+
 export function* watchSamples () {
     yield throttle(200, LOCATION_CHANGE, findSamples);
     yield takeEvery(WS_UPDATE_SAMPLE, wsSample);
@@ -52,7 +54,11 @@ export function* wsSample () {
 }
 
 export function* wsUpdateAnalysis (action) {
-    yield getAnalysis({analysisId: action.update.id});
+    const currentAnalysisId = yield select(getAnalysisDetailId);
+
+    if (currentAnalysisId === action.update.id) {
+        yield getAnalysis({analysisId: currentAnalysisId});
+    }
 }
 
 export function* findSamples (action) {

--- a/virtool/handlers/analyses.py
+++ b/virtool/handlers/analyses.py
@@ -76,6 +76,8 @@ async def remove(req):
     if not document["ready"]:
         return conflict("Analysis is still running")
 
+    await db.analyses.delete_one({"_id": analysis_id})
+
     await req.app["dispatcher"].dispatch("samples", "update", virtool.utils.base_processor(sample))
 
     return no_content()


### PR DESCRIPTION
- resolves #742 
- add `CLEAR_ANALYSIS` action type that trigger clearing (`null`) of `state.samples.analysisDetail`
- fix ineffective analysis removal endpoint
- fix unhandled property of `undefined` in `setNuvsBLAST()`
- only update analysis detail on websocket update when `id` fields match