### PR TITLE
Analysis subtraction value fix

### DIFF
--- a/client/src/js/analyses/components/Pathoscope/Mapping.js
+++ b/client/src/js/analyses/components/Pathoscope/Mapping.js
@@ -114,12 +114,12 @@ export const AnalysisMapping = ({ index, reference, subtraction, toReference, to
 };
 
 const mapStateToProps = state => {
-    const { index, read_count, reference, subtracted_count } = state.analyses.detail;
+    const { index, read_count, reference, subtracted_count, subtraction } = state.analyses.detail;
 
     return {
         index,
         reference,
-        subtraction: state.samples.detail.subtraction,
+        subtraction,
         toReference: read_count,
         toSubtraction: subtracted_count,
         total: state.samples.detail.quality.count

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -14,6 +14,9 @@ async def test_get(ready, error, mocker, spawn_client, resp_is):
         "results": {},
         "sample": {
             "id": "baz"
+        },
+        "subtraction": {
+            "id": "Plum"
         }
     }
 
@@ -63,10 +66,7 @@ async def test_get(ready, error, mocker, spawn_client, resp_is):
 
         assert await resp.json() == {
             "id": "foo",
-            "formatted": True,
-            "subtraction": {
-                "id": "Apple"
-            }
+            "formatted": True
         }
 
         m_format_analysis.assert_called_with(
@@ -86,7 +86,7 @@ async def test_get(ready, error, mocker, spawn_client, resp_is):
                 "id": "baz"
             },
             "subtraction": {
-                "id": "Apple"
+                "id": "Plum"
             }
         }
 

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -47,10 +47,6 @@ async def get(req):
     if document["ready"]:
         document = await virtool.analyses.format.format_analysis(req.app, document)
 
-    document["subtraction"] = {
-        "id": sample["subtraction"]["id"]
-    }
-
     return json_response(virtool.utils.base_processor(document))
 
 


### PR DESCRIPTION
- resolves #1735 
- fix incorrect subtraction name showing in pathoscope mapping overview
- fix incorrect subtraction being return from `GET /api/analyses/:id`