### PR TITLE
Tolerate missing GitHub response headers

### DIFF
--- a/virtool/github.py
+++ b/virtool/github.py
@@ -74,13 +74,10 @@ async def get_release(settings, session, slug, etag=None, release_id="latest"):
         headers["If-None-Match"] = etag
 
     async with virtool.http.proxy.ProxyRequest(settings, session.get, url, headers=headers) as resp:
-        logger.debug("Fetched release: {}/{} ({} - {}/{})".format(
-            slug,
-            release_id,
-            resp.status,
-            resp.headers["X-RateLimit-Remaining"],
-            resp.headers["X-RateLimit-Limit"]
-        ))
+        rate_limit_remaining = resp.headers.get("X-RateLimit-Remaining", "00")
+        rate_limit = resp.headers.get("X-RateLimit-Limit", "00")
+
+        logger.debug(f"Fetched release: {slug}/{release_id} ({resp.status} - {rate_limit_remaining}/{rate_limit})")
 
         if resp.status == 200:
             data = await resp.json()


### PR DESCRIPTION
- resolves #1272 
- fix `KeyError` when `X-RateLimit-Remaining` header is missing from GitHub response