### PR TITLE
Fix NuVs.reunite_pairs()

### DIFF
--- a/tests/test_bio.py
+++ b/tests/test_bio.py
@@ -149,7 +149,7 @@ def test_fastq(headers_only, tmpdir):
     if headers_only:
         assert virtool.bio.read_fastq_headers(str(tmpfile)) == [i[0] for i in expected]
     else:
-        assert virtool.bio.read_fastq(str(tmpfile)) == expected
+        assert list(virtool.bio.read_fastq_from_path(str(tmpfile))) == expected
 
 
 def test_reverse_complement():

--- a/virtool/jobs/nuvs.py
+++ b/virtool/jobs/nuvs.py
@@ -101,12 +101,12 @@ class Job(virtool.jobs.analysis.Job):
             unmapped_roots = {h.split(" ")[0] for h in headers}
 
             with open(os.path.join(self.params["analysis_path"], "unmapped_1.fq"), "w") as f:
-                for header, seq, quality in virtool.bio.read_fastq(self.params["read_paths"][0]):
+                for header, seq, quality in virtool.bio.read_fastq_from_path(self.params["read_paths"][0]):
                     if header.split(" ")[0] in unmapped_roots:
                         f.write("\n".join([header, seq, "+", quality]) + "\n")
 
             with open(os.path.join(self.params["analysis_path"], "unmapped_2.fq"), "w") as f:
-                for header, seq, quality in virtool.bio.read_fastq(self.params["read_paths"][1]):
+                for header, seq, quality in virtool.bio.read_fastq_from_path(self.params["read_paths"][1]):
                     if header.split(" ")[0] in unmapped_roots:
                         f.write("\n".join([header, seq, "+", quality]) + "\n")
 

--- a/virtool/jobs/nuvs.py
+++ b/virtool/jobs/nuvs.py
@@ -323,20 +323,9 @@ class Job(virtool.jobs.analysis.Job):
         self.dispatch("samples", "update", [sample_id])
 
     def cleanup(self):
-        self.db.analyses.delete_one({"_id": self.params["analysis_id"]})
+        super().cleanup()
 
         try:
             self.temp_dir.cleanup()
         except AttributeError:
             pass
-
-        try:
-            shutil.rmtree(self.params["analysis_path"])
-        except FileNotFoundError:
-            pass
-
-        sample_id = self.params["sample_id"]
-
-        virtool.db.sync.recalculate_algorithm_tags(self.db, sample_id)
-
-        self.dispatch("samples", "update", [sample_id])

--- a/virtool/jobs/pathoscope.py
+++ b/virtool/jobs/pathoscope.py
@@ -358,35 +358,6 @@ class Job(virtool.jobs.analysis.Job):
         self.dispatch("analyses", "update", [analysis_id])
         self.dispatch("samples", "update", [sample_id])
 
-    def cleanup(self):
-        """
-        Remove the analysis document and the analysis files. Dispatch the removal op. Recalculate and update the
-        algorithm tags for the sample document.
-
-        """
-        cache_id = self.intermediate.get("cache_id")
-
-        if cache_id:
-            self.db.caches.delete_one({"_id": cache_id})
-            cache_path = virtool.jobs.utils.join_cache_path(self.settings, cache_id)
-            try:
-                shutil.rmtree(cache_path)
-            except FileNotFoundError:
-                pass
-
-        self.db.analyses.delete_one({"_id": self.params["analysis_id"]})
-
-        try:
-            shutil.rmtree(self.params["analysis_path"])
-        except FileNotFoundError:
-            pass
-
-        sample_id = self.params["sample_id"]
-
-        virtool.db.sync.recalculate_algorithm_tags(self.db, sample_id)
-
-        self.dispatch("samples", "update", [sample_id])
-
     def cleanup_indexes(self):
         pass
 


### PR DESCRIPTION
- resolves #1386 
- fix bug in `NuVs.reunite_pairs()` that causes failure of NuVs job
- improve analysis job cleanup methods