### PR TITLE
Update virtool.indexes.db.create

### DIFF
--- a/tests/indexes/snapshots/snap_test_api.py
+++ b/tests/indexes/snapshots/snap_test_api.py
@@ -8,10 +8,10 @@ from snapshottest import GenericRepr, Snapshot
 snapshots = Snapshot()
 
 snapshots['TestCreate.test[True-uvloop] 1'] = {
-    '_id': 'xjqvxigh',
+    '_id': 'u3cuwaoq',
     'acquired': False,
     'args': {
-        'index_id': 'u3cuwaoq',
+        'index_id': 'xjqvxigh',
         'index_version': 9,
         'manifest': 'manifest',
         'ref_id': 'foo',
@@ -21,7 +21,7 @@ snapshots['TestCreate.test[True-uvloop] 1'] = {
     'rights': {
         'indexes': {
             'modify': [
-                'u3cuwaoq'
+                'xjqvxigh'
             ]
         },
         'references': {
@@ -47,12 +47,15 @@ snapshots['TestCreate.test[True-uvloop] 1'] = {
 }
 
 snapshots['TestCreate.test[True-uvloop] 2'] = {
-    '_id': 'u3cuwaoq',
+    '_id': 'xjqvxigh',
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'files': [
     ],
     'has_files': True,
     'has_json': False,
+    'job': {
+        'id': 'u3cuwaoq'
+    },
     'manifest': 'manifest',
     'ready': False,
     'reference': {
@@ -70,9 +73,9 @@ snapshots['TestCreate.test[True-uvloop] 3'] = {
     ],
     'has_files': True,
     'has_json': False,
-    'id': 'u3cuwaoq',
+    'id': 'xjqvxigh',
     'job': {
-        'id': 'xjqvxigh'
+        'id': 'u3cuwaoq'
     },
     'manifest': 'manifest',
     'ready': False,

--- a/tests/indexes/snapshots/snap_test_api.py
+++ b/tests/indexes/snapshots/snap_test_api.py
@@ -53,9 +53,6 @@ snapshots['TestCreate.test[True-uvloop] 2'] = {
     ],
     'has_files': True,
     'has_json': False,
-    'job': {
-        'id': 'xjqvxigh'
-    },
     'manifest': 'manifest',
     'ready': False,
     'reference': {

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -325,8 +325,8 @@ class TestCreate:
 
         assert resp.status == 201
 
-        expected_id = test_random_alphanumeric.history[1]
-        expected_job_id = test_random_alphanumeric.history[2]
+        expected_job_id = test_random_alphanumeric.history[1]
+        expected_id = test_random_alphanumeric.history[2]
 
         assert resp.headers["Location"] == "/api/indexes/{}".format(expected_id)
 

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -27,7 +27,7 @@ async def test_create(index_id, mocker, dbi, test_random_alphanumeric, static_ti
 
     mocker.patch("virtool.references.db.get_manifest", new=make_mocked_coro("manifest"))
 
-    document = await virtool.indexes.db.create(dbi, "foo", "test", index_id=index_id)
+    document = await virtool.indexes.db.create(dbi, "foo", "test", "bar", index_id=index_id)
 
     expected_index_id = test_random_alphanumeric.history[0] if index_id is None else "abc"
 
@@ -41,6 +41,9 @@ async def test_create(index_id, mocker, dbi, test_random_alphanumeric, static_ti
         "has_json": False,
         "reference": {
             "id": "foo"
+        },
+        "job": {
+            "id": "bar"
         },
         "user": {
             "id": "test"

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -233,7 +233,9 @@ async def create(req):
     rights.references.can_read(ref_id)
 
     job_id = await virtool.db.utils.get_new_id(db.jobs)
-    document["job"]["id"] = job_id
+    document["job"] = {
+        "id": job_id
+    }
 
     # Create job document.
     job = await virtool.jobs.db.create(

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -233,10 +233,6 @@ async def create(req):
     rights.indexes.can_modify(document["_id"])
     rights.references.can_read(ref_id)
 
-    document["job"] = {
-        "id": job_id
-    }
-
     # Create job document.
     job = await virtool.jobs.db.create(
         db,

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -216,8 +216,9 @@ async def create(req):
         return bad_request("There are no unbuilt changes")
 
     user_id = req["client"].user_id
+    job_id = await virtool.db.utils.get_new_id(db.jobs)
 
-    document = await virtool.indexes.db.create(db, ref_id, user_id)
+    document = await virtool.indexes.db.create(db, ref_id, user_id, job_id)
 
     # A dict of task_args for the rebuild job.
     task_args = {
@@ -232,7 +233,6 @@ async def create(req):
     rights.indexes.can_modify(document["_id"])
     rights.references.can_read(ref_id)
 
-    job_id = await virtool.db.utils.get_new_id(db.jobs)
     document["job"] = {
         "id": job_id
     }

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -232,6 +232,9 @@ async def create(req):
     rights.indexes.can_modify(document["_id"])
     rights.references.can_read(ref_id)
 
+    job_id = await virtool.db.utils.get_new_id(db.jobs)
+    document["job"]["id"] = job_id
+
     # Create job document.
     job = await virtool.jobs.db.create(
         db,
@@ -239,7 +242,7 @@ async def create(req):
         task_args,
         user_id,
         rights,
-        job_id=document["job"]["id"]
+        job_id=job_id
     )
 
     await req.app["jobs"].enqueue(job["_id"])

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -5,7 +5,7 @@ Work with indexes in the database.
 import asyncio
 import asyncio.tasks
 import typing
-from typing import Union
+from typing import Optional, Union
 
 import pymongo
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -45,16 +45,18 @@ FILES = (
 )
 
 
-async def create(db, ref_id: str, user_id: str) -> dict:
+async def create(db, ref_id: str, user_id: str, index_id: Optional[str] = None) -> dict:
     """
     Create a new index and update history to show the version and id of the new index.
 
     :param db: the application database client
     :param ref_id: the ID of the reference to create index for
     :param user_id: the ID of the current user
+    :param index_id: the ID of the index
+
     :return: the new index document
     """
-    index_id = await virtool.db.utils.get_new_id(db.indexes)
+    index_id = index_id or await virtool.db.utils.get_new_id(db.indexes)
 
     index_version = await get_next_version(db, ref_id)
 

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -58,8 +58,6 @@ async def create(db, ref_id: str, user_id: str) -> dict:
 
     index_version = await get_next_version(db, ref_id)
 
-    job_id = await virtool.db.utils.get_new_id(db.jobs)
-
     manifest = await virtool.references.db.get_manifest(db, ref_id)
 
     document = {
@@ -70,9 +68,6 @@ async def create(db, ref_id: str, user_id: str) -> dict:
         "ready": False,
         "has_files": True,
         "has_json": False,
-        "job": {
-            "id": job_id
-        },
         "reference": {
             "id": ref_id
         },

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -45,13 +45,14 @@ FILES = (
 )
 
 
-async def create(db, ref_id: str, user_id: str, index_id: Optional[str] = None) -> dict:
+async def create(db, ref_id: str, user_id: str, job_id: str, index_id: Optional[str] = None) -> dict:
     """
     Create a new index and update history to show the version and id of the new index.
 
     :param db: the application database client
     :param ref_id: the ID of the reference to create index for
     :param user_id: the ID of the current user
+    :param job_id: the ID of the job
     :param index_id: the ID of the index
 
     :return: the new index document
@@ -72,6 +73,9 @@ async def create(db, ref_id: str, user_id: str, index_id: Optional[str] = None) 
         "has_json": False,
         "reference": {
             "id": ref_id
+        },
+        "job": {
+            "id": job_id
         },
         "user": {
             "id": user_id


### PR DESCRIPTION
- Add optional `index_id` argument for `virtool.indexes.db.create` function
- Move `job_id` generation out of `virtool.indexes.db.create` function