### PR TITLE
AODP targets

### DIFF
--- a/tests/jobs/test_build_index.py
+++ b/tests/jobs/test_build_index.py
@@ -210,7 +210,7 @@ def test_remove_unused_index_files(tmpdir):
         active_index_ids
     )
 
-    assert os.listdir(str(tmpdir)) == active_index_ids
+    assert set(os.listdir(str(tmpdir))) == set(active_index_ids)
 
     for index_id in active_index_ids:
         assert os.listdir(os.path.join(str(tmpdir), index_id)) == ["test.fa"]

--- a/tests/references/snapshots/snap_test_api.py
+++ b/tests/references/snapshots/snap_test_api.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import GenericRepr, Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_create[uvloop-genome] 1'] = {
+    'contributors': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'data_type': 'genome',
+    'description': 'A bunch of viruses used for testing',
+    'groups': [
+    ],
+    'id': '9pfsom1b',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Test Viruses',
+    'organism': 'virus',
+    'otu_count': 22,
+    'restrict_source_types': False,
+    'source_types': [
+        'strain',
+        'isolate'
+    ],
+    'unbuilt_change_count': 5,
+    'user': {
+        'id': 'test'
+    },
+    'users': [
+        {
+            'build': True,
+            'id': 'test',
+            'modify': True,
+            'modify_otu': True,
+            'remove': True
+        }
+    ]
+}
+
+snapshots['test_create[uvloop-barcode] 1'] = {
+    'contributors': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'data_type': 'barcode',
+    'description': 'A bunch of viruses used for testing',
+    'groups': [
+    ],
+    'id': '9pfsom1b',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Test Viruses',
+    'organism': 'virus',
+    'otu_count': 22,
+    'restrict_source_types': False,
+    'source_types': [
+        'strain',
+        'isolate'
+    ],
+    'targets': [
+    ],
+    'unbuilt_change_count': 5,
+    'user': {
+        'id': 'test'
+    },
+    'users': [
+        {
+            'build': True,
+            'id': 'test',
+            'modify': True,
+            'modify_otu': True,
+            'remove': True
+        }
+    ]
+}
+
+snapshots['test_edit_group_or_user[True-uvloop-group-None] 1'] = {
+    'build': False,
+    'id': 'tech',
+    'modify': False,
+    'modify_otu': False,
+    'remove': True
+}
+
+snapshots['test_edit_group_or_user[True-uvloop-group-None] 2'] = {
+    '_id': 'foo',
+    'groups': [
+        {
+            'build': False,
+            'id': 'tech',
+            'modify': False,
+            'modify_otu': False,
+            'remove': True
+        }
+    ],
+    'users': [
+        {
+            'build': False,
+            'id': 'fred',
+            'modify': False,
+            'modify_otu': False,
+            'remove': False
+        }
+    ]
+}
+
+snapshots['test_edit_group_or_user[True-uvloop-user-None] 1'] = {
+    'build': False,
+    'id': 'fred',
+    'identicon': 'foo_identicon',
+    'modify': False,
+    'modify_otu': False,
+    'remove': True
+}
+
+snapshots['test_edit_group_or_user[True-uvloop-user-None] 2'] = {
+    '_id': 'foo',
+    'groups': [
+        {
+            'build': False,
+            'id': 'tech',
+            'modify': False,
+            'modify_otu': False,
+            'remove': False
+        }
+    ],
+    'users': [
+        {
+            'build': False,
+            'id': 'fred',
+            'modify': False,
+            'modify_otu': False,
+            'remove': True
+        }
+    ]
+}
+
+snapshots['test_delete_group_or_user[True-uvloop-group-None] 1'] = {
+    '_id': 'foo',
+    'groups': [
+    ],
+    'users': [
+        {
+            'build': False,
+            'id': 'fred',
+            'modify': False,
+            'modify_otu': False,
+            'remove': False
+        }
+    ]
+}
+
+snapshots['test_delete_group_or_user[True-uvloop-user-None] 1'] = {
+    '_id': 'foo',
+    'groups': [
+        {
+            'build': False,
+            'id': 'tech',
+            'modify': False,
+            'modify_otu': False,
+            'remove': False
+        }
+    ],
+    'users': [
+    ]
+}
+
+snapshots['test_add_group_or_user[True-uvloop-group-None] 1'] = {
+    'build': False,
+    'created_at': '2015-10-06T20:00:00Z',
+    'id': 'tech',
+    'modify': True,
+    'modify_otu': False,
+    'remove': False
+}
+
+snapshots['test_add_group_or_user[True-uvloop-group-None] 2'] = {
+    '_id': 'foo',
+    'groups': [
+        {
+            'build': False,
+            'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+            'id': 'tech',
+            'modify': True,
+            'modify_otu': False,
+            'remove': False
+        }
+    ],
+    'users': [
+    ]
+}
+
+snapshots['test_add_group_or_user[True-uvloop-user-None] 1'] = {
+    'build': False,
+    'created_at': '2015-10-06T20:00:00Z',
+    'id': 'fred',
+    'identicon': 'foo_identicon',
+    'modify': True,
+    'modify_otu': False,
+    'remove': False
+}
+
+snapshots['test_add_group_or_user[True-uvloop-user-None] 2'] = {
+    '_id': 'foo',
+    'groups': [
+    ],
+    'users': [
+        {
+            'build': False,
+            'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+            'id': 'fred',
+            'modify': True,
+            'modify_otu': False,
+            'remove': False
+        }
+    ]
+}
+
+snapshots['test_edit[uvloop-None] 1'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Bar',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['test_edit[uvloop-None] 2'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'name': 'Bar',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['test_edit[uvloop-None-genome] 1'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Bar',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['test_edit[uvloop-None-genome] 2'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'name': 'Bar',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['test_edit[uvloop-None-barcode] 1'] = {
+    'contributors': [
+    ],
+    'data_type': 'barcode',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Bar',
+    'otu_count': 0,
+    'targets': [
+        {
+            'description': '',
+            'name': 'CPN60',
+            'required': True
+        }
+    ],
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['test_edit[uvloop-None-barcode] 2'] = {
+    '_id': 'foo',
+    'data_type': 'barcode',
+    'description': 'This is a test reference.',
+    'name': 'Bar',
+    'targets': [
+        {
+            'description': '',
+            'name': 'CPN60',
+            'required': True
+        }
+    ],
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}

--- a/tests/references/snapshots/snap_test_db.py
+++ b/tests/references/snapshots/snap_test_db.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['TestEdit.test_control[uvloop-None-True] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'internal_control': {
+        'id': 'bar'
+    },
+    'name': 'Tester',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-None-False] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'internal_control': {
+        'id': 'bar'
+    },
+    'name': 'Tester',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-True] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'internal_control': None,
+    'name': 'Tester',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-False] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'internal_control': None,
+    'name': 'Tester',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-baz-True] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'internal_control': {
+        'id': 'baz'
+    },
+    'name': 'Tester',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-baz-False] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'internal_control': None,
+    'name': 'Tester',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-None-True] 2'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': {
+        'id': 'baz'
+    },
+    'latest_build': None,
+    'name': 'Tester',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-None-False] 2'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Tester',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-True] 2'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': {
+        'id': 'baz'
+    },
+    'latest_build': None,
+    'name': 'Tester',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-False] 2'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Tester',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-baz-True] 2'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': {
+        'id': 'baz'
+    },
+    'latest_build': None,
+    'name': 'Tester',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_control[uvloop-baz-False] 2'] = {
+    'contributors': [
+    ],
+    'data_type': 'genome',
+    'description': 'This is a test reference.',
+    'id': 'foo',
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Tester',
+    'otu_count': 0,
+    'unbuilt_change_count': 0,
+    'users': [
+        {
+            'id': 'bob',
+            'identicon': 'abc123'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_reference_name[uvloop] 1'] = {
+    '_id': 'foo',
+    'data_type': 'genome',
+    'internal_control': {
+        'id': 'bar'
+    },
+    'name': 'Bar',
+    'users': [
+        {
+            'id': 'bob'
+        }
+    ]
+}
+
+snapshots['TestEdit.test_reference_name[uvloop] 2'] = [
+    {
+        '_id': 'baz',
+        'reference': {
+            'id': 'foo',
+            'name': 'Bar'
+        }
+    },
+    {
+        '_id': 'boo',
+        'reference': {
+            'id': 'foo',
+            'name': 'Bar'
+        }
+    }
+]

--- a/tests/references/snapshots/snap_test_migrate.py
+++ b/tests/references/snapshots/snap_test_migrate.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_add_targets_field[uvloop] 1'] = [
+    {
+        '_id': 'foo',
+        'data_type': 'genome'
+    },
+    {
+        '_id': 'bar',
+        'data_type': 'barcode',
+        'targets': [
+        ]
+    }
+]

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -191,7 +191,8 @@ async def test_find_indexes(mocker, spawn_client, id_exists, md_proxy, resp_is):
     )
 
 
-async def test_create(mocker, spawn_client, test_random_alphanumeric, static_time):
+@pytest.mark.parametrize("data_type", ["genome", "barcode"])
+async def test_create(data_type, mocker, snapshot, spawn_client, test_random_alphanumeric, static_time):
     client = await spawn_client(authorize=True, permissions=["create_ref"])
 
     default_source_type = [
@@ -204,7 +205,7 @@ async def test_create(mocker, spawn_client, test_random_alphanumeric, static_tim
     data = {
         "name": "Test Viruses",
         "description": "A bunch of viruses used for testing",
-        "data_type": "genome",
+        "data_type": data_type,
         "organism": "virus"
     }
 
@@ -215,31 +216,9 @@ async def test_create(mocker, spawn_client, test_random_alphanumeric, static_tim
 
     assert resp.status == 201
 
-    assert resp.headers["Location"] == "/api/refs/" + test_random_alphanumeric.history[0]
+    assert resp.headers["Location"] == f"/api/refs/{test_random_alphanumeric.history[0]}"
 
-    assert await resp.json() == dict(
-        data,
-        id=test_random_alphanumeric.history[0],
-        created_at="2015-10-06T20:00:00Z",
-        user={
-            "id": "test"
-        },
-        users=[{
-            "build": True,
-            "id": "test",
-            "modify": True,
-            "modify_otu": True,
-            "remove": True
-        }],
-        groups=[],
-        contributors=[],
-        internal_control=None,
-        restrict_source_types=False,
-        otu_count=22,
-        unbuilt_change_count=5,
-        source_types=default_source_type,
-        latest_build=None
-    )
+    snapshot.assert_match(await resp.json())
 
     m_get_otu_count.assert_called_with(
         client.db,
@@ -252,104 +231,83 @@ async def test_create(mocker, spawn_client, test_random_alphanumeric, static_tim
     )
 
 
-@pytest.mark.parametrize("control_exists", [True, False])
-@pytest.mark.parametrize("control_id", [None, "", "baz"])
-async def test_edit(control_exists, control_id, mocker, spawn_client, check_ref_right, id_exists, resp_is):
+@pytest.mark.parametrize("data_type", ["genome", "barcode"])
+@pytest.mark.parametrize("error", [None, "403", "404", "422"])
+async def test_edit(data_type, error, mocker, snapshot, spawn_client, resp_is):
     client = await spawn_client(authorize=True)
 
-    m_find_one_and_update = mocker.patch.object(
-        client.db.references,
-        "find_one_and_update",
-        make_mocked_coro({
+    if error != "404":
+        await client.db.references.insert_one({
             "_id": "foo",
-            "name": "Test Reference"
+            "data_type": data_type,
+            "name": "Foo",
+            "users": [
+                {
+                    "id": "bob"
+                }
+            ]
         })
-    )
 
-    m_get_computed = mocker.patch(
-        "virtool.references.db.get_computed",
-        make_mocked_coro({
-            "computed": True
-        })
-    )
-
-    m_get_internal_control = mocker.patch(
-        "virtool.references.db.get_internal_control",
-        make_mocked_coro({"id": "baz"} if control_exists else None)
-    )
+    await client.db.users.insert_one({
+        "_id": "bob",
+        "identicon": "abc123"
+    })
 
     data = {
-        "name": "Tester",
-        "description": "This is a test reference."
+        "name": "Bar",
+        "description": "This is a test reference.",
+        "targets": [
+            {
+                "name": "CPN60",
+                "description": "",
+                "required": True
+            }
+        ]
     }
 
-    if control_id is not None:
-        data["internal_control"] = control_id
+    if error == "422":
+        data["targets"] = [
+            {
+                "description": True
+            }
+        ]
+
+    can_modify = error != "403"
+
+    mocker.patch("virtool.references.db.check_right", make_mocked_coro(return_value=can_modify))
 
     resp = await client.patch("/api/refs/foo", data)
 
-    id_exists.assert_called_with(
-        client.db.references,
-        "foo"
-    )
+    if error == "422":
+        assert await resp_is.invalid_input(resp, {
+            "targets": [
+                {
+                    "0": [
+                        {
+                            "description": ["must be of string type"],
+                            "name": ["required field"]
+                        }
+                    ]
+                }
+            ]
+        })
+        return
 
-    if not id_exists:
+    if error == "404":
         assert await resp_is.not_found(resp)
         return
 
-    check_ref_right.assert_called_with(
-        mocker.ANY,
-        "foo",
-        "modify"
-    )
-
-    assert check_ref_right.called_with_req()
-
-    if not check_ref_right:
+    if error == "403":
         assert await resp_is.insufficient_rights(resp)
         return
 
-    expected_internal_control = None
-
-    if control_id and control_exists:
-        expected_internal_control = {
-            "id": "baz"
-        }
-
-    update = {
-        "description": "This is a test reference.",
-        "name": "Tester"
-    }
-
-    if control_id is not None:
-        update["internal_control"] = expected_internal_control
-
-    m_find_one_and_update.assert_called_with(
-        {
-            "_id": "foo"
-        },
-        {
-            "$set": update
-        }
-    )
-
-    m_get_computed.assert_called_with(
-        client.db,
-        "foo",
-        control_id
-    )
-
-    if control_id:
-        m_get_internal_control.assert_called_with(
-            client.db,
-            "baz",
-            "foo"
-        )
+    snapshot.assert_match(await resp.json())
+    snapshot.assert_match(await client.db.references.find_one())
 
 
 @pytest.mark.parametrize("error", [None, "400_dne", "400_exists", "404"])
 @pytest.mark.parametrize("field", ["group", "user"])
-async def test_add_group_or_user(error, field, spawn_client, check_ref_right, resp_is, static_time):
+async def test_add_group_or_user(error, field, snapshot, spawn_client, check_ref_right, resp_is, static_time):
     """
     Test that the group or user is added to the reference when no error condition exists.
 
@@ -419,24 +377,13 @@ async def test_add_group_or_user(error, field, spawn_client, check_ref_right, re
 
     assert resp.status == 201
 
-    expected = {
-        "id": "tech" if field == "group" else "fred",
-        "created_at": static_time.iso,
-        "build": False,
-        "modify": True,
-        "modify_otu": False,
-        "remove": False
-    }
-
-    if field == "user":
-        expected["identicon"] = "foo_identicon"
-
-    assert await resp.json() == expected
+    snapshot.assert_match(await resp.json())
+    snapshot.assert_match(await client.db.references.find_one())
 
 
 @pytest.mark.parametrize("error", [None, "404_field", "404_ref"])
 @pytest.mark.parametrize("field", ["group", "user"])
-async def test_edit_group_or_user(error, field, spawn_client, check_ref_right, resp_is):
+async def test_edit_group_or_user(error, field, snapshot, spawn_client, check_ref_right, resp_is):
     client = await spawn_client(authorize=True)
 
     document = {
@@ -488,41 +435,13 @@ async def test_edit_group_or_user(error, field, spawn_client, check_ref_right, r
 
     assert resp.status == 200
 
-    expected = {
-        "id": subdocument_id,
-        "build": False,
-        "modify": False,
-        "modify_otu": False,
-        "remove": True
-    }
-
-    if field == "user":
-        expected["identicon"] = "foo_identicon"
-
-    assert await resp.json() == expected
-
-    assert await client.db.references.find_one() == {
-        "_id": "foo",
-        "groups": [{
-            "id": "tech",
-            "build": False,
-            "modify": False,
-            "modify_otu": False,
-            "remove": field == "group"
-        }],
-        "users": [{
-            "id": "fred",
-            "build": False,
-            "modify": False,
-            "modify_otu": False,
-            "remove": field == "user"
-        }]
-    }
+    snapshot.assert_match(await resp.json())
+    snapshot.assert_match(await client.db.references.find_one())
 
 
 @pytest.mark.parametrize("error", [None, "404_field", "404_ref"])
 @pytest.mark.parametrize("field", ["group", "user"])
-async def test_delete_group_or_user(error, field, spawn_client, check_ref_right, resp_is):
+async def test_delete_group_or_user(error, field, snapshot, spawn_client, check_ref_right, resp_is):
     client = await spawn_client(authorize=True)
 
     document = {
@@ -567,15 +486,4 @@ async def test_delete_group_or_user(error, field, spawn_client, check_ref_right,
 
     assert resp.status == 204
 
-    if field == "group":
-        expected = {
-            **document,
-            "groups": []
-        }
-    else:
-        expected = {
-            **document,
-            "users": []
-        }
-
-    assert await client.db.references.find_one() == expected
+    snapshot.assert_match(await client.db.references.find_one())

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -197,7 +197,7 @@ class TestEdit:
         if control_id is not None:
             update["internal_control"] = control_id
 
-        m_get_internal_control = mocker.patch(
+        mocker.patch(
             "virtool.references.db.get_internal_control",
             make_mocked_coro({"id": "baz"} if control_exists else None)
         )
@@ -211,7 +211,7 @@ class TestEdit:
         snapshot.assert_match(await dbi.references.find_one())
         snapshot.assert_match(document)
 
-    async def test_reference_name(self, mocker, snapshot, dbi):
+    async def test_reference_name(self, snapshot, dbi):
         """
         Test that analyses that are linked to the edited reference have their `reference.name` fields changed when
         the `name` field of the reference changes.

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from aiohttp.test_utils import make_mocked_coro
 
 import pytest
 
@@ -156,6 +157,114 @@ async def test_create_manifest(dbi, test_otu):
         "foo": 5,
         "bar": 11
     }
+
+
+class TestEdit:
+
+    @pytest.mark.parametrize("control_exists", [True, False])
+    @pytest.mark.parametrize("control_id", [None, "", "baz"])
+    async def test_control(self, control_exists, control_id, mocker, snapshot, dbi):
+        """
+        Test that the `internal_control` field is correctly set with various `internal_control` input value and the case
+        where the internal control ID refers to a non-existent OTU.
+
+        The field should only be set when the input value is truthy and the control ID exists.
+
+        """
+        await dbi.users.insert_one({
+            "_id": "bob",
+            "identicon": "abc123"
+        })
+
+        await dbi.references.insert_one({
+            "_id": "foo",
+            "data_type": "genome",
+            "internal_control": {
+                "id": "bar"
+            },
+            "users": [
+                {
+                    "id": "bob"
+                }
+            ]
+        })
+
+        update = {
+            "name": "Tester",
+            "description": "This is a test reference."
+        }
+
+        if control_id is not None:
+            update["internal_control"] = control_id
+
+        m_get_internal_control = mocker.patch(
+            "virtool.references.db.get_internal_control",
+            make_mocked_coro({"id": "baz"} if control_exists else None)
+        )
+
+        document = await virtool.references.db.edit(
+            dbi,
+            "foo",
+            update
+        )
+
+        snapshot.assert_match(await dbi.references.find_one())
+        snapshot.assert_match(document)
+
+    async def test_reference_name(self, mocker, snapshot, dbi):
+        """
+        Test that analyses that are linked to the edited reference have their `reference.name` fields changed when
+        the `name` field of the reference changes.
+
+        """
+        await dbi.users.insert_one({
+            "_id": "bob",
+            "identicon": "abc123"
+        })
+
+        await dbi.references.insert_one({
+            "_id": "foo",
+            "name": "Foo",
+            "data_type": "genome",
+            "internal_control": {
+                "id": "bar"
+            },
+            "users": [
+                {
+                    "id": "bob"
+                }
+            ]
+        })
+
+        await dbi.analyses.insert_many([
+            {
+                "_id": "baz",
+                "reference": {
+                    "id": "foo",
+                    "name": "Foo"
+                }
+            },
+            {
+                "_id": "boo",
+                "reference": {
+                    "id": "foo",
+                    "name": "Foo"
+                }
+            }
+        ])
+
+        update = {
+            "name": "Bar"
+        }
+
+        await virtool.references.db.edit(
+            dbi,
+            "foo",
+            update
+        )
+
+        snapshot.assert_match(await dbi.references.find_one())
+        snapshot.assert_match(await dbi.analyses.find().to_list(None))
 
 
 @pytest.mark.parametrize("missing", [None, "reference", "subdocument"])

--- a/tests/references/test_migrate.py
+++ b/tests/references/test_migrate.py
@@ -1,0 +1,31 @@
+import virtool.references.migrate
+from aiohttp.test_utils import make_mocked_coro
+
+
+async def test_migrate_references(mocker, dbi):
+    app = {
+        "db": dbi
+    }
+
+    m_add_targets_field = mocker.patch("virtool.references.migrate.add_targets_field", make_mocked_coro())
+
+    await virtool.references.migrate.migrate_references(app)
+
+    m_add_targets_field.assert_called_with(dbi.motor_client)
+
+
+async def test_add_targets_field(snapshot, dbi):
+    await dbi.references.insert_many([
+        {
+            "_id": "foo",
+            "data_type": "genome"
+        },
+        {
+            "_id": "bar",
+            "data_type": "barcode"
+        }
+    ])
+
+    await virtool.references.migrate.add_targets_field(dbi.motor_client)
+
+    snapshot.assert_match(await dbi.references.find().to_list(None))

--- a/virtool/db/migrate.py
+++ b/virtool/db/migrate.py
@@ -7,6 +7,7 @@ import virtool.caches.migrate
 import virtool.db.utils
 import virtool.jobs.db
 import virtool.otus.utils
+import virtool.references.migrate
 import virtool.samples.migrate
 import virtool.users.utils
 import virtool.utils
@@ -30,6 +31,7 @@ async def migrate(app):
     await migrate_status(db, app["version"])
     await migrate_subtraction(db)
     await virtool.samples.migrate.migrate_samples(app)
+    await virtool.references.migrate.migrate_references(app)
 
 
 async def migrate_files(db):

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -335,13 +335,12 @@ async def create(req):
 
     user_id = req["client"].user_id
 
-    clone_from = data.get("clone_from", None)
-    import_from = data.get("import_from", None)
-    remote_from = data.get("remote_from", None)
-    release_id = data.get("release_id", None) or 11447367
+    clone_from = data.get("clone_from")
+    import_from = data.get("import_from")
+    remote_from = data.get("remote_from")
+    release_id = data.get("release_id") or 11447367
 
     if clone_from:
-
         if not await db.references.count({"_id": clone_from}):
             return bad_request("Source reference does not exist")
 
@@ -480,10 +479,6 @@ async def create(req):
         "type": "string",
         "coerce": virtool.validators.strip
     },
-    "data_type": {
-        "type": "string",
-        "allowed": ["genome", "barcode"]
-    },
     "organism": {
         "type": "string",
         "coerce": virtool.validators.strip
@@ -501,6 +496,30 @@ async def create(req):
             "coerce": virtool.validators.strip,
             "empty": False
         }
+    },
+    "targets": {
+        "type": "list",
+        "schema": {
+            "type": "dict",
+            "schema": {
+                "name": {
+                    "type": "string",
+                    "empty": False,
+                    "required": True
+                },
+                "description": {
+                    "type": "string",
+                    "default": ""
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": False
+                },
+                "length": {
+                    "type": "integer"
+                }
+            }
+        }
     }
 })
 async def edit(req):
@@ -515,39 +534,11 @@ async def edit(req):
     if not await virtool.references.db.check_right(req, ref_id, "modify"):
         return insufficient_rights()
 
-    internal_control_id = data.get("internal_control", None)
-
-    if internal_control_id == "":
-        data["internal_control"] = None
-
-    elif internal_control_id:
-        internal_control = await virtool.references.db.get_internal_control(db, internal_control_id, ref_id)
-
-        if internal_control is None:
-            data["internal_control"] = None
-        else:
-            data["internal_control"] = {
-                "id": internal_control_id
-            }
-
-    document = await db.references.find_one_and_update({"_id": ref_id}, {
-        "$set": data
-    })
-
-    document = virtool.utils.base_processor(document)
-
-    document.update(await virtool.references.db.get_computed(db, ref_id, internal_control_id))
-
-    if "name" in data:
-        await db.analyses.update_many({"reference.id": ref_id}, {
-            "$set": {
-                "reference.name": document["name"]
-            }
-        })
-
-    users = await virtool.db.utils.get_one_field(db.references, "users", ref_id)
-
-    document["users"] = await virtool.users.db.attach_identicons(db, users)
+    document = await virtool.references.db.edit(
+        db,
+        ref_id,
+        data
+    )
 
     return json_response(document)
 

--- a/virtool/references/migrate.py
+++ b/virtool/references/migrate.py
@@ -1,0 +1,23 @@
+TARGETS_QUERY = {
+    "data_type": "barcode",
+    "targets": {
+        "$exists": False
+    }
+}
+
+
+async def migrate_references(app):
+    db = app["db"].motor_client
+
+    await add_targets_field(db)
+
+
+async def add_targets_field(db):
+    await db.references.update_many(TARGETS_QUERY, {
+        "$set": {
+            "targets": []
+        }
+    })
+
+
+


### PR DESCRIPTION
- add support for AODP target field; this will be used to set allowable targets for a barcode reference
- add `targets` field to barcode references during migration
- add support for `targets` field to API (reference creation and editing)