### PR TITLE
Return all reference fields in edit response

### DIFF
--- a/tests/api/test_references.py
+++ b/tests/api/test_references.py
@@ -329,8 +329,7 @@ async def test_edit(control_exists, control_id, mocker, spawn_client, check_ref_
         },
         {
             "$set": update
-        },
-        projection=virtool.db.references.PROJECTION
+        }
     )
 
     m_get_computed.assert_called_with(

--- a/virtool/api/references.py
+++ b/virtool/api/references.py
@@ -505,7 +505,7 @@ async def edit(req):
 
     document = await db.references.find_one_and_update({"_id": ref_id}, {
         "$set": data
-    }, projection=virtool.db.references.PROJECTION)
+    })
 
     document = virtool.utils.base_processor(document)
 


### PR DESCRIPTION
- resolves #1045 
- return all reference fields in edit response
- was incorrectly applying `PROJECTION`