### PR TITLE
Switch to asyncpg for async postgres as recommended by SQLAlchemy docs

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
         ports:
             - "27017:27017"
         volumes:
-            - ./mongo/data:/data/db
+            - /mongo/data:/data/db
         logging:
             driver: none
 
@@ -14,7 +14,8 @@ services:
         ports:
             - "6379:6379"
         volumes:
-            - ./redis/data:/data
+            - /redis/data:/data
+
         logging:
             driver: none
 
@@ -27,7 +28,7 @@ services:
             POSTGRES_USER: virtool
             POSTGRES_PASSWORD: virtool
         volumes:
-            - ./postgres/data:/var/lib/postgresql/data
+            - /postgres/data:/var/lib/postgresql/data
         logging:
             driver: none
 
@@ -37,5 +38,5 @@ services:
             PGADMIN_DEFAULT_EMAIL: dev@virtool.ca
             PGADMIN_DEFAULT_PASSWORD: virtool
         volumes:
-            - ./pgadmin4/data:/var/lib/pgadmin4/data
+            - /pgadmin4/data:/var/lib/pgadmin4/data
         depends_on: [postgres]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,17 +5,16 @@ services:
         ports:
             - "27017:27017"
         volumes:
-            - /mongo/data:/data/db
+            - ./mongo/data:/data/db
         logging:
             driver: none
-        
+
     redis:
         image: redis:6.0
         ports:
             - "6379:6379"
         volumes:
-            - /redis/data:/data
-              
+            - ./redis/data:/data
         logging:
             driver: none
 
@@ -28,7 +27,7 @@ services:
             POSTGRES_USER: virtool
             POSTGRES_PASSWORD: virtool
         volumes:
-            - /postgres/data:/var/lib/postgresql/data
+            - ./postgres/data:/var/lib/postgresql/data
         logging:
             driver: none
 
@@ -38,5 +37,5 @@ services:
             PGADMIN_DEFAULT_EMAIL: dev@virtool.ca
             PGADMIN_DEFAULT_PASSWORD: virtool
         volumes:
-            - /pgadmin4/data:/var/lib/pgadmin4/data
+            - ./pgadmin4/data:/var/lib/pgadmin4/data
         depends_on: [postgres]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ apipkg==1.5
 appdirs==1.4.3
 arrow==0.15.5
 async-timeout==3.0.1
+asyncpg==0.21.0
 atomicwrites==1.3.0
 attrs==19.3.0
 azure-core==1.7.0
@@ -51,7 +52,6 @@ packaging==20.4
 pathspec==0.8.0
 pluggy==0.13.1
 psutil==5.7.0
-psycopg2-binary==2.8.6
 py==1.8.1
 pycparser==2.20
 pymongo==3.10.1

--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import virtool.config
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,5 +31,5 @@ def pytest_addoption(parser):
     parser.addoption(
         "--postgres-connection-string",
         action="store",
-        default="postgresql://virtool:virtool@postgres/virtool"
+        default="postgresql+asyncpg://virtool:virtool@postgres/virtool"
     )

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -99,7 +99,7 @@ class VTClient:
 def spawn_client(loop, request, aiohttp_client, test_motor, test_db_name, create_user):
     db_connection_string = request.config.getoption("db_connection_string", "mongodb://localhost:27017")
     postgres_connection_string = request.config.getoption("postgres_connection_string",
-                                                          "postgresql://virtool:virtool@postgres/virtool")
+                                                          "postgresql+asyncpg://virtool:virtool@postgres/virtool")
 
     client = VTClient(loop, aiohttp_client, db_connection_string, postgres_connection_string, test_db_name, create_user)
 

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -118,9 +118,9 @@ def entry():
 )
 @click.option(
     "--postgres-connection-string",
-    help="The PostgreSQL connection string",
+    help="The PostgreSQL connection string (must begin with 'postgresql+asyncpg://')",
     type=str,
-    default="postgresql://virtool:virtool@localhost/virtool"
+    default="postgresql+asyncpg://virtool:virtool@localhost/virtool"
 )
 @click.option(
     "--proxy",
@@ -132,6 +132,7 @@ def entry():
     help="The Redis connection string",
     type=str,
     required=True,
+    default="redis://localhost:6379"
 )
 @click.option(
     "--verbose",

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -10,17 +10,20 @@ def configure(dev, verbose):
 
     logging.captureWarnings(True)
 
-    log_format = "%(asctime)-20s %(module)-11s %(levelname)-8s %(message)s"
+    log_format = "{asctime:<20} {module<11} {levelname:<8} {message}" \
+        if not verbose else \
+        "{asctime:<20} {module:<11} {levelname:<8} {message} [{name}:{funcName}:{lineno}]"
 
     coloredlogs.install(
         level=logging_level,
-        fmt=log_format
+        fmt=log_format,
+        style="{"
     )
 
     logger = logging.getLogger()
 
     handler = logging.handlers.RotatingFileHandler("virtool.log", maxBytes=1000000, backupCount=5)
-    handler.setFormatter(logging.Formatter(log_format))
+    handler.setFormatter(logging.Formatter(log_format, style="{"))
 
     logger.addHandler(handler)
 

--- a/virtool/postgres.py
+++ b/virtool/postgres.py
@@ -15,7 +15,7 @@ async def connect(postgres_connection_string: str) -> AsyncConnection:
     :return: an AsyncConnection object
 
     """
-    if not postgres_connection_string.startswith("postgresql://"):
+    if not postgres_connection_string.startswith("postgresql+asyncpg://"):
         logger.fatal("Invalid PostgreSQL connection string")
         sys.exit(1)
 


### PR DESCRIPTION
## Changes:

- `requirements.txt`: Added asyncpg. Removed psycopg2-binary.
- Changed postgres connection strings from `"postgresql://"` to `"postgresql+asyncpg://"`
- `docker-compose.dev.yml`: Changed persistent volumes for services created in relative path, not system root (not a good idea to pollute Linux system root dir)
- `virtool/logs.py`: Added a bit more info to verbose/dev logs to make local dev a bit easier (issue #1974)
- `run.py`: Added shebang so you can run Virtool with `$ ./run.py --dev server` although may be a good idea to run with `$ python run.py ...` if Python3 is not the default system/env Python

See [SQLAlchemy docs](https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html#synopsis-core) for use of [asyncpg](https://github.com/MagicStack/asyncpg) and connection strings beginning with `postgresql+asyncpg://` in example code.