### PR TITLE
Fix rounding for median depth calculations

### DIFF
--- a/client/src/js/analyses/__tests__/utils.test.js
+++ b/client/src/js/analyses/__tests__/utils.test.js
@@ -62,6 +62,26 @@ describe("formatPathoscopeData()", () => {
     });
 });
 
+describe("median()", () => {
+    it("should return median for odd-length list", () => {
+        const values = [17, 18, 5, 7, 41, 52, 67, 22, 3];
+        const result = median(values);
+        expect(result).toBe(18);
+    });
+
+    it("should return median for even-length list", () => {
+        const values = [17, 18, 5, 7, 41, 52, 67, 22];
+        const result = median(values);
+        expect(result).toBe(20);
+    });
+
+    it("should return median for even-length list with rounding", () => {
+        const values = [17, 18, 5, 7, 41, 52, 67, 21];
+        const result = median(values);
+        expect(result).toBe(20);
+    });
+});
+
 describe("mergeCoverage()", () => {
     let isolates;
 

--- a/client/src/js/analyses/utils.js
+++ b/client/src/js/analyses/utils.js
@@ -249,7 +249,7 @@ export const median = values => {
     const lowerIndex = Math.floor(midIndex);
     const upperIndex = Math.ceil(midIndex);
 
-    return (sorted[lowerIndex] + sorted[upperIndex]) / 2;
+    return Math.round((sorted[lowerIndex] + sorted[upperIndex]) / 2);
 };
 
 /**


### PR DESCRIPTION
- resolves #1833 
- round median result
- add tests for `median()`