### PR TITLE
Don't maintain cursor for whole life of CompressReadsProcess

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -215,7 +215,6 @@ async def test_blast(error, mocker, spawn_client, resp_is, static_time):
         return
 
     if error == "409_workflow":
-        print(await resp.json())
         assert await resp_is.conflict(resp, "Not a NuVs analysis")
         return
 


### PR DESCRIPTION
* Re-query the database for each sample compression 
* Set `is_compressed` on samples with both files gzipped