### PR TITLE
Eliminate loop parameter where possible

### DIFF
--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -24,7 +24,7 @@ def test_db_name(worker_id):
 
 @pytest.fixture
 def test_motor(test_db_connection_string, test_db_name, loop, request):
-    client = motor.motor_asyncio.AsyncIOMotorClient(test_db_connection_string, io_loop=loop)
+    client = motor.motor_asyncio.AsyncIOMotorClient(test_db_connection_string)
     loop.run_until_complete(client.drop_database(test_db_name))
     yield client[test_db_name]
     loop.run_until_complete(client.drop_database(test_db_name))
@@ -40,7 +40,7 @@ def dbs(test_db_connection_string, test_db_name, request):
 
 @pytest.fixture
 def dbi(test_motor, loop):
-    i = virtool.db.iface.DB(test_motor, make_mocked_coro(), loop)
+    i = virtool.db.iface.DB(test_motor, make_mocked_coro())
     loop.run_until_complete(i.connect())
     return i
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -18,7 +18,7 @@ def test_manager_instance(loop, dbi, tmpdir):
 
     scheduler = loop.run_until_complete(aiojobs.create_scheduler())
 
-    manager = virtool.files.Manager(loop, executor, dbi, files_path, watch_path)
+    manager = virtool.files.Manager(executor, dbi, files_path, watch_path)
 
     loop.run_until_complete(scheduler.spawn(manager.run()))
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -24,13 +24,13 @@ async def test_find_server_version(source, loop, mocker, tmpdir):
     tmpdir.join("VERSION")
 
     if source == "git":
-        assert await find_server_version(loop, str(tmpdir)) == "1.0.13"
+        assert await find_server_version(str(tmpdir)) == "1.0.13"
 
     elif source == "file":
         with open(os.path.join(str(tmpdir), "VERSION"), "w") as handle:
             handle.write("1.0.12")
 
-        assert await find_server_version(loop, str(tmpdir)) == "1.0.12"
+        assert await find_server_version(str(tmpdir)) == "1.0.12"
 
     else:
-        assert await find_server_version(loop, str(tmpdir)) == "Unknown"
+        assert await find_server_version(str(tmpdir)) == "Unknown"

--- a/virtool/api/subtractions.py
+++ b/virtool/api/subtractions.py
@@ -1,4 +1,3 @@
-import asyncio
 import shutil
 
 import virtool.db.jobs

--- a/virtool/api/subtractions.py
+++ b/virtool/api/subtractions.py
@@ -1,3 +1,4 @@
+import asyncio
 import shutil
 
 import virtool.db.jobs
@@ -183,6 +184,6 @@ async def remove(req):
 
     index_path = virtool.subtractions.calculate_index_path(settings, subtraction_id)
 
-    await req.loop.run_in_executor(None, shutil.rmtree, index_path, True)
+    await req.app["run_in_thread"](shutil.rmtree, index_path, True)
 
     return no_content()

--- a/virtool/db/files.py
+++ b/virtool/db/files.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 
@@ -81,5 +82,7 @@ async def remove(loop, db, settings, file_id):
     await db.files.delete_one({"_id": file_id})
 
     file_path = os.path.join(settings["data_path"], "files", file_id)
+
+    loop = asyncio.get_event_loop()
 
     await loop.run_in_executor(None, virtool.utils.rm, file_path)

--- a/virtool/db/hmm.py
+++ b/virtool/db/hmm.py
@@ -305,7 +305,7 @@ async def refresh(app):
 
         while True:
             await fetch_and_update_release(app)
-            await asyncio.sleep(600, loop=app.loop)
+            await asyncio.sleep(600)
     except asyncio.CancelledError:
         pass
 

--- a/virtool/db/iface.py
+++ b/virtool/db/iface.py
@@ -171,9 +171,8 @@ class Collection:
 
 class DB:
 
-    def __init__(self, client, dispatch, loop):
+    def __init__(self, client, dispatch):
         self.dispatch = dispatch
-        self.loop = loop
 
         for collection_name in COLLECTION_NAMES:
             setattr(self, collection_name, None)

--- a/virtool/db/references.py
+++ b/virtool/db/references.py
@@ -1098,7 +1098,7 @@ async def refresh_remotes(app):
                     ignore_errors=True
                 )
 
-            await asyncio.sleep(600, loop=app.loop)
+            await asyncio.sleep(600)
     except asyncio.CancelledError:
         pass
 

--- a/virtool/db/software.py
+++ b/virtool/db/software.py
@@ -173,7 +173,7 @@ async def install(app, release, process_id):
             progress=1
         )
 
-        await asyncio.sleep(1.5, loop=app.loop)
+        await asyncio.sleep(1.5)
 
         app["events"]["restart"].set()
 
@@ -190,7 +190,7 @@ async def refresh(app):
 
         while True:
             await fetch_and_update_releases(app, ignore_errors=True)
-            await asyncio.sleep(43200, loop=app.loop)
+            await asyncio.sleep(43200)
     except asyncio.CancelledError:
         pass
 

--- a/virtool/files.py
+++ b/virtool/files.py
@@ -60,8 +60,8 @@ def has_read_extension(filename):
 
 class Manager:
 
-    def __init__(self, loop, executor, db, files_path, watch_path, clean_interval=20):
-        self.loop = loop
+    def __init__(self, executor, db, files_path, watch_path, clean_interval=20):
+        self.loop = asyncio.get_event_loop()
         self.executor = executor
         self.db = db
         self.files_path = files_path
@@ -109,7 +109,7 @@ class Manager:
                 threshold = self.clean_interval / 0.3
 
                 while count < threshold:
-                    await asyncio.sleep(0.3, loop=self.loop)
+                    await asyncio.sleep(0.3)
 
         except asyncio.CancelledError:
             pass

--- a/virtool/jobs/manager.py
+++ b/virtool/jobs/manager.py
@@ -40,9 +40,6 @@ class IntegratedManager:
         #: A :class:`multiprocess.Queue` used to receive dispatch information from job processes.
         self.queue = multiprocessing.Queue()
 
-        #: The application IO loop
-        self.loop = app.loop
-
         #: The application database interface.
         self.dbi = app["db"]
 
@@ -96,7 +93,7 @@ class IntegratedManager:
                     msg = self.queue.get()
                     await self.dispatch(*msg)
 
-                await asyncio.sleep(0.1, loop=self.loop)
+                await asyncio.sleep(0.1)
 
         except asyncio.CancelledError:
             logging.debug("Cancelling running jobs")


### PR DESCRIPTION
- resolves #1275 
- the `loop` parameter does not have to be explicitly passed in most situations since Python 3.6