### PR TITLE
Download HMM Annotations as Compressed JSON file. 

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -138,7 +138,7 @@ def spawn_client(
                 "session_id": "dne"
             }
 
-        test_client = await aiohttp_client(app, auth=auth, cookies=cookies)
+        test_client = await aiohttp_client(app, auth=auth, cookies=cookies, auto_decompress=False)
 
         return VirtoolTestClient(test_client)
 
@@ -185,9 +185,9 @@ def spawn_job_client(
         if add_route_table:
             app.add_routes(add_route_table)
 
-        client = await aiohttp_client(app, auth=auth)
+        client = await aiohttp_client(app, auth=auth, auto_decompress=False)
         client.db = dbi
-        client.settings = app["config"]
+        client.settings = app["settings"]
 
         return client
 

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -1,8 +1,13 @@
+import json
+from pathlib import Path
+
+import aiofiles
 import aiohttp
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 
 import virtool.errors
+import virtool.utils
 
 
 async def test_find(mocker, spawn_client, hmm_document):
@@ -134,3 +139,30 @@ async def test_get(error, spawn_client, hmm_document, resp_is):
     expected.pop("_id")
 
     assert await resp.json() == expected
+
+
+async def test_get_hmm_annotations(spawn_job_client, tmpdir):
+    client = await spawn_job_client(authorize=True)
+    client.settings["data_path"] = Path(tmpdir)
+    db = client.app["db"]
+
+    await db.hmm.insert_one({"_id": "foo"})
+    await db.hmm.insert_one({"_id": "bar"})
+
+    compressed_hmm_annotations = Path(tmpdir) / "annotations.json.gz"
+    decompressed_hmm_annotations = Path(tmpdir) / "annotations.json"
+
+    async with client.get("/api/hmms/files/annotations.json.gz") as response:
+        assert response.status == 200
+
+        async with aiofiles.open(compressed_hmm_annotations, "wb") as f:
+            await f.write(await response.read())
+
+        print(compressed_hmm_annotations.read_text())
+
+        virtool.utils.decompress_file(compressed_hmm_annotations, decompressed_hmm_annotations)
+
+        async with aiofiles.open(decompressed_hmm_annotations, "r") as f:
+            hmms = json.loads(await f.read())
+
+        print(hmms)

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -134,15 +134,3 @@ async def test_get(error, spawn_client, hmm_document, resp_is):
     expected.pop("_id")
 
     assert await resp.json() == expected
-
-
-async def test_get_hmm_documents(dbi):
-    await dbi.hmm.insert_one({"_id": "foo"})
-    await dbi.hmm.insert_one({"_id": "bar"})
-
-    documents = await virtool.hmm.db.get_hmm_documents(dbi)
-
-    ids = [document["id"] for document in documents]
-
-    assert "foo" in ids
-    assert "bar" in ids

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -134,3 +134,15 @@ async def test_get(error, spawn_client, hmm_document, resp_is):
     expected.pop("_id")
 
     assert await resp.json() == expected
+
+
+async def test_get_hmm_documents(dbi):
+    await dbi.hmm.insert_one({"_id": "foo"})
+    await dbi.hmm.insert_one({"_id": "bar"})
+
+    documents = await virtool.hmm.db.get_hmm_documents(dbi)
+
+    ids = [document["id"] for document in documents]
+
+    assert "foo" in ids
+    assert "bar" in ids

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -158,11 +158,9 @@ async def test_get_hmm_annotations(spawn_job_client, tmpdir):
         async with aiofiles.open(compressed_hmm_annotations, "wb") as f:
             await f.write(await response.read())
 
-        print(compressed_hmm_annotations.read_text())
-
         virtool.utils.decompress_file(compressed_hmm_annotations, decompressed_hmm_annotations)
 
         async with aiofiles.open(decompressed_hmm_annotations, "r") as f:
             hmms = json.loads(await f.read())
 
-        print(hmms)
+        assert hmms == [{"id": "foo"}, {"id": "bar"}]

--- a/tests/hmm/test_db.py
+++ b/tests/hmm/test_db.py
@@ -1,10 +1,7 @@
-import asyncio
-import functools
 import json
 import os
 import shutil
 import sys
-from concurrent.futures.thread import ThreadPoolExecutor
 
 import pymongo.results
 import pytest
@@ -211,13 +208,9 @@ async def test_generate_annotations_json_file(dbi, tmpdir):
     await dbi.hmm.insert_one({"_id": "foo"})
     await dbi.hmm.insert_one({"_id": "bar"})
 
-    executor = ThreadPoolExecutor(1)
-    loop = asyncio.get_event_loop()
-
     path = await virtool.hmm.db.generate_annotations_json_file({
         "db": dbi,
         "settings": {"data_path": str(tmpdir)},
-        "run_in_executor": functools.partial(loop.run_in_executor, executor)
     })
 
     assert path.exists()

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -2,9 +2,12 @@
 API request handlers for managing and querying HMM data.
 
 """
+import gzip
 import os
+from pathlib import Path
 
 import aiohttp
+from aiohttp.web_fileresponse import FileResponse
 
 import virtool.api.utils
 import virtool.db.utils
@@ -15,7 +18,7 @@ import virtool.http.routes
 import virtool.tasks.pg
 import virtool.utils
 from virtool.api.response import bad_gateway, bad_request, conflict, json_response, no_content, not_found
-from virtool.hmm.db import HMMInstallTask
+from virtool.hmm.db import HMMInstallTask, generate_annotations_json_file
 
 routes = virtool.http.routes.Routes()
 
@@ -197,3 +200,15 @@ async def purge(req):
     await virtool.hmm.db.fetch_and_update_release(req.app)
 
     return no_content()
+
+
+@routes.jobs_api.get("/api/hmms/files/annotations.json.gz")
+async def get_hmm_annotations(request):
+    data_path = Path(request.app["settings"]["data_path"])
+    annotation_path = data_path / "hmm/annotations.json.gz"
+
+    if not annotation_path.exists():
+        json_path = await generate_annotations_json_file(request.app)
+        await request.app["run_in_thread"](virtool.utils.compress_file_with_gzip,
+                                           json_path, annotation_path)
+    return FileResponse(annotation_path)

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -204,6 +204,7 @@ async def purge(req):
 
 @routes.jobs_api.get("/api/hmms/files/annotations.json.gz")
 async def get_hmm_annotations(request):
+    """Get a compressed json file containing the database documents for all HMMs."""
     data_path = Path(request.app["settings"]["data_path"])
     annotation_path = data_path / "hmm/annotations.json.gz"
 
@@ -211,4 +212,5 @@ async def get_hmm_annotations(request):
         json_path = await generate_annotations_json_file(request.app)
         await request.app["run_in_thread"](virtool.utils.compress_file_with_gzip,
                                            json_path, annotation_path)
+
     return FileResponse(annotation_path)

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import shutil
+from pathlib import Path
 from typing import List
 
 import aiofiles
@@ -412,3 +413,23 @@ async def get_hmm_documents(db) -> List[dict]:
     """
     all_documents = db.hmm.find({})
     return [virtool.utils.base_processor(document) async for document in all_documents]
+
+
+async def generate_annotations_json_file(app: virtool.types.App) -> Path:
+    """
+    Generate the HMMs annotation file at `settings["data_path"]/hmm/annotations.json.gz
+
+    :param app: The app object.
+    :return: The path to the compressed annotations json file.
+    """
+    settings, db = app["settings"], app["db"]
+
+    annotations_path = Path(settings["data_path"]) / "hmm/annotations.json"
+    annotations_path.parent.mkdir(parents=True, exist_ok=True)
+
+    hmm_documents = await get_hmm_documents(db)
+
+    async with aiofiles.open(annotations_path, "w") as f:
+        await f.write(json.dumps(hmm_documents))
+
+    return annotations_path

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import shutil
+from typing import List
 
 import aiofiles
 import aiohttp.client_exceptions
@@ -401,3 +402,13 @@ async def refresh(app: virtool.types.App):
         pass
 
     logging.debug("Stopped HMM refresher")
+
+
+async def get_hmm_documents(db) -> List[dict]:
+    """
+    Get a list of all HMM documents currently available in the database.
+    :param db: The database object.
+    :return: A list of HMM documents.
+    """
+    all_documents = db.hmm.find({})
+    return [virtool.utils.base_processor(document) async for document in all_documents]


### PR DESCRIPTION
- Sets `auto_decompress` to false for test clients
    - Prevents client from decompressing gzipped files
- Adds route at `GET /api/hmm/files/annotations.json.gz` 
    - `GET /api/hmm/annotations.json.gz` could not be used as it overlaps with existing `GET /api/hmm/:id` endpoint. 
   