### PR TITLE
Improve color selector for label creation and editing

### DIFF
--- a/client/src/js/base/Color.js
+++ b/client/src/js/base/Color.js
@@ -1,0 +1,105 @@
+import React, { useCallback } from "react";
+import styled from "styled-components";
+import { borderRadius } from "../app/theme";
+import { Box } from "./Box";
+import { Input } from "./Input";
+
+const colors = [
+    // Grey
+    "D1D5DB",
+    "6B7280",
+    "374151",
+
+    // Red
+    "FCA5A5",
+    "EF4444",
+    "B91C1C",
+
+    // Yellow
+    "FCD34D",
+    "F59E0B",
+    "B45309",
+
+    // Green
+    "6EE7B7",
+    "10B981",
+    "047857",
+
+    // Blue
+    "93C5FD",
+    "3B82F6",
+    "1D4ED8",
+
+    // Indigo
+    "A5B4FC",
+    "6366F1",
+    "4338CA",
+
+    // Purple
+    "C4B5FD",
+    "8B5CF6",
+    "5B21B6",
+
+    // Pink
+    "FBCFE8",
+    "F472B6",
+    "EC4899"
+];
+
+const StyledColor = styled(Box)`
+    padding: 10px;
+`;
+
+const UnstyledColorSquare = ({ className, color, onClick }) => {
+    const handleClick = useCallback(() => onClick(color), [color, onClick]);
+    return <button className={className} type="button" title={color} onClick={handleClick} />;
+};
+
+const ColorSquare = styled(UnstyledColorSquare)`
+    backface-visibility: hidden;
+    background-color: ${props => props.color};
+    background-image: none;
+    border: none;
+    cursor: pointer;
+    flex: 1 0 auto;
+    width: auto;
+
+    &:first-child {
+        border-bottom-left-radius: ${borderRadius.sm};
+        border-top-left-radius: ${borderRadius.sm};
+    }
+
+    &:last-child {
+        border-bottom-right-radius: ${borderRadius.sm};
+        border-top-right-radius: ${borderRadius.sm};
+    }
+
+    &:focus {
+        box-shadow: rgb(0 0 0 / 25%) 0 0 5px 2px;
+        outline: solid white 2px;
+        z-index: 2;
+    }
+
+    &:hover {
+        transform: translateY(-2px);
+    }
+`;
+
+const ColorGrid = styled.div`
+    align-items: stretch;
+    background-color: transparent;
+    display: flex;
+    height: 30px;
+    margin-top: 10px;
+`;
+
+export const Color = ({ id, value, onChange }) => {
+    const squares = colors.map(color => <ColorSquare key={color} color={`#${color}`} onClick={onChange} />);
+
+    return (
+        <StyledColor>
+            <Input id={id} value={value} onChange={e => onChange(e.target.value)} />
+            <ColorGrid>{squares}</ColorGrid>
+        </StyledColor>
+    );
+};

--- a/client/src/js/base/__tests__/Color.test.js
+++ b/client/src/js/base/__tests__/Color.test.js
@@ -1,0 +1,28 @@
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { Color } from "../Color";
+
+describe("<Color />", () => {
+    it("should call onChange when color clicked or input changed", () => {
+        const value = "#DDDDDD";
+        const onChange = jest.fn();
+
+        const { getByRole, getByTitle } = renderWithProviders(<Color value={value} onChange={onChange} />);
+
+        // Change the input text value
+        expect(getByRole("textbox")).toHaveValue("#DDDDDD");
+
+        // Click on a color square
+        getByTitle("#C4B5FD").click();
+        expect(onChange).toHaveBeenLastCalledWith("#C4B5FD");
+
+        // Clear the text box to change input value
+        const textbox = getByRole("textbox");
+        userEvent.clear(textbox);
+        expect(onChange).toHaveBeenLastCalledWith("");
+
+        // Type one letter in the textbox
+        userEvent.type(textbox, "A");
+        expect(onChange).toHaveBeenLastCalledWith("#DDDDDDA");
+    });
+});

--- a/client/src/js/base/index.js
+++ b/client/src/js/base/index.js
@@ -10,6 +10,7 @@ export * from "./Breakpoints";
 export * from "./Button";
 export * from "./ButtonGroup";
 export * from "./ButtonToolbar";
+export * from "./Color";
 export * from "./Container";
 export * from "./Dropdown";
 export * from "./Dropdown";

--- a/client/src/js/labels/components/Create.js
+++ b/client/src/js/labels/components/Create.js
@@ -12,7 +12,7 @@ export class CreateLabel extends React.Component {
         super(props);
         this.state = {
             name: "",
-            color: "",
+            color: "#3C8786",
             description: "",
             errorName: "",
             errorColor: ""

--- a/client/src/js/labels/components/Form.js
+++ b/client/src/js/labels/components/Form.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { Button, Input, InputError, InputGroup, InputLabel, ModalBody, ModalFooter } from "../../base";
-import { ColorSelector } from "./ColorSelector";
+import styled from "styled-components";
+import { Box, Button, Color, Input, InputError, InputGroup, InputLabel, ModalBody, ModalFooter } from "../../base";
 
 export const LabelForm = ({ color, description, errorColor, errorName, name, onChange, onColorChange, onSubmit }) => {
     const handleSubmit = e => {
@@ -22,7 +22,10 @@ export const LabelForm = ({ color, description, errorColor, errorName, name, onC
                     <InputLabel htmlFor="label-description">Description</InputLabel>
                     <Input id="label-description" name="description" value={description} onChange={handleChange} />
                 </InputGroup>
-                <ColorSelector color={color} errorColor={errorColor} onColorChange={onColorChange} />
+                <InputGroup>
+                    <InputLabel>Color</InputLabel>
+                    <Color value={color} onChange={onColorChange} />
+                </InputGroup>
             </ModalBody>
             <ModalFooter>
                 <Button type="submit" color="blue" icon="save" name="save">

--- a/client/src/js/labels/components/Form.js
+++ b/client/src/js/labels/components/Form.js
@@ -1,6 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 import { Box, Button, Color, Input, InputError, InputGroup, InputLabel, ModalBody, ModalFooter } from "../../base";
+import { SampleLabel } from "../../samples/components/Label";
+
+const LabelFormPreview = styled(Box)`
+    padding: 10px;
+`;
 
 export const LabelForm = ({ color, description, errorColor, errorName, name, onChange, onColorChange, onSubmit }) => {
     const handleSubmit = e => {
@@ -26,6 +31,10 @@ export const LabelForm = ({ color, description, errorColor, errorName, name, onC
                     <InputLabel>Color</InputLabel>
                     <Color value={color} onChange={onColorChange} />
                 </InputGroup>
+                <label>Preview</label>
+                <LabelFormPreview>
+                    <SampleLabel color={color} name={name || "Preview"} />
+                </LabelFormPreview>
             </ModalBody>
             <ModalFooter>
                 <Button type="submit" color="blue" icon="save" name="save">

--- a/client/src/js/labels/components/Form.js
+++ b/client/src/js/labels/components/Form.js
@@ -21,15 +21,18 @@ export const LabelForm = ({ color, description, errorColor, errorName, name, onC
         <form onSubmit={handleSubmit}>
             <ModalBody>
                 <InputGroup>
-                    <InputLabel htmlFor="label-name">Name</InputLabel>
-                    <Input id="label-name" name="name" value={name} onChange={handleChange} error={errorName} />
+                    <InputLabel htmlFor="name">Name</InputLabel>
+                    <Input id="name" name="name" value={name} onChange={handleChange} error={errorName} />
                     <InputError>{errorName}</InputError>
-                    <InputLabel htmlFor="label-description">Description</InputLabel>
-                    <Input id="label-description" name="description" value={description} onChange={handleChange} />
                 </InputGroup>
                 <InputGroup>
-                    <InputLabel>Color</InputLabel>
-                    <Color value={color} onChange={onColorChange} />
+                    <InputLabel htmlFor="description">Description</InputLabel>
+                    <Input id="description" name="description" value={description} onChange={handleChange} />
+                </InputGroup>
+                <InputGroup>
+                    <InputLabel htmlFor="color">Color</InputLabel>
+                    <Color id="color" value={color} onChange={onColorChange} />
+                    <InputError>{errorColor}</InputError>
                 </InputGroup>
                 <label>Preview</label>
                 <LabelFormPreview>

--- a/client/src/js/labels/components/Item.js
+++ b/client/src/js/labels/components/Item.js
@@ -1,14 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { BoxGroupSection, Label, LinkIcon } from "../../base";
-
-const getContrastColor = props => {
-    const red = parseInt(props.color.substr(1, 2), 16);
-    const green = parseInt(props.color.substr(3, 2), 16);
-    const blue = parseInt(props.color.substr(5, 2), 16);
-    const yiq = (red * 299 + green * 587 + blue * 114) / 1000;
-    return yiq >= 128 ? "black" : "white";
-};
+import { BoxGroupSection, LinkIcon } from "../../base";
+import { SampleLabel } from "../../samples/components/Label";
 
 const LabelItemContainer = styled.div`
     position: relative;
@@ -21,12 +14,6 @@ const LabelItemBox = styled(BoxGroupSection)`
 
 const LabelItemExampleContainer = styled.div`
     min-width: 30%;
-`;
-
-const LabelItemExample = styled(Label)`
-    font-size: ${props => props.theme.fontSize.lg};
-    background-color: ${props => props.color};
-    color: ${getContrastColor};
 `;
 
 const LabelItemIcons = styled.div`
@@ -50,7 +37,7 @@ export const Item = ({ name, color, description, id }) => (
     <LabelItemContainer>
         <LabelItemBox>
             <LabelItemExampleContainer>
-                <LabelItemExample color={color}>{name}</LabelItemExample>
+                <SampleLabel name={name} color={color} />
             </LabelItemExampleContainer>
             {description}
         </LabelItemBox>

--- a/client/src/js/labels/components/__tests__/Create.test.js
+++ b/client/src/js/labels/components/__tests__/Create.test.js
@@ -17,21 +17,18 @@ describe("<CreateLabel>", () => {
     it("should call onSubmit when successfully submitted", () => {
         renderWithProviders(<CreateLabel {...props} />);
 
-        const colorInput = screen.getByLabelText("Color");
         const nameInput = screen.getByLabelText("Name");
         const descriptionInput = screen.getByLabelText("Description");
 
-        userEvent.type(colorInput, "#1DAD57");
         userEvent.type(descriptionInput, "This is a description");
         userEvent.type(nameInput, "Foo");
 
-        expect(colorInput).toHaveValue("#1DAD57");
         expect(descriptionInput).toHaveValue("This is a description");
         expect(nameInput).toHaveValue("Foo");
 
         userEvent.click(screen.getByRole("button", { name: "Save" }));
 
-        expect(props.onSubmit).toHaveBeenCalledWith("Foo", "This is a description", "#1DAD57");
+        expect(props.onSubmit).toHaveBeenCalledWith("Foo", "This is a description", "#3C8786");
     });
 
     it("should render error when submitted without color", () => {
@@ -41,6 +38,7 @@ describe("<CreateLabel>", () => {
 
         userEvent.type(screen.getByLabelText("Name"), "Foo");
         userEvent.type(screen.getByLabelText("Description"), "This is a description");
+        userEvent.clear(screen.getByLabelText("Color"));
 
         userEvent.click(screen.getByRole("button", { name: "Save" }));
 

--- a/client/src/js/labels/components/__tests__/Edit.test.js
+++ b/client/src/js/labels/components/__tests__/Edit.test.js
@@ -26,62 +26,54 @@ describe("<EditLabel>", () => {
         expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
     });
 
-    it("should initially populate inputs with props", () => {
-        renderWithProviders(<EditLabel {...props} />);
-
-        expect(screen.getByLabelText("Color")).toHaveValue("#1DAD57");
-        expect(screen.getByLabelText("Description")).toHaveValue("This is a description");
-        expect(screen.getByLabelText("Name")).toHaveValue("Foo");
-    });
-
     it("should call onSubmit when successfully submitted", () => {
         renderWithProviders(<EditLabel {...props} />);
         userEvent.click(screen.getByRole("button", { name: "Save" }));
         expect(props.onSubmit).toHaveBeenCalledWith(1, "Foo", "This is a description", "#1DAD57");
     });
 
-    it("should update color when input changes", () => {
-        renderWithProviders(<EditLabel {...props} />);
-
-        const colorInput = screen.getByLabelText("Color");
-        colorInput.value = "";
-        expect(colorInput).toHaveValue("");
-
-        userEvent.type(colorInput, "#000000");
-        expect(colorInput).toHaveValue("#000000");
-
-        userEvent.click(screen.getByRole("button", { name: "Save" }));
-        expect(props.onSubmit).toHaveBeenCalledWith(1, "Foo", "This is a description", "#000000");
-    });
-
-    it("should update description when input changes", () => {
+    it("should initialize and update name and description", () => {
         renderWithProviders(<EditLabel {...props} />);
 
         const descriptionInput = screen.getByLabelText("Description");
-        expect(descriptionInput).toHaveValue("This is a description");
-        descriptionInput.value = "";
-        expect(descriptionInput).toHaveValue("");
-
-        userEvent.type(descriptionInput, "This is a label");
-        expect(descriptionInput).toHaveValue("This is a label");
-
-        userEvent.click(screen.getByRole("button", { name: "Save" }));
-        expect(props.onSubmit).toHaveBeenCalledWith(1, "Foo", "This is a label", "#1DAD57");
-    });
-
-    it("should update name when input changes", () => {
-        renderWithProviders(<EditLabel {...props} />);
-
         const nameInput = screen.getByLabelText("Name");
 
-        nameInput.value = "";
+        // Field initialize from props.
+        expect(nameInput).toHaveValue("Foo");
+        expect(descriptionInput).toHaveValue("This is a description");
+
+        // Check fields clear.
+        userEvent.clear(descriptionInput);
+        userEvent.clear(nameInput);
+        expect(descriptionInput).toHaveValue("");
         expect(nameInput).toHaveValue("");
 
+        // Check typing changes input value
+        userEvent.type(descriptionInput, "This is a label");
         userEvent.type(nameInput, "Bar");
+        expect(descriptionInput).toHaveValue("This is a label");
         expect(nameInput).toHaveValue("Bar");
+    });
 
-        userEvent.click(screen.getByRole("button", { name: "Save" }));
-        expect(props.onSubmit).toHaveBeenCalledWith(1, "Bar", "This is a description", "#1DAD57");
+    it("should initialize and update color", () => {
+        renderWithProviders(<EditLabel {...props} />);
+
+        const colorInput = screen.getByLabelText("Color");
+
+        // Initializes from props.
+        expect(colorInput).toHaveValue(props.color);
+
+        // Updates when input cleared.
+        userEvent.clear(colorInput);
+        expect(colorInput).toHaveValue("");
+
+        // Updates when input is typed in.
+        userEvent.type(colorInput, "#DFDF12");
+        expect(colorInput).toHaveValue("#DFDF12");
+
+        // Updates when color square is clicked.
+        userEvent.click(screen.getByTitle("#3B82F6"));
+        expect(colorInput).toHaveValue("#3B82F6");
     });
 });
 

--- a/client/src/js/labels/components/__tests__/Form.test.js
+++ b/client/src/js/labels/components/__tests__/Form.test.js
@@ -25,15 +25,13 @@ describe("<LabelForm />", () => {
         expect(screen.getByLabelText("Name")).toHaveValue(props.name);
     });
 
-    it("should call onChange() when name field changed", () => {
+    it("should call onChange() when fields change", () => {
         renderWithProviders(<LabelForm {...props} />);
+
         const nameInput = screen.getByLabelText("Name");
         userEvent.type(nameInput, "B");
         expect(props.onChange).toHaveBeenCalledWith("name", "FooB");
-    });
 
-    it("should call onChange() when description field changed", () => {
-        renderWithProviders(<LabelForm {...props} />);
         const descriptionInput = screen.getByLabelText("Description");
         userEvent.type(descriptionInput, "A");
         expect(props.onChange).toHaveBeenCalledWith("description", "This is a test labelA");

--- a/client/src/js/samples/components/Label.js
+++ b/client/src/js/samples/components/Label.js
@@ -1,0 +1,24 @@
+import React from "react";
+import styled from "styled-components";
+import { borderRadius, getBorder } from "../../app/theme";
+import { Icon } from "../../base";
+
+const StyledSampleLabel = styled.span`
+    align-items: center;
+    border: ${getBorder};
+    border-radius: ${borderRadius.md};
+    display: inline-flex;
+    padding: 4px 8px;
+
+    i.fas {
+        color: ${props => props.color};
+        margin-right: 5px;
+    }
+`;
+
+export const SampleLabel = ({ color, name }) => (
+    <StyledSampleLabel color={color}>
+        <Icon name="circle" />
+        {name}
+    </StyledSampleLabel>
+);


### PR DESCRIPTION
This was supposed to be done with `react-color`. Instead, I created a custom base component for this.

* Add `Color` base component for selecting colors
* Use accessible buttons for color palette
* Use base component in label creation and editing forms
* Add  `SampleLabel` component and implement as preview in forms and in the label list

![image](https://user-images.githubusercontent.com/5943558/112388093-e25f6480-8caf-11eb-8b23-c7868c225c52.png)
![image](https://user-images.githubusercontent.com/5943558/112388128-ebe8cc80-8caf-11eb-99ab-7ef4700dc8b0.png)
