### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ build_exe_options = {
         ("client/dist", "client"),
         "LICENSE",
         "templates",
-        "readme.md",
-        "/usr/lib/x86_64-linux-gnu/libssl.so",
-        "/usr/lib/x86_64-linux-gnu/libz.so"
+        "readme.md"
     ],
     "includes": [
         "asyncio.base_events"
@@ -39,6 +37,7 @@ executables = [
 ]
 
 classifiers=[
+    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7"
 ]
 


### PR DESCRIPTION
- add Python 3.6 compatibility to classifiers
- remove `include_files` entries for `libssl.so` and `libz.so`