### PR TITLE
Skip software release fetch if server version unknown

### DIFF
--- a/virtool/db/software.py
+++ b/virtool/db/software.py
@@ -38,7 +38,7 @@ async def fetch_and_update_releases(app, ignore_errors=False):
     session = app["client"]
     settings = app["settings"]
 
-    if app is None:
+    if app is None or version is "Unknown":
         return list()
 
     try:


### PR DESCRIPTION
- resolves #1259
- warning is still logged in console