### PR TITLE
Fix bug in check_segment_or_target()

### DIFF
--- a/tests/otus/test_sequences.py
+++ b/tests/otus/test_sequences.py
@@ -63,7 +63,7 @@ async def test_check_segment_or_target(data_type, defined, missing, used, sequen
         return
 
     if data_type == "barcode":
-        if sequence_id is not None and missing:
+        if sequence_id is None and missing:
             assert message == "The 'target' field is required for barcode references"
             return
 

--- a/virtool/otus/sequences.py
+++ b/virtool/otus/sequences.py
@@ -34,7 +34,7 @@ async def check_segment_or_target(db, otu_id: str, isolate_id: str, sequence_id:
     if reference["data_type"] == "barcode":
         target = data.get("target")
 
-        if target is None and sequence_id is not None:
+        if sequence_id is None and target is None:
             return "The 'target' field is required for barcode references"
 
         if target:


### PR DESCRIPTION
Was returning error incorrectly when editing barcode sequence. Didn't detect missing target field when adding new barcode sequence.