### PR TITLE
Don't attempt account update with empty dict

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -30,11 +30,7 @@ async def get(req):
     Get complete user document.
 
     """
-    document = await req.app["db"].users.find_one(
-        req["client"].user_id,
-        virtool.account.db.PROJECTION
-    )
-
+    document = await virtool.account.db.get_document(req.app["db"], req["client"].user_id)
     return json_response(virtool.utils.base_processor(document))
 
 
@@ -85,9 +81,12 @@ async def edit(req):
     if "email" in data:
         update["email"] = data["email"]
 
-    document = await db.users.find_one_and_update({"_id": user_id}, {
-        "$set": update
-    }, projection=virtool.account.db.PROJECTION)
+    if update:
+        document = await db.users.find_one_and_update({"_id": user_id}, {
+            "$set": update
+        }, projection=virtool.account.db.PROJECTION)
+    else:
+        document = await virtool.account.db.get_document(db, user_id)
 
     return json_response(virtool.utils.base_processor(document))
 

--- a/virtool/account/db.py
+++ b/virtool/account/db.py
@@ -38,6 +38,13 @@ def compose_password_update(user_id: str, old_password: str, password: str) -> d
     }
 
 
+async def get_document(db, user_id):
+    return await db.users.find_one(
+        user_id,
+        PROJECTION
+    )
+
+
 async def get_alternate_id(db: virtool.db.core.DB, name: str) -> str:
     """
     Get an alternate id for an API key whose provided `name` is not unique. Appends an integer suffix to the end of the


### PR DESCRIPTION
- resolves #1453 
- don't attempt account update when update `dict` is empty; return existing document in response