### PR TITLE
Add sentry_sdk to cxfreeze packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ build_exe_options = {
         "motor",
         "numpy",
         "uvloop",
+        "sentry_sdk",
         "ssl"
     ]
 }


### PR DESCRIPTION
- fix missing package exception on startup in frozen application