### PR TITLE
Software update fixes

### DIFF
--- a/virtool/api/software.py
+++ b/virtool/api/software.py
@@ -18,6 +18,8 @@ routes = virtool.http.routes.Routes()
 async def get(req):
     db = req.app["db"]
 
+    await virtool.db.software.fetch_and_update_software_releases(req.app)
+
     document = await db.status.find_one("software")
 
     return json_response(virtool.utils.base_processor(document))

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -19,6 +19,7 @@ import virtool.app_settings
 import virtool.db.hmm
 import virtool.db.iface
 import virtool.db.references
+import virtool.db.software
 import virtool.db.status
 import virtool.errors
 import virtool.files
@@ -47,6 +48,7 @@ async def init_refresh(app):
     scheduler = aiojobs.aiohttp.get_scheduler_from_app(app)
     await scheduler.spawn(virtool.db.references.refresh_remotes(app))
     await scheduler.spawn(virtool.db.hmm.refresh(app))
+    await scheduler.spawn(virtool.db.software.refresh(app))
 
 
 async def init_version(app):

--- a/virtool/db/software.py
+++ b/virtool/db/software.py
@@ -163,6 +163,21 @@ async def install(app, release, process_id):
         await virtool.utils.reload(app)
 
 
+async def refresh(app):
+    """
+    To be run in job scheduler. Automatically checks for software releases every 12 hours.
+
+    :param app: the application object
+
+    """
+    try:
+        while True:
+            await fetch_and_update_software_releases(app)
+            await asyncio.sleep(43200, loop=app.loop)
+    except asyncio.CancelledError:
+        pass
+
+
 async def update_software_process(db, progress, step=None):
     """
     Update the process field in the software update document. Used to keep track of the current progress of the update

--- a/virtool/db/software.py
+++ b/virtool/db/software.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 
 import aiohttp
@@ -13,6 +14,8 @@ import virtool.http.utils
 import virtool.processes
 import virtool.software
 import virtool.utils
+
+logger = logging.getLogger(__name__)
 
 VIRTOOL_RELEASES_URL = "https://www.virtool.ca/releases"
 
@@ -39,8 +42,11 @@ async def fetch_and_update_software_releases(app):
         async with virtool.http.proxy.ProxyRequest(settings, session.get, VIRTOOL_RELEASES_URL) as resp:
             data = await resp.text()
             data = json.loads(data)
+
+        logger.debug("Retrieved software releases from www.virtool.ca")
     except aiohttp.ClientConnectionError:
         # Return any existing release list or `None`.
+        logger.debug("Could not retrieve software releases")
         return await virtool.db.utils.get_one_field(db.status, "releases", "software")
 
     data = data["software"]


### PR DESCRIPTION
- add some logging to the `virtool.db.software` module
- automatically refresh software releases every 12 hours using the same mechanism as remotes and HMMs
- make sure available releases are updated when the channel is changes or `GET /api/software` is requested