### PR TITLE
Process error logging

### DIFF
--- a/virtool/processes/process.py
+++ b/virtool/processes/process.py
@@ -1,5 +1,9 @@
-import virtool.processes.db
+import logging
+
 import virtool.db.utils
+import virtool.processes.db
+
+logger = logging.getLogger("process")
 
 
 class Process:
@@ -76,6 +80,9 @@ class Process:
         )
 
         await self.cleanup()
+
+        for error in errors:
+            logger.info(f"Process {id} encountered error '{error}'")
 
 
 class ProgressTracker:

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -139,18 +139,18 @@ class ImportReferenceProcess(virtool.processes.process.Process):
         try:
             self.import_data = await self.run_in_thread(virtool.references.utils.load_reference_file, path)
         except json.decoder.JSONDecodeError as err:
-            return self.error([{
+            return await self.error([{
                 "id": "json_error",
                 "message": str(err).split("JSONDecodeError: ")[1]
             }])
         except OSError as err:
             if "Not a gzipped file" in str(err):
-                return self.error([{
+                return await self.error([{
                     "id": "not_gzipped",
                     "message": "Not a gzipped file"
                 }])
             else:
-                return self.error([{
+                return await self.error([{
                     "id": "unhandled",
                     "message": str(err)
                 }])


### PR DESCRIPTION
- fix `Process.error` calls not being awaited
- log errors in `Process` instances
