### PR TITLE
Fix 763

### DIFF
--- a/client/src/js/hmm/api.js
+++ b/client/src/js/hmm/api.js
@@ -8,9 +8,8 @@ export const nextPage = ({ page }) => (
     Request.get(`/api/hmms?page=${page}`)
 );
 
-export const install = ({ release_id }) => (
+export const install = () => (
     Request.post("/api/hmms/status/updates")
-        .send({ release_id })
 );
 
 export const get = ({ hmmId }) => (

--- a/virtool/api/genbank.py
+++ b/virtool/api/genbank.py
@@ -3,7 +3,6 @@ Provides request handlers for managing and viewing analyses.
 
 """
 import aiohttp
-import aiohttp.client_exceptions
 
 import virtool.genbank
 import virtool.http.proxy
@@ -32,5 +31,5 @@ async def get(req):
 
         return json_response(data)
 
-    except aiohttp.client_exceptions.ClientConnectorError:
+    except aiohttp.ClientConnectorError:
         return bad_gateway("Could not reach NCBI")

--- a/virtool/api/genbank.py
+++ b/virtool/api/genbank.py
@@ -3,7 +3,7 @@ Provides request handlers for managing and viewing analyses.
 
 """
 import aiohttp
-import aiohttp.web
+import aiohttp.client_exceptions
 
 import virtool.genbank
 import virtool.http.proxy
@@ -27,10 +27,10 @@ async def get(req):
     try:
         data = await virtool.genbank.fetch(settings, session, accession)
 
-        if data is None:
-            return not_found()
+            if data is None:
+                return not_found()
 
-        return json_response(data)
+            return json_response(data)
 
     except aiohttp.client_exceptions.ClientConnectorError:
-        return bad_gateway("Could not reach Genbank")
+        return bad_gateway("Could not reach NCBI")

--- a/virtool/api/genbank.py
+++ b/virtool/api/genbank.py
@@ -27,10 +27,10 @@ async def get(req):
     try:
         data = await virtool.genbank.fetch(settings, session, accession)
 
-            if data is None:
-                return not_found()
+        if data is None:
+            return not_found()
 
-            return json_response(data)
+        return json_response(data)
 
     except aiohttp.client_exceptions.ClientConnectorError:
         return bad_gateway("Could not reach NCBI")

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -1,6 +1,6 @@
 import os
 
-import aiohttp.client_exceptions
+import aiohttp
 import aiojobs.aiohttp
 
 import virtool.db.hmm
@@ -12,7 +12,7 @@ import virtool.github
 import virtool.hmm
 import virtool.http.routes
 import virtool.utils
-from virtool.api.utils import bad_gateway, bad_request, compose_regex_query, conflict, json_response, no_content,\
+from virtool.api.utils import bad_gateway, bad_request, compose_regex_query, conflict, json_response, no_content, \
     not_found, paginate
 
 routes = virtool.http.routes.Routes()
@@ -66,7 +66,7 @@ async def get_release(req):
 
         raise
 
-    except aiohttp.client_exceptions.ClientConnectorError:
+    except aiohttp.ClientConnectorError:
         return bad_gateway("Could not reach GitHub")
 
     if release is None:

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -72,11 +72,7 @@ async def list_updates(req):
     return json_response(updates)
 
 
-@routes.post("/api/hmms/status/updates", permission="modify_hmm", schema={
-    "release_id": {
-        "type": ["integer", "string"]
-    }
-})
+@routes.post("/api/hmms/status/updates", permission="modify_hmm")
 async def install(req):
     """
     Install the latest official HMM database from GitHub.
@@ -88,8 +84,6 @@ async def install(req):
 
     if await db.status.count({"_id": "hmm", "updates.ready": False}):
         return conflict("Install already in progress")
-
-    release_id = req["data"].get("release_id", None)
 
     process = await virtool.db.processes.register(
         db,
@@ -106,14 +100,6 @@ async def install(req):
 
     release = document.get("release", None)
 
-    if not release or not release_id or release_id != release["id"]:
-        release = await virtool.github.get_release(
-            req.app["settings"],
-            req.app["client"],
-            "virtool/virtool-hmm",
-            None,
-            release_id or "latest"
-        )
 
         release = virtool.github.format_release(release)
 

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -57,7 +57,18 @@ async def get_status(req):
 
 @routes.get("/api/hmms/status/release")
 async def get_release(req):
-    release = await virtool.db.hmm.fetch_and_update_hmm_release(req.app)
+    try:
+        release = await virtool.db.hmm.fetch_and_update_hmm_release(req.app)
+
+    except virtool.errors.GitHubError as err:
+        if "404" in str(err):
+            return bad_gateway("GitHub repository does not exist")
+
+        raise
+
+    except aiohttp.client_exceptions.ClientConnectorError:
+        return bad_gateway("Could not reach GitHub")
+
     return json_response(release)
 
 

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -103,24 +103,8 @@ async def install(req):
 
     release = document.get("release", None)
 
-    if not release:
-        try:
-            release = await virtool.github.get_release(
-                req.app["settings"],
-                req.app["client"],
-                "virtool/virtool-hmm"
-            )
-
-        except aiohttp.client_exceptions.ClientConnectorError:
-            return bad_gateway("Could not reach GitHub")
-
-        except virtool.errors.GitHubError as err:
-            if "Not Found" in str(err):
-                return bad_gateway("GitHub repository not found")
-
-            raise
-
-        release = virtool.github.format_release(release)
+    if release is None:
+        return bad_request("Target release does not exist")
 
     update = virtool.github.create_update_subdocument(release, False, user_id)
 

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -69,6 +69,9 @@ async def get_release(req):
     except aiohttp.client_exceptions.ClientConnectorError:
         return bad_gateway("Could not reach GitHub")
 
+    if release is None:
+        return not_found("Release not found")
+
     return json_response(release)
 
 

--- a/virtool/api/hmm.py
+++ b/virtool/api/hmm.py
@@ -58,7 +58,7 @@ async def get_status(req):
 @routes.get("/api/hmms/status/release")
 async def get_release(req):
     try:
-        release = await virtool.db.hmm.fetch_and_update_hmm_release(req.app)
+        release = await virtool.db.hmm.fetch_and_update_release(req.app)
 
     except virtool.errors.GitHubError as err:
         if "404" in str(err):
@@ -174,6 +174,6 @@ async def purge(req):
         }
     })
 
-    await virtool.db.hmm.fetch_and_update_hmm_release(req.app)
+    await virtool.db.hmm.fetch_and_update_release(req.app)
 
     return no_content()

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -1,8 +1,8 @@
 import asyncio
 import os
 
+import aiohttp
 import aiojobs.aiohttp
-import aiohttp.client_exceptions
 
 import virtool.db.history
 import virtool.db.indexes
@@ -16,7 +16,7 @@ import virtool.http.routes
 import virtool.otus
 import virtool.references
 import virtool.utils
-from virtool.api.utils import bad_gateway, bad_request, compose_regex_query, insufficient_rights, json_response,\
+from virtool.api.utils import bad_gateway, bad_request, compose_regex_query, insufficient_rights, json_response, \
     no_content, not_found, paginate
 
 routes = virtool.http.routes.Routes()
@@ -114,7 +114,7 @@ async def get_release(req):
 
     try:
         release = await virtool.db.references.fetch_and_update_release(req.app, ref_id)
-    except aiohttp.client_exceptions.ClientConnectorError:
+    except aiohttp.ClientConnectorError:
         return bad_gateway("Could not reach GitHub")
 
     if release is None:
@@ -387,7 +387,7 @@ async def create(req):
                 release_id=release_id
             )
 
-        except aiohttp.client_exceptions.ClientConnectionError:
+        except aiohttp.ClientConnectionError:
             return bad_gateway("Could not reach GitHub")
 
         except virtool.errors.GitHubError as err:
@@ -396,7 +396,7 @@ async def create(req):
 
             raise
 
-        except aiohttp.client_exceptions.ClientConnectorError:
+        except aiohttp.ClientConnectorError:
             return bad_gateway("Could not reach GitHub")
 
         release = virtool.github.format_release(release)

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -387,8 +387,11 @@ async def create(req):
                 release_id=release_id
             )
 
+        except aiohttp.client_exceptions.ClientConnectionError:
+            return bad_gateway("Could not reach GitHub")
+
         except virtool.errors.GitHubError as err:
-            if "Not Found" in str(err):
+            if "404" in str(err):
                 return bad_gateway("Could not retrieve latest GitHub release")
 
             raise

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -312,6 +312,9 @@ async def create(req):
 
     if clone_from:
 
+        if not await db.references.count({"_id": clone_from}):
+            return bad_request("Source reference does not exist")
+
         manifest = await virtool.db.references.get_manifest(db, clone_from)
 
         document = await virtool.db.references.create_clone(

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -157,12 +157,12 @@ async def update(req):
     if not await virtool.db.references.check_right(req, ref_id, "modify"):
         return insufficient_rights()
 
-    process = await virtool.db.processes.register(db, "update_remote_reference")
-
     release = await virtool.db.utils.get_one_field(db.references, "release", ref_id)
 
     if release is None:
         return bad_request("Target release does not exist")
+
+    process = await virtool.db.processes.register(db, "update_remote_reference")
 
     release, update_subdocument = await virtool.db.references.update(
         req.app,

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -369,12 +369,22 @@ async def create(req):
         ))
 
     elif remote_from:
-        release = await virtool.github.get_release(
-            settings,
-            req.app["client"],
-            remote_from,
-            release_id=release_id
-        )
+        try:
+            release = await virtool.github.get_release(
+                settings,
+                req.app["client"],
+                remote_from,
+                release_id=release_id
+            )
+
+        except virtool.errors.GitHubError as err:
+            if "Not Found" in str(err):
+                return bad_gateway("Could not retrieve latest GitHub release")
+
+            raise
+
+        except aiohttp.client_exceptions.ClientConnectorError:
+            return bad_gateway("Could not reach GitHub")
 
         release = virtool.github.format_release(release)
 

--- a/virtool/api/settings.py
+++ b/virtool/api/settings.py
@@ -1,7 +1,6 @@
 import os
 
 import aiohttp
-import aiohttp.client_exceptions
 
 import virtool.app_settings
 import virtool.http.routes
@@ -107,7 +106,7 @@ async def check_proxy(req):
 
                         return json_response(dict(body, message="Could not reach internet"), status=400)
 
-                except aiohttp.client_exceptions.ClientProxyConnectionError:
+                except aiohttp.ClientProxyConnectionError:
                     return json_response(dict(body, message="Could not connect to proxy"), status=400)
 
     return json_response(dict(body, message="Proxy use is not enabled"), status=400)

--- a/virtool/app_settings.py
+++ b/virtool/app_settings.py
@@ -62,6 +62,12 @@ SCHEMA = {
     "sample_all_write": get_default_boolean(False),
     "sample_unique_names": get_default_boolean(True),
 
+    # HMM
+    "hmm_slug": {
+        "type": "string",
+        "default": "virtool/virtool-hmm"
+    },
+
     # MongoDB
     "db_name": {"type": "string", "default": "virtool"},
     "db_host": {"type": "string", "default": "localhost"},

--- a/virtool/db/hmm.py
+++ b/virtool/db/hmm.py
@@ -197,12 +197,20 @@ async def install(app, process_id, release, user_id):
 
         path = os.path.join(temp_path, "hmm.tar.gz")
 
-        await virtool.http.utils.download_file(
-            app,
-            release["download_url"],
-            path,
-            progress_tracker.add
-        )
+        try:
+            await virtool.http.utils.download_file(
+                app,
+                release["download_url"],
+                path,
+                progress_tracker.add
+            )
+        except (aiohttp.ClientConnectorError, virtool.errors.GitHubError):
+            await virtool.db.processes.update(
+                db,
+                process_id,
+                errors=["Could not download HMM data"],
+                step="unpack"
+            )
 
         await virtool.db.processes.update(
             db,

--- a/virtool/db/hmm.py
+++ b/virtool/db/hmm.py
@@ -89,7 +89,7 @@ async def fetch_and_update_hmm_release(app, ignore_errors=False):
         release = await virtool.github.get_release(
             settings,
             session,
-            "virtool/virtool-hmm",
+            settings["hmm_slug"],
             etag
         )
 

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -1067,23 +1067,11 @@ async def refresh_remotes(app):
         pass
 
 
-async def update(app, process_id, ref_id, release_id, user_id):
+async def update(app, process_id, ref_id, release, user_id):
 
     db = app["db"]
 
     created_at = virtool.utils.timestamp()
-
-    if release_id:
-        remotes_from = await virtool.db.utils.get_one_field(db.references, ref_id, "remotes_from")
-
-        release = await virtool.github.get_release(
-            app["settings"],
-            app["client"],
-            remotes_from["slug"],
-            release_id=release_id
-        )
-    else:
-        release = await virtool.db.utils.get_one_field(db.references, "release", ref_id)
 
     update_subdocument = virtool.github.create_update_subdocument(
         release,

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -1058,7 +1058,8 @@ async def refresh_remotes(app):
             for ref_id in await db.references.distinct("_id", {"remotes_from": {"$exists": True}}):
                 await fetch_and_update_release(
                     app,
-                    ref_id
+                    ref_id,
+                    ignore_errors=True
                 )
 
             await asyncio.sleep(600, loop=app.loop)

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -1,8 +1,8 @@
-import aiohttp.client_exceptions
 import asyncio
 import json.decoder
 import os
 
+import aiohttp
 import pymongo
 import semver
 
@@ -317,7 +317,7 @@ async def fetch_and_update_release(app, ref_id, ignore_errors=False):
         if updated:
             updated = virtool.github.format_release(updated)
 
-    except (aiohttp.client_exceptions.ClientConnectorError, virtool.errors.GitHubError) as err:
+    except (aiohttp.ClientConnectorError, virtool.errors.GitHubError) as err:
         if "ClientConnectorError" in str(err):
             errors = ["Could not reach GitHub"]
 
@@ -885,7 +885,7 @@ async def finish_remote(app, release, ref_id, created_at, process_id, user_id):
             process_id,
             progress_tracker.add
         )
-    except (aiohttp.client_exceptions.ClientConnectorError, virtool.errors.GitHubError):
+    except (aiohttp.ClientConnectorError, virtool.errors.GitHubError):
         return await virtool.db.processes.update(
             db,
             process_id,
@@ -1176,7 +1176,7 @@ async def finish_update(app, ref_id, created_at, process_id, release, user_id):
             process_id,
             progress_tracker.add
         )
-    except (aiohttp.client_exceptions.ClientConnectorError, virtool.errors.GitHubError):
+    except (aiohttp.ClientConnectorError, virtool.errors.GitHubError):
         return await virtool.db.processes.update(
             db,
             process_id,

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -880,12 +880,19 @@ async def finish_remote(app, release, ref_id, created_at, process_id, user_id):
         increment=0.1
     )
 
-    import_data = await download_and_parse_release(
-        app,
-        release["download_url"],
-        process_id,
-        progress_tracker.add
-    )
+    try:
+        import_data = await download_and_parse_release(
+            app,
+            release["download_url"],
+            process_id,
+            progress_tracker.add
+        )
+    except aiohttp.client_exceptions.ClientConnectorError:
+        return await virtool.db.processes.update(
+            db,
+            process_id,
+            errors=["Could not download reference data"]
+        )
 
     errors = virtool.references.check_import_data(
         import_data,

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -314,7 +314,8 @@ async def fetch_and_update_release(app, ref_id, ignore_errors=False):
             etag
         )
 
-        updated = virtool.github.format_release(updated)
+        if updated:
+            updated = virtool.github.format_release(updated)
 
     except (aiohttp.client_exceptions.ClientConnectorError, virtool.errors.GitHubError) as err:
         if "ClientConnectorError" in str(err):

--- a/virtool/db/software.py
+++ b/virtool/db/software.py
@@ -20,11 +20,14 @@ logger = logging.getLogger(__name__)
 VIRTOOL_RELEASES_URL = "https://www.virtool.ca/releases"
 
 
-async def fetch_and_update_software_releases(app):
+async def fetch_and_update_releases(app, ignore_errors=False):
     """
     Get a list of releases, from the Virtool website, published since the current server version.
 
     :param app: the application object
+
+    :param ignore_errors: ignore errors during request to virtool.ca
+    :type ignore_errors: bool
 
     :return: a list of releases
     :rtype: Coroutine[list]
@@ -44,9 +47,19 @@ async def fetch_and_update_software_releases(app):
             data = json.loads(data)
 
         logger.debug("Retrieved software releases from www.virtool.ca")
-    except aiohttp.ClientConnectionError:
+    except aiohttp.ClientConnectorError:
         # Return any existing release list or `None`.
         logger.debug("Could not retrieve software releases")
+
+        await db.status.update_one({"_id": "software"}, {
+            "$set": {
+                "errors": ["Could not retrieve software releases"]
+            }
+        })
+
+        if not ignore_errors:
+            raise
+
         return await virtool.db.utils.get_one_field(db.status, "releases", "software")
 
     data = data["software"]
@@ -71,6 +84,7 @@ async def fetch_and_update_software_releases(app):
 
     await db.status.update_one({"_id": "software"}, {
         "$set": {
+            "errors": [],
             "releases": releases
         }
     })
@@ -172,7 +186,7 @@ async def refresh(app):
     """
     try:
         while True:
-            await fetch_and_update_software_releases(app)
+            await fetch_and_update_releases(app, ignore_errors=True)
             await asyncio.sleep(43200, loop=app.loop)
     except asyncio.CancelledError:
         pass

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -1,5 +1,4 @@
 import logging
-import aiohttp.client_exceptions
 
 import virtool.errors
 import virtool.http.proxy

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -1,4 +1,5 @@
 import logging
+import aiohttp.client_exceptions
 
 import virtool.errors
 import virtool.http.proxy
@@ -73,25 +74,29 @@ async def get_release(settings, session, slug, etag=None, release_id="latest"):
     if etag:
         headers["If-None-Match"] = etag
 
-    async with virtool.http.proxy.ProxyRequest(settings, session.get, url, headers=headers) as resp:
-        logger.debug("Fetched release: {}/{} ({} - {}/{})".format(
-            slug,
-            release_id,
-            resp.status,
-            resp.headers["X-RateLimit-Remaining"],
-            resp.headers["X-RateLimit-Limit"]
-        ))
+    try:
+        async with virtool.http.proxy.ProxyRequest(settings, session.get, url, headers=headers) as resp:
+            logger.debug("Fetched release: {}/{} ({} - {}/{})".format(
+                slug,
+                release_id,
+                resp.status,
+                resp.headers["X-RateLimit-Remaining"],
+                resp.headers["X-RateLimit-Limit"]
+            ))
 
-        if resp.status == 200:
-            data = await resp.json()
+            if resp.status == 200:
+                data = await resp.json()
 
-            if len(data["assets"]) == 0:
+                if len(data["assets"]) == 0:
+                    return None
+
+                return dict(data, etag=resp.headers["etag"])
+
+            elif resp.status == 304:
                 return None
 
-            return dict(data, etag=resp.headers["etag"])
+            else:
+                raise virtool.errors.GitHubError("Encountered error {}".format(resp.status))
 
-        elif resp.status == 304:
-            return None
-
-        else:
-            raise virtool.errors.GitHubError("Encountered error {}".format(resp.status))
+    except aiohttp.client_exceptions.ClientConnectorError:
+        raise virtool.errors.GitHubError("Could not reach GitHub")

--- a/virtool/http/proxy.py
+++ b/virtool/http/proxy.py
@@ -1,5 +1,6 @@
-import aiohttp
 import os
+
+import aiohttp
 from aiohttp import web
 
 import virtool.errors
@@ -73,7 +74,7 @@ async def middleware(req, handler):
             "message": str(err)
         }, status=500)
 
-    except aiohttp.client_exceptions.ClientProxyConnectionError:
+    except aiohttp.ClientProxyConnectionError:
         return json_response({
             "id": "proxy_error",
             "message": "Could not connect to proxy"

--- a/virtool/http/utils.py
+++ b/virtool/http/utils.py
@@ -23,7 +23,7 @@ async def download_file(app, url, target_path, progress_handler=None):
     """
     async with virtool.http.proxy.ProxyRequest(app["settings"], app["client"].get, url) as resp:
         if resp.status != 200:
-            return None
+            raise virtool.errors.GitHubError("Could not download file")
 
         async with aiofiles.open(target_path, "wb") as handle:
             while True:


### PR DESCRIPTION
- resolves #763 
- resolves #980
- add `hmm_slug` setting for setting which GitHub repo to fetch HMM install from
- don't raise exception when `ClientConnectorError` occurs during internet requests in scheduled release refresh jobs
- only allow initial install of stored HMM release
- only allow update to stored remote reference release
- only allow update to stored software release
- return `400` for cloning ref if source ref doesn't exist
- return `502` for  Genbank request when cannot connect to NCBI
- return `502` when creating a remote ref fails due to GitHub connection or `404` error
- return `502` when listing latest software releases if request to www.virtool.ca fails
- return `502` when getting latest remote HMM release if GitHub request fails
- return `502` when getting latest remote ref release if GitHub request fails
- set error on HMM install process if the data file cannot be downloaded
- set error on remote ref install and update processes if the data files cannot be downloaded
- store fetching `errors` in HMM status, remote reference `release`, and software status documents

