### PR TITLE
Don't show None Found and install official for refs

### DIFF
--- a/client/src/js/references/components/List.js
+++ b/client/src/js/references/components/List.js
@@ -50,7 +50,7 @@ class ReferenceList extends React.Component {
                     noContainer
                 />
             );
-        } else if (installOfficialComponent) {
+        } else if (!installOfficialComponent) {
             noRefs = <NoneFound noun="References" />;
         }
 


### PR DESCRIPTION
- resolves #1185 
- hide **None Found** message when official reference can be installed