### PR TITLE
Allow deletion of all subtractions

### DIFF
--- a/client/src/js/samples/components/General.js
+++ b/client/src/js/samples/components/General.js
@@ -106,7 +106,11 @@ export const SampleDetailGeneral = ({
                     <tr>
                         <th>Subtraction</th>
                         <td>
-                            <Link to={`/subtraction/${subtraction.id}`}>{subtraction.name}</Link>
+                            {subtraction ? (
+                                <Link to={`/subtraction/${subtraction.id}`}>{subtraction.name}</Link>
+                            ) : (
+                                "None"
+                            )}
                         </td>
                     </tr>
                 </tbody>

--- a/client/src/js/subtraction/components/Detail.js
+++ b/client/src/js/subtraction/components/Detail.js
@@ -43,26 +43,21 @@ export class SubtractionDetail extends React.Component {
             return <LoadingPlaceholder message="Subtraction is still being imported" />;
         }
 
-        let editIcon;
-        let removeIcon;
-
-        if (this.props.canModify) {
-            editIcon = <Icon name="pencil-alt" color="orange" onClick={() => this.setState({ showEdit: true })} />;
-
-            if (!detail.linked_samples.length) {
-                removeIcon = <Icon name="trash" color="red" onClick={this.props.onShowRemove} />;
-            }
-        }
-
         return (
             <div>
                 <ViewHeader title={detail.name}>
                     <ViewHeaderTitle>
                         {detail.name}
-                        <ViewHeaderIcons>
-                            {editIcon}
-                            {removeIcon}
-                        </ViewHeaderIcons>
+                        {this.props.canModify && (
+                            <ViewHeaderIcons>
+                                <Icon
+                                    name="pencil-alt"
+                                    color="orange"
+                                    onClick={() => this.setState({ showEdit: true })}
+                                />
+                                <Icon name="trash" color="red" onClick={this.props.onShowRemove} />
+                            </ViewHeaderIcons>
+                        )}
                     </ViewHeaderTitle>
                 </ViewHeader>
 

--- a/client/src/js/subtraction/components/__tests__/Detail.test.js
+++ b/client/src/js/subtraction/components/__tests__/Detail.test.js
@@ -14,7 +14,7 @@ describe("<SubtractionDetail />", () => {
                     { id: "bar", name: "Bar" },
                     { id: "baz", name: "Baz" }
                 ],
-                file: { id: "foo-file" },
+                file: { id: "123-Foo.fa.gz", name: "Foo.fa.gz" },
                 gc: { a: 0.2, t: 0.2, g: 0.2, c: 0.2, n: 0.2 },
                 nickname: "foo-nickname"
             },
@@ -49,14 +49,14 @@ describe("<SubtractionDetail />", () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it("should render remove button when there are no linked samples", () => {
-        props.detail.linked_samples = [];
+    it("should not render icons when [canModify=false]", () => {
+        props.canModify = false;
         const wrapper = shallow(<SubtractionDetail {...props} />);
         expect(wrapper).toMatchSnapshot();
     });
 
-    it("should not render icons when [canModify=false]", () => {
-        props.canModify = false;
+    it("should render file id when name not defined", () => {
+        delete props.detail.file.name;
         const wrapper = shallow(<SubtractionDetail {...props} />);
         expect(wrapper).toMatchSnapshot();
     });

--- a/client/src/js/subtraction/components/__tests__/__snapshots__/Detail.test.js.snap
+++ b/client/src/js/subtraction/components/__tests__/__snapshots__/Detail.test.js.snap
@@ -7,7 +7,6 @@ exports[`<SubtractionDetail /> should not render icons when [canModify=false] 1`
   >
     <ViewHeader__ViewHeaderTitle>
       Foo
-      <ViewHeader__ViewHeaderIcons />
     </ViewHeader__ViewHeaderTitle>
   </ViewHeader>
   <Table>
@@ -25,7 +24,7 @@ exports[`<SubtractionDetail /> should not render icons when [canModify=false] 1`
           File
         </th>
         <td>
-          foo-file
+          Foo.fa.gz
         </td>
       </tr>
       <tr>
@@ -75,6 +74,13 @@ exports[`<SubtractionDetail /> should render 1`] = `
           name="pencil-alt"
           onClick={[Function]}
         />
+        <Icon
+          color="red"
+          faStyle="fas"
+          fixedWidth={false}
+          name="trash"
+          onClick={[MockFunction]}
+        />
       </ViewHeader__ViewHeaderIcons>
     </ViewHeader__ViewHeaderTitle>
   </ViewHeader>
@@ -93,7 +99,82 @@ exports[`<SubtractionDetail /> should render 1`] = `
           File
         </th>
         <td>
-          foo-file
+          Foo.fa.gz
+        </td>
+      </tr>
+      <tr>
+        <th>
+          Sequence Count
+        </th>
+        <td />
+      </tr>
+      <tr>
+        <th>
+          GC Estimate
+        </th>
+        <td>
+          0.400
+        </td>
+      </tr>
+      <tr>
+        <th>
+          Linked Samples
+        </th>
+        <td>
+          2
+        </td>
+      </tr>
+    </tbody>
+  </Table>
+  <Connect(EditSubtraction)
+    onHide={[Function]}
+    show={false}
+  />
+  <Connect(RemoveSubtraction) />
+</div>
+`;
+
+exports[`<SubtractionDetail /> should render file id when name not defined 1`] = `
+<div>
+  <ViewHeader
+    title="Foo"
+  >
+    <ViewHeader__ViewHeaderTitle>
+      Foo
+      <ViewHeader__ViewHeaderIcons>
+        <Icon
+          color="orange"
+          faStyle="fas"
+          fixedWidth={false}
+          name="pencil-alt"
+          onClick={[Function]}
+        />
+        <Icon
+          color="red"
+          faStyle="fas"
+          fixedWidth={false}
+          name="trash"
+          onClick={[MockFunction]}
+        />
+      </ViewHeader__ViewHeaderIcons>
+    </ViewHeader__ViewHeaderTitle>
+  </ViewHeader>
+  <Table>
+    <tbody>
+      <tr>
+        <th>
+          Nickname
+        </th>
+        <td>
+          foo-nickname
+        </td>
+      </tr>
+      <tr>
+        <th>
+          File
+        </th>
+        <td>
+          123-Foo.fa.gz
         </td>
       </tr>
       <tr>
@@ -136,79 +217,4 @@ exports[`<SubtractionDetail /> should render pending message when subtraction is
 <LoadingPlaceholder
   message="Subtraction is still being imported"
 />
-`;
-
-exports[`<SubtractionDetail /> should render remove button when there are no linked samples 1`] = `
-<div>
-  <ViewHeader
-    title="Foo"
-  >
-    <ViewHeader__ViewHeaderTitle>
-      Foo
-      <ViewHeader__ViewHeaderIcons>
-        <Icon
-          color="orange"
-          faStyle="fas"
-          fixedWidth={false}
-          name="pencil-alt"
-          onClick={[Function]}
-        />
-        <Icon
-          color="red"
-          faStyle="fas"
-          fixedWidth={false}
-          name="trash"
-          onClick={[MockFunction]}
-        />
-      </ViewHeader__ViewHeaderIcons>
-    </ViewHeader__ViewHeaderTitle>
-  </ViewHeader>
-  <Table>
-    <tbody>
-      <tr>
-        <th>
-          Nickname
-        </th>
-        <td>
-          foo-nickname
-        </td>
-      </tr>
-      <tr>
-        <th>
-          File
-        </th>
-        <td>
-          foo-file
-        </td>
-      </tr>
-      <tr>
-        <th>
-          Sequence Count
-        </th>
-        <td />
-      </tr>
-      <tr>
-        <th>
-          GC Estimate
-        </th>
-        <td>
-          0.400
-        </td>
-      </tr>
-      <tr>
-        <th>
-          Linked Samples
-        </th>
-        <td>
-          0
-        </td>
-      </tr>
-    </tbody>
-  </Table>
-  <Connect(EditSubtraction)
-    onHide={[Function]}
-    show={false}
-  />
-  <Connect(RemoveSubtraction) />
-</div>
 `;

--- a/tests/subtractions/test_migrate.py
+++ b/tests/subtractions/test_migrate.py
@@ -1,6 +1,39 @@
 import virtool.subtractions.migrate
 
 
+async def test_add_deleted_field(dbi):
+    await dbi.subtraction.insert_many([
+        {
+            "_id": "Foo",
+            "deleted": False
+        },
+        {
+            "_id": "Bar",
+            "deleted": True
+        },
+        {
+            "_id": "Baz"
+        }
+    ])
+
+    await virtool.subtractions.migrate.add_deleted_field(dbi)
+
+    assert await dbi.subtraction.find().to_list(None) == [
+        {
+            "_id": "Foo",
+            "deleted": False
+        },
+        {
+            "_id": "Bar",
+            "deleted": True
+        },
+        {
+            "_id": "Baz",
+            "deleted": False
+        }
+    ]
+
+
 async def test_add_name_field(dbi):
     await dbi.subtraction.insert_many([
         {

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -1,4 +1,7 @@
+import shutil
+
 import virtool.db.utils
+import virtool.subtractions.utils
 import virtool.utils
 
 PROJECTION = [
@@ -13,15 +16,42 @@ PROJECTION = [
 ]
 
 
-async def get_linked_samples(db, subtraction_id):
-    cursor = db.samples.find({"subtraction.id": subtraction_id}, ["name"])
-    return [virtool.utils.base_processor(d) async for d in cursor]
-
-
 async def attach_subtraction(db, document: dict):
-    if "subtraction" in document:
+    if document.get("subtraction"):
         document["subtraction"]["name"] = await virtool.db.utils.get_one_field(
             db.subtraction,
             "name",
             document["subtraction"]["id"]
         )
+
+
+async def get_linked_samples(db, subtraction_id):
+    cursor = db.samples.find({"subtraction.id": subtraction_id}, ["name"])
+    return [virtool.utils.base_processor(d) async for d in cursor]
+
+
+async def unlink_default_subtractions(db, subtraction_id):
+    await db.samples.update_many({"subtraction.id": subtraction_id}, {
+        "$set": {
+            "subtraction": None
+        }
+    })
+
+
+async def delete(app, subtraction_id):
+    db = app["db"]
+    settings = app["settings"]
+
+    update_result = await db.subtraction.update_one({"_id": subtraction_id, "deleted": False}, {
+        "$set": {
+            "deleted": True
+        }
+    })
+
+    await unlink_default_subtractions(db, subtraction_id)
+
+    if update_result.modified_count:
+        index_path = virtool.subtractions.utils.calculate_index_path(settings, subtraction_id)
+        await app["run_in_thread"](shutil.rmtree, index_path, True)
+
+    return update_result.modified_count

--- a/virtool/subtractions/migrate.py
+++ b/virtool/subtractions/migrate.py
@@ -4,6 +4,12 @@ import virtool.db.migrate
 
 logger = logging.getLogger("migrate")
 
+DELETE_QUERY = {
+    "deleted": {
+        "$exists": False
+    }
+}
+
 NAME_QUERY = {
     "name": {
         "$exists": False
@@ -17,6 +23,15 @@ async def migrate_subtractions(app):
     await virtool.db.migrate.delete_unready(db.subtraction)
 
     await add_name_field(db)
+    await add_deleted_field(db)
+
+
+async def add_deleted_field(db):
+    await db.subtraction.update_many(DELETE_QUERY, {
+        "$set": {
+            "deleted": False
+        }
+    })
 
 
 async def add_name_field(db):


### PR DESCRIPTION
- allow deletion of subtractions with linked samples
- subtractions are not actually fully deleted; they have the `deleted` field set  and their files are removed from disk.
- deleted subtractions are not returned in search results