### PR TITLE
Fix API handler for finding jobs

### DIFF
--- a/client/src/js/analyses/components/NuVs/__tests__/__snapshots__/BLAST.test.js.snap
+++ b/client/src/js/analyses/components/NuVs/__tests__/__snapshots__/BLAST.test.js.snap
@@ -66,7 +66,7 @@ exports[`<NuVsBLAST /> renders <BLASTInProgress /> subcomponent 1`] = `
             time="2018-02-14T17:12:00.000000Z"
           />
           . Checking again in 
-          10 months ago
+          a year ago
           .
         </small>
       </FlexItem>

--- a/virtool/api/jobs.py
+++ b/virtool/api/jobs.py
@@ -18,7 +18,7 @@ async def find(req):
     """
     db = req.app["db"]
 
-    term = req.query.get("term", None)
+    term = req.query.get("find", None)
 
     db_query = dict()
 


### PR DESCRIPTION
- resolves #1216 
- fix non-functional job searching
- incorrect query parameter `term` being used in API handler instead of `find`