### PR TITLE
Replace coloredlogs with Rich log handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,7 @@ python-dateutil==2.8.1
 regex==2020.4.4
 requests==2.24.0
 requests-oauthlib==1.3.0
+rich==9.8.0
 semver==2.9.1
 sentry-sdk==0.14.3
 six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ certifi==2020.6.20
 cffi==1.14.0
 chardet==3.0.4
 click==7.1.1
-coloredlogs==14.0
 configobj==5.0.6
 contextvars==2.4
 coverage==5.0.4

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -21,6 +21,7 @@ def configure(dev, verbose):
     logger = logging.getLogger("rich")
 
     handler = logging.handlers.RotatingFileHandler("virtool.log", maxBytes=1000000, backupCount=5)
+    handler.setFormatter(logging.Formatter(log_format))
 
     logger.addHandler(handler)
 

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -9,7 +9,8 @@ def configure(dev, verbose):
 
     logging.captureWarnings(True)
 
-    log_format = "%(asctime)-20s %(module)-11s %(message)s"
+    log_file_format = "{levelname:<8} {asctime:<20} {module:<11} {message} [{name}:{funcName}:{lineno}]"
+    log_format = "%(asctime)-20s %(module)-11s %(message)8s"
 
     logging.basicConfig(
         level=logging_level,
@@ -18,10 +19,10 @@ def configure(dev, verbose):
         handlers=[RichHandler(level=logging_level, show_time=False, rich_tracebacks=True, markup=True)]
     )
 
-    logger = logging.getLogger("rich")
+    logger = logging.getLogger()
 
     handler = logging.handlers.RotatingFileHandler("virtool.log", maxBytes=1000000, backupCount=5)
-    handler.setFormatter(logging.Formatter(log_format))
+    handler.setFormatter(logging.Formatter(log_file_format, style="{"))
 
     logger.addHandler(handler)
 

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -1,8 +1,6 @@
 import logging.handlers
 from rich.logging import RichHandler
 
-import coloredlogs
-
 
 def configure(dev, verbose):
     verbose = dev or verbose

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -9,15 +9,13 @@ def configure(dev, verbose):
 
     logging.captureWarnings(True)
 
-    log_format = "%(asctime)-20s %(module)-11s %(message)s" \
-        if not verbose else \
-        "%(asctime)-20s %(module)-11s %(message)s"
+    log_format = "%(asctime)-20s %(module)-11s %(message)s"
 
     logging.basicConfig(
         level=logging_level,
         format=log_format,
         datefmt="%Y-%m-%d %H:%M:%S",
-        handlers=[RichHandler(level=logging_level, show_time=False, rich_tracebacks=True)]
+        handlers=[RichHandler(level=logging_level, show_time=False, rich_tracebacks=True, markup=True)]
     )
 
     logger = logging.getLogger("rich")

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -9,14 +9,14 @@ def configure(dev, verbose):
 
     logging.captureWarnings(True)
 
-    log_file_format = "{levelname:<8} {asctime:<20} {module:<11} {message} [{name}:{funcName}:{lineno}]"
-    log_format = "%(module)-11s %(message)8s"
+    log_file_format = "{asctime:<20} {levelname:<8} {module:<11} {message} [{name}:{funcName}:{lineno}]"
+    log_format = "%(asctime)-20s %(levelname)-8s %(module)-11s %(message)8s"
 
     logging.basicConfig(
         level=logging_level,
         format=log_format,
         datefmt="[%Y-%m-%d %H:%M:%S]",
-        handlers=[RichHandler(level=logging_level, rich_tracebacks=True, markup=True)]
+        handlers=[RichHandler(level=logging_level, show_time=False, show_level=False, rich_tracebacks=True, markup=True)]
     )
 
     logger = logging.getLogger()

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -1,4 +1,5 @@
 import logging.handlers
+from rich.logging import RichHandler
 
 import coloredlogs
 
@@ -10,20 +11,20 @@ def configure(dev, verbose):
 
     logging.captureWarnings(True)
 
-    log_format = "{asctime:<20} {module:<11} {levelname:<8} {message}" \
+    log_format = "%(asctime)-20s %(module)-11s %(message)s" \
         if not verbose else \
-        "{asctime:<20} {module:<11} {levelname:<8} {message} [{name}:{funcName}:{lineno}]"
+        "%(asctime)-20s %(module)-11s %(message)s"
 
-    coloredlogs.install(
+    logging.basicConfig(
         level=logging_level,
-        fmt=log_format,
-        style="{"
+        format=log_format,
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=[RichHandler(level=logging_level, show_time=False, rich_tracebacks=True)]
     )
 
-    logger = logging.getLogger()
+    logger = logging.getLogger("rich")
 
     handler = logging.handlers.RotatingFileHandler("virtool.log", maxBytes=1000000, backupCount=5)
-    handler.setFormatter(logging.Formatter(log_format, style="{"))
 
     logger.addHandler(handler)
 

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -10,13 +10,13 @@ def configure(dev, verbose):
     logging.captureWarnings(True)
 
     log_file_format = "{levelname:<8} {asctime:<20} {module:<11} {message} [{name}:{funcName}:{lineno}]"
-    log_format = "%(asctime)-20s %(module)-11s %(message)8s"
+    log_format = "%(module)-11s %(message)8s"
 
     logging.basicConfig(
         level=logging_level,
         format=log_format,
         datefmt="%Y-%m-%d %H:%M:%S",
-        handlers=[RichHandler(level=logging_level, show_time=False, rich_tracebacks=True, markup=True)]
+        handlers=[RichHandler(level=logging_level, rich_tracebacks=True, markup=True)]
     )
 
     logger = logging.getLogger()

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -15,7 +15,7 @@ def configure(dev, verbose):
     logging.basicConfig(
         level=logging_level,
         format=log_format,
-        datefmt="%Y-%m-%d %H:%M:%S",
+        datefmt="[%Y-%m-%d %H:%M:%S]",
         handlers=[RichHandler(level=logging_level, rich_tracebacks=True, markup=True)]
     )
 


### PR DESCRIPTION
Related to [#114](https://app.clubhouse.io/virtool/story/114/use-built-in-rich-log-handler-for-python-console-log)
- I removed the `{name}:{funcName}:{lineno}` in the console log format since Rich is able to directly link to the path of the log call, though this doesn't seem to work in PyCharm for some reason.