### PR TITLE
Allow SQL tests to be parallelized using xdist

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
       - name: test
         run: |
           pip install -qr requirements.txt
-          pytest  -x --db-connection-string mongodb://mongo:27017 --redis-connection-string redis://redis:6379 --postgres-connection-string postgresql+asyncpg://virtool:virtool@postgres/test --cov --cov-report xml
+          pytest  -x --db-connection-string mongodb://mongo:27017 --redis-connection-string redis://redis:6379 --postgres-connection-string postgresql+asyncpg://virtool:virtool@postgres --cov --cov-report xml
 
       - name: Run codacy-coverage-reporter
         if: ${{ github.event_name == 'push' }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,5 +32,5 @@ def pytest_addoption(parser):
     parser.addoption(
         "--postgres-connection-string",
         action="store",
-        default="postgresql+asyncpg://virtool:virtool@localhost/test"
+        default="postgresql+asyncpg://virtool:virtool@localhost"
     )

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -7,7 +7,15 @@ import virtool.users.utils
 
 class VTClient:
 
-    def __init__(self, loop, test_client, db_connection_string, postgres_connection_string, db_name, create_user):
+    def __init__(
+            self,
+            loop,
+            test_client,
+            db_connection_string,
+            postgres_connection_string,
+            db_name,
+            create_user
+    ):
         self._loop = loop
         self._test_client = test_client
         self._create_user = create_user
@@ -98,10 +106,26 @@ class VTClient:
 
 
 @pytest.fixture
-def spawn_client(loop, request, aiohttp_client, test_motor, test_db_name, test_session, create_user):
-    db_connection_string = request.config.getoption("db_connection_string", "mongodb://localhost:27017")
-    postgres_connection_string = request.config.getoption("postgres_connection_string")
+def spawn_client(
+        loop,
+        pg_connection_string,
+        pg_engine,
+        request,
+        aiohttp_client,
+        test_motor,
+        test_db_name,
+        test_session,
+        create_user
+):
+    db_connection_string = request.config.getoption("db_connection_string")
 
-    client = VTClient(loop, aiohttp_client, db_connection_string, postgres_connection_string, test_db_name, create_user)
+    client = VTClient(
+        loop,
+        aiohttp_client,
+        db_connection_string,
+        pg_connection_string,
+        test_db_name,
+        create_user
+    )
 
     return client.connect

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -9,14 +9,12 @@ class VTClient:
 
     def __init__(
             self,
-            loop,
             test_client,
             db_connection_string,
             postgres_connection_string,
             db_name,
             create_user
     ):
-        self._loop = loop
         self._test_client = test_client
         self._create_user = create_user
         self._db_connection_string = db_connection_string
@@ -113,16 +111,14 @@ def spawn_client(
         request,
         aiohttp_client,
         test_motor,
+        test_db_connection_string,
         test_db_name,
         pg_session,
         create_user
 ):
-    db_connection_string = request.config.getoption("db_connection_string")
-
     client = VTClient(
-        loop,
         aiohttp_client,
-        db_connection_string,
+        test_db_connection_string,
         pg_connection_string,
         test_db_name,
         create_user

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -114,7 +114,7 @@ def spawn_client(
         aiohttp_client,
         test_motor,
         test_db_name,
-        test_session,
+        pg_session,
         create_user
 ):
     db_connection_string = request.config.getoption("db_connection_string")

--- a/tests/fixtures/postgres.py
+++ b/tests/fixtures/postgres.py
@@ -1,39 +1,88 @@
 import pytest
-
 from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from virtool.postgres import Base
 
 
 @pytest.fixture
-def test_pg_connection_string(request):
+def pg_base_connection_string(request, pg_db_name):
+    """
+    A Postgres connection string without the database name at the end.
+
+    eg. postgresql+asyncpg://virtool:virtool@localhost
+
+    """
     return request.config.getoption("postgres_connection_string")
 
 
-@pytest.fixture(scope="function")
-async def pg_engine(test_pg_connection_string):
-    pg_connection_string = test_pg_connection_string.split('/')
-    pg_connection_string[-1] = 'virtool'
-    engine = create_async_engine('/'.join(pg_connection_string), isolation_level="AUTOCOMMIT")
+@pytest.fixture
+def pg_db_name(worker_id):
+    """
+    An auto-generated Postgres database name. One database is generated for each xdist worker.
+
+    eg. test_2 (for worker-2)
+
+    """
+    return f"test_{worker_id}"
+
+
+@pytest.fixture
+def pg_connection_string(pg_base_connection_string: str, pg_db_name: str):
+    """
+    A full Postgres connection string with the auto-generated test database name appended.
+
+     eg. postgresql+asyncpg://virtool:virtool@localhost/test_2
+
+    """
+    return f"{pg_base_connection_string}/{pg_db_name}"
+
+
+@pytest.fixture
+async def pg_engine(
+        pg_db_name: str,
+        pg_base_connection_string: str,
+        pg_connection_string: str
+) -> AsyncEngine:
+    """
+    Return a SQLAlchemy :class:`AsyncEngine` object for an auto-generated test database.
+
+    Test database are specific to xdist workers.
+
+    """
+    engine = create_async_engine(f"{pg_base_connection_string}", isolation_level="AUTOCOMMIT")
+
     async with engine.connect() as conn:
         try:
-            await conn.execute(text("CREATE DATABASE test"))
-        except ProgrammingError:
-            pass
-    return create_async_engine(test_pg_connection_string)
+            await conn.execute(text(f"CREATE DATABASE {pg_db_name}"))
+        except ProgrammingError as exc:
+            if "DuplicateDatabaseError" not in str(exc):
+                raise
+
+    return create_async_engine(pg_connection_string)
 
 
-@pytest.fixture(scope="function")
-async def test_session(pg_engine, loop):
+@pytest.fixture
+async def test_session(pg_engine: AsyncEngine) -> AsyncSession:
+    """
+    Return an :class:`AsyncSession` object backed by a test database that can be used for testing
+    calls to SQLAlchemy.
+
+    Empties tables using `TRUNCATE` between tests.
+
+    """
     async with pg_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
+        await conn.execute(text("TRUNCATE labels"))
+
     session = AsyncSession(bind=pg_engine)
+
     yield session
+
     async with pg_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+
     await session.close()

--- a/tests/fixtures/postgres.py
+++ b/tests/fixtures/postgres.py
@@ -64,7 +64,7 @@ async def pg_engine(
 
 
 @pytest.fixture
-async def test_session(pg_engine: AsyncEngine) -> AsyncSession:
+async def pg_session(pg_engine: AsyncEngine) -> AsyncSession:
     """
     Return an :class:`AsyncSession` object backed by a test database that can be used for testing
     calls to SQLAlchemy.

--- a/tests/labels/test_api.py
+++ b/tests/labels/test_api.py
@@ -2,7 +2,7 @@ import pytest
 from virtool.labels.models import Label
 
 
-async def test_find(spawn_client, test_session):
+async def test_find(spawn_client, pg_session):
     """
     Test that a ``GET /api/labels`` return a complete list of labels.
 
@@ -30,7 +30,7 @@ async def test_find(spawn_client, test_session):
         }
     ])
 
-    async with test_session as session:
+    async with pg_session as session:
         session.add_all([label_1, label_2])
         await session.commit()
 
@@ -56,7 +56,7 @@ async def test_find(spawn_client, test_session):
 
 
 @pytest.mark.parametrize("error", [None, "404"])
-async def test_get(error, spawn_client, all_permissions, test_session, resp_is):
+async def test_get(error, spawn_client, all_permissions, pg_session, resp_is):
     """
     Test that a ``GET /api/labels/:label_id`` return the correct label document.
 
@@ -83,7 +83,7 @@ async def test_get(error, spawn_client, all_permissions, test_session, resp_is):
 
     if not error:
         label = Label(id=1, name="Bug", color="#a83432", description="This is a test")
-        async with test_session as session:
+        async with pg_session as session:
             session.add(label)
             await session.commit()
 
@@ -105,7 +105,7 @@ async def test_get(error, spawn_client, all_permissions, test_session, resp_is):
 
 
 @pytest.mark.parametrize("error", [None, "400_exists", "422_color"])
-async def test_create(error, spawn_client, test_random_alphanumeric, test_session, resp_is):
+async def test_create(error, spawn_client, test_random_alphanumeric, pg_session, resp_is):
     """
     Test that a label can be added to the database at ``POST /api/labels``.
 
@@ -132,7 +132,7 @@ async def test_create(error, spawn_client, test_random_alphanumeric, test_sessio
 
     if error == "400_exists":
         label = Label(id=1, name="Bug")
-        async with test_session as session:
+        async with pg_session as session:
             session.add(label)
             await session.commit()
 
@@ -167,7 +167,7 @@ async def test_create(error, spawn_client, test_random_alphanumeric, test_sessio
 
 
 @pytest.mark.parametrize("error", [None, "404", "400_exists", "422_color", "422_data"])
-async def test_edit(error, spawn_client, test_session, resp_is):
+async def test_edit(error, spawn_client, pg_session, resp_is):
     """
         Test that a label can be edited to the database at ``PATCH /api/labels/:label_id``.
 
@@ -195,7 +195,7 @@ async def test_edit(error, spawn_client, test_session, resp_is):
     if error != "404":
         label_1 = Label(id=1, name="Bug", color="#a83432", description="This is a bug")
         label_2 = Label(id=2, name="Question", color="#03fc20", description="Question from a user")
-        async with test_session as session:
+        async with pg_session as session:
             session.add_all([label_1, label_2])
             await session.commit()
 
@@ -239,7 +239,7 @@ async def test_edit(error, spawn_client, test_session, resp_is):
 
 
 @pytest.mark.parametrize("error", [None, "400"])
-async def test_remove(error, spawn_client, test_session, resp_is):
+async def test_remove(error, spawn_client, pg_session, resp_is):
     """
         Test that a label can be deleted to the database at ``DELETE /api/labels/:label_id``.
 
@@ -248,7 +248,7 @@ async def test_remove(error, spawn_client, test_session, resp_is):
 
     if not error:
         label = Label(id=1, name="Bug", color="#a83432", description="This is a bug")
-        async with test_session as session:
+        async with pg_session as session:
             session.add(label)
             await session.commit()
 

--- a/tests/labels/test_db.py
+++ b/tests/labels/test_db.py
@@ -1,7 +1,7 @@
 from virtool.labels.db import attach_sample_count
 
 
-async def test_attach_sample_count(spawn_client, test_session):
+async def test_attach_sample_count(spawn_client, pg_session):
     client = await spawn_client(authorize=True)
 
     await client.db.samples.insert_many([

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -67,7 +67,7 @@ class MockJobInterface:
     })
 ])
 async def test_find(find, per_page, page, label_filter, d_range, meta, snapshot, spawn_client, static_time,
-                    test_session):
+                    pg_session):
     client = await spawn_client(authorize=True)
 
     time_1 = arrow.get(static_time.datetime).datetime
@@ -78,7 +78,7 @@ async def test_find(find, per_page, page, label_filter, d_range, meta, snapshot,
     label_2 = Label(id=2, name="Info", color="#03fc20", description="This is a info")
     label_3 = Label(id=3, name="Question", color="#0d321d", description="This is a question")
 
-    async with test_session as session:
+    async with pg_session as session:
         session.add_all([label_1, label_2, label_3])
         await session.commit()
 
@@ -161,13 +161,13 @@ async def test_find(find, per_page, page, label_filter, d_range, meta, snapshot,
 
 @pytest.mark.parametrize("error", [None, "404"])
 @pytest.mark.parametrize("ready", [True, False])
-async def test_get(error, ready, mocker, snapshot, spawn_client, resp_is, static_time, test_session):
+async def test_get(error, ready, mocker, snapshot, spawn_client, resp_is, static_time, pg_session):
     mocker.patch("virtool.samples.utils.get_sample_rights", return_value=(True, True))
 
     client = await spawn_client(authorize=True)
 
     label_1 = Label(id=1, name="Bug", color="#a83432", description="This is a bug")
-    async with test_session as session:
+    async with pg_session as session:
         session.add(label_1)
         await session.commit()
 
@@ -385,14 +385,14 @@ class TestCreate:
         assert await resp_is.bad_request(resp, "File does not exist")
 
     @pytest.mark.parametrize("exists", [True, False])
-    async def test_label_dne(self, exists, spawn_client, test_session, resp_is):
+    async def test_label_dne(self, exists, spawn_client, pg_session, resp_is):
         client = await spawn_client(authorize=True, permissions=["create_sample"])
 
         client.app["settings"]["sample_unique_names"] = True
 
         if exists:
             label = Label(id=1, name="Orange", color="#FFA500", description="An orange")
-            async with test_session as session:
+            async with pg_session as session:
                 session.add(label)
                 await session.commit()
 

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -279,13 +279,13 @@ class TestRemoveSamples:
         assert not await dbi.samples.count_documents({})
 
 
-async def test_attach_labels(spawn_client, test_session):
+async def test_attach_labels(spawn_client, pg_session):
     client = await spawn_client(authorize=True)
 
     label_1 = Label(id=1, name="Bug", color="#a83432", description="This is a bug")
     label_2 = Label(id=2, name="Question", color="#03fc20", description="This is a question")
 
-    async with test_session as session:
+    async with pg_session as session:
         session.add_all([label_1, label_2])
         await session.commit()
 

--- a/tests/samples/test_utils.py
+++ b/tests/samples/test_utils.py
@@ -14,10 +14,10 @@ def labels():
 
 
 @pytest.mark.parametrize("exists", [0, 1, 2])
-async def test_check_labels(exists, labels, spawn_client, test_session):
+async def test_check_labels(exists, labels, spawn_client, pg_session):
     ids = [label.id for label in labels]
 
-    async with test_session as session:
+    async with pg_session as session:
         session.add_all(labels[:exists])
 
         await session.commit()


### PR DESCRIPTION
Dedicate a Postgres database to each xdist worker when running tests in parallel.

* Use the `worker_id` to construct the database name
* Tests running on each worker connect to the same worker-specific database for each test
* The labels table is cleared with `TRUNCATE` after each test — this will have to revised for other tables

Cleaned up and commented fixture code a bit.