### PR TITLE
Prevent printing of Bowtie output for NuVs jobs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,6 @@ semver==2.8.1
 six==1.11.0
 uvloop==0.11.2
 virtool.job==0.1.4
-virtool.nuvs==0.1.1
+virtool.nuvs==0.1.2
 visvalingamwyatt==0.1.2
 yarl==1.2.6


### PR DESCRIPTION
- upgrade `virtool.nuvs` to `0.1.2`