### PR TITLE
Fix users API issues

### DIFF
--- a/virtool/api/users.py
+++ b/virtool/api/users.py
@@ -113,12 +113,17 @@ async def edit(req):
 
     if "groups" in data:
         missing = [g for g in data["groups"] if g not in groups]
-        return bad_request("Groups do not exist: " + ", ".join(missing))
+
+        if missing:
+            return bad_request("Groups do not exist: " + ", ".join(missing))
 
     if "primary_group" in data and data["primary_group"] not in groups:
         return bad_request("Primary group does not exist")
 
     user_id = req.match_info["user_id"]
+
+    if "administrator" in data and user_id == req["client"].user_id:
+        return bad_request("Users cannot modify their own administrative status")
 
     try:
         document = await virtool.db.users.edit(


### PR DESCRIPTION
- resolves #937
- resolves #943 
- return `400` when user tries to modify their own `administrator` flag
- fix `400` with _Groups do not exist_ message occuring on every request modifying the user `groups` field