### PR TITLE
Fix websocket issues

### DIFF
--- a/client/src/js/app/websocket.js
+++ b/client/src/js/app/websocket.js
@@ -95,7 +95,10 @@ export default function WSConnection({ getState, dispatch }) {
 
         if (modifier) {
             const action = modifier(getState(), message);
-            return dispatch(action);
+
+            if (action) {
+                return dispatch(action);
+            }
         }
     };
 


### PR DESCRIPTION
- resolves #1350 
- resolves #1351 
- resolves #1352 

All errors were due to `undefined` actions being dispatched as a result of a websocket message. When the message is ignored don't dispatch anything!