### PR TITLE
Support pagination for users

### DIFF
--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -11,7 +11,7 @@ async def test_find(spawn_client, create_user, static_time):
     """
     client = await spawn_client(authorize=True, administrator=True, permissions=["create_sample"])
 
-    user_ids = ["bob", "fred", "john"]
+    user_ids = ["bob", "fred"]
 
     await client.db.users.insert_many([create_user(user_id) for user_id in user_ids])
 
@@ -19,24 +19,70 @@ async def test_find(spawn_client, create_user, static_time):
 
     assert resp.status == 200
 
-    base_dict = {
-        "administrator": False,
-        "identicon": "identicon",
-        "force_reset": False,
-        "groups": [],
-        "last_password_change": static_time.iso,
-        "permissions": {p: False for p in PERMISSIONS},
-        "primary_group": "technician"
+    assert await resp.json() == {
+        "documents": [
+            {
+                "administrator": False,
+                "force_reset": False,
+                "groups": [],
+                "id": "bob",
+                "identicon": "identicon",
+                "last_password_change": static_time.iso,
+                "permissions": {
+                    "cancel_job": False,
+                    "create_ref": False,
+                    "create_sample": False,
+                    "modify_hmm": False,
+                    "modify_subtraction": False,
+                    "remove_file": False,
+                    "remove_job": False,
+                    "upload_file": False},
+                "primary_group": "technician"},
+            {
+                "administrator": False,
+                "force_reset": False,
+                "groups": [],
+                "id": "fred",
+                "identicon": "identicon",
+                "last_password_change": static_time.iso,
+                "permissions": {
+                    "cancel_job": False,
+                    "create_ref": False,
+                    "create_sample": False,
+                    "modify_hmm": False,
+                    "modify_subtraction": False,
+                    "remove_file": False,
+                    "remove_job": False,
+                    "upload_file": False
+                },
+                "primary_group": "technician"
+            },
+            {
+                "administrator": True,
+                "force_reset": False,
+                "groups": [],
+                "id": "test",
+                "identicon": "identicon",
+                "last_password_change": static_time.iso,
+                "permissions": {
+                    "cancel_job": False,
+                    "create_ref": False,
+                    "create_sample": True,
+                    "modify_hmm": False,
+                    "modify_subtraction": False,
+                    "remove_file": False,
+                    "remove_job": False,
+                    "upload_file": False
+                },
+                "primary_group": "technician"
+            }
+        ],
+        "found_count": 3,
+        "page": 1,
+        "page_count": 1,
+        "per_page": 25,
+        "total_count": 3
     }
-
-    expected = [dict(base_dict, id=user_id) for user_id in user_ids + ["test"]]
-
-    expected[3].update({
-        "administrator": True,
-        "permissions": dict(base_dict["permissions"], create_sample=True)
-    })
-
-    assert sorted(await resp.json(), key=itemgetter("id")) == sorted(expected, key=itemgetter("id"))
 
 
 @pytest.mark.parametrize("not_found", [False, True])

--- a/virtool/api/users.py
+++ b/virtool/api/users.py
@@ -1,5 +1,4 @@
-from cerberus import Validator
-
+import virtool.db.hmm
 import virtool.db.users
 import virtool.db.utils
 import virtool.errors
@@ -7,7 +6,8 @@ import virtool.groups
 import virtool.http.routes
 import virtool.users
 import virtool.utils
-from virtool.api.utils import bad_request, conflict, invalid_input, json_response, no_content, not_found
+from virtool.api.utils import bad_request, compose_regex_query, conflict, json_response, no_content, not_found,\
+    paginate
 
 
 routes = virtool.http.routes.Routes()
@@ -19,9 +19,24 @@ async def find(req):
     Get a list of all user documents in the database.
 
     """
-    users = await req.app["db"].users.find({}, virtool.db.users.PROJECTION).to_list(None)
+    db = req.app["db"]
 
-    return json_response([virtool.utils.base_processor(user) for user in users])
+    term = req.query.get("find", None)
+
+    db_query = dict()
+
+    if term:
+        db_query.update(compose_regex_query(term, ["_id"]))
+
+    data = await paginate(
+        db.users,
+        db_query,
+        req.query,
+        sort="_id",
+        projection=virtool.db.users.PROJECTION
+    )
+
+    return json_response(data)
 
 
 @routes.get("/api/users/{user_id}", admin=True)


### PR DESCRIPTION
- resolves #973
- add API support for paging at `GET /api/users`
- support searching by user name (`id`)