### PR TITLE
Job component tests

### DIFF
--- a/client/src/js/jobs/components/Icons.js
+++ b/client/src/js/jobs/components/Icons.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { Icon, Loader } from "../../base";
+
+export const JobActionIcon = ({ state, canCancel, canRemove, onCancel, onRemove }) => {
+    if ((state === "waiting" || state === "running") && canCancel) {
+        return <Icon bsStyle="danger" name="ban" onClick={onCancel} style={{ fontSize: "17px" }} pullRight />;
+    } else if (canRemove) {
+        return <Icon bsStyle="danger" name="trash" onClick={onRemove} style={{ fontSize: "17px" }} pullRight />;
+    }
+
+    return null;
+};
+
+export const JobStatusIcon = ({ state }) => {
+    if (state === "waiting" || state === "running") {
+        return <Loader size="14px" color="#3c8786" />;
+    }
+
+    if (state === "complete") {
+        return <Icon name="check fa-fw" bsStyle="success" />;
+    }
+
+    if (state === "error" || state === "cancelled") {
+        return <Icon name="times fa-fw" bsStyle="danger" />;
+    }
+
+    return null;
+};

--- a/client/src/js/jobs/components/Item.js
+++ b/client/src/js/jobs/components/Item.js
@@ -4,9 +4,10 @@ import { capitalize } from "lodash-es";
 import { Row, Col } from "react-bootstrap";
 import { connect } from "react-redux";
 import { push } from "connected-react-router";
-import { Icon, RelativeTime, ProgressBar, Flex, FlexItem, Loader } from "../../base";
+import { RelativeTime, ProgressBar, Flex, FlexItem } from "../../base";
 import { getTaskDisplayName } from "../../utils/utils";
 import { cancelJob, removeJob } from "../actions";
+import { JobActionIcon, JobStatusIcon } from "./Icons";
 
 export class JobItem extends React.Component {
     static propTypes = {
@@ -39,34 +40,6 @@ export class JobItem extends React.Component {
     };
 
     render() {
-        let actionIcon;
-        let statusIcon;
-
-        if ((this.props.state === "waiting" || this.props.state === "running") && this.props.canCancel) {
-            actionIcon = (
-                <Icon bsStyle="danger" name="ban" onClick={this.handleCancel} style={{ fontSize: "17px" }} pullRight />
-            );
-
-            statusIcon = <Loader size="14px" color="#3c8786" />;
-        } else if (this.props.canRemove) {
-            actionIcon = (
-                <Icon
-                    bsStyle="danger"
-                    name="trash"
-                    onClick={this.handleRemove}
-                    style={{ fontSize: "17px" }}
-                    pullRight
-                />
-            );
-
-            statusIcon =
-                this.props.state === "complete" ? (
-                    <Icon name="check fa-fw" bsStyle="success" />
-                ) : (
-                    <Icon name="times fa-fw" bsStyle="danger" />
-                );
-        }
-
         let progressStyle = "success";
 
         const progressValue = this.props.progress * 100;
@@ -97,14 +70,22 @@ export class JobItem extends React.Component {
                     </Col>
                     <Col xsHidden sm={2} md={2}>
                         <Flex justifyContent="flex-end">
-                            <FlexItem>{statusIcon}</FlexItem>
+                            <FlexItem>
+                                <JobStatusIcon state={this.props.state} />
+                            </FlexItem>
                             <FlexItem pad>
                                 <strong>{capitalize(this.props.state)}</strong>
                             </FlexItem>
                         </Flex>
                     </Col>
                     <Col xs={1} sm={1} md={1}>
-                        {actionIcon || null}
+                        <JobActionIcon
+                            state={this.props.state}
+                            canCancel={this.props.canCancel}
+                            canRemove={this.props.canRemove}
+                            onCancel={this.onCancel}
+                            onRemove={this.onRemove}
+                        />
                     </Col>
                 </Row>
             </div>
@@ -112,7 +93,7 @@ export class JobItem extends React.Component {
     }
 }
 
-const mapDispatchToProps = dispatch => ({
+export const mapDispatchToProps = dispatch => ({
     onCancel: jobId => {
         dispatch(cancelJob(jobId));
     },

--- a/client/src/js/jobs/components/__tests__/Icons.test.js
+++ b/client/src/js/jobs/components/__tests__/Icons.test.js
@@ -1,0 +1,67 @@
+import { JobActionIcon, JobStatusIcon } from "../Icons";
+
+describe("<JobActionIcon />", () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            state: "waiting",
+            canCancel: true,
+            onCancel: jest.fn(),
+            canRemove: true,
+            onRemove: jest.fn()
+        };
+    });
+
+    it("should render when[state='waiting' && canCancel=true]", () => {
+        const wrapper = shallow(<JobActionIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[state='runing' && canCancel=true]", () => {
+        props.state = "runing";
+        const wrapper = shallow(<JobActionIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[canCancel=false && canRemove=true]", () => {
+        props.canCancel = false;
+        const wrapper = shallow(<JobActionIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[canCancel=false && canRemove=false]", () => {
+        props.canCancel = false;
+        props.canRemove = false;
+        const wrapper = shallow(<JobActionIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});
+
+describe("<JobStatusIcon />", () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            state: "waiting"
+        };
+    });
+
+    it("should render when[state='waiting']", () => {
+        const wrapper = shallow(<JobStatusIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[state='running']", () => {
+        const wrapper = shallow(<JobStatusIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[state='complete']", () => {
+        const wrapper = shallow(<JobStatusIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[state='error']", () => {
+        const wrapper = shallow(<JobStatusIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it("should render when[state='cancelled']", () => {
+        const wrapper = shallow(<JobStatusIcon {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/client/src/js/jobs/components/__tests__/JobItem.test.js
+++ b/client/src/js/jobs/components/__tests__/JobItem.test.js
@@ -1,0 +1,59 @@
+import { JobItem, mapDispatchToProps } from "../Item";
+
+describe("<JobItem />", () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            id: "foo",
+            progress: 1,
+            state: "bar",
+            task: "baz",
+            created_at: "Foo",
+            user: {
+                id: "Bar"
+            },
+            canCancel: true,
+            canRemove: true,
+            handleCancel: "Baz",
+            handleRemove: "foe"
+        };
+    });
+    it("should render", () => {
+        const wrapper = shallow(<JobItem {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});
+
+describe("mapDispatchToProps", () => {
+    it("should return onCancel() in props", () => {
+        const dispatch = jest.fn();
+        const props = mapDispatchToProps(dispatch);
+
+        props.onCancel("foo");
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "CANCEL_JOB_REQUESTED",
+            jobId: "foo"
+        });
+    });
+    it("should return onNavigate() in props", () => {
+        const dispatch = jest.fn();
+        const props = mapDispatchToProps(dispatch);
+
+        props.onNavigate("foo");
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { args: ["/jobs/foo"], method: "push" },
+            type: "@@router/CALL_HISTORY_METHOD"
+        });
+    });
+    it("should return onRemove() in props", () => {
+        const dispatch = jest.fn();
+        const props = mapDispatchToProps(dispatch);
+
+        props.onRemove("foo");
+        expect(dispatch).toHaveBeenCalledWith({
+            jobId: "foo",
+            type: "REMOVE_JOB_REQUESTED"
+        });
+    });
+});

--- a/client/src/js/jobs/components/__tests__/__snapshots__/Icons.test.js.snap
+++ b/client/src/js/jobs/components/__tests__/__snapshots__/Icons.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<JobActionIcon /> should render when[canCancel=false && canRemove=false] 1`] = `""`;
+
+exports[`<JobActionIcon /> should render when[canCancel=false && canRemove=true] 1`] = `
+<Icon
+  bsStyle="danger"
+  faStyle="fas"
+  fixedWidth={false}
+  name="trash"
+  onClick={[MockFunction]}
+  pullRight={true}
+  style={
+    Object {
+      "fontSize": "17px",
+    }
+  }
+/>
+`;
+
+exports[`<JobActionIcon /> should render when[state='runing' && canCancel=true] 1`] = `
+<Icon
+  bsStyle="danger"
+  faStyle="fas"
+  fixedWidth={false}
+  name="trash"
+  onClick={[MockFunction]}
+  pullRight={true}
+  style={
+    Object {
+      "fontSize": "17px",
+    }
+  }
+/>
+`;
+
+exports[`<JobActionIcon /> should render when[state='waiting' && canCancel=true] 1`] = `
+<Icon
+  bsStyle="danger"
+  faStyle="fas"
+  fixedWidth={false}
+  name="ban"
+  onClick={[MockFunction]}
+  pullRight={true}
+  style={
+    Object {
+      "fontSize": "17px",
+    }
+  }
+/>
+`;
+
+exports[`<JobStatusIcon /> should render when[state='cancelled'] 1`] = `
+<Loader
+  color="#3c8786"
+  size="14px"
+/>
+`;
+
+exports[`<JobStatusIcon /> should render when[state='complete'] 1`] = `
+<Loader
+  color="#3c8786"
+  size="14px"
+/>
+`;
+
+exports[`<JobStatusIcon /> should render when[state='error'] 1`] = `
+<Loader
+  color="#3c8786"
+  size="14px"
+/>
+`;
+
+exports[`<JobStatusIcon /> should render when[state='running'] 1`] = `
+<Loader
+  color="#3c8786"
+  size="14px"
+/>
+`;
+
+exports[`<JobStatusIcon /> should render when[state='waiting'] 1`] = `
+<Loader
+  color="#3c8786"
+  size="14px"
+/>
+`;

--- a/client/src/js/jobs/components/__tests__/__snapshots__/JobItem.test.js.snap
+++ b/client/src/js/jobs/components/__tests__/__snapshots__/JobItem.test.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<JobItem /> should render 1`] = `
+<div
+  className="list-group-item hoverable spaced job"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "#555",
+    }
+  }
+>
+  <ProgressBar
+    affixed={true}
+    bsStyle="success"
+    now={100}
+  />
+  <Row
+    bsClass="row"
+    componentClass="div"
+  >
+    <Col
+      bsClass="col"
+      componentClass="div"
+      md={4}
+      sm={4}
+      xs={6}
+    >
+      <strong>
+        Baz
+      </strong>
+    </Col>
+    <Col
+      bsClass="col"
+      componentClass="div"
+      md={5}
+      sm={5}
+      xs={5}
+    >
+      Started 
+      <RelativeTime
+        time="Foo"
+      />
+       by 
+      Bar
+    </Col>
+    <Col
+      bsClass="col"
+      componentClass="div"
+      md={2}
+      sm={2}
+      xsHidden={true}
+    >
+      <Flex
+        alignContent="stretch"
+        alignItems="stretch"
+        direction="row"
+        justifyContent="flex-end"
+        wrap="nowrap"
+      >
+        <FlexItem
+          alignSelf={null}
+          basis="auto"
+          grow={0}
+          shrink={1}
+        >
+          <JobStatusIcon
+            state="bar"
+          />
+        </FlexItem>
+        <FlexItem
+          alignSelf={null}
+          basis="auto"
+          grow={0}
+          pad={true}
+          shrink={1}
+        >
+          <strong>
+            Bar
+          </strong>
+        </FlexItem>
+      </Flex>
+    </Col>
+    <Col
+      bsClass="col"
+      componentClass="div"
+      md={1}
+      sm={1}
+      xs={1}
+    >
+      <JobActionIcon
+        canCancel={true}
+        canRemove={true}
+        state="bar"
+      />
+    </Col>
+  </Row>
+</div>
+`;


### PR DESCRIPTION
- resolve #1521 
- move `JobItem` icons to separate components `StatusIcon` and `ActionIcon`
- add tests for `StatusIcon`, `ActionIcon`, and `JobItem`