### PR TITLE
Don't build subtraction FASTA files for removed subtractions

### DIFF
--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -38,7 +38,7 @@ class WriteSubtractionFASTATask(virtool.tasks.task.Task):
         db = self.db
         settings = self.app["settings"]
 
-        async for subtraction in db.subtraction.find():
+        async for subtraction in db.subtraction.find({"deleted": False}):
             path = virtool.subtractions.utils.join_subtraction_path(settings, subtraction["_id"])
             has_file = True
 


### PR DESCRIPTION
Only build FASTA for subtractions with the `deleted` filed set `false`.