### PR TITLE
Fix Websocket connection problem

### DIFF
--- a/client/src/js/app/websocket.js
+++ b/client/src/js/app/websocket.js
@@ -107,7 +107,7 @@ export default function WSConnection({ getState, dispatch }) {
     this.establishConnection = () => {
         const protocol = window.location.protocol === "https:" ? "wss" : "ws";
 
-        this.connection = new window.WebSocket(`${protocol}://localhost:9950/ws`);
+        this.connection = new window.WebSocket(`${protocol}://${window.location.host}/ws`);
 
         this.connection.onopen = () => {
             this.interval = 500;


### PR DESCRIPTION
- `localhost:9950` was inadvertently hard-coded as the Websocket host address
- replace `localhost:9950` with value from `window.location.host`
