### PR TITLE
Fix BLAST error when missing 'sciname'

### DIFF
--- a/virtool/bio.py
+++ b/virtool/bio.py
@@ -364,6 +364,26 @@ async def check_rid(settings, rid):
             return "Status=WAITING" not in await resp.text()
 
 
+def format_blast_hit(hit):
+    cleaned = {key: hit["description"][0].get(key, "") for key in ["accession", "taxid", "title"]}
+
+    hsps = {key: hit["hsps"][0][key] for key in [
+        "identity",
+        "evalue",
+        "align_len",
+        "score",
+        "bit_score",
+        "gaps"
+    ]}
+
+    return {
+        **cleaned,
+        **hsps,
+        "name": hit["description"][0].get("sciname", "No name"),
+        "len": hit["len"]
+    }
+
+
 async def get_ncbi_blast_result(settings, rid):
     params = {
         "CMD": "Get",
@@ -405,27 +425,7 @@ def parse_blast_content(content, rid):
         output["masking"] = None
 
     output["stat"] = result["stat"]
-
-    output["hits"] = list()
-
-    for hit in result["hits"]:
-        cleaned = {key: hit["description"][0].get(key, "") for key in ["taxid", "title", "accession"]}
-
-        cleaned["len"] = hit["len"]
-        cleaned["name"] = hit["description"][0]["sciname"]
-
-        hsps = {key: hit["hsps"][0][key] for key in [
-            "identity",
-            "evalue",
-            "align_len",
-            "score",
-            "bit_score",
-            "gaps"
-        ]}
-
-        cleaned.update(hsps)
-
-        output["hits"].append(cleaned)
+    output["hits"] = [format_blast_hit(h) for h in result["hits"]]
 
     return output
 

--- a/virtool/bio.py
+++ b/virtool/bio.py
@@ -364,7 +364,14 @@ async def check_rid(settings, rid):
             return "Status=WAITING" not in await resp.text()
 
 
-def format_blast_hit(hit):
+def format_blast_hit(hit: dict) -> dict:
+    """
+    Format a BLAST hit from NCBI into a format more usable by Virtool.
+
+    :param hit: the BLAST hit
+    :return: the formatted hit
+
+    """
     cleaned = {key: hit["description"][0].get(key, "") for key in ["accession", "taxid", "title"]}
 
     hsps = {key: hit["hsps"][0][key] for key in [


### PR DESCRIPTION
- resolves #1459 
- use 'No name' as name value when `sciname` field is missing in NCBI BLAST data