### PR TITLE
Avoid InvalidStateError in to_list()

### DIFF
--- a/virtool/api/account.py
+++ b/virtool/api/account.py
@@ -140,9 +140,9 @@ async def get_api_keys(req):
 
     user_id = req["client"].user_id
 
-    api_keys = await db.keys.find({"user.id": user_id}, API_KEY_PROJECTION).to_list(None)
+    cursor = db.keys.find({"user.id": user_id}, API_KEY_PROJECTION)
 
-    return json_response(api_keys, status=200)
+    return json_response([d async for d in cursor] , status=200)
 
 
 @routes.get("/api/account/keys/{key_id}")

--- a/virtool/api/groups.py
+++ b/virtool/api/groups.py
@@ -17,9 +17,8 @@ async def find(req):
     Get a list of all existing group documents.
 
     """
-    documents = await req.app["db"].groups.find().to_list(None)
-
-    return json_response([virtool.utils.base_processor(d) for d in documents])
+    cursor = await req.app["db"].groups.find()
+    return json_response([virtool.utils.base_processor(d) async for d in cursor])
 
 
 @routes.post("/api/groups", admin=True, schema={

--- a/virtool/api/groups.py
+++ b/virtool/api/groups.py
@@ -17,7 +17,7 @@ async def find(req):
     Get a list of all existing group documents.
 
     """
-    cursor = await req.app["db"].groups.find()
+    cursor = req.app["db"].groups.find()
     return json_response([virtool.utils.base_processor(d) async for d in cursor])
 
 

--- a/virtool/api/otus.py
+++ b/virtool/api/otus.py
@@ -624,9 +624,9 @@ async def list_sequences(req):
     projection.remove("otu_id")
     projection.remove("isolate_id")
 
-    documents = await db.sequences.find({"otu_id": otu_id, "isolate_id": isolate_id}, projection).to_list(None)
+    cursor = db.sequences.find({"otu_id": otu_id, "isolate_id": isolate_id}, projection)
 
-    return json_response([virtool.utils.base_processor(d) for d in documents])
+    return json_response([virtool.utils.base_processor(d) async for d in cursor])
 
 
 @routes.get("/api/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence_id}")
@@ -871,6 +871,6 @@ async def list_history(req):
     if not await db.otus.find({"_id": otu_id}).count():
         return not_found()
 
-    documents = await db.history.find({"otu.id": otu_id}).to_list(None)
+    cursor = await db.history.find({"otu.id": otu_id})
 
-    return json_response(documents)
+    return json_response([d async for d in cursor)

--- a/virtool/api/otus.py
+++ b/virtool/api/otus.py
@@ -873,4 +873,4 @@ async def list_history(req):
 
     cursor = await db.history.find({"otu.id": otu_id})
 
-    return json_response([d async for d in cursor)
+    return json_response([d async for d in cursor])

--- a/virtool/db/analyses.py
+++ b/virtool/db/analyses.py
@@ -65,9 +65,9 @@ async def format_nuvs(db, settings, document):
 
     hit_ids = list({h["hit"] for s in document["results"] for o in s["orfs"] for h in o["hits"]})
 
-    hmms = await db.hmm.find({"_id": {"$in": hit_ids}}, ["cluster", "families", "names"]).to_list(None)
+    cursor = db.hmm.find({"_id": {"$in": hit_ids}}, ["cluster", "families", "names"])
 
-    hmms = {hmm.pop("_id"): hmm for hmm in hmms}
+    hmms = {d.pop("_id"): d async for d in cursor}
 
     for sequence in document["results"]:
         for orf in sequence["orfs"]:

--- a/virtool/db/groups.py
+++ b/virtool/db/groups.py
@@ -1,3 +1,4 @@
+import asyncio
 import virtool.db.users
 import virtool.groups
 import virtool.utils
@@ -16,17 +17,12 @@ async def get_merged_permissions(db, id_list):
     :rtype: dict
 
     """
-    groups = await db.groups.find({
-        "_id": {
-            "$in": id_list
-        }
-    }, {"_id": False}).to_list(None)
-
+    groups = await asyncio.shield(db.groups.find({"_id": {"$in": id_list}}, {"_id": False}).to_list(None))
     return virtool.groups.merge_group_permissions(groups)
 
 
 async def update_member_users(db, group_id, remove=False):
-    groups = await db.groups.find().to_list(None)
+    groups = await asyncio.shield(db.groups.find().to_list(None))
 
     async for user in db.users.find({"groups": group_id}, ["administrator", "groups", "permissions", "primary_group"]):
         if remove:

--- a/virtool/db/history.py
+++ b/virtool/db/history.py
@@ -144,15 +144,15 @@ async def get_contributors(db, query):
     :rtype: List[dict]
 
     """
-    contributors = await db.history.aggregate([
+    cursor = db.history.aggregate([
         {"$match": query},
         {"$group": {
             "_id": "$user.id",
             "count": {"$sum": 1}
         }}
-    ]).to_list(None)
+    ])
 
-    return [{"id": c["_id"], "count": c["count"]} for c in contributors]
+    return [{"id": c["_id"], "count": c["count"]} async for c in cursor]
 
 
 async def get_most_recent_change(db, otu_id):

--- a/virtool/db/hmm.py
+++ b/virtool/db/hmm.py
@@ -37,7 +37,7 @@ async def delete_unreferenced_hmms(db):
     :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
 
     """
-    agg = await db.analyses.aggregate([
+    cursor = db.analyses.aggregate([
         {"$match": {
             "algorithm": "nuvs"
         }},
@@ -50,9 +50,9 @@ async def delete_unreferenced_hmms(db):
         {"$group": {
             "_id": "$results.orfs.hits.hit"
         }}
-    ]).to_list(None)
+    ])
 
-    referenced_ids = list(set(a["_id"] for a in agg))
+    referenced_ids = list(set(a["_id"] async for a in cursor))
 
     delete_result = await db.hmm.delete_many({"_id": {"$nin": referenced_ids}})
 

--- a/virtool/db/indexes.py
+++ b/virtool/db/indexes.py
@@ -161,7 +161,7 @@ async def get_otus(db, index_id):
     :rtype: List[dict]
 
     """
-    otus = await db.history.aggregate([
+    cursor = db.history.aggregate([
         {"$match": {
             "index.id": index_id
         }},
@@ -180,9 +180,9 @@ async def get_otus(db, index_id):
         {"$sort": {
             "name": 1
         }}
-    ]).to_list(None)
+    ])
 
-    return [{"id": v["_id"], "name": v["name"], "change_count": v["count"]} for v in otus]
+    return [{"id": v["_id"], "name": v["name"], "change_count": v["count"]} async for v in cursor]
 
 
 async def get_modification_stats(db, index_id):

--- a/virtool/db/jobs.py
+++ b/virtool/db/jobs.py
@@ -42,7 +42,7 @@ async def clear(db, complete=False, failed=False):
 
 
 async def get_waiting_and_running_ids(db):
-    agg = await db.jobs.aggregate([
+    cursor = await db.jobs.aggregate([
         {"$project": {
             "status": {
                 "$arrayElemAt": ["$status", -1]
@@ -59,9 +59,9 @@ async def get_waiting_and_running_ids(db):
         {"$project": {
             "_id": True
         }}
-    ]).to_list(None)
+    ])
 
-    return [a["_id"] for a in agg]
+    return [a["_id"] async for a in cursor]
 
 
 def processor(document):

--- a/virtool/db/jobs.py
+++ b/virtool/db/jobs.py
@@ -42,7 +42,7 @@ async def clear(db, complete=False, failed=False):
 
 
 async def get_waiting_and_running_ids(db):
-    cursor = await db.jobs.aggregate([
+    cursor = db.jobs.aggregate([
         {"$project": {
             "status": {
                 "$arrayElemAt": ["$status", -1]

--- a/virtool/db/otus.py
+++ b/virtool/db/otus.py
@@ -140,8 +140,8 @@ async def find(db, names, term, req_query, verified, ref_id=None):
         }
 
     if names is True or names == "true":
-        data = await db.otus.find({**db_query, **base_query}, ["name"], sort=[("name", 1)]).to_list(None)
-        return [virtool.utils.base_processor(d) for d in data]
+        cursor = db.otus.find({**db_query, **base_query}, ["name"], sort=[("name", 1)])
+        return [virtool.utils.base_processor(d) async for d in cursor]
 
     data = await paginate(
         db.otus,
@@ -181,11 +181,10 @@ async def join(db, query, document=None):
     if document is None:
         return None
 
-    # Get the sequence entries associated with the isolate ids.
-    sequences = await db.sequences.find({"otu_id": document["_id"]}).to_list(None) or list()
+    cursor = db.sequences.find({"otu_id": document["_id"]})
 
     # Merge the sequence entries into the otu entry.
-    return virtool.otus.merge_otu(document, sequences)
+    return virtool.otus.merge_otu(document, [d async for d in cursor])
 
 
 async def join_and_format(db, otu_id, joined=None, issues=False):

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -635,7 +635,7 @@ async def create_original(db, settings):
     first_change = await db.history.find_one({}, ["created_at"], sort=[("created_at", pymongo.ASCENDING)])
     created_at = first_change["created_at"]
 
-    users = await db.users.find({}, ["_id", "administrator", "permissions"]).to_list(None)
+    users = await asyncio.shield(db.users.find({}, ["_id", "administrator", "permissions"]).to_list(None))
 
     for user in users:
         permissions = user.pop("permissions")

--- a/virtool/db/samples.py
+++ b/virtool/db/samples.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import virtool.errors
@@ -106,7 +107,7 @@ async def recalculate_algorithm_tags(db, sample_id):
     :type sample_id: str
 
     """
-    analyses = await db.analyses.find({"sample.id": sample_id}, ["ready", "algorithm"]).to_list(None)
+    analyses = await asyncio.shield(db.analyses.find({"sample.id": sample_id}, ["ready", "algorithm"]).to_list(None))
 
     update = virtool.samples.calculate_algorithm_tags(analyses)
 

--- a/virtool/db/subtractions.py
+++ b/virtool/db/subtractions.py
@@ -10,5 +10,5 @@ PROJECTION = [
 
 
 async def get_linked_samples(db, subtraction_id):
-    linked_samples = await db.samples.find({"subtraction.id": subtraction_id}, ["name"]).to_list(None)
-    return [virtool.utils.base_processor(d) for d in linked_samples]
+    cursor = await db.samples.find({"subtraction.id": subtraction_id}, ["name"])
+    return [virtool.utils.base_processor(d) async for d in cursor]

--- a/virtool/jobs/job.py
+++ b/virtool/jobs/job.py
@@ -13,9 +13,7 @@ import virtool.utils
 
 class Job:
 
-    def __init__(self, loop, executor, db, settings, capture_exception, job_id, task_name, task_args, proc,
-                 mem):
-
+    def __init__(self, loop, executor, db, settings, capture_exception, job_id, task_name, task_args, proc, mem):
         self.loop = loop
         self.executor = executor
         self.db = db

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -59,11 +59,10 @@ async def join_legacy_virus(db, virus_id):
         if document is None:
             return None
 
-        # Get the sequence entries associated with the isolate ids.
-        sequences = await db.sequences.find({"virus_id": document["_id"]}).to_list(None) or list()
+        cursor = db.sequences.find({"virus_id": document["_id"]})
 
         # Merge the sequence entries into the otu entry.
-        return virtool.otus.merge_otu(document, sequences)
+        return virtool.otus.merge_otu(document, [d async for d in cursor])
 
 
 async def organize(db, settings, server_version):


### PR DESCRIPTION
- resolves #1004 
- avoids unhandled `InvalidStateError` exceptions that are raised when request is cancelled while awaiting `to_list()` coroutine of motor cursor
- prefer `async for` over `to_list()` as much as possible
- use `asyncio.shield` to protect `to_list()` when it is required