### PR TITLE
Sentry Javascript SDK update

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -204,6 +204,63 @@
         }
       }
     },
+    "@sentry/browser": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-4.6.3.tgz",
+      "integrity": "sha512-g7JEuU8U+pWmgdX7McUe/N8tavRZ4sskZT2tnvjz3pGwxU+TJsm/jrdbApMKQ5MaTSCp+/eDUulAbGOkzJ9uuw==",
+      "requires": {
+        "@sentry/core": "4.6.3",
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.6.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-4.6.3.tgz",
+      "integrity": "sha512-FZ+P7+Z1efDAA4OPgLpTNZM0uRmvvSSZAdfKhmDXNO+Xq3gD8RsdirxGjJHhH2lXgcVLCX8g2+0RVjBKVzuKxw==",
+      "requires": {
+        "@sentry/hub": "4.6.3",
+        "@sentry/minimal": "4.6.3",
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.6.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-4.6.3.tgz",
+      "integrity": "sha512-WLs5XVErDW831o/Gpj2T8Ga+7ca7nHxZmHn08JRqHQz5TkJ7U74/KUAHYsifViaI7hAHKIywWbZpIwIh3X7+Lw==",
+      "requires": {
+        "@sentry/types": "4.5.3",
+        "@sentry/utils": "4.6.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-4.6.3.tgz",
+      "integrity": "sha512-8+K6Txme/XBlcLkLY6CjJYyEpvGVxPm/Vpxw/kerI6bYTc0uCps7e7G2lX3TxYz1O+iYPs685uN8o/v8D7+bDg==",
+      "requires": {
+        "@sentry/hub": "4.6.3",
+        "@sentry/types": "4.5.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-4.5.3.tgz",
+      "integrity": "sha512-7ll1PAFNjrBNX9rzy3P2qAQrpQwHaDO3uKj735qsnGw34OtAS8Xr8WYrjI14f9fMPa/XIeWvMPb4GMic28V/ag=="
+    },
+    "@sentry/utils": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-4.6.3.tgz",
+      "integrity": "sha512-GNZjIErN99gqJfLMC1L4X4lzu3x1l562UGpuiv3iMQXoNCy8mpNeKtjizoocCGTLHmWB91m6wd2WTHH7P0POjA==",
+      "requires": {
+        "@sentry/types": "4.5.3",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
@@ -4561,13 +4618,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4580,18 +4635,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4694,8 +4746,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4705,7 +4756,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4718,20 +4768,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4748,7 +4795,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4821,8 +4867,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4832,7 +4877,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4938,7 +4982,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@sentry/browser": "^4.6.3",
     "babel": "^6.23.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.26.0",

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -11,6 +11,13 @@
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.11/css/all.css" integrity="sha384-p2jx59pefphTFIpeqCcISO9MdVfIm4pNnsL08A6v5vaQc4owkQqxMV8kg4Yvhaw/" crossorigin="anonymous">
 
+    <script>
+        window.virtool = {
+          version: "VERSION",
+          dev: "DEV"
+        }
+    </script>
+
     <head>
         <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon %>?v=2" type="images/x-icon" />
     </head>

--- a/client/src/js/index.js
+++ b/client/src/js/index.js
@@ -11,11 +11,14 @@ import { listProcesses } from "./processes/actions";
 
 export * from "../style/style.less";
 
-browser.Sentry.init({
-    dsn: "https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541"
-});
+if (!window.virtool.dev) {
+    Sentry.init({
+        dsn: "https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541",
+        version: window.virtool.version
+    });
 
-window.Sentry = Sentry;
+    window.Sentry = Sentry;
+}
 
 const history = createHistory();
 

--- a/client/src/js/index.js
+++ b/client/src/js/index.js
@@ -1,7 +1,7 @@
 import createHistory from "history/createBrowserHistory";
 import React from "react";
 import ReactDOM from "react-dom";
-import Raven from "raven-js";
+import * as Sentry from "@sentry/browser";
 import App from "./app/App";
 import { createAppStore } from "./app/reducer";
 import WSConnection from "./app/websocket";
@@ -11,9 +11,11 @@ import { listProcesses } from "./processes/actions";
 
 export * from "../style/style.less";
 
-Raven.config("https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541").install();
+browser.Sentry.init({
+    dsn: "https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541"
+});
 
-window.Raven = Raven;
+window.Sentry = Sentry;
 
 const history = createHistory();
 

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -246,8 +246,15 @@ async def index_handler(req: web.Request) -> web.Response:
     force_reset = req["client"].force_reset
 
     if req["client"].user_id and not force_reset:
-        with open(os.path.join(req.app["client_path"], "index.html"), "r") as handle:
-            return web.Response(body=handle.read(), content_type="text/html")
+        path = os.path.join(req.app["client_path"], "index.html")
+
+        html = mako.template.Template(filename=path).render()
+
+        html = html.replace("VERSION", req.app["version"])
+
+        html = html.replace('"DEV"', "true" if req.app["settings"]["dev"] else "false")
+
+        return web.Response(body=html, content_type="text/html")
 
     path_base = "login"
 


### PR DESCRIPTION
- use `@sentry/browser`  instead of `raven-js`
- include release information in Sentry reports
- don't report errors in `dev` mode