### PR TITLE
Don't show fatal git error during startup

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import subprocess
 
-from virtool.app import find_server_version
+import virtool.version
 
 
 @pytest.mark.parametrize("source", [None, "git", "file"])
@@ -24,13 +24,13 @@ async def test_find_server_version(source, loop, mocker, tmpdir):
     tmpdir.join("VERSION")
 
     if source == "git":
-        assert await find_server_version(str(tmpdir)) == "1.0.13"
+        assert await virtool.version.determine_server_version(str(tmpdir)) == "1.0.13"
 
     elif source == "file":
         with open(os.path.join(str(tmpdir), "VERSION"), "w") as handle:
             handle.write("1.0.12")
 
-        assert await find_server_version(str(tmpdir)) == "1.0.12"
+        assert await virtool.version.determine_server_version(str(tmpdir)) == "1.0.12"
 
     else:
-        assert await find_server_version(str(tmpdir)) == "Unknown"
+        assert await virtool.version.determine_server_version(str(tmpdir)) == "Unknown"

--- a/virtool/version.py
+++ b/virtool/version.py
@@ -1,0 +1,53 @@
+import asyncio
+import os
+import subprocess
+import aiofiles
+
+import logging
+
+logger = logging.getLogger("app")
+
+
+async def determine_server_version(install_path="."):
+    loop = asyncio.get_event_loop()
+
+    version = await loop.run_in_executor(None, determine_server_version_from_git)
+
+    if version:
+        return version
+
+    try:
+        version_file_path = os.path.join(install_path, "VERSION")
+
+        async with aiofiles.open(version_file_path, "r") as version_file:
+            content = await version_file.read()
+            return content.rstrip()
+
+    except FileNotFoundError:
+        logger.critical("Could not determine software version.")
+        return "Unknown"
+
+
+def determine_server_version_from_git():
+    try:
+        command = [
+            "git",
+            "describe",
+            "--tags"
+        ]
+
+        output = subprocess.check_output(
+            command,
+            stderr=subprocess.STDOUT
+        )
+
+        output = output.decode().rstrip()
+
+        if not output or "Not a git repository" in output:
+            return None
+
+        return output
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    return None


### PR DESCRIPTION
- prevent 'Not a git repository' error from displaying in console during startup
- error displayed when trying to get version from git tag