### PR TITLE
Fix z-index on SourceTypes input

### DIFF
--- a/client/src/js/references/components/SourceTypes.js
+++ b/client/src/js/references/components/SourceTypes.js
@@ -128,7 +128,6 @@ export class SourceTypes extends React.Component {
                                             disabled={disabled}
                                             onChange={this.handleChange}
                                             value={this.state.value}
-                                            style={{ zIndex: 10000 }}
                                         />
                                         <InputGroup.Button>
                                             <Button type="submit" bsStyle="primary" disabled={disabled}>

--- a/client/src/js/references/components/__tests__/__snapshots__/SourceTypes.test.js.snap
+++ b/client/src/js/references/components/__tests__/__snapshots__/SourceTypes.test.js.snap
@@ -71,11 +71,6 @@ exports[`<SourceTypes /> renders when global 1`] = `
                 componentClass="input"
                 disabled={false}
                 onChange={[Function]}
-                style={
-                  Object {
-                    "zIndex": 10000,
-                  }
-                }
                 type="text"
                 value=""
               />
@@ -179,11 +174,6 @@ exports[`<SourceTypes /> renders when not global and not remote 1`] = `
                 componentClass="input"
                 disabled={false}
                 onChange={[Function]}
-                style={
-                  Object {
-                    "zIndex": 10000,
-                  }
-                }
                 type="text"
                 value=""
               />
@@ -280,11 +270,6 @@ exports[`<SourceTypes /> renders when not global and remote 1`] = `
                 componentClass="input"
                 disabled={true}
                 onChange={[Function]}
-                style={
-                  Object {
-                    "zIndex": 10000,
-                  }
-                }
                 type="text"
                 value=""
               />


### PR DESCRIPTION
- resolves #1273 
- fix `z-index` for `<SourceTypes>` input element so it stays below the modal overlay