### PR TITLE
Small files

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,12 @@ kind: pipeline
 name: server
 
 steps:
+  - name: ping
+    image: mongo:3.6
+    commands:
+      - sleep 5
+      - mongo --host mongo --eval "db.version()"
+
   - name: test
     image: python:3.6-jessie
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,7 @@ steps:
 services:
   - name: mongo
     image: mongo:3.6
-    command: [ --smallfiles ]
+    command: [ --smallfiles, --nojournal ]
     ports:
       - 27017
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,11 +32,14 @@ steps:
       - cp -r hmmer-3.1b2-linux-intel-x86_64 /opt/hmmer
       - for FILE in /opt/hmmer/binaries/*; do ln -s $FILE /usr/local/bin/${FILE}; done
       - pip install -qr requirements.txt
-      - pytest -x --aiohttp-loop uvloop --db-host db --cov --cov-report xml
+      - pytest -x --aiohttp-loop uvloop --db-host mongo --cov --cov-report xml
 
 services:
-  - name: db
-    image: mongo:3.6-jessie
+  - name: mongo
+    image: mongo:3.6
+    command: [ --smallfiles ]
+    ports:
+      - 27017
 
 ---
 kind: pipeline


### PR DESCRIPTION
- use the `--smallfiles` argument when starting MongoDB service in `.drone.yml`
- add a ping step to match the [example in the Drone docs](https://docs.drone.io/examples/service/mongo/)