### PR TITLE
Fix app hanging and user lockout on forced password reset

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -402,7 +402,7 @@ async def reset(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
     """
     db = req.app["db"]
-    session_id = req["client"].session_id
+    session_id = req.cookies.get("session_id")
 
     password = req["data"]["password"]
     reset_code = req["data"]["reset_code"]
@@ -433,7 +433,10 @@ async def reset(req: aiohttp.web.Request) -> aiohttp.web.Response:
         remember=session.get("reset_remember", False)
     )
 
-    req["client"].authorize(new_session, is_api=False)
+    try:
+        req["client"].authorize(new_session, is_api=False)
+    except AttributeError:
+        pass
 
     resp = json_response({
         "login": False,


### PR DESCRIPTION
From looking at the middleware code it seems that it isn't a bug that `req["client"]` might resolve to `None`, but it seems like a few different endpoints are expecting it not to be (another example is [this one](https://app.clubhouse.io/virtool/story/445/put-500-error-thrown-on-successful-creation-of-first-user)), so I'm not sure how else this should be approached.