### PR TITLE
Fix 1195

### DIFF
--- a/virtool/jobs/nuvs.py
+++ b/virtool/jobs/nuvs.py
@@ -393,11 +393,20 @@ class Job(virtool.jobs.job.Job):
         self.dispatch("samples", "update", [sample_id])
 
     def cleanup(self):
+        self.db.analyses.delete_one({"_id": self.params["analysis_id"]})
+
         try:
             self.temp_dir.cleanup()
         except AttributeError:
             pass
 
-        virtool.db.sync.recalculate_algorithm_tags(self.db, self.params["sample_id"])
+        try:
+            shutil.rmtree(self.params["analysis_path"])
+        except FileNotFoundError:
+            pass
 
-        super().cleanup()
+        sample_id = self.params["sample_id"]
+
+        virtool.db.sync.recalculate_algorithm_tags(self.db, sample_id)
+
+        self.dispatch("samples", "update", [sample_id])

--- a/virtool/jobs/pathoscope.py
+++ b/virtool/jobs/pathoscope.py
@@ -439,7 +439,11 @@ class Job(virtool.jobs.job.Job):
         except FileNotFoundError:
             pass
 
-        virtool.db.sync.recalculate_algorithm_tags(self.db, self.params["sample_id"])
+        sample_id = self.params["sample_id"]
+
+        virtool.db.sync.recalculate_algorithm_tags(self.db, sample_id)
+
+        self.dispatch("samples", "update", [sample_id])
 
     def cleanup_indexes(self):
         pass


### PR DESCRIPTION
- resolves #1195 
- remove directory and dispatch recalculated sample algorithm tags in `cleanup` method for failed NuVs analyses
- dispatch recalculated sample algorithm tags in `cleanup` method for failed Pathoscope analyses