### PR TITLE
Fixed inactive checkbox for API control

### DIFF
--- a/virtool/settings/api.py
+++ b/virtool/settings/api.py
@@ -36,5 +36,5 @@ async def update(req):
 
     return json_response({
         **settings,
-        **{key: req.app["settings"][key] for key in virtool.settings.db.CONFIG_PROJECTION}
+        **{key: req.app["settings"].get(key) for key in virtool.settings.db.CONFIG_PROJECTION}
     })


### PR DESCRIPTION
Both Sentry and API control checkbox's were broken. Ended up just being a mistake in the backed causing the server response to break. 