### PR TITLE
Fix make_analysis_dir test failure

### DIFF
--- a/tests/jobs/test_analysis.py
+++ b/tests/jobs/test_analysis.py
@@ -101,6 +101,11 @@ async def mock_job(tmpdir, mocker, request, dbi):
 
 async def test_make_analysis_dir(dbs, mock_job):
     await virtool.jobs.analysis.make_analysis_dir(mock_job)
+
+    # This tests fails sometimes if the directory list is taken immediately after running the job
+    # step. Sleep for 100 ms.
+    await asyncio.sleep(0.1)
+
     assert set(os.listdir(mock_job.temp_dir.name)) == {"raw", "baz", "reads"}
 
 

--- a/virtool/jobs/analysis.py
+++ b/virtool/jobs/analysis.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pathlib
 import shutil
+from asyncio import gather
 from typing import Union
 
 import pymongo.errors
@@ -112,9 +113,11 @@ async def make_analysis_dir(job):
     TODO: integrate into analysis working directory tree creation at start of all analysis workflows in virtool-workflow
 
     """
-    await job.run_in_executor(os.mkdir, job.params["temp_analysis_path"])
-    await job.run_in_executor(os.mkdir, job.params["raw_path"])
-    await job.run_in_executor(os.mkdir, job.params["reads_path"])
+    await gather(
+        job.run_in_executor(os.mkdir, job.params["temp_analysis_path"]),
+        job.run_in_executor(os.mkdir, job.params["raw_path"]),
+        job.run_in_executor(os.mkdir, job.params["reads_path"])
+    )
 
 
 async def prepare_reads(job: virtool.jobs.job.Job):


### PR DESCRIPTION
Fixed an issue where this test for `virtool.jobs.analysis.make_analysis_dir` would fail sporadically. This is due to a delay between the aforementioned function writing subdirectories into the analyiss directory and them being able to be listed by `os.listdir`.

* Added a short `asyncio.sleep` between calling `make_analysis_dir()` and listing the directory.
* Used `asyncio.gather` to write analysis subdirectories in parallel

