### PR TITLE
Coerce types of integer and boolean config values

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import pytest
 import virtool.config
+import virtool.utils
 
 
 @pytest.fixture
@@ -72,6 +73,7 @@ def test_schema():
         },
         "port": {
             "type": "integer",
+            "coerce": int,
             "default": 9950
         },
 
@@ -88,26 +90,32 @@ def test_schema():
         # Host resource limits
         "proc": {
             "type": "integer",
+            "coerce": int,
             "default": 8
         },
         "mem": {
             "type": "integer",
+            "coerce": int,
             "default": 16
         },
         "lg_mem": {
             "default": 16,
+            "coerce": int,
             "type": "integer"
         },
         "lg_proc": {
             "default": 8,
+            "coerce": int,
             "type": "integer"
         },
         "sm_mem": {
             "default": 4,
+            "coerce": int,
             "type": "integer"
         },
         "sm_proc": {
             "default": 2,
+            "coerce": int,
             "type": "integer"
         },
 
@@ -129,6 +137,7 @@ def test_schema():
 
         "force_setup": {
             "type": "boolean",
+            "coerce": virtool.utils.to_bool,
             "default": False
         },
 

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -381,6 +381,9 @@ def create_app(force_settings=None):
 
     do_setup = virtool.config.should_do_setup(config)
 
+    import pprint
+    pprint.pprint(config)
+
     if not do_setup:
         # Don't use authentication in setup mode.
         middlewares.append(virtool.http.auth.middleware)


### PR DESCRIPTION
- resolves #1348 
- coerce `int` and `bool` config values to their correct types
