### PR TITLE
Reuse virtool.db.mongo.check_mongo_version

### DIFF
--- a/tests/db/test_migrate.py
+++ b/tests/db/test_migrate.py
@@ -24,7 +24,7 @@ async def test_migrate_status(has_software, has_software_update, has_version, mo
     if has_version:
         await dbi.status.insert_one({"_id": "version"})
 
-    mocker.patch("virtool.db.utils.determine_mongo_version", make_mocked_coro("3.6.3"))
+    mocker.patch("virtool.db.mongo.check_mongo_version", make_mocked_coro("3.6.3"))
 
     app = {
         "db": dbi,

--- a/tests/db/test_mongo.py
+++ b/tests/db/test_mongo.py
@@ -1,0 +1,19 @@
+import logging
+
+import pytest
+
+from virtool.db.mongo import check_mongo_version
+
+
+@pytest.mark.parametrize("version", ["3.5.9", "3.6.0", "3.6.1"])
+async def test_check_mongo_version(dbi, caplog, mocker, version):
+    mocker.patch("virtool.db.mongo.get_server_version", return_value=version)
+
+    caplog.set_level(logging.INFO)
+
+    try:
+        await check_mongo_version(dbi)
+
+        assert caplog.messages[0] == f"Found MongoDB {version}"
+    except SystemExit as e:
+        assert e.code == 1

--- a/virtool/db/migrate.py
+++ b/virtool/db/migrate.py
@@ -2,7 +2,7 @@ import logging
 
 import pymongo.errors
 
-import virtool.db.utils
+import virtool.db.mongo
 import virtool.types
 from virtool.analyses.migrate import migrate_analyses
 from virtool.caches.migrate import migrate_caches
@@ -68,7 +68,7 @@ async def migrate_status(app: virtool.types.App):
         }
     })
 
-    mongo_version = await virtool.db.utils.determine_mongo_version(db)
+    mongo_version = await virtool.db.mongo.check_mongo_version(db)
 
     await db.status.update_many({}, {
         "$unset": {

--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -53,7 +53,7 @@ async def check_mongo_version(db: AsyncIOMotorClient):
     :param db: the application database object
 
     """
-    server_version = (await db.server_info())["version"]
+    server_version = await get_server_version(db)
 
     if semver.compare(server_version, MINIMUM_MONGO_VERSION) == -1:
         logger.critical(
@@ -62,3 +62,7 @@ async def check_mongo_version(db: AsyncIOMotorClient):
         sys.exit(1)
 
     logger.info(f"Found MongoDB {server_version}")
+
+
+async def get_server_version(db: AsyncIOMotorClient) -> str:
+    return (await db.server_info())["version"]

--- a/virtool/db/utils.py
+++ b/virtool/db/utils.py
@@ -48,18 +48,6 @@ async def delete_unready(collection):
     await collection.delete_many({"ready": False})
 
 
-async def determine_mongo_version(db):
-    """
-    Return the MongoDB server version of a passed database object (`db`).
-
-    :param db: a database object
-    :return: the MongoDB server version
-
-    """
-    server_info = await db.motor_client.client.server_info()
-    return server_info["version"]
-
-
 async def get_new_id(collection, excluded: Optional[Sequence[str]] = None) -> str:
     """
     Returns a new, unique, id that can be used for inserting a new document. Will not return any id

--- a/virtool/software/db.py
+++ b/virtool/software/db.py
@@ -5,13 +5,14 @@ import os
 
 import aiohttp
 
-import virtool.tasks.db
+import virtool.db.mongo
 import virtool.db.utils
 import virtool.http.proxy
 import virtool.http.utils
+import virtool.software.utils
+import virtool.software.utils
+import virtool.tasks.db
 import virtool.tasks.task
-import virtool.software.utils
-import virtool.software.utils
 import virtool.utils
 
 logger = logging.getLogger(__name__)
@@ -169,7 +170,7 @@ async def fetch_and_update_releases(app, ignore_errors=False):
     await db.status.update_one({"_id": "software"}, {
         "$set": {
             "errors": [],
-            "mongo_version": await virtool.db.utils.determine_mongo_version(db),
+            "mongo_version": await virtool.db.mongo.check_mongo_version(db),
             "releases": releases
         }
     })


### PR DESCRIPTION
- Remove `virtool.db.utils.determine_mongo_version` and replace usages with `check_mongo_version`
- Add tests for `check_mongo_version`