### PR TITLE
Wait for another job if a compatible cache is being created

### DIFF
--- a/tests/jobs/test_utils.py
+++ b/tests/jobs/test_utils.py
@@ -80,6 +80,7 @@ def test_find_cache(exists, missing, returned_hash, mocker, dbs):
             "program": "skewer-0.2.2",
             "hash": "abc123",
             "missing": missing,
+            "ready": True,
             "sample": {
                 "id": "foo"
             }
@@ -100,6 +101,7 @@ def test_find_cache(exists, missing, returned_hash, mocker, dbs):
         "program": "skewer-0.2.2",
         "hash": "abc123",
         "missing": False,
+        "ready": True,
         "sample": {
             "id": "foo"
         }

--- a/virtool/jobs/utils.py
+++ b/virtool/jobs/utils.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 from typing import Union
 
 import virtool.caches.db
@@ -98,12 +99,20 @@ def find_cache(db, sample_id: str, program: str, parameters: dict) -> Union[dict
     :return: a cache document
 
     """
+
     document = db.caches.find_one({
         "hash": virtool.caches.db.calculate_cache_hash(parameters),
         "missing": False,
         "program": program,
         "sample.id": sample_id
     })
+
+    if document:
+        cache_id = document["_id"]
+
+        while document["ready"] is False:
+            time.sleep(2)
+            document = db.caches.find_one(cache_id)
 
     return virtool.utils.base_processor(document)
 


### PR DESCRIPTION
Resolves #1877 

If an analysis job finds a compatible read cache, wait for it to be ready if it is still being created. Resolves situation where jobs could attempt to use unready caches.