### PR TITLE
Remove warning over no subtractions being available

### DIFF
--- a/client/src/js/samples/components/Create/Create.js
+++ b/client/src/js/samples/components/Create/Create.js
@@ -103,13 +103,6 @@ export class CreateSample extends React.Component {
             this.setState({ errorName: "Required Field" });
         }
 
-        if (!this.props.subtractions || !this.props.subtractions.length) {
-            hasError = true;
-            this.setState({
-                errorSubtraction: "At least one subtraction must be added to Virtool before samples can be analyzed."
-            });
-        }
-
         if (!this.state.selected.length) {
             hasError = true;
             this.setState({
@@ -177,7 +170,7 @@ export class CreateSample extends React.Component {
 
         const pairedness = this.state.selected.length === 2 ? "Paired" : "Unpaired";
 
-        const { errorName, errorSubtraction, errorFile } = this.state;
+        const { errorName, errorFile } = this.state;
 
         const subtractionId = this.state.subtractionId || get(this.props.subtractions, [0, "id"]);
 
@@ -225,7 +218,6 @@ export class CreateSample extends React.Component {
                                 <Select name="subtractionId" value={subtractionId} onChange={this.handleChange}>
                                     {subtractionComponents}
                                 </Select>
-                                <InputError>{errorSubtraction}</InputError>
                             </InputGroup>
 
                             <InputGroup>

--- a/client/src/js/samples/components/Create/__tests__/Create.test.js
+++ b/client/src/js/samples/components/Create/__tests__/Create.test.js
@@ -120,14 +120,6 @@ describe("<CreateSample>", () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it("should display error when form submitted with no subtractions available", () => {
-        props.subtractions = [];
-        const wrapper = shallow(<CreateSample {...props} />);
-        wrapper.setState({ ...state, selected: ["foo"] });
-        wrapper.find("form").simulate("submit", e);
-        expect(wrapper).toMatchSnapshot();
-    });
-
     it("handleSubmit() should update errorFile when form is submitted and [this.props.selected=[]]", () => {
         const wrapper = shallow(<CreateSample {...props} />);
         wrapper.setState({

--- a/client/src/js/samples/components/Create/__tests__/__snapshots__/Create.test.js.snap
+++ b/client/src/js/samples/components/Create/__tests__/__snapshots__/Create.test.js.snap
@@ -82,7 +82,6 @@ exports[`<CreateSample> should display error when form submitted with no name 1`
               Sub Bar
             </option>
           </Select>
-          <Input__InputError />
         </InputGroup>
         <InputGroup>
           <Input__InputLabel>
@@ -116,119 +115,6 @@ exports[`<CreateSample> should display error when form submitted with no name 1`
           Array [
             "abc123-Foo.fq.gz",
             "789xyz-Bar.fq.gz",
-          ]
-        }
-      />
-    </Modal__ModalBody>
-    <Modal__ModalFooter>
-      <SaveButton />
-    </Modal__ModalFooter>
-  </form>
-</Modal>
-`;
-
-exports[`<CreateSample> should display error when form submitted with no subtractions available 1`] = `
-<Modal
-  label="Create Sample"
-  onExited={[Function]}
-  onHide={[MockFunction]}
-  show={true}
-  size="lg"
->
-  <ModalHeader>
-    Create Sample
-  </ModalHeader>
-  <form
-    onSubmit={[Function]}
-  >
-    <Modal__ModalBody>
-      <Create__CreateSampleFields>
-        <InputGroup>
-          <Input__InputLabel>
-            Sample Name
-          </Input__InputLabel>
-          <Input__InputContainer
-            align="right"
-          >
-            <Input
-              autocomplete={false}
-              error=""
-              name="name"
-              onChange={[Function]}
-              value="Sample 1"
-            />
-            <Input__InputIcon
-              disabled={false}
-              name="magic"
-              onClick={[Function]}
-            />
-          </Input__InputContainer>
-          <Input__InputError />
-        </InputGroup>
-        <InputGroup>
-          <Input__InputLabel>
-            Locale
-          </Input__InputLabel>
-          <Input
-            name="locale"
-            onChange={[Function]}
-            value="Timbuktu"
-          />
-        </InputGroup>
-        <InputGroup>
-          <Input__InputLabel>
-            Isolate
-          </Input__InputLabel>
-          <Input
-            name="isolate"
-            onChange={[Function]}
-            value="Isolate"
-          />
-        </InputGroup>
-        <InputGroup>
-          <Input__InputLabel>
-            Default Subtraction
-          </Input__InputLabel>
-          <Select
-            name="subtractionId"
-            onChange={[Function]}
-            value="sub_bar"
-          />
-          <Input__InputError>
-            At least one subtraction must be added to Virtool before samples can be analyzed.
-          </Input__InputError>
-        </InputGroup>
-        <InputGroup>
-          <Input__InputLabel>
-            Host
-          </Input__InputLabel>
-          <Input
-            name="host"
-            onChange={[Function]}
-            value="Host"
-          />
-        </InputGroup>
-        <InputGroup>
-          <Input__InputLabel>
-            Pairedness
-          </Input__InputLabel>
-          <Input
-            readOnly={true}
-            value="Unpaired"
-          />
-        </InputGroup>
-      </Create__CreateSampleFields>
-      <LibraryTypeSelector
-        libraryType="normal"
-        onSelect={[Function]}
-      />
-      <ReadSelector
-        error=""
-        files={Array []}
-        onSelect={[Function]}
-        selected={
-          Array [
-            "foo",
           ]
         }
       />
@@ -320,7 +206,6 @@ exports[`<CreateSample> should render 1`] = `
               Sub Bar
             </option>
           </Select>
-          <Input__InputError />
         </InputGroup>
         <InputGroup>
           <Input__InputLabel>

--- a/client/src/js/subtraction/components/List.js
+++ b/client/src/js/subtraction/components/List.js
@@ -46,17 +46,6 @@ export class SubtractionList extends React.Component {
             subtractionComponents = <NoneFoundBox noun="subtractions" />;
         }
 
-        let alert;
-
-        if (!this.props.ready_host_count && !this.props.total_count) {
-            alert = (
-                <Alert color="orange" level>
-                    <Icon name="exclamation-circle" />
-                    <strong>A host genome must be added before samples can be created and analyzed.</strong>
-                </Alert>
-            );
-        }
-
         return (
             <div>
                 <ViewHeader title="Subtraction">
@@ -64,8 +53,6 @@ export class SubtractionList extends React.Component {
                         Subtraction <Badge>{this.props.total_count}</Badge>
                     </ViewHeaderTitle>
                 </ViewHeader>
-
-                {alert}
 
                 <SubtractionToolbar />
 


### PR DESCRIPTION
The multi-subtraction feature will allow users to use zero or more subtractions in their analyses. This warning is longer required.