### PR TITLE
Index Deletion Endpoint and `spawn_job_client` Test Fixture

### DIFF
--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -421,7 +421,7 @@ async def test(error, snapshot, spawn_client, resp_is):
 
 
 @pytest.mark.parametrize("error", [None, 404])
-async def test_delete_index(spawn_client, error):
+async def test_delete_index(spawn_job_client, error):
     index_id = "index1"
     index_document = {
         "_id": index_id,
@@ -435,7 +435,7 @@ async def test_delete_index(spawn_client, error):
         }
     } for _id in ("history1", "history2", "history3")]
 
-    client = await spawn_client(authorize=True)
+    client = await spawn_job_client(authorize=True, enable_api=True)
     indexes = client.db.indexes
     history = client.db.history
 

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -241,6 +241,29 @@ async def find_history(req):
     return json_response(data)
 
 
+def reset_history(history: Collection, index_id: str):
+    """
+    Set the index.id and index.version fields with the given index id to 'unbuilt'.
+
+    :param history: The history collection of the database.
+    :param index_id: The ID of the index which failed to build
+    """
+    query = {
+        "_id": {
+            "$in": await history.distinct("_id", {"index.id": index_id})
+        }
+    }
+
+    return await history.update_many(query, {
+        "$set": {
+            "index": {
+                "id": "unbuilt",
+                "version": "unbuilt"
+            }
+        }
+    })
+
+
 @routes.delete("/api/indexes/{index_id}", jobs_only=True)
 def delete_index(req: aiohttp.web.Request):
     index_id = req.match_info["index_id"]

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -14,6 +14,7 @@ import virtool.references.db
 import virtool.utils
 from virtool.api.response import bad_request, conflict, insufficient_rights, json_response, \
     not_found
+from virtool.db.core import Collection
 from virtool.jobs.utils import JobRights
 
 routes = virtool.http.routes.Routes()
@@ -244,4 +245,10 @@ async def find_history(req):
 def delete_index(req: aiohttp.web.Request):
     index_id = req.match_info["index_id"]
     db = req.app["db"]
-    indexes = db.indexes
+    indexes: Collection = db.indexes
+
+    delete_result = await indexes.delete_one({"_id": index_id})
+
+    if delete_result.deleted_count != 1:
+        # Document could not be deleted.
+        return not_found(f"There is no index with id: {index_id}.")

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import aiohttp
+
 import virtool.api.utils
 import virtool.db.utils
 import virtool.history.db
@@ -236,3 +238,10 @@ async def find_history(req):
     )
 
     return json_response(data)
+
+
+@routes.delete("/api/indexes/{index_id}", jobs_only=True)
+def delete_index(req: aiohttp.web.Request):
+    index_id = req.match_info["index_id"]
+    db = req.app["db"]
+    indexes = db.indexes


### PR DESCRIPTION
Adds a DELETE endpoint at `/api/indexes/{index_id}` which is only accessible to virtool jobs. This route is intendend to be used when a `build_index` job fails.

- Deletes the index with the given ID from the database.
- Resets any history database entries referencing that index.
	- `"index.id"` and `"index.version"` set to `"unbuilt"`
- Returns a `404 NOT FOUND` response if the index does not exist.
- Returns a `204 NO CONTENT` response otherwise.


Adds a new test fixture `spawn_job_client` which provides an aiohttp client which can authenticate with the API as a Job. It accepts thesame arguments as the `spawn_client` fixture.


