### PR TITLE
Export remote

### DIFF
--- a/virtool/api/downloads.py
+++ b/virtool/api/downloads.py
@@ -93,13 +93,13 @@ async def download_reference(req):
 
     scope = req.query.get("scope", "built")
 
-    if scope not in ["built", "unbuilt", "unverified"]:
+    if scope not in ["built", "remote", "unbuilt", "unverified"]:
         scope = "built"
 
     otu_list = await virtool.db.references.export(db, ref_id, scope)
 
     data = {
-        "data": otu_list,
+        "otus": otu_list,
         "data_type": document["data_type"],
         "organism": document["organism"]
     }

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -681,7 +681,7 @@ async def export(db, ref_id, scope):
         "reference.id": ref_id
     }
 
-    if scope == "built":
+    if scope == "built" or scope == "remote":
         query["last_indexed_version"] = {"$ne": None}
 
         async for document in db.otus.find(query):
@@ -703,7 +703,7 @@ async def export(db, ref_id, scope):
             current = await virtool.db.otus.join(db, document["_id"], document)
             otu_list.append(current)
 
-    return otu_list
+    return virtool.references.clean_export_list(otu_list, scope == "remote")
 
 
 async def finish_clone(app, ref_id, created_at, manifest, process_id, user_id):
@@ -954,20 +954,17 @@ async def insert_joined_otu(db, otu, created_at, ref_id, user_id, remote=False):
             "id": remote_id
         }
 
-    used_isolate_ids = set()
-
     for isolate in otu["isolates"]:
-        if not remote:
-            isolate_id = virtool.utils.random_alphanumeric(3, excluded=used_isolate_ids)
-            used_isolate_ids.add(isolate_id)
-            isolate["id"] = isolate_id
-
         for sequence in isolate.pop("sequences"):
-            remote_sequence_id = sequence.pop("_id")
+            try:
+                remote_sequence_id = sequence["remote"]["id"]
+                sequence.pop("_id")
+            except KeyError:
+                remote_sequence_id = sequence.pop("_id")
 
             all_sequences.append({
                 **sequence,
-                "accession": sequence.pop("accession", None) or remote_sequence_id,
+                "accession": sequence["accession"],
                 "isolate_id": isolate["id"],
                 "reference": {
                     "id": ref_id


### PR DESCRIPTION
- allow export of references in the `remote` scope
- OTU, isolate, and sequence `_id` and `id` fields are set with the values from the original remote reference if there is one
- provides the ability to remote, clone, modify, and export references for submitting changes to remote reference repos