### PR TITLE
Render full length e-value in expanded NuVs items

### DIFF
--- a/client/src/js/analyses/components/NuVs/ORF.js
+++ b/client/src/js/analyses/components/NuVs/ORF.js
@@ -83,7 +83,7 @@ export default class NuVsORF extends React.Component {
                             <small className="text-primary text-strong">{this.props.pos[1] - this.props.pos[0]}</small>
                         </FlexItem>
                         <FlexItem pad={5}>
-                            <small className="text-danger text-strong">{hmm ? hmm.best_e : null}</small>
+                            <small className="text-danger text-strong">{hmm ? hmm.full_e : null}</small>
                         </FlexItem>
                     </Flex>
                 </div>


### PR DESCRIPTION
- resolves #1337 
- use full-length HMMER e-value in all cases when rendering e-value in NuVs results view