### PR TITLE
Fix job logging

### DIFF
--- a/virtool/config.py
+++ b/virtool/config.py
@@ -191,7 +191,8 @@ def cli(ctx, data_path, db_connection_string, db_name, dev, force_version, no_se
 )
 @click.pass_context
 def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fetching):
-    virtool.logs.configure(ctx.obj["dev"], ctx.obj["verbose"])
+    virtool.logs.configure_server(ctx.obj["dev"], ctx.obj["verbose"])
+    
     config = {
         **ctx.obj,
         "host": host,
@@ -233,7 +234,8 @@ def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fet
 )
 @click.pass_context
 def start_runner(ctx, job_list, mem, proc, temp_path):
-    virtool.logs.configure(ctx.obj["dev"], ctx.obj["verbose"])
+    virtool.logs.configure_runner(ctx.obj["dev"], ctx.obj["verbose"])
+
     config = {
         **ctx.obj,
         "job_list": job_list,

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -1,4 +1,3 @@
-import uvloop
 import asyncio
 import json
 import logging
@@ -7,14 +6,15 @@ import sys
 
 import click
 import psutil
+import uvloop
 
 import virtool.app
 import virtool.db.mongo
 import virtool.db.utils
-import virtool.jobs.runner
 import virtool.jobs.classes
 import virtool.jobs.job
 import virtool.jobs.run
+import virtool.jobs.runner
 import virtool.logs
 import virtool.redis
 import virtool.utils
@@ -140,7 +140,8 @@ def entry():
     is_flag=True
 )
 @click.pass_context
-def cli(ctx, data_path, db_connection_string, db_name, dev, force_version, no_sentry, proxy, postgres_connection_string, redis_connection_string, verbose):
+def cli(ctx, data_path, db_connection_string, db_name, dev, force_version, no_sentry, proxy, postgres_connection_string,
+        redis_connection_string, verbose):
     ctx.ensure_object(dict)
     ctx.obj.update({
         "data_path": data_path,
@@ -192,7 +193,7 @@ def cli(ctx, data_path, db_connection_string, db_name, dev, force_version, no_se
 @click.pass_context
 def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fetching):
     virtool.logs.configure_server(ctx.obj["dev"], ctx.obj["verbose"])
-    
+
     config = {
         **ctx.obj,
         "host": host,
@@ -292,7 +293,8 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 )
 @click.pass_context
 def start_agent(ctx, job_list, lg_mem, lg_proc, mem, proc, sm_mem, sm_proc, temp_path):
-    virtool.logs.configure(ctx.obj["dev"], ctx.obj["verbose"])
+    virtool.logs.configure_base_logger(ctx.obj["dev"], ctx.obj["verbose"])
+
     config = {
         **ctx.obj,
         "job_list": job_list,
@@ -304,6 +306,7 @@ def start_agent(ctx, job_list, lg_mem, lg_proc, mem, proc, sm_mem, sm_proc, temp
         "sm_proc": sm_proc,
         "temp_path": temp_path
     }
+
     validate_limits(config)
 
     logger.info("Starting in agent mode")

--- a/virtool/jobs/job.py
+++ b/virtool/jobs/job.py
@@ -160,10 +160,10 @@ class Job:
         if stderr_handler:
             async def _stderr_handler(line):
                 await stderr_handler(line)
-                logger.info(f"STDERR: {line.rstrip()}")
+                logger.info(f"STDERR: {line.decode().rstrip()}")
         else:
             async def _stderr_handler(line):
-                logger.info(f"STDERR: {line.rstrip()}")
+                logger.info(f"STDERR: {line.decode().rstrip()}")
 
         self._process = await asyncio.create_subprocess_exec(
             *command,

--- a/virtool/jobs/job.py
+++ b/virtool/jobs/job.py
@@ -5,6 +5,8 @@ Classes, exceptions, and utilities for creating Virtool jobs.
 import asyncio
 import concurrent.futures.thread
 import logging
+import logging.handlers
+import os
 import subprocess
 import sys
 import tempfile
@@ -13,11 +15,12 @@ from typing import Optional
 
 import virtool.db.mongo
 import virtool.db.utils
-import virtool.jobs.runner
 import virtool.jobs.db
+import virtool.jobs.runner
 import virtool.redis
 import virtool.settings.db
 import virtool.utils
+from virtool.logs import get_log_format
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +87,12 @@ class Job:
         )
 
     async def _run(self):
+        log_path = os.path.join(self.settings["data_path"], "logs", "jobs", self.id)
+        handler = logging.FileHandler(log_path)
+        handler.setFormatter(logging.Formatter(get_log_format(True), style="{"))
+
+        logger.addHandler(handler)
+
         logger.debug("Job run method called")
 
         self._executor = concurrent.futures.thread.ThreadPoolExecutor()
@@ -127,6 +136,8 @@ class Job:
             self.temp_dir.cleanup
         )
 
+        logger.removeHandler(handler)
+
     async def run_in_executor(self, func, *args):
         return await asyncio.get_event_loop().run_in_executor(self._executor, func, *args)
 
@@ -136,7 +147,8 @@ class Job:
             stdout_handler=None,
             stderr_handler=None,
             env: Optional[dict] = None,
-            cwd: Optional[str] = None
+            cwd: Optional[str] = None,
+            decode: bool = True
     ):
         logger.info(f"Running command in subprocess: {' '.join(command)}")
 

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -1,37 +1,65 @@
 import logging.handlers
+from logging import Logger
 
 import coloredlogs
 
 
-def get_log_format(verbose):
+def get_log_format(verbose: bool) -> str:
+    """
+    Return a log format given `verbose`, which indicates whether the instance should adopt verbose logging.
+
+    :param verbose: the log format should be verbose
+
+    """
     if verbose:
-        return "{asctime:<20} {module:<11} {levelname:<8} {message} [{name}:{funcName}:{lineno}]"
+        return "{asctime:<20} {module:<11} {levelname:<8} {message} ({name}:{funcName}:{lineno})"
 
     return "{asctime:<20} {module:<11} {levelname:<8} {message}"
 
 
-def configure_base_logger(dev, verbose):
+def configure_base_logger(dev: bool, verbose: bool) -> Logger:
+    """
+    Return a base class:`Logger` object that can be used for both runner and server instances.
+
+    Configures the logging level and installs colored logs. If `dev` or `verbose` is `True`, the logger will record
+    additional source path information in the log and write logs at the `DEBUG` level.
+
+    :param dev: the logger should produce verbose logs
+    :param verbose: the logger should produce verbose logs
+
+    """
     verbose = dev or verbose
 
     logging_level = logging.DEBUG if verbose else logging.INFO
 
     logging.captureWarnings(True)
 
-    coloredlogs.install(
-        level=logging_level,
-        fmt=get_log_format(verbose),
-        style="{"
-    )
+    coloredlogs.install(level=logging_level, fmt=get_log_format(verbose), style="{")
 
     logger = logging.getLogger()
 
     return logger
 
 
-def configure_server(dev, verbose):
+def configure_server(dev: bool, verbose: bool) -> Logger:
+    """
+    Configure and return a logger for a server instance.
+
+    Logs are written to the `server.log` file in the run directory.
+
+    Configures the logging level and installs colored logs. If `dev` or `verbose` is `True`, the logger will record
+    additional source path information in the log and write logs at the `DEBUG` level.
+
+    :param dev: the logger should produce verbose logs
+    :param verbose: the logger should produce verbose logs
+
+    """
     logger = configure_base_logger(dev, verbose)
 
-    handler = logging.handlers.RotatingFileHandler("server.log", maxBytes=1000000, backupCount=3)
+    handler = logging.handlers.RotatingFileHandler(
+        "server.log", maxBytes=1000000, backupCount=3
+    )
+
     handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
 
     logger.addHandler(handler)
@@ -39,10 +67,25 @@ def configure_server(dev, verbose):
     return logger
 
 
-def configure_runner(dev, verbose):
+def configure_runner(dev: bool, verbose: bool) -> Logger:
+    """
+    Configure a logger for a server instance.
+
+    Logs are written to the `runner.log` file in the run directory.
+
+    Configures the logging level and installs colored logs. If `dev` or `verbose` is `True`, the logger will record
+    additional source path information in the log and write logs at the `DEBUG` level.
+
+    :param dev: the logger should produce verbose logs
+    :param verbose: the logger should produce verbose logs
+
+    """
     logger = configure_base_logger(dev, verbose)
 
-    handler = logging.handlers.RotatingFileHandler("runner.log", maxBytes=1000000, backupCount=3)
+    handler = logging.handlers.RotatingFileHandler(
+        "runner.log", maxBytes=1000000, backupCount=3
+    )
+
     handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
 
     logger.addHandler(handler)

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -3,27 +3,47 @@ import logging.handlers
 import coloredlogs
 
 
-def configure(dev, verbose):
+def get_log_format(verbose):
+    if verbose:
+        return "{asctime:<20} {module:<11} {levelname:<8} {message} [{name}:{funcName}:{lineno}]"
+
+    return "{asctime:<20} {module:<11} {levelname:<8} {message}"
+
+
+def configure_base_logger(dev, verbose):
     verbose = dev or verbose
 
     logging_level = logging.DEBUG if verbose else logging.INFO
 
     logging.captureWarnings(True)
 
-    log_format = "{asctime:<20} {module:<11} {levelname:<8} {message}" \
-        if not verbose else \
-        "{asctime:<20} {module:<11} {levelname:<8} {message} [{name}:{funcName}:{lineno}]"
-
     coloredlogs.install(
         level=logging_level,
-        fmt=log_format,
+        fmt=get_log_format(verbose),
         style="{"
     )
 
     logger = logging.getLogger()
 
-    handler = logging.handlers.RotatingFileHandler("virtool.log", maxBytes=1000000, backupCount=5)
-    handler.setFormatter(logging.Formatter(log_format, style="{"))
+    return logger
+
+
+def configure_server(dev, verbose):
+    logger = configure_base_logger(dev, verbose)
+
+    handler = logging.handlers.RotatingFileHandler("server.log", maxBytes=1000000, backupCount=3)
+    handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
+
+    logger.addHandler(handler)
+
+    return logger
+
+
+def configure_runner(dev, verbose):
+    logger = configure_base_logger(dev, verbose)
+
+    handler = logging.handlers.RotatingFileHandler("runner.log", maxBytes=1000000, backupCount=3)
+    handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
 
     logger.addHandler(handler)
 


### PR DESCRIPTION
Split logs for runner and server into separate files and resume writing job logs to dedicated log files at `<data_path>/logs/jobs/<job_id>`.

Decode standard error before writing to logs. This clears up a lot of `b'...'` cruft in the logs from Python.

