### PR TITLE
Add return value in check_mongo_version()

### DIFF
--- a/tests/db/test_mongo.py
+++ b/tests/db/test_mongo.py
@@ -7,7 +7,7 @@ from virtool.db.mongo import check_mongo_version
 
 @pytest.mark.parametrize("version", ["3.5.9", "3.6.0", "3.6.1"])
 async def test_check_mongo_version(dbi, caplog, mocker, version):
-    mocker.patch("virtool.db.mongo.get_server_version", return_value=version)
+    mocker.patch("virtool.db.mongo.get_mongo_version", return_value=version)
 
     caplog.set_level(logging.INFO)
 

--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -53,18 +53,20 @@ async def check_mongo_version(db: AsyncIOMotorClient):
     :param db: the application database object
 
     """
-    server_version = await get_server_version(db)
+    mongo_version = await get_mongo_version(db)
 
-    if semver.compare(server_version, MINIMUM_MONGO_VERSION) == -1:
+    if semver.compare(mongo_version, MINIMUM_MONGO_VERSION) == -1:
         logger.critical(
-            f"Virtool requires MongoDB {MINIMUM_MONGO_VERSION}. Found {server_version}."
+            f"Virtool requires MongoDB {MINIMUM_MONGO_VERSION}. Found {mongo_version}."
         )
         sys.exit(1)
 
-    logger.info(f"Found MongoDB {server_version}")
+    logger.info(f"Found MongoDB {mongo_version}")
+
+    return mongo_version
 
 
-async def get_server_version(db: AsyncIOMotorClient) -> str:
+async def get_mongo_version(db: AsyncIOMotorClient) -> str:
     """
     Gets a server version string from the running MongoDB client.
 


### PR DESCRIPTION
[ch335]
The problem is because `check_mongo_version` didn't have a return value, so the `mongo_version` is null which makes home page keep loading.