### PR TITLE
Fake mode for jobs API

### DIFF
--- a/tests/dev/snapshots/snap_test_fake.py
+++ b/tests/dev/snapshots/snap_test_fake.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import GenericRepr, Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_create_fake_user[uvloop] 1'] = {
+    '_id': 'bob',
+    'administrator': True,
+    'force_reset': False,
+    'groups': [
+    ],
+    'identicon': '81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9',
+    'invalidate_sessions': True,
+    'last_password_change': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'permissions': {
+        'cancel_job': False,
+        'create_ref': False,
+        'create_sample': False,
+        'modify_hmm': False,
+        'modify_subtraction': False,
+        'remove_file': False,
+        'remove_job': False,
+        'upload_file': False
+    },
+    'primary_group': '',
+    'settings': {
+        'quick_analyze_workflow': 'pathoscope_bowtie',
+        'show_ids': True,
+        'show_versions': True,
+        'skip_quick_analyze_dialog': True
+    }
+}

--- a/tests/dev/test_fake.py
+++ b/tests/dev/test_fake.py
@@ -1,0 +1,17 @@
+from os.path import isdir
+
+from virtool.dev.fake import create_fake_data_path, create_fake_user
+
+
+def test_create_fake_data_path():
+    path = create_fake_data_path()
+    assert "virtool_fake_" in path
+    assert isdir(path)
+
+
+async def test_create_fake_user(snapshot, dbi, static_time):
+    app = {
+        "db": dbi
+    }
+    await create_fake_user(app)
+    snapshot.assert_match(await dbi.users.find_one({}, {"password": False}))

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -75,6 +75,7 @@ def create_app(
             "redis_connection_string": redis_connection_string,
             "postgres_connection_string": pg_connection_string,
             "db_name": test_db_name,
+            "fake": False,
             "force_version": "v0.0.0",
             "no_client": True,
             "no_check_db": True,
@@ -178,6 +179,7 @@ def spawn_job_client(
             db_connection_string=test_db_connection_string,
             db_name=test_db_name,
             dev=dev,
+            fake=False,
             postgres_connection_string=pg_connection_string,
             redis_connection_string=redis_connection_string,
         )

--- a/tests/fixtures/postgres.py
+++ b/tests/fixtures/postgres.py
@@ -1,11 +1,7 @@
-from asyncio import gather
-
 import pytest
-from sqlalchemy import text
-from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
-import virtool.api.json
+from virtool.pg.testing import create_test_database
 from virtool.pg.utils import Base
 
 
@@ -55,16 +51,7 @@ async def pg(
     Test database are specific to xdist workers.
 
     """
-    engine = create_async_engine(f"{pg_base_connection_string}", isolation_level="AUTOCOMMIT", json_serializer=virtool.api.json.dumps)
-
-    async with engine.connect() as conn:
-        try:
-            await conn.execute(text(f"CREATE DATABASE {pg_db_name}"))
-        except ProgrammingError as exc:
-            if "DuplicateDatabaseError" not in str(exc):
-                raise
-
-    await engine.dispose()
+    await create_test_database(pg_base_connection_string, pg_db_name)
 
     pg = create_async_engine(pg_connection_string)
 

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -28,7 +28,7 @@ import virtool.software.db
 import virtool.startup
 import virtool.utils
 import virtool.version
-from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown, logger
+from virtool.process_utils import create_app_runner, logger, wait_for_restart, wait_for_shutdown
 
 logger = logging.getLogger(__name__)
 

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -263,12 +263,21 @@ def start_runner(ctx, job_list, mem, proc, temp_path):
     help="The port to listen on",
     type=int
 )
+@click.option(
+    "--fake",
+    help="Start the jobs API with fake data for integration testing",
+    type=bool,
+    is_flag=True
+)
 @click.pass_context
-def start_jobs_api(ctx, port, host):
+def start_jobs_api(ctx, fake, port, host):
     """Start a Virtool Jobs API server"""
     logger.info("Starting jobs API process")
     asyncio.get_event_loop().run_until_complete(
         virtool.jobs_api.main.run(
-            **dict(host=host, port=port, **ctx.obj)
+            fake=fake,
+            host=host,
+            port=port,
+            **ctx.obj
         )
     )

--- a/virtool/dev/fake.py
+++ b/virtool/dev/fake.py
@@ -1,0 +1,184 @@
+"""
+Code for creating a fake database and application data directory on jobs API startup.
+
+TODO: Add more fake data and files
+TODO: Port over to the normal API
+
+"""
+
+from logging import getLogger
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import virtool.analyses.db
+import virtool.users.db
+from virtool.types import App
+from virtool.uploads.models import Upload
+from virtool.utils import ensure_data_dir, random_alphanumeric
+
+logger = getLogger(__name__)
+
+USER_ID = "bob"
+
+
+async def populate(app: App):
+    await create_fake_user(app)
+    await create_fake_subtractions(app)
+
+
+async def remove_fake_data_path(app: App):
+    """
+    Remove the temporary fake application data directory created when the jobs API is run with the
+    ``--fake`` option.
+
+    :param app: the application object
+
+    """
+    data_path = app["config"].get("data_path")
+
+    # Be extra sure this is a fake application directory we should remove.
+    if data_path and app["config"]["fake"] and "virtool_fake_" in data_path:
+        rmtree(data_path)
+        logger.debug(f"Removed fake data directory: {data_path}")
+
+
+async def drop_fake_mongo(app: App):
+    """
+    Drop a fake Mongo database if the instance was run with the ``--fake`` option.
+
+    :param app: the application object
+
+    """
+    db_name = app["config"]["db_name"]
+
+    # Be extra sure this is a fake database we should drop.
+    if "fake-" in db_name and app["config"]["fake"]:
+        await app["db"].motor_client.client.drop_database(db_name)
+        logger.debug(f"Dropped fake Mongo database: {db_name}")
+
+
+def create_fake_data_path() -> str:
+    """
+    Create a temporary directory to use as a location for data for a fake instance.
+
+    :return: the data path
+
+    """
+    data_path = str(mkdtemp(prefix=f"virtool_fake_{random_alphanumeric()}_"))
+    ensure_data_dir(data_path)
+    return data_path
+
+
+async def create_fake_user(app: App):
+    """
+    Create a fake user called Bob.
+
+    :param app: the application object
+
+    """
+    await virtool.users.db.create(
+        app["db"],
+        USER_ID,
+        "hello_world",
+        True
+    )
+
+    await virtool.users.db.edit(
+        app["db"],
+        "bob",
+        administrator=True,
+        force_reset=False
+    )
+
+    logger.debug("Created fake user")
+
+
+async def create_fake_subtractions(app: App):
+    """
+    Create fake subtractions and their associated uploads and subtraction files.
+
+    Two subtractions are ready for use. One has ``ready`` set to ``False`` and can be used for
+    testing subtraction finalization.
+
+    :param app: the application object
+
+    """
+    async with AsyncSession(app["pg"]) as session:
+        upload = Upload(name="test.fa.gz", type="subtraction", user=USER_ID)
+
+        session.add(upload)
+        await session.flush()
+
+        upload_id = upload.id
+        upload_name = upload.name
+
+        await session.commit()
+
+    upload = {
+        "id": upload_id,
+        "name": upload_name
+    }
+
+    await app["db"].subtraction.insert_many([
+        {
+            "_id": "subtraction_1",
+            "name": "Subtraction 1",
+            "nickname": "",
+            "deleted": False,
+            "ready": True,
+            "file": upload,
+            "user": {
+                "id": USER_ID
+            }
+        },
+        {
+            "_id": "subtraction_2",
+            "name": "Subtraction 2",
+            "nickname": "",
+            "deleted": False,
+            "ready": True,
+            "file": upload,
+            "user": {
+                "id": USER_ID
+            }
+        },
+        {
+            "_id": "subtraction_unready",
+            "name": "Subtraction Unready",
+            "nickname": "",
+            "deleted": False,
+            "ready": False,
+            "file": upload,
+            "user": {
+                "id": USER_ID
+            }
+        }
+    ])
+
+    logger.debug("Created fake subtractions")
+
+
+async def analysis(app: App):
+    """
+    Create a complete fake analysis in the database.
+
+    :param app: the application object
+
+    """
+    sample_id = "sample_1"
+    ref_id = "reference_1"
+    subtractions = [
+        "subtraction_1",
+        "subtraction_2",
+    ]
+
+    await virtool.analyses.db.create(
+        app,
+        sample_id,
+        ref_id,
+        subtractions,
+        USER_ID,
+        "pathoscope"
+    )

--- a/virtool/pg/testing.py
+++ b/virtool/pg/testing.py
@@ -1,0 +1,32 @@
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import virtool.api.json
+
+
+async def create_test_database(connection_string: str, name: str):
+    """
+    Create a testing database with the passed name.
+
+    Used for creating disposable databases during test runs and when the ``--fake`` option is in
+    use on the backend.
+
+    :param connection_string: the base connection string
+    :type name: the database name
+
+    """
+    engine = create_async_engine(
+        f"{connection_string}",
+        isolation_level="AUTOCOMMIT",
+        json_serializer=virtool.api.json.dumps
+    )
+
+    async with engine.connect() as conn:
+        try:
+            await conn.execute(text(f"CREATE DATABASE {name}"))
+        except ProgrammingError as exc:
+            if "DuplicateDatabaseError" not in str(exc):
+                raise
+
+    await engine.dispose()


### PR DESCRIPTION
Introduce a `--fake` configuration flag the starts the jobs API server with MongoDB and Postgres databases containing fake data as well as a temporary directory containing accompanying fake data files.

The the flag is set. The following configuration values are replaced with temporary values:
| Key | What happens |
| ------ | ------------- |
| `data_path` | A temporary directory is created and its path is used for the `data_path` config value |
| `db_name` | A temporary MongoDB database is created and the name is used for the `db_name` value |
| `pg_connection_string` | A temporary Postgres database is created and its name replaces the one in the `pg_connection_string` | 

The data generation is not complete yet. This PR focuses on the functionality for supporting a fake mode for integration and frontend testing.

**To-do**
* Clean up Postgres database when server shuts down
* Finish fake data generation