### PR TITLE
Error tests

### DIFF
--- a/client/src/js/base/__tests__/Checkbox.test.js
+++ b/client/src/js/base/__tests__/Checkbox.test.js
@@ -34,7 +34,7 @@ describe("Checkbox", () => {
         expect(props.onClick).toHaveBeenCalled();
     });
 
-    it("should call onClick when [props.disabled===true] ", () => {
+    it("should call onClick when [props.disabled===true]", () => {
         props.disabled = true;
         const wrapper = shallow(<Checkbox {...props} />);
         wrapper.find(StyledCheckbox).simulate("click");

--- a/client/src/js/caches/__tests__/reducer.test.js
+++ b/client/src/js/caches/__tests__/reducer.test.js
@@ -5,7 +5,7 @@ describe("<cacheReducer />", () => {
     const state = {
         detail: null
     };
-    it("should return ", () => {
+    it("should return", () => {
         const action = {
             type: "UNHANDLED"
         };

--- a/client/src/js/errors/reducer.js
+++ b/client/src/js/errors/reducer.js
@@ -63,7 +63,7 @@ export const getErrorName = action => replace(action.type, "_FAILED", "_ERROR");
  * Clears error if a new request is made for the same category.
  *
  * @func
- * @param state {object}
+ * @param action {object}
  * @returns {object}
  */
 export const resetErrorName = action => {

--- a/client/src/js/otus/__tests__/reducer.test.js
+++ b/client/src/js/otus/__tests__/reducer.test.js
@@ -190,7 +190,7 @@ describe("OTUs Reducer:", () => {
         });
     });
 
-    describe("Actions that close all modals: ", () => {
+    describe("Actions that close all modals:", () => {
         const actionList = [
             GET_OTU.SUCCEEDED,
             EDIT_OTU.SUCCEEDED,

--- a/client/src/js/references/components/Detail/Targets/__tests__/Add.test.js
+++ b/client/src/js/references/components/Detail/Targets/__tests__/Add.test.js
@@ -115,7 +115,7 @@ describe("mapStateToProps()", () => {
 });
 
 describe("mapDispatchToProps()", () => {
-    it("should return onSubmit() in props ", () => {
+    it("should return onSubmit() in props", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
         props.onSubmit("foo", "bar");

--- a/client/src/js/references/components/Detail/Targets/__tests__/Targets.test.js
+++ b/client/src/js/references/components/Detail/Targets/__tests__/Targets.test.js
@@ -115,7 +115,7 @@ describe("mapStateToProps()", () => {
 });
 
 describe("mapDispatchToProps()", () => {
-    it("should return onRemove in props ", () => {
+    it("should return onRemove in props", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
         props.onRemove("foo", "bar");

--- a/client/src/js/samples/components/Create/__tests__/ReadSelector.test.js
+++ b/client/src/js/samples/components/Create/__tests__/ReadSelector.test.js
@@ -19,7 +19,7 @@ describe("<ReadSelector />", () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it("should call onChange() on update if files change ", () => {
+    it("should call onChange() on update if files change", () => {
         const wrapper = shallow(<ReadSelector {...props} />);
         wrapper.setProps({
             files: [{ id: "foo", size: 2048, name: "Bar" }]
@@ -27,7 +27,7 @@ describe("<ReadSelector />", () => {
         expect(props.onSelect).toHaveBeenCalled();
     });
 
-    it("should not call onChange() on update files do not change ", () => {
+    it("should not call onChange() on update files do not change", () => {
         const files = props.files;
         const wrapper = shallow(<ReadSelector {...props} />);
         wrapper.setProps({

--- a/client/src/js/users/components/__tests__/PrimaryGroup.test.js
+++ b/client/src/js/users/components/__tests__/PrimaryGroup.test.js
@@ -39,7 +39,7 @@ describe("mapStateToProps", () => {
 });
 
 describe("mapDispatchToProps", () => {
-    it("should return onSetPrimaryGroup() in props ", () => {
+    it("should return onSetPrimaryGroup() in props", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
 


### PR DESCRIPTION
Improve error reducer tests.

- use `const` over `let` where possible
- remove invalid test loop and use parametrization