### PR TITLE
No file manager

### DIFF
--- a/client/src/js/jobs/components/Step.js
+++ b/client/src/js/jobs/components/Step.js
@@ -27,7 +27,7 @@ const JobStepTimestamp = ({ timestamp }) => (
         <Icon name="clock" />
         <span>{format(new Date(timestamp), "hh:mm:ss")}</span>
         <Icon name="calendar" />
-        <span>{format(new Date(timestamp), "YYYY-MM-DD")}</span>
+        <span>{format(new Date(timestamp), "yyyy-MM-dd")}</span>
     </StyledJobStepTimestamp>
 );
 

--- a/tests/uploads/test_db.py
+++ b/tests/uploads/test_db.py
@@ -1,0 +1,31 @@
+import virtool.uploads.db
+
+
+async def test_finish_upload(mocker, dbi):
+    app = {
+        "db": dbi,
+        "settings": {
+            "data_path": "/foo"
+        }
+    }
+
+    stats = {
+        "size": 2048
+    }
+
+    await dbi.files.insert_one({
+        "_id": "bar",
+        "ready": False
+    })
+
+    mocker.patch("virtool.utils.file_stats", return_value=stats)
+
+    await virtool.uploads.db.finish_upload(app, "bar")
+
+    assert await dbi.files.find_one() == {
+        "_id": "bar",
+        "size": 2048,
+        "ready": True
+    }
+
+

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -3,6 +3,7 @@ import os
 from cerberus import Validator
 
 import virtool.files.db
+import virtool.uploads.db
 import virtool.samples.db
 import virtool.db.utils
 import virtool.http.routes
@@ -73,6 +74,8 @@ async def upload(req):
     file_id = document["id"]
 
     await naive_writer(req, file_id)
+
+    await virtool.uploads.db.finish_upload(req.app, file_id)
 
     headers = {
         "Location": f"/api/files/{file_id}"

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -1,0 +1,15 @@
+import os
+import virtool.utils
+
+
+async def finish_upload(app, file_id):
+    path = os.path.join(app["settings"]["data_path"], "files", file_id)
+
+    size = virtool.utils.file_stats(path)["size"]
+
+    await app["db"].files.update_one({"_id": file_id}, {
+        "$set": {
+            "size": size,
+            "ready": True
+        }
+    })


### PR DESCRIPTION
- make file uploads work when the file manager is disabled using `--no-file-manager`
- fix client crash in job detail view