### PR TITLE
Use `PUT` instead of `POST` in endpoints that upload reads

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -813,17 +813,17 @@ async def test_upload_reads(paired, conflict, compressed, snapshot, spawn_job_cl
         "_id": "test",
     })
 
-    resp = await client.post("/api/samples/test/reads", data=data)
+    resp = await client.put("/api/samples/test/reads/reads_1.fq.gz", data=data)
 
     if compressed and paired:
         data["file"] = open(path / "reads_2.fq.gz", "rb")
-        resp_2 = await client.post("/api/samples/test/reads", data=data)
+        resp_2 = await client.put("/api/samples/test/reads/reads_2.fq.gz", data=data)
 
         if conflict:
             data["file"] = open(path / "reads_2.fq.gz", "rb")
-            resp_3 = await client.post("/api/samples/test/reads", data=data)
+            resp_3 = await client.put("/api/samples/test/reads/reads_2.fq.gz", data=data)
 
-            assert await resp_is.conflict(resp_3, "Sample is already associated with two reads files")
+            assert await resp_is.conflict(resp_3, "Reads file is already associated with this sample")
             return
 
     if compressed:
@@ -1011,13 +1011,13 @@ async def test_upload_reads_cache(paired, snapshot, static_time, spawn_job_clien
         }
     })
 
-    resp = await client.post("/api/samples/test/caches/aodp-abcdefgh/reads", data=data)
+    resp = await client.put("/api/samples/test/caches/aodp-abcdefgh/reads/reads_1.fq.gz", data=data)
 
     assert resp.status == 201
 
     if paired:
         data["file"] = open(path / "reads_2.fq.gz", "rb")
-        resp_2 = await client.post("/api/samples/test/caches/aodp-abcdefgh/reads", data=data)
+        resp_2 = await client.put("/api/samples/test/caches/aodp-abcdefgh/reads/reads_2.fq.gz", data=data)
 
         assert resp.status, resp_2.status == 201
         snapshot.assert_match(await resp_2.json())

--- a/virtool/analyses/files.py
+++ b/virtool/analyses/files.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional
+from typing import Dict
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -77,38 +77,3 @@ async def create_nuvs_analysis_files(pg: AsyncEngine, analysis_id: str, files: l
             analysis_file.name_on_disk = f"{analysis_file.id}-{analysis_file.name}"
 
         await session.commit()
-
-
-async def delete_analysis_file(pg: AsyncEngine, file_id: int):
-    """
-    Deletes a row in the `analysis_files` SQL by its row `id`
-
-    :param pg: PostgreSQL AsyncEngine object
-    :param file_id: Row `id` to delete
-    """
-    async with AsyncSession(pg) as session:
-        analysis_file = (await session.execute(select(AnalysisFile).where(AnalysisFile.id == file_id))).scalar()
-
-        if not analysis_file:
-            return None
-
-        await session.delete(analysis_file)
-
-        await session.commit()
-
-
-async def get_analysis_file(pg: AsyncEngine, file_id: int) -> Optional[AnalysisFile]:
-    """
-    Get a row that represents an analysis result file by its `id`
-
-    :param pg: PostgreSQL AsyncEngine object
-    :param file_id: Row `id` to get
-    :return: Row from the `analysis_files` SQL table
-    """
-    async with AsyncSession(pg) as session:
-        upload = (await session.execute(select(AnalysisFile).filter_by(id=file_id))).scalar()
-
-        if not upload:
-            return None
-
-    return upload

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -36,6 +36,7 @@ from virtool.http.schema import schema
 from virtool.jobs.utils import JobRights
 from virtool.samples.models import ArtifactType, SampleArtifact, SampleArtifactCache
 from virtool.samples.utils import bad_labels_response, check_labels
+from virtool.uploads.utils import is_gzip_compressed
 
 logger = logging.getLogger("samples")
 
@@ -787,7 +788,7 @@ async def upload_artifact(req):
     return json_response(artifact, status=201, headers=headers)
 
 
-@routes.jobs_api.post("/api/samples/{sample_id}/reads")
+@routes.jobs_api.put("/api/samples/{sample_id}/reads/{name}")
 async def upload_reads(req):
     """
     Upload sample reads using the Jobs API.
@@ -795,20 +796,26 @@ async def upload_reads(req):
     """
     db = req.app["db"]
     pg = req.app["pg"]
+    name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
 
-    reads_file_path = Path(virtool.samples.utils.join_sample_path(req.app["settings"], sample_id))
+    possible_reads = ["reads_1.fq.gz", "reads_2.fq.gz"]
+
+    if name not in possible_reads:
+        return bad_request("File name is not an accepted reads file")
+
+    reads_path = Path(virtool.samples.utils.join_sample_path(req.app["settings"], sample_id)) / name
 
     if not await db.samples.find_one(sample_id):
         return not_found()
 
     existing_reads = await virtool.samples.files.get_existing_reads(pg, sample_id)
 
-    if existing_reads == ["reads_1.fq.gz", "reads_2.fq.gz"]:
-        return conflict("Sample is already associated with two reads files")
+    if name in existing_reads:
+        return conflict("Reads file is already associated with this sample")
 
     try:
-        size, name_on_disk = await virtool.uploads.utils.naive_writer(req, reads_file_path, compressed=True)
+        size = await virtool.uploads.utils.naive_writer(req, reads_path, is_gzip_compressed)
     except asyncio.CancelledError:
         logger.debug(f"Reads file upload aborted for {sample_id}")
         return aiohttp.web.Response(status=499)
@@ -816,17 +823,7 @@ async def upload_reads(req):
     if size is None:
         return bad_request("File is not compressed")
 
-    if "1" in name_on_disk:
-        name = "reads_1.fq.gz"
-    elif "2" in name_on_disk:
-        name = "reads_2.fq.gz"
-    else:
-        return bad_request("File name is not an accepted reads file")
-
-    if name in existing_reads:
-        return conflict("Reads file is already associated with this sample")
-
-    reads = await virtool.samples.files.create_reads_file(pg, size, name, name_on_disk, sample_id)
+    reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
 
     headers = {
         "Location": f"/api/samples/{sample_id}/reads/{reads['name_on_disk']}"
@@ -914,7 +911,7 @@ async def upload_artifacts_cache(req):
     return json_response(artifact, status=201, headers=headers)
 
 
-@routes.jobs_api.post("/api/samples/{sample_id}/caches/{key}/reads")
+@routes.jobs_api.put("/api/samples/{sample_id}/caches/{key}/reads/{name}")
 async def upload_reads_cache(req):
     """
     Upload reads files to cache using the Jobs API.
@@ -922,21 +919,27 @@ async def upload_reads_cache(req):
     """
     db = req.app["db"]
     pg = req.app["pg"]
+    name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
     key = req.match_info["key"]
 
-    cache_path = Path(virtool.caches.utils.join_cache_path(req.app["settings"], key))
+    possible_reads = ["reads_1.fq.gz", "reads_2.fq.gz"]
+
+    if name not in possible_reads:
+        return bad_request("File name is not an accepted reads file")
+
+    cache_path = Path(virtool.caches.utils.join_cache_path(req.app["settings"], key)) / name
 
     if not await db.caches.count_documents({"key": key, "sample.id": sample_id}):
         return not_found("Cache doesn't exist with given key")
 
     existing_reads = await virtool.samples.files.get_existing_reads(pg, sample_id, cache=True)
 
-    if existing_reads == ["reads_1.fq.gz", "reads_2.fq.gz"]:
-        return conflict("Sample is already associated with two reads files")
+    if name in existing_reads:
+        return conflict("Reads file is already associated with this sample")
 
     try:
-        size, name_on_disk = await virtool.uploads.utils.naive_writer(req, cache_path, compressed=True)
+        size = await virtool.uploads.utils.naive_writer(req, cache_path, is_gzip_compressed)
     except asyncio.CancelledError:
         logger.debug(f"Reads cache file upload aborted for {key}")
         return aiohttp.web.Response(status=499)
@@ -944,17 +947,7 @@ async def upload_reads_cache(req):
     if size is None:
         return bad_request("File is not compressed")
 
-    if "1" in name_on_disk:
-        name = "reads_1.fq.gz"
-    elif "2" in name_on_disk:
-        name = "reads_2.fq.gz"
-    else:
-        return bad_request("File name is not an accepted reads file")
-
-    if name in existing_reads:
-        return conflict("Reads file is already associated with this sample")
-
-    reads = await virtool.samples.files.create_reads_file(pg, size, name, name_on_disk, sample_id)
+    reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
 
     headers = {
         "Location": f"/api/samples/{sample_id}/caches/{key}/reads/{reads['id']}"

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -814,12 +814,11 @@ async def upload_reads(req):
 
     try:
         size = await virtool.uploads.utils.naive_writer(req, reads_path, is_gzip_compressed)
+    except OSError:
+        return bad_request("File is not compressed")
     except asyncio.CancelledError:
         logger.debug(f"Reads file upload aborted for {sample_id}")
         return aiohttp.web.Response(status=499)
-
-    if size is None:
-        return bad_request("File is not compressed")
 
     reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
 
@@ -936,12 +935,11 @@ async def upload_reads_cache(req):
 
     try:
         size = await virtool.uploads.utils.naive_writer(req, cache_path, is_gzip_compressed)
+    except OSError:
+        return bad_request("File is not compressed")
     except asyncio.CancelledError:
         logger.debug(f"Reads cache file upload aborted for {key}")
         return aiohttp.web.Response(status=499)
-
-    if size is None:
-        return bad_request("File is not compressed")
 
     reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
 

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -799,9 +799,7 @@ async def upload_reads(req):
     name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
 
-    possible_reads = ["reads_1.fq.gz", "reads_2.fq.gz"]
-
-    if name not in possible_reads:
+    if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         return bad_request("File name is not an accepted reads file")
 
     reads_path = Path(virtool.samples.utils.join_sample_path(req.app["settings"], sample_id)) / name
@@ -923,9 +921,7 @@ async def upload_reads_cache(req):
     sample_id = req.match_info["sample_id"]
     key = req.match_info["key"]
 
-    possible_reads = ["reads_1.fq.gz", "reads_2.fq.gz"]
-
-    if name not in possible_reads:
+    if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         return bad_request("File name is not an accepted reads file")
 
     cache_path = Path(virtool.caches.utils.join_cache_path(req.app["settings"], key)) / name

--- a/virtool/uploads/utils.py
+++ b/virtool/uploads/utils.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional
 
 import aiofiles
 import aiohttp.web


### PR DESCRIPTION
* Use `PUT /api/samples/:id/reads/:filename`
* Use `PUT /api/samples/:id/caches/:key/reads/:filename`
* Refactor `naive_writer()` to accept `Callable` instead of `bool`, work only with complete paths
* Remove unused functions in `analyses.files`