### PR TITLE
Remove Job Authentication Logic From `virtool.http.auth` 

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -20,9 +20,10 @@ import virtool.users.utils
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, json_response, no_content, not_found
-
 #: A MongoDB projection to use when returning API key documents to clients. The key should never be sent to client after
 #: its creation.
+from virtool.http.schema import schema
+
 API_KEY_PROJECTION = {
     "_id": False,
     "user": False
@@ -42,7 +43,8 @@ async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.patch("/api/account", schema={
+@routes.patch("/api/account")
+@schema({
     "email": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -110,7 +112,8 @@ async def get_settings(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(account_settings)
 
 
-@routes.patch("/api/account/settings", schema={
+@routes.patch("/api/account/settings")
+@schema({
     "show_ids": {
         "type": "boolean",
         "required": False
@@ -182,7 +185,8 @@ async def get_api_key(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(document, status=200)
 
 
-@routes.post("/api/account/keys", schema={
+@routes.post("/api/account/keys")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -220,7 +224,8 @@ async def create_api_key(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(document, headers=headers, status=201)
 
 
-@routes.patch("/api/account/keys/{key_id}", schema={
+@routes.patch("/api/account/keys/{key_id}")
+@schema({
     "permissions": {
         "type": "dict",
         "validator": virtool.validators.is_permission_dict,
@@ -296,7 +301,8 @@ async def remove_all_api_keys(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return no_content()
 
 
-@routes.post("/api/account/login", public=True, schema={
+@routes.post("/api/account/login", public=True)
+@schema({
     "username": {
         "type": "string",
         "empty": False,
@@ -379,7 +385,8 @@ async def logout(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return resp
 
 
-@routes.post("/api/account/reset", public=True, schema={
+@routes.post("/api/account/reset", public=True)
+@schema({
     "password": {
         "type": "string",
         "required": True

--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -20,10 +20,10 @@ import virtool.users.utils
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, json_response, no_content, not_found
-#: A MongoDB projection to use when returning API key documents to clients. The key should never be sent to client after
-#: its creation.
 from virtool.http.schema import schema
 
+#: A MongoDB projection to use when returning API key documents to clients. The key should never be sent to client after
+#: its creation.
 API_KEY_PROJECTION = {
     "_id": False,
     "user": False

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -30,7 +30,6 @@ from virtool.samples.db import recalculate_workflow_tags
 from virtool.utils import base_processor
 
 routes = virtool.http.routes.Routes()
-job_routes = aiohttp.web.RouteTableDef()
 
 
 @routes.get("/api/analyses")
@@ -250,7 +249,7 @@ async def blast(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(blast_data, headers=headers, status=201)
 
 
-@job_routes.patch("/api/analyses/{analysis_id}")
+@routes.patch("/api/analyses/{analysis_id}", jobs_only=True)
 @schema({"results": {"type": "dict", "required": True}})
 async def patch_analysis(req: aiohttp.web.Request):
     """Sets the result for an analysis and marks it as ready."""

--- a/virtool/groups/api.py
+++ b/virtool/groups/api.py
@@ -1,12 +1,13 @@
 import pymongo.errors
 
 import virtool.groups.db
-import virtool.users.db
 import virtool.http.routes
+import virtool.users.db
 import virtool.users.utils
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, json_response, no_content, not_found
+from virtool.http.schema import schema
 
 routes = virtool.http.routes.Routes()
 
@@ -21,7 +22,8 @@ async def find(req):
     return json_response([virtool.utils.base_processor(d) async for d in cursor])
 
 
-@routes.post("/api/groups", admin=True, schema={
+@routes.post("/api/groups", admin=True)
+@schema({
     "group_id": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -67,7 +69,8 @@ async def get(req):
     return not_found()
 
 
-@routes.patch("/api/groups/{group_id}", admin=True, schema={
+@routes.patch("/api/groups/{group_id}", admin=True)
+@schema({
     "permissions": {
         "type": "dict",
         "default": {},

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -83,9 +83,6 @@ async def authenticate_with_key(req: web.Request, handler: Callable):
     except virtool.errors.AuthError:
         return unauthorized("Malformed Authorization header")
 
-    if holder_id.startswith("job-"):
-        return await authenticate_with_job_key(req, handler, holder_id[4:], key)
-
     return await authenticate_with_api_key(req, handler, holder_id, key)
 
 

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -16,10 +16,7 @@ import virtool.users.sessions
 import virtool.users.utils
 import virtool.utils
 from virtool.api.response import unauthorized
-from virtool.db.utils import get_one_field
-from virtool.http.client import JobClient, UserClient
-from virtool.jobs.utils import JobRights
-from virtool.utils import hash_key
+from virtool.http.client import UserClient
 
 AUTHORIZATION_PROJECTION = [
     "user",
@@ -105,37 +102,6 @@ async def authenticate_with_api_key(req, handler, user_id: str, key: str):
         document["groups"],
         document["permissions"],
         user_id
-    )
-
-    return await handler(req)
-
-
-async def authenticate_with_job_key(req: web.Request, handler: Callable, job_id: str, key: str):
-    """
-    Authenticate the request with a job ID and secure key.
-
-    :param req: the request to authenticate
-    :param handler: the handler to call the request with when authentication succeeds
-    :param job_id: the job to authenticate against
-    :param key: the job key to authenticate with
-
-    """
-    db = req.app["db"]
-
-    document = await db.jobs.find_one({
-        "_id": job_id,
-        "key": hash_key(key)
-    })
-
-    if not document:
-        return unauthorized("Invalid authorization header")
-
-    rights = await get_one_field(db.jobs, "rights", job_id)
-
-    req["client"] = JobClient(
-        get_ip(req),
-        job_id,
-        JobRights(rights)
     )
 
     return await handler(req)

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -1,6 +1,6 @@
 import json.decoder
 from functools import wraps
-from typing import Any, Callable, Dict
+from typing import Callable
 
 import aiohttp.web
 from cerberus import Validator
@@ -32,11 +32,8 @@ class Routes(aiohttp.web.RouteTableDef):
 def protect(
         route_decorator: Callable,
         admin: bool,
-        allow_jobs: bool,
-        jobs_only: bool,
         permission: str,
         public: bool,
-        schema: Dict[str, Any]
 ):
     if permission and permission not in virtool.users.utils.PERMISSIONS:
         raise ValueError("Invalid permission: " + permission)

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -1,4 +1,5 @@
 import json.decoder
+from functools import wraps
 from typing import Any, Callable, Dict
 
 import aiohttp.web
@@ -11,20 +12,26 @@ from virtool.http.client import JobClient
 
 class Routes(aiohttp.web.RouteTableDef):
 
+    @staticmethod
+    def _protected(method):
+        @wraps(method)
+        def _method(*args, admin=False, permission=None, public=False, **kwargs):
+            return protect(method(*args, **kwargs), admin, permission, public)
+
+        return _method
+
     def __init__(self):
         super().__init__()
 
-    def get(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
-            public=False, schema=None,
-            **kwargs):
+    def get(self, *args, admin=False, allow_jobs=False, permission=None,
+            public=False, **kwargs):
         route_decorator = super().get(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
+        return protect(route_decorator, admin, permission, public)
 
-    def post(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
-             public=False,
-             schema=None, **kwargs):
+    def post(self, *args, admin=False, permission=None,
+             public=False, **kwargs):
         route_decorator = super().post(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
+        return protect(route_decorator, admin, permission, public)
 
     def patch(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
               public=False,

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -22,34 +22,11 @@ class Routes(aiohttp.web.RouteTableDef):
 
     def __init__(self):
         super().__init__()
-
-    def get(self, *args, admin=False, allow_jobs=False, permission=None,
-            public=False, **kwargs):
-        route_decorator = super().get(*args, **kwargs)
-        return protect(route_decorator, admin, permission, public)
-
-    def post(self, *args, admin=False, permission=None,
-             public=False, **kwargs):
-        route_decorator = super().post(*args, **kwargs)
-        return protect(route_decorator, admin, permission, public)
-
-    def patch(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
-              public=False,
-              schema=None, **kwargs):
-        route_decorator = super().patch(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
-
-    def put(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
-            public=False, schema=None,
-            **kwargs):
-        route_decorator = super().put(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
-
-    def delete(self, *args, admin=False, allow_jobs=False, jobs_only=False, permission=None,
-               public=False,
-               schema=None, **kwargs):
-        route_decorator = super().delete(*args, **kwargs)
-        return protect(route_decorator, admin, allow_jobs, jobs_only, permission, public, schema)
+        self.get = self._protected(self.get)
+        self.post = self._protected(self.post)
+        self.delete = self._protected(self.delete)
+        self.put = self._protected(self.put)
+        self.patch = self._protected(self.patch)
 
 
 def protect(

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -35,6 +35,21 @@ class Routes(aiohttp.web.RouteTableDef):
               jobs_only: bool = False,
               jobs_allowed: bool = True,
               **kwargs: Any) -> Callable[[RouteHandler], RouteHandler]:
+        """
+        Create a decorator which registers an aiohttp route.
+
+        This function is called by :class:`RouteTableDef`'s method functions, such as :func:`.get`. Any keyword
+        arguments passed to those functions will be forwarded here, allowing the `jobs_only` and `jobs_allowed`
+        flags to be handled.
+
+        :param method: The name of the method type. Constants for these names are contained in `aiohttp.hdrs` and
+            are prefixed with `METH_`.
+        :param path: The path of the route.
+        :param jobs_only: If True, the route will be added to the :obj:`.job_routes` attribute only.
+        :param jobs_allowed: If True,  the route will be added to the route table, and to :obj:`.job_routes`.
+        :param kwargs: Any keyword arguments are passed to the `RouteDef` object.
+        :return: A decorator which adds the :class:`RouteHandler` to the route table, and/or :obj:`.job_routes`
+        """
 
         if jobs_only:
             def _route_decorator(handler: RouteHandler):

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -33,32 +33,32 @@ class Routes(aiohttp.web.RouteTableDef):
               method: str,
               path: str,
               jobs_only: bool = False,
-              jobs_allowed: bool = True,
+              allow_jobs: bool = True,
               **kwargs: Any) -> Callable[[RouteHandler], RouteHandler]:
         """
         Create a decorator which registers an aiohttp route.
 
         This function is called by :class:`RouteTableDef`'s method functions, such as :func:`.get`. Any keyword
-        arguments passed to those functions will be forwarded here, allowing the `jobs_only` and `jobs_allowed`
+        arguments passed to those functions will be forwarded here, allowing the `jobs_only` and `allow_jobs`
         flags to be handled.
 
         :param method: The name of the method type. Constants for these names are contained in `aiohttp.hdrs` and
             are prefixed with `METH_`.
         :param path: The path of the route.
         :param jobs_only: If True, the route will be added to the :obj:`.job_routes` attribute only.
-        :param jobs_allowed: If True,  the route will be added to the route table, and to :obj:`.job_routes`.
+        :param allow_jobs: If True,  the route will be added to the route table, and to :obj:`.job_routes`.
         :param kwargs: Any keyword arguments are passed to the `RouteDef` object.
         :return: A decorator which adds the :class:`RouteHandler` to the route table, and/or :obj:`.job_routes`
         """
 
         if jobs_only:
             def _route_decorator(handler: RouteHandler):
-                self.job_routes.append(handler)
+                self.job_routes.append(RouteDef(method, path, handler, {}))
                 return handler
-        elif jobs_allowed:
+        elif allow_jobs:
             def _route_decorator(handler: RouteHandler):
-                self.job_routes.append(RouteDef(method, path, handler, kwargs))
-                super(Routes, self).route(method, path, **kwargs)
+                self.job_routes.append(RouteDef(method, path, handler, {}))
+                super(Routes, self).route(method, path, **kwargs)(handler)
                 return handler
         else:
             _route_decorator = super(Routes, self).route(method, path, **kwargs)

--- a/virtool/http/schema.py
+++ b/virtool/http/schema.py
@@ -18,7 +18,7 @@ def schema(schema_dict: dict):
     :return: A decorator which wraps a :class:`RouteHandler`, ensuring that the JSON body
         of the request matches the cerberus schema.
     """
-    validator = cerberus.Validator(schema_dict)
+    validator = cerberus.Validator(schema_dict, purge_unknown=True)
 
     def _validate_schema_against_json_body(handler: RouteHandler):
         @wraps(handler)

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -1,6 +1,6 @@
 import asyncio
 
-import aiohttp
+import aiohttp.web
 
 import virtool.api.utils
 import virtool.db.utils
@@ -18,7 +18,6 @@ from virtool.indexes.db import reset_history
 from virtool.jobs.utils import JobRights
 
 routes = virtool.http.routes.Routes()
-job_routes = aiohttp.web.RouteTableDef()
 
 
 @routes.get("/api/indexes")
@@ -242,7 +241,7 @@ async def find_history(req):
     return json_response(data)
 
 
-@job_routes.delete("/api/indexes/{index_id}")
+@routes.delete("/api/indexes/{index_id}", jobs_only=True)
 async def delete_index(req: aiohttp.web.Request):
     """Delete the index with the given id and reset history relating to that index."""
     index_id = req.match_info["index_id"]

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -8,6 +8,7 @@ import virtool.utils
 from virtool.api.response import bad_request, conflict, json_response, no_content, \
     not_found
 from virtool.db.utils import get_one_field
+from virtool.http.schema import schema
 from virtool.jobs.db import PROJECTION
 from virtool.utils import base_processor
 
@@ -57,13 +58,14 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.patch("/api/jobs/{job_id}", schema={
+@routes.patch("/api/jobs/{job_id}", allow_jobs=True)
+@schema({
     "acquired": {
         "type": "boolean",
         "allowed": [True],
         "required": True
     }
-}, allow_jobs=True)
+})
 async def acquire(req):
     """
     Sets the acquired field on the job document.
@@ -107,7 +109,8 @@ async def cancel(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.post("/api/jobs/{job_id}/status", schema={
+@routes.post("/api/jobs/{job_id}/status", allow_jobs=True)
+@schema({
     "state": {
         "type": "string",
         "allowed": [
@@ -134,7 +137,7 @@ async def cancel(req):
         "default": None,
         "nullable": True
     }
-}, allow_jobs=True)
+})
 async def push_status(req):
     db = req.app["db"]
     data = req["data"]

--- a/virtool/jobs_api/routes.py
+++ b/virtool/jobs_api/routes.py
@@ -2,10 +2,10 @@ import aiohttp.web
 
 import virtool.analyses.api
 import virtool.indexes.api
+import virtool.routes
 
 
 async def init_routes(app: aiohttp.web.Application):
     """Add routes to jobs API."""
-    for routes in (virtool.analyses.api.job_routes,
-                   virtool.indexes.api.job_routes):
-        app.add_routes(routes)
+    for routes in virtool.routes.ROUTES:
+        app.add_routes(routes.job_routes)

--- a/virtool/labels/api.py
+++ b/virtool/labels/api.py
@@ -4,11 +4,12 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import virtool.http.routes
-import virtool.validators
 import virtool.db.utils
+import virtool.http.routes
 import virtool.labels.db
+import virtool.validators
 from virtool.api.response import bad_request, empty_request, json_response, no_content, not_found
+from virtool.http.schema import schema
 from virtool.labels.models import Label
 
 routes = virtool.http.routes.Routes()
@@ -50,7 +51,8 @@ async def get(req):
     return json_response(document)
 
 
-@routes.post("/api/labels", schema={
+@routes.post("/api/labels")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -72,7 +74,6 @@ async def get(req):
 async def create(req):
     """
     Add a new label to the labels database.
-
     """
     data = req["data"]
 
@@ -96,7 +97,8 @@ async def create(req):
     return json_response(document, status=201, headers=headers)
 
 
-@routes.patch("/api/labels/{label_id}", schema={
+@routes.patch("/api/labels/{label_id}")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -15,6 +15,7 @@ import virtool.references.utils
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, insufficient_rights, json_response, no_content, not_found
+from virtool.http.schema import schema
 
 SCHEMA_VALIDATOR = {
     "type": "list",
@@ -82,7 +83,8 @@ async def get(req):
     return json_response(complete)
 
 
-@routes.post("/api/refs/{ref_id}/otus", schema={
+@routes.post("/api/refs/{ref_id}/otus")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -139,7 +141,8 @@ async def create(req):
     return json_response(document, status=201, headers=headers)
 
 
-@routes.patch("/api/otus/{otu_id}", schema={
+@routes.patch("/api/otus/{otu_id}")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -269,7 +272,8 @@ async def get_isolate(req):
     return json_response(isolate)
 
 
-@routes.post("/api/otus/{otu_id}/isolates", schema={
+@routes.post("/api/otus/{otu_id}/isolates")
+@schema({
     "source_type": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -327,7 +331,8 @@ async def add_isolate(req):
     )
 
 
-@routes.patch("/api/otus/{otu_id}/isolates/{isolate_id}", schema={
+@routes.patch("/api/otus/{otu_id}/isolates/{isolate_id}")
+@schema({
     "source_type": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -479,7 +484,8 @@ async def get_sequence(req):
     return json_response(sequence)
 
 
-@routes.post("/api/otus/{otu_id}/isolates/{isolate_id}/sequences", schema={
+@routes.post("/api/otus/{otu_id}/isolates/{isolate_id}/sequences")
+@schema({
     "accession": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -559,7 +565,8 @@ async def create_sequence(req):
     return json_response(sequence_document, status=201, headers=headers)
 
 
-@routes.patch("/api/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence_id}", schema={
+@routes.patch("/api/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence_id}")
+@schema({
     "accession": {
         "type": "string",
         "coerce": virtool.validators.strip,

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -5,21 +5,22 @@ import aiohttp
 import aiojobs.aiohttp
 
 import virtool.api.utils
-import virtool.history.db
-import virtool.indexes.db
-import virtool.otus.db
-import virtool.tasks.db
-import virtool.references.db
-import virtool.users.db
 import virtool.db.utils
 import virtool.errors
 import virtool.github
+import virtool.history.db
 import virtool.http.routes
+import virtool.indexes.db
+import virtool.otus.db
 import virtool.otus.utils
+import virtool.references.db
 import virtool.references.utils
+import virtool.tasks.db
+import virtool.users.db
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_gateway, bad_request, insufficient_rights, json_response, no_content, not_found
+from virtool.http.schema import schema
 
 routes = virtool.http.routes.Routes()
 
@@ -255,7 +256,8 @@ async def find_indexes(req):
     return json_response(data)
 
 
-@routes.post("/api/refs", permission="create_ref", schema={
+@routes.post("/api/refs", permission="create_ref")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -445,7 +447,8 @@ async def create(req):
     return json_response(virtool.utils.base_processor(document), headers=headers, status=201)
 
 
-@routes.patch("/api/refs/{ref_id}", schema={
+@routes.patch("/api/refs/{ref_id}")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -597,7 +600,8 @@ async def get_group(req):
                 return json_response(group)
 
 
-@routes.post("/api/refs/{ref_id}/groups", schema={
+@routes.post("/api/refs/{ref_id}/groups")
+@schema({
     **RIGHTS_SCHEMA, "group_id": {
         "type": "string",
         "required": True
@@ -634,7 +638,8 @@ async def add_group(req):
     return json_response(subdocument, headers=headers, status=201)
 
 
-@routes.post("/api/refs/{ref_id}/users", schema={
+@routes.post("/api/refs/{ref_id}/users")
+@schema({
     **RIGHTS_SCHEMA, "user_id": {
         "type": "string",
         "required": True
@@ -673,7 +678,8 @@ async def add_user(req):
     return json_response(subdocument, headers=headers, status=201)
 
 
-@routes.patch("/api/refs/{ref_id}/groups/{group_id}", schema=RIGHTS_SCHEMA)
+@routes.patch("/api/refs/{ref_id}/groups/{group_id}")
+@schema(RIGHTS_SCHEMA)
 async def edit_group(req):
     db = req.app["db"]
     data = req["data"]
@@ -693,7 +699,8 @@ async def edit_group(req):
     return json_response(subdocument)
 
 
-@routes.patch("/api/refs/{ref_id}/users/{user_id}", schema=RIGHTS_SCHEMA)
+@routes.patch("/api/refs/{ref_id}/users/{user_id}")
+@schema(RIGHTS_SCHEMA)
 async def edit_user(req):
     db = req.app["db"]
     data = req["data"]

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -18,6 +18,7 @@ import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, insufficient_rights, invalid_query, \
     json_response, no_content, not_found
+from virtool.http.schema import schema
 from virtool.jobs.utils import JobRights
 from virtool.samples.utils import bad_labels_response, check_labels
 
@@ -177,7 +178,8 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.post("/api/samples", permission="create_sample", schema={
+@routes.post("/api/samples", permission="create_sample")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -343,7 +345,8 @@ async def create(req):
     return json_response(virtool.utils.base_processor(document), status=201, headers=headers)
 
 
-@routes.patch("/api/samples/{sample_id}", schema={
+@routes.patch("/api/samples/{sample_id}")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -422,7 +425,8 @@ async def replace(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.patch("/api/samples/{sample_id}/rights", schema={
+@routes.patch("/api/samples/{sample_id}/rights")
+@schema({
     "group": {
         "type": "string"
     },
@@ -546,7 +550,8 @@ async def find_analyses(req):
     return json_response(data)
 
 
-@routes.post("/api/samples/{sample_id}/analyses", schema={
+@routes.post("/api/samples/{sample_id}/analyses")
+@schema({
     "ref_id": {
         "type": "string",
         "required": True

--- a/virtool/settings/api.py
+++ b/virtool/settings/api.py
@@ -1,8 +1,9 @@
-import virtool.settings.db
 import virtool.http.routes
+import virtool.settings.db
 import virtool.settings.schema
 import virtool.utils
 from virtool.api.response import json_response
+from virtool.http.schema import schema
 
 routes = virtool.http.routes.Routes()
 
@@ -17,7 +18,8 @@ async def get(req):
     })
 
 
-@routes.patch("/api/settings", admin=True, schema=virtool.settings.schema.SCHEMA)
+@routes.patch("/api/settings", admin=True)
+@schema(virtool.settings.schema.SCHEMA)
 async def update(req):
     """
     Update application settings based on request data.

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -10,6 +10,7 @@ import virtool.subtractions.utils
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, json_response, no_content, not_found
+from virtool.http.schema import schema
 from virtool.jobs.utils import JobRights
 
 routes = virtool.http.routes.Routes()
@@ -82,7 +83,8 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.post("/api/subtractions", permission="modify_subtraction", schema={
+@routes.post("/api/subtractions", permission="modify_subtraction")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -106,7 +108,7 @@ async def create(req):
     """
     db = req.app["db"]
     data = req["data"]
-    
+
     file_id = data["file_id"]
 
     file = await db.files.find_one(file_id, ["name"])
@@ -171,7 +173,8 @@ async def create(req):
     return json_response(virtool.utils.base_processor(document), headers=headers, status=201)
 
 
-@routes.patch("/api/subtractions/{subtraction_id}", permission="modify_subtraction", schema={
+@routes.patch("/api/subtractions/{subtraction_id}", permission="modify_subtraction")
+@schema({
     "name": {
         "type": "string",
         "coerce": virtool.validators.strip,

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -30,6 +30,7 @@ import virtool.users.utils
 import virtool.utils
 import virtool.validators
 from virtool.api.response import bad_request, conflict, json_response, no_content, not_found
+from virtool.http.schema import schema
 
 routes = virtool.http.routes.Routes()
 
@@ -74,7 +75,8 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.post("/api/users", admin=True, schema={
+@routes.post("/api/users", admin=True)
+@schema({
     "user_id": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -130,7 +132,8 @@ async def create(req):
     )
 
 
-@routes.put("/api/users/first", public=True, schema={
+@routes.put("/api/users/first", public=True)
+@schema({
     "user_id": {
         "type": "string",
         "coerce": virtool.validators.strip,
@@ -201,7 +204,8 @@ async def create_first(req):
     return resp
 
 
-@routes.patch("/api/users/{user_id}", admin=True, schema={
+@routes.patch("/api/users/{user_id}", admin=True)
+@schema({
     "administrator": {
         "type": "boolean"
     },


### PR DESCRIPTION
- Removes logic relating to job authentication from `virtool.http.auth.middleware`
	- Job authentication logic is now handled by `virtool.jobs_api.auth.middleware`
- Updates all API routes that were using the `schema` parameter to use the `@schema` decorator instead
- Changes behaviour of `jobs_only` and `allow_jobs` flags
	- `virtool.http.routes.Routes` maintains a separate list of routes (`RouteDef`) called `job_routes`
	- When `jobs_only` flag is given, the route will be added to `job_routes` only, and not the main route table.
	- When `jobs_allowed` flag is given, the route will be added to `job_routes` and the main route table.
	- When neither flag is given, routes are added to the main route table only
- Collects jobs API routes via `virtool.routes.ROUTES` and `Routes.job_routes`.