### PR TITLE
Organize cleanup

### DIFF
--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -4,34 +4,6 @@ from aiohttp.test_utils import make_mocked_coro
 
 import virtool.organize
 
-ORIGINAL_REFERENCE = {
-    "id": "original"
-}
-
-
-async def test_add_original_reference(dbi):
-    await dbi.analyses.insert_many([
-        {
-            "_id": "baz"
-        },
-        {
-            "_id": "hello_world"
-        }
-    ])
-
-    await virtool.organize.add_original_reference(dbi.analyses)
-
-    assert await dbi.analyses.find().to_list(None) == [
-        {
-            "_id": "baz",
-            "reference": ORIGINAL_REFERENCE
-        },
-        {
-            "_id": "hello_world",
-            "reference": ORIGINAL_REFERENCE
-        }
-    ]
-
 
 async def test_delete_unready(dbi):
     await dbi.analyses.insert_many([
@@ -55,51 +27,6 @@ async def test_delete_unready(dbi):
     ]
 
 
-async def test_organize_analyses(dbi):
-    """
-    Test that documents with the ``ready`` field set to ``False`` are deleted from the collection. These documents
-    are assumed to be associated with defunct analysis jobs.
-
-    """
-    await dbi.analyses.insert_many([
-        {
-            "_id": 1,
-            "ready": True
-        },
-        {
-            "_id": 2,
-            "ready": False
-        },
-        {
-            "_id": 3,
-            "ready": True
-        },
-        {
-            "_id": 4,
-            "ready": False
-        }
-    ])
-
-    await virtool.organize.organize_analyses(dbi)
-
-    assert await dbi.analyses.find().to_list(None) == [
-        {
-            "_id": 1,
-            "ready": True,
-            "reference": {
-                "id": "original"
-            }
-        },
-        {
-            "_id": 3,
-            "ready": True,
-            "reference": {
-                "id": "original"
-            }
-        }
-    ]
-
-
 async def test_organize_files(dbi):
     documents = [
         {"_id": 1},
@@ -119,9 +46,6 @@ async def test_organize_files(dbi):
 async def test_organize_groups(dbi):
 
     await dbi.groups.insert_many([
-        {
-            "_id": "administrator"
-        },
         {
             "_id": "foobar",
             "permissions": {
@@ -148,85 +72,6 @@ async def test_organize_groups(dbi):
             "upload_file": False
         }
     }]
-
-
-async def test_organize_indexes(mocker):
-    m_add_original_reference = mocker.patch("virtool.organize.add_original_reference", new=make_mocked_coro())
-    m_db = mocker.Mock()
-
-    await virtool.organize.organize_indexes(m_db)
-
-    m_add_original_reference.assert_called_with(m_db.motor_client.indexes)
-
-
-@pytest.mark.parametrize("has_otu", [True, False])
-@pytest.mark.parametrize("has_references", [True, False])
-async def test_organize_references(has_references, has_otu, mocker, dbi):
-    if has_otu:
-        await dbi.otus.insert_one({
-            "_id": "foobar"
-        })
-
-    if has_references:
-        await dbi.references.insert_one({
-            "_id": "baz"
-        })
-
-    m = mocker.patch("virtool.db.references.create_original", new=make_mocked_coro())
-
-    settings = {
-        "default_source_types": [
-            "culture",
-            "strain"
-        ]
-    }
-
-    await virtool.organize.organize_references(dbi, settings)
-
-    document = await dbi.references.find_one()
-
-    if has_otu and not has_references:
-        assert document is None
-        m.assert_called_with(dbi.motor_client, settings)
-
-    else:
-        assert not m.called
-
-    if has_references:
-        assert await dbi.references.find_one() == {
-            "_id": "baz"
-        }
-
-
-@pytest.mark.parametrize("collection_name", [None, "viruses", "kinds"])
-async def test_organize_otus(collection_name, test_motor):
-    if collection_name is not None:
-        await getattr(test_motor, collection_name).insert_many([
-            {
-                "_id": 1
-            },
-            {
-                "_id": 2
-            }
-        ])
-
-    await virtool.organize.organize_otus(test_motor)
-
-    results = await test_motor.otus.find().to_list(None)
-
-    if collection_name:
-        assert results == [
-            {
-                "_id": 1
-            },
-            {
-                "_id": 2
-            }
-        ]
-    else:
-        assert results == []
-
-    assert "viruses" not in await test_motor.collection_names()
 
 
 @pytest.mark.parametrize("has_software", [True, False])
@@ -280,37 +125,3 @@ async def test_organize_subtraction(mocker):
     await virtool.organize.organize_subtraction(m_db)
 
     assert m_delete_unready.call_args[0][0] == m_db.subtraction
-
-
-async def test_organize_users(dbi):
-    documents = [
-        {
-            "_id": "foo",
-            "groups": [
-                "test"
-            ]
-        },
-        {
-            "_id": "bar",
-            "groups": [
-                "test",
-                "administrator"
-            ]
-        }
-    ]
-
-    await dbi.users.insert_many(documents)
-
-    await virtool.organize.organize_users(dbi)
-
-    documents[0].update({
-        "groups": ["test"],
-        "administrator": False
-    })
-
-    documents[1].update({
-        "groups": ["test"],
-        "administrator": True
-    })
-
-    assert await dbi.users.find().to_list(None) == documents

--- a/virtool/api/downloads.py
+++ b/virtool/api/downloads.py
@@ -105,7 +105,7 @@ async def download_reference(req):
         "organism": document["organism"]
     }
 
-    # Convert the list of viruses to a JSON-formatted string.
+    # Convert the list of OTUs to a JSON-formatted string.
     json_string = json.dumps(data, cls=CustomEncoder)
 
     # Compress the JSON string with gzip.

--- a/virtool/api/utils.py
+++ b/virtool/api/utils.py
@@ -89,7 +89,7 @@ def no_content():
 def bad_gateway(message="Bad gateway"):
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``502`` status and the JSON body
-    ``{"message": "Bad gatway"}``.
+    ``{"message": "Bad gateway"}``.
 
     :param message: text to send instead of 'Bad gateway'
     :type message: str

--- a/virtool/db/iface.py
+++ b/virtool/db/iface.py
@@ -198,7 +198,6 @@ class DB:
         await self.bind_collection("status")
         await self.bind_collection("subtraction", projection=virtool.db.subtractions.PROJECTION)
         await self.bind_collection("users", projection=virtool.db.users.PROJECTION)
-        await self.bind_collection("viruses", projection=virtool.db.otus.PROJECTION)
 
     async def bind_collection(self, name, processor=None, projection=None, silent=False):
         collection = Collection(

--- a/virtool/db/indexes.py
+++ b/virtool/db/indexes.py
@@ -219,7 +219,7 @@ async def tag_unbuilt_changes(db, ref_id, index_id, index_version):
 
 async def get_unbuilt_stats(db, ref_id=None):
     """
-    Get the number of unbuilt changes and number of OTUs affected by those changes. Used to populate the metdata for a
+    Get the number of unbuilt changes and number of OTUs affected by those changes. Used to populate the metadata for a
     index find request.
 
     Can search against a specific reference or all references.

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -681,7 +681,6 @@ async def download_and_parse_release(app, url, process_id, progress_handler):
 
 
 async def export(db, ref_id, scope):
-    # A list of joined viruses.
     otu_list = list()
 
     query = {

--- a/virtool/organize.py
+++ b/virtool/organize.py
@@ -1,10 +1,6 @@
 import logging
-import os
-import shutil
 
-import dictdiffer
 import pymongo.errors
-from pymongo import UpdateOne
 
 import virtool.db.history
 import virtool.db.otus
@@ -18,138 +14,25 @@ import virtool.utils
 
 logger = logging.getLogger(__name__)
 
-REFERENCE_QUERY = {
-    "reference": {
-        "$exists": False
-    }
-}
-
-
-async def add_original_reference(collection):
-    await collection.update_many(REFERENCE_QUERY, {
-        "$set": {
-            "reference": {
-                "id": "original"
-            }
-        }
-    })
-
 
 async def delete_unready(collection):
     await collection.delete_many({"ready": False})
 
 
-async def join_legacy_virus(db, virus_id):
-    """
-    Join the otu associated with the supplied ``virus_id`` with its sequences. If a otu entry is also passed,
-    the database will not be queried for the otu based on its id.
-
-    :param db: the application database client
-    :type db: :class:`~motor.motor_asyncio.AsyncIOMotorClient`
-
-    :param virus_id: the id of the virus to join
-    :type virus_id: str
-
-    :return: the joined otu document
-    :rtype: Coroutine[dict]
-
-    """
-    # Get the otu entry if a ``document`` parameter was not passed.
-    document = await db.otus.find_one(virus_id)
-
-    if document is None:
-        return None
-
-    cursor = db.sequences.find({"virus_id": document["_id"]})
-
-    # Merge the sequence entries into the otu entry.
-    return virtool.otus.merge_otu(document, [d async for d in cursor])
-
-
 async def organize(db, settings, server_version):
     await organize_files(db)
-    await organize_otus(db)
-    await organize_history(db)
-    await organize_indexes(db)
-    await organize_users(db)
     await organize_groups(db)
-    await organize_references(db, settings)
-    await organize_sequences(db)
-    await organize_analyses(db)
     await organize_status(db, server_version)
     await organize_subtraction(db)
     await organize_samples(db)
-    await organize_paths(db, settings)
-    await organize_dev(db)
-
-
-async def organize_dev(db):
-    await db.references.update_many({"groups": {"$exists": False}}, {
-        "$set": {
-            "groups": []
-        }
-    })
-
-
-async def organize_analyses(db):
-    """
-    Delete any analyses with the ``ready`` field set to ``False``.
-
-    """
-    logger.info(" • analyses")
-
-    motor_client = db.motor_client
-
-    await delete_unready(motor_client.analyses)
-    await add_original_reference(motor_client.analyses)
-
-    if await motor_client.analyses.count({"diagnosis.virus": {"$exists": True}}):
-        async for document in motor_client.references.find({}, ["name"]):
-            query = {
-                "reference.id": document["_id"],
-                "reference.name": {
-                    "$ne": document["name"]
-                }
-            }
-
-            await motor_client.analyses.update_many(query, {
-                "$set": {
-                    "reference.name": document["name"]
-                }
-            })
-
-        query = {
-            "algorithm": "pathoscope_bowtie",
-            "diagnosis.virus": {
-                "$exists": True
-            }
-        }
-
-        buffer = list()
-
-        async for document in motor_client.analyses.find(query, ["diagnosis"]):
-            diagnosis = document["diagnosis"]
-
-            for hit in diagnosis:
-                hit["otu"] = hit.pop("virus")
-
-            op = UpdateOne({"_id": document["_id"]}, {
-                "$set": {
-                    "diagnosis": diagnosis
-                }
-            })
-
-            buffer.append(op)
-
-            if len(buffer) == 40:
-                await db.motor_client.analyses.bulk_write(buffer)
-                buffer = list()
-
-        if len(buffer):
-            await db.motor_client.analyses.bulk_write(buffer)
 
 
 async def organize_files(db):
+    """
+    Make all files unreserved. This is only called when the server first starts.
+
+    :param db:
+    """
     logger.info(" • files")
 
     await db.files.update_many({}, {
@@ -160,9 +43,13 @@ async def organize_files(db):
 
 
 async def organize_groups(db):
-    logger.info(" • groups")
+    """
+    Ensure that the permissions object for each group matches the permissions defined in `virtool.users.PERMISSIONS`.
 
-    await db.groups.delete_one({"_id": "administrator"})
+    :param db:
+
+    """
+    logger.info(" • groups")
 
     async for group in db.groups.find():
         await db.groups.update_one({"_id": group["_id"]}, {
@@ -172,194 +59,11 @@ async def organize_groups(db):
         }, silent=True)
 
 
-async def organize_history(db):
-    logger.info(" • history")
-
-    motor_client = db.motor_client
-
-    if await motor_client.analyses.count({"reference": {"$exists": False}}):
-        await motor_client.history.update_many({"virus": {"$exists": True}}, {
-            "$rename": {
-                "virus": "otu"
-            },
-            "$set": {
-                "reference": {
-                    "id": "original"
-                }
-            }
-        })
-
-        # Get all OTU ids that have ever existed.
-        historical_otu_ids = await db.history.distinct("otu.id")
-
-        for otu_id in historical_otu_ids:
-
-            versions = list()
-
-            patched = await join_legacy_virus(db, otu_id) or dict()
-
-            first_version = patched.get("version", None)
-
-            versions.append(patched or None)
-
-            async for change in db.history.find({"otu.id": otu_id}, sort=[("otu.version", -1)]):
-                if first_version is not None and change["otu"]["version"] == first_version:
-                    continue
-
-                elif change["method_name"] == "remove":
-                    patched = change["diff"]
-                    versions.append(patched)
-
-                elif change["method_name"] == "create":
-                    patched = change["diff"]
-                    versions.append(patched)
-
-                else:
-                    patched = dictdiffer.revert(change["diff"], patched)
-                    versions.append(patched)
-
-            versions.reverse()
-
-            versions = [revise_otu(otu) for otu in versions]
-
-            previous = versions[0]
-
-            updates = list()
-
-            for otu in versions:
-                if otu is None:
-                    change_id = "{}.removed".format(otu_id)
-
-                    updates.append(UpdateOne({"_id": change_id}, {
-                        "$set": {
-                            "diff": previous
-                        }
-                    }))
-
-                    break
-
-                change_id = "{}.{}".format(otu_id, otu["version"])
-
-                if otu["version"] == 0:
-                    updates.append(UpdateOne({"_id": change_id}, {
-                        "$set": {
-                            "diff": previous
-                        }
-                    }))
-
-                    continue
-
-                diff = list(dictdiffer.diff(previous, otu))
-
-                updates.append(UpdateOne({"_id": change_id}, {
-                    "$set": {
-                        "diff": diff
-                    }
-
-                }))
-
-            await motor_client.history.bulk_write(updates)
-
-        await add_original_reference(db.motor_client.otus)
-
-
-async def organize_indexes(db):
-    logger.info(" • indexes")
-
-    await add_original_reference(db.motor_client.indexes)
-
-
-async def organize_otus(db):
-    logger.info(" • otus")
-
-    if "otus" in await db.collection_names():
-        return
-
-    if "viruses" in await db.collection_names():
-        await db.viruses.rename("otus")
-
-    if "kinds" in await db.collection_names():
-        await db.kinds.rename("otus")
-
-
-async def organize_paths(db, settings):
-    logger.info("Checking paths...")
-
-    data_path = settings["data_path"]
-
-    old_reference_path = os.path.join(data_path, "reference")
-
-    if os.path.exists(old_reference_path):
-        old_indexes_path = os.path.join(old_reference_path, "viruses")
-
-        if not os.path.exists(old_indexes_path):
-            old_indexes_path = os.path.join(old_reference_path, "otus")
-
-        if not os.path.exists(old_indexes_path):
-            old_indexes_path = None
-
-        if old_indexes_path:
-            references_path = os.path.join(data_path, "references")
-
-            os.mkdir(references_path)
-
-            if await db.references.count({"_id": "original"}):
-                os.rename(old_indexes_path, os.path.join(references_path, "original"))
-
-        old_subtractions_path = os.path.join(old_reference_path, "subtraction")
-
-        if os.path.exists(old_subtractions_path):
-            os.rename(old_subtractions_path, os.path.join(data_path, "subtractions"))
-
-        shutil.rmtree(old_reference_path)
-
-
-async def organize_references(db, settings):
-    logger.info(" • references")
-
-    if await db.otus.count() and not await db.references.count():
-        await virtool.db.references.create_original(db.motor_client, settings)
-
-
 async def organize_samples(db):
     motor_client = db.motor_client
 
     for sample_id in await motor_client.samples.distinct("_id"):
         await virtool.db.samples.recalculate_algorithm_tags(motor_client, sample_id)
-
-
-async def organize_sequences(db):
-    logger.info(" • sequences")
-
-    motor_client = db.motor_client
-
-    buffer = list()
-
-    async for document in motor_client.sequences.find(REFERENCE_QUERY, ["virus_id"]):
-
-        otu_id = document.pop("virus_id")
-
-        op = UpdateOne({"_id": document["_id"]}, {
-            "$set": {
-                "accession": document["_id"],
-                "otu_id": otu_id,
-                "reference": {
-                    "id": "original"
-                }
-            },
-            "$unset": {
-                "virus_id": ""
-            }
-        })
-
-        buffer.append(op)
-
-        if len(buffer) == 50:
-            await motor_client.sequences.bulk_write(buffer)
-            buffer = list()
-
-    if len(buffer):
-        await motor_client.sequences.bulk_write(buffer)
 
 
 async def organize_status(db, server_version):
@@ -408,38 +112,4 @@ async def organize_status(db, server_version):
 
 async def organize_subtraction(db):
     logger.info(" • subtraction")
-
     await delete_unready(db.subtraction)
-
-
-async def organize_users(db):
-    logger.info(" • users")
-
-    async for document in db.users.find({"administrator": {"$exists": False}}, ["groups"]):
-        await db.users.update_one({"_id": document["_id"]}, {
-            "$set": {
-                "administrator": "administrator" in document["groups"]
-            },
-            "$pull": {
-                "groups": "administrator"
-            }
-        }, silent=True)
-
-
-def revise_otu(otu):
-    if otu is None:
-        return None
-
-    reference = {
-        "id": "original"
-    }
-
-    otu["reference"] = reference
-
-    for isolate in otu["isolates"]:
-        for sequence in isolate["sequences"]:
-            sequence["accession"] = sequence["_id"]
-            sequence["reference"] = reference
-            sequence["otu_id"] = sequence.pop("virus_id")
-
-    return otu

--- a/virtool/otus.py
+++ b/virtool/otus.py
@@ -284,8 +284,8 @@ def verify(joined):
     # Give an isolate_inconsistency error the number of sequences is not the same for every isolate. Only give the
     # error if the otu is not also emtpy (empty_otu error).
     errors["isolate_inconsistency"] = (
-            len(set(isolate_sequence_counts)) != 1 and not
-    (errors["empty_otu"] or errors["empty_isolate"])
+        len(set(isolate_sequence_counts)) != 1 and not
+        (errors["empty_otu"] or errors["empty_isolate"])
     )
 
     # If there is an error in the otu, return the errors object. Otherwise return False.


### PR DESCRIPTION
- resolves #1022 
- fix some typos
- fix some minor style issues
- remove `create_original()` function
- remove unnecessary database organization code from `virtool.organize`
- update some comments