### PR TITLE
Log a message each time a legacy sample is compressed

### DIFF
--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -424,3 +424,5 @@ class CompressReadsProcess(Process):
         async for sample in self.db.samples.find({"is_legacy": True}):
             await compress_reads(self.app, sample)
             await tracker.add(1)
+
+            logger.info(f"Compressed legacy sample {sample['_id']} ({tracker.count}/{tracker.total}")


### PR DESCRIPTION
During `CompressReadsProcess`, log sample ID and compressed count versus total.