### PR TITLE
Send cloned_from field in ref responses

### DIFF
--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -18,6 +18,7 @@ import virtool.utils
 PROJECTION = [
     "_id",
     "remotes_from",
+    "cloned_from",
     "created_at",
     "data_type",
     "imported_from",


### PR DESCRIPTION
- resolves #790 
- add `cloned_from` to reference `PROJECTION`
