### PR TITLE
Rename hash field to key for cache documents

### DIFF
--- a/tests/caches/snapshots/snap_test_db.py
+++ b/tests/caches/snapshots/snap_test_db.py
@@ -11,8 +11,8 @@ snapshots['test_create[uvloop-paired] return'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'id': '9pfsom1b',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': True,
@@ -37,7 +37,7 @@ snapshots['test_create[uvloop-paired] db'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': True,
@@ -61,8 +61,8 @@ snapshots['test_create[uvloop-unpaired] return'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'id': '9pfsom1b',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': False,
@@ -87,7 +87,7 @@ snapshots['test_create[uvloop-unpaired] db'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': False,
@@ -111,8 +111,8 @@ snapshots['test_create_program[uvloop] return'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'id': '9pfsom1b',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': False,
@@ -137,7 +137,7 @@ snapshots['test_create_program[uvloop] db'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': False,
@@ -161,8 +161,8 @@ snapshots['test_create_duplicate[uvloop] return'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'id': 'u3cuwaoq',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': False,
@@ -187,7 +187,7 @@ snapshots['test_create_duplicate[uvloop] db'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': False,
     'missing': False,
     'paired': False,
@@ -211,8 +211,8 @@ snapshots['test_create_legacy[uvloop] return'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'id': '9pfsom1b',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': True,
     'missing': False,
     'paired': False,
@@ -237,7 +237,7 @@ snapshots['test_create_legacy[uvloop] db'] = {
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
-    'hash': '68b60be51a667882d3aaa02a93259dd526e9c990',
+    'key': '68b60be51a667882d3aaa02a93259dd526e9c990',
     'legacy': True,
     'missing': False,
     'paired': False,

--- a/tests/caches/snapshots/snap_test_migrate.py
+++ b/tests/caches/snapshots/snap_test_migrate.py
@@ -21,3 +21,14 @@ snapshots['test_add_missing_field[uvloop] 1'] = [
         'missing': False
     }
 ]
+
+snapshots['test_rename_hash_field[uvloop] 1'] = [
+    {
+        '_id': 'foo',
+        'key': 'a97439e170adc4365c5b92bd2c148ed57d75e566'
+    },
+    {
+        '_id': 'bar',
+        'key': 'd7fh3ee170adc4365c5b92bd2c1f3fd5745te566'
+    }
+]

--- a/tests/caches/test_db.py
+++ b/tests/caches/test_db.py
@@ -18,8 +18,8 @@ def trim_parameters():
     }
 
 
-def test_calculate_cache_hash(trim_parameters):
-    hashed = virtool.caches.db.calculate_cache_hash(trim_parameters)
+def test_calculate_cache_key(trim_parameters):
+    hashed = virtool.caches.db.calculate_cache_key(trim_parameters)
     assert hashed == "68b60be51a667882d3aaa02a93259dd526e9c990"
 
 
@@ -37,18 +37,18 @@ async def test_find(exists, missing, returned_hash, mocker, dbi):
         await dbi.caches.insert_one({
             "_id": "bar",
             "program": "skewer-0.2.2",
-            "hash": "abc123",
+            "key": "abc123",
             "missing": missing,
             "sample": {
                 "id": "foo"
             }
         })
 
-    m_calculate_cache_hash = mocker.patch("virtool.caches.db.calculate_cache_hash", return_value=returned_hash)
+    m_calculate_cache_key = mocker.patch("virtool.caches.db.calculate_cache_key", return_value=returned_hash)
 
     result = await virtool.caches.db.find(dbi, "foo", "skewer-0.2.2", parameters)
 
-    m_calculate_cache_hash.assert_called_with(parameters)
+    m_calculate_cache_key.assert_called_with(parameters)
 
     if missing or not exists or returned_hash == "foobar":
         assert result is None
@@ -57,7 +57,7 @@ async def test_find(exists, missing, returned_hash, mocker, dbi):
     assert result == {
         "id": "bar",
         "program": "skewer-0.2.2",
-        "hash": "abc123",
+        "key": "abc123",
         "missing": False,
         "sample": {
             "id": "foo"

--- a/tests/caches/test_migrate.py
+++ b/tests/caches/test_migrate.py
@@ -4,6 +4,7 @@ from aiohttp.test_utils import make_mocked_coro
 
 async def test_migrate_caches(mocker, dbi):
     m_add_missing_field = mocker.patch("virtool.caches.migrate.add_missing_field", make_mocked_coro())
+    m_rename_hash_field = mocker.patch("virtool.caches.migrate.rename_hash_field", make_mocked_coro())
 
     app = {
         "db": dbi,
@@ -15,6 +16,7 @@ async def test_migrate_caches(mocker, dbi):
     await virtool.caches.migrate.migrate_caches(app)
 
     m_add_missing_field.assert_called_with(app)
+    m_rename_hash_field.assert_called_with(app)
 
 
 async def test_add_missing_field(snapshot, tmpdir, dbi):
@@ -43,5 +45,26 @@ async def test_add_missing_field(snapshot, tmpdir, dbi):
     ])
 
     await virtool.caches.migrate.add_missing_field(app)
+
+    snapshot.assert_match(await dbi.caches.find().to_list(None))
+
+
+async def test_rename_hash_field(snapshot, dbi):
+    app = {
+        "db": dbi
+    }
+
+    await dbi.caches.insert_many([
+        {
+            "_id": "foo",
+            "hash": "a97439e170adc4365c5b92bd2c148ed57d75e566"
+        },
+        {
+            "_id": "bar",
+            "hash": "d7fh3ee170adc4365c5b92bd2c1f3fd5745te566"
+        }
+    ])
+
+    await virtool.caches.migrate.rename_hash_field(app)
 
     snapshot.assert_match(await dbi.caches.find().to_list(None))

--- a/virtool/caches/db.py
+++ b/virtool/caches/db.py
@@ -19,22 +19,22 @@ PROJECTION = (
     "_id",
     "created_at",
     "files",
-    "hash",
+    "key",
     "program",
     "ready",
     "sample"
 )
 
 
-def calculate_cache_hash(parameters: Dict[str, Any]) -> str:
+def calculate_cache_key(parameters: Dict[str, Any]) -> str:
     """
-    Calculate a hash from the parameters `dict` for a cache.
+    Calculate a key from the parameters `dict` for a cache.
 
-    The parameters are arguments passed to a trimming program. Caches can be reused when the hash
+    The parameters are arguments passed to a trimming program. Caches can be reused when the key
     of the trim parameters for a a new analysis matches an existing cache.
 
     :param parameters: the trimming parameters
-    :return: the cache hash
+    :return: the cache key
 
     """
     string = json.dumps(parameters, sort_keys=True)
@@ -56,7 +56,7 @@ async def find(db, sample_id: str, program: str, parameters: Dict[str, Any]) -> 
 
     """
     document = await db.caches.find_one({
-        "hash": virtool.caches.db.calculate_cache_hash(parameters),
+        "key": virtool.caches.db.calculate_cache_key(parameters),
         "missing": False,
         "program": program,
         "sample.id": sample_id
@@ -136,7 +136,7 @@ async def create(
             "_id": cache_id,
             "created_at": virtool.utils.timestamp(),
             "files": list(),
-            "hash": calculate_cache_hash(parameters),
+            "key": calculate_cache_key(parameters),
             "legacy": legacy,
             "missing": False,
             "paired": paired,

--- a/virtool/caches/migrate.py
+++ b/virtool/caches/migrate.py
@@ -16,6 +16,7 @@ async def migrate_caches(app: App):
 
     """
     await add_missing_field(app)
+    await rename_hash_field(app)
 
 
 async def add_missing_field(app: App):
@@ -41,5 +42,21 @@ async def add_missing_field(app: App):
     await db.caches.update_many({"_id": {"$nin": found_cache_ids}}, {
         "$set": {
             "missing": True
+        }
+    })
+
+
+async def rename_hash_field(app: App):
+    """
+    Rename `hash` field to `key` for all existing caches.
+
+    :param app: the application object
+
+    """
+    db = app["db"]
+
+    await db.caches.update_many({}, {
+        "$rename": {
+            "hash": "key"
         }
     })


### PR DESCRIPTION
Add a migrate function for renaming `hash` field to `key` for existing cache documents