### PR TITLE
Fix log message for software refresher task

### DIFF
--- a/virtool/software/db.py
+++ b/virtool/software/db.py
@@ -193,7 +193,7 @@ async def refresh(app):
     except asyncio.CancelledError:
         pass
 
-    logging.debug("Started HMM refresher")
+    logging.debug("Stopped software refresher")
 
 
 async def update_software_task(db, progress, step=None):


### PR DESCRIPTION
Related story: [ch-147](https://app.clubhouse.io/virtool/story/147/fix-log-message-for-hmm-refresher-task)