### PR TITLE
Add `init_executors` to app startup for jobs API.

### DIFF
--- a/virtool/jobs_api/main.py
+++ b/virtool/jobs_api/main.py
@@ -29,6 +29,7 @@ async def create_app(**config):
         virtool.startup.init_settings,
         virtool.startup.init_postgres,
         virtool.startup.init_events,
+        virtool.startup.init_executors,
         virtool.jobs_api.routes.init_routes,
     ])
 


### PR DESCRIPTION
Adds `run_in_thread`, `executor`, `run_in_process`, and `process_executor` fields to the `app` object on startup. 