### PR TITLE
Pathoscope analysis

### DIFF
--- a/client/src/js/actionTypes.js
+++ b/client/src/js/actionTypes.js
@@ -130,6 +130,7 @@ export const GET_INDEX = createRequestActionType("GET_INDEX");
 export const GET_UNBUILT = createRequestActionType("GET_UNBUILT");
 export const CREATE_INDEX = createRequestActionType("CREATE_INDEX");
 export const GET_INDEX_HISTORY = createRequestActionType("GET_INDEX_HISTORY");
+export const LIST_READY_INDEXES = createRequestActionType("LIST_READY_INDEXES");
 
 // Subtraction
 export const WS_UPDATE_SUBTRACTION = "WS_UPDATE_SUBTRACTION";

--- a/client/src/js/indexes/actions.js
+++ b/client/src/js/indexes/actions.js
@@ -4,7 +4,8 @@ import {
     GET_INDEX,
     GET_UNBUILT,
     CREATE_INDEX,
-    GET_INDEX_HISTORY
+    GET_INDEX_HISTORY,
+    LIST_READY_INDEXES
 } from "../actionTypes";
 
 /**
@@ -31,12 +32,21 @@ export const findIndexes = (refId, page) => ({
     page
 });
 
+/**
+ * Returns action that can trigger an API call for getting all ready OTU indexes.
+ *
+ * @func
+ * @returns {object}
+ */
+export const listReadyIndexes = () => ({
+    type: LIST_READY_INDEXES.REQUESTED
+});
 
 /**
  * Returns action that can trigger an API call for getting specific OTU index.
  *
  * @func
- * @param indexVersion {string} the version number of the index.
+ * @param indexId {string} the unique index id.
  * @returns {object}
  */
 export const getIndex = (indexId) => ({
@@ -71,7 +81,7 @@ export const createIndex = (refId) => ({
  * Returns action that can trigger an API call for getting a specific page in the index version history.
  *
  * @func
- * @param indexVersion {string} the version number of the index.
+ * @param indexId {string} the unique index id.
  * @param page {number} the page to retrieve from the list of changes.
  * @returns {object}
  */

--- a/client/src/js/indexes/api.js
+++ b/client/src/js/indexes/api.js
@@ -8,6 +8,11 @@ export const get = ({ indexId }) => (
     Request.get(`/api/indexes/${indexId}`)
 );
 
+export const listReady = () => (
+    Request.get(`/api/indexes`)
+        .query({ready: true})
+);
+
 export const getUnbuilt = ({ refId }) => (
     Request.get(`/api/refs/${refId}/history?unbuilt=true`)
 );

--- a/client/src/js/indexes/sagas.js
+++ b/client/src/js/indexes/sagas.js
@@ -10,7 +10,7 @@ import {
     GET_UNBUILT,
     CREATE_INDEX,
     GET_INDEX_HISTORY,
-    GET_REFERENCE
+    GET_REFERENCE, LIST_READY_INDEXES
 } from "../actionTypes";
 
 export function* watchIndexes () {
@@ -20,6 +20,7 @@ export function* watchIndexes () {
     yield takeLatest(GET_UNBUILT.REQUESTED, getUnbuilt);
     yield takeEvery(CREATE_INDEX.REQUESTED, createIndex);
     yield takeLatest(GET_INDEX_HISTORY.REQUESTED, getIndexHistory);
+    yield takeLatest(LIST_READY_INDEXES.REQUESTED, listReadyIndexes);
 }
 
 export function* wsUpdateIndex (action) {
@@ -37,6 +38,10 @@ export function* getIndex (action) {
 
 export function* getUnbuilt (action) {
     yield apiCall(indexesAPI.getUnbuilt, action, GET_UNBUILT);
+}
+
+export function* listReadyIndexes (action) {
+    yield apiCall(indexesAPI.listReady, action, LIST_READY_INDEXES);
 }
 
 export function* createIndex (action) {

--- a/client/src/js/samples/components/Analyses/List.js
+++ b/client/src/js/samples/components/Analyses/List.js
@@ -8,7 +8,7 @@ import AnalysisItem from "./Item";
 import CreateAnalysis from "./Create";
 import { analyze } from "../../actions";
 import { getCanModify } from "../../selectors";
-import { findIndexes } from "../../../indexes/actions";
+import {listReadyIndexes} from "../../../indexes/actions";
 import { fetchHmms } from "../../../hmm/actions";
 import { Icon, Button, LoadingPlaceholder, NoneFound, Flex, FlexItem } from "../../../base";
 
@@ -42,13 +42,13 @@ class AnalysesList extends React.Component {
     }
 
     componentDidMount () {
-        this.props.onFindIndexes();
         this.props.onFetchHMMs();
+        this.props.onListReadyIndexes();
     }
 
     render () {
 
-        if (this.props.analyses === null || this.props.hmms.documents === null || this.props.indexArray === null) {
+        if (this.props.analyses === null || this.props.hmms.documents === null || this.props.indexes === null) {
             return <LoadingPlaceholder margin="37px" />;
         }
 
@@ -109,7 +109,7 @@ class AnalysesList extends React.Component {
 const mapStateToProps = (state) => ({
     detail: state.samples.detail,
     analyses: state.samples.analyses,
-    indexArray: state.indexes.documents,
+    indexes: state.samples.readyIndexes,
     hmms: state.hmms,
     canModify: getCanModify(state)
 });
@@ -124,8 +124,8 @@ const mapDispatchToProps = (dispatch) => ({
         dispatch(fetchHmms());
     },
 
-    onFindIndexes: () => {
-        dispatch(findIndexes());
+    onListReadyIndexes: () => {
+        dispatch(listReadyIndexes());
     }
 
 });

--- a/client/src/js/samples/components/Analyses/Pathoscope/List.js
+++ b/client/src/js/samples/components/Analyses/Pathoscope/List.js
@@ -42,7 +42,7 @@ export default class PathoscopeList extends React.Component {
             height,
             width
         };
-    }
+    };
 
     render () {
 

--- a/client/src/js/samples/reducer.js
+++ b/client/src/js/samples/reducer.js
@@ -14,7 +14,7 @@ import {
     ANALYZE,
     BLAST_NUVS,
     REMOVE_ANALYSIS,
-    GET_ANALYSIS_PROGRESS
+    GET_ANALYSIS_PROGRESS, LIST_READY_INDEXES
 } from "../actionTypes";
 
 export const initialState = {
@@ -28,7 +28,8 @@ export const initialState = {
     showRemove: false,
     editError: false,
     reservedFiles: [],
-    readyHosts: null
+    readyHosts: null,
+    readyIndexes: null
 };
 
 export const setNuvsBLAST = (state, analysisId, sequenceIndex, data = "ip") => {
@@ -68,6 +69,9 @@ export default function samplesReducer (state = initialState, action) {
 
         case GET_SAMPLE.SUCCEEDED:
             return {...state, detail: action.data};
+
+        case LIST_READY_INDEXES.SUCCEEDED:
+            return {...state, readyIndexes: action.data};
 
         case UPDATE_SAMPLE.SUCCEEDED: {
             if (state.documents === null) {

--- a/tests/api/test_samples.py
+++ b/tests/api/test_samples.py
@@ -641,7 +641,7 @@ class TestAnalyze:
         client = await spawn_client(authorize=True, job_manager=True)
 
         test_analysis = {
-            "id": "test_analysis",
+            "_id": "test_analysis",
             "ready": False,
             "created_at": "'2015-10-06T20:00:00Z'",
             "job": {
@@ -691,6 +691,8 @@ class TestAnalyze:
             assert resp.status == 201
 
             assert resp.headers["Location"] == "/api/analyses/test_analysis"
+
+            test_analysis["id"] = test_analysis.pop("_id")
 
             assert await resp.json() == test_analysis
 

--- a/virtool/api/samples.py
+++ b/virtool/api/samples.py
@@ -351,6 +351,8 @@ async def analyze(req):
         data["algorithm"]
     )
 
+    document = virtool.utils.base_processor(document)
+
     return json_response(
         document,
         status=201,


### PR DESCRIPTION
- add indexes find endpoint query (`?ready=true`) for ready indexes
- fix analyze endpoint return body
- in client, list ready indexes from API when analysis list mounts