### PR TITLE
Fix sort order for Pathoscope

### DIFF
--- a/client/src/js/analyses/selectors.js
+++ b/client/src/js/analyses/selectors.js
@@ -98,13 +98,13 @@ export const getSortIds = createSelector([getWorkflow, getResults, getSortKey], 
             return map(sortBy(results, "sequence.length").reverse(), "id");
 
         case "depth":
-            return map(sortBy(results, "depth"), "id");
+            return map(sortBy(results, "depth").reverse(), "id");
 
         case "coverage":
             return map(sortBy(results, "coverage").reverse(), "id");
 
         case "weight":
-            return map(sortBy(results, "pi"), "id");
+            return map(sortBy(results, "pi").reverse(), "id");
 
         case "identity":
             return map(sortBy(results, "identity").reverse(), "id");


### PR DESCRIPTION
- reverse the depth and weight sort orders to make more sense
- items with higher depths and weights are shown at the top of the list now