### PR TITLE
Add SQL relationship between uploads and sample reads

### DIFF
--- a/tests/fixtures/postgres.py
+++ b/tests/fixtures/postgres.py
@@ -71,10 +71,6 @@ async def pg(
     async with pg.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
-        await conn.execute(text("TRUNCATE analysis_files"))
-        await conn.execute(text("TRUNCATE labels"))
-        await conn.execute(text("TRUNCATE uploads"))
-        await conn.execute(text("TRUNCATE subtraction_files"))
         await conn.commit()
 
     return pg

--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -580,45 +580,12 @@ snapshots['test_upload_artifacts[uvloop-fastq] 1'] = {
     'uploaded_at': '2015-10-06T20:00:00Z'
 }
 
-snapshots['test_upload_reads[uvloop-True-True-False] 1'] = {
-    'id': 1,
-    'name': 'reads_1.fq.gz',
-    'name_on_disk': 'reads_1.fq.gz',
-    'sample': 'test',
-    'size': 9081,
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
-snapshots['test_upload_reads[uvloop-True-False-False] 1'] = {
-    'id': 1,
-    'name': 'reads_1.fq.gz',
-    'name_on_disk': 'reads_1.fq.gz',
-    'sample': 'test',
-    'size': 9081,
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
 snapshots['test_get_cache[uvloop-None] 1'] = {
     'id': 'bar',
     'key': 'abc123',
     'program': 'skewer-0.2.2',
     'sample': {
         'id': 'foo'
-    }
-}
-
-snapshots['test_create_cache[uvloop-key] 1'] = {
-    'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-    ],
-    'id': 'a1b2c3d4',
-    'key': 'aodp-abcdefgh',
-    'legacy': False,
-    'missing': False,
-    'paired': False,
-    'ready': False,
-    'sample': {
-        'id': 'test'
     }
 }
 
@@ -638,6 +605,7 @@ snapshots['test_upload_reads_cache[uvloop-True] 1'] = {
     'name_on_disk': 'reads_2.fq.gz',
     'sample': 'test',
     'size': 9081,
+    'upload': None,
     'uploaded_at': '2015-10-06T20:00:00Z'
 }
 
@@ -647,6 +615,7 @@ snapshots['test_upload_reads_cache[uvloop-False] 1'] = {
     'name_on_disk': 'reads_1.fq.gz',
     'sample': 'test',
     'size': 9081,
+    'upload': None,
     'uploaded_at': '2015-10-06T20:00:00Z'
 }
 
@@ -890,4 +859,14 @@ snapshots['TestCreateCache.test[uvloop-key] 1'] = {
     'sample': {
         'id': 'test'
     }
+}
+
+snapshots['TestUploadReads.test_upload_reads[uvloop-True] 1'] = {
+    'id': 1,
+    'name': 'reads_1.fq.gz',
+    'name_on_disk': 'reads_1.fq.gz',
+    'sample': 'test',
+    'size': 9081,
+    'upload': 1,
+    'uploaded_at': '2015-10-06T20:00:00Z'
 }

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -11,7 +11,7 @@ import virtool.caches.utils
 import virtool.samples.db
 import virtool.uploads.db
 from virtool.labels.models import Label
-from virtool.samples.models import SampleReadsFile, SampleArtifact
+from virtool.samples.models import SampleReads, SampleArtifact
 from virtool.uploads.models import Upload
 
 
@@ -976,7 +976,7 @@ async def test_download_reads(suffix, error, tmpdir, spawn_client, spawn_job_cli
             "_id": "foo",
         })
 
-    sample_reads = SampleReadsFile(id=1, sample="foo", name=file_name, name_on_disk=file_name)
+    sample_reads = SampleReads(id=1, sample="foo", name=file_name, name_on_disk=file_name)
 
     if error != "404_reads":
         async with AsyncSession(pg) as session:

--- a/virtool/dispatcher/fetchers.py
+++ b/virtool/dispatcher/fetchers.py
@@ -268,7 +268,7 @@ class UploadsFetcher(AbstractFetcher):
         async with AsyncSession(self._pg) as session:
             result = await session.execute(select(Upload).filter(Upload.id.in_(change.id_list)))
 
-        records = list(result.scalars())
+        records = list(result.unique().scalars())
 
         for record in records:
             for connection in connections:

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -15,7 +15,6 @@ import virtool.analyses.db
 import virtool.analyses.utils
 import virtool.api.utils
 import virtool.caches.db
-import virtool.caches.db
 import virtool.caches.utils
 import virtool.db.utils
 import virtool.errors

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -1,5 +1,4 @@
 import asyncio.tasks
-import aiohttp.web
 import logging
 import os
 from copy import deepcopy
@@ -16,9 +15,9 @@ import virtool.analyses.db
 import virtool.analyses.utils
 import virtool.api.utils
 import virtool.caches.db
+import virtool.caches.db
 import virtool.caches.utils
 import virtool.db.utils
-import virtool.caches.db
 import virtool.errors
 import virtool.http.routes
 import virtool.jobs.db
@@ -290,7 +289,7 @@ async def create(req):
 
     if non_existent_subtractions:
         return bad_request(f"Subtractions do not exist: {','.join(non_existent_subtractions)}")
-        
+
     if "labels" in data:
         non_existent_labels = await check_labels(pg, data["labels"])
 
@@ -824,6 +823,11 @@ async def upload_reads(req):
     name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
 
+    try:
+        upload = int(req.query.get("upload"))
+    except TypeError:
+        upload = None
+
     if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         return bad_request("File name is not an accepted reads file")
 
@@ -845,7 +849,7 @@ async def upload_reads(req):
         logger.debug(f"Reads file upload aborted for {sample_id}")
         return aiohttp.web.Response(status=499)
 
-    reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
+    reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id, upload_id=upload)
 
     headers = {
         "Location": f"/api/samples/{sample_id}/reads/{reads['name_on_disk']}"

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -7,9 +7,9 @@ import virtool.pg.utils
 import virtool.utils
 from virtool.samples.models import (
     SampleArtifact,
-    SampleReadsFile,
+    SampleReads,
     SampleArtifactCache,
-    SampleReadsFileCache,
+    SampleReadsCache,
 )
 from virtool.uploads.models import Upload
 
@@ -27,7 +27,7 @@ async def get_existing_reads(
     """
     async with AsyncSession(pg) as session:
         query = await session.execute(
-            select(SampleReadsFile if not cache else SampleReadsFileCache).filter_by(
+            select(SampleReads if not cache else SampleReadsCache).filter_by(
                 sample=sample
             )
         )
@@ -89,7 +89,7 @@ async def create_reads_file(
     """
 
     async with AsyncSession(pg) as session:
-        reads = SampleReadsFile() if not cache else SampleReadsFileCache()
+        reads = SampleReads() if not cache else SampleReadsCache()
 
         reads.sample, reads.name, reads.name_on_disk, reads.size, reads.uploaded_at = (
             sample_id,

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, DateTime, Enum, Integer, String
+from sqlalchemy.sql.schema import ForeignKey
 
 from virtool.pg.utils import Base, SQLEnum
 
@@ -51,6 +52,7 @@ class SampleReadsFile(Base):
     name = Column(String(length=13), nullable=False)
     name_on_disk = Column(String, nullable=False)
     size = Column(Integer)
+    upload = Column(Integer, ForeignKey('uploads.id'))
     uploaded_at = Column(DateTime)
 
     def __repr__(self):

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -40,12 +40,12 @@ class SampleArtifact(Base):
                f"uploaded_at={self.uploaded_at}"
 
 
-class SampleReadsFile(Base):
+class SampleReads(Base):
     """
     SQL model to store new sample reads files
 
     """
-    __tablename__ = "sample_reads_files"
+    __tablename__ = "sample_reads"
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)
@@ -56,7 +56,7 @@ class SampleReadsFile(Base):
     uploaded_at = Column(DateTime)
 
     def __repr__(self):
-        return f"<SampleReadsFile(id={self.id}, sample={self.sample}, name={self.name}, " \
+        return f"<SampleReads(id={self.id}, sample={self.sample}, name={self.name}, " \
                f"name_on_disk={self.name_on_disk}, size={self.size}, uploaded_at={self.uploaded_at})>"
 
 
@@ -81,12 +81,12 @@ class SampleArtifactCache(Base):
                f"uploaded_at={self.uploaded_at}"
 
 
-class SampleReadsFileCache(Base):
+class SampleReadsCache(Base):
     """
     SQL model to store cached sample reads files
 
     """
-    __tablename__ = "sample_reads_files_cache"
+    __tablename__ = "sample_reads_cache"
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)
@@ -96,5 +96,5 @@ class SampleReadsFileCache(Base):
     uploaded_at = Column(DateTime)
 
     def __repr__(self):
-        return f"<SampleReadsFileCache(id={self.id}, sample={self.sample}, name={self.name}, " \
+        return f"<SampleReadsCache(id={self.id}, sample={self.sample}, name={self.name}, " \
                f"name_on_disk={self.name_on_disk}, size={self.size}, uploaded_at={self.uploaded_at})>"

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -64,7 +64,7 @@ class MigrateFilesTask(virtool.tasks.task.Task):
 
 
 async def create(pg: AsyncEngine, name: str, upload_type: str, reserved: bool = False,
-                 user: Union[None, str] = None) -> Dict[str, any]:
+                 user: Optional[str] = None) -> Dict[str, any]:
     """
     Creates a new row in the `uploads` SQL table. Returns a dictionary representation
     of the new row.

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -150,7 +150,7 @@ async def find(pg, user: str = None, upload_type: str = None) -> List[dict]:
 
         results = await session.execute(select(Upload).filter(*filters))
 
-    for result in results.scalars().all():
+    for result in results.unique().scalars().all():
         uploads.append(result.to_dict())
 
     return uploads

--- a/virtool/uploads/models.py
+++ b/virtool/uploads/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Boolean, Column, DateTime, Enum, Integer, String
+from sqlalchemy.orm import relationship
 
 from virtool.pg.utils import Base, SQLEnum
 
@@ -27,6 +28,7 @@ class Upload(Base):
     name = Column(String)
     name_on_disk = Column(String, unique=True)
     ready = Column(Boolean, default=False, nullable=False)
+    reads = relationship("SampleReadsFile", lazy="joined")
     removed = Column(Boolean, default=False, nullable=False)
     removed_at = Column(DateTime)
     reserved = Column(Boolean, default=False, nullable=False)

--- a/virtool/uploads/models.py
+++ b/virtool/uploads/models.py
@@ -28,7 +28,7 @@ class Upload(Base):
     name = Column(String)
     name_on_disk = Column(String, unique=True)
     ready = Column(Boolean, default=False, nullable=False)
-    reads = relationship("SampleReadsFile", lazy="joined")
+    reads = relationship("SampleReads", lazy="joined")
     removed = Column(Boolean, default=False, nullable=False)
     removed_at = Column(DateTime)
     reserved = Column(Boolean, default=False, nullable=False)


### PR DESCRIPTION
I decided on a one-to-many relationship since it's likely that a single upload will be associated with many different sample reads, but a sample reads entry will be only be associated with a single upload.
 
[ch604]