### PR TITLE
Support Last-Modified caching for anaylsis GET requests

### DIFF
--- a/tests/analyses/snapshots/snap_test_api.py
+++ b/tests/analyses/snapshots/snap_test_api.py
@@ -2,14 +2,37 @@
 # snapshottest: v1 - https://goo.gl/zC4yUc
 from __future__ import unicode_literals
 
-from snapshottest import Snapshot
+from snapshottest import GenericRepr, Snapshot
 
 
 snapshots = Snapshot()
 
 snapshots['test_get[uvloop-None-True] format_analysis'] = {
     '_id': 'foobar',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'ready': True,
+    'results': {
+    },
+    'sample': {
+        'id': 'baz'
+    },
+    'subtraction': {
+        'id': 'plum',
+        'name': 'Plum'
+    },
+    'workflow': 'pathoscope_bowtie'
+}
+
+snapshots['test_get[uvloop-None-True] 1'] = {
+    'created_at': '2015-10-06T20:00:00Z',
+    'formatted': True,
+    'id': 'foo'
+}
+
+snapshots['test_get[uvloop-None-False] 1'] = {
+    'created_at': '2015-10-06T20:00:00Z',
+    'id': 'foobar',
+    'ready': False,
     'results': {
     },
     'sample': {

--- a/virtool/api/json.py
+++ b/virtool/api/json.py
@@ -6,9 +6,13 @@ class CustomEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
-            return obj.replace(tzinfo=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+            return isoformat(obj)
 
         return json.JSONEncoder.default(self, obj)
+
+
+def isoformat(obj):
+    return obj.replace(tzinfo=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def dumps(obj: object) -> str:

--- a/virtool/api/response.py
+++ b/virtool/api/response.py
@@ -2,7 +2,7 @@ from aiohttp import web
 from typing import Optional
 
 
-def json_response(data: dict, status: int = 200, headers: Optional[bool] = None) -> web.Response:
+def json_response(data: dict, status: int = 200, headers: Optional[dict] = None) -> web.Response:
     """
     Return a response object whose attached JSON dict will be formatted by middleware depending on the request's
     `Accept` header.
@@ -29,6 +29,10 @@ def no_content() -> web.Response:
 
     """
     return web.Response(status=204)
+
+
+def not_modified() -> web.Response:
+    return web.Response(status=304)
 
 
 def bad_gateway(message: str = "Bad gateway") -> web.Response:


### PR DESCRIPTION
- support browser caching for analysis requests at `GET /api/analyses/:id`
- use `Last-Modified` and `If-Modified-Since` headers to support `304 Not Modified` responses
