### PR TITLE
Handle FileNotFoundError when generate FASTA file

### DIFF
--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -58,7 +58,7 @@ class WriteSubtractionFASTATask(virtool.tasks.task.Task):
         db = self.db
         settings = self.app["settings"]
 
-        async for subtraction in db.subtraction.find():
+        async for subtraction in db.subtraction.find({"deleted": False}):
             path = virtool.subtractions.utils.join_subtraction_path(settings, subtraction["_id"])
             has_file = True
 


### PR DESCRIPTION
ch-248
Only generate FASTA file for subtractions with `deleted` set to `False`