### PR TITLE
Create index on created_at analysis field

### DIFF
--- a/virtool/app.py
+++ b/virtool/app.py
@@ -178,6 +178,7 @@ async def init_check_db(app):
 
     logger.info("Creating database indexes...")
     await db.analyses.create_index("sample.id")
+    await db.analyses.create_index([("created_at", -1)])
     await db.history.create_index("otu.id")
     await db.history.create_index("index.id")
     await db.history.create_index("created_at")


### PR DESCRIPTION
- resolves #1157 
- prevents memory limit error when sorting documents