### PR TITLE
Add reference field to OTU projection

### DIFF
--- a/virtool/db/otus.py
+++ b/virtool/db/otus.py
@@ -10,10 +10,11 @@ from virtool.api.utils import compose_regex_query, paginate
 
 PROJECTION = [
     "_id",
-    "name",
     "abbreviation",
-    "version",
-    "verified"
+    "name",
+    "reference",
+    "verified",
+    "version"
 ]
 
 SEQUENCE_PROJECTION = [


### PR DESCRIPTION
- resolves #1051 
- include `reference` in OTU projection
- `reference` will be included in websocket messages and `GET /api/otus` and `GET /api/refs/:id/outs` responses
