### PR TITLE
Index Deletion Endpoint 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 .pytest_cache
 client/node_modules
 client/dist
-tests
 data
 docker
 docs

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,44 +1,48 @@
 version: "3.1"
 services:
-    mongo: 
-        image: mongo:4.4
-        ports:
-            - "27017:27017"
-        volumes:
-            - vt_mongo_data:/data/db
-        logging:
-            driver: none
-    redis:
-        image: redis:6.0
-        ports:
-            - "6379:6379"
-        volumes:
-            - vt_redis_data:/data
-        logging:
-            driver: none
-    postgres:
-        image: postgres:13.1
-        ports:
-            - "5432:5432"
-        restart: always
-        environment:
-            POSTGRES_USER: virtool
-            POSTGRES_PASSWORD: virtool
-        volumes:
-            - vt_postgres_data:/var/lib/postgresql/data
-        logging:
-            driver: none
+  mongo:
+    image: mongo:4.4
+    ports:
+      - "27017:27017"
+    volumes:
+      - vt_mongo_data:/data/db
+    logging:
+      driver: none
+  redis:
+    image: redis:6.0
+    ports:
+      - "6379:6379"
+    volumes:
+      - vt_redis_data:/data
+    logging:
+      driver: none
+  postgres:
+    image: postgres:13.1
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      POSTGRES_USER: virtool
+      POSTGRES_PASSWORD: virtool
+    volumes:
+      - vt_postgres_data:/var/lib/postgresql/data
+    logging:
+      driver: none
 
-    pgadmin4:
-        image: dpage/pgadmin4:4.29
-        environment:
-            PGADMIN_DEFAULT_EMAIL: dev@virtool.ca
-            PGADMIN_DEFAULT_PASSWORD: virtool
-        volumes:
-            - vt_pgadmin4_data:/var/lib/pgadmin4/data
-        depends_on: [postgres]
+  pgadmin4:
+    image: dpage/pgadmin4:4.29
+    environment:
+      PGADMIN_DEFAULT_EMAIL: dev@virtool.ca
+      PGADMIN_DEFAULT_PASSWORD: virtool
+    volumes:
+      - vt_pgadmin4_data:/var/lib/pgadmin4/data
+    depends_on: [ postgres ]
+
+  server:
+    image: vt_server
+    command: -x --db-connection-string=mongodb://mongo:27017 --redis-connection-string redis://redis:6379 --postgres-connection-string postgresql+asyncpg://virtool:virtool@postgres
 volumes:
-    vt_mongo_data:
-    vt_redis_data:
-    vt_postgres_data:
-    vt_pgadmin4_data:
+  vt_mongo_data:
+  vt_redis_data:
+  vt_postgres_data:
+  vt_pgadmin4_data:

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,14 @@
+FROM virtool/external-tools:0.2.0
+
+WORKDIR virtool
+
+ADD . .
+
+RUN ls
+
+RUN pip install -qr requirements.txt
+
+
+RUN ls -l
+
+ENTRYPOINT ["pytest"]

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -192,7 +192,7 @@ def spawn_job_client(
         job_id, key = "test_job", "test_key"
         await dbi.jobs.insert_one({
             "_id": job_id,
-            "key": key,
+            "key": hash_key(key),
         })
 
         # Spawn a test client.

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -201,8 +201,9 @@ def spawn_job_client(
         client.db = dbi
 
         # Enable the API in the settings.
-        client.settings = test_client.settings
-        client.settings["enable_api"] = True
+        if enable_api:
+            client.settings = test_client.settings
+            client.settings["enable_api"] = True
 
         # Set the `AUTHORIZATION` header before each request.
         client.delete = job_authenticated(client.delete, job_id, key)

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -439,6 +439,10 @@ async def test_delete_index(spawn_job_client, error):
     indexes = client.db.indexes
     history = client.db.history
 
+    test_job = await client.db.jobs.find_one({"_id": "test_job"})
+    assert test_job["_id"] == "test_job"
+    assert test_job["key"] == "test_key"
+
     if error != 404:
         await indexes.insert_one(index_document)
         await history.insert_many(mock_history_documents)

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -439,10 +439,6 @@ async def test_delete_index(spawn_job_client, error):
     indexes = client.db.indexes
     history = client.db.history
 
-    test_job = await client.db.jobs.find_one({"_id": "test_job"})
-    assert test_job["_id"] == "test_job"
-    assert test_job["key"] == "test_key"
-
     if error != 404:
         await indexes.insert_one(index_document)
         await history.insert_many(mock_history_documents)

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -421,7 +421,7 @@ async def test(error, snapshot, spawn_client, resp_is):
 
 
 @pytest.mark.parametrize("error", [None, 404])
-async def test_delete_index(spawn_client, error):
+async def test_delete_index(spawn_job_client, error):
     index_id = "index1"
     index_document = {
         "_id": index_id,
@@ -435,7 +435,7 @@ async def test_delete_index(spawn_client, error):
         }
     } for _id in ("history1", "history2", "history3")]
 
-    client = await spawn_client(authorize=True)
+    client = await spawn_job_client(authorize=True, enable_api=True)
     indexes = client.db.indexes
     history = client.db.history
 

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -241,6 +241,29 @@ async def find_history(req):
     return json_response(data)
 
 
+def reset_history(history: Collection, index_id: str):
+    """
+    Set the index.id and index.version fields with the given index id to 'unbuilt'.
+
+    :param history: The history collection of the database.
+    :param index_id: The ID of the index which failed to build
+    """
+    query = {
+        "_id": {
+            "$in": await history.distinct("_id", {"index.id": index_id})
+        }
+    }
+
+    return await history.update_many(query, {
+        "$set": {
+            "index": {
+                "id": "unbuilt",
+                "version": "unbuilt"
+            }
+        }
+    })
+
+
 @routes.delete("/api/indexes/{index_id}", jobs_only=True)
 def delete_index(req: aiohttp.web.Request):
     index_id = req.match_info["index_id"]

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -269,9 +269,8 @@ async def delete_index(req: aiohttp.web.Request):
     """Delete the index with the given id and reset history relating to that index."""
     index_id = req.match_info["index_id"]
     db = req.app["db"]
-    indexes: Collection = db.indexes
 
-    delete_result = await indexes.delete_one({"_id": index_id})
+    delete_result = await db.indexes.delete_one({"_id": index_id})
 
     if delete_result.deleted_count != 1:
         # Document could not be deleted.

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -14,6 +14,7 @@ import virtool.references.db
 import virtool.utils
 from virtool.api.response import bad_request, conflict, insufficient_rights, json_response, \
     not_found
+from virtool.db.core import Collection
 from virtool.jobs.utils import JobRights
 
 routes = virtool.http.routes.Routes()
@@ -244,4 +245,10 @@ async def find_history(req):
 def delete_index(req: aiohttp.web.Request):
     index_id = req.match_info["index_id"]
     db = req.app["db"]
-    indexes = db.indexes
+    indexes: Collection = db.indexes
+
+    delete_result = await indexes.delete_one({"_id": index_id})
+
+    if delete_result.deleted_count != 1:
+        # Document could not be deleted.
+        return not_found(f"There is no index with id: {index_id}.")

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import aiohttp
+
 import virtool.api.utils
 import virtool.db.utils
 import virtool.history.db
@@ -236,3 +238,10 @@ async def find_history(req):
     )
 
     return json_response(data)
+
+
+@routes.delete("/api/indexes/{index_id}", jobs_only=True)
+def delete_index(req: aiohttp.web.Request):
+    index_id = req.match_info["index_id"]
+    db = req.app["db"]
+    indexes = db.indexes

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -14,7 +14,7 @@ import virtool.references.db
 import virtool.utils
 from virtool.api.response import bad_request, conflict, insufficient_rights, json_response, \
     not_found, no_content
-from virtool.db.core import Collection
+from virtool.db.core import DB
 from virtool.jobs.utils import JobRights
 
 routes = virtool.http.routes.Routes()
@@ -241,7 +241,7 @@ async def find_history(req):
     return json_response(data)
 
 
-async def reset_history(history: Collection, index_id: str):
+async def reset_history(db: DB, index_id: str):
     """
     Set the index.id and index.version fields with the given index id to 'unbuilt'.
 
@@ -250,11 +250,11 @@ async def reset_history(history: Collection, index_id: str):
     """
     query = {
         "_id": {
-            "$in": await history.distinct("_id", {"index.id": index_id})
+            "$in": await db.history.distinct("_id", {"index.id": index_id})
         }
     }
 
-    return await history.update_many(query, {
+    return await db.history.update_many(query, {
         "$set": {
             "index": {
                 "id": "unbuilt",

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -10,7 +10,6 @@ import pymongo
 import virtool.api.utils
 import virtool.history.db
 import virtool.utils
-from virtool.db.core import DB
 
 PROJECTION = [
     "_id",
@@ -229,7 +228,7 @@ async def get_unbuilt_stats(db, ref_id: Union[str, None] = None) -> dict:
     }
 
 
-async def reset_history(db: DB, index_id: str):
+async def reset_history(db, index_id: str):
     """
     Set the index.id and index.version fields with the given index id to 'unbuilt'.
 


### PR DESCRIPTION
Adds a DELETE endpoint at /api/indexes/{index_id} which is only accessible to virtool jobs. This route is intendend to be used when a build_index job fails.

- Deletes the index with the given ID from the database.
- Resets any history database entries referencing that index.
	- "index.id" and "index.version" set to "unbuilt"
- Returns a 404 NOT FOUND response if the index does not exist.
- Returns a 204 NO CONTENT response otherwise.
- Adds a new test fixture spawn_job_client which provides an aiohttp client which can authenticate with the API as a Job. It accepts thesame arguments as the spawn_client fixture.