### PR TITLE
Fix crash in client when loading samples settings

### DIFF
--- a/client/src/js/samples/components/Samples.js
+++ b/client/src/js/samples/components/Samples.js
@@ -1,29 +1,20 @@
 import React from "react";
-import { Switch, Route } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
+import { Container } from "../../base";
 
 import FileManager from "../../files/components/Manager";
-import UniqueNames from "../../administration/components/UniqueNames";
-import SampleRights from "../../administration/components/SampleRights";
-import { Container, ViewHeader } from "../../base";
 import SampleDetail from "./Detail";
 import SamplesList from "./List";
+import SamplesSettings from "./Settings";
 
 export const SampleFileManager = () => <FileManager fileType="reads" />;
-
-export const SampleSettings = () => (
-    <div className="settings-container">
-        <ViewHeader title="Sample Settings" />
-        <UniqueNames />
-        <SampleRights />
-    </div>
-);
 
 export const Samples = () => (
     <Container>
         <Switch>
             <Route path="/samples" component={SamplesList} exact />
             <Route path="/samples/files" component={SampleFileManager} exact />
-            <Route path="/samples/settings" component={SampleSettings} />
+            <Route path="/samples/settings" component={SamplesSettings} />
             <Route path="/samples/:sampleId" component={SampleDetail} />
         </Switch>
     </Container>

--- a/client/src/js/samples/components/Settings.js
+++ b/client/src/js/samples/components/Settings.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { connect } from "react-redux";
+import SampleRights from "../../administration/components/SampleRights";
+import UniqueNames from "../../administration/components/UniqueNames";
+import { mapSettingsStateToProps } from "../../administration/mappers";
+import { LoadingPlaceholder, ViewHeader } from "../../base";
+
+export const SamplesSettings = ({ loading }) => {
+    if (loading) {
+        return <LoadingPlaceholder />;
+    }
+
+    return (
+        <div className="settings-container">
+            <ViewHeader title="Sample Settings" />
+            <UniqueNames />
+            <SampleRights />
+        </div>
+    );
+};
+
+export default connect(mapSettingsStateToProps)(SamplesSettings);

--- a/client/src/js/samples/components/__tests__/Samples.test.js
+++ b/client/src/js/samples/components/__tests__/Samples.test.js
@@ -1,15 +1,8 @@
-import Samples, { SampleFileManager, SampleSettings } from "../Samples";
+import Samples, { SampleFileManager } from "../Samples";
 
 describe("<SampleFileManager />", () => {
     it("should render", () => {
         const wrapper = shallow(<SampleFileManager />);
-        expect(wrapper).toMatchSnapshot();
-    });
-});
-
-describe("<SamplesSettings />", () => {
-    it("should render", () => {
-        const wrapper = shallow(<SampleSettings />);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/client/src/js/samples/components/__tests__/Settings.test.js
+++ b/client/src/js/samples/components/__tests__/Settings.test.js
@@ -1,0 +1,8 @@
+import { SamplesSettings } from "../Settings";
+
+describe("<SamplesSettings />", () => {
+    it.each([true, false])("should render when [loading=%p]", loading => {
+        const wrapper = shallow(<SamplesSettings loading={loading} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/client/src/js/samples/components/__tests__/__snapshots__/Samples.test.js.snap
+++ b/client/src/js/samples/components/__tests__/__snapshots__/Samples.test.js.snap
@@ -28,7 +28,15 @@ exports[`<Samples /> should render 1`] = `
       path="/samples/files"
     />
     <Route
-      component={[Function]}
+      component={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "WrappedComponent": [Function],
+          "compare": null,
+          "displayName": "Connect(SamplesSettings)",
+          "type": [Function],
+        }
+      }
       path="/samples/settings"
     />
     <Route
@@ -45,16 +53,4 @@ exports[`<Samples /> should render 1`] = `
     />
   </Switch>
 </Container>
-`;
-
-exports[`<SamplesSettings /> should render 1`] = `
-<div
-  className="settings-container"
->
-  <ViewHeader
-    title="Sample Settings"
-  />
-  <Connect(UniqueNames) />
-  <Connect(SampleRights) />
-</div>
 `;

--- a/client/src/js/samples/components/__tests__/__snapshots__/Settings.test.js.snap
+++ b/client/src/js/samples/components/__tests__/__snapshots__/Settings.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SamplesSettings /> should render when [loading=false] 1`] = `
+<div
+  className="settings-container"
+>
+  <ViewHeader
+    title="Sample Settings"
+  />
+  <Connect(UniqueNames) />
+  <Connect(SampleRights) />
+</div>
+`;
+
+exports[`<SamplesSettings /> should render when [loading=true] 1`] = `<LoadingPlaceholder />`;


### PR DESCRIPTION
- fix client crash when loading samples settings
- settings UI would be rendered even if settings hadn't been fetched yet