### PR TITLE
Set `--host` default to None for jobs API.

### DIFF
--- a/virtool/config.py
+++ b/virtool/config.py
@@ -2,10 +2,10 @@ import asyncio
 import json
 import logging
 import os
-import sys
 
 import click
 import psutil
+import sys
 import uvloop
 
 import virtool.app
@@ -253,7 +253,7 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
 @cli.command("jobsAPI")
 @click.option(
     "--host",
-    default="localhost",
+    default=None,
     help="The host to listen on",
     type=str
 )


### PR DESCRIPTION
A `None` host will configure the server to listen on all interfaces.

The current default, "localhost", causes the server to only listen on it's own localhost. This prevents the server from working with docker-compose port forwarding.