### PR TITLE
Fix back button issues

### DIFF
--- a/client/src/js/account/components/API/Create.js
+++ b/client/src/js/account/components/API/Create.js
@@ -1,10 +1,10 @@
 import CX from "classnames";
-import { push } from "connected-react-router";
 import { mapValues } from "lodash-es";
 import React from "react";
 import { Col, Row } from "react-bootstrap";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { connect } from "react-redux";
+import { pushState } from "../../../app/actions";
 
 import { Button, Flex, FlexItem, Icon, Input, InputError, Modal, SaveButton } from "../../../base";
 import { routerLocationHasState } from "../../../utils/utils";
@@ -158,7 +158,7 @@ export const mapDispatchToProps = dispatch => ({
     },
 
     onHide: () => {
-        dispatch(push({ ...window.location, state: { createAPIKey: false } }));
+        dispatch(pushState({ createAPIKey: false }));
         dispatch(clearAPIKey());
     }
 });

--- a/client/src/js/account/components/API/__tests__/Create.test.js
+++ b/client/src/js/account/components/API/__tests__/Create.test.js
@@ -1,10 +1,6 @@
-import { CLEAR_API_KEY, CREATE_API_KEY } from "../../../../app/actionTypes";
-import { CreateAPIKey, getInitialState, mapDispatchToProps, mapStateToProps } from "../Create";
+import { CLEAR_API_KEY, CREATE_API_KEY, PUSH_STATE } from "../../../../app/actionTypes";
 import * as utils from "../../../../utils/utils";
-
-const connectedReactRouter = require("connected-react-router");
-
-jest.mock("connected-react-router");
+import { CreateAPIKey, getInitialState, mapDispatchToProps, mapStateToProps } from "../Create";
 
 const createMockEvent = value => {
     const e = {
@@ -183,16 +179,13 @@ describe("mapDispatchToProps()", () => {
     });
 
     it("should return functional props.onHide", () => {
-        const pushAction = {
-            type: "PUSH",
-            foo: "bar"
-        };
-
-        connectedReactRouter.push.mockReturnValue(pushAction);
-
         props.onHide();
-
-        expect(dispatch).toHaveBeenCalledWith(pushAction);
+        expect(dispatch).toHaveBeenCalledWith({
+            type: PUSH_STATE,
+            state: {
+                createAPIKey: false
+            }
+        });
         expect(dispatch).toHaveBeenCalledWith({
             type: CLEAR_API_KEY
         });

--- a/client/src/js/analyses/components/NuVs/Export.js
+++ b/client/src/js/analyses/components/NuVs/Export.js
@@ -4,15 +4,13 @@
  * @author igboyes
  *
  */
-import React from "react";
-import { push } from "connected-react-router";
 import { forEach, map, reduce, replace } from "lodash-es";
-import { connect } from "react-redux";
-
+import React from "react";
 import { Modal } from "react-bootstrap";
-
-import { followDynamicDownload, routerLocationHasState } from "../../../utils/utils";
+import { connect } from "react-redux";
+import { pushState } from "../../../app/actions";
 import { Button, ButtonGroup } from "../../../base/index";
+import { followDynamicDownload, routerLocationHasState } from "../../../utils/utils";
 import { getResults } from "../../selectors";
 import NuVsExportPreview from "./ExportPreview";
 
@@ -155,7 +153,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onHide: () => {
-        dispatch(push({ state: { export: false } }));
+        dispatch(pushState({ export: false }));
     }
 });
 

--- a/client/src/js/indexes/sagas.js
+++ b/client/src/js/indexes/sagas.js
@@ -1,6 +1,6 @@
-import { push } from "connected-react-router";
 import { get } from "lodash-es";
 import { all, put, select, takeEvery, takeLatest } from "redux-saga/effects";
+import { pushState } from "../app/actions";
 import {
     CREATE_INDEX,
     FIND_INDEXES,
@@ -67,7 +67,7 @@ export function* listReadyIndexes(action) {
 
 export function* createIndex(action) {
     const extraFunc = {
-        closeModal: put(push({ state: { rebuild: false } }))
+        closeModal: put(pushState({ rebuild: false }))
     };
     yield setPending(apiCall(indexesAPI.create, action, CREATE_INDEX, {}, extraFunc));
 }

--- a/client/src/js/nav/components/Sidebar.js
+++ b/client/src/js/nav/components/Sidebar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { connect } from "react-redux";
-import { Route, Switch, withRouter } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 import SidebarItem from "./SidebarItem";
 
 const StyledSidebar = styled.nav`
@@ -71,4 +71,4 @@ const mapStateToProps = state => ({
     administrator: state.account.administrator
 });
 
-export default withRouter(connect(mapStateToProps, null)(Sidebar));
+export default connect(mapStateToProps, null)(Sidebar);

--- a/client/src/js/otus/components/Create.js
+++ b/client/src/js/otus/components/Create.js
@@ -1,13 +1,12 @@
-import React from "react";
-import { connect } from "react-redux";
-import { push } from "connected-react-router";
-import { withRouter } from "react-router-dom";
-import { Modal } from "react-bootstrap";
 import { get } from "lodash-es";
-import { createOTU } from "../actions";
+import React from "react";
+import { Modal } from "react-bootstrap";
+import { connect } from "react-redux";
+import { pushState } from "../../app/actions";
 import { clearError } from "../../errors/actions";
+import { getTargetChange, routerLocationHasState } from "../../utils/utils";
+import { createOTU } from "../actions";
 import { getNextState } from "../utils";
-import { getTargetChange } from "../../utils/utils";
 import OTUForm from "./OTUForm";
 
 const getInitialState = () => ({
@@ -84,7 +83,7 @@ class CreateOTU extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    show: !!state.router.location.state && state.router.location.state.createOTU,
+    show: routerLocationHasState(state, "createOTU"),
     error: get(state, "errors.CREATE_OTU_ERROR.message", ""),
     pending: state.otus.createPending,
     refId: state.references.detail.id
@@ -95,8 +94,8 @@ const mapDispatchToProps = dispatch => ({
         dispatch(createOTU(refId, name, abbreviation));
     },
 
-    onHide: ({ location }) => {
-        dispatch(push({ ...location, state: { createOTU: false } }));
+    onHide: () => {
+        dispatch(pushState({ createOTU: false }));
     },
 
     onClearError: error => {
@@ -104,4 +103,4 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CreateOTU));
+export default connect(mapStateToProps, mapDispatchToProps)(CreateOTU);

--- a/client/src/js/otus/components/Detail/Editor.js
+++ b/client/src/js/otus/components/Detail/Editor.js
@@ -1,7 +1,6 @@
 import { get, map } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
-import { withRouter } from "react-router-dom";
 import styled from "styled-components";
 import { Badge, Box, BoxGroup, Icon, SectionHeader } from "../../../base";
 
@@ -114,4 +113,4 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(IsolateEditor));
+export default connect(mapStateToProps, mapDispatchToProps)(IsolateEditor);

--- a/client/src/js/otus/components/List.js
+++ b/client/src/js/otus/components/List.js
@@ -1,6 +1,6 @@
-import { push } from "connected-react-router";
 import React from "react";
 import { connect } from "react-redux";
+import { pushState } from "../../app/actions";
 import { LoadingPlaceholder, NoneFound, ScrollList } from "../../base";
 import RebuildAlert from "../../indexes/components/RebuildAlert";
 import ReferenceDetailHeader from "../../references/components/Detail/Header";
@@ -63,7 +63,7 @@ export const mapStateToProps = state => ({
 
 export const mapDispatchToProps = dispatch => ({
     onHide: () => {
-        dispatch(push({ state: { createOTU: false } }));
+        dispatch(pushState({ createOTU: false }));
     },
 
     onLoadNextPage: (refId, term, verified, page) => {

--- a/client/src/js/otus/components/__tests__/List.test.js
+++ b/client/src/js/otus/components/__tests__/List.test.js
@@ -1,3 +1,4 @@
+import { PUSH_STATE } from "../../../app/actionTypes";
 import { mapStateToProps, mapDispatchToProps, OTUsList } from "../List";
 
 describe("<OTUsList />", () => {
@@ -63,17 +64,10 @@ describe("mapDispatchToProps", () => {
     it("should return onHide in props", () => {
         props.onHide();
         expect(dispatch).toHaveBeenCalledWith({
-            payload: {
-                args: [
-                    {
-                        state: {
-                            createOTU: false
-                        }
-                    }
-                ],
-                method: "push"
-            },
-            type: "@@router/CALL_HISTORY_METHOD"
+            type: PUSH_STATE,
+            state: {
+                createOTU: false
+            }
         });
     });
 

--- a/client/src/js/otus/components/__tests__/__snapshots__/List.test.js.snap
+++ b/client/src/js/otus/components/__tests__/__snapshots__/List.test.js.snap
@@ -6,7 +6,7 @@ exports[`<OTUsList /> should render 1`] = `
   <Connect(ReferenceDetailTabs) />
   <Connect(RebuildAlert) />
   <Connect(OTUToolbar) />
-  <withRouter(Connect(CreateOTU))
+  <Connect(CreateOTU)
     documents={
       Array [
         "foo",
@@ -71,7 +71,7 @@ exports[`<OTUsList /> should render when [this.props.documents.length == false] 
   <Connect(ReferenceDetailTabs) />
   <Connect(RebuildAlert) />
   <Connect(OTUToolbar) />
-  <withRouter(Connect(CreateOTU))
+  <Connect(CreateOTU)
     documents={false}
     onLoadNextPage={
       [MockFunction] {

--- a/client/src/js/references/components/Add.js
+++ b/client/src/js/references/components/Add.js
@@ -1,14 +1,14 @@
 import React from "react";
-import styled from "styled-components";
-import { connect } from "react-redux";
-import { push } from "connected-react-router";
 import { Modal } from "react-bootstrap";
-import { routerLocationHasState } from "../../utils/utils";
+import { connect } from "react-redux";
+import styled from "styled-components";
+import { pushState } from "../../app/actions";
 import { TabLink, Tabs } from "../../base";
+import { routerLocationHasState } from "../../utils/utils";
+import CloneReference from "./Clone";
+import CreateReference from "./Create";
 
 import ImportReference from "./Import";
-import CreateReference from "./Create";
-import CloneReference from "./Clone";
 
 const AddReferenceTabs = styled(Tabs)`
     margin-bottom: 0;
@@ -104,7 +104,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => ({
     onHide: () => {
-        dispatch(push({ state: { newReference: false } }));
+        dispatch(pushState({ newReference: false }));
     }
 });
 

--- a/client/src/js/references/components/Detail/Edit.js
+++ b/client/src/js/references/components/Detail/Edit.js
@@ -1,12 +1,12 @@
 import React from "react";
-import { connect } from "react-redux";
-import { push } from "connected-react-router";
 import { Modal } from "react-bootstrap";
-import { ReferenceForm } from "../Form";
-import { editReference } from "../../actions";
-import { clearError } from "../../../errors/actions";
+import { connect } from "react-redux";
+import { pushState } from "../../../app/actions";
 import { SaveButton } from "../../../base";
-import { routerLocationHasState, getTargetChange } from "../../../utils/utils";
+import { clearError } from "../../../errors/actions";
+import { getTargetChange, routerLocationHasState } from "../../../utils/utils";
+import { editReference } from "../../actions";
+import { ReferenceForm } from "../Form";
 
 const getInitialState = detail => ({
     name: detail.name,
@@ -98,7 +98,7 @@ const mapDispatchToProps = dispatch => ({
     },
 
     onHide: () => {
-        dispatch(push({ state: { editReference: false } }));
+        dispatch(pushState({ editReference: false }));
     },
 
     onClearError: error => {

--- a/client/src/js/references/sagas.js
+++ b/client/src/js/references/sagas.js
@@ -1,5 +1,6 @@
 import { push } from "connected-react-router";
 import { put, takeEvery, takeLatest, throttle } from "redux-saga/effects";
+import { pushState } from "../app/actions";
 import {
     ADD_REFERENCE_GROUP,
     ADD_REFERENCE_USER,
@@ -48,14 +49,14 @@ export function* removeReference(action) {
 
 export function* importReference(action) {
     const extraFunc = {
-        closeModal: put(push({ state: { importReference: false } }))
+        closeModal: put(pushState({ importReference: false }))
     };
     yield setPending(apiCall(referenceAPI.importReference, action, IMPORT_REFERENCE, {}, extraFunc));
 }
 
 export function* cloneReference(action) {
     const extraFunc = {
-        closeModal: put(push({ state: { cloneReference: false } }))
+        closeModal: put(pushState({ cloneReference: false }))
     };
     yield setPending(apiCall(referenceAPI.cloneReference, action, CLONE_REFERENCE, {}, extraFunc));
 }

--- a/client/src/js/samples/components/Create/Create.js
+++ b/client/src/js/samples/components/Create/Create.js
@@ -1,8 +1,8 @@
-import { push } from "connected-react-router";
 import { filter, get, map, replace, split } from "lodash-es";
 import React from "react";
 import { Col, ControlLabel, InputGroup, Modal, Row } from "react-bootstrap";
 import { connect } from "react-redux";
+import { pushState } from "../../../app/actions";
 import { Button, Icon, InputError, LoadingPlaceholder, SaveButton } from "../../../base";
 import { clearError } from "../../../errors/actions";
 import { listSubtractionIds } from "../../../subtraction/actions";
@@ -288,7 +288,7 @@ const mapDispatchToProps = dispatch => ({
     },
 
     onHide: () => {
-        dispatch(push({ ...window.location, state: { create: false } }));
+        dispatch(pushState({ create: false }));
     },
 
     onClearError: error => {

--- a/client/src/js/samples/components/Edit.js
+++ b/client/src/js/samples/components/Edit.js
@@ -1,12 +1,12 @@
-import React from "react";
 import { get, pick } from "lodash-es";
-import { push } from "connected-react-router";
+import React from "react";
+import { Col, Modal, Row } from "react-bootstrap";
 import { connect } from "react-redux";
-import { Row, Col, Modal } from "react-bootstrap";
+import { pushState } from "../../app/actions";
+import { InputError, SaveButton } from "../../base";
+import { clearError } from "../../errors/actions";
 
 import { editSample } from "../actions";
-import { clearError } from "../../errors/actions";
-import { SaveButton, InputError } from "../../base";
 
 const getInitialState = ({ name, isolate, host, locale }) => ({
     name: name || "",
@@ -131,7 +131,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onHide: () => {
-        dispatch(push({ state: { showEdit: false } }));
+        dispatch(pushState({ showEdit: false }));
     },
 
     onEdit: (sampleId, update) => {

--- a/client/src/js/samples/components/Item.js
+++ b/client/src/js/samples/components/Item.js
@@ -1,10 +1,10 @@
-import { push } from "connected-react-router";
 import { find, includes } from "lodash-es";
 import React from "react";
 import { Col, Row } from "react-bootstrap";
 import { connect } from "react-redux";
 import { LinkContainer } from "react-router-bootstrap";
 import styled from "styled-components";
+import { pushState } from "../../app/actions";
 import { Checkbox, Flex, FlexItem, Icon, ListGroupItem, Loader, RelativeTime } from "../../base";
 import { selectSample } from "../actions";
 
@@ -134,7 +134,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         dispatch(selectSample(ownProps.id));
     },
     onQuickAnalyze: () => {
-        dispatch(push({ state: { createAnalysis: [ownProps.id] } }));
+        dispatch(pushState({ createAnalysis: [ownProps.id] }));
     }
 });
 

--- a/client/src/js/samples/components/Remove.js
+++ b/client/src/js/samples/components/Remove.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { connect } from "react-redux";
-import { push } from "connected-react-router";
+import { pushState } from "../../app/actions";
+import { RemoveModal } from "../../base";
 import { routerLocationHasState } from "../../utils/utils";
 import { removeSample } from "../actions";
-import { RemoveModal } from "../../base";
 
 export const RemoveSample = ({ id, name, show, onHide, onConfirm }) => (
     <RemoveModal noun="Sample" name={name} show={show} onConfirm={() => onConfirm(id)} onHide={onHide} />
@@ -23,7 +23,7 @@ const mapDispatchToProps = dispatch => ({
         dispatch(removeSample(sampleId));
     },
     onHide: () => {
-        dispatch(push({ state: { removeSample: false } }));
+        dispatch(pushState({ removeSample: false }));
     }
 });
 

--- a/client/src/js/samples/components/Toolbar.js
+++ b/client/src/js/samples/components/Toolbar.js
@@ -1,7 +1,7 @@
-import { push } from "connected-react-router";
 import React from "react";
 import { Col, FormControl, FormGroup, InputGroup, ListGroup, ListGroupItem, Row } from "react-bootstrap";
 import { connect } from "react-redux";
+import { pushState } from "../../app/actions";
 import { Button, Flex, FlexItem, Icon, LinkButton } from "../../base";
 import { checkAdminOrPermission } from "../../utils/utils";
 import { clearSampleSelection, findSamples } from "../actions";
@@ -100,7 +100,7 @@ const mapDispatchToProps = dispatch => ({
         dispatch(toggleSelectSample(sampleId));
     },
     onQuickAnalyze: selected => {
-        dispatch(push({ state: { createAnalysis: selected } }));
+        dispatch(pushState({ createAnalysis: selected }));
     }
 });
 

--- a/client/src/js/subtraction/components/Create.js
+++ b/client/src/js/subtraction/components/Create.js
@@ -1,10 +1,10 @@
-import { push } from "connected-react-router";
 import { filter, get, map } from "lodash-es";
 import React from "react";
 import { Col, Modal, Row } from "react-bootstrap";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { pushState } from "../../app/actions";
 import { BoxGroup, BoxGroupSection, Button, Icon, InputError, NoneFoundSection, RelativeTime } from "../../base";
 import { clearError } from "../../errors/actions";
 
@@ -206,7 +206,7 @@ const mapDispatchToProps = dispatch => ({
     },
 
     onHide: () => {
-        dispatch(push({ ...window.location, state: { createSubtraction: false } }));
+        dispatch(pushState({ createSubtraction: false }));
     },
 
     onClearError: error => {

--- a/client/src/js/subtraction/components/Detail.js
+++ b/client/src/js/subtraction/components/Detail.js
@@ -1,8 +1,8 @@
-import { push } from "connected-react-router";
 import { get } from "lodash-es";
 import numbro from "numbro";
 import React from "react";
 import { connect } from "react-redux";
+import { pushState } from "../../app/actions";
 import { Flex, FlexItem, Icon, LoadingPlaceholder, NotFound, Table, ViewHeader } from "../../base";
 import { checkAdminOrPermission } from "../../utils/utils";
 
@@ -124,7 +124,7 @@ const mapDispatchToProps = dispatch => ({
     },
 
     onShowRemove: () => {
-        dispatch(push({ state: { removeSubtraction: true } }));
+        dispatch(pushState({ removeSubtraction: true }));
     }
 });
 

--- a/client/src/js/subtraction/components/Remove.js
+++ b/client/src/js/subtraction/components/Remove.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { connect } from "react-redux";
-import { push } from "connected-react-router";
-import { removeSubtraction } from "../actions";
+import { pushState } from "../../app/actions";
 import { RemoveModal } from "../../base";
 import { routerLocationHasState } from "../../utils/utils";
+import { removeSubtraction } from "../actions";
 
 export const RemoveSubtraction = ({ id, show, onConfirm, onHide }) => (
     <RemoveModal id={id} name={id} noun="Subtraction" show={show} onHide={onHide} onConfirm={() => onConfirm(id)} />
@@ -15,7 +15,7 @@ export const mapStateToProps = state => ({
 
 export const mapDispatchToProps = dispatch => ({
     onHide: () => {
-        dispatch(push({ state: { removeSubtraction: false } }));
+        dispatch(pushState({ removeSubtraction: false }));
     },
 
     onConfirm: subtractionId => {

--- a/client/src/js/subtraction/components/__tests__/Remove.test.js
+++ b/client/src/js/subtraction/components/__tests__/Remove.test.js
@@ -1,7 +1,7 @@
 jest.mock("../../../utils/utils");
 
 import { push } from "connected-react-router";
-import { REMOVE_SUBTRACTION } from "../../../app/actionTypes";
+import { PUSH_STATE, REMOVE_SUBTRACTION } from "../../../app/actionTypes";
 import { RemoveSubtraction, mapStateToProps, mapDispatchToProps } from "../Remove";
 import { routerLocationHasState } from "../../../utils/utils";
 
@@ -57,7 +57,10 @@ describe("mapDispatchToProps", () => {
 
     it("should return onHide() in props", () => {
         props.onHide();
-        expect(dispatch).toHaveBeenCalledWith(push({ state: { removeSubtraction: false } }));
+        expect(dispatch).toHaveBeenCalledWith({
+            type: PUSH_STATE,
+            state: { removeSubtraction: false }
+        });
     });
 
     it("should return onConfirm() in props", () => {

--- a/client/src/js/updates/components/Install.js
+++ b/client/src/js/updates/components/Install.js
@@ -1,13 +1,13 @@
-import React from "react";
-import Request from "superagent";
 import { forEach, reduce, replace, split, trimEnd } from "lodash-es";
+import React from "react";
 import { Modal, ProgressBar } from "react-bootstrap";
 import { connect } from "react-redux";
-import { push } from "connected-react-router";
-
-import { installSoftwareUpdates } from "../actions";
+import Request from "superagent";
+import { pushState } from "../../app/actions";
 import { Button, Label, Loader } from "../../base";
 import { byteSize, routerLocationHasState } from "../../utils/utils";
+
+import { installSoftwareUpdates } from "../actions";
 import { ReleaseMarkdown } from "./Release";
 
 export const attemptReload = () => {
@@ -118,7 +118,7 @@ const mapDispatchToProps = dispatch => ({
     },
 
     onHide: () => {
-        dispatch(push({ state: { install: false } }));
+        dispatch(pushState({ install: false }));
     }
 });
 

--- a/client/src/js/updates/components/Releases.js
+++ b/client/src/js/updates/components/Releases.js
@@ -1,7 +1,7 @@
-import { push } from "connected-react-router";
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
+import { pushState } from "../../app/actions";
 import { Icon, Panel } from "../../base";
 import Install from "./Install";
 import ReleasesList from "./List";
@@ -38,7 +38,7 @@ export const mapStateToProps = state => ({
 
 export const mapDispatchToProps = dispatch => ({
     onShowInstall: () => {
-        dispatch(push({ state: { install: true } }));
+        dispatch(pushState({ install: true }));
     }
 });
 

--- a/client/src/js/updates/components/__tests__/Releases.test.js
+++ b/client/src/js/updates/components/__tests__/Releases.test.js
@@ -1,4 +1,5 @@
 import { push } from "connected-react-router";
+import { PUSH_STATE } from "../../../app/actionTypes";
 import { Releases, mapDispatchToProps, mapStateToProps } from "../Releases";
 
 describe("<Releases />", () => {
@@ -52,6 +53,9 @@ describe("mapDispatchToProps()", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
         props.onShowInstall();
-        expect(dispatch).toHaveBeenCalledWith(push({ state: { install: true } }));
+        expect(dispatch).toHaveBeenCalledWith({
+            type: PUSH_STATE,
+            state: { install: true }
+        });
     });
 });

--- a/client/src/js/users/components/Create.js
+++ b/client/src/js/users/components/Create.js
@@ -1,14 +1,14 @@
+import { get, pick } from "lodash-es";
 import React from "react";
-import { connect } from "react-redux";
-import { push } from "connected-react-router";
 import { Modal } from "react-bootstrap";
-import { pick, get } from "lodash-es";
+import { connect } from "react-redux";
 
 import styled from "styled-components";
-import { createUser } from "../actions";
+import { pushState } from "../../app/actions";
+import { Checkbox, device, InputError, SaveButton } from "../../base";
 import { clearError } from "../../errors/actions";
-import { InputError, Checkbox, SaveButton, device } from "../../base";
-import { routerLocationHasState, getTargetChange } from "../../utils/utils";
+import { getTargetChange, routerLocationHasState } from "../../utils/utils";
+import { createUser } from "../actions";
 
 const CreateUserContainer = styled.div`
     margin: 15px;
@@ -160,7 +160,7 @@ export const mapDispatchToProps = dispatch => ({
     },
 
     onHide: () => {
-        dispatch(push({ ...window.location, state: { createUser: false } }));
+        dispatch(pushState({ createUser: false }));
     },
 
     onClearError: error => {

--- a/client/src/js/users/components/__tests__/Create.test.js
+++ b/client/src/js/users/components/__tests__/Create.test.js
@@ -1,6 +1,4 @@
-jest.mock("connected-react-router");
-
-import { push } from "connected-react-router";
+import { PUSH_STATE } from "../../../app/actionTypes";
 import { CreateUser, mapDispatchToProps, mapStateToProps } from "../Create";
 
 describe("<CreateUser />", () => {
@@ -157,13 +155,8 @@ describe("mapDispatchToProps", () => {
         });
     });
     it("should return onHide() in props", () => {
-        push.mockReturnValue({
-            type: "PUSH"
-        });
-
-        result.onHide({ ...window.location, state: { createUser: false } });
-
-        expect(dispatch).toHaveBeenCalledWith({ type: "PUSH" });
+        result.onHide();
+        expect(dispatch).toHaveBeenCalledWith({ type: PUSH_STATE, state: { createUser: false } });
     });
 
     it("should return onClearError() in props", () => {

--- a/client/src/js/utils/sagas.js
+++ b/client/src/js/utils/sagas.js
@@ -7,6 +7,7 @@ import { push } from "connected-react-router";
 import { get, includes } from "lodash-es";
 import { matchPath } from "react-router-dom";
 import { all, put } from "redux-saga/effects";
+import { pushState } from "../app/actions";
 import { LOGOUT, SET_APP_PENDING, UNSET_APP_PENDING } from "../app/actionTypes";
 import { createFindURL } from "./utils";
 
@@ -89,7 +90,7 @@ export function* pushFindTerm(term, contains) {
  * @param update {object} a new state object
  */
 export function* pushHistoryState(update) {
-    yield put(push({ ...window.location, state: update }));
+    yield put(pushState(update));
 }
 
 /**

--- a/client/src/js/utils/sagas.js
+++ b/client/src/js/utils/sagas.js
@@ -3,7 +3,7 @@
  *
  * @module sagaUtils
  */
-import { push } from "connected-react-router";
+import { replace } from "connected-react-router";
 import { get, includes } from "lodash-es";
 import { matchPath } from "react-router-dom";
 import { all, put } from "redux-saga/effects";
@@ -79,7 +79,7 @@ export function* pushFindTerm(term, contains) {
     const url = createFindURL(term);
 
     if (!contains || includes(url.pathname, contains)) {
-        yield put(push(url.pathname + url.search));
+        yield put(replace(url.pathname + url.search));
     }
 }
 


### PR DESCRIPTION
- resolves #1189 
- fix situations where back button had to be clicked more times than expected
- due to extra navigation changes when calling `pushFindTerm`; use `replace` over `push`