### PR TITLE
Mongo logging

### DIFF
--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -15,7 +15,7 @@ def configure(verbose=False):
         fmt=log_format
     )
 
-    logger = logging.getLogger("virtool")
+    logger = logging.getLogger()
 
     handler = logging.handlers.RotatingFileHandler("virtool.log", maxBytes=1000000, backupCount=5)
     handler.setFormatter(logging.Formatter(log_format))

--- a/virtool/setup/db.py
+++ b/virtool/setup/db.py
@@ -52,6 +52,7 @@ async def check_setup(db_connection_string, db_name):
     try:
         await db.collection_names(include_system_collections=False)
     except OperationFailure as err:
+        logger.warning(f"Database Setup: {str(err)}")
         if any(substr in str(err) for substr in ["Authentication failed", "no users authenticated"]):
             return {
                 "db_connection_string": "",
@@ -60,7 +61,8 @@ async def check_setup(db_connection_string, db_name):
                 "error": "auth_error"
             }
         raise
-    except (ConnectionFailure, ServerSelectionTimeoutError, TypeError, ValueError):
+    except (ConnectionFailure, ServerSelectionTimeoutError, TypeError, ValueError) as err:
+        logger.warning(f"Database Setup: {str(err)}")
         return {
             "db_connection_string": "",
             "db_name": "",


### PR DESCRIPTION
- log warnings for failed database connection attempts during setup
- write all server log lines to file instead of just the `"virtool"` logger