### PR TITLE
Fixed documentation link in navbar

### DIFF
--- a/client/src/js/nav/components/NavBar.js
+++ b/client/src/js/nav/components/NavBar.js
@@ -80,7 +80,11 @@ export class Bar extends React.Component {
                         <Icon name="comments" />
                     </NavBarItem>
 
-                    <NavBarItem target="_blank" to="//virtool.ca/docs/manual" rel="noopener noreferrer">
+                    <NavBarItem
+                        target="_blank"
+                        to="//virtool.ca/docs/manual/start/installation/"
+                        rel="noopener noreferrer"
+                    >
                         <Icon name="book" />
                     </NavBarItem>
 

--- a/client/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
+++ b/client/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
@@ -51,7 +51,7 @@ exports[`<Bar /> should render 1`] = `
     <NavBarItem
       rel="noopener noreferrer"
       target="_blank"
-      to="//virtool.ca/docs/manual"
+      to="//virtool.ca/docs/manual/start/installation/"
     >
       <Icon
         faStyle="fas"


### PR DESCRIPTION
Changed the path from //virtool.ca/docs/manual to //virtool.ca/docs/manual/start/installation/