### PR TITLE
Fix cancellation of waiting jobs

### DIFF
--- a/virtool/jobs/db.py
+++ b/virtool/jobs/db.py
@@ -40,12 +40,19 @@ PROJECTION = [
 ]
 
 
-async def cancel(db, job_id):
+async def cancel(db, job_id: str) -> dict:
+    """
+    Add a cancellation status sub-document to the job identified by `job_id`.
+
+    :param db: the application database connection
+    :param job_id: the ID of the job to add a cancellation status for
+
+    """
     document = await db.jobs.find_one(job_id, ["status"])
 
     latest = document["status"][-1]
 
-    await db.jobs.update_one({"_id": job_id}, {
+    return await db.jobs.find_one_and_update({"_id": job_id}, {
         "$push": {
             "status": {
                 "state": "cancelled",
@@ -55,7 +62,7 @@ async def cancel(db, job_id):
                 "timestamp": virtool.utils.timestamp()
             }
         }
-    })
+    }, projection=virtool.jobs.db.PROJECTION)
 
 
 async def clear(db, complete=False, failed=False):

--- a/virtool/jobs/interface.py
+++ b/virtool/jobs/interface.py
@@ -1,7 +1,9 @@
 import logging
+from asyncio import gather
 
 import virtool.db.utils
 import virtool.jobs.utils
+import virtool.jobs.db
 
 logger = logging.getLogger(__name__)
 
@@ -20,19 +22,35 @@ class JobInterface:
 
         logger.debug(f"Enqueued job: {job_id}")
 
-    async def cancel(self, job_id):
+    async def cancel(self, job_id: str) -> dict:
         """
-        Cancel the job with the given `job_id` if it is in the `_jobs_dict`.
+        Cancel the job with the given `job_id`.
+
+        If the job is still waiting, its ID will be in a Redis list. Remove the ID from the list and append a cancelled
+        status records the job document's status field.
+
+        If the job is running, set its state to `cancelling` and publish its ID to the cancellation Redis PubSub
+        channel. Listening runners will see the ID and cancel their jobs if their current job ID matches.
+
+        :param job_id: the ID of the job to cancel
+        :return: the updated job document
 
         """
+        counts = await gather(
+            self.redis.lrem("jobs_lg", 0, job_id),
+            self.redis.lrem("jobs_sm", 0, job_id)
+        )
+
+        if any(counts):
+            logger.debug(f"Removed job from Redis job queue: {job_id}")
+            return await virtool.jobs.db.cancel(self.db, job_id)
+
         document = await self.db.jobs.find_one_and_update({"_id": job_id}, {
             "$set": {
                 "state": "cancelling"
             }
         })
 
-        await self.redis.lrem("jobs_lg", 0, job_id)
-        await self.redis.lrem("jobs_sm", 0, job_id)
         await self.redis.publish("channel:cancel", job_id)
 
         logger.debug(f"Requested job cancellation via Redis: {job_id}")

--- a/virtool/jobs/job.py
+++ b/virtool/jobs/job.py
@@ -128,6 +128,10 @@ class Job:
 
             await self._cleanup()
 
+        if self._process:
+            self._process.terminate()
+            await self._process.wait()
+
         logger.debug("Stopping cancellation watch")
         self._watch_cancel_task.cancel()
 


### PR DESCRIPTION
A cancellation status sub-document was not being pushed when queued job IDs were dropped from Redis on cancellation. This has been fixed by calling `jobs.cancel()` when a job ID is successfully dropped from a Redis job list.

Additionally, subprocesses were not being terminated properly. This has been fixed by calling `terminate` and `wait` explicitly on job `Process` objects.