### PR TITLE
Database Setup Fix

### DIFF
--- a/virtool/db/core.py
+++ b/virtool/db/core.py
@@ -271,6 +271,3 @@ class DB:
             projection,
             silent
         )
-
-    async def collection_names(self):
-        return await self.motor_client.collection_names()

--- a/virtool/setup/db.py
+++ b/virtool/setup/db.py
@@ -24,7 +24,7 @@ async def check_setup(db_connection_string, db_name):
     db = get_db(db_connection_string, db_name)
 
     try:
-        await db.collection_names(include_system_collections=False)
+        names = await db.list_collection_names()
     except OperationFailure as err:
         logger.warning(f"Database Setup: {str(err)}")
         if any(substr in str(err) for substr in ["Authentication failed", "no users authenticated"]):


### PR DESCRIPTION
- possible fix for #1403
- use `list_collection_names()` method instead of `collection_names()` to verify database connection during setup