### PR TITLE
Reference exporting

### DIFF
--- a/virtool/api/downloads.py
+++ b/virtool/api/downloads.py
@@ -103,7 +103,7 @@ async def download_reference(req):
     body = await req.app["run_in_process"](gzip.compress, bytes(json_string, "utf-8"))
 
     return web.Response(
-        headers={"Content-Disposition": "attachment; filename='reference.json.gz'"},
+        headers={"Content-Disposition": "attachment; filename='reference.{}.json.gz'".format(scope)},
         content_type="application/gzip",
         body=body
     )

--- a/virtool/api/downloads.py
+++ b/virtool/api/downloads.py
@@ -88,7 +88,12 @@ async def download_reference(req):
 
     document = await db.references.find_one(ref_id, ["data_type", "organism"])
 
-    otu_list = await virtool.db.references.export(db, ref_id)
+    if document is None:
+        return not_found()
+
+    scope = req.query.get("scope", "built")
+
+    otu_list = await virtool.db.references.export(db, ref_id, scope)
 
     data = {
         "data": otu_list,

--- a/virtool/api/downloads.py
+++ b/virtool/api/downloads.py
@@ -93,6 +93,9 @@ async def download_reference(req):
 
     scope = req.query.get("scope", "built")
 
+    if scope not in ["built", "unbuilt", "unverified"]:
+        scope = "built"
+
     otu_list = await virtool.db.references.export(db, ref_id, scope)
 
     data = {

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -1,6 +1,4 @@
 import asyncio
-import gzip
-import json
 import os
 
 import pymongo

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -683,6 +683,11 @@ async def export(db, ref_id, scope):
             last_verified = await virtool.db.history.patch_to_verified(db, document["_id"])
             otu_list.append(last_verified)
 
+    else:
+        async for document in db.otus.find(query):
+            current = await virtool.db.otus.join(db, document["_id"], document)
+            otu_list.append(current)
+
     return otu_list
 
 

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -658,7 +658,7 @@ async def download_and_parse_release(app, url, process_id, progress_handler):
         return await app["run_in_thread"](virtool.references.load_reference_file, download_path)
 
 
-async def export(db, ref_id, scope="built"):
+async def export(db, ref_id, scope):
     # A list of joined viruses.
     otu_list = list()
 
@@ -677,6 +677,11 @@ async def export(db, ref_id, scope="built"):
             )
 
             otu_list.append(joined)
+
+    elif scope == "unbuilt":
+        async for document in db.otus.find(query):
+            last_verified = await virtool.db.history.patch_to_verified(db, document["_id"])
+            otu_list.append(last_verified)
 
     return otu_list
 


### PR DESCRIPTION
- resolves #761
- documentation is updated
- implements reference exporting in API (`/download/refs/:ref_id`)
- query parameter allows scoping of export to built, unbuilt, or unverified changes