### PR TITLE
Use Accept headers

### DIFF
--- a/client/src/js/account/api.js
+++ b/client/src/js/account/api.js
@@ -4,7 +4,7 @@
  * @module account/api
  */
 
-import Request from "superagent";
+import { Request } from "../app/request";
 
 /**
  * Gets the complete data for the current account.

--- a/client/src/js/administration/api.js
+++ b/client/src/js/administration/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const get = () => Request.get("/api/settings");
 

--- a/client/src/js/analyses/api.js
+++ b/client/src/js/analyses/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ sampleId, term, page = 1 }) =>
     Request.get(`/api/samples/${sampleId}/analyses`).query({ find: term, page });

--- a/client/src/js/app/request.js
+++ b/client/src/js/app/request.js
@@ -1,0 +1,11 @@
+import Superagent from "superagent";
+
+const createRequest = method => url => Superagent[method](url).set("Accept", "application/json");
+
+export const Request = {
+    get: createRequest("get"),
+    post: createRequest("post"),
+    patch: createRequest("patch"),
+    put: createRequest("put"),
+    delete: createRequest("delete")
+};

--- a/client/src/js/caches/api.js
+++ b/client/src/js/caches/api.js
@@ -1,9 +1,4 @@
-/**
- * Functions for communication with API endpoints related to sample caches.
- *
- * @module files/api
- */
-import Request from "superagent";
+import { Request } from "../app/request";
 
 /**
  * Get the cache record identified get ``cacheId``..

--- a/client/src/js/files/api.js
+++ b/client/src/js/files/api.js
@@ -3,7 +3,7 @@
  *
  * @module files/api
  */
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ fileType, page, perPage }) =>
     Request.get("/api/files").query({

--- a/client/src/js/groups/api.js
+++ b/client/src/js/groups/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const list = () => Request.get("/api/groups");
 

--- a/client/src/js/hmm/api.js
+++ b/client/src/js/hmm/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ term, page }) => Request.get("/api/hmms").query({ find: term, page });
 

--- a/client/src/js/indexes/api.js
+++ b/client/src/js/indexes/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ refId, term, page }) => Request.get(`/api/refs/${refId}/indexes`).query({ find: term, page });
 

--- a/client/src/js/jobs/api.js
+++ b/client/src/js/jobs/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ term, page }) => Request.get("/api/jobs").query({ find: term, page });
 

--- a/client/src/js/otus/api.js
+++ b/client/src/js/otus/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ refId, term, verified, page }) =>
     Request.get(`/api/refs/${refId}/otus`).query({ find: term, page, verified: verified ? false : undefined });

--- a/client/src/js/processes/api.js
+++ b/client/src/js/processes/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const list = () => Request.get("/api/processes");
 

--- a/client/src/js/references/api.js
+++ b/client/src/js/references/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ term, page }) => Request.get("/api/refs").query({ find: term, page });
 

--- a/client/src/js/samples/api.js
+++ b/client/src/js/samples/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ term, page, pathoscope, nuvs }) =>
     Request.get("/api/samples").query({

--- a/client/src/js/subtraction/api.js
+++ b/client/src/js/subtraction/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ term, page }) => Request.get("/api/subtractions").query({ find: term, page });
 

--- a/client/src/js/updates/api.js
+++ b/client/src/js/updates/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const get = () => Request.get("/api/software");
 

--- a/client/src/js/users/api.js
+++ b/client/src/js/users/api.js
@@ -1,4 +1,4 @@
-import Request from "superagent";
+import { Request } from "../app/request";
 
 export const find = ({ term, page }) => Request.get("/api/users").query({ find: term, page });
 

--- a/virtool/api/json.py
+++ b/virtool/api/json.py
@@ -11,16 +11,28 @@ class CustomEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def dumps(obj):
+def dumps(obj: object) -> str:
     """
-    A wrapper for :func:`json.dumps` that applies pretty formatting to the output. Used as ``dumps`` argument for
+    A wrapper for :func:`json.dumps` is able to encode datetime objects in input. Used as ``dumps`` argument for
     :func:`.json_response`.
 
     :param obj: a JSON-serializable object
-    :type obj: object
-
     :return: a JSON string
-    :rtype: str
-
     """
-    return json.dumps(obj, indent=4, sort_keys=False, cls=CustomEncoder)
+    return json.dumps(obj, cls=CustomEncoder)
+
+
+def pretty_dumps(obj: object) -> str:
+    """
+    A wrapper for :func:`json.dumps` that applies pretty formatting to the output. Sorts keys and adds indentation.
+    Used as ``dumps`` argument for :func:`.json_response`.
+
+    :param obj: a JSON-serializable object
+    :return: a JSON string
+    """
+    return json.dumps(
+        obj,
+        cls=CustomEncoder,
+        indent=4,
+        sort_keys=True
+    )

--- a/virtool/api/response.py
+++ b/virtool/api/response.py
@@ -1,51 +1,43 @@
 from aiohttp import web
+from typing import Optional
 
-from virtool.api.json import dumps
 
-
-def json_response(data, status=200, headers=None):
+def json_response(data: dict, status: int = 200, headers: Optional[bool] = None) -> web.Response:
     """
-    A wrapper for ``aiohttp.web.json_response`` that uses :func:``.dumps`` to pretty format the JSON response.
+    Return a response object whose attached JSON dict will be formatted by middleware depending on the request's
+    `Accept` header.
 
     :param data: the data to send in the response as JSON
-    :type data: object
-
     :param status: the HTTP status code for the response
-    :type status: int
-
     :param headers: HTTP response headers
-    :type headers: dict
-
     :return: the response
-    :rtype: :class:`aiohttp.web.Response`
 
     """
     headers = headers or {}
 
-    return web.json_response(data, status=status, headers=headers, dumps=dumps)
+    resp = web.Response(status=status, headers=headers)
+    resp["json_data"] = data
+
+    return resp
 
 
-def no_content():
+def no_content() -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``204`` status and no body.
 
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return web.Response(status=204)
 
 
-def bad_gateway(message="Bad gateway"):
+def bad_gateway(message: str = "Bad gateway") -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``502`` status and the JSON body
     ``{"message": "Bad gateway"}``.
 
     :param message: text to send instead of 'Bad gateway'
-    :type message: str
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({
@@ -54,16 +46,13 @@ def bad_gateway(message="Bad gateway"):
     }, status=502)
 
 
-def bad_request(message="Bad request"):
+def bad_request(message: str = "Bad request") -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``400`` status the JSON body
     ``{"message": "Bad request"}``.
 
     :param message: text to send instead of 'Bad request'
-    :type message: str
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({
@@ -72,16 +61,13 @@ def bad_request(message="Bad request"):
     }, status=400)
 
 
-def insufficient_rights(message="Insufficient rights"):
+def insufficient_rights(message: str = "Insufficient rights") -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``401`` status and the JSON body
     ``{"message": "Bad request"}``.
 
     :param message: text to send instead of 'Bad request'
-    :type message: str
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({
@@ -90,16 +76,13 @@ def insufficient_rights(message="Insufficient rights"):
     }, status=403)
 
 
-def not_found(message="Not found"):
+def not_found(message: str = "Not found") -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``404`` status the JSON body
     ``{"message": "Not found"}``.
 
     :param message: text to send instead of 'Not found'
-    :type message: str
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({
@@ -108,16 +91,13 @@ def not_found(message="Not found"):
     }, status=404)
 
 
-def conflict(message="Conflict"):
+def conflict(message: str = "Conflict") -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``409`` status the JSON body
     ``{"message": "Conflict"}``.
 
     :param message: text to send instead of 'Not found'
-    :type message: str
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({
@@ -126,16 +106,13 @@ def conflict(message="Conflict"):
     }, status=409)
 
 
-def invalid_input(errors):
+def invalid_input(errors: dict) -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``422`` status the JSON body
     ``{"message": "Invalid input", "errors": <errors>}``.
 
     :param errors: error output from a :class:`cerberus.Validator` that led to the error response
-    :type errors: dict
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({
@@ -145,16 +122,13 @@ def invalid_input(errors):
     }, status=422)
 
 
-def invalid_query(errors):
+def invalid_query(errors: dict) -> web.Response:
     """
     A shortcut for creating a :class:`~aiohttp.web.Response` object with a ``422`` status the JSON body
     ``{"message": "Invalid query", "errors": <errors>}``.
 
     :param errors: error output from a :class:`cerberus.Validator` that led to the error response
-    :type errors: dict
-
     :return: the response
-    :rtype: :class:`aiohttp.Response`
 
     """
     return json_response({

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -20,6 +20,7 @@ import virtool.dispatcher
 import virtool.errors
 import virtool.files.manager
 import virtool.hmm.db
+import virtool.http.accept
 import virtool.http.auth
 import virtool.http.csp
 import virtool.http.errors
@@ -407,6 +408,7 @@ def create_app(config):
 
     """
     middlewares = [
+        virtool.http.accept.middleware,
         virtool.http.csp.middleware,
         virtool.http.errors.middleware,
         virtool.http.proxy.middleware,

--- a/virtool/http/accept.py
+++ b/virtool/http/accept.py
@@ -1,0 +1,31 @@
+import aiohttp.web
+
+import virtool.api.json
+
+
+@aiohttp.web.middleware
+async def middleware(req, handler):
+    """
+    Formats JSON if 'application/json' content type was not in request 'Accept' header.
+
+    """
+    accepts_json = False
+
+    for accept in req.headers.getall("ACCEPT", []):
+        if "application/json" in accept.lower():
+            accepts_json = True
+            break
+
+    resp = await handler(req)
+
+    if "json_data" in resp:
+        json_data = resp.pop("json_data")
+
+        resp.headers["Content-Type"] = "application/json; charset=utf=8"
+
+        if accepts_json:
+            resp.body = virtool.api.json.dumps(json_data)
+        else:
+            resp.body = virtool.api.json.pretty_dumps(json_data)
+
+    return resp


### PR DESCRIPTION
- format JSON responses differently based on request `Accept` header
- `application/json` = no indentation or key sorting
- not `application/json` = ident and sort keys