### PR TITLE
Add target support to OTU sequence editor

### DIFF
--- a/client/src/js/otus/actions.js
+++ b/client/src/js/otus/actions.js
@@ -202,7 +202,7 @@ export const removeIsolate = (otuId, isolateId, nextIsolateId) => ({
  * @param segment {string} the schema segment associated with the OTU
  * @returns {object}
  */
-export const addSequence = (otuId, isolateId, sequenceId, definition, host, sequence, segment) => ({
+export const addSequence = (otuId, isolateId, sequenceId, definition, host, sequence, segment, target) => ({
     type: ADD_SEQUENCE.REQUESTED,
     otuId,
     isolateId,
@@ -210,7 +210,8 @@ export const addSequence = (otuId, isolateId, sequenceId, definition, host, sequ
     definition,
     host,
     sequence,
-    segment
+    segment,
+    target
 });
 
 /**
@@ -336,7 +337,12 @@ export const showRemoveIsolate = simpleActionCreator(SHOW_REMOVE_ISOLATE);
  * @func
  * @returns {object}
  */
-export const showAddSequence = simpleActionCreator(SHOW_ADD_SEQUENCE);
+export const showAddSequence = targetName => {
+    return {
+        type: SHOW_ADD_SEQUENCE,
+        targetName
+    };
+};
 
 /**
  * Returns action for displaying the edit sequence modal.

--- a/client/src/js/otus/api.js
+++ b/client/src/js/otus/api.js
@@ -43,13 +43,14 @@ export const setIsolateAsDefault = ({ otuId, isolateId }) =>
 
 export const removeIsolate = ({ otuId, isolateId }) => Request.delete(`/api/otus/${otuId}/isolates/${isolateId}`);
 
-export const addSequence = ({ otuId, isolateId, sequenceId, definition, host, sequence, segment }) =>
+export const addSequence = ({ otuId, isolateId, sequenceId, definition, host, sequence, segment, target }) =>
     Request.post(`/api/otus/${otuId}/isolates/${isolateId}/sequences`).send({
         accession: sequenceId,
         definition,
         host,
         sequence,
-        segment
+        segment,
+        target
     });
 
 export const editSequence = ({ otuId, isolateId, sequenceId, definition, host, sequence, segment }) =>

--- a/client/src/js/otus/components/Detail/AddSequence.js
+++ b/client/src/js/otus/components/Detail/AddSequence.js
@@ -12,9 +12,10 @@ import React from "react";
 import { connect } from "react-redux";
 import { Modal, InputGroup, ControlLabel } from "react-bootstrap";
 import { get, find, concat, map } from "lodash-es";
-
 import { addSequence, hideOTUModal } from "../../actions";
+
 import { clearError } from "../../../errors/actions";
+
 import { Button, Icon, InputError, Loader } from "../../../base";
 import { getGenbank } from "../../api";
 import { getTargetChange } from "../../../utils/utils";
@@ -140,7 +141,8 @@ class AddSequence extends React.Component {
                 this.state.definition,
                 this.state.host,
                 this.state.sequence,
-                this.state.segment
+                this.state.segment,
+                this.props.targetName
             );
         } else {
             this.setState({
@@ -206,8 +208,11 @@ class AddSequence extends React.Component {
                 />
             </StyledAccessionSegmentCol>
         );
+
+        let targetName;
         if (this.props.dataType === "barcode") {
             AccessionSegmentCol = <StyledAccessionCol>{AccessionCol}</StyledAccessionCol>;
+            targetName = this.props.targetName;
         }
 
         return (
@@ -215,6 +220,7 @@ class AddSequence extends React.Component {
                 <Modal.Header onHide={this.props.onHide} closeButton>
                     Add Sequence
                 </Modal.Header>
+                <Modal.Body>{targetName}</Modal.Body>
                 <SequenceForm
                     host={this.state.host}
                     definition={this.state.definition}
@@ -231,22 +237,26 @@ class AddSequence extends React.Component {
     }
 }
 
-const mapStateToProps = state => ({
-    sequences: state.otus.activeIsolate.sequences,
-    show: state.otus.addSequence,
-    otuId: state.otus.detail.id,
-    isolateId: state.otus.activeIsolateId,
-    error: get(state, "errors.ADD_SEQUENCE_ERROR", ""),
-    dataType: state.references.detail.data_type
-});
+const mapStateToProps = state => {
+    return {
+        sequences: state.otus.activeIsolate.sequences,
+        show: !!state.otus.addSequence,
+        targetName: state.otus.addSequence,
+        otuId: state.otus.detail.id,
+        isolateId: state.otus.activeIsolateId,
+        error: get(state, "errors.ADD_SEQUENCE_ERROR", ""),
+        dataType: state.references.detail.data_type,
+        targets: state.references.detail.targets
+    };
+};
 
 const mapDispatchToProps = dispatch => ({
     onHide: () => {
         dispatch(hideOTUModal());
     },
 
-    onSave: (otuId, isolateId, sequenceId, definition, host, sequence, segment) => {
-        dispatch(addSequence(otuId, isolateId, sequenceId, definition, host, sequence, segment));
+    onSave: (otuId, isolateId, sequenceId, definition, host, sequence, segment, target) => {
+        dispatch(addSequence(otuId, isolateId, sequenceId, definition, host, sequence, segment, target));
     },
 
     onClearError: error => {

--- a/client/src/js/otus/components/Detail/AddSequence.js
+++ b/client/src/js/otus/components/Detail/AddSequence.js
@@ -241,7 +241,7 @@ const mapStateToProps = state => {
     return {
         sequences: state.otus.activeIsolate.sequences,
         show: !!state.otus.addSequence,
-        targetName: state.otus.addSequence,
+        targetName: state.otus.targetName,
         otuId: state.otus.detail.id,
         isolateId: state.otus.activeIsolateId,
         error: get(state, "errors.ADD_SEQUENCE_ERROR", ""),

--- a/client/src/js/otus/components/Detail/IsolateDetail.js
+++ b/client/src/js/otus/components/Detail/IsolateDetail.js
@@ -8,6 +8,7 @@ import { setIsolateAsDefault, showEditIsolate, showRemoveIsolate } from "../../a
 import EditIsolate from "./EditIsolate";
 import RemoveIsolate from "./RemoveIsolate";
 import IsolateSequences from "./Sequences";
+import IsolateTargets from "./Targets";
 
 const IsolateDetailBox = styled(BoxGroup)`
     margin: 0;
@@ -79,6 +80,13 @@ export class IsolateDetail extends React.Component {
             );
         }
 
+        const isolateComponent =
+            this.props.dataType === "barcode" ? (
+                <IsolateTargets />
+            ) : (
+                <IsolateSequences canModify={this.props.canModify} />
+            );
+
         return (
             <div>
                 <EditIsolate
@@ -107,7 +115,7 @@ export class IsolateDetail extends React.Component {
                             />
                         </div>
                     </IsolateDetailHeader>
-                    <IsolateSequences canModify={this.props.canModify} />
+                    {isolateComponent}
                 </IsolateDetailBox>
             </div>
         );

--- a/client/src/js/otus/components/Detail/Sequence.js
+++ b/client/src/js/otus/components/Detail/Sequence.js
@@ -6,6 +6,16 @@ import styled from "styled-components";
 import { Badge, BoxGroupSection, Icon, InfoLabel, Label, Table } from "../../../base";
 import { followDownload } from "../../../utils/utils";
 
+const TargetField = styled.div`
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+`;
+
+const Name = styled.div`
+    font-weight: bold;
+`;
+
 const SequenceHeader = styled.div`
     align-items: center;
     display: flex;
@@ -58,7 +68,11 @@ class Sequence extends React.Component {
         showEditSequence: PropTypes.func,
         showRemoveSequence: PropTypes.func,
         canModify: PropTypes.bool,
-        dataType: PropTypes.string
+        dataType: PropTypes.string,
+        name: PropTypes.string,
+        description: PropTypes.string,
+        required: PropTypes.string,
+        length: PropTypes.number
     };
 
     handleCloseClick = () => {
@@ -114,22 +128,44 @@ class Sequence extends React.Component {
         if (!this.state.in && this.props.segment) {
             segment = <InfoLabel className="text-mono">{this.props.segment}</InfoLabel>;
         }
-        const SegmentRow = () => {
-            if (this.props.dataType === "barcode") {
-                return null;
-            }
-            return (
+
+        let segmentTargetRow;
+
+        if (this.props.dataType === "barcode") {
+            segmentTargetRow = (
+                <tr>
+                    <th>Target</th>
+                    <td>
+                        <TargetField>
+                            <Name>{this.props.name}</Name>
+                            <span>{this.props.required}</span>
+                            <span>{this.props.length}</span>
+                        </TargetField>
+                        {this.props.description}
+                    </td>
+                </tr>
+            );
+        } else {
+            segmentTargetRow = (
                 <tr>
                     <th>Segment</th>
                     <td>{segment}</td>
                 </tr>
             );
-        };
+        }
+
+        const headerRow =
+            this.props.dataType === "barcode" ? (
+                <SequenceHeaderDefinition>{this.props.name}</SequenceHeaderDefinition>
+            ) : (
+                <SequenceHeaderDefinition>{this.props.definition}</SequenceHeaderDefinition>
+            );
+
         return (
             <BoxGroupSection onClick={this.state.in ? null : () => this.setState({ in: true })}>
                 <SequenceHeader>
                     <Label>{accession}</Label>
-                    <SequenceHeaderDefinition>{this.props.definition}</SequenceHeaderDefinition>
+                    {headerRow}
                     {segment}
                     {buttons}
                 </SequenceHeader>
@@ -145,7 +181,7 @@ class Sequence extends React.Component {
                                     <th>Definition</th>
                                     <td>{this.props.definition}</td>
                                 </tr>
-                                <SegmentRow />
+                                {segmentTargetRow}
                                 <tr>
                                     <th>Host</th>
                                     <td>{this.props.host}</td>
@@ -169,6 +205,7 @@ class Sequence extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    dataType: state.references.detail.data_type
+    dataType: state.references.detail.data_type,
+    targets: state.references.detail.targets
 });
 export default connect(mapStateToProps)(Sequence);

--- a/client/src/js/otus/components/Detail/Sequences.js
+++ b/client/src/js/otus/components/Detail/Sequences.js
@@ -50,12 +50,7 @@ export const IsolateSequences = props => {
                 <strong>Sequences</strong>
                 <Badge>{props.sequences.length}</Badge>
                 {props.canModify ? (
-                    <a
-                        href="#"
-                        onClick={() => {
-                            props.showAddSequence(props.targetName);
-                        }}
-                    >
+                    <a href="#" onClick={props.showAddSequence}>
                         Add Sequence
                     </a>
                 ) : null}
@@ -110,8 +105,8 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-    showAddSequence: targetName => {
-        dispatch(showAddSequence(targetName));
+    showAddSequence: () => {
+        dispatch(showAddSequence());
     },
 
     showEditSequence: sequenceId => {

--- a/client/src/js/otus/components/Detail/Target.js
+++ b/client/src/js/otus/components/Detail/Target.js
@@ -1,0 +1,47 @@
+import React from "react";
+import styled from "styled-components";
+import { BoxGroupSection, Button, Badge } from "../../../base";
+
+const TargetComponents = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 91px;
+`;
+
+const RequiredLength = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-left: 10px;
+    div {
+        color: ${props => props.theme.color.red};
+        font-weight: bold;
+    }
+`;
+
+const AddButton = styled.div`
+    display: flex;
+    justify-content: center;
+    padding-top: 15px;
+`;
+
+export class Target extends React.Component {
+    render() {
+        const lengthSection = this.props.length ? <Badge>{this.props.length}</Badge> : "";
+
+        return (
+            <BoxGroupSection>
+                <TargetComponents>
+                    <span>{this.props.name}</span>
+                    <RequiredLength>
+                        <div>{this.props.required}</div>
+                        {lengthSection}
+                    </RequiredLength>
+                </TargetComponents>
+                <span>{this.props.description}</span>
+                <AddButton>
+                    <Button onClick={this.props.onClick}>Add</Button>
+                </AddButton>
+            </BoxGroupSection>
+        );
+    }
+}

--- a/client/src/js/otus/components/Detail/Targets.js
+++ b/client/src/js/otus/components/Detail/Targets.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { connect } from "react-redux";
-import { differenceWith, filter, get, isEqual, map, find } from "lodash-es";
+import { get, map, find } from "lodash-es";
 import { BoxGroupSection } from "../../../base";
 import { checkRefRight, formatIsolateName } from "../../../utils/utils";
 import { showAddSequence, showEditSequence, showRemoveSequence } from "../../actions";
-import { getActiveIsolate, getTargetName, getSequences } from "../../selectors";
+import { getActiveIsolate, getSequences } from "../../selectors";
 import { Target } from "./Target";
 import AddSequence from "./AddSequence";
 import Sequence from "./Sequence";
@@ -55,53 +55,31 @@ export const IsolateTargets = props => {
             </BoxGroupSection>
 
             {targetComponents}
-            <EditSequence
-                otuId={props.otuId}
-                isolateId={props.activeIsolateId}
-                schema={props.schema}
-                error={props.error}
-            />
+            <EditSequence otuId={props.otuId} isolateId={props.activeIsolateId} error={props.error} />
 
-            <RemoveSequence
-                otuId={props.otuId}
-                isolateId={props.activeIsolateId}
-                isolateName={props.isolateName}
-                schema={props.schema}
-            />
+            <RemoveSequence otuId={props.otuId} isolateId={props.activeIsolateId} isolateName={props.isolateName} />
 
-            <AddSequence targetName={props.targetName} />
+            <AddSequence />
         </div>
     );
 };
 
 const mapStateToProps = state => {
     const activeIsolateId = state.otus.activeIsolateId;
-    const schema = state.otus.detail.schema;
 
     const activeIsolate = getActiveIsolate(state);
     const sequences = getSequences(state);
 
-    const targetName = getTargetName(state);
-
-    const originalSchema = map(schema, "name");
-    const sequencesWithSegment = filter(sequences, "segment");
-    const segmentsInUse = map(sequencesWithSegment, "segment");
-    const remainingSchema = differenceWith(originalSchema, segmentsInUse, isEqual);
-
     return {
-        remainingSchema,
         activeIsolateId,
         sequences,
-        schema,
-        targetName,
+
         otuId: state.otus.detail.id,
         editing: state.otus.editSequence,
         isolateName: formatIsolateName(activeIsolate),
         canModify: !get(state, "references.detail.remotes_from") && checkRefRight(state, "modify_otu"),
         error: get(state, "errors.EDIT_SEQUENCE_ERROR.message", ""),
-        targets: state.references.detail.targets,
-        schema: state.otus.detail.schema,
-        targetName: state.otus.addSequence
+        targets: state.references.detail.targets
     };
 };
 

--- a/client/src/js/otus/reducer.js
+++ b/client/src/js/otus/reducer.js
@@ -192,7 +192,7 @@ export default function OTUsReducer(state = initialState, action) {
             return { ...state, removeIsolate: true };
 
         case SHOW_ADD_SEQUENCE:
-            return { ...state, addSequence: true };
+            return { ...state, addSequence: action.targetName, targetName: action.targetName };
 
         case SHOW_EDIT_SEQUENCE:
             return { ...state, editSequence: action.sequenceId };

--- a/client/src/js/otus/reducer.js
+++ b/client/src/js/otus/reducer.js
@@ -192,7 +192,7 @@ export default function OTUsReducer(state = initialState, action) {
             return { ...state, removeIsolate: true };
 
         case SHOW_ADD_SEQUENCE:
-            return { ...state, addSequence: action.targetName, targetName: action.targetName };
+            return { ...state, addSequence: true, targetName: action.targetName };
 
         case SHOW_EDIT_SEQUENCE:
             return { ...state, editSequence: action.sequenceId };

--- a/client/src/js/otus/selectors.js
+++ b/client/src/js/otus/selectors.js
@@ -1,5 +1,40 @@
+import { find, indexOf, map, sortBy } from "lodash-es";
 import { getTermSelectorFactory } from "../utils/selectors";
 
 const getStateTerm = state => state.otus.term;
 
 export const getTerm = getTermSelectorFactory(getStateTerm);
+
+export const getTargetName = state => {
+    if (state.references.detail.targets) {
+        return state.references.detail.targets[0].name;
+    }
+    return null;
+};
+
+export const getSequences = state => {
+    const activeIsolate = getActiveIsolate(state);
+    const sequences = activeIsolate.sequences;
+    const originalSchema = map(state.otus.detail.schema, "name");
+    let index;
+
+    if (activeIsolate) {
+        return sortBy(sequences, [
+            entry => {
+                index = indexOf(originalSchema, entry.segment);
+                if (index !== -1) {
+                    return index;
+                }
+                return originalSchema.length;
+            }
+        ]);
+    }
+    return null;
+};
+
+export const getActiveIsolate = state => {
+    if (state.otus.detail.isolates.length) {
+        return find(state.otus.detail.isolates, { id: state.otus.activeIsolateId });
+    }
+    return null;
+};


### PR DESCRIPTION
- resolve #1638 
- add `Targets` component
- customize sequence add and edit dialogs for barcode references
- update API requests to include target field when required