### PR TITLE
Separate Route Decorators For Jobs API

### DIFF
--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -77,7 +77,8 @@ async def find(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(data)
 
 
-@routes.get("/api/analyses/{analysis_id}", allow_jobs=True)
+@routes.get("/api/analyses/{analysis_id}")
+@routes.jobs_api.get("/api/analyses/{analysis_id}")
 async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
     """
     Get a complete analysis document.
@@ -132,7 +133,8 @@ async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(virtool.utils.base_processor(document), headers=headers)
 
 
-@routes.delete("/api/analyses/{analysis_id}", allow_jobs=True)
+@routes.delete("/api/analyses/{analysis_id}")
+@routes.jobs_api.delete("/api/analyses/{analysis_id}")
 async def remove(req: aiohttp.web.Request) -> aiohttp.web.Response:
     """
     Remove an analysis document by its id.
@@ -341,7 +343,7 @@ async def blast(req: aiohttp.web.Request) -> aiohttp.web.Response:
     return json_response(blast_data, headers=headers, status=201)
 
 
-@routes.patch("/api/analyses/{analysis_id}", jobs_only=True)
+@routes.jobs_api.patch("/api/analyses/{analysis_id}")
 @schema({"results": {"type": "dict", "required": True}})
 async def patch_analysis(req: aiohttp.web.Request):
     """Sets the result for an analysis and marks it as ready."""

--- a/virtool/caches/api.py
+++ b/virtool/caches/api.py
@@ -16,7 +16,8 @@ from virtool.api.response import json_response, not_found
 routes = virtool.http.routes.Routes()
 
 
-@routes.get("/api/caches/{cache_id}", allow_jobs=True)
+@routes.get("/api/caches/{cache_id}")
+@routes.jobs_api.get("/api/caches/{cache_id}")
 async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
     """
     Return the complete representation for the cache with the given `cache_id`.

--- a/virtool/downloads/api.py
+++ b/virtool/downloads/api.py
@@ -19,7 +19,6 @@ import virtool.downloads.db
 import virtool.downloads.utils
 import virtool.errors
 import virtool.history.db
-from virtool.hmm.utils import hmm_data_exists
 import virtool.http.routes
 import virtool.otus.db
 import virtool.otus.utils
@@ -27,6 +26,7 @@ import virtool.references.db
 import virtool.samples.utils
 import virtool.subtractions.utils
 import virtool.utils
+from virtool.hmm.utils import hmm_data_exists
 
 routes = virtool.http.routes.Routes()
 
@@ -170,7 +170,8 @@ async def download_isolate(req):
     })
 
 
-@routes.get("/download/otus/{otu_id}", allow_jobs=True)
+@routes.get("/download/otus/{otu_id}")
+@routes.jobs_api.get("/download/otus/{otu_id}")
 async def download_otu(req):
     """
     Download a FASTA file containing the sequences for all isolates in a single Virtool otu.
@@ -199,7 +200,8 @@ async def download_otu(req):
     })
 
 
-@routes.get("/download/indexes/{index_id}", allow_jobs=True)
+@routes.get("/download/indexes/{index_id}")
+@routes.jobs_api.get("/download/indexes/{index_id}")
 async def download_index_json(req):
     """
     Download a gzipped JSON file named ``reference.json.gz`` for a given index.

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -157,7 +157,8 @@ async def install(req):
     return json_response(update)
 
 
-@routes.get("/api/hmms/{hmm_id}", allow_jobs=True)
+@routes.get("/api/hmms/{hmm_id}")
+@routes.jobs_api.get("/api/hmms/{hmm_id}")
 async def get(req):
     """
     Get a complete individual HMM annotation document.

--- a/virtool/http/root.py
+++ b/virtool/http/root.py
@@ -6,7 +6,8 @@ API_URL_ROOT = "https://www.virtool.ca/docs/developer/api"
 routes = virtool.http.routes.Routes()
 
 
-@routes.get("/api", allow_jobs=True)
+@routes.get("/api")
+@routes.jobs_api.get("/api")
 async def get(req):
     """
     Returns a generic message. Used during testing for acquiring a ``session_id``.

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -1,13 +1,13 @@
 from functools import wraps
 from typing import Callable
 
-import aiohttp.web
+from aiohttp.web_routedef import RouteTableDef
 
 import virtool.users.utils
 from virtool.api.response import json_response, unauthorized
 
 
-class Routes(aiohttp.web.RouteTableDef):
+class Routes(RouteTableDef):
 
     @staticmethod
     def _protected(method):
@@ -25,7 +25,7 @@ class Routes(aiohttp.web.RouteTableDef):
         self.put = self._protected(self.put)
         self.patch = self._protected(self.patch)
 
-        self.job_routes = []
+        self.jobs_api = RouteTableDef()
 
 
 def protect(

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -1,12 +1,10 @@
 from functools import wraps
-from typing import Callable, Any
+from typing import Callable
 
 import aiohttp.web
-from aiohttp.web_routedef import RouteDef
 
 import virtool.users.utils
 from virtool.api.response import json_response, unauthorized
-from virtool.types import RouteHandler
 
 
 class Routes(aiohttp.web.RouteTableDef):
@@ -28,42 +26,6 @@ class Routes(aiohttp.web.RouteTableDef):
         self.patch = self._protected(self.patch)
 
         self.job_routes = []
-
-    def route(self,
-              method: str,
-              path: str,
-              jobs_only: bool = False,
-              allow_jobs: bool = True,
-              **kwargs: Any) -> Callable[[RouteHandler], RouteHandler]:
-        """
-        Create a decorator which registers an aiohttp route.
-
-        This function is called by :class:`RouteTableDef`'s method functions, such as :func:`.get`. Any keyword
-        arguments passed to those functions will be forwarded here, allowing the `jobs_only` and `allow_jobs`
-        flags to be handled.
-
-        :param method: The name of the method type. Constants for these names are contained in `aiohttp.hdrs` and
-            are prefixed with `METH_`.
-        :param path: The path of the route.
-        :param jobs_only: If True, the route will be added to the :obj:`.job_routes` attribute only.
-        :param allow_jobs: If True,  the route will be added to the route table, and to :obj:`.job_routes`.
-        :param kwargs: Any keyword arguments are passed to the `RouteDef` object.
-        :return: A decorator which adds the :class:`RouteHandler` to the route table, and/or :obj:`.job_routes`
-        """
-
-        if jobs_only:
-            def _route_decorator(handler: RouteHandler):
-                self.job_routes.append(RouteDef(method, path, handler, {}))
-                return handler
-        elif allow_jobs:
-            def _route_decorator(handler: RouteHandler):
-                self.job_routes.append(RouteDef(method, path, handler, {}))
-                super(Routes, self).route(method, path, **kwargs)(handler)
-                return handler
-        else:
-            _route_decorator = super(Routes, self).route(method, path, **kwargs)
-
-        return _route_decorator
 
 
 def protect(

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -76,7 +76,8 @@ async def find(req):
     return json_response(ready_indexes)
 
 
-@routes.get("/api/indexes/{index_id}", allow_jobs=True)
+@routes.get("/api/indexes/{index_id}")
+@routes.jobs_api.get("/api/indexes/{index_id}")
 async def get(req):
     """
     Get the complete document for a given index.
@@ -241,7 +242,7 @@ async def find_history(req):
     return json_response(data)
 
 
-@routes.delete("/api/indexes/{index_id}", jobs_only=True)
+@routes.jobs_api.delete("/api/indexes/{index_id}")
 async def delete_index(req: aiohttp.web.Request):
     """Delete the index with the given id and reset history relating to that index."""
     index_id = req.match_info["index_id"]

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -42,7 +42,8 @@ async def find(req):
     return json_response(data)
 
 
-@routes.get("/api/jobs/{job_id}", allow_jobs=True)
+@routes.get("/api/jobs/{job_id}")
+@routes.jobs_api.get("/api/jobs/{job_id}")
 async def get(req):
     """
     Return the complete document for a given job.
@@ -58,7 +59,8 @@ async def get(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.patch("/api/jobs/{job_id}", allow_jobs=True)
+@routes.patch("/api/jobs/{job_id}")
+@routes.jobs_api.patch("/api/jobs/{job_id}")
 @schema({
     "acquired": {
         "type": "boolean",
@@ -109,7 +111,8 @@ async def cancel(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.post("/api/jobs/{job_id}/status", allow_jobs=True)
+@routes.post("/api/jobs/{job_id}/status")
+@routes.jobs_api.post("/api/jobs/{job_id}/status")
 @schema({
     "state": {
         "type": "string",

--- a/virtool/jobs_api/routes.py
+++ b/virtool/jobs_api/routes.py
@@ -8,4 +8,4 @@ import virtool.routes
 async def init_routes(app: aiohttp.web.Application):
     """Add routes to jobs API."""
     for routes in virtool.routes.ROUTES:
-        app.add_routes(routes.job_routes)
+        app.add_routes(routes.jobs_api)

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -72,7 +72,8 @@ async def find(req):
     return json_response(data)
 
 
-@routes.get("/api/refs/{ref_id}", allow_jobs=True)
+@routes.get("/api/refs/{ref_id}")
+@routes.jobs_api.get("/api/refs/{ref_id}")
 async def get(req):
     """
     Get the complete representation of a specific reference.

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -135,7 +135,8 @@ async def find(req):
     return json_response(data)
 
 
-@routes.get("/api/samples/{sample_id}", allow_jobs=True)
+@routes.get("/api/samples/{sample_id}")
+@routes.jobs_api.get("/api/samples/{sample_id}")
 async def get(req):
     """
     Get a complete sample document.
@@ -478,7 +479,8 @@ async def set_rights(req):
     return json_response(document)
 
 
-@routes.delete("/api/samples/{sample_id}", allow_jobs=True)
+@routes.delete("/api/samples/{sample_id}")
+@routes.jobs_api.delete("/api/samples/{sample_id}")
 async def remove(req):
     """
     Remove a sample document and all associated analyses.

--- a/virtool/settings/api.py
+++ b/virtool/settings/api.py
@@ -8,7 +8,8 @@ from virtool.http.schema import schema
 routes = virtool.http.routes.Routes()
 
 
-@routes.get("/api/settings", allow_jobs=True)
+@routes.get("/api/settings")
+@routes.jobs_api.get("/api/settings")
 async def get(req):
     settings = await virtool.settings.db.get(req.app["db"])
 

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -12,11 +12,10 @@ import virtool.samples.utils
 import virtool.subtractions.db
 import virtool.subtractions.files
 import virtool.subtractions.utils
-import virtool.utils
 import virtool.uploads.db
 import virtool.uploads.utils
+import virtool.utils
 import virtool.validators
-
 from virtool.api.response import bad_request, invalid_query, json_response, no_content, not_found
 from virtool.http.schema import schema
 from virtool.jobs.utils import JobRights
@@ -75,7 +74,8 @@ async def find(req):
     return json_response(data)
 
 
-@routes.get("/api/subtractions/{subtraction_id}", allow_jobs=True)
+@routes.get("/api/subtractions/{subtraction_id}")
+@routes.jobs_api.get("/api/subtractions/{subtraction_id}")
 async def get(req):
     """
     Get a complete host document.
@@ -212,7 +212,8 @@ async def upload(req):
         return bad_request("Unsupported subtraction file name")
 
     file_type = virtool.subtractions.utils.check_subtraction_file_type(file_name)
-    subtraction_file = await virtool.subtractions.files.create_subtraction_file(pg, subtraction_id, file_type, file_name)
+    subtraction_file = await virtool.subtractions.files.create_subtraction_file(pg, subtraction_id, file_type,
+                                                                                file_name)
     file_id = subtraction_file["id"]
     path = Path(req.app["settings"]["data_path"]) / "subtractions" / subtraction_id / file_name
 
@@ -288,10 +289,8 @@ async def edit(req):
     return json_response(virtool.utils.base_processor(document))
 
 
-@routes.delete(
-    "/api/subtractions/{subtraction_id}",
-    allow_jobs=True, permission="modify_subtraction"
-)
+@routes.delete("/api/subtractions/{subtraction_id}", permission="modify_subtraction")
+@routes.jobs_api.delete("/api/subtractions/{subtraction_id}")
 async def remove(req):
     db = req.app["db"]
     settings = req.app["settings"]


### PR DESCRIPTION
- Removes support for `allow_jobs` and `jobs_only` flags. 
- Adds `jobs_api` attribute of `virtool.http.routes.Routes`.
- Adds explicit route decorators for job routes.

To add a job route

```python
@routes.jobs_api.get("/api/path")
def handler(req):
	...
```

To use the same handler for both APIs 

```python
@routes.get("/api/path")
@routes.jobs_api.get("/api/path")
def handler(req):
	...
```