### PR TITLE
Fix KeyError when using API

### DIFF
--- a/virtool/app.py
+++ b/virtool/app.py
@@ -82,9 +82,9 @@ def create_app(config):
 
     """
     middlewares = [
+        virtool.http.csp.middleware,
         virtool.http.auth.middleware,
         virtool.http.accept.middleware,
-        virtool.http.csp.middleware,
         virtool.http.errors.middleware,
         virtool.http.proxy.middleware,
         virtool.http.query.middleware


### PR DESCRIPTION
If auth failed, the nonce was not being attached to the request object and resulting in a KeyError when the response is finally being prepared.

Moved the nonce/CSP middleware to be used first so the nonce is set even if the authentication fails.