### PR TITLE
Start Jobs API Server Process

### DIFF
--- a/jobs_api_process.py
+++ b/jobs_api_process.py
@@ -1,3 +1,6 @@
+import aiohttp
+import aiojobs
+
 import virtool.http.accept
 import virtool.http.auth
 import virtool.http.csp
@@ -15,6 +18,10 @@ async def start_aiohttp_server():
         virtool.http.proxy.middleware,
         virtool.http.query.middleware
     ]
+
+    app = aiohttp.web.Application(middlewares=middlewares)
+
+    aiojobs.aiohttp.setup(app)
 
 
 async def run(**kwargs):

--- a/jobs_api_process.py
+++ b/jobs_api_process.py
@@ -7,13 +7,14 @@ import virtool.http.csp
 import virtool.http.errors
 import virtool.http.proxy
 import virtool.http.query
+import virtool.startup
 
 
 async def start_aiohttp_server():
     middlewares = [
-        virtool.http.csp.middleware,
-        virtool.http.auth.middleware,
         virtool.http.accept.middleware,
+        virtool.http.auth.middleware,
+        virtool.http.csp.middleware,
         virtool.http.errors.middleware,
         virtool.http.proxy.middleware,
         virtool.http.query.middleware
@@ -22,6 +23,15 @@ async def start_aiohttp_server():
     app = aiohttp.web.Application(middlewares=middlewares)
 
     aiojobs.aiohttp.setup(app)
+
+    app.on_startup += [
+        virtool.startup.init_check_db,
+        virtool.startup.init_db,
+        virtool.startup.init_paths,
+        virtool.startup.init_postgres,
+        virtool.startup.init_settings,
+        virtool.startup.init_version,
+    ]
 
 
 async def run(**kwargs):

--- a/jobs_api_process.py
+++ b/jobs_api_process.py
@@ -1,0 +1,21 @@
+import virtool.http.accept
+import virtool.http.auth
+import virtool.http.csp
+import virtool.http.errors
+import virtool.http.proxy
+import virtool.http.query
+
+
+async def start_aiohttp_server():
+    middlewares = [
+        virtool.http.csp.middleware,
+        virtool.http.auth.middleware,
+        virtool.http.accept.middleware,
+        virtool.http.errors.middleware,
+        virtool.http.proxy.middleware,
+        virtool.http.query.middleware
+    ]
+
+
+async def run(**kwargs):
+    ...

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -1,13 +1,10 @@
 import asyncio
 import logging
-import os
-import sys
 
 import aiohttp.web
 import aiojobs
 import aiojobs.aiohttp
 
-import virtool.config
 import virtool.db.core
 import virtool.db.migrate
 import virtool.db.utils
@@ -31,48 +28,9 @@ import virtool.software.db
 import virtool.startup
 import virtool.utils
 import virtool.version
+from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown, logger
 
 logger = logging.getLogger(__name__)
-
-
-async def on_shutdown(app: aiohttp.web.Application):
-    """
-    A function called when the app is shutting down.
-
-    :param app: the app object
-    :type app: :class:`aiohttp.web.Application`
-
-    """
-    logger.debug("Shutting down")
-
-    try:
-        await app["client"].close()
-    except KeyError:
-        pass
-
-    try:
-        await app["dispatcher"].close()
-    except KeyError:
-        pass
-
-    try:
-        app["executor"].shutdown(wait=True)
-    except KeyError:
-        pass
-
-    try:
-        app["process_executor"].shutdown(wait=True)
-    except KeyError:
-        pass
-
-    scheduler = virtool.startup.get_scheduler_from_app(app)
-    await scheduler.close()
-
-    try:
-        app["redis"].close()
-        await app["redis"].wait_closed()
-    except KeyError:
-        pass
 
 
 def create_app(config):
@@ -122,40 +80,6 @@ def create_app(config):
     return app
 
 
-async def create_app_runner(app: aiohttp.web.Application, host: str, port: int) -> aiohttp.web.AppRunner:
-    """
-    Create an :class:`aiohttp.web.AppRunner` to allow customization of signal handlers.
-
-    The basic :func:`aiohttp.web.run_app` sets up handlers for `SIGINT` and `SIGTERM` that can interfere with Virtool
-    code such as that for restarting the server after software update. This custom runner allows handling of signals
-    as well as restart and shutdown events from users.
-
-    https://docs.aiohttp.org/en/stable/web_advanced.html#application-runners
-
-    :param app: the application
-    :param host: the host to listen on
-    :param port: the port to listen on
-    :return: a custom :class:`~aiohttp.web.AppRunner`
-
-    """
-    runner = aiohttp.web.AppRunner(app)
-
-    await runner.setup()
-
-    site = aiohttp.web.TCPSite(runner, host, port)
-
-    try:
-        await site.start()
-    except OSError as err:
-        if err.args[0] == 48:
-            logger.fatal(f"Could not bind address {(host, port)}")
-            sys.exit(1)
-
-    logger.info(f"Listening at http://{host}:{port}")
-
-    return runner
-
-
 async def run_app(config):
     app = create_app(config)
 
@@ -174,41 +98,41 @@ async def run_app(config):
         task.cancel()
 
 
-async def wait_for_restart(runner: aiohttp.web.AppRunner, events: dict):
+async def on_shutdown(app: aiohttp.web.Application):
     """
-    Wait for the shutdown event and restart if it is encountered.
+    A function called when the app is shutting down.
 
-    Restart is accomplished using :func:`os.execl` or :func:`os.execv` after cleaning up the `runner`.
-
-    :param runner: the :class:`~aiohttp.web.AppRunner` returned by :func:`.create_app_runner`
-    :param events: a dict containing the `restart` and `shutdown` :class:`~asyncio.Event` objects
+    :param app: the app object
+    :type app: :class:`aiohttp.web.Application`
 
     """
-    await events["restart"].wait()
-    await asyncio.sleep(0.5)
-    await runner.cleanup()
+    logger.debug("Shutting down")
 
-    exe = sys.executable
+    try:
+        await app["client"].close()
+    except KeyError:
+        pass
 
-    if exe.endswith("python") or "python3" in exe:
-        os.execl(exe, exe, *sys.argv)
-        return
+    try:
+        await app["dispatcher"].close()
+    except KeyError:
+        pass
 
-    if exe.endswith("run"):
-        os.execv(exe, sys.argv)
-        return
+    try:
+        app["executor"].shutdown(wait=True)
+    except KeyError:
+        pass
 
-    raise SystemError("Could not determine executable type")
+    try:
+        app["process_executor"].shutdown(wait=True)
+    except KeyError:
+        pass
 
+    scheduler = virtool.startup.get_scheduler_from_app(app)
+    await scheduler.close()
 
-async def wait_for_shutdown(runner: aiohttp.web.AppRunner, events: dict):
-    """
-    Wait for the shutdown event and terminate if it is encountered.
-
-    :param runner: the :class:`~aiohttp.web.AppRunner` returned by :func:`.create_app_runner`
-    :param events: a dict containing the `restart` and `shutdown` :class:`~asyncio.Event` objects
-
-    """
-    await events["shutdown"].wait()
-    await asyncio.sleep(0.5)
-    await runner.cleanup()
+    try:
+        app["redis"].close()
+        await app["redis"].wait_closed()
+    except KeyError:
+        pass

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -8,7 +8,6 @@ import click
 import psutil
 import uvloop
 
-import jobs_api_process
 import virtool.app
 import virtool.db.mongo
 import virtool.db.utils
@@ -16,6 +15,7 @@ import virtool.jobs.classes
 import virtool.jobs.job
 import virtool.jobs.run
 import virtool.jobs.runner
+import virtool.jobs_api_process
 import virtool.logs
 import virtool.redis
 import virtool.utils
@@ -254,4 +254,4 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 @click.pass_context
 def start_jobs_api(ctx):
     logger.info("Starting jobs API process")
-    asyncio.get_event_loop().run_until_complete(jobs_api_process.run(**ctx.obj))
+    asyncio.get_event_loop().run_until_complete(virtool.jobs_api_process.run(**ctx.obj))

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -250,5 +250,6 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 
 
 @cli.command("jobsAPI")
-def start_jobs_api():
+@click.pass_context
+def start_jobs_api(ctx):
     ...

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -8,6 +8,7 @@ import click
 import psutil
 import uvloop
 
+import jobs_api_process
 import virtool.app
 import virtool.db.mongo
 import virtool.db.utils
@@ -252,4 +253,5 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 @cli.command("jobsAPI")
 @click.pass_context
 def start_jobs_api(ctx):
-    ...
+    logger.info("Starting jobs API process")
+    asyncio.get_event_loop().run_until_complete(jobs_api_process.run(**ctx.obj))

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -251,7 +251,24 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 
 
 @cli.command("jobsAPI")
+@click.option(
+    "--host",
+    default="localhost",
+    help="The host to listen on",
+    type=str
+)
+@click.option(
+    "--port",
+    default=9950,
+    help="The port to listen on",
+    type=int
+)
 @click.pass_context
-def start_jobs_api(ctx):
+def start_jobs_api(ctx, port, host):
+    """Start a Virtool Jobs API server"""
     logger.info("Starting jobs API process")
-    asyncio.get_event_loop().run_until_complete(virtool.jobs_api_process.run(**ctx.obj))
+    asyncio.get_event_loop().run_until_complete(
+        virtool.jobs_api_process.run(
+            **dict(host=host, port=port, **ctx.obj)
+        )
+    )

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -247,3 +247,8 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 
     logger.info("Starting in runner mode")
     asyncio.get_event_loop().run_until_complete(virtool.jobs.run.run(config, virtool.jobs.runner.JobRunner))
+
+
+@cli.command("jobsAPI")
+def start_jobs_api():
+    ...

--- a/virtool/jobs_api_process.py
+++ b/virtool/jobs_api_process.py
@@ -15,6 +15,13 @@ from virtool.app import create_app_runner, wait_for_restart, wait_for_shutdown
 
 
 async def start_aiohttp_server(host: str, port: int, **config):
+    """
+    Start the aiohttp server
+
+    1. Add middlewares
+    2. Add `on_startup` functions
+    3. Start server asynchronously via :class:`aiohttp.AppRunner`
+    """
     middlewares = [
         virtool.http.accept.middleware,
         virtool.http.auth.middleware,
@@ -46,6 +53,13 @@ async def start_aiohttp_server(host: str, port: int, **config):
 
 
 async def run(dev: bool, verbose: bool, **config):
+    """
+    Run the jobs API server.
+
+    :param dev: If True, the log level will be set to DEBUG
+    :param verbose: Same effect as :obj:`dev`
+    :param config: Any other configuration options as keyword arguments
+    """
     logger = virtool.logs.configure_jobs_api_server(dev, verbose)
     app, runner = await start_aiohttp_server(**config)
 

--- a/virtool/jobs_api_process.py
+++ b/virtool/jobs_api_process.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Tuple
 
 import aiohttp.web
 import aiojobs.aiohttp
@@ -14,7 +15,9 @@ import virtool.startup
 from virtool.app import create_app_runner, wait_for_restart, wait_for_shutdown
 
 
-async def start_aiohttp_server(host: str, port: int, **config):
+async def start_aiohttp_server(
+        host: str, port: int, **config
+) -> Tuple[aiohttp.web.Application, aiohttp.web.AppRunner]:
     """
     Start the aiohttp server
 

--- a/virtool/jobs_api_process.py
+++ b/virtool/jobs_api_process.py
@@ -12,7 +12,7 @@ import virtool.http.proxy
 import virtool.http.query
 import virtool.logs
 import virtool.startup
-from virtool.app import create_app_runner, wait_for_restart, wait_for_shutdown
+from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown
 
 
 async def start_aiohttp_server(

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -91,3 +91,17 @@ def configure_runner(dev: bool, verbose: bool) -> Logger:
     logger.addHandler(handler)
 
     return logger
+
+
+def configure_jobs_api_server(dev: bool, verbose: bool):
+    logger = configure_base_logger(dev, verbose)
+
+    handler = logging.handlers.RotatingFileHandler(
+        "jobs_api_server.log", maxBytes=1000000, backupCount=3
+    )
+
+    handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
+
+    logger.addHandler(handler)
+
+    return logger

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -94,6 +94,7 @@ def configure_runner(dev: bool, verbose: bool) -> Logger:
 
 
 def configure_jobs_api_server(dev: bool, verbose: bool):
+    """Configure logging for the jobs API server."""
     logger = configure_base_logger(dev, verbose)
 
     handler = logging.handlers.RotatingFileHandler(

--- a/virtool/process_utils.py
+++ b/virtool/process_utils.py
@@ -1,0 +1,82 @@
+import asyncio
+import logging
+import os
+import sys
+
+import aiohttp.web
+
+logger = logging.getLogger(__name__)
+
+
+async def create_app_runner(app: aiohttp.web.Application, host: str, port: int) -> aiohttp.web.AppRunner:
+    """
+    Create an :class:`aiohttp.web.AppRunner` to allow customization of signal handlers.
+
+    The basic :func:`aiohttp.web.run_app` sets up handlers for `SIGINT` and `SIGTERM` that can interfere with Virtool
+    code such as that for restarting the server after software update. This custom runner allows handling of signals
+    as well as restart and shutdown events from users.
+
+    https://docs.aiohttp.org/en/stable/web_advanced.html#application-runners
+
+    :param app: the application
+    :param host: the host to listen on
+    :param port: the port to listen on
+    :return: a custom :class:`~aiohttp.web.AppRunner`
+
+    """
+    runner = aiohttp.web.AppRunner(app)
+
+    await runner.setup()
+
+    site = aiohttp.web.TCPSite(runner, host, port)
+
+    try:
+        await site.start()
+    except OSError as err:
+        if err.args[0] == 48:
+            logger.fatal(f"Could not bind address {(host, port)}")
+            sys.exit(1)
+
+    logger.info(f"Listening at http://{host}:{port}")
+
+    return runner
+
+
+async def wait_for_restart(runner: aiohttp.web.AppRunner, events: dict):
+    """
+    Wait for the shutdown event and restart if it is encountered.
+
+    Restart is accomplished using :func:`os.execl` or :func:`os.execv` after cleaning up the `runner`.
+
+    :param runner: the :class:`~aiohttp.web.AppRunner` returned by :func:`.create_app_runner`
+    :param events: a dict containing the `restart` and `shutdown` :class:`~asyncio.Event` objects
+
+    """
+    await events["restart"].wait()
+    await asyncio.sleep(0.5)
+    await runner.cleanup()
+
+    exe = sys.executable
+
+    if exe.endswith("python") or "python3" in exe:
+        os.execl(exe, exe, *sys.argv)
+        return
+
+    if exe.endswith("run"):
+        os.execv(exe, sys.argv)
+        return
+
+    raise SystemError("Could not determine executable type")
+
+
+async def wait_for_shutdown(runner: aiohttp.web.AppRunner, events: dict):
+    """
+    Wait for the shutdown event and terminate if it is encountered.
+
+    :param runner: the :class:`~aiohttp.web.AppRunner` returned by :func:`.create_app_runner`
+    :param events: a dict containing the `restart` and `shutdown` :class:`~asyncio.Event` objects
+
+    """
+    await events["shutdown"].wait()
+    await asyncio.sleep(0.5)
+    await runner.cleanup()


### PR DESCRIPTION
Adds a separate server process for the Jobs API.

- Add `jobsAPI` subcommand to start the process
	- `python run.py {options} jobsAPI`
- Add aiohttp middlewares used by the Virtool server
- Setup `on_startup` initialization functions via `aiojobs`
- Configure logging for the new process
- Handle restart and shutdown, as handled in the main server process