### PR TITLE
Fix reference item internal gap

### DIFF
--- a/client/src/js/references/components/Item/Item.js
+++ b/client/src/js/references/components/Item/Item.js
@@ -12,7 +12,7 @@ const ReferenceItemBody = styled.div`
     align-items: stretch;
     display: grid;
     grid-template-columns: 1fr;
-    grid-column-gap: ${props => props.theme.gap.column};
+    grid-gap: ${props => props.theme.gap.column};
     margin-bottom: 5px;
     padding: 0 15px 5px;
 


### PR DESCRIPTION
Information bubbles were squished against one another on smaller displays.