### PR TITLE
Migration fixes

### DIFF
--- a/client/src/js/analyses/analyses-reducer.test.js
+++ b/client/src/js/analyses/analyses-reducer.test.js
@@ -80,11 +80,31 @@ describe("Analyses Reducer", () => {
         expect(result).toEqual(expected);
     });
 
-    it("should handle GET_ANALYSIS_SUCCEEDED", () => {
+    it("should handle GET_ANALYSIS_SUCCEEDED for nuvs", () => {
+        state = {};
+        action = {
+            type: "GET_ANALYSIS_SUCCEEDED",
+            algorithm: "nuvs",
+            data: {
+                diagnosis: []
+            }
+        };
+        result = reducer(state, action);
+        expected = {
+            ...state,
+            detail: action.data,
+            data: action.data
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle GET_ANALYSIS_SUCCEEDED for pathoscope", () => {
         state = {};
         action = {
             type: "GET_ANALYSIS_SUCCEEDED",
             data: {
+                algorithm: "pathoscope_bowtie",
                 diagnosis: []
             }
         };

--- a/client/src/js/analyses/components/NuVs/BLAST.js
+++ b/client/src/js/analyses/components/NuVs/BLAST.js
@@ -149,7 +149,7 @@ const NuVsBLAST = (props) => {
 };
 
 const mapStateToProps = (state) => ({
-    analysisId: state.samples.analysisDetail.id
+    analysisId: state.analyses.detail.id
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/src/js/analyses/reducer.js
+++ b/client/src/js/analyses/reducer.js
@@ -144,7 +144,13 @@ export default function samplesReducer (state = initialState, action) {
             };
 
         case GET_ANALYSIS.SUCCEEDED: {
-            const data = addDepth(formatData(action.data), state.showMedian);
+            let data;
+
+            if (action.data.algorithm === "pathoscope_bowtie") {
+                data = addDepth(formatData(action.data), state.showMedian);
+            } else {
+                data = action.data;
+            }
 
             return {
                 ...state,

--- a/client/src/js/analyses/sagas.js
+++ b/client/src/js/analyses/sagas.js
@@ -5,7 +5,7 @@ import {apiCall} from "../sagaUtils";
 
 import * as analysesAPI from "./api";
 
-export const getAnalysisDetailId = (state) => get(state, "samples.analysisDetail.id", null);
+export const getAnalysisDetailId = (state) => get(state, "analysis.detail.id", null);
 
 export function* watchAnalyses () {
     yield takeEvery(WS_UPDATE_ANALYSIS, wsUpdateAnalysis);

--- a/tests/db/test_history.py
+++ b/tests/db/test_history.py
@@ -204,7 +204,7 @@ async def test_get_most_recent_change(exists, dbi, static_time):
                 "otu": {
                     "id": "6116cba1",
                     "name": "Prunus virus F",
-                    "version": 1
+                    "version": 2
                 },
                 "index": {
                     "id": "unbuilt"
@@ -226,7 +226,7 @@ async def test_get_most_recent_change(exists, dbi, static_time):
             "otu": {
                 "id": "6116cba1",
                 "name": "Prunus virus F",
-                "version": 1
+                "version": 2
             }
         }
     else:

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -518,7 +518,9 @@ async def edit(req):
             }
         })
 
-    document["users"] = await virtool.db.users.attach_identicons(db, document["users"])
+    users = await virtool.db.utils.get_one_field(db.references, "users", ref_id)
+
+    document["users"] = await virtool.db.users.attach_identicons(db, users)
 
     return json_response(document)
 

--- a/virtool/api/users.py
+++ b/virtool/api/users.py
@@ -78,6 +78,9 @@ async def create(req):
     data = await req.json()
     settings = req.app["settings"]
 
+    if data["user_id"] == "virtool":
+        return bad_request("Reserved user name: virtool")
+
     if len(data["password"]) < settings["minimum_password_length"]:
         return bad_request("Password does not meet length requirement")
 

--- a/virtool/db/groups.py
+++ b/virtool/db/groups.py
@@ -4,6 +4,18 @@ import virtool.utils
 
 
 async def get_merged_permissions(db, id_list):
+    """
+    Get the merged permissions that are inherited as a result of membership in the groups defined in `id_list`.
+
+    :param db: the application database interface
+
+    :param id_list: a list of group ids
+    :type id_list: list
+
+    :return: the merged permissions
+    :rtype: dict
+
+    """
     groups = await db.groups.find({
         "_id": {
             "$in": id_list

--- a/virtool/db/history.py
+++ b/virtool/db/history.py
@@ -122,7 +122,7 @@ async def find(db, req_query, base_query=None):
         {},
         req_query,
         base_query=base_query,
-        sort="created_at",
+        sort="otu.version",
         projection=LIST_PROJECTION,
         reverse=True
     )
@@ -172,7 +172,7 @@ async def get_most_recent_change(db, otu_id):
     return await db.history.find_one({
         "otu.id": otu_id,
         "index.id": "unbuilt"
-    }, MOST_RECENT_PROJECTION, sort=[("created_at", -1)])
+    }, MOST_RECENT_PROJECTION, sort=[("otu.version", -1)])
 
 
 async def patch_to_verified(db, otu_id):
@@ -183,7 +183,7 @@ async def patch_to_verified(db, otu_id):
 
     patched = deepcopy(current)
 
-    async for change in db.history.find({"otu.id": otu_id}, sort=[("created_at", -1)]):
+    async for change in db.history.find({"otu.id": otu_id}, sort=[("otu.version", -1)]):
         if change["method_name"] == "remove":
             patched = change["diff"]
 
@@ -227,7 +227,7 @@ async def patch_to_version(db, otu_id, version):
     patched = deepcopy(current)
 
     # Sort the changes by descending timestamp.
-    async for change in db.history.find({"otu.id": otu_id}, sort=[("created_at", -1)]):
+    async for change in db.history.find({"otu.id": otu_id}, sort=[("otu.version", -1)]):
         if change["otu"]["version"] == "removed" or change["otu"]["version"] > version:
             reverted_history_ids.append(change["_id"])
 

--- a/virtool/db/hmm.py
+++ b/virtool/db/hmm.py
@@ -98,7 +98,7 @@ async def fetch_and_update_release(app, ignore_errors=False):
         # The release dict will only be replaced if there is a 200 response from GitHub. A 304 indicates the release
         # has not changed and `None` is returned from `get_release()`.
         if updated:
-            release = virtool.github.format_release(release)
+            release = virtool.github.format_release(updated)
 
             release["newer"] = bool(
                 release is None or (

--- a/virtool/db/iface.py
+++ b/virtool/db/iface.py
@@ -177,7 +177,7 @@ class DB:
         for collection_name in COLLECTION_NAMES:
             setattr(self, collection_name, None)
 
-        self._client = client
+        self.motor_client = client
 
     async def connect(self):
         await self.bind_collection("analyses", projection=virtool.db.analyses.PROJECTION)
@@ -198,11 +198,12 @@ class DB:
         await self.bind_collection("status")
         await self.bind_collection("subtraction", projection=virtool.db.subtractions.PROJECTION)
         await self.bind_collection("users", projection=virtool.db.users.PROJECTION)
+        await self.bind_collection("viruses", projection=virtool.db.otus.PROJECTION)
 
     async def bind_collection(self, name, processor=None, projection=None, silent=False):
         collection = Collection(
             name,
-            self._client[name],
+            self.motor_client[name],
             self.dispatch,
             processor or virtool.utils.base_processor,
             projection,
@@ -212,4 +213,4 @@ class DB:
         setattr(self, name, collection)
 
     async def collection_names(self):
-        return await self._client.collection_names()
+        return await self.motor_client.collection_names()

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -656,6 +656,7 @@ async def create_original(db, settings):
         "genome",
         created_at=created_at,
         ref_id="original",
+        user_id="virtool",
         users=users
     )
 

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -279,10 +279,10 @@ async def organize_subtraction(db):
 async def organize_users(db):
     logger.info(" • users")
 
-    async for document in db.users.find({"groups": "administrator"}):
+    async for document in db.users.find({}, ["groups"]):
         await db.users.update_one({"_id": document["_id"]}, {
             "$set": {
-                "administrator": True
+                "administrator": "administrator" in document["groups"]
             },
             "$pull": {
                 "groups": "administrator"

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -102,6 +102,14 @@ async def organize_groups(db):
 async def organize_history(db):
     logger.info(" • history")
 
+    await db.history.update_many({}, {
+        "$set": {
+            "reference": {
+                "id": "original"
+            }
+        }
+    }, silent=True)
+
     document_ids = await db.history.distinct("_id", {"reference": {"$exists": False}})
 
     document_ids = [_id for _id in document_ids if ".removed" in _id or ".0" in _id]

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -222,6 +222,11 @@ async def organize_references(db, settings):
 
     if await db.otus.count() and not await db.references.count():
         await virtool.db.references.create_original(db, settings)
+async def organize_samples(db):
+    motor_client = db.motor_client
+
+    for sample_id in await motor_client.samples.distinct("_id"):
+        await virtool.db.samples.recalculate_algorithm_tags(motor_client, sample_id)
 
 
 async def organize_sequences(db):

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -73,7 +73,7 @@ async def organize_analyses(db):
             "$set": {
                 "reference.name": document["name"]
             }
-        })
+        }, silent=True)
 
 
 async def organize_files(db):
@@ -83,7 +83,7 @@ async def organize_files(db):
         "$set": {
             "reserved": False
         }
-    })
+    }, silent=True)
 
 
 async def organize_groups(db):
@@ -96,7 +96,7 @@ async def organize_groups(db):
             "$set": {
                 "permissions": {perm: group["permissions"].get(perm, False) for perm in virtool.users.PERMISSIONS}
             }
-        })
+        }, silent=True)
 
 
 async def organize_history(db):
@@ -118,12 +118,9 @@ async def organize_history(db):
         "$set": {
             "diff.reference": {
                 "id": "original"
-            },
-            "reference": {
-                "id": "original"
             }
         }
-    })
+    }, silent=True)
 
 
 async def organize_indexes(db):
@@ -198,7 +195,7 @@ async def organize_sequences(db):
             }
         })
 
-        await db.sequences.insert_one(document)
+        await db.sequences.insert_one(document, silent=True)
 
     await db.sequences.delete_many(REFERENCE_QUERY)
 
@@ -259,4 +256,4 @@ async def organize_users(db):
             "$pull": {
                 "groups": "administrator"
             }
-        })
+        }, silent=True)

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -261,7 +261,7 @@ async def organize_history(db):
 async def organize_indexes(db):
     logger.info(" • indexes")
 
-    await add_original_reference(db.indexes)
+    await add_original_reference(db.motor_client.indexes)
 
 
 async def organize_otus(db):


### PR DESCRIPTION
- resolves #1023
- always sort history by `otu.version` rather than `created_at`
- expose `MotorClient` in `virtool.db.iface.DB` as `motor_client` attribute
- fix error getting active `analysisId` in `<BLAST />` component
- fix exception attaching identicons at ref edit endpoint (#1023)
- fix issue getting HMM release for fresh database
- only add depth information to pathoscope detail in client (not NuVs)
- update `getAnalysisDetailId()` state selection function
- update the `organize.py` module to migrate v2 databases to v3