### PR TITLE
Downgrade `idna` to version `2.10`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ fastdiff==0.2.0
 greenlet==1.0.0
 hiredis==1.0.1
 humanfriendly==8.1
-idna==3.1
+idna==2.10
 idna-ssl==1.1.0
 immutables==0.11
 importlib-metadata==1.6.0


### PR DESCRIPTION
Resolves dependency conflict described in [ch440]