### PR TITLE
Stop writing `subtraction.files` when subtraction files are uploaded

### DIFF
--- a/tests/subtractions/snapshots/snap_test_api.py
+++ b/tests/subtractions/snapshots/snap_test_api.py
@@ -134,3 +134,17 @@ snapshots['test_job_remove[uvloop-True-False] 2'] = {
     'subtractions': [
     ]
 }
+
+snapshots['test_finalize_subtraction[uvloop-None] 2'] = {
+    '_id': 'foo',
+    'gc': {
+        'a': 0.319,
+        'c': 0.18,
+        'g': 0.18,
+        'n': 0.002,
+        't': 0.319
+    },
+    'name': 'Foo',
+    'nickname': 'Foo Subtraction',
+    'ready': True
+}

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -129,43 +129,7 @@ async def test_finalize_subtraction(error, spawn_job_client, snapshot, resp_is, 
     assert resp.status == 200
     snapshot.assert_match(await resp.json())
 
-    document = await client.db.subtraction.find_one("foo")
-    assert document == {
-        "_id": "foo",
-        "name": "Foo",
-        "nickname": "Foo Subtraction",
-        "gc": {
-            "a": 0.319,
-            "t": 0.319,
-            "g": 0.18,
-            "c": 0.18,
-            "n": 0.002
-        },
-        "ready": True,
-        "files": [
-            {
-                "id": 1,
-                "name": "subtraction.fq.gz",
-                "size": 12345,
-                "subtraction": "foo",
-                "type": "fasta"
-            },
-            {
-                "id": 2,
-                "name": "subtraction.1.bt2",
-                "size": 56437,
-                "subtraction": "foo",
-                "type": "bowtie2"
-            },
-            {
-                "id": 3,
-                "name": "subtraction.2.bt2",
-                "size": 93845,
-                "subtraction": "foo",
-                "type": "bowtie2"
-            }
-        ]
-    }
+    snapshot.assert_match(await client.db.subtraction.find_one("foo"))
 
 
 @pytest.mark.parametrize("ready", [True, False])

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -81,12 +81,6 @@ async def test_upload(error, tmpdir, spawn_job_client, snapshot, resp_is, pg_ses
     assert resp.status == 201
     assert os.listdir(tmpdir / "subtractions" / "foo") == ["subtraction.1.bt2"]
     snapshot.assert_match(await resp.json())
-    document = await client.db.subtraction.find_one("foo")
-    assert document == {
-        '_id': 'foo',
-        'name': 'Foo',
-        'files': [1]
-    }
 
 
 @pytest.mark.parametrize("error", [None, "404", "409", "422"])

--- a/tests/subtractions/test_utils.py
+++ b/tests/subtractions/test_utils.py
@@ -15,8 +15,8 @@ def test_join_subtraction_path():
     assert path == "/foo/subtractions/bar"
 
 
-async def test_prepare_files_field(pg, test_subtraction_files):
-    files = await virtool.subtractions.utils.prepare_files_field(pg, "foo")
+async def test_get_subtraction_files(pg, test_subtraction_files):
+    files = await virtool.subtractions.utils.get_subtraction_files(pg, "foo")
 
     assert files == [
             {

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -334,10 +334,11 @@ async def finalize_subtraction(req: aiohttp.web.Request):
     updated_document = await db.subtraction.find_one_and_update({"_id": subtraction_id}, {
         "$set": {
             "gc": data["gc"],
-            "ready": True,
-            "files": await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)
+            "ready": True
         }
     })
+
+    updated_document["files"] = await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)
 
     return json_response(virtool.utils.base_processor(updated_document))
 

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -99,7 +99,7 @@ async def get(req):
         return not_found()
 
     document["linked_samples"] = await virtool.subtractions.db.get_linked_samples(db, subtraction_id)
-    document["files"] = await virtool.subtractions.utils.prepare_files_field(pg, subtraction_id)
+    document["files"] = await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)
 
     return json_response(virtool.utils.base_processor(document))
 
@@ -240,8 +240,8 @@ async def upload(req):
     subtraction_file = await virtool.uploads.db.finalize(pg, size, upload_id, SubtractionFile)
 
     await db.subtraction.find_one_and_update({"_id": subtraction_id}, {
-        "$push": {
-            "files": upload_id
+        "$set": {
+            "files": [row for row in await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)]
         }
     })
 
@@ -296,7 +296,7 @@ async def edit(req):
         return not_found()
 
     document["linked_samples"] = await virtool.subtractions.db.get_linked_samples(db, subtraction_id)
-    document["files"] = await virtool.subtractions.utils.prepare_files_field(pg, subtraction_id)
+    document["files"] = await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)
 
     return json_response(virtool.utils.base_processor(document))
 
@@ -341,7 +341,7 @@ async def finalize_subtraction(req: aiohttp.web.Request):
         "$set": {
             "gc": data["gc"],
             "ready": True,
-            "files": await virtool.subtractions.utils.prepare_files_field(pg, subtraction_id)
+            "files": await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)
         }
     })
 

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -289,8 +289,13 @@ async def edit(req):
     if document is None:
         return not_found()
 
-    document["linked_samples"] = await virtool.subtractions.db.get_linked_samples(db, subtraction_id)
-    document["files"] = await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)
+    files, linked_samples = await asyncio.gather(*[virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id),
+                                                   virtool.subtractions.db.get_linked_samples(db, subtraction_id)])
+
+    document.update({
+        "files": files,
+        "linked_samples": linked_samples
+    })
 
     return json_response(virtool.utils.base_processor(document))
 

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -239,12 +239,6 @@ async def upload(req):
 
     subtraction_file = await virtool.uploads.db.finalize(pg, size, upload_id, SubtractionFile)
 
-    await db.subtraction.find_one_and_update({"_id": subtraction_id}, {
-        "$set": {
-            "files": [row for row in await virtool.subtractions.utils.get_subtraction_files(pg, subtraction_id)]
-        }
-    })
-
     headers = {
         "Location": f"/api/subtractions/{subtraction_id}/files/{file_name}"
     }

--- a/virtool/subtractions/utils.py
+++ b/virtool/subtractions/utils.py
@@ -76,7 +76,7 @@ def join_subtraction_index_path(settings: dict, subtraction_id: str) -> str:
     )
 
 
-async def prepare_files_field(pg: AsyncEngine, subtraction: str):
+async def get_subtraction_files(pg: AsyncEngine, subtraction: str):
     """
     Prepare a list of files from 'SubtractionFile' table to be added to 'files' field.
 


### PR DESCRIPTION
* Rename `prepare_files_field` to `get_subtraction_files`. I can change this to `attach_subtraction_files` but currently, the function only returns a list of files instead of returning an updated dictionary.