### PR TITLE
Fix bad await before iterating motor cursor

### DIFF
--- a/virtool/api/otus.py
+++ b/virtool/api/otus.py
@@ -871,6 +871,6 @@ async def list_history(req):
     if not await db.otus.find({"_id": otu_id}).count():
         return not_found()
 
-    cursor = await db.history.find({"otu.id": otu_id})
+    cursor = db.history.find({"otu.id": otu_id})
 
     return json_response([d async for d in cursor])

--- a/virtool/db/subtractions.py
+++ b/virtool/db/subtractions.py
@@ -10,5 +10,5 @@ PROJECTION = [
 
 
 async def get_linked_samples(db, subtraction_id):
-    cursor = await db.samples.find({"subtraction.id": subtraction_id}, ["name"])
+    cursor = db.samples.find({"subtraction.id": subtraction_id}, ["name"])
     return [virtool.utils.base_processor(d) async for d in cursor]


### PR DESCRIPTION
- resolves #1055 
- remove unwanted `await` statements before `async` iteration through motor cursors