### PR TITLE
Remove utility function pushHistoryState()

### DIFF
--- a/client/src/js/subtraction/sagas.js
+++ b/client/src/js/subtraction/sagas.js
@@ -1,5 +1,6 @@
 import { push } from "connected-react-router";
-import { call, put, takeLatest, throttle } from "redux-saga/effects";
+import { put, takeLatest, throttle } from "redux-saga/effects";
+import { pushState } from "../app/actions";
 import {
     CREATE_SUBTRACTION,
     FIND_SUBTRACTIONS,
@@ -8,7 +9,7 @@ import {
     REMOVE_SUBTRACTION,
     UPDATE_SUBTRACTION
 } from "../app/actionTypes";
-import { apiCall, pushFindTerm, pushHistoryState, setPending } from "../utils/sagas";
+import { apiCall, pushFindTerm, setPending } from "../utils/sagas";
 import * as subtractionAPI from "./api";
 
 export function* findSubtractions(action) {
@@ -22,7 +23,7 @@ export function* getSubtraction(action) {
 
 export function* createSubtraction(action) {
     const extraFunc = {
-        closeModal: call(pushHistoryState, { createSubtraction: false })
+        closeModal: put(pushState({ createSubtraction: false }))
     };
     yield setPending(apiCall(subtractionAPI.create, action, CREATE_SUBTRACTION, {}, extraFunc));
 }

--- a/client/src/js/users/sagas.js
+++ b/client/src/js/users/sagas.js
@@ -1,7 +1,8 @@
 import { push } from "connected-react-router";
 import { put, takeEvery, takeLatest, throttle } from "redux-saga/effects";
+import { pushState } from "../app/actions";
 import { CREATE_FIRST_USER, CREATE_USER, EDIT_USER, FIND_USERS, GET_USER, REMOVE_USER } from "../app/actionTypes";
-import { apiCall, pushFindTerm, pushHistoryState, setPending } from "../utils/sagas";
+import { apiCall, pushFindTerm, setPending } from "../utils/sagas";
 import * as usersAPI from "./api";
 
 function* findUsers(action) {
@@ -15,7 +16,7 @@ function* getUser(action) {
 
 function* createUser(action) {
     const extraFunc = {
-        closeModal: pushHistoryState({ createUser: false })
+        closeModal: put(pushState({ createUser: false }))
     };
 
     yield setPending(apiCall(usersAPI.create, action, CREATE_USER, {}, extraFunc));

--- a/client/src/js/utils/sagas.js
+++ b/client/src/js/utils/sagas.js
@@ -84,16 +84,6 @@ export function* pushFindTerm(term, contains) {
 }
 
 /**
- * Pushes new user-defined state to history.
- *
- * @generator
- * @param update {object} a new state object
- */
-export function* pushHistoryState(update) {
-    yield put(pushState(update));
-}
-
-/**
  * Should be called in the event of an HTTP error during an API call. Dispatches a ``FAILED`` request-style action
  * containing data related to the HTTP error.
  *


### PR DESCRIPTION
- remove generation utility function `pushHistoryState()`
- easily accomplished with `put(pushState(...))`