### PR TITLE
Fix KeyError when handling GET request for sample

### DIFF
--- a/virtool/db/migrate.py
+++ b/virtool/db/migrate.py
@@ -44,7 +44,6 @@ async def migrate_files(db):
     """
     Make all files unreserved. This is only called when the server first starts.
 
-    :param db:
     """
     logger.info(" • files")
 

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -132,14 +132,16 @@ async def get(req):
 
     document["caches"] = caches
 
-    for index, file in enumerate(document["files"]):
-        snake_case = document["name"].replace(" ", "_")
+    if document["imported"] is True:
+        # Only update file fields if sample creation is complete.
+        for index, file in enumerate(document["files"]):
+            snake_case = document["name"].replace(" ", "_")
 
-        file.update({
-            "name": file["name"].replace("reads_", f"{snake_case}_"),
-            "download_url": file["download_url"].replace("reads_", f"{snake_case}_"),
-            "replace_url": f"/upload/samples/{sample_id}/files/{index + 1}"
-        })
+            file.update({
+                "name": file["name"].replace("reads_", f"{snake_case}_"),
+                "download_url": file["download_url"].replace("reads_", f"{snake_case}_"),
+                "replace_url": f"/upload/samples/{sample_id}/files/{index + 1}"
+            })
 
     return json_response(virtool.utils.base_processor(document))
 


### PR DESCRIPTION
- resolves #1464 
- error occurred for samples still being imported that don't have a fully a defined `files` field