### PR TITLE
Full aiojobs

### DIFF
--- a/tests/api/test_analyses.py
+++ b/tests/api/test_analyses.py
@@ -1,5 +1,4 @@
 import pytest
-from copy import deepcopy
 from aiohttp.test_utils import make_mocked_coro
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,11 @@
 import concurrent.futures
+
+import aiojobs.aiohttp
 from aiohttp import web
 
 import virtool.app
-import virtool.app_settings
 import virtool.app_dispatcher
+import virtool.app_settings
 import virtool.jobs.manager
 
 
@@ -56,15 +58,3 @@ class TestInitSettings:
         await virtool.app.init_settings(app)
 
         assert app["settings"].stub.called
-
-
-async def test_init_dispatcher(loop):
-    """
-    Test that a instance of :class:`~virtool.app_dispatcher.Dispatcher` is attached to the app state.
-
-    """
-    app = web.Application(loop=loop)
-
-    await virtool.app.init_dispatcher(app)
-
-    assert isinstance(app["dispatcher"], virtool.app_dispatcher.Dispatcher)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 
-import aiojobs.aiohttp
 from aiohttp import web
 
 import virtool.app

--- a/virtool/api/analyses.py
+++ b/virtool/api/analyses.py
@@ -4,6 +4,8 @@ Provides request handlers for managing and viewing analyses.
 """
 import asyncio
 
+import aiojobs.aiohttp
+
 import virtool.analyses
 import virtool.bio
 import virtool.db.analyses
@@ -109,13 +111,13 @@ async def blast(req):
 
     # Wait on BLAST request as a Task until the it completes on NCBI. At that point the sequence in the DB will be
     # updated with the BLAST result.
-    asyncio.ensure_future(virtool.bio.wait_for_blast_result(
+    aiojobs.aiohttp.spawn(req, virtool.bio.wait_for_blast_result(
         db,
         req.app["settings"],
         analysis_id,
         sequence_index,
         rid
-    ), loop=req.app.loop)
+    ))
 
     headers = {
         "Location": "/api/analyses/{}/{}/blast".format(analysis_id, sequence_index)

--- a/virtool/api/analyses.py
+++ b/virtool/api/analyses.py
@@ -2,8 +2,6 @@
 Provides request handlers for managing and viewing analyses.
 
 """
-import asyncio
-
 import aiojobs.aiohttp
 
 import virtool.analyses

--- a/virtool/api/analyses.py
+++ b/virtool/api/analyses.py
@@ -111,7 +111,7 @@ async def blast(req):
 
     # Wait on BLAST request as a Task until the it completes on NCBI. At that point the sequence in the DB will be
     # updated with the BLAST result.
-    aiojobs.aiohttp.spawn(req, virtool.bio.wait_for_blast_result(
+    await aiojobs.aiohttp.spawn(req, virtool.bio.wait_for_blast_result(
         db,
         req.app["settings"],
         analysis_id,

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -251,7 +251,9 @@ async def init_file_manager(app):
             clean_interval=20
         )
 
-        app["file_manager"].start()
+        scheduler = aiojobs.aiohttp.get_scheduler_from_app(app)
+
+        await scheduler.spawn(app["file_manager"].run())
     else:
         logger.warning("Did not initialize file manager. Path does not exist: {}".format(files_path))
         app["file_manager"] = None
@@ -287,11 +289,6 @@ async def on_shutdown(app):
     """
     await app["dispatcher"].close()
     await app["client"].close()
-
-    file_manager = app.get("file_manager", None)
-
-    if file_manager is not None:
-        await file_manager.close()
 
     app["process_executor"].shutdown(wait=True)
 

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -114,6 +114,10 @@ async def init_dispatcher(app):
     """
     app["dispatcher"] = virtool.app_dispatcher.Dispatcher(app.loop)
 
+    scheduler = aiojobs.aiohttp.get_scheduler_from_app(app)
+
+    await scheduler.spawn(app["dispatcher"].run())
+
 
 async def init_db(app):
     """
@@ -287,7 +291,6 @@ async def on_shutdown(app):
     :type app: :class:`aiohttp.web.Application`
 
     """
-    await app["dispatcher"].close()
     await app["client"].close()
 
     app["process_executor"].shutdown(wait=True)

--- a/virtool/app_dispatcher.py
+++ b/virtool/app_dispatcher.py
@@ -32,9 +32,8 @@ class Dispatcher:
         #: A dict of all active connections.
         self.connections = list()
         self.alive = True
-        self._ping_task = asyncio.ensure_future(self.ping_connections(), loop=loop)
 
-    async def ping_connections(self):
+    async def run(self):
         to_remove = list()
 
         try:
@@ -54,7 +53,8 @@ class Dispatcher:
                 await asyncio.sleep(5, loop=self.loop)
 
         except asyncio.CancelledError:
-            pass
+            for connection in self.connections:
+                await connection.close()
 
     def add_connection(self, connection):
         """
@@ -140,12 +140,3 @@ class Dispatcher:
 
         for connection in connections_to_remove:
             self.remove_connection(connection)
-
-    async def close(self):
-        self.alive = False
-
-        if self._ping_task is not None:
-            self._ping_task.cancel()
-
-        for connection in self.connections:
-            await connection.close()


### PR DESCRIPTION
- resolves #567 
- use `aiojobs` for all long running tasks
- only task that doesn't use `aiojobs` is `Job` execution