### PR TITLE
Fix SPAdes for sRNA samples

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ semver==2.8.1
 six==1.11.0
 uvloop==0.11.2
 virtool.job==0.1.4
-virtool.nuvs==0.1.3
+virtool.nuvs==0.1.4
 virtool.pathoscope==0.1.2
 visvalingamwyatt==0.1.2
 yarl==1.2.6


### PR DESCRIPTION
- upgrade to `virtool.nuvs==0.1.4`; includes fix for SPAdes failures for NuVs jobs on sRNA samples.