### PR TITLE
Show warning for undersized sample files

### DIFF
--- a/client/src/js/samples/components/Files/Files.js
+++ b/client/src/js/samples/components/Files/Files.js
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import { getLinkedJob } from "../../../jobs/actions";
 import SampleFilesMessage from "../LegacyAlert";
+import SampleFileSizeWarning from "../SampleFileSizeWarning.js";
 import SampleFilesCache from "./Cache";
 import SampleFilesRaw from "./Raw";
 
@@ -15,6 +16,7 @@ const SampleDetailFiles = ({ onGetJob, jobId }) => {
 
     return (
         <div>
+            <SampleFileSizeWarning />
             <SampleFilesMessage />
             <SampleFilesRaw />
             <SampleFilesCache />

--- a/client/src/js/samples/components/General.js
+++ b/client/src/js/samples/components/General.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import { BoxGroup, BoxGroupHeader, Table } from "../../base";
 import EditSample from "./Edit";
+import SampleFileSizeWarning from "./SampleFileSizeWarning.js";
 
 export const SampleDetailGeneral = ({
     count,
@@ -18,6 +19,7 @@ export const SampleDetailGeneral = ({
     srna
 }) => (
     <div>
+        <SampleFileSizeWarning />
         <Table>
             <tbody>
                 <tr>

--- a/client/src/js/samples/components/SampleFileSizeWarning.js
+++ b/client/src/js/samples/components/SampleFileSizeWarning.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { connect } from "react-redux";
+import styled from "styled-components";
+import { Icon, WarningAlert } from "../../base";
+import { getFilesUndersized } from "../selectors";
+
+export const StyledSampleFileSizeWarning = styled(WarningAlert)`
+    align-items: center;
+    display: flex;
+
+    strong {
+        margin-left: 3px;
+    }
+`;
+
+export const SampleFileSizeWarning = ({ show }) => {
+    if (show) {
+        return (
+            <StyledSampleFileSizeWarning>
+                <Icon name="exclamation-triangle" />
+                <strong>The read files in this sample are smaller than expected</strong>
+            </StyledSampleFileSizeWarning>
+        );
+    }
+
+    return null;
+};
+
+export const mapStateToProps = state => ({
+    show: getFilesUndersized(state)
+});
+
+export default connect(mapStateToProps)(SampleFileSizeWarning);

--- a/client/src/js/samples/components/__tests__/__snapshots__/General.test.js.snap
+++ b/client/src/js/samples/components/__tests__/__snapshots__/General.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`<SampleDetailGeneral /> should render with [paired=false] 1`] = `
 <div>
+  <Connect(SampleFileSizeWarning) />
   <Table>
     <tbody>
       <tr>
@@ -124,6 +125,7 @@ exports[`<SampleDetailGeneral /> should render with [paired=false] 1`] = `
 
 exports[`<SampleDetailGeneral /> should render with [paired=true] 1`] = `
 <div>
+  <Connect(SampleFileSizeWarning) />
   <Table>
     <tbody>
       <tr>
@@ -246,6 +248,7 @@ exports[`<SampleDetailGeneral /> should render with [paired=true] 1`] = `
 
 exports[`<SampleDetailGeneral /> should render with [srna=false] 1`] = `
 <div>
+  <Connect(SampleFileSizeWarning) />
   <Table>
     <tbody>
       <tr>
@@ -368,6 +371,7 @@ exports[`<SampleDetailGeneral /> should render with [srna=false] 1`] = `
 
 exports[`<SampleDetailGeneral /> should render with [srna=true] 1`] = `
 <div>
+  <Connect(SampleFileSizeWarning) />
   <Table>
     <tbody>
       <tr>

--- a/client/src/js/samples/selectors.js
+++ b/client/src/js/samples/selectors.js
@@ -1,4 +1,4 @@
-import { every, filter, get, includes } from "lodash-es";
+import { every, filter, get, some, includes } from "lodash-es";
 import { createSelector } from "reselect";
 import { getTermSelectorFactory } from "../utils/selectors";
 
@@ -68,3 +68,5 @@ export const getSelectedDocuments = createSelector(
         return filter(documents, document => includes(selected, document.id));
     }
 );
+
+export const getFilesUndersized = state => some(state.samples.detail.files, file => file.size < 10000000);


### PR DESCRIPTION
- resolve #1483
- add warning component for `General` and `File`
- show when filesize less than 100mb