### PR TITLE
Fix errors in analysis viewers due to multi-subtractions

### DIFF
--- a/client/src/js/analyses/components/Item.js
+++ b/client/src/js/analyses/components/Item.js
@@ -17,10 +17,10 @@ const StyledAnalysisItem = styled(SpacedBox)`
     }
 `;
 
-const AnalysisItemContent = styled.div`
+const AnalysisItemTag = styled.span`
     align-items: center;
-    display: flex;
-    margin-top: 10px;
+    display: inline-flex;
+    margin-right: 15px;
 
     ${SlashList} {
         margin: 0;
@@ -28,11 +28,13 @@ const AnalysisItemContent = styled.div`
 
     i {
         margin-right: 5px;
-
-        &:last-of-type {
-            margin-left: 20px;
-        }
     }
+`;
+
+const AnalysisItemTags = styled.div`
+    align-items: center;
+    display: flex;
+    margin-top: 10px;
 `;
 
 const AnalysisItemTop = styled.div`
@@ -56,11 +58,18 @@ export const AnalysisItem = props => {
         ready,
         reference,
         sampleId,
-        subtraction,
+        subtractions,
         user,
         workflow,
         onRemove
     } = props;
+
+    const subtractionComponents = subtractions.map(subtraction => (
+        <AnalysisItemTag key={subtraction.id}>
+            <Icon name="not-equal" />
+            <Link to={`/subtraction/${subtraction.id}`}>{subtraction.name}</Link>
+        </AnalysisItemTag>
+    ));
 
     return (
         <StyledAnalysisItem>
@@ -69,19 +78,20 @@ export const AnalysisItem = props => {
                 <AnalysisItemRightIcon canModify={canModify} onRemove={onRemove} ready={ready} />
             </AnalysisItemTop>
             <Attribution user={user.id} time={created_at} />
-            <AnalysisItemContent>
-                <Icon name="equals" />
-                <SlashList>
-                    <li>
-                        <Link to={`/refs/${reference.id}`}>{reference.name}</Link>
-                    </li>
-                    <li>
-                        <Link to={`/refs/${reference.id}/indexes/${index.id}`}>Index {index.version}</Link>
-                    </li>
-                </SlashList>
-                <Icon name="not-equal" />
-                <Link to={`/subtraction/${subtraction.id}`}>{subtraction.name}</Link>
-            </AnalysisItemContent>
+            <AnalysisItemTags>
+                <AnalysisItemTag key="reference">
+                    <Icon name="equals" />
+                    <SlashList>
+                        <li>
+                            <Link to={`/refs/${reference.id}`}>{reference.name}</Link>
+                        </li>
+                        <li>
+                            <Link to={`/refs/${reference.id}/indexes/${index.id}`}>Index {index.version}</Link>
+                        </li>
+                    </SlashList>
+                </AnalysisItemTag>
+                {subtractionComponents}
+            </AnalysisItemTags>
         </StyledAnalysisItem>
     );
 };

--- a/client/src/js/analyses/components/Pathoscope/Mapping.js
+++ b/client/src/js/analyses/components/Pathoscope/Mapping.js
@@ -73,13 +73,13 @@ export const AnalysisMapping = ({ index, reference, subtraction, toReference, to
     );
 };
 
-const mapStateToProps = state => {
-    const { index, read_count, reference, subtractedCount, subtraction } = state.analyses.detail;
+export const mapStateToProps = state => {
+    const { index, read_count, reference, subtractedCount, subtractions } = state.analyses.detail;
 
     return {
         index,
         reference,
-        subtraction,
+        subtraction: subtractions[0],
         toReference: read_count,
         toSubtraction: subtractedCount,
         total: state.samples.detail.quality.count

--- a/client/src/js/analyses/components/__tests__/Item.test.js
+++ b/client/src/js/analyses/components/__tests__/Item.test.js
@@ -13,18 +13,26 @@ describe("<AnalysisItem />", () => {
             created_at: "2018-02-14T17:12:00.000000Z",
             id: "baz",
             index: {
+                id: "ind",
                 version: 3
             },
             placeholder: false,
             ready: false,
             reference: {
+                id: "foo",
                 name: "Foo"
             },
             sampleId: "bar",
-            subtraction: {
-                id: "baz",
-                name: "Prunus persica"
-            },
+            subtractions: [
+                {
+                    id: "pru",
+                    name: "Prunus persica"
+                },
+                {
+                    id: "ara",
+                    name: "Arabidopsis thaliana"
+                }
+            ],
             user: {
                 id: "bob"
             },

--- a/client/src/js/analyses/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/client/src/js/analyses/components/__tests__/__snapshots__/Item.test.js.snap
@@ -18,40 +18,62 @@ exports[`<AnalysisItem /> should render 1`] = `
     time="2018-02-14T17:12:00.000000Z"
     user="bob"
   />
-  <Item__AnalysisItemContent>
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="equals"
-    />
-    <SlashList>
-      <li>
-        <Link
-          to="/refs/undefined"
-        >
-          Foo
-        </Link>
-      </li>
-      <li>
-        <Link
-          to="/refs/undefined/indexes/undefined"
-        >
-          Index 
-          3
-        </Link>
-      </li>
-    </SlashList>
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="not-equal"
-    />
-    <Link
-      to="/subtraction/baz"
+  <Item__AnalysisItemTags>
+    <Item__AnalysisItemTag
+      key="reference"
     >
-      Prunus persica
-    </Link>
-  </Item__AnalysisItemContent>
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="equals"
+      />
+      <SlashList>
+        <li>
+          <Link
+            to="/refs/foo"
+          >
+            Foo
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/refs/foo/indexes/ind"
+          >
+            Index 
+            3
+          </Link>
+        </li>
+      </SlashList>
+    </Item__AnalysisItemTag>
+    <Item__AnalysisItemTag
+      key="pru"
+    >
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="not-equal"
+      />
+      <Link
+        to="/subtraction/pru"
+      >
+        Prunus persica
+      </Link>
+    </Item__AnalysisItemTag>
+    <Item__AnalysisItemTag
+      key="ara"
+    >
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="not-equal"
+      />
+      <Link
+        to="/subtraction/ara"
+      >
+        Arabidopsis thaliana
+      </Link>
+    </Item__AnalysisItemTag>
+  </Item__AnalysisItemTags>
 </Item__StyledAnalysisItem>
 `;
 
@@ -73,40 +95,62 @@ exports[`<AnalysisItem /> should render when [placeholder=true] 1`] = `
     time="2018-02-14T17:12:00.000000Z"
     user="bob"
   />
-  <Item__AnalysisItemContent>
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="equals"
-    />
-    <SlashList>
-      <li>
-        <Link
-          to="/refs/undefined"
-        >
-          Foo
-        </Link>
-      </li>
-      <li>
-        <Link
-          to="/refs/undefined/indexes/undefined"
-        >
-          Index 
-          3
-        </Link>
-      </li>
-    </SlashList>
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="not-equal"
-    />
-    <Link
-      to="/subtraction/baz"
+  <Item__AnalysisItemTags>
+    <Item__AnalysisItemTag
+      key="reference"
     >
-      Prunus persica
-    </Link>
-  </Item__AnalysisItemContent>
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="equals"
+      />
+      <SlashList>
+        <li>
+          <Link
+            to="/refs/foo"
+          >
+            Foo
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/refs/foo/indexes/ind"
+          >
+            Index 
+            3
+          </Link>
+        </li>
+      </SlashList>
+    </Item__AnalysisItemTag>
+    <Item__AnalysisItemTag
+      key="pru"
+    >
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="not-equal"
+      />
+      <Link
+        to="/subtraction/pru"
+      >
+        Prunus persica
+      </Link>
+    </Item__AnalysisItemTag>
+    <Item__AnalysisItemTag
+      key="ara"
+    >
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="not-equal"
+      />
+      <Link
+        to="/subtraction/ara"
+      >
+        Arabidopsis thaliana
+      </Link>
+    </Item__AnalysisItemTag>
+  </Item__AnalysisItemTags>
 </Item__StyledAnalysisItem>
 `;
 
@@ -128,39 +172,61 @@ exports[`<AnalysisItem /> should render when [ready=false] 1`] = `
     time="2018-02-14T17:12:00.000000Z"
     user="bob"
   />
-  <Item__AnalysisItemContent>
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="equals"
-    />
-    <SlashList>
-      <li>
-        <Link
-          to="/refs/undefined"
-        >
-          Foo
-        </Link>
-      </li>
-      <li>
-        <Link
-          to="/refs/undefined/indexes/undefined"
-        >
-          Index 
-          3
-        </Link>
-      </li>
-    </SlashList>
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="not-equal"
-    />
-    <Link
-      to="/subtraction/baz"
+  <Item__AnalysisItemTags>
+    <Item__AnalysisItemTag
+      key="reference"
     >
-      Prunus persica
-    </Link>
-  </Item__AnalysisItemContent>
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="equals"
+      />
+      <SlashList>
+        <li>
+          <Link
+            to="/refs/foo"
+          >
+            Foo
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/refs/foo/indexes/ind"
+          >
+            Index 
+            3
+          </Link>
+        </li>
+      </SlashList>
+    </Item__AnalysisItemTag>
+    <Item__AnalysisItemTag
+      key="pru"
+    >
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="not-equal"
+      />
+      <Link
+        to="/subtraction/pru"
+      >
+        Prunus persica
+      </Link>
+    </Item__AnalysisItemTag>
+    <Item__AnalysisItemTag
+      key="ara"
+    >
+      <Icon
+        faStyle="fas"
+        fixedWidth={false}
+        name="not-equal"
+      />
+      <Link
+        to="/subtraction/ara"
+      >
+        Arabidopsis thaliana
+      </Link>
+    </Item__AnalysisItemTag>
+  </Item__AnalysisItemTags>
 </Item__StyledAnalysisItem>
 `;

--- a/client/src/js/analyses/utils.js
+++ b/client/src/js/analyses/utils.js
@@ -160,7 +160,19 @@ export const formatPathoscopeData = detail => {
         return detail;
     }
 
-    const { cache, created_at, results, id, index, read_count, ready, reference, subtraction, user, workflow } = detail;
+    const {
+        cache,
+        created_at,
+        results,
+        id,
+        index,
+        read_count,
+        ready,
+        reference,
+        subtractions,
+        user,
+        workflow
+    } = detail;
 
     const formatted = map(results, otu => {
         const isolateNames = [];
@@ -221,7 +233,7 @@ export const formatPathoscopeData = detail => {
         results: formatted,
         read_count,
         ready,
-        subtraction,
+        subtractions,
         subtractedCount: detail.subtracted_count,
         user,
         workflow


### PR DESCRIPTION
* List subtractions for analysis list items
* Assume single item array for Pathoscope. This will have to be updated when the Pathoscope workflow supports multiple subtractions.