### PR TITLE
Handle null subtraction fields in samples when migrating to multi-subtraction

### DIFF
--- a/tests/samples/test_migrate.py
+++ b/tests/samples/test_migrate.py
@@ -17,12 +17,23 @@ async def test_change_to_subtractions_list(snapshot, dbi):
         },
         {
             "_id": "baz",
-            "subtraction": {
-                "id": "malus"
-            }
+            "subtraction": None
         }
     ])
 
     await virtool.samples.migrate.change_to_subtractions_list(dbi)
 
-    snapshot.assert_match(await dbi.samples.find().to_list(None))
+    assert await dbi.samples.find().to_list(None) == [
+        {
+            "_id": "foo",
+            "subtractions": ["prunus"]
+        },
+        {
+            "_id": "bar",
+            "subtractions": ["malus"]
+        },
+        {
+            "_id": "baz",
+            "subtractions": []
+        }
+    ]

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -1,4 +1,5 @@
 import virtool.subtractions.db
+from virtool.subtractions.db import unlink_default_subtractions
 
 
 async def test_attach_subtractions(dbi):
@@ -33,3 +34,21 @@ async def test_attach_subtractions(dbi):
             }
         ]
     }
+
+
+async def test_unlink_default_subtractions(dbi):
+    await dbi.samples.insert_many([
+        {"_id": "foo", "subtractions": ["1", "2", "3"]},
+        {"_id": "bar", "subtractions": ["2", "5", "8"]},
+        {"_id": "baz", "subtractions": ["2"]}
+    ])
+
+    await unlink_default_subtractions(dbi, "2")
+
+
+
+    assert await dbi.samples.find().to_list(None) == [
+        {"_id": "foo", "subtractions": ["1", "3"]},
+        {"_id": "bar", "subtractions": ["5", "8"]},
+        {"_id": "baz", "subtractions": []}
+    ]

--- a/virtool/samples/migrate.py
+++ b/virtool/samples/migrate.py
@@ -44,9 +44,14 @@ async def change_to_subtractions_list(db):
 
     """
     async for document in db.samples.find({"subtraction": {"$exists": True}}):
+        try:
+            subtractions = [document["subtraction"]["id"]]
+        except TypeError:
+            subtractions = list()
+
         await db.samples.update_one({"_id": document["_id"]}, {
             "$set": {
-                "subtractions": [document["subtraction"]["id"]]
+                "subtractions": subtractions
             },
             "$unset": {
                 "subtraction": ""

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -129,9 +129,9 @@ async def get_linked_samples(db, subtraction_id):
 
 
 async def unlink_default_subtractions(db, subtraction_id):
-    await db.samples.update_many({"subtraction.id": subtraction_id}, {
-        "$set": {
-            "subtraction": None
+    await db.samples.update_many({"subtractions": subtraction_id}, {
+        "$pull": {
+            "subtractions": subtraction_id
         }
     })
 


### PR DESCRIPTION
When the `subtraction` field is `null`, transform to a `subtractions` field set as an empty array. Currently, null `subtraction` fields cause a `TypeError`.

Additionally, update sample-subtraction unlinking when a subtraction is removed to drop the subtraction ID from `subtractions` instead of setting the `subtraction` field to `null`.