### PR TITLE
Build barcode

### DIFF
--- a/tests/jobs/snapshots/snap_test_build_index.py
+++ b/tests/jobs/snapshots/snap_test_build_index.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_write_sequences_to_file 1'] = '''>foo
+ATTGAGAGATAGAGACAC
+>bar
+GGGTACGAGTTTCTATCG
+>baz
+GGCTTCGGACTTTTTTCG
+'''
+
+snapshots['test_get_sequences_from_patched_otus[genome] 1'] = [
+    {
+        '_id': '1',
+        'sequence': 'AGAGGATAGAGACACA'
+    },
+    {
+        '_id': '2',
+        'sequence': 'GGGTAGTCGATCTGGC'
+    },
+    {
+        '_id': '5',
+        'sequence': 'TTTGAGCCACACCCCC'
+    },
+    {
+        '_id': '6',
+        'sequence': 'GCCCACCCATTAGAAC'
+    }
+]
+
+snapshots['test_get_sequences_from_patched_otus[barcode] 1'] = [
+    {
+        '_id': '1',
+        'sequence': 'AGAGGATAGAGACACA'
+    },
+    {
+        '_id': '2',
+        'sequence': 'GGGTAGTCGATCTGGC'
+    },
+    {
+        '_id': '3',
+        'default': True,
+        'sequence': 'TTTAGAGTTGGATTAC'
+    },
+    {
+        '_id': '4',
+        'default': True,
+        'sequence': 'AAAGGAGAGAGAAACC'
+    },
+    {
+        '_id': '5',
+        'sequence': 'TTTGAGCCACACCCCC'
+    },
+    {
+        '_id': '6',
+        'sequence': 'GCCCACCCATTAGAAC'
+    }
+]
+
+snapshots['test_get_sequences_from_patched_otus[genome] 2'] = {
+    '1': 'foo',
+    '2': 'foo',
+    '3': 'foo',
+    '4': 'foo',
+    '5': 'bar',
+    '6': 'bar'
+}
+
+snapshots['test_get_sequences_from_patched_otus[barcode] 2'] = {
+    '1': 'foo',
+    '2': 'foo',
+    '3': 'foo',
+    '4': 'foo',
+    '5': 'bar',
+    '6': 'bar'
+}

--- a/tests/jobs/test_build_index.py
+++ b/tests/jobs/test_build_index.py
@@ -1,0 +1,240 @@
+import os
+import pytest
+import types
+import virtool.jobs.build_index
+
+
+@pytest.fixture
+def fake_otus():
+    return [
+        {
+            "_id": "foo",
+            "isolates": [
+                {
+                    "id": "foo_1",
+                    "default": True,
+                    "sequences": [
+                        {
+                            "_id": "1",
+                            "sequence": "AGAGGATAGAGACACA"
+                        },
+                        {
+                            "_id": "2",
+                            "sequence": "GGGTAGTCGATCTGGC"
+                        }
+                    ]
+                },
+                {
+                    "id": "foo_2",
+                    "default": False,
+                    "sequences": [
+                        {
+                            "_id": "3",
+                            "sequence": "TTTAGAGTTGGATTAC",
+                            "default": True
+                        },
+                        {
+                            "_id": "4",
+                            "sequence": "AAAGGAGAGAGAAACC",
+                            "default": True
+                        }
+                    ]
+                },
+            ]
+        },
+        {
+            "_id": "bar",
+            "isolates": [
+                {
+                    "id": "bar_1",
+                    "default": True,
+                    "sequences": [
+                        {
+                            "_id": "5",
+                            "sequence": "TTTGAGCCACACCCCC"
+                        },
+                        {
+                            "_id": "6",
+                            "sequence": "GCCCACCCATTAGAAC"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+
+
+@pytest.fixture
+def mock_job(tmpdir, mocker, request, dbs, test_db_connection_string, test_db_name):
+    tmpdir.mkdir("references").mkdir("foo")
+
+    settings = {
+        "data_path": str(tmpdir),
+        "db_name": test_db_name
+    }
+
+    dbs.references.insert_one({
+        "_id": "foo",
+        "data_type": "genome"
+    })
+
+    dbs.jobs.insert_one({
+        "_id": "foobar",
+        "task": "build_index",
+        "args": {
+            "index_id": "bar",
+            "ref_id": "foo"
+        },
+        "proc": 2,
+        "mem": 8
+    })
+
+    queue = mocker.Mock()
+
+    job = virtool.jobs.build_index.Job(
+        test_db_connection_string,
+        test_db_name,
+        settings,
+        "foobar",
+        queue
+    )
+
+    job.init_db()
+
+    return job
+
+
+@pytest.mark.parametrize("data_type", ["genome", "barcode"])
+def test_check_db(dbs, data_type, tmpdir, mock_job):
+    """
+    Test that method provides the required parameters and that `data_type` is derived correctly.
+
+    """
+    dbs.references.update_one({"_id": "foo"}, {
+        "$set": {
+            "data_type": data_type
+        }
+    })
+
+    mock_job.check_db()
+
+    assert mock_job.params == {
+        "data_type": data_type,
+        "index_id": "bar",
+        "index_path": os.path.join(str(tmpdir), "references/foo/bar"),
+        "ref_id": "foo",
+        "reference_path": os.path.join(str(tmpdir), "references/foo")
+    }
+
+
+def test_mk_index_dir(dbs, tmpdir, mock_job):
+    """
+    Test that index dir is created successfully.
+
+    """
+    mock_job.check_db()
+    assert not os.path.exists(mock_job.params["index_path"])
+
+    # Path exists after `mk_index_dir` runs.
+    mock_job.mk_index_dir()
+    assert os.path.exists(mock_job.params["index_path"])
+
+
+def test_get_patched_otus(mocker, dbs):
+    m = mocker.patch("virtool.db.sync.patch_otu_to_version", return_value=(None, {"_id": "foo"}, None))
+
+    manifest = {
+        "foo": 2,
+        "bar": 10,
+        "baz": 4
+    }
+
+    patched_otus = virtool.jobs.build_index.get_patched_otus(dbs, manifest)
+
+    assert isinstance(patched_otus, types.GeneratorType)
+
+    assert list(patched_otus) == [
+        {"_id": "foo"},
+        {"_id": "foo"},
+        {"_id": "foo"}
+    ]
+
+    m.assert_has_calls([
+        mocker.call(dbs, "foo", 2),
+        mocker.call(dbs, "bar", 10),
+        mocker.call(dbs, "baz", 4)
+    ])
+
+
+@pytest.mark.parametrize("data_type", ["genome", "barcode"])
+def test_get_sequences_from_patched_otus(data_type, mocker, snapshot, dbs, fake_otus):
+    sequence_otu_dict = dict()
+
+    sequences = virtool.jobs.build_index.get_sequences_from_patched_otus(
+        fake_otus,
+        data_type,
+        sequence_otu_dict
+    )
+
+    assert isinstance(sequences, types.GeneratorType)
+
+    snapshot.assert_match(list(sequences))
+    snapshot.assert_match(sequence_otu_dict)
+
+
+def test_remove_unused_index_files(tmpdir):
+    """
+    Test that all and only non-active indexes are removed.
+
+    """
+    active_index_ids = [
+        "foo",
+        "baz"
+    ]
+
+    index_ids = [
+        "foo",
+        "bar",
+        "baz",
+        "boo"
+    ]
+
+    for index_id in index_ids:
+        tmpdir.mkdir(index_id).join("test.fa").write("hello world")
+
+    for index_id in index_ids:
+        assert os.listdir(os.path.join(str(tmpdir), index_id)) == ["test.fa"]
+
+    virtool.jobs.build_index.remove_unused_index_files(
+        str(tmpdir),
+        active_index_ids
+    )
+
+    assert os.listdir(str(tmpdir)) == active_index_ids
+
+    for index_id in active_index_ids:
+        assert os.listdir(os.path.join(str(tmpdir), index_id)) == ["test.fa"]
+
+
+def test_write_sequences_to_file(snapshot, tmpdir):
+    sequences = [
+        {
+            "_id": "foo",
+            "sequence": "ATTGAGAGATAGAGACAC"
+        },
+        {
+            "_id": "bar",
+            "sequence": "GGGTACGAGTTTCTATCG"
+        },
+        {
+            "_id": "baz",
+            "sequence": "GGCTTCGGACTTTTTTCG"
+        }
+    ]
+
+    path = os.path.join(str(tmpdir), "output.fa")
+
+    virtool.jobs.build_index.write_sequences_to_file(path, sequences)
+
+    with open(path, "r") as f:
+        snapshot.assert_match(f.read())

--- a/virtool/jobs/build_index.py
+++ b/virtool/jobs/build_index.py
@@ -34,6 +34,8 @@ class Job(virtool.jobs.job.Job):
         """
         self.params = dict(self.task_args)
 
+        document = self.db.references.find_one(self.params["ref_id"], ["library_type"])
+
         self.params["reference_path"] = os.path.join(
             self.settings["data_path"],
             "references",
@@ -44,6 +46,8 @@ class Job(virtool.jobs.job.Job):
             self.params["reference_path"],
             self.params["index_id"]
         )
+
+        self.params["library_type"] = document["library_type"]
 
     def mk_index_dir(self):
         """
@@ -109,15 +113,16 @@ class Job(virtool.jobs.job.Job):
         The root name for the new reference is 'reference'
 
         """
-        command = [
-            "bowtie2-build",
-            "-f",
-            "--threads", str(self.proc),
-            os.path.join(self.params["index_path"], "ref.fa"),
-            os.path.join(self.params["index_path"], "reference")
-        ]
+        if self.params["library_type"] != "amplicon":
+            command = [
+                "bowtie2-build",
+                "-f",
+                "--threads", str(self.proc),
+                os.path.join(self.params["index_path"], "ref.fa"),
+                os.path.join(self.params["index_path"], "reference")
+            ]
 
-        self.run_subprocess(command)
+            self.run_subprocess(command)
 
     def replace_old(self):
         """

--- a/virtool/jobs/build_index.py
+++ b/virtool/jobs/build_index.py
@@ -1,4 +1,5 @@
 import os
+import typing
 
 import virtool.history.db
 import virtool.indexes.db
@@ -34,8 +35,6 @@ class Job(virtool.jobs.job.Job):
         """
         self.params = dict(self.task_args)
 
-        document = self.db.references.find_one(self.params["ref_id"], ["library_type"])
-
         self.params["reference_path"] = os.path.join(
             self.settings["data_path"],
             "references",
@@ -47,7 +46,9 @@ class Job(virtool.jobs.job.Job):
             self.params["index_id"]
         )
 
-        self.params["library_type"] = document["library_type"]
+        document = self.db.references.find_one(self.params["ref_id"], ["data_type"])
+
+        self.params["data_type"] = document["data_type"]
 
     def mk_index_dir(self):
         """
@@ -65,37 +66,22 @@ class Job(virtool.jobs.job.Job):
         the accession numbers.
 
         """
-        fasta_dict = dict()
+        patched_otus = get_patched_otus(
+            self.db,
+            self.params["manifest"]
+        )
+
         sequence_otu_map = dict()
 
-        for patch_id, patch_version in self.params["manifest"].items():
-            document = self.db.otus.find_one(patch_id)
-
-            if document["version"] == patch_version:
-                joined = virtool.db.sync.join_otu(self.db, patch_id, document)
-            else:
-                _, joined, _ = virtool.db.sync.patch_otu_to_version(self.db, patch_id, patch_version)
-
-            for isolate in joined["isolates"]:
-                for sequence in isolate["sequences"]:
-                    sequence_otu_map[sequence["_id"]] = patch_id
-
-            # Extract the list of sequences from the joined patched patch.
-            sequences = virtool.otus.utils.extract_default_sequences(joined)
-
-            defaults = list()
-
-            try:
-                for sequence in sequences:
-                    defaults.append(sequence["_id"])
-                    fasta_dict[sequence["_id"]] = sequence["sequence"]
-
-            except TypeError:
-                raise
+        sequences = get_sequences_from_patched_otus(
+            patched_otus,
+            self.params["data_type"],
+            sequence_otu_map
+        )
 
         fasta_path = os.path.join(self.params["index_path"], "ref.fa")
 
-        write_fasta_dict_to_file(fasta_path, fasta_dict)
+        write_sequences_to_file(fasta_path, sequences)
 
         index_id = self.params["index_id"]
 
@@ -113,7 +99,7 @@ class Job(virtool.jobs.job.Job):
         The root name for the new reference is 'reference'
 
         """
-        if self.params["library_type"] != "amplicon":
+        if self.params["data_type"] != "barcode":
             command = [
                 "bowtie2-build",
                 "-f",
@@ -160,7 +146,7 @@ class Job(virtool.jobs.job.Job):
 
         self.dispatch("indexes", "update", id_list)
 
-        # Find otus with changes.
+        # Find OTUs with changes.
         pipeline = [
             {"$project": {
                 "reference": True,
@@ -192,7 +178,9 @@ class Job(virtool.jobs.job.Job):
 
     def cleanup(self):
         """
-        Cleanup if the job fails. Removes the nascent index document and change the *index_id* and *index_version*
+        Cleanup if the job fails.
+
+        Removes the nascent index document and change the *index_id* and *index_version*
         fields all history items being included in the new index to be 'unbuilt'.
 
         """
@@ -226,26 +214,82 @@ class Job(virtool.jobs.job.Job):
         virtool.utils.rm(self.params["index_path"], True)
 
 
-def remove_unused_index_files(base_path, retained):
+def get_patched_otus(db, manifest: dict) -> typing.Generator[dict, None, None]:
     """
-    Cleans up unused index dirs. Only the **active** index (latest ready index) is ever available for running
-    analysis from the web client. Any older indexes are removed from disk. If a running analysis still needs an old
-    index, it cannot be removed.
+    Get joined OTUs patched to a specific version based on a manifest of OTU ids and versions.
 
-    This method removes old index dirs while ensuring to retain old ones that are still references by pending
-    analyses.
+    :param db: the job database client
+    :param manifest: the manifest
+    :return:
 
     """
-    for dir_name in os.listdir(base_path):
-        if dir_name not in retained:
+    for patch_id, patch_version in manifest.items():
+        _, joined, _ = virtool.db.sync.patch_otu_to_version(db, patch_id, patch_version)
+        yield joined
+
+
+def get_sequences_from_patched_otus(otus: typing.Iterable[dict], data_type: str, sequence_otu_map: dict) -> typing.Generator[dict, None, None]:
+    """
+    Return sequence documents based on an `Iterable` of joined OTU documents. Writes a map of sequence IDs to OTU IDs
+    into the passed `sequence_otu_map`.
+
+    If `data_type` is `barcode`, all sequences are returned. Otherwise, only sequences of default isolates are returned.
+
+    :param otus: an Iterable of joined OTU documents
+    :param data_type: the data type of the parent reference for the OTUs
+    :param sequence_otu_map: a dict to populate with sequence-OTU map information
+    :return: a generator that yields sequence documents
+
+    """
+    for otu in otus:
+        otu_id = otu["_id"]
+
+        for isolate in otu["isolates"]:
+            for sequence in isolate["sequences"]:
+                sequence_id = sequence["_id"]
+                sequence_otu_map[sequence_id] = otu_id
+
+        if data_type == "barcode":
+            for sequence in virtool.otus.utils.extract_sequences(otu):
+                yield sequence
+        else:
+            for sequence in virtool.otus.utils.extract_default_sequences(otu):
+                yield sequence
+
+
+def remove_unused_index_files(reference_path: str, active_index_ids: list):
+    """
+    Cleans up unused index files for a reference given it's path.
+
+    Only the **active** index (latest ready index) is available for running analysis from the web client. Any older
+    indexes are removed from disk. If a running analysis still needs an old index, it will not be removed.
+
+    :param reference_path: the path to the reference
+    :param active_index_ids: ids of indexes that are still in use by analysis jobs
+
+    """
+    for index_id in os.listdir(reference_path):
+        if index_id not in active_index_ids:
             try:
-                virtool.utils.rm(os.path.join(base_path, dir_name), recursive=True)
-            except OSError:
+                virtool.utils.rm(os.path.join(reference_path, index_id), recursive=True)
+            except FileNotFoundError:
                 pass
 
 
-def write_fasta_dict_to_file(path, fasta_dict):
+def write_sequences_to_file(path: str, sequences: typing.Iterable):
+    """
+    Write a FASTA file based on a given `Iterable` containing sequence documents.
+
+    Headers will contain the `_id` field of the document and the sequence text is from the `sequence` field.
+
+    :param path: the path to write the file to
+    :param sequences: the sequences to write to file
+
+    """
     with open(path, "w") as handle:
-        for sequence_id, sequence in fasta_dict.items():
-            line = f">{sequence_id}\n{sequence}\n"
+        for sequence in sequences:
+            sequence_id = sequence["_id"]
+            sequence_data = sequence["sequence"]
+
+            line = f">{sequence_id}\n{sequence_data}\n"
             handle.write(line)

--- a/virtool/otus/utils.py
+++ b/virtool/otus/utils.py
@@ -51,6 +51,12 @@ def extract_default_sequences(joined: dict) -> List[dict]:
             return isolate["sequences"]
 
 
+def extract_sequences(otu):
+    for isolate in otu["isolates"]:
+        for sequence in isolate["sequences"]:
+            yield sequence
+
+
 def extract_sequence_ids(otu):
     """
     Extract all sequence ids from a merged otu.


### PR DESCRIPTION
Make the **Build Index** job support AODP barcode FASTA references.
- skip exeuting `bowtie-build` if reference is barcode type
- generate a complete reference FASTA instead of just default isolates
- add more tests