### PR TITLE
Motor update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ jdcal==1.4.1
 Mako==1.1.0
 MarkupSafe==1.1.1
 more-itertools==7.2.0
-motor==1.3.1
+motor==2.1.0
 multidict==4.5.2
 numpy==1.17.3
 openpyxl==2.6.2
@@ -41,7 +41,7 @@ pluggy==0.13.0
 psutil==5.6.5
 py==1.8.0
 pycparser==2.19
-pymongo==3.7.1
+pymongo==3.10.1
 pyparsing==2.4.4
 pytest==5.2.2
 pytest-aiohttp==0.3.0

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -375,7 +375,7 @@ async def test_remove_api_key(error, spawn_client, resp_is):
         return
 
     assert await resp_is.no_content(resp)
-    assert await client.db.keys.count() == 0
+    assert await client.db.keys.count_documents({}) == 0
 
 
 async def test_remove_all_api_keys(spawn_client, resp_is):

--- a/tests/caches/test_db.py
+++ b/tests/caches/test_db.py
@@ -107,7 +107,7 @@ async def test_remove(exception, dbi):
 
     await virtool.caches.db.remove(app, "baz")
 
-    assert await dbi.caches.count() == 0
+    assert await dbi.caches.count_documents({}) == 0
 
     app["run_in_thread"].assert_called_with(
         virtool.utils.rm,

--- a/tests/files/test_manager.py
+++ b/tests/files/test_manager.py
@@ -144,7 +144,7 @@ async def test_handle_create(tracked, dbi, test_manager_instance):
         }
     else:
         assert document is None
-        assert await dbi.files.count() == 0
+        assert await dbi.files.count_documents({}) == 0
 
 
 @pytest.mark.parametrize("tracked", [True, False])
@@ -197,4 +197,4 @@ async def test_handle_delete(dbi, test_manager_instance):
 
     await test_manager_instance.handle_delete(filename)
 
-    assert not await dbi.files.count()
+    assert not await dbi.files.count_documents({})

--- a/tests/groups/test_api.py
+++ b/tests/groups/test_api.py
@@ -163,7 +163,7 @@ async def test_remove(error, mocker, spawn_client, no_permissions, resp_is):
 
     assert resp.status == 204
 
-    assert not await client.db.groups.count({"_id": "test"})
+    assert not await client.db.groups.count_documents({"_id": "test"})
 
     m_update_member_users.assert_called_with(
         client.db,

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -123,11 +123,11 @@ async def test_tag_unbuilt_changes(dbi, create_mock_history):
             }
         })
 
-    assert await dbi.history.count({"index.id": "unbuilt"}) == 8
-    assert await dbi.history.count({"reference.id": "foobar", "index.id": "unbuilt"}) == 4
-    assert await dbi.history.count({"reference.id": "hxn167", "index.id": "unbuilt"}) == 4
+    assert await dbi.history.count_documents({"index.id": "unbuilt"}) == 8
+    assert await dbi.history.count_documents({"reference.id": "foobar", "index.id": "unbuilt"}) == 4
+    assert await dbi.history.count_documents({"reference.id": "hxn167", "index.id": "unbuilt"}) == 4
 
     await virtool.indexes.db.tag_unbuilt_changes(dbi, "hxn167", "foo", 5)
 
-    assert await dbi.history.count({"reference.id": "foobar", "index.id": "unbuilt"}) == 4
-    assert await dbi.history.count({"reference.id": "hxn167", "index.id": "foo", "index.version": 5}) == 4
+    assert await dbi.history.count_documents({"reference.id": "foobar", "index.id": "unbuilt"}) == 4
+    assert await dbi.history.count_documents({"reference.id": "hxn167", "index.id": "foo", "index.version": 5}) == 4

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -391,7 +391,7 @@ class TestEdit:
 
         assert resp.status == 200
         snapshot.assert_match(await resp.json())
-        assert await client.db.history.count() == 0
+        assert await client.db.history.count_documents({}) == 0
 
     async def test_not_found(self, spawn_client, resp_is):
         client = await spawn_client(authorize=True, permissions=["modify_otu"])
@@ -433,7 +433,7 @@ async def test_remove(abbreviation, exists, snapshot, spawn_client, check_ref_ri
         return
 
     assert resp.status == 204
-    assert await client.db.otus.find({"_id": "6116cba1"}).count() == 0
+    assert await client.db.otus.count_documents({"_id": "6116cba1"}) == 0
     snapshot.assert_match(await client.db.history.find_one(), "history")
 
 
@@ -793,7 +793,7 @@ class TestSetAsDefault:
 
         snapshot.assert_match(new, "joined")
 
-        assert await client.db.history.count() == 0
+        assert await client.db.history.count_documents({}) == 0
 
     @pytest.mark.parametrize("otu_id,isolate_id", [
         ("6116cba1", "test"),
@@ -827,7 +827,7 @@ class TestRemoveIsolate:
         await client.db.otus.insert_one(test_otu)
         await client.db.sequences.insert_one(test_sequence)
 
-        assert await client.db.otus.find({"isolates.id": "cab8b360"}).count() == 1
+        assert await client.db.otus.count_documents({"isolates.id": "cab8b360"}) == 1
 
         resp = await client.delete("/api/otus/6116cba1/isolates/cab8b360")
 
@@ -836,8 +836,8 @@ class TestRemoveIsolate:
             return
 
         assert resp.status == 204
-        assert await client.db.otus.find({"isolates.id": "cab8b360"}).count() == 0
-        assert await client.db.sequences.count() == 0
+        assert await client.db.otus.count_documents({"isolates.id": "cab8b360"}) == 0
+        assert await client.db.sequences.count_documents({}) == 0
 
         snapshot.assert_match(await client.db.history.find_one(), "history")
 
@@ -865,8 +865,8 @@ class TestRemoveIsolate:
             return
 
         assert resp.status == 204
-        assert await client.db.otus.find({"isolates.id": "cab8b360"}).count() == 0
-        assert not await client.db.sequences.count()
+        assert await client.db.otus.count_documents({"isolates.id": "cab8b360"}) == 0
+        assert not await client.db.sequences.count_documents({})
 
         snapshot.assert_match(await client.db.otus.find_one({"isolates.id": "bcb9b352"}), "otu")
         snapshot.assert_match(await client.db.history.find_one(), "history")

--- a/tests/otus/test_sequences.py
+++ b/tests/otus/test_sequences.py
@@ -285,4 +285,4 @@ async def test_remove(snapshot, dbi, test_otu, static_time):
     snapshot.assert_match(await dbi.otus.find_one())
     snapshot.assert_match(await dbi.history.find_one())
 
-    assert await dbi.sequences.count() == 0
+    assert await dbi.sequences.count_documents({}) == 0

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -275,4 +275,4 @@ class TestRemoveSamples:
 
         assert os.listdir(str(samples_dir)) == []
 
-        assert not await dbi.samples.count()
+        assert not await dbi.samples.count_documents({})

--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -221,7 +221,7 @@ async def update_api_key(req):
 
     key_id = req.match_info.get("key_id")
 
-    if not await db.keys.count({"id": key_id}):
+    if not await db.keys.count_documents({"id": key_id}):
         return not_found()
 
     user_id = req["client"].user_id

--- a/virtool/analyses/migrate.py
+++ b/virtool/analyses/migrate.py
@@ -39,7 +39,7 @@ async def add_subtractions_to_analyses(db):
     :return:
     """
     # Return early if all analyses have subtraction fields.
-    if await db.analyses.count({"subtraction": {"$exists": False}}) == 0:
+    if await db.analyses.count_documents({"subtraction": {"$exists": False}}) == 0:
         return
 
     pipeline = [

--- a/virtool/api.py
+++ b/virtool/api.py
@@ -247,7 +247,7 @@ async def paginate(
         sort=sort
     )
 
-    found_count = await asyncio.shield(cursor.count())
+    found_count = await collection.count_documents(db_query)
 
     page_count = int(math.ceil(found_count / per_page))
 
@@ -259,7 +259,7 @@ async def paginate(
 
         documents = [await collection.apply_processor(d) for d in await asyncio.shield(cursor.to_list(per_page))]
 
-    total_count = await collection.count(base_query)
+    total_count = await collection.count_documents(base_query)
 
     return {
         "documents": documents,

--- a/virtool/db/core.py
+++ b/virtool/db/core.py
@@ -50,7 +50,7 @@ class Collection:
         # No dispatches are necessary for these collection methods and they can be directly referenced instead of
         # wrapped.
         self.aggregate = self._collection.aggregate
-        self.count = self._collection.count
+        self.count_documents = self._collection.count_documents
         self.create_index = self._collection.create_index
         self.create_indexes = self._collection.create_indexes
         self.distinct = self._collection.distinct

--- a/virtool/db/migrate.py
+++ b/virtool/db/migrate.py
@@ -121,7 +121,7 @@ async def migrate_status(db, server_version):
             "release": None
         })
     except pymongo.errors.DuplicateKeyError:
-        if await db.hmm.count():
+        if await db.hmm.count_documents({}):
             await db.status.update_one({"_id": "hmm", "installed": {"$exists": False}}, {
                 "$set": {
                     "installed": None

--- a/virtool/db/utils.py
+++ b/virtool/db/utils.py
@@ -107,7 +107,7 @@ async def id_exists(collection, _id):
     :rtype: bool
 
     """
-    return bool(await collection.count({"_id": _id}))
+    return bool(await collection.count_documents({"_id": _id}))
 
 
 async def ids_exist(collection, id_list):
@@ -124,4 +124,4 @@ async def ids_exist(collection, id_list):
     :rtype: bool
 
     """
-    return await collection.count({"_id": {"$in": id_list}}) == len(id_list)
+    return await collection.count_documents({"_id": {"$in": id_list}}) == len(id_list)

--- a/virtool/files/db.py
+++ b/virtool/files/db.py
@@ -35,7 +35,7 @@ async def generate_file_id(db, filename: str) -> str:
     prefix = await virtool.db.utils.get_new_id(db.files)
     file_id = f"{prefix}-{filename}"
 
-    if await db.files.count({"_id": file_id}):
+    if await db.files.count_documents({"_id": file_id}):
         return await generate_file_id(db, filename)
 
     return file_id

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -95,7 +95,7 @@ async def install(req):
 
     user_id = req["client"].user_id
 
-    if await db.status.count({"_id": "hmm", "updates.ready": False}):
+    if await db.status.count_documents({"_id": "hmm", "updates.ready": False}):
         return conflict("Install already in progress")
 
     process = await virtool.processes.db.register(

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -182,7 +182,7 @@ async def index_handler(req: web.Request) -> web.Response:
     :return: the response
 
     """
-    requires_first_user = not await req.app["db"].users.count()
+    requires_first_user = not await req.app["db"].users.count_documents({})
 
     requires_login = not req["client"].user_id
 

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -120,13 +120,13 @@ async def create(req):
     if not await virtool.references.db.check_right(req, reference, "build"):
         return insufficient_rights()
 
-    if await db.indexes.count({"reference.id": ref_id, "ready": False}):
+    if await db.indexes.count_documents({"reference.id": ref_id, "ready": False}):
         return conflict("Index build already in progress")
 
-    if await db.otus.count({"reference.id": ref_id, "verified": False}):
+    if await db.otus.count_documents({"reference.id": ref_id, "verified": False}):
         return bad_request("There are unverified OTUs")
 
-    if not await db.history.count({"reference.id": ref_id, "index.id": "unbuilt"}):
+    if not await db.history.count_documents({"reference.id": ref_id, "index.id": "unbuilt"}):
         return bad_request("There are no unbuilt changes")
 
     index_id = await virtool.db.utils.get_new_id(db.indexes)
@@ -206,7 +206,7 @@ async def find_history(req):
 
     index_id = req.match_info["index_id"]
 
-    if not await db.indexes.count({"_id": index_id}):
+    if not await db.indexes.count_documents({"_id": index_id}):
         return not_found()
 
     term = req.query.get("term")

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -441,7 +441,7 @@ async def list_sequences(req):
     otu_id = req.match_info["otu_id"]
     isolate_id = req.match_info["isolate_id"]
 
-    if not await db.otus.find({"_id": otu_id, "isolates.id": isolate_id}).count():
+    if not await db.otus.count_documents({"_id": otu_id, "isolates.id": isolate_id}):
         return not_found()
 
     projection = list(virtool.otus.db.SEQUENCE_PROJECTION)
@@ -596,7 +596,7 @@ async def edit_sequence(req):
 
     document = await db.otus.find_one({"_id": otu_id, "isolates.id": isolate_id}, ["reference", "segment"])
 
-    if not document or not await db.sequences.count({"_id": sequence_id}):
+    if not document or not await db.sequences.count_documents({"_id": sequence_id}):
         return not_found()
 
     if not await virtool.references.db.check_right(req, document["reference"]["id"], "modify_otu"):
@@ -643,7 +643,7 @@ async def remove_sequence(req):
     isolate_id = req.match_info["isolate_id"]
     sequence_id = req.match_info["sequence_id"]
 
-    if not await db.sequences.count({"_id": sequence_id}):
+    if not await db.sequences.count_documents({"_id": sequence_id}):
         return not_found()
 
     document = await db.otus.find_one({"_id": otu_id, "isolates.id": isolate_id}, ["reference"])
@@ -671,7 +671,7 @@ async def list_history(req):
 
     otu_id = req.match_info["otu_id"]
 
-    if not await db.otus.find({"_id": otu_id}).count():
+    if not await db.otus.count_documents({"_id": otu_id}):
         return not_found()
 
     cursor = db.history.find({"otu.id": otu_id}, projection=virtool.history.db.LIST_PROJECTION)

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -47,7 +47,7 @@ async def check_name_and_abbreviation(
     name_count = 0
 
     if name:
-        name_count = await db.otus.count({
+        name_count = await db.otus.count_documents({
             "lower_name": name.lower(),
             "reference.id": ref_id
         })
@@ -55,7 +55,7 @@ async def check_name_and_abbreviation(
     abbr_count = 0
 
     if abbreviation:
-        abbr_count = await db.otus.count({
+        abbr_count = await db.otus.count_documents({
             "abbreviation": abbreviation,
             "reference.id": ref_id
         })

--- a/virtool/otus/sequences.py
+++ b/virtool/otus/sequences.py
@@ -189,7 +189,7 @@ async def get(db, otu_id: str, isolate_id: str, sequence_id: str) -> Union[dict,
     :return: the sequence document
 
     """
-    if not await db.otus.count({"_id": otu_id, "isolates.id": isolate_id}):
+    if not await db.otus.count_documents({"_id": otu_id, "isolates.id": isolate_id}):
         return None
 
     query = {

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -103,7 +103,7 @@ async def get_release(req):
     if not await virtool.db.utils.id_exists(db.references, ref_id):
         return not_found()
 
-    if not await db.references.count({"_id": ref_id, "remotes_from": {"$exists": True}}):
+    if not await db.references.count_documents({"_id": ref_id, "remotes_from": {"$exists": True}}):
         return bad_request("Not a remote reference")
 
     try:
@@ -210,7 +210,7 @@ async def find_history(req):
 
     ref_id = req.match_info["ref_id"]
 
-    if not await db.references.count({"_id": ref_id}):
+    if not await db.references.count_documents({"_id": ref_id}):
         return not_found()
 
     base_query = {
@@ -316,7 +316,7 @@ async def create(req):
     release_id = data.get("release_id") or 11447367
 
     if clone_from:
-        if not await db.references.count({"_id": clone_from}):
+        if not await db.references.count_documents({"_id": clone_from}):
             return bad_request("Source reference does not exist")
 
         manifest = await virtool.references.db.get_manifest(db, clone_from)
@@ -348,7 +348,7 @@ async def create(req):
         await aiojobs.aiohttp.spawn(req, p.run())
 
     elif import_from:
-        if not await db.files.count({"_id": import_from}):
+        if not await db.files.count_documents({"_id": import_from}):
             return not_found("File not found")
 
         path = os.path.join(req.app["settings"]["data_path"], "files", import_from)
@@ -571,7 +571,7 @@ async def list_groups(req):
     db = req.app["db"]
     ref_id = req.match_info["ref_id"]
 
-    if not await db.references.count({"_id": ref_id}):
+    if not await db.references.count_documents({"_id": ref_id}):
         return not_found()
 
     groups = await virtool.db.utils.get_one_field(db.references, "groups", ref_id)

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -272,7 +272,7 @@ class RemoveReferenceProcess(virtool.processes.process.Process):
         ref_id = self.context["ref_id"]
         user_id = self.context["user_id"]
 
-        otu_count = await self.db.otus.count({"reference.id": ref_id})
+        otu_count = await self.db.otus.count_documents({"reference.id": ref_id})
 
         tracker = self.get_tracker(otu_count)
 
@@ -467,10 +467,10 @@ async def add_group_or_user(db, ref_id, field, data):
 
     subdocument_id = data.get("group_id") or data["user_id"]
 
-    if field == "groups" and await db.groups.count({"_id": subdocument_id}) == 0:
+    if field == "groups" and await db.groups.count_documents({"_id": subdocument_id}) == 0:
         raise virtool.errors.DatabaseError("group does not exist")
 
-    if field == "users" and await db.users.count({"_id": subdocument_id}) == 0:
+    if field == "users" and await db.users.count_documents({"_id": subdocument_id}) == 0:
         raise virtool.errors.DatabaseError("user does not exist")
 
     if subdocument_id in [s["id"] for s in document[field]]:
@@ -854,7 +854,7 @@ async def get_otu_count(db, ref_id: str) -> int:
     :return: the OTU count
 
     """
-    return await db.otus.count({
+    return await db.otus.count_documents({
         "reference.id": ref_id
     })
 
@@ -868,7 +868,7 @@ async def get_unbuilt_count(db, ref_id: str) -> int:
     :return: the number of unbuilt changes
 
     """
-    return await db.history.count({
+    return await db.history.count_documents({
         "reference.id": ref_id,
         "index.id": "unbuilt"
     })
@@ -910,7 +910,7 @@ async def create_document(
         user_id: Union[str, None] = None,
         users=None
 ):
-    if ref_id and await db.references.count({"_id": ref_id}):
+    if ref_id and await db.references.count_documents({"_id": ref_id}):
         raise virtool.errors.DatabaseError("ref_id already exists")
 
     ref_id = ref_id or await virtool.db.utils.get_new_id(db.otus)

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -200,7 +200,7 @@ async def create(req):
         return bad_request(name_error_message)
 
     # Make sure a subtraction host was submitted and it exists.
-    if not await db.subtraction.count({"_id": data["subtraction"], "is_host": True}):
+    if not await db.subtraction.count_documents({"_id": data["subtraction"], "is_host": True}):
         return bad_request("Subtraction does not exist")
 
     # Make sure all of the passed file ids exist.
@@ -375,7 +375,7 @@ async def set_rights(req):
 
     sample_id = req.match_info["sample_id"]
 
-    if not await db.samples.count({"_id": sample_id}):
+    if not await db.samples.count_documents({"_id": sample_id}):
         return not_found()
 
     user_id = req["client"].user_id
@@ -504,10 +504,10 @@ async def analyze(req):
 
         raise
 
-    if not await db.references.count({"_id": ref_id}):
+    if not await db.references.count_documents({"_id": ref_id}):
         return bad_request("Reference does not exist")
 
-    if not await db.indexes.count({"reference.id": ref_id, "ready": True}):
+    if not await db.indexes.count_documents({"reference.id": ref_id, "ready": True}):
         return bad_request("No ready index")
 
     subtraction_id = data.get("subtraction_id")

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -102,7 +102,7 @@ async def check_name(db, settings, name, sample_id=None):
                 "$ne": sample_id
             }
 
-        if await db.samples.count(query):
+        if await db.samples.count_documents(query):
             return "Sample name is already in use"
 
     return None
@@ -205,7 +205,7 @@ async def periodically_prune_old_files(app: aiohttp.web.Application):
         sample_id = sample["_id"]
 
         # Count running analyses that are still using the old non-cache trimmed files.
-        count = await db.analyses.count({
+        count = await db.analyses.count_documents({
             "sample.id": sample_id,
             "ready": False,
             "cache": {
@@ -272,7 +272,7 @@ async def refresh_replacements(db, sample_id: str) -> list:
     for file in files:
         replacement = file.get("replacement")
 
-        if replacement and not await db.files.count({"_id": replacement["id"]}):
+        if replacement and not await db.files.count_documents({"_id": replacement["id"]}):
             file["replacement"] = None
 
     document = await db.samples.find_one_and_update({"_id": sample_id}, {
@@ -330,7 +330,7 @@ async def remove_samples(db, settings: dict, id_list: list) -> pymongo.results.D
 
 async def validate_force_choice_group(db, data):
     try:
-        if not await db.groups.count({"_id": data["group"]}):
+        if not await db.groups.count_documents({"_id": data["group"]}):
             return "Group does not exist"
 
     except KeyError:

--- a/virtool/samples/migrate.py
+++ b/virtool/samples/migrate.py
@@ -41,7 +41,7 @@ async def add_library_type(db):
     If the `srna` field is not defined `library_type` is set to normal.
 
     """
-    if await db.samples.count(LIBRARY_TYPE_QUERY):
+    if await db.samples.count_documents(LIBRARY_TYPE_QUERY):
         updates = list()
 
         async for document in db.samples.find(LIBRARY_TYPE_QUERY, ["_id", "srna"]):

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -38,7 +38,7 @@ async def find(req):
     )
 
     data.update({
-        "ready_count": await db.subtraction.count({"ready": True})
+        "ready_count": await db.subtraction.count_documents({"ready": True})
     })
 
     return json_response(data)
@@ -91,7 +91,7 @@ async def create(req):
 
     subtraction_id = data["subtraction_id"]
 
-    if await db.subtraction.count({"_id": subtraction_id}):
+    if await db.subtraction.count_documents({"_id": subtraction_id}):
         return bad_request("Subtraction name already exists")
 
     file_id = data["file_id"]
@@ -185,7 +185,7 @@ async def remove(req):
 
     subtraction_id = req.match_info["subtraction_id"]
 
-    if await db.samples.count({"subtraction.id": subtraction_id}):
+    if await db.samples.count_documents({"subtraction.id": subtraction_id}):
         return conflict("Has linked samples")
 
     delete_result = await db.subtraction.delete_one({"_id": subtraction_id})

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -133,7 +133,7 @@ async def create_first(req):
     db = req.app["db"]
     data = await req.json()
 
-    if await db.users.count():
+    if await db.users.count_documents({}):
         return conflict("Virtool already has at least one user")
 
     if data["user_id"] == "virtool":

--- a/virtool/users/db.py
+++ b/virtool/users/db.py
@@ -241,7 +241,7 @@ async def edit(db, user_id, administrator=None, force_reset=None, groups=None, p
 
 
 async def is_member_of_group(db, user_id, group_id):
-    return bool(await db.users.count({"_id": user_id, "groups": group_id}))
+    return bool(await db.users.count_documents({"_id": user_id, "groups": group_id}))
 
 
 async def validate_credentials(db, user_id, password):

--- a/virtool/users/sessions.py
+++ b/virtool/users/sessions.py
@@ -64,7 +64,7 @@ async def create_session_id(db: virtool.db.core.DB) -> str:
     """
     session_id = secrets.token_hex(32)
 
-    if await db.sessions.count({"_id": session_id}):
+    if await db.sessions.count_documents({"_id": session_id}):
         return await create_session_id(db)
 
     return session_id


### PR DESCRIPTION
- upgrade `motor` and `pymongo` (makes Virtool compatible with Python 3.7+ only)
- update usages of `count()` to `count_documents()`
- update instances of `find({}).count()` to `count_documents({})`