### PR TITLE
Fetch only post-4.0.0 releases for software updates

### DIFF
--- a/virtool/software/db.py
+++ b/virtool/software/db.py
@@ -16,7 +16,7 @@ import virtool.utils
 
 logger = logging.getLogger(__name__)
 
-VIRTOOL_RELEASES_URL = "https://www.virtool.ca/releases3"
+VIRTOOL_RELEASES_URL = "https://www.virtool.ca/releases4"
 
 
 async def fetch_and_update_releases(app, ignore_errors=False):


### PR DESCRIPTION
Virtool 3.0.0 releases will not be fetched after Virtool 4.1.0 is installed.