### PR TITLE
Support upload of analysis files

### DIFF
--- a/tests/analyses/snapshots/snap_test_api.py
+++ b/tests/analyses/snapshots/snap_test_api.py
@@ -10,6 +10,18 @@ snapshots = Snapshot()
 snapshots['test_get[uvloop-None-True] format_analysis'] = {
     '_id': 'foobar',
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'files': [
+        {
+            'analysis': 'foobar',
+            'description': None,
+            'format': 'fasta',
+            'id': 1,
+            'name': 'reference.fa',
+            'name_on_disk': '1-reference.fa',
+            'size': None,
+            'uploaded_at': None
+        }
+    ],
     'ready': True,
     'results': {
     },
@@ -31,6 +43,18 @@ snapshots['test_get[uvloop-None-True] 1'] = {
 
 snapshots['test_get[uvloop-None-False] 1'] = {
     'created_at': '2015-10-06T20:00:00Z',
+    'files': [
+        {
+            'analysis': 'foobar',
+            'description': None,
+            'format': 'fasta',
+            'id': 1,
+            'name': 'reference.fa',
+            'name_on_disk': '1-reference.fa',
+            'size': None,
+            'uploaded_at': None
+        }
+    ],
     'id': 'foobar',
     'ready': False,
     'results': {

--- a/tests/analyses/snapshots/snap_test_api.py
+++ b/tests/analyses/snapshots/snap_test_api.py
@@ -158,3 +158,8 @@ snapshots['test_upload_file[uvloop-None] 1'] = {
     'size': 20466,
     'uploaded_at': '2015-10-06T20:00:00Z'
 }
+
+snapshots['test_download_file[uvloop-False] 1'] = {
+    'id': 'not_found',
+    'message': 'Not found'
+}

--- a/tests/analyses/snapshots/snap_test_api.py
+++ b/tests/analyses/snapshots/snap_test_api.py
@@ -123,3 +123,14 @@ snapshots['test_find[uvloop] 1'] = {
     'per_page': 25,
     'total_count': 3
 }
+
+snapshots['test_upload_file[uvloop-None] 1'] = {
+    'analysis': 'foobar',
+    'description': None,
+    'format': 'fasta',
+    'id': 1,
+    'name': 'reference.fa',
+    'name_on_disk': '1-reference.fa',
+    'size': 20466,
+    'uploaded_at': '2015-10-06T20:00:00Z'
+}

--- a/tests/analyses/snapshots/snap_test_api.py
+++ b/tests/analyses/snapshots/snap_test_api.py
@@ -163,3 +163,18 @@ snapshots['test_download_file[uvloop-False] 1'] = {
     'id': 'not_found',
     'message': 'Not found'
 }
+
+snapshots['test_download_file[uvloop-True-False] 1'] = {
+    'id': 'not_found',
+    'message': 'Uploaded file not found at expected location'
+}
+
+snapshots['test_download_file[uvloop-False-True] 1'] = {
+    'id': 'not_found',
+    'message': 'Not found'
+}
+
+snapshots['test_download_file[uvloop-False-False] 1'] = {
+    'id': 'not_found',
+    'message': 'Not found'
+}

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -1,3 +1,7 @@
+import os
+import sys
+from pathlib import Path
+
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 
@@ -233,6 +237,68 @@ async def test_remove(mocker, error, spawn_client, resp_is):
     assert await client.db.analyses.find_one() is None
 
     assert m_remove.called_with("data/samples/baz/analyses/foobar", True)
+
+
+@pytest.mark.parametrize("error", [None, "400", "404", "422"])
+async def test_upload_file(error, resp_is, spawn_client, static_time, snapshot, tmpdir):
+    """
+    Test that an analysis result file is properly uploaded, a record is inserted into the `analysis_files` SQL table,
+    and that the `list` field in a given analysis is updated to reflect the new file.
+
+    """
+    tmpdir.mkdir("files")
+
+    path = Path(sys.path[0]) / "tests" / "test_files" / "aodp" / "reference.fa"
+
+    data = {
+        "file": open(path, "rb")
+    }
+
+    client = await spawn_client(authorize=True, administrator=True)
+
+    client.app["settings"]["data_path"] = str(tmpdir)
+
+    if error == "400":
+        format_ = "foo"
+    else:
+        format_ = "fasta"
+
+    if error != "404":
+        await client.db.analyses.insert_one({
+            "_id": "foobar",
+            "ready": True,
+            "job": {
+                "id": "hello"
+            },
+            "files": []
+        })
+
+    if error == "422":
+        resp = await client.post_form(f"/api/analyses/foobar/files?format=fasta", data=data)
+    else:
+        resp = await client.post_form(f"/api/analyses/foobar/files?name=reference.fa&format={format_}", data=data)
+
+    if error is None:
+        assert resp.status == 201
+
+        snapshot.assert_match(await resp.json())
+
+        assert os.listdir(tmpdir / "analyses") == ["1-reference.fa"]
+
+        document = await client.db.analyses.find_one("foobar")
+
+        assert document["files"] == ["1-reference.fa"]
+
+    elif error == "400":
+        assert await resp_is.bad_request(resp, "Unsupported analysis file format")
+
+    elif error == "404":
+        assert resp.status == 404
+
+    elif error == "422":
+        assert await resp_is.invalid_query(resp, {
+            "name": ["required field"]
+        })
 
 
 @pytest.mark.parametrize("error", [None, "400", "403", "404_analysis", "404_sequence", "409_workflow", "409_ready"])

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -296,7 +296,7 @@ async def test_upload_file(error, files, resp_is, spawn_client, static_time, sna
 
         document = await client.db.analyses.find_one("foobar")
 
-        assert document["files"] == ["1-reference.fa"]
+        assert document["files"] == [1]
 
     elif error == 400:
         assert await resp_is.bad_request(resp, "Unsupported analysis file format")

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -311,7 +311,7 @@ async def test_upload_file(error, files, resp_is, spawn_client, static_time, sna
 
 
 @pytest.mark.parametrize("exists", [True, False])
-async def test_download_file(exists, files, spawn_client, tmpdir):
+async def test_download_file(exists, files, spawn_client, snapshot, tmpdir):
     """
     Test that you can properly download an analysis result file using details from the `analysis_files` SQL table
 
@@ -320,7 +320,7 @@ async def test_download_file(exists, files, spawn_client, tmpdir):
 
     client.app["settings"]["data_path"] = str(tmpdir)
 
-    if not exists:
+    if exists:
         await client.db.analyses.insert_one({
             "_id": "foobar",
             "ready": True,
@@ -334,7 +334,10 @@ async def test_download_file(exists, files, spawn_client, tmpdir):
 
     resp = await client.get("/api/analyses/foobar/files/1")
 
-    assert resp.status == 200 if not exists else 404
+    assert resp.status == 200 if exists else 404
+
+    if not exists:
+        snapshot.assert_match(await resp.json())
 
 
 @pytest.mark.parametrize("error", [None, "400", "403", "404_analysis", "404_sequence", "409_workflow", "409_ready"])

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -322,6 +322,7 @@ async def test_download_file(file_exists, row_exists, files, spawn_client, snaps
     client.app["settings"]["data_path"] = str(tmpdir)
 
     expected_path = Path(client.app["settings"]["data_path"]) / "analyses" / "1-reference.fa"
+    file_size = 0
 
     await client.db.analyses.insert_one({
         "_id": "foobar",
@@ -350,8 +351,6 @@ async def test_download_file(file_exists, row_exists, files, spawn_client, snaps
     else:
         assert resp.status == 404
         snapshot.assert_match(await resp.json())
-
-    
 
 
 @pytest.mark.parametrize("error", [None, "400", "403", "404_analysis", "404_sequence", "409_workflow", "409_ready"])

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -323,7 +323,6 @@ async def test_download_file(file_exists, row_exists, files, spawn_client, snaps
     client.app["settings"]["data_path"] = str(tmpdir)
 
     expected_path = Path(client.app["settings"]["data_path"]) / "analyses" / "1-reference.fa"
-    file_size = 0
 
     await client.db.analyses.insert_one({
         "_id": "foobar",

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -6,6 +6,7 @@ import pytest
 from aiohttp.test_utils import make_mocked_coro
 
 import virtool.analyses.db
+import virtool.analyses.files
 from virtool.utils import base_processor
 
 
@@ -66,7 +67,7 @@ async def test_get(ready, files, error, mocker, snapshot, spawn_client, static_t
     if error != "404":
         await client.db.analyses.insert_one(document)
 
-        await virtool.analyses.db.create_row(pg_engine, "foobar", "fasta", "reference.fa")
+        await virtool.analyses.files.create_analysis_file(pg_engine, "foobar", "fasta", "reference.fa")
 
     m_format_analysis = mocker.patch(
         "virtool.analyses.format.format_analysis",

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -283,7 +283,7 @@ async def test_upload_file(error, files, resp_is, spawn_client, static_time, sna
         })
 
     if error == 422:
-        resp = await client.post_form(f"/api/analyses/foobar/files?format=fasta", data=files)
+        resp = await client.post_form("/api/analyses/foobar/files?format=fasta", data=files)
     else:
         resp = await client.post_form(f"/api/analyses/foobar/files?name=reference.fa&format={format_}", data=files)
 
@@ -330,7 +330,7 @@ async def test_download_file(exists, files, spawn_client, tmpdir):
             "files": []
         })
 
-    await client.post_form(f"/api/analyses/foobar/files?name=reference.fa&format=fasta", data=files)
+    await client.post_form("/api/analyses/foobar/files?name=reference.fa&format=fasta", data=files)
 
     resp = await client.get("/api/analyses/foobar/files/1")
 

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -338,8 +338,6 @@ async def test_download_file(file_exists, row_exists, files, spawn_client, snaps
 
         assert expected_path.is_file()
 
-        file_size = expected_path.stat().st_size
-
     if not file_exists and row_exists:
         expected_path.unlink()
 
@@ -347,7 +345,7 @@ async def test_download_file(file_exists, row_exists, files, spawn_client, snaps
 
     if file_exists and row_exists:
         assert resp.status == 200
-        assert file_size == resp.content_length
+        assert expected_path.read_bytes() == await resp.content.read()
     else:
         assert resp.status == 404
         snapshot.assert_match(await resp.json())

--- a/tests/analyses/test_utils.py
+++ b/tests/analyses/test_utils.py
@@ -2,12 +2,13 @@ import pytest
 
 import virtool.analyses.db
 import virtool.analyses.utils
+import virtool.analyses.files
 
 
 @pytest.mark.parametrize("exists", [True, False])
 async def test_attach_analysis_files(exists, spawn_client, pg_engine):
     if exists:
-        await virtool.analyses.db.create_row(pg_engine, "foobar", "fasta", "reference-fa")
+        await virtool.analyses.files.create_analysis_file(pg_engine, "foobar", "fasta", "reference-fa")
 
     files = await virtool.analyses.utils.attach_analysis_files(pg_engine, "foobar")
 

--- a/tests/analyses/test_utils.py
+++ b/tests/analyses/test_utils.py
@@ -1,16 +1,30 @@
 import pytest
 
+import virtool.analyses.db
 import virtool.analyses.utils
+
+
+@pytest.mark.parametrize("exists", [True, False])
+async def test_attach_analysis_files(exists, spawn_client, pg_engine):
+    if exists:
+        await virtool.analyses.db.create_row(pg_engine, "foobar", "fasta", "reference-fa")
+
+    files = await virtool.analyses.utils.attach_analysis_files(pg_engine, "foobar")
+
+    if exists:
+        assert files != []
+    else:
+        assert files == []
 
 
 @pytest.mark.parametrize("coverage,expected", [
     (
-        [0, 0, 1, 1, 2, 3, 3, 3, 4, 4, 3, 2],
-        [(0, 0), (1, 0), (2, 1), (3, 1), (4, 2), (5, 3), (7, 3), (8, 4), (9, 4), (10, 3), (11, 2)]
+            [0, 0, 1, 1, 2, 3, 3, 3, 4, 4, 3, 2],
+            [(0, 0), (1, 0), (2, 1), (3, 1), (4, 2), (5, 3), (7, 3), (8, 4), (9, 4), (10, 3), (11, 2)]
     ),
     (
-        [0, 0, 1, 1, 2, 3, 3, 3, 4, 4, 3, 2, 1, 1],
-        [(0, 0), (1, 0), (2, 1), (3, 1), (4, 2), (5, 3), (7, 3), (8, 4), (9, 4), (10, 3), (11, 2), (12, 1), (13, 1)]
+            [0, 0, 1, 1, 2, 3, 3, 3, 4, 4, 3, 2, 1, 1],
+            [(0, 0), (1, 0), (2, 1), (3, 1), (4, 2), (5, 3), (7, 3), (8, 4), (9, 4), (10, 3), (11, 2), (12, 1), (13, 1)]
     )
 ])
 def test_collapse_pathoscope_coverage(coverage, expected):

--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from sqlalchemy import select
 
 from virtool.uploads.api import UPLOAD_TYPES
 from virtool.uploads.models import Upload
@@ -54,12 +53,6 @@ class TestUpload:
         assert resp.status == 201
 
         snapshot.assert_match(await resp.json())
-
-        # check if new `upload` was properly committed to db
-        async with pg_session as session:
-            upload = (await session.execute(select(Upload).filter(Upload.id == 1))).scalar()
-
-            assert upload is not None
 
         assert os.listdir(tmpdir / "files") == ["1-Test.fq.gz"]
 

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -233,10 +233,6 @@ async def upload(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
     analysis_file = await virtool.uploads.db.finalize(pg, size, file_id, AnalysisFile)
 
-    if not analysis_file:
-        await req.app["run_in_thread"](os.remove, analysis_file_path)
-        return not_found("Row not found in table after file upload")
-
     files.append(file_id)
 
     await db.analyses.update_one({"_id": analysis_id}, {

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -219,7 +219,7 @@ async def upload(req: aiohttp.web.Request) -> aiohttp.web.Response:
     files = document.get("files", [])
 
     if name_on_disk in files:
-        return bad_request("File is already associated with analysis")
+        return conflict("File is already associated with analysis")
 
     file_id = analysis_file["id"]
     analysis_file_path = Path(req.app["settings"]["data_path"]) / "analyses" / name_on_disk

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -186,7 +186,7 @@ async def remove(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return no_content()
 
 
-@routes.post("/api/analyses/{id}/files")
+@routes.post("/api/analyses/{id}/files", permission="upload_file")
 async def upload(req: aiohttp.web.Request) -> aiohttp.web.Response:
     """
     Upload a new analysis result file to the `analysis_files` SQL table and the `analyses` folder in the Virtool

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -227,7 +227,7 @@ async def upload(req: aiohttp.web.Request) -> aiohttp.web.Response:
     try:
         size = await virtool.uploads.utils.naive_writer(req, analysis_file_path)
     except asyncio.CancelledError:
-        logger.debug(f"Upload aborted: {file_id}")
+        logger.debug(f"Analysis file upload aborted: {file_id}")
         await virtool.analyses.db.delete_row(pg, file_id)
 
         return aiohttp.web.Response(status=499)

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -216,9 +216,8 @@ async def upload(req: aiohttp.web.Request) -> aiohttp.web.Response:
     analysis_file = await virtool.analyses.db.create_row(pg, analysis_id, analysis_format, name)
 
     file_id = analysis_file["id"]
-    files = document.get("files", [])
 
-    if file_id in files:
+    if file_id in document.get("files", []):
         return conflict("File is already associated with analysis")
 
     analysis_file_path = Path(req.app["settings"]["data_path"]) / "analyses" / analysis_file["name_on_disk"]
@@ -233,10 +232,8 @@ async def upload(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
     analysis_file = await virtool.uploads.db.finalize(pg, size, file_id, AnalysisFile)
 
-    files.append(file_id)
-
     await db.analyses.update_one({"_id": analysis_id}, {
-        "$set": {"files": files}
+        "$push": {"files": file_id}
     })
 
     headers = {

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -244,15 +244,15 @@ async def create_row(pg: AsyncEngine, analysis_id: int, analysis_format: str, na
         return analysis_file
 
 
-async def delete_row(pg: AsyncEngine, analysis_file_id: int):
+async def delete_row(pg: AsyncEngine, file_id: int):
     """
     Deletes a row in the `analysis_files` SQL by its row `id`
 
     :param pg: PostgreSQL AsyncEngine object
-    :param analysis_file_id: Row `id` to delete
+    :param file_id: Row `id` to delete
     """
     async with AsyncSession(pg) as session:
-        analysis_file = (await session.execute(select(AnalysisFile).where(AnalysisFile.id == analysis_file_id))).scalar()
+        analysis_file = (await session.execute(select(AnalysisFile).where(AnalysisFile.id == file_id))).scalar()
 
         if not analysis_file:
             return None
@@ -260,6 +260,23 @@ async def delete_row(pg: AsyncEngine, analysis_file_id: int):
         await session.delete(analysis_file)
 
         await session.commit()
+
+
+async def get_row(pg: AsyncEngine, file_id: int):
+    """
+    Get a row that represents an analysis result file by its `id`
+
+    :param pg: PostgreSQL AsyncEngine object
+    :param file_id: Row `id` to get
+    :return:
+    """
+    async with AsyncSession(pg) as session:
+        upload = (await session.execute(select(AnalysisFile).filter_by(id=file_id))).scalar()
+
+        if not upload:
+            return None
+
+        return upload
 
 
 async def update_nuvs_blast(

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -6,8 +6,8 @@ import asyncio
 import os
 from typing import Any, Dict, Optional, Tuple
 
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.analyses.utils
 import virtool.bio
@@ -214,7 +214,7 @@ async def create(
     return document
 
 
-async def create_row(pg: AsyncEngine, analysis_id: int, analysis_format: str, name: str) -> Dict[str, any]:
+async def create_row(pg: AsyncEngine, analysis_id: str, analysis_format: str, name: str) -> Dict[str, any]:
     """
     Create a row in the `analysis_files` SQL table that represents an analysis result file.
 
@@ -262,7 +262,7 @@ async def delete_row(pg: AsyncEngine, file_id: int):
         await session.commit()
 
 
-async def get_row(pg: AsyncEngine, file_id: int):
+async def get_row(pg: AsyncEngine, file_id: int) -> Optional[AnalysisFile]:
     """
     Get a row that represents an analysis result file by its `id`
 
@@ -276,7 +276,7 @@ async def get_row(pg: AsyncEngine, file_id: int):
         if not upload:
             return None
 
-        return upload
+    return upload
 
 
 async def update_nuvs_blast(

--- a/virtool/analyses/files.py
+++ b/virtool/analyses/files.py
@@ -60,7 +60,7 @@ async def get_analysis_file(pg: AsyncEngine, file_id: int) -> Optional[AnalysisF
 
     :param pg: PostgreSQL AsyncEngine object
     :param file_id: Row `id` to get
-    :return:
+    :return: Row from the `analysis_files` SQL table
     """
     async with AsyncSession(pg) as session:
         upload = (await session.execute(select(AnalysisFile).filter_by(id=file_id))).scalar()

--- a/virtool/analyses/files.py
+++ b/virtool/analyses/files.py
@@ -1,0 +1,71 @@
+from typing import Dict, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.analyses.models import AnalysisFile
+
+
+async def create_analysis_file(pg: AsyncEngine, analysis_id: str, analysis_format: str, name: str) -> Dict[str, any]:
+    """
+    Create a row in the `analysis_files` SQL table that represents an analysis result file.
+
+    :param pg: PostgreSQL AsyncEngine object
+    :param analysis_id: ID that corresponds to a parent analysis
+    :param analysis_format: Format of the analysis result file
+    :param name: Name of the analysis result file
+    :return: A dictionary representation of the newly created row
+    """
+    async with AsyncSession(pg) as session:
+        analysis_file = AnalysisFile(
+            name=name,
+            analysis=analysis_id,
+            format=analysis_format
+        )
+
+        session.add(analysis_file)
+
+        await session.flush()
+
+        analysis_file.name_on_disk = f"{analysis_file.id}-{analysis_file.name}"
+
+        analysis_file = analysis_file.to_dict()
+
+        await session.commit()
+
+        return analysis_file
+
+
+async def delete_analysis_file(pg: AsyncEngine, file_id: int):
+    """
+    Deletes a row in the `analysis_files` SQL by its row `id`
+
+    :param pg: PostgreSQL AsyncEngine object
+    :param file_id: Row `id` to delete
+    """
+    async with AsyncSession(pg) as session:
+        analysis_file = (await session.execute(select(AnalysisFile).where(AnalysisFile.id == file_id))).scalar()
+
+        if not analysis_file:
+            return None
+
+        await session.delete(analysis_file)
+
+        await session.commit()
+
+
+async def get_analysis_file(pg: AsyncEngine, file_id: int) -> Optional[AnalysisFile]:
+    """
+    Get a row that represents an analysis result file by its `id`
+
+    :param pg: PostgreSQL AsyncEngine object
+    :param file_id: Row `id` to get
+    :return:
+    """
+    async with AsyncSession(pg) as session:
+        upload = (await session.execute(select(AnalysisFile).filter_by(id=file_id))).scalar()
+
+        if not upload:
+            return None
+
+    return upload

--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -1,0 +1,43 @@
+import enum
+from sqlalchemy import Column, Integer, String, DateTime, Enum
+
+from virtool.postgres import Base
+
+
+class AnalysisFormat(str, enum.Enum):
+    """
+    Enumerated type for analysis file formats
+
+    """
+
+    @classmethod
+    def to_list(cls):
+        return [e.value for e in cls.__members__.values()]
+
+    sam = "sam"
+    bam = "bam"
+    fasta = "fasta"
+    fastq = "fastq"
+    csv = "csv"
+    tsv = "tsv"
+    json = "json"
+
+
+ANALYSIS_FORMATS = [*AnalysisFormat.to_list(), None]
+
+
+class AnalysisFile(Base):
+    """
+    SQL table to store new analysis files
+
+    """
+    __tablename__ = "analysis_files"
+
+    id = Column(Integer, primary_key=True)
+    analysis = Column(String)
+    description = Column(String)
+    format = Column(Enum(AnalysisFormat))
+    name = Column(String)
+    name_on_disk = Column(String, unique=True)
+    size = Column(Integer)
+    uploaded_at = Column(DateTime)

--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -28,7 +28,7 @@ ANALYSIS_FORMATS = [*AnalysisFormat.to_list(), None]
 
 class AnalysisFile(Base):
     """
-    SQL table to store new analysis files
+    SQL model to store new analysis files
 
     """
     __tablename__ = "analysis_files"

--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -41,3 +41,8 @@ class AnalysisFile(Base):
     name_on_disk = Column(String, unique=True)
     size = Column(Integer)
     uploaded_at = Column(DateTime)
+
+    def __repr__(self):
+        return f"<AnalysisFile(id={self.id}, analysis={self.analysis}, description={self.description}, " \
+               f"format={self.format}, name={self.name}, name_on_disk={self.name_on_disk}, size={self.size}, " \
+               f"uploaded_at={self.uploaded_at})>"

--- a/virtool/analyses/utils.py
+++ b/virtool/analyses/utils.py
@@ -27,10 +27,7 @@ async def attach_analysis_files(pg: AsyncEngine, analysis_id: str) -> List[Dict]
     async with AsyncSession(pg) as session:
         results = (await session.execute(select(AnalysisFile).filter_by(analysis=analysis_id))).scalars().all()
 
-        for result in results:
-            files.append(result.to_dict())
-
-    return files
+    return [result.to_dict() for result in results]
 
 
 def find_nuvs_sequence_by_index(

--- a/virtool/analyses/utils.py
+++ b/virtool/analyses/utils.py
@@ -22,8 +22,6 @@ async def attach_analysis_files(pg: AsyncEngine, analysis_id: str) -> List[Dict]
     :param analysis_id: An id for a specific analysis
     :return: List of file details for each file associated with an analysis
     """
-    files = []
-
     async with AsyncSession(pg) as session:
         results = (await session.execute(select(AnalysisFile).filter_by(analysis=analysis_id))).scalars().all()
 

--- a/virtool/postgres.py
+++ b/virtool/postgres.py
@@ -1,9 +1,10 @@
 import logging
 import sys
+from enum import Enum
 
 from sqlalchemy import text
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.ext.declarative import declarative_base
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,13 @@ async def create_tables(engine):
 
 
 def to_dict(self):
-    return {c.name: getattr(self, c.name, None) for c in self.__table__.columns}
+    row = dict()
+    for c in self.__table__.columns:
+        column = getattr(self, c.name, None)
+
+        row[c.name] = column if not isinstance(column, Enum) else column.value
+
+    return row
 
 
 Base.to_dict = to_dict

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -52,12 +52,12 @@ async def create(req):
 
         return aiohttp.web.Response(status=499)
 
-    upload = await virtool.uploads.db.finalize(pg, size, upload_id, virtool.utils.timestamp())
+    upload = await virtool.uploads.db.finalize(pg, size, upload_id, Upload)
 
     if not upload:
         await req.app["run_in_thread"](os.remove, file_path)
 
-        return not_found("Document not found in table after file upload")
+        return not_found("Row not found in table after file upload")
 
     logger.debug(f"Upload succeeded: {upload_id}")
 

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -12,17 +12,9 @@ import virtool.uploads.db
 import virtool.uploads.utils
 import virtool.utils
 from virtool.api.response import invalid_query, json_response, bad_request, not_found
-from virtool.uploads.models import Upload
+from virtool.uploads.models import Upload, UPLOAD_TYPES
 
 logger = logging.getLogger("uploads")
-
-UPLOAD_TYPES = [
-    "hmm",
-    "reference",
-    "reads",
-    "subtraction",
-    None
-]
 
 routes = virtool.http.routes.Routes()
 

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from typing import Union, Optional, List, Dict
 
@@ -49,18 +48,20 @@ async def create(pg: AsyncEngine, name: str, upload_type: str, reserved: bool = 
         return upload
 
 
-async def finalize(pg: AsyncEngine, size: int, upload_id: int, uploaded_at: datetime) -> Optional[dict]:
+async def finalize(pg, size: int, id_: int, table: Type[any]) -> Optional[dict]:
     """
-    Finalize `Upload` entry creation after the file has been uploaded locally.
+    Finalize row creation after the file has been uploaded locally.
 
     :param pg: PostgreSQL AsyncEngine object
     :param size: Size of the new file in bytes
-    :param upload_id: Row `id` corresponding to the recently created `upload` entry
-    :param uploaded_at: Timestamp from when the file was uploaded
+    :param id_: Row `id` corresponding to the recently created `upload` entry
+    :param table: SQL table to retrieve row from
     :return: Dictionary representation of new row in the `uploads` SQL table
     """
+    uploaded_at = virtool.utils.timestamp()
+
     async with AsyncSession(pg) as session:
-        upload = (await session.execute(select(Upload).filter(Upload.id == upload_id))).scalar()
+        upload = (await session.execute(select(table).filter_by(id=id_))).scalar()
 
         if not upload:
             return None
@@ -73,7 +74,7 @@ async def finalize(pg: AsyncEngine, size: int, upload_id: int, uploaded_at: date
 
         await session.commit()
 
-        return upload
+    return upload
 
 
 async def find(pg, user: str = None, upload_type: str = None) -> List[dict]:

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, Optional, List, Dict
+from typing import Union, Optional, List, Dict, Type
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine

--- a/virtool/uploads/models.py
+++ b/virtool/uploads/models.py
@@ -10,10 +10,18 @@ class UploadType(str, enum.Enum):
     Enumerated type for possible upload types
 
     """
+
+    @classmethod
+    def to_list(cls):
+        return [e.value for e in cls.__members__.values()]
+
     hmm = "hmm"
     reference = "reference"
     reads = "reads"
     subtraction = "subtraction"
+
+
+UPLOAD_TYPES = [*UploadType.to_list(), None]
 
 
 class Upload(Base):

--- a/virtool/uploads/utils.py
+++ b/virtool/uploads/utils.py
@@ -28,6 +28,11 @@ async def naive_writer(req, file_path) -> int:
 
     size = 0
 
+    try:
+        file_path.parent.mkdir()
+    except FileExistsError:
+        pass
+
     async with aiofiles.open(file_path, "wb") as handle:
         while True:
             chunk = await file.read_chunk(CHUNK_SIZE)

--- a/virtool/uploads/utils.py
+++ b/virtool/uploads/utils.py
@@ -1,5 +1,6 @@
 import aiofiles
 from cerberus import Validator
+import os
 
 CHUNK_SIZE = 4096
 
@@ -29,7 +30,7 @@ async def naive_writer(req, file_path) -> int:
     size = 0
 
     try:
-        file_path.parent.mkdir()
+        await req.app["run_in_thread"](os.mkdir, file_path.parent)
     except FileExistsError:
         pass
 


### PR DESCRIPTION
- Implement SQL model for `analysis_files`, a table to store analysis result files
- Support uploading at `POST /api/analyses/:id/files`
- Support downloading at `GET /api/analyses/:id/files/:id`
- Attach detailed file information from `analysis_files` SQL table to `GET /api/analyses/:id` calls