### PR TITLE
Update GitHub action to run on release/5.0.0 and feature branches

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,10 +3,12 @@ name: Virtool CI
 on:
   push:
     branches:
-      - release-5.0.0
+      - release/5.0.0
+      - feature/**
   pull_request:
     branches:
-      - release-5.0.0
+      - release/5.0.0
+      - feature/**
 
 jobs:
   server:


### PR DESCRIPTION
Update branch filters to match new names. Make sure CI is run for `feature/` branches.