### PR TITLE
Convert invalid FastQC per-base quality value lists to zeros

### DIFF
--- a/tests/jobs/test_fastqc.py
+++ b/tests/jobs/test_fastqc.py
@@ -33,3 +33,11 @@ def test_run_fastqc(paired, mocker):
         expected.append("/reads/reads_2.fq.gz")
 
     m_run_subprocess.assert_called_with(expected)
+
+
+@pytest.mark.parametrize("split_line,result", [
+    (["120-125", "NaN", "4.0", "8", "NaN"], [4, 4, 4, 4]),
+    (["120-125", "NaN", "NaN", "NaN", "NaN"], [0, 0, 0, 0])
+])
+def test_handle_base_quality_nan(split_line, result):
+    assert virtool.jobs.fastqc.handle_base_quality_nan(split_line) == result

--- a/virtool/jobs/fastqc.py
+++ b/virtool/jobs/fastqc.py
@@ -164,21 +164,27 @@ def run_fastqc(run_subprocess, proc, read_paths, fastqc_path):
     run_subprocess(command)
 
 
-def handle_base_quality_nan(split):
+def handle_base_quality_nan(split_line: list) -> list:
     """
+    Parse a per-base quality line containing NaN values.
 
-    :param split:
-    :return:
+    :param split_line: the quality line split into a List
+    :return: replacement values
+
     """
-    values = split[1:]
+    values = split_line[1:]
 
-    for value in split[1:]:
+    for value in values:
         try:
             value = round(int(value.split(".")[0]), 2)
             return [value for _ in values]
         except ValueError:
             pass
 
-    joined = ",".join(split)
+    # Return all zeroes if none of the quality values are numbers.
+    if set(values) == {"NaN"}:
+        return [0] * 4
+
+    joined = ",".join(split_line)
 
     raise ValueError(f"Could not parse base quality values '{joined}'")


### PR DESCRIPTION
- prevent exception during sample creation for samples with tailing N's
- convert `['NaN', 'NaN', 'NaN', 'NaN']` to `[0, 0, 0, 0]`