### PR TITLE
Add process for compressing legacy samples

### DIFF
--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -22,6 +22,7 @@ snapshots['TestCreate.test[uvloop-none] 1'] = {
     'group_write': True,
     'hold': True,
     'id': '9pfsom1b',
+    'is_legacy': False,
     'library_type': 'normal',
     'name': 'Foobar',
     'nuvs': False,
@@ -52,6 +53,7 @@ snapshots['TestCreate.test[uvloop-users_primary_group] 1'] = {
     'group_write': True,
     'hold': True,
     'id': '9pfsom1b',
+    'is_legacy': False,
     'library_type': 'normal',
     'name': 'Foobar',
     'nuvs': False,
@@ -82,6 +84,7 @@ snapshots['TestCreate.test[uvloop-force_choice] 1'] = {
     'group_write': True,
     'hold': True,
     'id': '9pfsom1b',
+    'is_legacy': False,
     'library_type': 'normal',
     'name': 'Foobar',
     'nuvs': False,
@@ -112,6 +115,7 @@ snapshots['TestCreate.test[uvloop-none] 2'] = {
     'group_read': True,
     'group_write': True,
     'hold': True,
+    'is_legacy': False,
     'library_type': 'normal',
     'name': 'Foobar',
     'nuvs': False,
@@ -142,6 +146,7 @@ snapshots['TestCreate.test[uvloop-users_primary_group] 2'] = {
     'group_read': True,
     'group_write': True,
     'hold': True,
+    'is_legacy': False,
     'library_type': 'normal',
     'name': 'Foobar',
     'nuvs': False,
@@ -172,6 +177,7 @@ snapshots['TestCreate.test[uvloop-force_choice] 2'] = {
     'group_read': True,
     'group_write': True,
     'hold': True,
+    'is_legacy': False,
     'library_type': 'normal',
     'name': 'Foobar',
     'nuvs': False,
@@ -426,7 +432,6 @@ snapshots['test_get[uvloop-False-None] 1'] = {
 snapshots['test_find_analyses[uvloop-None-None] 1'] = {
     'documents': [
         {
-            'workflow': 'pathoscope_bowtie',
             'created_at': '2015-10-06T20:00:00Z',
             'id': 'test_1',
             'index': {
@@ -446,10 +451,10 @@ snapshots['test_find_analyses[uvloop-None-None] 1'] = {
             },
             'user': {
                 'id': 'bob'
-            }
+            },
+            'workflow': 'pathoscope_bowtie'
         },
         {
-            'workflow': 'pathoscope_bowtie',
             'created_at': '2015-10-06T20:00:00Z',
             'id': 'test_2',
             'index': {
@@ -469,10 +474,10 @@ snapshots['test_find_analyses[uvloop-None-None] 1'] = {
             },
             'user': {
                 'id': 'fred'
-            }
+            },
+            'workflow': 'pathoscope_bowtie'
         },
         {
-            'workflow': 'pathoscope_bowtie',
             'created_at': '2015-10-06T20:00:00Z',
             'id': 'test_3',
             'index': {
@@ -492,7 +497,8 @@ snapshots['test_find_analyses[uvloop-None-None] 1'] = {
             },
             'user': {
                 'id': 'fred'
-            }
+            },
+            'workflow': 'pathoscope_bowtie'
         }
     ],
     'found_count': 3,
@@ -505,7 +511,6 @@ snapshots['test_find_analyses[uvloop-None-None] 1'] = {
 snapshots['test_find_analyses[uvloop-bob-None] 1'] = {
     'documents': [
         {
-            'workflow': 'pathoscope_bowtie',
             'created_at': '2015-10-06T20:00:00Z',
             'id': 'test_1',
             'index': {
@@ -525,7 +530,8 @@ snapshots['test_find_analyses[uvloop-bob-None] 1'] = {
             },
             'user': {
                 'id': 'bob'
-            }
+            },
+            'workflow': 'pathoscope_bowtie'
         }
     ],
     'found_count': 1,
@@ -538,7 +544,6 @@ snapshots['test_find_analyses[uvloop-bob-None] 1'] = {
 snapshots['test_find_analyses[uvloop-Baz-None] 1'] = {
     'documents': [
         {
-            'workflow': 'pathoscope_bowtie',
             'created_at': '2015-10-06T20:00:00Z',
             'id': 'test_1',
             'index': {
@@ -558,10 +563,10 @@ snapshots['test_find_analyses[uvloop-Baz-None] 1'] = {
             },
             'user': {
                 'id': 'bob'
-            }
+            },
+            'workflow': 'pathoscope_bowtie'
         },
         {
-            'workflow': 'pathoscope_bowtie',
             'created_at': '2015-10-06T20:00:00Z',
             'id': 'test_2',
             'index': {
@@ -581,7 +586,8 @@ snapshots['test_find_analyses[uvloop-Baz-None] 1'] = {
             },
             'user': {
                 'id': 'fred'
-            }
+            },
+            'workflow': 'pathoscope_bowtie'
         }
     ],
     'found_count': 2,

--- a/tests/samples/snapshots/snap_test_db.py
+++ b/tests/samples/snapshots/snap_test_db.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_compress_reads[uvloop-True] 1'] = {
+    '_id': 'foo',
+    'files': [
+        {
+            'download_url': '/download/samples/foo/reads_1.fq.gz',
+            'from': {
+                'id': 'M_S11_R1_001.fastq',
+                'name': 'M_S11_R1_001.fastq',
+                'size': 3750821789
+            },
+            'name': 'reads_1.fq.gz',
+            'raw': False,
+            'size': 6586501
+        },
+        {
+            'download_url': '/download/samples/foo/reads_2.fq.gz',
+            'from': {
+                'id': 'M_S11_R1_001.fastq',
+                'name': 'M_S11_R1_001.fastq',
+                'size': 3750821789
+            },
+            'name': 'reads_2.fq.gz',
+            'raw': False,
+            'size': 6586501
+        }
+    ],
+    'paired': True
+}
+
+snapshots['test_compress_reads[uvloop-False] 1'] = {
+    '_id': 'foo',
+    'files': [
+        {
+            'download_url': '/download/samples/foo/reads_1.fq.gz',
+            'from': {
+                'id': 'M_S11_R1_001.fastq',
+                'name': 'M_S11_R1_001.fastq',
+                'size': 3750821789
+            },
+            'name': 'reads_1.fq.gz',
+            'raw': False,
+            'size': 6586501
+        }
+    ],
+    'paired': False
+}

--- a/tests/samples/snapshots/snap_test_migrate.py
+++ b/tests/samples/snapshots/snap_test_migrate.py
@@ -78,3 +78,26 @@ snapshots['test_update_pairedness[uvloop] 1'] = [
         'paired': False
     }
 ]
+
+snapshots['test_add_is_legacy[uvloop] 1'] = [
+    {
+        '_id': 'foo',
+        'files': [
+            {
+                'id': 1,
+                'raw': False
+            }
+        ],
+        'is_legacy': True
+    },
+    {
+        '_id': 'bar',
+        'files': [
+            {
+                'id': 1,
+                'raw': True
+            }
+        ],
+        'is_legacy': False
+    }
+]

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -1,8 +1,21 @@
+import filecmp
+import gzip
+import json
 import os
+import shutil
+import sys
+from pathlib import Path
+from pprint import pprint
+from unittest.mock import call
+
 import pytest
+from aiohttp.test_utils import make_mocked_coro
 
 import virtool.samples.db
 import virtool.samples.utils
+import virtool.samples.db
+
+FASTQ_PATH = Path(sys.path[0]) / "tests/test_files/test.fq"
 
 
 class TestCalculateWorkflowTags:
@@ -276,3 +289,213 @@ class TestRemoveSamples:
         assert os.listdir(str(samples_dir)) == []
 
         assert not await dbi.samples.count_documents({})
+
+
+class TestCheckIsLegacy:
+
+    @pytest.mark.parametrize("is_legacy,files", [
+        (False, [{"raw": True}]),
+        (True, [{"raw": False}]),
+        (False, [{"raw": True}, {"raw": False}]),
+        (True, [{"raw": False}, {"raw": False}]),
+    ])
+    def test_raw(self, is_legacy, files):
+        """
+
+
+        """
+        files[0]["name"] = "reads_1.fastq"
+
+        try:
+            files[1]["name"] = "reads_2.fastq"
+        except IndexError:
+            pass
+
+        sample = {
+            "_id": "foo",
+            "paired": len(files) == 2,
+            "files": files
+        }
+
+        assert virtool.samples.db.check_is_legacy(sample) is is_legacy
+
+    @pytest.mark.parametrize("paired", [True, False])
+    def test_names(self, paired):
+        """
+        Test that checks fail when names are not as expected.
+
+        """
+        files = [{
+            "name": "reads.fastq",
+            "raw": False
+        }]
+
+        if paired:
+            files.append({
+                "name": "reads_two.fastq",
+                "raw": False
+            })
+
+        sample = {
+            "_id": "foo",
+            "files": files,
+            "paired": paired
+        }
+
+        assert virtool.samples.db.check_is_legacy(sample) is False
+
+
+@pytest.mark.parametrize("paired", [True, False])
+async def test_compress_reads(paired, dbi, snapshot, tmpdir):
+    async def run_in_thread(func, *args):
+        return func(*args)
+
+    sample_dir = tmpdir.mkdir("samples").mkdir("foo")
+
+    shutil.copy(FASTQ_PATH, sample_dir / "reads_1.fastq")
+
+    if paired:
+        shutil.copy(FASTQ_PATH, sample_dir / "reads_2.fastq")
+
+    app_dict = {
+        "db": dbi,
+        "run_in_thread": run_in_thread,
+        "settings": {
+            "data_path": str(tmpdir)
+        }
+    }
+
+    sample_id = "foo"
+
+    file = {
+        "name": "reads_1.fastq",
+        "download_url": f"/download/samples/{sample_id}/reads_1.fastq",
+        "size": 3750821789,
+        "raw": False,
+        "from": {
+            "id": "M_S11_R1_001.fastq",
+            "name": "M_S11_R1_001.fastq",
+            "size": 3750821789
+        }
+    }
+
+    files = [file]
+
+    if paired:
+        files.append({
+            **file,
+            "name": "reads_2.fastq",
+            "download_url": f"/download/samples/{sample_id}/reads_2.fastq"
+        })
+
+    sample = {
+        "_id": sample_id,
+        "files": files,
+        "paired": paired
+    }
+
+    await dbi.samples.insert_one(sample)
+
+    await virtool.samples.db.compress_reads(app_dict, sample)
+
+    expected_listdir = ["reads_1.fq.gz", "reads_2.fq.gz"] if paired else ["reads_1.fq.gz"]
+
+    assert sorted(os.listdir(sample_dir)) == expected_listdir
+
+    with open(FASTQ_PATH, "r") as f:
+        expected_content = f.read()
+
+    with gzip.open(sample_dir / "reads_1.fq.gz", "rt") as f:
+        assert expected_content == f.read()
+
+    if paired:
+        with gzip.open(sample_dir / "reads_2.fq.gz", "rt") as f:
+            assert expected_content == f.read()
+
+    snapshot.assert_match(await dbi.samples.find_one())
+
+
+async def test_compress_reads_process(mocker, dbi):
+    """
+    Ensure `compress_reads` is called correctly given a samples collection.
+
+    """
+    app_dict = {
+        "db": dbi,
+        "run_in_thread": make_mocked_coro(),
+        "settings": dict()
+    }
+
+    await dbi.samples.insert_many([
+        {
+            "_id": "foo",
+            "files": [
+                {"raw": True},
+                {"raw": False}
+            ]
+        },
+        {
+            "_id": "fab",
+            "files": [
+                {"raw": False}
+            ]
+        },
+        {
+            "_id": "bar",
+            "files": [
+                {"raw": True}
+            ]
+        },
+        {
+            "_id": "baz",
+            "files": [
+                {"raw": True},
+                {"raw": True}
+            ]
+        },
+        {
+            "_id": "fob",
+            "files": [
+                {"raw": False},
+                {"raw": False}
+            ]
+        }
+    ])
+
+    await dbi.processes.insert_one({
+        "_id": "foo",
+        "context": {
+            "test": True
+        }
+    })
+
+    m_compress_reads = mocker.patch("virtool.samples.db.compress_reads", make_mocked_coro())
+
+    process = virtool.samples.db.CompressReadsProcess(app_dict, "foo")
+
+    await process.run()
+
+    assert len(m_compress_reads.mock_calls) == 3
+
+    m_compress_reads.assert_has_calls([
+        call(app_dict, {
+            "_id": "foo",
+            "files": [
+                {"raw": True},
+                {"raw": False}
+            ]
+        }),
+        call(app_dict, {
+            "_id": "fab",
+            "files": [
+                {"raw": False}
+            ]
+        }),
+        call(app_dict, {
+            "_id": "fob",
+            "files": [
+                {"raw": False},
+                {"raw": False}
+            ]
+        })
+    ])

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -429,36 +429,15 @@ async def test_compress_reads_process(mocker, dbi):
     await dbi.samples.insert_many([
         {
             "_id": "foo",
-            "files": [
-                {"raw": True},
-                {"raw": False}
-            ]
+            "is_legacy": True
         },
         {
             "_id": "fab",
-            "files": [
-                {"raw": False}
-            ]
+            "is_legacy": False
         },
         {
             "_id": "bar",
-            "files": [
-                {"raw": True}
-            ]
-        },
-        {
-            "_id": "baz",
-            "files": [
-                {"raw": True},
-                {"raw": True}
-            ]
-        },
-        {
-            "_id": "fob",
-            "files": [
-                {"raw": False},
-                {"raw": False}
-            ]
+            "is_legacy": True
         }
     ])
 
@@ -475,27 +454,15 @@ async def test_compress_reads_process(mocker, dbi):
 
     await process.run()
 
-    assert len(m_compress_reads.mock_calls) == 3
+    assert len(m_compress_reads.mock_calls) == 2
 
     m_compress_reads.assert_has_calls([
         call(app_dict, {
             "_id": "foo",
-            "files": [
-                {"raw": True},
-                {"raw": False}
-            ]
+            "is_legacy": True
         }),
         call(app_dict, {
-            "_id": "fab",
-            "files": [
-                {"raw": False}
-            ]
-        }),
-        call(app_dict, {
-            "_id": "fob",
-            "files": [
-                {"raw": False},
-                {"raw": False}
-            ]
+            "_id": "bar",
+            "is_legacy": True
         })
     ])

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -1,11 +1,8 @@
-import filecmp
 import gzip
-import json
 import os
 import shutil
 import sys
 from pathlib import Path
-from pprint import pprint
 from unittest.mock import call
 
 import pytest
@@ -13,7 +10,6 @@ from aiohttp.test_utils import make_mocked_coro
 
 import virtool.samples.db
 import virtool.samples.utils
-import virtool.samples.db
 
 FASTQ_PATH = Path(sys.path[0]) / "tests/test_files/test.fq"
 

--- a/tests/samples/test_migrate.py
+++ b/tests/samples/test_migrate.py
@@ -1,6 +1,27 @@
 import virtool.samples.migrate
 
 
+async def test_add_is_legacy(snapshot, dbi):
+    await dbi.samples.insert_many([
+        {
+            "_id": "foo",
+            "files": [
+                {"id": 1, "raw": False}
+            ]
+        },
+        {
+            "_id": "bar",
+            "files": [
+                {"id": 1, "raw": True}
+            ]
+        }
+    ])
+
+    await virtool.samples.migrate.add_is_legacy(dbi)
+
+    snapshot.assert_match(await dbi.samples.find().to_list(None))
+
+
 async def test_add_library_type(snapshot, dbi):
     """
     Test that samples are assigned a library_type field with different `srna` field values.

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -37,6 +37,8 @@ import virtool.setup.setup
 import virtool.software.db
 import virtool.utils
 import virtool.version
+from virtool.processes.db import register
+from virtool.samples.db import CompressReadsProcess
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +79,10 @@ async def init_refresh(app: web.Application):
     await scheduler.spawn(virtool.references.db.refresh_remotes(app))
     await scheduler.spawn(virtool.hmm.db.refresh(app))
     await scheduler.spawn(virtool.software.db.refresh(app))
+
+    process = await register(app["db"], "compress_reads")
+    p = CompressReadsProcess(app, process["id"])
+    await scheduler.spawn(p.run())
 
 
 async def init_version(app: web.Application):

--- a/virtool/jobs/analysis.py
+++ b/virtool/jobs/analysis.py
@@ -133,11 +133,9 @@ class Job(virtool.jobs.job.Job):
             return self._fetch_cache(cache)
 
         sample = self.db.samples.find_one(self.params["sample_id"])
-        paths = virtool.samples.utils.join_legacy_read_paths(self.settings, sample)
 
-        if paths:
-            self.params["read_paths"] = self._fetch_legacy(paths)
-            return
+        if sample["is_legacy"]:
+            return self._fetch_legacy()
 
         return self._create_cache(parameters)
 
@@ -225,15 +223,10 @@ class Job(virtool.jobs.job.Job):
 
         self._set_cache_id(cache["id"])
 
-    def _fetch_legacy(self, legacy_read_paths):
-        local_paths = list()
-
-        for path in legacy_read_paths:
+    def _fetch_legacy(self):
+        for path in self.params["read_paths"]:
             local_path = os.path.join(self.params["reads_path"], pathlib.Path(path).name)
-            local_paths.append(local_path)
             shutil.copy(path, local_path)
-
-        return local_paths
 
     def _run_cache_qc(self, cache_id, temp_path):
         fastqc_path = os.path.join(temp_path, "fastqc")

--- a/virtool/processes/steps.py
+++ b/virtool/processes/steps.py
@@ -1,6 +1,7 @@
 FIRST_STEPS = {
     "delete_reference": "delete_indexes",
     "clone_reference": "copy_otus",
+    "compress_reads": "compress_samples",
     "import_reference": "load_file",
     "remote_reference": "download",
     "update_remote_reference": "download",

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -241,6 +241,7 @@ async def create(req):
         "nuvs": False,
         "pathoscope": False,
         "created_at": virtool.utils.timestamp(),
+        "is_legacy": False,
         "format": "fastq",
         "ready": False,
         "quality": None,

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -34,6 +34,7 @@ LIST_PROJECTION = [
 PROJECTION = [
     "_id",
     "created_at",
+    "is_legacy",
     "library_type",
     "name",
     "pathoscope",

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -416,11 +416,10 @@ class CompressReadsProcess(Process):
         ]
 
     async def compress_samples(self):
-        query = {"files.raw": False}
-        count = await self.db.samples.count_documents(query)
+        count = await self.db.samples.count_documents({"is_legacy": True})
 
         tracker = self.get_tracker(count)
 
-        async for sample in self.db.samples.find(query):
+        async for sample in self.db.samples.find({"is_legacy": True}):
             await compress_reads(self.app, sample)
             await tracker.add(1)

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import aiohttp.web
 import asyncio
 import logging
@@ -10,6 +12,9 @@ import virtool.errors
 import virtool.samples.utils
 import virtool.utils
 import virtool.samples.utils
+from virtool.processes.process import Process
+from virtool.samples.utils import join_legacy_read_paths
+from virtool.utils import compress_file, file_stats
 
 logger = logging.getLogger(__name__)
 
@@ -334,3 +339,88 @@ async def validate_force_choice_group(db, data):
         return "Group value required for sample creation"
 
     return None
+
+
+def check_is_legacy(sample: Dict[str, Any]) -> bool:
+    """
+    Check if a sample has legacy read files.
+
+    :param sample: the sample document
+    :return: legacy boolean
+    """
+    files = sample["files"]
+
+    return (
+        # All files have the `raw` flag set false indicating they are legacy data.
+        all(file.get("raw", False) is False for file in files) and
+
+        # File naming matches expectations.
+        files[0]["name"] == "reads_1.fastq" and
+        (sample["paired"] is False or files[1]["name"] == "reads_2.fastq")
+    )
+
+
+async def compress_reads(app, sample: Dict[str, Any]):
+    """
+    Compress the reads for one legacy samples.
+
+    :param app: the application object
+    :param sample: the sample document
+
+    """
+    if not check_is_legacy(sample):
+        return
+
+    paths = join_legacy_read_paths(app["settings"], sample)
+
+    data_path = app["settings"]["data_path"]
+    sample_id = sample["_id"]
+
+    files = list()
+
+    for i, path in enumerate(paths):
+        target_filename = "reads_1.fq.gz" if "reads_1.fastq" in path else "reads_2.fq.gz"
+        target_path = os.path.join(data_path, "samples", sample_id, target_filename)
+
+        await app["run_in_thread"](compress_file, path, target_path, 1)
+
+        stats = await app["run_in_thread"](file_stats, target_path)
+
+        assert os.path.isfile(target_path)
+
+        files.append({
+            "name": target_filename,
+            "download_url": f"/download/samples/{sample_id}/{target_filename}",
+            "size": stats["size"],
+            "raw": False,
+            "from": sample["files"][i]["from"]
+        })
+
+    await app["db"].samples.update_one({"_id": sample_id}, {
+        "$set": {
+            "files": files
+        }
+    })
+
+    for path in paths:
+        await app["run_in_thread"](os.remove, path)
+
+
+class CompressReadsProcess(Process):
+
+    def __init__(self, app, process_id):
+        super().__init__(app, process_id)
+
+        self.steps = [
+            self.compress_samples
+        ]
+
+    async def compress_samples(self):
+        query = {"files.raw": False}
+        count = await self.db.samples.count_documents(query)
+
+        tracker = self.get_tracker(count)
+
+        async for sample in self.db.samples.find(query):
+            await compress_reads(self.app, sample)
+            await tracker.add(1)

--- a/virtool/samples/migrate.py
+++ b/virtool/samples/migrate.py
@@ -29,9 +29,24 @@ async def migrate_samples(app):
     await update_pairedness(motor_client)
     await prune_fields(motor_client)
     await add_library_type(motor_client)
+    await add_is_legacy(motor_client)
 
     for sample_id in await motor_client.samples.distinct("_id"):
         await virtool.samples.db.recalculate_workflow_tags(motor_client, sample_id)
+
+
+async def add_is_legacy(db):
+    await db.samples.update_many({"files.raw": False}, {
+        "$set": {
+            "is_legacy": True
+        }
+    })
+
+    await db.samples.update_many({"files.raw": True}, {
+        "$set": {
+            "is_legacy": False
+        }
+    })
 
 
 async def add_library_type(db):


### PR DESCRIPTION
Set a new `is_legacy` field on samples based on the state of their sample files. The current legacy checks use multiple different methods for checking the `files` field (flaky).

Add a process that starts on application start that compresses all legacy sample FASTQ files. Update the caching code to understand this change. Until caching is complete, analysis jobs for uncompressed legacy samples will fail.