### PR TITLE
Ensure the indexes collection exists before creating an index on it

### DIFF
--- a/virtool/app.py
+++ b/virtool/app.py
@@ -225,6 +225,12 @@ async def init_check_db(app):
     logger.info("Checking database...")
     await virtool.db.migrate.migrate(app)
 
+    # Make sure the indexes collection exists before later trying to set an compound index on it.
+    try:
+        await db.motor_client.create_collection("indexes")
+    except pymongo.errors.CollectionInvalid:
+        pass
+
     logger.info("Creating database indexes...")
     await db.analyses.create_index("sample.id")
     await db.analyses.create_index([("created_at", -1)])


### PR DESCRIPTION
Resolves exception on start complaining about setting an index on the non-existent collection indexes.