### PR TITLE
Blakesmith/ch376/analysis finalization endpoint

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -348,11 +348,11 @@ async def test_blast(error, mocker, spawn_client, resp_is, static_time):
 
 @pytest.mark.parametrize("error", [None, 422, 404, 409])
 async def test_patch_to_set_result(spawn_client, error, resp_is):
-    analysis_document = dict(
-        _id="analysis1",
-        sample=dict(id="sample1"),
-        workflow="test_workflow",
-    )
+    analysis_document = {
+        "_id": "analysis1",
+        "sample": {"id": "sample1"},
+        "workflow": "test_workflow",
+    }
 
     patch_json = {
         "results": {
@@ -377,7 +377,7 @@ async def test_patch_to_set_result(spawn_client, error, resp_is):
         assert response.status == error
     else:
         assert response.status == 200
-        document = await client.db.analyses.find_one(dict(_id=analysis_document["_id"]))
+        document = await client.db.analyses.find_one({"_id": analysis_document["_id"]})
 
         assert document["results"] == patch_json["results"]
         assert document["ready"]

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -382,4 +382,6 @@ async def test_patch_to_set_result(spawn_client, error, resp_is):
         assert document["results"] == patch_json["results"]
         assert document["ready"] is True
 
+        response_json = await response.json()
 
+        assert response_json == document

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -1,6 +1,8 @@
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 
+from virtool.utils import base_processor
+
 
 @pytest.mark.parametrize("ready", [True, False])
 @pytest.mark.parametrize("error", [None, "400", "403", "404"])
@@ -384,4 +386,4 @@ async def test_patch_to_set_result(spawn_client, error, resp_is):
 
         response_json = await response.json()
 
-        assert response_json == document
+        assert response_json == base_processor(document)

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -380,6 +380,6 @@ async def test_patch_to_set_result(spawn_client, error, resp_is):
         document = await client.db.analyses.find_one({"_id": analysis_document["_id"]})
 
         assert document["results"] == patch_json["results"]
-        assert document["ready"]
+        assert document["ready"] is True
 
 

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -8,8 +8,6 @@ from typing import Any, Dict
 
 import aiohttp.web
 import aiojobs.aiohttp
-from aiohttp.web_exceptions import HTTPConflict, HTTPBadRequest, HTTPInternalServerError, HTTPNotFound, HTTPOk, \
-    HTTPForbidden
 from virtool_core.samples.db import recalculate_workflow_tags
 
 import virtool.analyses.db

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 
 import aiohttp.web
 import aiojobs.aiohttp
-from virtool_core.samples.db import recalculate_workflow_tags
 
 import virtool.analyses.db
 import virtool.analyses.format
@@ -26,6 +25,7 @@ import virtool.utils
 from virtool.api.response import bad_request, conflict, insufficient_rights, \
     json_response, no_content, not_found
 from virtool.db.core import Collection, DB
+from virtool.samples.db import recalculate_workflow_tags
 
 routes = virtool.http.routes.Routes()
 
@@ -256,7 +256,7 @@ async def patch_analysis(req: aiohttp.web.Request):
     analyses: Collection = db.analyses
     analysis_id: str = req.match_info["analysis_id"]
 
-    analysis_document: Dict[str, Any] = await analyses.find_one(dict(_id=analysis_id))
+    analysis_document: Dict[str, Any] = await analyses.find_one({"_id": analysis_id})
 
     if not analysis_document:
         return not_found(f"There is no analysis with id {analysis_id}")
@@ -264,7 +264,7 @@ async def patch_analysis(req: aiohttp.web.Request):
     if "ready" in analysis_document and analysis_document["ready"]:
         return conflict("There is already a result for this analysis.")
 
-    await analyses.update_one(dict(_id=analysis_id), {
+    await analyses.update_one({"_id":analysis_id}, {
         "$set": {
             "results": (await req.json())["results"],
             "ready": True
@@ -273,7 +273,7 @@ async def patch_analysis(req: aiohttp.web.Request):
 
     await recalculate_workflow_tags(db, analysis_document["sample"]["id"])
 
-    return json_response(dict(message=f"The result has been set for analysis {analysis_id}."))
+    return json_response({"message": f"The result has been set for analysis {analysis_id}."})
 
 
 

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -266,11 +266,9 @@ async def patch_analysis(req: aiohttp.web.Request):
     if "ready" in analysis_document and analysis_document["ready"]:
         return conflict("There is already a result for this analysis.")
 
-    request_json: Dict[str, Any] = await req.json()
-
     await analyses.update_one(dict(_id=analysis_id), {
         "$set": {
-            "results": request_json["results"],
+            "results": (await req.json())["results"],
             "ready": True
         }
     })

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -248,7 +248,7 @@ async def blast(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
 
 @routes.patch("/api/analyses/{analysis_id}", schema={
-    "results": {"type": "dict", 'required': True}
+    "results": {"type": "dict", "required": True}
 })
 async def patch_analysis(req: aiohttp.web.Request):
     """Sets the result for an analysis and marks it as ready."""
@@ -264,16 +264,18 @@ async def patch_analysis(req: aiohttp.web.Request):
     if "ready" in analysis_document and analysis_document["ready"]:
         return conflict("There is already a result for this analysis.")
 
-    await analyses.update_one({"_id":analysis_id}, {
+    request_json = await req.json()
+
+    await analyses.update_one({"_id": analysis_id}, {
         "$set": {
-            "results": (await req.json())["results"],
+            "results": request_json["results"],
             "ready": True
         }
     })
 
     await recalculate_workflow_tags(db, analysis_document["sample"]["id"])
 
-    return json_response({"message": f"The result has been set for analysis {analysis_id}."})
+    return aiohttp.web.Response(status=200)
 
 
 

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -242,3 +242,8 @@ async def blast(req: aiohttp.web.Request) -> aiohttp.web.Response:
     }
 
     return json_response(blast_data, headers=headers, status=201)
+
+
+@routes.patch("/api/analyses/{analysis_id}")
+def patch_analysis(analysis_id):
+    ...

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -266,7 +266,7 @@ async def patch_analysis(req: aiohttp.web.Request):
 
     request_json = await req.json()
 
-    await analyses.update_one({"_id": analysis_id}, {
+    updated_analysis_document = await analyses.find_one_and_update({"_id": analysis_id}, {
         "$set": {
             "results": request_json["results"],
             "ready": True
@@ -275,9 +275,4 @@ async def patch_analysis(req: aiohttp.web.Request):
 
     await recalculate_workflow_tags(db, analysis_document["sample"]["id"])
 
-    return aiohttp.web.Response(status=200)
-
-
-
-
-
+    return json_response(updated_analysis_document)

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -26,6 +26,7 @@ from virtool.api.response import bad_request, conflict, insufficient_rights, \
     json_response, no_content, not_found
 from virtool.db.core import Collection, DB
 from virtool.samples.db import recalculate_workflow_tags
+from virtool.utils import base_processor
 
 routes = virtool.http.routes.Routes()
 
@@ -275,4 +276,4 @@ async def patch_analysis(req: aiohttp.web.Request):
 
     await recalculate_workflow_tags(db, analysis_document["sample"]["id"])
 
-    return json_response(updated_analysis_document)
+    return json_response(base_processor(updated_analysis_document))


### PR DESCRIPTION
Adds a *PATCH* route at `"/api/analyses/{analysis_id}"` for setting the analysis results.

The request JSON is expected to have a `"results"` field containing a JSON object. The JSON object given will be stored in the `"results"` field of the analysis document in MongoDB. The analysis document will also be marked as ready by setting `"ready"` to `True`.

The route will return the following response codes:

<dl>
	<dt>404 Not Found</dt>
	<dd>When the analysis_id given in the URL does not correspond to an analysis.</dd>
	<dt>409 Conflict</dt>
	<dd>When the "ready" field is already set on the analysis document (there is already a result).</dd>
	<dt>422 Unprocessible Entry</dt>
	<dd>When the request JSON does not have a "results" field, or the field is not an object.</dd>
	<dt>200 OK<dt>
	<dd>When the "results" and "ready" fields are successfully set on the analysis document.</dd> 

</dl>

Additionally, `recalculate_workflow_tags` will be called (status code 200), and does not need to be called by the consumer of the API.