### PR TITLE
API endpoint for reporting job status

### DIFF
--- a/tests/fixtures/jobs.py
+++ b/tests/fixtures/jobs.py
@@ -1,9 +1,43 @@
+from typing import MutableMapping
+
 import pytest
 
 
+class TestJob(MutableMapping):
+
+    def __init__(self, db, data: dict):
+        self._data = data
+        self._db = db
+
+    @property
+    def id(self):
+        return self._data["_id"]
+
+    async def fetch(self):
+        return self._db.jobs.find_one({"_id": self.id})
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def __delitem__(self, key):
+        del self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __repr__(self):
+        return repr(self._data)
+
+
 @pytest.fixture
-def test_job(static_time):
-    return {
+def test_job(dbi, static_time):
+    return TestJob(dbi, {
         "_id": "4c530449",
         "acquired": False,
         "args": {
@@ -51,4 +85,4 @@ def test_job(static_time):
         "user": {
             "id": "igboyes"
         }
-    }
+    })

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -14,36 +14,42 @@ class Routes(aiohttp.web.RouteTableDef):
     def __init__(self):
         super().__init__()
 
-    def get(self, *args, admin=False, allow_jobs=False, permission=None, public=False, schema=None,
+    def get(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
+            public=False, schema=None,
             **kwargs):
         route_decorator = super().get(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, permission, public, schema)
+        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
 
-    def post(self, *args, admin=False, allow_jobs=False, permission=None, public=False,
+    def post(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
+             public=False,
              schema=None, **kwargs):
         route_decorator = super().post(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, permission, public, schema)
+        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
 
-    def patch(self, *args, admin=False, allow_jobs=False, permission=None, public=False,
+    def patch(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
+              public=False,
               schema=None, **kwargs):
         route_decorator = super().patch(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, permission, public, schema)
+        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
 
-    def put(self, *args, admin=False, allow_jobs=False, permission=None, public=False, schema=None,
+    def put(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
+            public=False, schema=None,
             **kwargs):
         route_decorator = super().put(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, permission, public, schema)
+        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
 
-    def delete(self, *args, admin=False, allow_jobs=False, permission=None, public=False,
+    def delete(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
+               public=False,
                schema=None, **kwargs):
         route_decorator = super().delete(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, permission, public, schema)
+        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
 
 
 def protect(
         route_decorator: Callable,
         admin: bool,
         allow_jobs: bool,
+        jobs_only: bool,
         permission: str,
         public: bool,
         schema: Dict[str, Any]
@@ -58,10 +64,18 @@ def protect(
             if not public and client is None:
                 return unauthorized("Requires authorization")
 
-            if isinstance(client, JobClient) and not allow_jobs:
+            is_job_client = isinstance(client, JobClient)
+
+            if is_job_client and not allow_jobs and not jobs_only:
                 return json_response({
                     "id": "no_jobs",
                     "message": "Job access is forbidden"
+                }, status=403)
+
+            if not is_job_client and jobs_only:
+                return json_response({
+                    "id": "jobs_only",
+                    "message": "Only job access is allowed at this endpoint"
                 }, status=403)
 
             if client is None or not client.administrator:

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -5,7 +5,8 @@ import virtool.http.routes
 import virtool.jobs.db
 import virtool.users.db
 import virtool.utils
-from virtool.api.response import bad_request, conflict, json_response, no_content, not_found
+from virtool.api.response import bad_request, conflict, json_response, no_content, \
+    not_found
 from virtool.db.utils import get_one_field
 from virtool.jobs.db import PROJECTION
 from virtool.utils import base_processor
@@ -104,6 +105,66 @@ async def cancel(req):
     document = await req.app["jobs"].cancel(job_id)
 
     return json_response(virtool.utils.base_processor(document))
+
+
+@routes.post("/api/jobs/{job_id}/status", schema={
+    "state": {
+        "type": "string",
+        "allowed": [
+            "waiting",
+            "running",
+            "complete",
+            "cancelled",
+            "error"
+        ],
+        "required": True
+    },
+    "stage": {
+        "type": "string",
+        "required": True,
+    },
+    "progress": {
+        "type": "integer",
+        "required": True,
+        "min": 0,
+        "max": 100
+    },
+    "error": {
+        "type": "dict",
+        "default": None,
+        "nullable": True
+    }
+}, allow_jobs=True)
+async def push_status(req):
+    db = req.app["db"]
+    data = req["data"]
+
+    job_id = req.match_info["job_id"]
+
+    status = await get_one_field(db.jobs, "status", job_id)
+
+    if status is None:
+        return not_found()
+
+    if status[-1]["state"] in ("complete", "cancelled", "error"):
+        return conflict("Job is finished")
+
+    document = await db.jobs.find_one_and_update({"_id": job_id}, {
+        "$set": {
+            "state": data["state"]
+        },
+        "$push": {
+            "status": {
+                "state": data["state"],
+                "stage": data["stage"],
+                "error": data["error"],
+                "progress": data["progress"],
+                "timestamp": virtool.utils.timestamp()
+            }
+        }
+    })
+
+    return json_response(document["status"][-1], status=201)
 
 
 @routes.delete("/api/jobs", permission="remove_job")


### PR DESCRIPTION
Add API endpoint for pushing job status reports.
```
POST /api/jobs/:id/status
```
- can only be accessed by clients authenticating using job tokens
- returns `409` if job is already finished

Example request body:
```json
{
  "state": "complete",
  "stage": "build",
  "progress": 100
}
```