### PR TITLE
Fix RuntimeError due to abruptly closed TCP transport

### DIFF
--- a/virtool/api/websocket.py
+++ b/virtool/api/websocket.py
@@ -20,8 +20,12 @@ async def root(req):
 
     req.app["dispatcher"].add_connection(connection)
 
-    async for _ in ws:
-        pass
+    try:
+        async for _ in ws:
+            pass
+    except RuntimeError as err:
+        if "TCPTransport" not in str(err):
+            raise
 
     logger.info("Connection closed")
 

--- a/virtool/dispatcher.py
+++ b/virtool/dispatcher.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from copy import deepcopy
 


### PR DESCRIPTION
- may resolve #1044
- attempt to handler `RuntimeError` in websocket handler
- this happens only on websocket connections made by up-to-date Safari browers
