### PR TITLE
Resolve reference user and group issues

### DIFF
--- a/tests/api/test_references.py
+++ b/tests/api/test_references.py
@@ -94,10 +94,7 @@ async def test_add_group_or_user(error, field, mocker, spawn_client, resp_is):
         assert await resp.json() == expected
 
         m_add_group_or_user.assert_called_with(client.db, "foobar", field + "s", {
-            "build": False,
             "modify": True,
-            "modify_otu": False,
-            "remove": False,
             field + "_id": "baz"
         })
 
@@ -129,9 +126,6 @@ async def test_edit_group_or_user(error, field, mocker, spawn_client, resp_is):
         assert await resp.json() == expected
 
         m_edit_group_or_user.assert_called_with(client.db, "foobar", "baz", field + "s", {
-            "build": False,
-            "modify": False,
-            "modify_otu": False,
             "remove": True
         })
 

--- a/tests/db/test_references.py
+++ b/tests/db/test_references.py
@@ -1,14 +1,17 @@
-import gzip
-import json
 import os
-import shutil
 import sys
 
 import pytest
-from aiohttp.test_utils import make_mocked_coro
 
 import virtool.db.references
 import virtool.errors
+
+RIGHTS = {
+    "build": False,
+    "modify": False,
+    "modify_otu": False,
+    "remove": False
+}
 
 TEST_IMPORT_FILE_PATH = os.path.join(sys.path[0], "tests", "test_files", "files", "import.json.gz")
 
@@ -21,12 +24,8 @@ async def test_add_group_or_user(error, field, rights, test_dbi, static_time):
     ref_id = "foo"
 
     subdocuments = [
-        {
-            "id": "bar"
-        },
-        {
-            "id": "baz"
-        }
+        {**RIGHTS, "id": "bar"},
+        {**RIGHTS, "id": "baz"}
     ]
 
     if error != "missing":
@@ -106,12 +105,8 @@ async def test_edit_group_or_user(field, missing, test_dbi, static_time):
     ref_id = "foo"
 
     subdocuments = [
-        {
-            "id": "bar"
-        },
-        {
-            "id": "baz"
-        }
+        {**RIGHTS, "id": "bar"},
+        {**RIGHTS, "id": "baz"}
     ]
 
     if missing != "reference":

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -22,20 +22,16 @@ routes = virtool.http.routes.Routes()
 
 RIGHTS_SCHEMA = {
     "build": {
-        "type": "boolean",
-        "default": False
+        "type": "boolean"
     },
     "modify": {
-        "type": "boolean",
-        "default": False
+        "type": "boolean"
     },
     "modify_otu": {
-        "type": "boolean",
-        "default": False
+        "type": "boolean"
     },
     "remove": {
-        "type": "boolean",
-        "default": False
+        "type": "boolean"
     }
 }
 

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -15,7 +15,7 @@ import virtool.http.routes
 import virtool.otus
 import virtool.references
 import virtool.utils
-from virtool.api.utils import compose_regex_query, conflict, json_response, no_content, not_found, paginate
+from virtool.api.utils import bad_request, compose_regex_query, conflict, json_response, no_content, not_found, paginate
 
 routes = virtool.http.routes.Routes()
 
@@ -565,8 +565,14 @@ async def add_group(req):
 
     try:
         subdocument = await virtool.db.references.add_group_or_user(db, ref_id, "groups", data)
-    except virtool.errors.DatabaseError:
-        raise conflict("Group already exists")
+    except virtool.errors.DatabaseError as err:
+        if "already exists" in str(err):
+            return conflict("Group already exists")
+
+        if "does not exist" in str(err):
+            return bad_request("Group does not exist")
+
+        raise
 
     if subdocument is None:
         return not_found()
@@ -591,8 +597,14 @@ async def add_user(req):
 
     try:
         subdocument = await virtool.db.references.add_group_or_user(db, ref_id, "users", data)
-    except virtool.errors.DatabaseError:
-        raise conflict("Group already exists")
+    except virtool.errors.DatabaseError as err:
+        if "already exists" in str(err):
+            return conflict("User already exists")
+
+        if "does not exist" in str(err):
+            return bad_request("User does not exist")
+
+        raise
 
     if subdocument is None:
         return not_found()

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -270,7 +270,7 @@ async def edit_group_or_user(db, ref_id, subdocument_id, field, data):
 
     for subdocument in document[field]:
         if subdocument["id"] == subdocument_id:
-            rights = {key: data.get(key, False) for key in virtool.references.RIGHTS}
+            rights = {key: data.get(key, subdocument[key]) for key in virtool.references.RIGHTS}
             subdocument.update(rights)
 
             await db.references.update_one({"_id": ref_id}, {

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -52,6 +52,12 @@ async def add_group_or_user(db, ref_id, field, data):
 
     subdocument_id = data.get("group_id", None) or data["user_id"]
 
+    if field == "groups" and await db.groups.count({"_id": subdocument_id}) == 0:
+        raise virtool.errors.DatabaseError("group does not exist")
+
+    if field == "users" and await db.users.count({"_id": subdocument_id}) == 0:
+        raise virtool.errors.DatabaseError("user does not exist")
+
     if subdocument_id in [s["id"] for s in document[field]]:
         raise virtool.errors.DatabaseError(field[:-1] + " already exists")
 


### PR DESCRIPTION
- resolves #750
- fix issue when editing existing ref users and groups where rights were not calculated correctly
- return a `404 Not found` response when added group or user id does not exist