### PR TITLE
Labels and NoneFound

### DIFF
--- a/client/src/js/account/components/Profile.js
+++ b/client/src/js/account/components/Profile.js
@@ -2,9 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import { map } from "lodash-es";
 import { connect } from "react-redux";
-import { Label } from "react-bootstrap";
 
-import { Flex, FlexItem, Identicon, Icon } from "../../base";
+import { Flex, FlexItem, Identicon, Icon, Label } from "../../base";
 import ChangePassword from "./Password";
 import Email from "./Email";
 

--- a/client/src/js/analyses/components/Create.js
+++ b/client/src/js/analyses/components/Create.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { connect } from "react-redux";
 import { map, forEach, some, xorBy } from "lodash-es";
-import { Badge, Modal, ListGroup, Col, Label } from "react-bootstrap";
+import { Badge, Modal, ListGroup, Col } from "react-bootstrap";
 import { pushState } from "../../app/actions";
-import { AlgorithmSelect, Button, ListGroupItem, NoneFound, Checkbox, FlexItem, Flex } from "../../base/index";
+import { AlgorithmSelect, Button, Label, ListGroupItem, NoneFound, Checkbox, FlexItem, Flex } from "../../base/index";
 import { getSelectedDocuments } from "../../samples/selectors";
 import { analyze } from "../actions";
 

--- a/client/src/js/analyses/components/Item.js
+++ b/client/src/js/analyses/components/Item.js
@@ -2,10 +2,10 @@ import React from "react";
 import CX from "classnames";
 import { connect } from "react-redux";
 import { LinkContainer } from "react-router-bootstrap";
-import { Row, Col, Label } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 
 import { getTaskDisplayName } from "../../utils/utils";
-import { Icon, Loader, RelativeTime } from "../../base";
+import { Icon, Label, Loader, RelativeTime } from "../../base";
 import { removeAnalysis } from "../actions";
 import { getCanModify } from "../../samples/selectors";
 

--- a/client/src/js/analyses/components/Pathoscope/Mapping.js
+++ b/client/src/js/analyses/components/Pathoscope/Mapping.js
@@ -1,10 +1,10 @@
 import numbro from "numbro";
 import React from "react";
 import { connect } from "react-redux";
-import { Label, ProgressBar } from "react-bootstrap";
+import { ProgressBar } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import { Box, Flex, FlexItem, Icon } from "../../../base";
+import { Box, Flex, FlexItem, Icon, Label } from "../../../base";
 import { getColor } from "../../../base/utils";
 import { toThousand } from "../../../utils/utils";
 

--- a/client/src/js/analyses/components/Pathoscope/__tests__/__snapshots__/Mapping.test.js.snap
+++ b/client/src/js/analyses/components/Pathoscope/__tests__/__snapshots__/Mapping.test.js.snap
@@ -7,10 +7,7 @@ exports[`AnalysisMappingReference should render 1`] = `
   >
     Foo
   </Link>
-  <Label
-    bsClass="label"
-    bsStyle="default"
-  >
+  <Label>
     3
   </Label>
 </Mapping__StyledAnalysisMappingReference>

--- a/client/src/js/analyses/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/client/src/js/analyses/components/__tests__/__snapshots__/Item.test.js.snap
@@ -48,8 +48,6 @@ exports[`<AnalysisItem /> should render 1`] = `
         <span>
           Foo
           <Label
-            bsClass="label"
-            bsStyle="default"
             style={
               Object {
                 "marginLeft": "5px",
@@ -184,8 +182,6 @@ exports[`<AnalysisItem /> should render when [ready=false] 1`] = `
         <span>
           Foo
           <Label
-            bsClass="label"
-            bsStyle="default"
             style={
               Object {
                 "marginLeft": "5px",

--- a/client/src/js/base/Label.js
+++ b/client/src/js/base/Label.js
@@ -1,0 +1,4 @@
+import styled from "styled-components";
+import { Label as BsLabel } from "react-bootstrap";
+
+export const Label = styled(BsLabel)``;

--- a/client/src/js/base/NotFound.js
+++ b/client/src/js/base/NotFound.js
@@ -1,21 +1,33 @@
 import React from "react";
+import styled from "styled-components";
 import PropTypes from "prop-types";
-import { Jumbotron } from "react-bootstrap";
+import { Label } from "./Label";
+
+const StyledNotFound = styled.div`
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 400px;
+    justify-content: center;
+
+    ${Label} {
+        font-size: 36px;
+    }
+
+    strong {
+        font-size: 16px;
+        padding-top: 15px;
+    }
+`;
 
 /**
  * A component used for 404 Not Found errors.
  */
-export const NotFound = ({ status, message }) => (
-    <Jumbotron className="not-found">
-        <h1 style={{ margin: "0 0 10px 0" }}>
-            <span className="label label-danger" style={{ padding: "10px 25px" }}>
-                {status || 404}
-            </span>
-            <small style={{ color: "black", paddingLeft: "15px" }}>
-                <strong>{message || "Not found"}</strong>
-            </small>
-        </h1>
-    </Jumbotron>
+export const NotFound = ({ status = "404", message }) => (
+    <StyledNotFound>
+        <Label bsStyle="danger">{status}</Label>
+        <strong>{message || "Not found"}</strong>
+    </StyledNotFound>
 );
 
 NotFound.propTypes = {

--- a/client/src/js/base/__tests__/NotFound.test.js
+++ b/client/src/js/base/__tests__/NotFound.test.js
@@ -3,26 +3,18 @@ import { NotFound } from "../NotFound";
 describe("<NotFound />", () => {
     let wrapper;
 
-    it("renders correctly", () => {
+    it("should render default", () => {
         wrapper = shallow(<NotFound />);
         expect(wrapper).toMatchSnapshot();
     });
 
-    it("renders optional alternate message and status", () => {
-        wrapper = shallow(<NotFound status={409} message="Test" />);
+    it("should render with status", () => {
+        const wrapper = shallow(<NotFound status={409} />);
+        expect(wrapper).toMatchSnapshot();
+    });
 
-        expect(
-            wrapper
-                .find("span")
-                .children()
-                .text()
-        ).toEqual("409");
-        expect(
-            wrapper
-                .find("strong")
-                .children()
-                .text()
-        ).toEqual("Test");
+    it("should render with message", () => {
+        wrapper = shallow(<NotFound message="Resource missing" />);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/client/src/js/base/__tests__/__snapshots__/NotFound.test.js.snap
+++ b/client/src/js/base/__tests__/__snapshots__/NotFound.test.js.snap
@@ -1,79 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<NotFound /> renders correctly 1`] = `
-<Jumbotron
-  bsClass="jumbotron"
-  className="not-found"
-  componentClass="div"
->
-  <h1
-    style={
-      Object {
-        "margin": "0 0 10px 0",
-      }
-    }
+exports[`<NotFound /> should render default 1`] = `
+<NotFound__StyledNotFound>
+  <Label
+    bsStyle="danger"
   >
-    <span
-      className="label label-danger"
-      style={
-        Object {
-          "padding": "10px 25px",
-        }
-      }
-    >
-      404
-    </span>
-    <small
-      style={
-        Object {
-          "color": "black",
-          "paddingLeft": "15px",
-        }
-      }
-    >
-      <strong>
-        Not found
-      </strong>
-    </small>
-  </h1>
-</Jumbotron>
+    404
+  </Label>
+  <strong>
+    Not found
+  </strong>
+</NotFound__StyledNotFound>
 `;
 
-exports[`<NotFound /> renders optional alternate message and status 1`] = `
-<Jumbotron
-  bsClass="jumbotron"
-  className="not-found"
-  componentClass="div"
->
-  <h1
-    style={
-      Object {
-        "margin": "0 0 10px 0",
-      }
-    }
+exports[`<NotFound /> should render with message 1`] = `
+<NotFound__StyledNotFound>
+  <Label
+    bsStyle="danger"
   >
-    <span
-      className="label label-danger"
-      style={
-        Object {
-          "padding": "10px 25px",
-        }
-      }
-    >
-      409
-    </span>
-    <small
-      style={
-        Object {
-          "color": "black",
-          "paddingLeft": "15px",
-        }
-      }
-    >
-      <strong>
-        Test
-      </strong>
-    </small>
-  </h1>
-</Jumbotron>
+    404
+  </Label>
+  <strong>
+    Resource missing
+  </strong>
+</NotFound__StyledNotFound>
+`;
+
+exports[`<NotFound /> should render with status 1`] = `
+<NotFound__StyledNotFound>
+  <Label
+    bsStyle="danger"
+  >
+    409
+  </Label>
+  <strong>
+    Not found
+  </strong>
+</NotFound__StyledNotFound>
 `;

--- a/client/src/js/base/index.js
+++ b/client/src/js/base/index.js
@@ -28,6 +28,7 @@ import { ViewHeader } from "./ViewHeader";
 
 export * from "./Box";
 export * from "./ExternalLink";
+export * from "./Label";
 export * from "./LoadingPlaceholder";
 export * from "./Logo";
 export * from "./TabLink";

--- a/client/src/js/groups/components/Groups.js
+++ b/client/src/js/groups/components/Groups.js
@@ -1,9 +1,9 @@
 import { push } from "connected-react-router";
 import { filter, find, get, includes, map, sortBy, transform } from "lodash-es";
 import React from "react";
-import { Col, InputGroup, Label, ListGroup, Modal, Panel, Row } from "react-bootstrap";
+import { Col, InputGroup, ListGroup, Modal, Panel, Row } from "react-bootstrap";
 import { connect } from "react-redux";
-import { AutoProgressBar, Button, Icon, InputError, ListGroupItem, LoadingPlaceholder } from "../../base";
+import { AutoProgressBar, Button, Icon, InputError, Label, ListGroupItem, LoadingPlaceholder } from "../../base";
 import { clearError } from "../../errors/actions";
 import { routerLocationHasState } from "../../utils/utils";
 

--- a/client/src/js/hmm/components/Detail.js
+++ b/client/src/js/hmm/components/Detail.js
@@ -1,9 +1,9 @@
 import { get, map } from "lodash-es";
 import React from "react";
-import { Badge, Col, Label, Panel, Row, Table } from "react-bootstrap";
+import { Badge, Col, Panel, Row, Table } from "react-bootstrap";
 import { connect } from "react-redux";
 
-import { LoadingPlaceholder, NotFound, ViewHeader } from "../../base";
+import { Label, LoadingPlaceholder, NotFound, ViewHeader } from "../../base";
 import { getHmm } from "../actions";
 import { HMMTaxonomy } from "./Taxonomy";
 

--- a/client/src/js/hmm/components/Item.js
+++ b/client/src/js/hmm/components/Item.js
@@ -2,9 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import { LinkContainer } from "react-router-bootstrap";
 import { keys, map, reject } from "lodash-es";
-import { Col, Label, Row } from "react-bootstrap";
+import { Col, Row } from "react-bootstrap";
 
-import { ListGroupItem } from "../../base";
+import { Label, ListGroupItem } from "../../base";
 
 export default function HMMItem({ cluster, families, id, names }) {
     const filteredFamilies = reject(keys(families), family => family === "None");

--- a/client/src/js/hmm/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/client/src/js/hmm/components/__tests__/__snapshots__/Item.test.js.snap
@@ -39,10 +39,7 @@ exports[`<HMMItem /> should render 1`] = `
           <span
             key="0"
           >
-            <Label
-              bsClass="label"
-              bsStyle="default"
-            >
+            <Label>
               Family1
             </Label>
              
@@ -50,10 +47,7 @@ exports[`<HMMItem /> should render 1`] = `
           <span
             key="1"
           >
-            <Label
-              bsClass="label"
-              bsStyle="default"
-            >
+            <Label>
               Family2
             </Label>
              
@@ -61,10 +55,7 @@ exports[`<HMMItem /> should render 1`] = `
           <span
             key="2"
           >
-            <Label
-              bsClass="label"
-              bsStyle="default"
-            >
+            <Label>
               Family3
             </Label>
              

--- a/client/src/js/otus/components/Detail/History.js
+++ b/client/src/js/otus/components/Detail/History.js
@@ -10,11 +10,11 @@ import React from "react";
 import PropTypes from "prop-types";
 import { get, groupBy, map, reverse, sortBy } from "lodash-es";
 import { connect } from "react-redux";
-import { Row, Col, ListGroup, Label } from "react-bootstrap";
+import { Row, Col, ListGroup } from "react-bootstrap";
 import { checkRefRight } from "../../../utils/utils";
 
 import { getOTUHistory, revert } from "../../actions";
-import { Flex, FlexItem, ListGroupItem, RelativeTime, Icon, LoadingPlaceholder } from "../../../base";
+import { Flex, FlexItem, ListGroupItem, RelativeTime, Icon, Label, LoadingPlaceholder } from "../../../base";
 
 const methodIconProps = {
     add_isolate: {

--- a/client/src/js/otus/components/Detail/IsolateDetail.js
+++ b/client/src/js/otus/components/Detail/IsolateDetail.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { capitalize, get } from "lodash-es";
 import { connect } from "react-redux";
-import { Label, Panel, Table } from "react-bootstrap";
+import { Panel, Table } from "react-bootstrap";
 
-import { Icon } from "../../../base";
+import { Icon, Label } from "../../../base";
 import { checkRefRight, followDownload } from "../../../utils/utils";
 import { setIsolateAsDefault, showEditIsolate, showRemoveIsolate } from "../../actions";
 import EditIsolate from "./EditIsolate";

--- a/client/src/js/otus/components/Detail/Segment.js
+++ b/client/src/js/otus/components/Detail/Segment.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Col, Row, Label } from "react-bootstrap";
-import { Icon, ListGroupItem } from "../../../base";
+import { Col, Row } from "react-bootstrap";
+import { Icon, Label, ListGroupItem } from "../../../base";
 
 export default class Segment extends React.Component {
     handleRemove = () => {

--- a/client/src/js/updates/components/Install.js
+++ b/client/src/js/updates/components/Install.js
@@ -1,12 +1,12 @@
 import React from "react";
 import Request from "superagent";
 import { forEach, reduce, replace, split, trimEnd } from "lodash-es";
-import { Label, Modal, ProgressBar } from "react-bootstrap";
+import { Modal, ProgressBar } from "react-bootstrap";
 import { connect } from "react-redux";
 import { push } from "connected-react-router";
 
 import { installSoftwareUpdates } from "../actions";
-import { Button, Loader } from "../../base";
+import { Button, Label, Loader } from "../../base";
 import { byteSize, routerLocationHasState } from "../../utils/utils";
 import { ReleaseMarkdown } from "./Release";
 

--- a/client/src/js/updates/components/__tests__/__snapshots__/Install.test.js.snap
+++ b/client/src/js/updates/components/__tests__/__snapshots__/Install.test.js.snap
@@ -33,10 +33,7 @@ exports[`<SoftwareInstall /> should render 1`] = `
     onHide={[MockFunction]}
   >
     Software Update 
-    <Label
-      bsClass="label"
-      bsStyle="default"
-    >
+    <Label>
       test
     </Label>
   </ModalHeader>


### PR DESCRIPTION
- extend `react-bootstrap/Label` as base component and implement in all usages
- drop `react-bootstrap/Jumbotron` from `<NotFound />`