### PR TITLE
Store pathoscope results to disk when DocumentToLarge

### DIFF
--- a/tests/db/test_analyses.py
+++ b/tests/db/test_analyses.py
@@ -53,5 +53,5 @@ async def test_format_analysis(algorithm, mocker):
         assert not m_format_pathoscope.called
 
     elif algorithm == "pathoscope":
-        m_format_pathoscope.assert_called_with("db", document)
+        m_format_pathoscope.assert_called_with("db", "settings", document)
         assert not m_format_nuvs.called

--- a/virtool/analyses.py
+++ b/virtool/analyses.py
@@ -34,6 +34,17 @@ def get_nuvs_json_path(data_path, analysis_id, sample_id):
     )
 
 
+def get_pathoscope_json_path(data_path, analysis_id, sample_id):
+    return os.path.join(
+        data_path,
+        "samples",
+        analysis_id,
+        "analysis",
+        sample_id,
+        "pathoscope.json"
+    )
+
+
 def get_nuvs_sequence_by_index(document, sequence_index):
     """
     Get a sequence from a NuVs analysis document by its sequence index.

--- a/virtool/db/analyses.py
+++ b/virtool/db/analyses.py
@@ -46,7 +46,7 @@ async def format_analysis(db, settings, document):
         return await format_nuvs(db, settings, document)
 
     if algorithm and "pathoscope" in algorithm:
-        return await format_pathoscope(db, document)
+        return await format_pathoscope(db, settings, document)
 
     raise ValueError("Could not determine analysis algorithm")
 
@@ -73,7 +73,18 @@ async def format_nuvs(db, settings, document):
     return document
 
 
-async def format_pathoscope(db, document):
+async def format_pathoscope(db, settings, document):
+    if document["diagnosis"] == "file":
+        path = virtool.analyses.get_pathoscope_json_path(
+            settings["data_path"],
+            document["_id"],
+            document["sample"]["id"]
+        )
+
+        async with aiofiles.open(path, "r") as f:
+            json_string = await f.read()
+            document.update(json.loads(json_string))
+
     formatted = dict()
 
     otu_specifiers = {(hit["otu"]["id"], hit["otu"]["version"]) for hit in document["diagnosis"]}


### PR DESCRIPTION
- resolves #1026 
- write pathoscope result to disk when `DocumentToLarge` error is encountered