### PR TITLE
Update docstrings and typing for virtool.account module

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -1,14 +1,21 @@
+"""
+API request handlers for account endpoints.
+
+These endpoints modify and return data about the user account associated with the session or API key making the
+requests.
+
+"""
 import aiohttp.web
 
-import virtool.analyses.utils
-import virtool.http.utils
-import virtool.users.checks
 import virtool.account.db
-import virtool.users.sessions
-import virtool.users.db
+import virtool.analyses.utils
 import virtool.db.utils
 import virtool.http.auth
 import virtool.http.routes
+import virtool.http.utils
+import virtool.users.checks
+import virtool.users.db
+import virtool.users.sessions
 import virtool.users.utils
 import virtool.utils
 import virtool.validators
@@ -143,7 +150,11 @@ async def update_settings(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
 
 @routes.get("/api/account/keys")
-async def get_api_keys(req: aiohttp.web.Request) -> aiohttp.web.Response:
+async def list_api_keys(req: aiohttp.web.Request) -> aiohttp.web.Response:
+    """
+    List API keys associated with the authenticated user account.
+
+    """
     db = req.app["db"]
 
     user_id = req["client"].user_id
@@ -155,6 +166,10 @@ async def get_api_keys(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
 @routes.get("/api/account/keys/{key_id}")
 async def get_api_key(req: aiohttp.web.Request) -> aiohttp.web.Response:
+    """
+    Get the complete representation of the API key identified by the `key_id`.
+
+    """
     db = req.app["db"]
     user_id = req["client"].user_id
     key_id = req.match_info["key_id"]
@@ -252,6 +267,10 @@ async def update_api_key(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
 @routes.delete("/api/account/keys/{key_id}")
 async def remove_api_key(req: aiohttp.web.Request) -> aiohttp.web.Response:
+    """
+    Remove an API key by its ID.
+
+    """
     db = req.app["db"]
     user_id = req["client"].user_id
     key_id = req.match_info["key_id"]
@@ -270,7 +289,7 @@ async def remove_api_key(req: aiohttp.web.Request) -> aiohttp.web.Response:
 @routes.delete("/api/account/keys")
 async def remove_all_api_keys(req: aiohttp.web.Request) -> aiohttp.web.Response:
     """
-    Remove all API keys for the session account.
+    Remove all API keys for the account associated with the requesting session.
 
     """
     await req.app["db"].keys.delete_many({"user.id": req["client"].user_id})

--- a/virtool/account/db.py
+++ b/virtool/account/db.py
@@ -1,23 +1,15 @@
 """
 Work with the current user account and its API keys.
 
-API Key Schema:
-- _id (str) the hashed API key - never returned
-- id (str) the API key ID
-- name (str) user-defined name for the API key
-- groups (Array[str]) list of groups the API key user is a member of
-- permissions (Object) user-defined permissions possessed by the key - permission names are keys with boolean values
-- created_at (datetime) when the API key was created)
-- user (Object) describes the parent user
-    id (str) the user ID
-
 """
+from typing import Dict, Any
+
 import virtool.account.utils
 import virtool.users.db
 import virtool.users.utils
 import virtool.utils
 
-PROJECTION = [
+PROJECTION = (
     "_id",
     "administrator",
     "email",
@@ -27,10 +19,10 @@ PROJECTION = [
     "permissions",
     "primary_group",
     "settings"
-]
+)
 
 
-def compose_password_update(password: str) -> dict:
+def compose_password_update(password: str) -> Dict[str, Any]:
     """
     Compose an update dict for self-changing a users account password. This will disable forced reset and won't
     invalidate current sessions, unlike a password change by an administrator.
@@ -39,8 +31,6 @@ def compose_password_update(password: str) -> dict:
     :return: a password update
 
     """
-    # Update the user document. Remove all sessions so those clients will have to authenticate with the new
-    # password.
     return {
         "password": virtool.users.utils.hash_password(password),
         "invalidate_sessions": False,
@@ -49,7 +39,7 @@ def compose_password_update(password: str) -> dict:
     }
 
 
-async def get(db, user_id: str) -> dict:
+async def get(db, user_id: str) -> Dict[str, Any]:
     """
     Get appropriately projected user document by id.
 
@@ -87,7 +77,7 @@ async def get_alternate_id(db, name: str) -> str:
         suffix += 1
 
 
-async def create_api_key(db, name: str, permissions: dict, user_id: str) -> dict:
+async def create_api_key(db, name: str, permissions: Dict[str, bool], user_id: str) -> Dict[str, Any]:
     """
     Create a new API key for the account with the given `user_id`.
 

--- a/virtool/account/utils.py
+++ b/virtool/account/utils.py
@@ -13,7 +13,7 @@ def generate_api_key() -> Tuple[str, str]:
     Generate an API key using UUID. Returns a `tuple` containing the raw API key to be returned once to the user and the
     SHA-256 hash of the API key to be stored in the database.
 
-    :return: a new API key
+    :return: a new API key and its hash
 
     """
     raw = uuid.uuid4().hex

--- a/virtool/db/utils.py
+++ b/virtool/db/utils.py
@@ -15,7 +15,7 @@ def apply_projection(document, projection):
     :rtype: dict
 
     """
-    if isinstance(projection, list):
+    if isinstance(projection, (list, tuple)):
         if "_id" not in projection:
             projection.append("_id")
 


### PR DESCRIPTION
- rename `get_api_keys()` to `list_api_keys()`
- remove schema — it is at www.virtool.ca now
- add or extend typing
- add or extend docstrings