### PR TITLE
Fix missing analysis_path attr in create sample job

### DIFF
--- a/virtool/jobs/create_sample.py
+++ b/virtool/jobs/create_sample.py
@@ -51,6 +51,7 @@ class CreateSample(virtool.jobs.job.Job):
 
         #: The ordered list of :ref:`stage methods <stage-methods>` that are called by the job.
         self._stage_list = [
+            self.check_db,
             self.make_sample_dir,
             self.trim_reads,
             self.save_trimmed,


### PR DESCRIPTION
- resolves #1100 
- fix missing `analysis_path` job attribute in `CreateSample` job class