### PR TITLE
AODP API changes

### DIFF
--- a/tests/references/snapshots/snap_test_api.py
+++ b/tests/references/snapshots/snap_test_api.py
@@ -219,37 +219,6 @@ snapshots['test_add_group_or_user[True-uvloop-user-None] 2'] = {
     ]
 }
 
-snapshots['test_edit[uvloop-None] 1'] = {
-    'contributors': [
-    ],
-    'data_type': 'genome',
-    'description': 'This is a test reference.',
-    'id': 'foo',
-    'internal_control': None,
-    'latest_build': None,
-    'name': 'Bar',
-    'otu_count': 0,
-    'unbuilt_change_count': 0,
-    'users': [
-        {
-            'id': 'bob',
-            'identicon': 'abc123'
-        }
-    ]
-}
-
-snapshots['test_edit[uvloop-None] 2'] = {
-    '_id': 'foo',
-    'data_type': 'genome',
-    'description': 'This is a test reference.',
-    'name': 'Bar',
-    'users': [
-        {
-            'id': 'bob'
-        }
-    ]
-}
-
 snapshots['test_edit[uvloop-None-genome] 1'] = {
     'contributors': [
     ],

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -535,6 +535,7 @@ async def create_sequence(req):
         db,
         otu_id,
         isolate_id,
+        None,
         ref_id,
         data
     )
@@ -605,6 +606,7 @@ async def edit_sequence(req):
         db,
         otu_id,
         isolate_id,
+        sequence_id,
         document["reference"]["id"],
         data
     )

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -534,6 +534,7 @@ async def create_sequence(req):
     message = await virtool.otus.sequences.check_segment_or_target(
         db,
         otu_id,
+        isolate_id,
         ref_id,
         data
     )
@@ -603,6 +604,7 @@ async def edit_sequence(req):
     message = await virtool.otus.sequences.check_segment_or_target(
         db,
         otu_id,
+        isolate_id,
         document["reference"]["id"],
         data
     )

--- a/virtool/otus/sequences.py
+++ b/virtool/otus/sequences.py
@@ -13,7 +13,7 @@ import virtool.otus.utils
 import virtool.utils
 
 
-async def check_segment_or_target(db, otu_id: str, isolate_id: str, ref_id: str, data: dict) -> Union[str, None]:
+async def check_segment_or_target(db, otu_id: str, isolate_id: str, sequence_id: Union[str, None], ref_id: str, data: dict) -> Union[str, None]:
     """
     Returns an error message string if the segment or target provided in `data` is not compatible with the parent
     reference (target) or OTU (segment).
@@ -23,6 +23,7 @@ async def check_segment_or_target(db, otu_id: str, isolate_id: str, ref_id: str,
     :param db: the application database object
     :param otu_id: the ID of the parent OTU
     :param isolate_id: the ID of the parent isolate
+    :param sequence_id: the ID of the sequence if one is being edited
     :param ref_id: the ID of the parent reference
     :param data: the data dict containing a target or segment value
     :return: message or `None` if check passes
@@ -31,18 +32,29 @@ async def check_segment_or_target(db, otu_id: str, isolate_id: str, ref_id: str,
     reference = await db.references.find_one(ref_id, ["data_type", "targets"])
 
     if reference["data_type"] == "barcode":
-        try:
-            target = data["target"]
-        except KeyError:
+        target = data.get("target")
+
+        if target is None and sequence_id is not None:
             return "The 'target' field is required for barcode references"
 
-        if target not in {t["name"] for t in reference.get("targets", [])}:
-            return f"Target {target} is not defined for the parent reference"
+        if target:
+            if target not in {t["name"] for t in reference.get("targets", [])}:
+                return f"Target {target} is not defined for the parent reference"
 
-        used_targets = await db.sequences.distinct("target", {"otu_id": otu_id, "isolate_id": isolate_id})
+            used_targets_query = {
+                "otu_id": otu_id,
+                "isolate_id": isolate_id
+            }
 
-        if target in used_targets:
-            return f"Target {target} is already used in isolate {isolate_id}"
+            if sequence_id:
+                used_targets_query["_id"] = {
+                    "$ne": sequence_id
+                }
+
+            used_targets = await db.sequences.distinct("target", used_targets_query)
+
+            if target in used_targets:
+                return f"Target {target} is already used in isolate {isolate_id}"
 
     if reference["data_type"] == "genome" and data.get("segment"):
         schema = await virtool.db.utils.get_one_field(db.otus, "schema", otu_id) or list()

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -534,6 +534,14 @@ async def edit(req):
     if not await virtool.references.db.check_right(req, ref_id, "modify"):
         return insufficient_rights()
 
+    targets = data.get("targets")
+
+    if targets:
+        names = [t["name"] for t in targets]
+
+        if len(names) != len(set(names)):
+            return bad_request("The targets field may not contain duplicate names")
+
     document = await virtool.references.db.edit(
         db,
         ref_id,


### PR DESCRIPTION
Return errors when:
- trying to create a sequence with a `target` that is already in use in the isolate
- trying to edit a sequence with a `target` that is in use in another sequence in the isolate
- trying to edit a reference with a `targets` field that contains duplicate names