### PR TITLE
Use virtool/external-tools:0.2.0 in GitHub action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   server:
-
     runs-on: ubuntu-latest
     services:
       redis:
@@ -31,7 +30,7 @@ jobs:
           --health-retries 5
 
     container:
-      image: virtool/external-tools:0.1.2
+      image: virtool/external-tools:0.2.0
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Upgrades to Python 3.8. This should resolve test failures due to typing.