### PR TITLE
Change OTU best hit to max Depth, display mean depth for isolates

### DIFF
--- a/client/src/js/samples/components/Analyses/Pathoscope/Controller.js
+++ b/client/src/js/samples/components/Analyses/Pathoscope/Controller.js
@@ -127,6 +127,7 @@ export default class PathoscopeController extends React.Component {
                                         <Button title="Sort Direction" onClick={this.toggleSortDescending}>
                                             <Icon
                                                 name={this.state.sortDescending ? "sort-amount-down" : "sort-amount-up"}
+                                                tip="Sort List"
                                             />
                                         </Button>
                                     </InputGroup.Button>
@@ -137,7 +138,7 @@ export default class PathoscopeController extends React.Component {
                                     >
                                         <option className="text-primary" value="coverage">Coverage</option>
                                         <option className="text-success" value="pi">Weight</option>
-                                        <option className="text-danger" value="best">Best Hit</option>
+                                        <option className="text-danger" value="maxDepth">Depth</option>
                                     </FormControl>
                                 </InputGroup>
                             </FormGroup>
@@ -145,6 +146,7 @@ export default class PathoscopeController extends React.Component {
                             <Button
                                 icon="compress"
                                 title="Collapse"
+                                tip="Collapse Opened"
                                 onClick={this.collapseAll}
                                 className="hidden-xs"
                                 disabled={this.state.expanded.length === 0}
@@ -153,6 +155,7 @@ export default class PathoscopeController extends React.Component {
                             <Button
                                 icon="chart-pie"
                                 title="Change Weight Format"
+                                tip="Change Weight Format"
                                 active={!this.state.showReads}
                                 className="hidden-xs"
                                 onClick={this.toggleShowReads}
@@ -167,6 +170,7 @@ export default class PathoscopeController extends React.Component {
                             >
                                 <Button
                                     title="Filter"
+                                    tip="Filter Results"
                                     onClick={this.filter}
                                     active={this.state.filterOTUs || this.state.filterIsolates}
                                 >

--- a/client/src/js/samples/components/Analyses/Pathoscope/Entry.js
+++ b/client/src/js/samples/components/Analyses/Pathoscope/Entry.js
@@ -1,7 +1,7 @@
 import React from "react";
 import CX from "classnames";
 import PropTypes from "prop-types";
-import { Row, Col, Label } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 
 import AnalysisValueLabel from "../ValueLabel";
 import { Flex, FlexItem } from "../../../../base";
@@ -15,6 +15,7 @@ export default class PathoscopeEntry extends React.Component {
         abbreviation: PropTypes.string,
         pi: PropTypes.number,
         best: PropTypes.number,
+        maxDepth: PropTypes.number,
         reads: PropTypes.number,
         coverage: PropTypes.number,
         in: PropTypes.bool,
@@ -43,8 +44,6 @@ export default class PathoscopeEntry extends React.Component {
                 </button>
             );
         }
-
-        const flexStyle = {height: "21px"};
 
         const piValue = this.props.showReads ? Math.round(this.props.reads) : toScientificNotation(this.props.pi);
 
@@ -78,28 +77,20 @@ export default class PathoscopeEntry extends React.Component {
                         />
                     </Col>
                     <Col xs={6} sm={4} md={2}>
-                        <Flex alignItems="center" alignContent="center" style={flexStyle}>
-                            <FlexItem>
-                                <Label>Best Hit</Label>
-                            </FlexItem>
-                            <FlexItem pad={5}>
-                                <strong className="text-danger">
-                                    {toScientificNotation(this.props.best)}
-                                </strong>
-                            </FlexItem>
-                        </Flex>
+                        <AnalysisValueLabel
+                            bsStyle="danger"
+                            label="Max Depth"
+                            value={this.props.maxDepth}
+                        />
                     </Col>
                     <Col xs={6} sm={4} md={2}>
-                        <Flex alignItems="center" style={flexStyle}>
-                            <FlexItem>
-                                <Label>Coverage</Label>
-                            </FlexItem>
-                            <FlexItem grow={1} pad={5}>
-                                <strong className="text-primary">
-                                    {toScientificNotation(this.props.coverage)}
-                                </strong>
-                            </FlexItem>
-                            <FlexItem>
+                        <Flex alignItems="center" style={{height: "21px"}}>
+                            <AnalysisValueLabel
+                                bsStyle="primary"
+                                label="Coverage"
+                                value={this.props.coverage}
+                            />
+                            <FlexItem pad={30}>
                                 {closeButton}
                             </FlexItem>
                         </Flex>

--- a/client/src/js/samples/components/Analyses/Pathoscope/Isolate.js
+++ b/client/src/js/samples/components/Analyses/Pathoscope/Isolate.js
@@ -15,6 +15,7 @@ export default class PathoscopeIsolate extends React.Component {
         best: PropTypes.number,
         coverage: PropTypes.number,
         maxDepth: PropTypes.number,
+        meanDepth: PropTypes.number,
         reads: PropTypes.number,
         sequences: PropTypes.arrayOf(PropTypes.object),
         setScroll: PropTypes.func,
@@ -78,7 +79,7 @@ export default class PathoscopeIsolate extends React.Component {
                         </FlexItem>
                         <FlexItem pad={5}>
                             <strong className="small text-danger">
-                                {toScientificNotation(this.props.best)}
+                                {toScientificNotation(this.props.meanDepth)}
                             </strong>
                         </FlexItem>
                         <FlexItem pad={5}>

--- a/client/src/js/samples/components/Analyses/Pathoscope/Viewer.js
+++ b/client/src/js/samples/components/Analyses/Pathoscope/Viewer.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { map, max, maxBy, sumBy, reduce, sortBy } from "lodash-es";
+import { map, max, maxBy, sumBy, reduce, sortBy, round } from "lodash-es";
 import PropTypes from "prop-types";
 
 import { Alert } from "../../../../base";
@@ -13,6 +13,22 @@ const calculateIsolateCoverage = (isolate, length) => (
     ), 0)
 );
 
+const getSumDepth = (alignArray) => {
+
+    const sumDepth = reduce(alignArray, (sum, align, i) => {
+        if (i === 0) {
+            return 0;
+        } else if (i === (alignArray.length - 1)) {
+            return sum + align[1];
+        }
+        const numBasesFromLastEntry = (alignArray[i][0] - alignArray[i - 1][0]) - 1;
+        const depthSumBetween = numBasesFromLastEntry * alignArray[i - 1][1];
+        return sum + depthSumBetween + align[1];
+    }, 0);
+
+    return (sumDepth || 0);
+};
+
 const PathoscopeViewer = (props) => {
 
     if (props.diagnosis.length > 0) {
@@ -21,7 +37,7 @@ const PathoscopeViewer = (props) => {
 
         const data = map(props.diagnosis, baseOTU => {
             // Go through each isolate associated with the OTU, adding properties for weight, best-hit, read count,
-            // and coverage. These values will be calculated from the sequences owned by each isolate.
+            // mean depth, and coverage. These values will be calculated from the sequences owned by each isolate.
             let isolates = map(baseOTU.isolates, isolate => {
                 // Make a name for the isolate by joining the source type and name, eg. "Isolate" + "Q47".
                 let name = formatIsolateName(isolate);
@@ -33,12 +49,16 @@ const PathoscopeViewer = (props) => {
                 const sequences = map(isolate.sequences, sequence => {
                     const reads = Math.round(sequence.pi * mappedReadCount);
                     const depth = sequence.align ? max(map(sequence.align, p => p[1])) : 0;
-                    return {...sequence, reads, depth};
+                    const sumDepth = getSumDepth(sequence.align);
+
+                    return {...sequence, reads, depth, sumDepth};
                 });
 
                 const length = sumBy(sequences, "length");
+                const totalSeqDepth = sumBy(sequences, "sumDepth");
+                const meanDepth = Math.round(totalSeqDepth / length);
 
-                const coverage = calculateIsolateCoverage(isolate, length);
+                const coverage = round(calculateIsolateCoverage(isolate, length), 3);
 
                 return {
                     ...isolate,
@@ -48,6 +68,7 @@ const PathoscopeViewer = (props) => {
                     best: sumBy(sequences, "best"),
                     reads: sumBy(sequences, "reads"),
                     maxDepth: maxBy(sequences, "depth").depth,
+                    meanDepth,
                     coverage
                 };
             });


### PR DESCRIPTION
- resolves #906 
- Changes Pathoscope UI to display "Depth" listing order instead of "Best Hit", displays *max* depth values for OTU entries
- Changes Isolate entries to display *average* depth values instead of best hit 
(possibly confusing since it displays the mean depth rather than the max?)
- isolate average depths are calculated by:
1. calculating the sum of depth values at each base position for a sequence
2. calculating the sum of all sequences' depth sums
3. dividing this total depth value by the total length of the isolate, rounded to the nearest integer