### PR TITLE
API error response updates

### DIFF
--- a/run.py
+++ b/run.py
@@ -46,7 +46,12 @@ if __name__ == "__main__":
             ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             ssl_context.load_cert_chain(cert_path, key_path)
 
-    app = create_app(loop, skip_setup=skip_setup, force_version=args.force_version, no_sentry=args.no_sentry)
+    app = create_app(
+        loop,
+        skip_setup=skip_setup,
+        force_version=args.force_version,
+        no_sentry=args.no_sentry
+    )
 
     host = args.host or settings_temp.get("server_host", "localhost")
 

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -27,25 +27,6 @@ async def test_get(spawn_client, static_time):
     }
 
 
-async def test_get_settings(spawn_client):
-    """
-    Test that a ``GET /account/settings`` returns the settings for the session user.
-
-    """
-    client = await spawn_client(authorize=True)
-
-    resp = await client.get("/api/account/settings")
-
-    assert resp.status == 200
-
-    assert await resp.json() == {
-        "skip_quick_analyze_dialog": True,
-        "show_ids": True,
-        "show_versions": True,
-        "quick_analyze_algorithm": "pathoscope_bowtie"
-    }
-
-
 @pytest.mark.parametrize("error", [
     None,
     "email_error",
@@ -108,6 +89,25 @@ async def test_edit(error, spawn_client, resp_is, static_time):
             "email": "dev@virtool.ca",
             "id": "test"
         }
+
+
+async def test_get_settings(spawn_client):
+    """
+    Test that a ``GET /account/settings`` returns the settings for the session user.
+
+    """
+    client = await spawn_client(authorize=True)
+
+    resp = await client.get("/api/account/settings")
+
+    assert resp.status == 200
+
+    assert await resp.json() == {
+        "skip_quick_analyze_dialog": True,
+        "show_ids": True,
+        "show_versions": True,
+        "quick_analyze_algorithm": "pathoscope_bowtie"
+    }
 
 
 @pytest.mark.parametrize("invalid_input", [False, True])

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -66,7 +66,7 @@ class TestCreate:
 
     async def test_exists(self, spawn_client, resp_is, all_permissions):
         """
-        Test that a 409 is returned when attempting to create a new group at ``POST /api/groups/:group_id`` when the
+        Test that a 400 is returned when attempting to create a new group at ``POST /api/groups/:group_id`` when the
         ``group_id`` already exists.
 
         """
@@ -81,7 +81,7 @@ class TestCreate:
             "group_id": "test"
         })
 
-        assert await resp_is.conflict(resp, "Group already exists")
+        assert await resp_is.bad_request(resp, "Group already exists")
 
     async def test_missing(self, spawn_client, resp_is):
         client = await spawn_client(authorize=True, administrator=True, permissions=["manage_users"])

--- a/tests/api/test_otus.py
+++ b/tests/api/test_otus.py
@@ -181,14 +181,14 @@ class TestCreate:
             "test"
         )
 
-    @pytest.mark.parametrize("exists", [True, False])
-    @pytest.mark.parametrize("message", [
-        False,
-        "Name already exists",
-        "Abbreviation already exists",
-        "Name and abbreviation already exist"
+    @pytest.mark.parametrize("error,message", [
+        (None, None),
+        ("400_name_exists", "Name already exists"),
+        ("400_abbr_exists", "Abbreviation already exists"),
+        ("400_both_exist", "Name and abbreviation already exist"),
+        ("404", None)
     ])
-    async def test_field_exists(self, exists, message, mocker, spawn_client, check_ref_right, resp_is):
+    async def test_field_exists(self, error, message, mocker, spawn_client, check_ref_right, resp_is):
         """
         Test that the request fails with ``409 Conflict`` if the requested otu name already exists.
 
@@ -204,7 +204,7 @@ class TestCreate:
 
         client = await spawn_client(authorize=True)
 
-        if exists:
+        if error != "404":
             await client.db.references.insert_one({
                 "_id": "foo"
             })
@@ -216,7 +216,7 @@ class TestCreate:
 
         resp = await client.post("/api/refs/foo/otus", data)
 
-        if not exists:
+        if error == "404":
             assert await resp_is.not_found(resp)
             return
 
@@ -232,11 +232,11 @@ class TestCreate:
             "TMV"
         )
 
-        if message:
-            assert await resp_is.conflict(resp, message)
+        if error:
+            assert await resp_is.bad_request(resp, message)
+            return
 
-        else:
-            assert resp.status == 201
+        assert resp.status == 201
 
 
 class TestEdit:
@@ -479,10 +479,7 @@ class TestEdit:
             assert await resp_is.insufficient_rights(resp)
             return
 
-        print(409, message)
-        print(resp.status, await resp.json())
-
-        assert await resp_is.conflict(resp, message)
+        assert await resp_is.bad_request(resp, message)
 
     @pytest.mark.parametrize("old_name,old_abbreviation,data", [
         (
@@ -1773,15 +1770,6 @@ class TestEditSequence:
             "Edited sequence KX269872 in Isolate 8816-v2",
             "test"
         )
-
-    async def test_empty_input(self, spawn_client, resp_is):
-        client = await spawn_client(authorize=True, permissions=["modify_otu"])
-
-        resp = await client.patch("/api/otus/6116cba1/isolates/cab8b360/sequences/KX269872", {})
-
-        assert resp.status == 400
-
-        assert await resp_is.bad_request(resp, "Empty Input")
 
     @pytest.mark.parametrize("foobar", ["otu_id", "isolate_id", "sequence_id"])
     async def test_not_found(self, foobar, spawn_client, resp_is, test_otu, test_sequence):

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -165,7 +165,7 @@ class TestCreate:
 
         resp = await client.post("/api/users", data)
 
-        assert await resp_is.conflict(resp, "User already exists")
+        assert await resp_is.bad_request(resp, "User already exists")
 
 
 @pytest.mark.parametrize("data", [
@@ -213,7 +213,7 @@ async def test_edit(data, error, spawn_client, resp_is, static_time, create_user
 
     if "primary_group" in data:
         if error == "group_dne":
-            assert await resp_is.not_found(resp, "Group does not exist")
+            assert await resp_is.bad_request(resp, "Primary group does not exist")
 
         elif error == "not_group_member":
             assert await resp_is.conflict(resp, "User is not member of group")

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -26,6 +26,7 @@ class VTClient:
             self._test_db_name,
             disable_job_manager=not job_manager,
             disable_file_manager=not file_manager,
+            disable_refreshing=True,
             ignore_settings=True,
             skip_db_checks=True,
             skip_setup=not setup_mode,

--- a/virtool/api/account.py
+++ b/virtool/api/account.py
@@ -246,9 +246,6 @@ async def update_api_key(req):
             {"id": key_id, "user.id": user_id}
         )
 
-        if key_permissions is None:
-            return not_found()
-
         key_permissions.update(permissions)
 
         update["permissions"] = virtool.users.limit_permissions(key_permissions, user["permissions"])

--- a/virtool/api/analyses.py
+++ b/virtool/api/analyses.py
@@ -41,7 +41,7 @@ async def get(req):
 
     read, write = virtool.samples.get_sample_rights(sample, req["client"])
 
-    if not read or not write:
+    if not read:
         return insufficient_rights()
 
     if document["ready"]:
@@ -141,4 +141,4 @@ async def blast(req):
         "Location": "/api/analyses/{}/{}/blast".format(analysis_id, sequence_index)
     }
 
-    return json_response(blast_data, headers=headers, status=200)
+    return json_response(blast_data, headers=headers, status=201)

--- a/virtool/api/analyses.py
+++ b/virtool/api/analyses.py
@@ -34,6 +34,16 @@ async def get(req):
     if document is None:
         return not_found()
 
+    sample = await db.samples.find_one({"_id": document["sample"]["id"]}, virtool.db.samples.PROJECTION)
+
+    if not sample:
+        return bad_request("Parent sample does not exist")
+
+    read, write = virtool.samples.get_sample_rights(sample, req["client"])
+
+    if not read or not write:
+        return insufficient_rights()
+
     if document["ready"]:
         document = await virtool.db.analyses.format_analysis(db, req.app["settings"], document)
 
@@ -58,7 +68,7 @@ async def remove(req):
     sample = await db.samples.find_one({"_id": document["sample"]["id"]}, virtool.db.samples.PROJECTION)
 
     if not sample:
-        return not_found("Sample not found")
+        return bad_request("Parent sample does not exist")
 
     read, write = virtool.samples.get_sample_rights(sample, req["client"])
 
@@ -86,13 +96,13 @@ async def blast(req):
     analysis_id = req.match_info["analysis_id"]
     sequence_index = int(req.match_info["sequence_index"])
 
-    document = await db.analyses.find_one({"_id": analysis_id}, ["ready", "algorithm", "results"])
+    document = await db.analyses.find_one({"_id": analysis_id}, ["ready", "algorithm", "results", "sample"])
 
     if not document:
         return not_found("Analysis not found")
 
     if document["algorithm"] != "nuvs":
-        return bad_request("Not a NuVs analysis")
+        return conflict("Not a NuVs analysis")
 
     if not document["ready"]:
         return conflict("Analysis is still running")
@@ -101,6 +111,16 @@ async def blast(req):
 
     if sequence is None:
         return not_found("Sequence not found")
+
+    sample = await db.samples.find_one({"_id": document["sample"]["id"]}, virtool.db.samples.PROJECTION)
+
+    if not sample:
+        return bad_request("Parent sample does not exist")
+
+    read, write = virtool.samples.get_sample_rights(sample, req["client"])
+
+    if not write:
+        return insufficient_rights()
 
     # Start a BLAST at NCBI with the specified sequence. Return a RID that identifies the BLAST run.
     rid, _ = await virtool.bio.initialize_ncbi_blast(req.app["settings"], sequence)

--- a/virtool/api/downloads.py
+++ b/virtool/api/downloads.py
@@ -34,10 +34,10 @@ async def download_isolate(req):
         filename, fasta = await virtool.db.downloads.generate_isolate_fasta(db, otu_id, isolate_id)
     except virtool.errors.DatabaseError as err:
         if "OTU does not exist" in str(err):
-            return not_found("OTU does not exist")
+            return not_found("OTU not found")
 
         if "Isolate does not exist" in str(err):
-            return not_found("Isolate does not exist")
+            return not_found("Isolate not found")
 
         raise
 
@@ -60,10 +60,10 @@ async def download_otu(req):
         filename, fasta = await virtool.db.downloads.generate_otu_fasta(db, otu_id)
     except virtool.errors.DatabaseError as err:
         if "Sequence does not exist" in str(err):
-            return not_found("Sequence does not exist")
+            return not_found("Sequence not found")
 
         if "OTU does not exist" in str(err):
-            return not_found("OTU does not exist")
+            return not_found("OTU not found")
 
         raise
 
@@ -131,13 +131,13 @@ async def download_sequence(req):
         filename, fasta = await virtool.db.downloads.generate_sequence_fasta(db, sequence_id)
     except virtool.errors.DatabaseError as err:
         if "Sequence does not exist" in str(err):
-            return not_found("Sequence does not exist")
+            return not_found("Sequence not found")
 
         if "Isolate does not exist" in str(err):
-            return not_found("Isolate does not exist")
+            return not_found("Isolate not found")
 
         if "OTU does not exist" in str(err):
-            return not_found("OTU does not exist")
+            return not_found("OTU not found")
 
         raise
 

--- a/virtool/api/files.py
+++ b/virtool/api/files.py
@@ -57,7 +57,7 @@ async def remove(req):
     virtool.utils.rm(file_path)
 
     if delete_result.deleted_count == 0:
-        return not_found("Document does not exist")
+        return not_found()
 
     return json_response({
         "file_id": file_id,

--- a/virtool/api/genbank.py
+++ b/virtool/api/genbank.py
@@ -3,11 +3,12 @@ Provides request handlers for managing and viewing analyses.
 
 """
 import aiohttp
+import aiohttp.web
 
 import virtool.genbank
 import virtool.http.proxy
 import virtool.http.routes
-from virtool.api.utils import json_response, not_found
+from virtool.api.utils import bad_gateway, json_response, not_found
 
 routes = virtool.http.routes.Routes()
 
@@ -20,12 +21,16 @@ async def get(req):
 
     """
     accession = req.match_info["accession"]
+    session = req.app["client"]
     settings = req.app["settings"]
 
-    async with aiohttp.ClientSession() as session:
+    try:
         data = await virtool.genbank.fetch(settings, session, accession)
 
         if data is None:
             return not_found()
 
         return json_response(data)
+
+    except aiohttp.client_exceptions.ClientConnectorError:
+        return bad_gateway("Could not reach Genbank")

--- a/virtool/api/groups.py
+++ b/virtool/api/groups.py
@@ -6,7 +6,7 @@ import virtool.http.routes
 import virtool.users
 import virtool.utils
 import virtool.validators
-from virtool.api.utils import conflict, json_response, not_found, no_content
+from virtool.api.utils import bad_request, conflict, json_response, not_found, no_content
 
 routes = virtool.http.routes.Routes()
 
@@ -44,7 +44,7 @@ async def create(req):
     try:
         await db.groups.insert_one(document)
     except pymongo.errors.DuplicateKeyError:
-        return conflict("Group already exists")
+        return bad_request("Group already exists")
 
     headers = {
         "Location": "/api/groups/" + data["group_id"]

--- a/virtool/api/history.py
+++ b/virtool/api/history.py
@@ -35,10 +35,10 @@ async def get(req):
 
     document = await db.history.find_one(change_id, virtool.db.history.PROJECTION)
 
-    if not document:
-        return not_found()
+    if document:
+        return json_response(virtool.utils.base_processor(document))
 
-    return json_response(virtool.utils.base_processor(document))
+    return not_found()
 
 
 @routes.delete("/api/history/{change_id}")

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -72,7 +72,7 @@ async def list_updates(req):
     return json_response(updates)
 
 
-@routes.post("/api/hmms/status/updates", schema={
+@routes.post("/api/hmms/status/updates", permission="modify_hmm", schema={
     "release_id": {
         "type": ["integer", "string"]
     }
@@ -149,7 +149,7 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.delete("/api/hmms")
+@routes.delete("/api/hmms", permission="modify_hmm")
 async def purge(req):
     """
     Delete all unreferenced HMMs and hide the rest.

--- a/virtool/api/indexes.py
+++ b/virtool/api/indexes.py
@@ -6,7 +6,8 @@ import virtool.history
 import virtool.http.routes
 import virtool.jobs.build_index
 import virtool.utils
-from virtool.api.utils import compose_regex_query, conflict, insufficient_rights, json_response, not_found, paginate
+from virtool.api.utils import bad_request, compose_regex_query, conflict, insufficient_rights, json_response,\
+    not_found, paginate
 
 routes = virtool.http.routes.Routes()
 
@@ -115,10 +116,10 @@ async def create(req):
         return conflict("Index build already in progress")
 
     if await db.otus.count({"reference.id": ref_id, "verified": False}):
-        return conflict("There are unverified otus")
+        return bad_request("There are unverified OTUs")
 
     if not await db.history.count({"reference.id": ref_id, "index.id": "unbuilt"}):
-        return conflict("There are no unbuilt changes")
+        return bad_request("There are no unbuilt changes")
 
     index_id = await virtool.db.utils.get_new_id(db.indexes)
 

--- a/virtool/api/jobs.py
+++ b/virtool/api/jobs.py
@@ -6,7 +6,7 @@ import virtool.jobs.job
 import virtool.jobs.utils
 import virtool.resources
 import virtool.utils
-from virtool.api.utils import compose_regex_query, bad_request, json_response, no_content, not_found, paginate
+from virtool.api.utils import compose_regex_query, conflict, json_response, no_content, not_found, paginate
 
 routes = virtool.http.routes.Routes()
 
@@ -71,7 +71,7 @@ async def cancel(req):
         return not_found()
 
     if not virtool.jobs.utils.is_running_or_waiting(document):
-        return bad_request("Not cancellable")
+        return conflict("Not cancellable")
 
     await req.app["job_manager"].cancel(job_id)
 
@@ -115,10 +115,7 @@ async def remove(req):
         return not_found()
 
     if virtool.jobs.utils.is_running_or_waiting(document):
-        return json_response({
-            "id": "conflict",
-            "message": "Job is running or waiting and cannot be removed"
-        }, status=409)
+        return conflict("Job is running or waiting and cannot be removed")
 
     # Removed the documents associated with the job ids from the database.
     await db.jobs.delete_one({"_id": job_id})

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -311,6 +311,7 @@ async def create(req):
     release_id = data.get("release_id", None) or 11447367
 
     if clone_from:
+
         manifest = await virtool.db.references.get_manifest(db, clone_from)
 
         document = await virtool.db.references.create_clone(
@@ -549,9 +550,6 @@ async def get_group(req):
     if document is None:
         return not_found()
 
-    if not await virtool.db.references.check_right(req, document, "modify"):
-        return insufficient_rights()
-
     if document is not None:
         for group in document.get("groups", list()):
             if group["id"] == group_id:
@@ -587,9 +585,6 @@ async def add_group(req):
             return bad_request("Group does not exist")
 
         raise
-
-    if subdocument is None:
-        return not_found()
 
     headers = {
         "Location": "/api/refs/{}/groups/{}".format(ref_id, subdocument["id"])
@@ -693,9 +688,6 @@ async def delete_group(req):
         return insufficient_rights()
 
     deleted_id = await virtool.db.references.delete_group_or_user(db, ref_id, group_id, "groups")
-
-    if not deleted_id:
-        return not_found()
 
     return no_content()
 

--- a/virtool/api/samples.py
+++ b/virtool/api/samples.py
@@ -9,7 +9,7 @@ import virtool.http.routes
 import virtool.jobs.analysis
 import virtool.samples
 import virtool.utils
-from virtool.api.utils import bad_request, compose_regex_query, conflict, insufficient_rights, invalid_query, \
+from virtool.api.utils import bad_request, compose_regex_query, insufficient_rights, invalid_query, \
     json_response, no_content, not_found, paginate
 
 QUERY_SCHEMA = {
@@ -151,7 +151,7 @@ async def create(req):
     name_error_message = await virtool.db.samples.check_name(db, req.app["settings"], data["name"])
 
     if name_error_message:
-        return conflict(name_error_message)
+        return bad_request(name_error_message)
 
     # Make sure a subtraction host was submitted and it exists.
     if not await db.subtraction.count({"_id": data["subtraction"], "is_host": True}):

--- a/virtool/api/subtractions.py
+++ b/virtool/api/subtractions.py
@@ -6,7 +6,7 @@ import virtool.http.routes
 import virtool.samples
 import virtool.subtractions
 import virtool.utils
-from virtool.api.utils import compose_regex_query, conflict, json_response, no_content, not_found, paginate
+from virtool.api.utils import bad_request, compose_regex_query, conflict, json_response, no_content, not_found, paginate
 
 routes = virtool.http.routes.Routes()
 
@@ -83,14 +83,14 @@ async def create(req):
     subtraction_id = data["subtraction_id"]
 
     if await db.subtraction.count({"_id": subtraction_id}):
-        return conflict("Subtraction name already exists.")
+        return bad_request("Subtraction name already exists")
 
     file_id = data["file_id"]
 
     file = await db.files.find_one(file_id, ["name"])
 
     if file is None:
-        return not_found("File not found")
+        return bad_request("File does not exist")
 
     job_id = await virtool.db.utils.get_new_id(db.jobs)
 

--- a/virtool/api/utils.py
+++ b/virtool/api/utils.py
@@ -86,6 +86,24 @@ def no_content():
     return web.Response(status=204)
 
 
+def bad_gateway(message="Bad gateway"):
+    """
+    A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``502`` status and the JSON body
+    ``{"message": "Bad gatway"}``.
+
+    :param message: text to send instead of 'Bad gateway'
+    :type message: str
+
+    :return: the response
+    :rtype: :class:`aiohttp.Response`
+
+    """
+    return json_response({
+        "id": "bad_gateway",
+        "message": message
+    }, status=502)
+
+
 def bad_request(message="Bad request"):
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``400`` status the JSON body

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -296,8 +296,8 @@ async def on_shutdown(app):
     app["process_executor"].shutdown(wait=True)
 
 
-def create_app(loop, db_name=None, disable_job_manager=False, disable_file_manager=False, force_version=None,
-               ignore_settings=False, no_sentry=False, skip_db_checks=False, skip_setup=False):
+def create_app(loop, db_name=None, disable_job_manager=False, disable_file_manager=False, disable_refreshing=False,
+               force_version=None, ignore_settings=False, no_sentry=False, skip_db_checks=False, skip_setup=False):
     """
     Creates the Virtool application.
 
@@ -356,7 +356,8 @@ def create_app(loop, db_name=None, disable_job_manager=False, disable_file_manag
         if not disable_file_manager:
             app.on_startup.append(init_file_manager)
 
-        app.on_startup.append(init_refresh)
+        if not disable_refreshing:
+            app.on_startup.append(init_refresh)
 
         app.on_shutdown.append(on_shutdown)
 

--- a/virtool/db/samples.py
+++ b/virtool/db/samples.py
@@ -165,9 +165,9 @@ async def remove_samples(db, settings, id_list):
 async def validate_force_choice_group(db, data):
     try:
         if not await db.groups.count({"_id": data["group"]}):
-            return "Group not found"
+            return "Group does not exist"
 
     except KeyError:
-        return "Server requires a 'group' field for sample creation"
+        return "Group value required for sample creation"
 
     return None


### PR DESCRIPTION
- change `404` errors to `400` where not found does not apply to URL resources
- change `409` errors to `400` where conflict isn't confined to the resource (ie. inter-resource)
- change error message wording where applicable
- don't run automatic remote and HMM refresh in API test environment
- improve some API tests