### PR TITLE
Fix file size in database and client

### DIFF
--- a/client/src/js/files/components/File.js
+++ b/client/src/js/files/components/File.js
@@ -10,7 +10,7 @@ export default class File extends React.Component {
     static propTypes = {
         id: PropTypes.string,
         name: PropTypes.string,
-        size: PropTypes.object,
+        size: PropTypes.number,
         file: PropTypes.object,
         uploaded_at: PropTypes.string,
         user: PropTypes.object,
@@ -49,7 +49,7 @@ export default class File extends React.Component {
                         <strong>{name}</strong>
                     </Col>
                     <Col md={2}>
-                        {byteSize(size.size)}
+                        {byteSize(size)}
                     </Col>
                     <Col md={4}>
                         {creation}

--- a/client/src/js/samples/components/Create/ReadItem.js
+++ b/client/src/js/samples/components/Create/ReadItem.js
@@ -10,7 +10,7 @@ export default class ReadItem extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
-        size: PropTypes.object.isRequired,
+        size: PropTypes.number.isRequired,
         onSelect: PropTypes.func.isRequired,
         selected: PropTypes.bool
     };
@@ -30,7 +30,7 @@ export default class ReadItem extends React.PureComponent {
                     <Icon name="file" /> {this.props.name}
                 </Col>
                 <Col md={4}>
-                    {byteSize(this.props.size.size)}
+                    {byteSize(this.props.size)}
                 </Col>
             </Row>
         </ListGroupItem>

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -169,7 +169,8 @@ async def test_handle_close(tracked, mocker, test_dbi, test_manager_instance):
     When a file is
 
     """
-    m_file_status = mocker.patch("virtool.utils.file_stats", return_value=245)
+    m_file_status = mocker.patch("virtool.utils.file_stats", return_value={"modify": "foobar", "size": 245})
+
     m_remove = mocker.patch("os.remove")
 
     filename = "foobar-test.fq"

--- a/virtool/files.py
+++ b/virtool/files.py
@@ -190,9 +190,11 @@ class Manager:
         """
         path = os.path.join(self.files_path, filename)
 
+        size = virtool.utils.file_stats(path)["size"]
+
         update_result = await self.db.files.update_one({"_id": filename}, {
             "$set": {
-                "size": virtool.utils.file_stats(path),
+                "size": size,
                 "ready": True
             }
         })


### PR DESCRIPTION
- resolves #956 
- correctly store file `size` in database at integer, not object
- fix file and read file size variables in client
