### PR TITLE
Replace accessions in sequence autofill with retrieved values

### DIFF
--- a/client/src/js/otus/components/Detail/AddSequence.js
+++ b/client/src/js/otus/components/Detail/AddSequence.js
@@ -73,10 +73,11 @@ class AddSequence extends React.Component {
         this.setState({ autofillPending: true }, () => {
             getGenbank(this.state.id).then(
                 resp => {
-                    const { definition, host, sequence } = resp.body;
+                    const { accession, definition, host, sequence } = resp.body;
 
                     this.setState({
                         autofillPending: false,
+                        id: accession,
                         definition,
                         host,
                         sequence,


### PR DESCRIPTION
- resolves #1397 
- update form with full accessions (eg. _NC00111.2_ instead of _NC00111_) from Genbank autofill responses