### PR TITLE
Fix depth and median depth calculations

### DIFF
--- a/client/src/js/analyses/components/Pathoscope/Isolate.js
+++ b/client/src/js/analyses/components/Pathoscope/Isolate.js
@@ -1,4 +1,4 @@
-import {map, sortBy} from "lodash-es";
+import {map} from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import {Flex, FlexItem} from "../../../base/index";
@@ -51,7 +51,7 @@ export default class PathoscopeIsolate extends React.Component {
             whiteSpace: "nowrap"
         };
 
-        const hitComponents = map(sortBy(this.props.sequences, hit => hit.length), (hit, i) =>
+        const hitComponents = map(this.props.sequences, (hit, i) =>
             <Coverage
                 key={i}
                 data={hit.align}


### PR DESCRIPTION
- resolves #1076 
- fix calculation of median depth
- calculate OTU-level depth from the max observed mean or median depth for each sequence in the OTU