### PR TITLE
Run `MoveSampleFilesTask` on application start

### DIFF
--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -26,8 +26,7 @@ snapshots['test_get[uvloop-True-None] 1'] = {
         {
             'download_url': '/download/samples/files/file_1.fq.gz',
             'id': 'foo',
-            'name': 'Bar.fq.gz',
-            'replace_url': '/upload/samples/test/files/1'
+            'name': 'Bar.fq.gz'
         }
     ],
     'id': 'test',
@@ -42,6 +41,7 @@ snapshots['test_get[uvloop-True-None] 1'] = {
     'name': 'Test',
     'reads': [
         {
+            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
             'id': 1,
             'name': 'reads_1.fq.gz',
             'name_on_disk': 'reads_1.fq.gz',

--- a/tests/samples/snapshots/snap_test_migrate.py
+++ b/tests/samples/snapshots/snap_test_migrate.py
@@ -7,78 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_add_library_type[uvloop] 1'] = [
-    {
-        '_id': 'foo',
-        'library_type': 'srna'
-    },
-    {
-        '_id': 'bar',
-        'library_type': 'normal'
-    },
-    {
-        '_id': 'baz',
-        'library_type': 'normal'
-    },
-    {
-        '_id': 'boo',
-        'library_type': 'srna'
-    }
-]
-
-snapshots['test_update_ready[uvloop] 1'] = [
-    {
-        '_id': 'foo',
-        'imported': True,
-        'ready': True
-    },
-    {
-        '_id': 'baz',
-        'imported': True,
-        'ready': True
-    },
-    {
-        '_id': 'far',
-        'ready': True
-    }
-]
-
-snapshots['test_prune_fields[uvloop] 1'] = [
-    {
-        '_id': 'foo'
-    },
-    {
-        '_id': 'bar',
-        'ready': True
-    }
-]
-
-snapshots['test_update_pairedness[uvloop] 1'] = [
-    {
-        '_id': 'foo',
-        'files': [
-            '1'
-        ],
-        'paired': False
-    },
-    {
-        '_id': 'bar',
-        'files': [
-            '1',
-            '2'
-        ],
-        'paired': True
-    },
-    {
-        '_id': 'baz',
-        'paired': True
-    },
-    {
-        '_id': 'boo',
-        'paired': False
-    }
-]
-
 snapshots['test_add_is_legacy[uvloop] 1'] = [
     {
         '_id': 'foo',
@@ -99,26 +27,5 @@ snapshots['test_add_is_legacy[uvloop] 1'] = [
             }
         ],
         'is_legacy': False
-    }
-]
-
-snapshots['test_change_to_subtractions_list[uvloop] 1'] = [
-    {
-        '_id': 'foo',
-        'subtractions': [
-            'prunus'
-        ]
-    },
-    {
-        '_id': 'bar',
-        'subtractions': [
-            'malus'
-        ]
-    },
-    {
-        '_id': 'baz',
-        'subtractions': [
-            'malus'
-        ]
     }
 ]

--- a/virtool/dispatcher/dispatcher.py
+++ b/virtool/dispatcher/dispatcher.py
@@ -146,7 +146,7 @@ class Dispatcher:
         try:
             fetcher = getattr(self._fetchers, change.interface)
         except AttributeError:
-            raise ValueError(f"Unknown dispatch interface: {change.interface}")
+            logger.warning(f"Unknown dispatch interface: {change.interface}")
 
         if change.operation not in (DELETE, INSERT, UPDATE):
             raise ValueError(f"Unknown dispatch operation: {change.operation}")

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -185,7 +185,7 @@ async def get(req):
     document = await virtool.samples.db.attach_artifacts_and_reads(pg, document)
 
     if document["ready"]:
-        for index, file in enumerate(document["reads"]):
+        for file in document["reads"]:
             file.update({
                 "download_url": f"/api/samples/{sample_id}/reads/{file['name']}"
             })

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -180,20 +180,15 @@ async def get(req):
 
     document["caches"] = caches
 
-    if document["ready"] is True:
-        # Only update file fields if sample creation is complete.
-        for index, file in enumerate(document["files"]):
-            snake_case = document["name"].replace(" ", "_")
-
-            file.update({
-                "name": file["name"].replace("reads_", f"{snake_case}_"),
-                "download_url": file["download_url"].replace("reads_", f"{snake_case}_"),
-                "replace_url": f"/upload/samples/{sample_id}/files/{index + 1}"
-            })
-
     document = await virtool.subtractions.db.attach_subtractions(db, document)
     document = await virtool.samples.db.attach_labels(pg, document)
     document = await virtool.samples.db.attach_artifacts_and_reads(pg, document)
+
+    if document["ready"]:
+        for index, file in enumerate(document["reads"]):
+            file.update({
+                "download_url": f"/api/samples/{sample_id}/reads/{file['name']}"
+            })
 
     return json_response(virtool.utils.base_processor(document))
 

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -457,10 +457,10 @@ class MoveSampleFilesTask(Task):
     Move pre-SQL samples' file information to new `sample_reads` and `uploads` tables.
 
     """
-    task_type = "migrate_files"
+    task_type = "move_sample_files"
 
-    def __init__(self, app, process_id):
-        super().__init__(app, process_id)
+    def __init__(self, app, task_id):
+        super().__init__(app, task_id)
 
         self.steps = [
             self.move_sample_files

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -15,10 +15,8 @@ import pymongo.errors
 
 import virtool.analyses.db
 import virtool.config
-import virtool.db.core
 import virtool.db.migrate
 import virtool.db.mongo
-import virtool.db.utils
 import virtool.dev.fake
 import virtool.dispatcher
 import virtool.hmm.db
@@ -233,8 +231,8 @@ async def init_fake_config(app: App):
 
 async def init_jobs_client(app: aiohttp.web_app.Application):
     """
-    An application `on_startup` callback that initializes a Virtool :class:`virtool.job_manager.Manager` object and
-    puts it in app state.
+    An application `on_startup` callback that initializes a Virtool
+    :class:`virtool.job_manager.Manager` object and puts it in app state.
 
     :param app: the app object
     :type app: :class:`aiohttp.aiohttp.web.Application`
@@ -313,7 +311,9 @@ async def init_routes(app: aiohttp.web_app.Application):
 
 
 async def init_sentry(app: typing.Union[dict, aiohttp.web_app.Application]):
-    if not app["settings"]["no_sentry"] and app["settings"].get("enable_sentry", True) and not app["settings"]["dev"]:
+    if (not app["settings"]["no_sentry"]
+            and app["settings"].get("enable_sentry", True)
+            and not app["settings"]["dev"]):
         logger.info("Configuring Sentry")
         virtool.sentry.setup(app["version"])
 
@@ -342,8 +342,8 @@ async def init_version(app: typing.Union[dict, aiohttp.web.Application]):
     """
     Bind the application version to the application state `dict`.
 
-    The value will come by checking `--force-version`, the `VERSION` file, or the current Git tag if the containing
-    folder is a Git repository.
+    The value will come by checking `--force-version`, the `VERSION` file, or the current Git tag
+    if the containing folder is a Git repository.
 
     :param app: the application object
 
@@ -364,8 +364,8 @@ async def init_version(app: typing.Union[dict, aiohttp.web.Application]):
 
 async def init_task_runner(app: aiohttp.web.Application):
     """
-    An application `on_startup` callback that initializes a Virtool :class:`virtool.tasks.runner.TaskRunner` object and
-    puts it in app state.
+    An application `on_startup` callback that initializes a Virtool
+    :class:`virtool.tasks.runner.TaskRunner` object and puts it in app state.
 
     :param app: the app object
 
@@ -385,7 +385,8 @@ async def init_tasks(app: aiohttp.web.Application):
     scheduler = get_scheduler_from_app(app)
 
     logger.info("Checking subtraction FASTA files")
-    subtractions_without_fasta = await virtool.subtractions.db.check_subtraction_fasta_files(app["db"], app["settings"])
+    subtractions_without_fasta = await virtool.subtractions.db.check_subtraction_fasta_files(
+        app["db"], app["settings"])
     for subtraction in subtractions_without_fasta:
         await app["tasks"].add(WriteSubtractionFASTATask, context={"subtraction": subtraction})
 
@@ -396,5 +397,6 @@ async def init_tasks(app: aiohttp.web.Application):
     await app["tasks"].add(AddSubtractionFilesTask)
     await app["tasks"].add(StoreNuvsFilesTask)
     await app["tasks"].add(CompressSamplesTask)
+    await app["tasks"].add(MoveSampleFilesTask)
 
     await scheduler.spawn(app["tasks"].add_periodic(MigrateFilesTask, 3600))


### PR DESCRIPTION
* Run `MoveSampleFilesTask` on application start and change `task_name` to `move_sample_files`. Change `process_id` to `task_id`.
* Log a warning instead of throwing an exception when a `Change` for an unknown dispatcher interface is received.
* Add `download_url` to records in `reads` field of sample response. Remove the legacy `files` field processing that was causing an exception when fetching a sample record.
* Remove some deprecated test snapshots



