### PR TITLE
Fix too-short sessions

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -1,6 +1,7 @@
 import aiohttp.web
 
 import virtool.analyses.utils
+import virtool.http.utils
 import virtool.users.checks
 import virtool.account.db
 import virtool.users.sessions
@@ -330,8 +331,8 @@ async def login(req):
 
     resp = json_response({"reset": False}, status=201)
 
-    resp.set_cookie("session_id", session["_id"], httponly=True)
-    resp.set_cookie("session_token", token, httponly=True)
+    virtool.http.utils.set_session_id_cookie(resp, session["_id"])
+    virtool.http.utils.set_session_token_cookie(resp, token)
 
     return resp
 
@@ -353,7 +354,7 @@ async def logout(req):
 
     resp = aiohttp.web.Response(status=200)
 
-    resp.set_cookie("session_id", session["_id"])
+    virtool.http.utils.set_session_id_cookie(resp, session["_id"])
     resp.del_cookie("session_token")
 
     return resp
@@ -416,8 +417,8 @@ async def reset(req):
         "reset": False
     }, status=200)
 
-    resp.set_cookie("session_id", new_session["_id"], httponly=True)
-    resp.set_cookie("session_token", token, httponly=True)
+    virtool.http.utils.set_session_id_cookie(resp, new_session["_id"])
+    virtool.http.utils.set_session_token_cookie(resp, token)
 
     # Authenticate and return a redirect response to the `return_to` path. This is identical to the process used for
     # successful login requests.

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -7,6 +7,7 @@ import mako.template
 from aiohttp import web
 
 import virtool.app_routes
+import virtool.http.utils
 import virtool.users.sessions
 import virtool.users.db
 import virtool.db.utils
@@ -166,7 +167,7 @@ async def middleware(req, handler):
     if req.path != "/api/account/reset":
         await virtool.users.sessions.clear_reset_code(db, session["_id"])
 
-    resp.set_cookie("session_id", req["client"].session_id, httponly=True)
+    virtool.http.utils.set_session_id_cookie(resp, req["client"].session_id)
 
     if req.path == "/api/":
         resp.del_cookie("session_token")

--- a/virtool/http/utils.py
+++ b/virtool/http/utils.py
@@ -1,4 +1,5 @@
 import aiofiles
+import aiohttp.web_response
 
 import virtool.errors
 import virtool.http.proxy
@@ -36,3 +37,11 @@ async def download_file(app, url, target_path, progress_handler=None):
 
                 if progress_handler:
                     await progress_handler(len(chunk))
+
+
+def set_session_id_cookie(resp: aiohttp.web_response.Response, session_id: str):
+    resp.set_cookie("session_id", session_id, httponly=True, max_age=2600000)
+
+
+def set_session_token_cookie(resp: aiohttp.web_response.Response, session_token: str):
+    resp.set_cookie("session_token", session_token, httponly=True, max_age=2600000)

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -1,3 +1,4 @@
+import virtool.http.utils
 import virtool.users.checks
 import virtool.hmm.db
 import virtool.users.sessions
@@ -177,8 +178,8 @@ async def create_first(req):
         status=201
     )
 
-    resp.set_cookie("session_id", session["_id"])
-    resp.set_cookie("session_token", token)
+    virtool.http.utils.set_session_id_cookie(resp, session["_id"])
+    virtool.http.utils.set_session_token_cookie(resp, token)
 
     return resp
 


### PR DESCRIPTION
- define resuable functions for setting session cookie values
- set cookie expiry of `2600000` seconds (sessions expired at browsing session end)