### PR TITLE
Fix 1143

### DIFF
--- a/virtool/db/history.py
+++ b/virtool/db/history.py
@@ -34,7 +34,7 @@ PROJECTION = LIST_PROJECTION + [
 ]
 
 
-async def add(db, method_name, old, new, description, user_id):
+async def add(db, method_name, old, new, description, user_id, silent=False):
     """
     Add a change document to the history collection.
 
@@ -55,6 +55,9 @@ async def add(db, method_name, old, new, description, user_id):
 
     :param user_id: the id of the requesting user
     :type user_id: str
+
+    :param silent: don't dispatch a message
+    :type: silent: bool
 
     :return: the change document
     :rtype: Coroutine[dict]
@@ -111,7 +114,7 @@ async def add(db, method_name, old, new, description, user_id):
     else:
         document["diff"] = virtool.history.calculate_diff(old, new)
 
-    await db.history.insert_one(document)
+    await db.history.insert_one(document, silent=silent)
 
     return document
 

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -171,7 +171,8 @@ async def cleanup_removed(db, process_id, ref_id, user_id):
             db,
             document["_id"],
             user_id,
-            document=document
+            document=document,
+            silent=True
         )
 
         await progress_tracker.add(1)
@@ -985,7 +986,8 @@ async def insert_change(db, otu_id, verb, user_id, old=None):
         old,
         joined,
         description,
-        user_id
+        user_id,
+        silent=True
     )
 
 
@@ -1040,7 +1042,7 @@ async def insert_joined_otu(db, otu, created_at, ref_id, user_id, remote=False):
                 }
             })
 
-    document = await db.otus.insert_one(otu)
+    document = await db.otus.insert_one(otu, silent=True)
 
     for sequence in all_sequences:
         await db.sequences.insert_one(dict(sequence, otu_id=document["_id"]), silent=True)


### PR DESCRIPTION
- resolves #1143 
- add `silent` keyword argument to database function signatures where necessary
- prevent dispatches for large reference operations (except remote updates)