### PR TITLE
Create fake OTUs in fake mode

### DIFF
--- a/tests/otus/snapshots/snap_test_db.py
+++ b/tests/otus/snapshots/snap_test_db.py
@@ -7,61 +7,6 @@ from snapshottest import GenericRepr, Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_create[uvloop-TMV] 1'] = {
-    '_id': '9pfsom1b',
-    'abbreviation': 'TMV',
-    'isolates': [
-    ],
-    'last_indexed_version': None,
-    'lower_name': 'bar',
-    'name': 'Bar',
-    'reference': {
-        'id': 'foo'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 0
-}
-
-snapshots['test_create[uvloop-TMV] 2'] = {
-    '_id': '9pfsom1b.0',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Created Bar (TMV)',
-    'diff': {
-        '_id': '9pfsom1b',
-        'abbreviation': 'TMV',
-        'isolates': [
-        ],
-        'last_indexed_version': None,
-        'lower_name': 'bar',
-        'name': 'Bar',
-        'reference': {
-            'id': 'foo'
-        },
-        'schema': [
-        ],
-        'verified': False,
-        'version': 0
-    },
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'create',
-    'otu': {
-        'id': '9pfsom1b',
-        'name': 'Bar',
-        'version': 0
-    },
-    'reference': {
-        'id': 'foo'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
 snapshots['test_edit[uvloop-None] history'] = {
     '_id': '6116cba1.1',
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
@@ -214,61 +159,6 @@ snapshots['test_edit[uvloop-TMV] otu'] = {
     'version': 1
 }
 
-snapshots['test_create[uvloop-] 1'] = {
-    '_id': '9pfsom1b',
-    'abbreviation': '',
-    'isolates': [
-    ],
-    'last_indexed_version': None,
-    'lower_name': 'bar',
-    'name': 'Bar',
-    'reference': {
-        'id': 'foo'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 0
-}
-
-snapshots['test_create[uvloop-] 2'] = {
-    '_id': '9pfsom1b.0',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Created Bar',
-    'diff': {
-        '_id': '9pfsom1b',
-        'abbreviation': '',
-        'isolates': [
-        ],
-        'last_indexed_version': None,
-        'lower_name': 'bar',
-        'name': 'Bar',
-        'reference': {
-            'id': 'foo'
-        },
-        'schema': [
-        ],
-        'verified': False,
-        'version': 0
-    },
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'create',
-    'otu': {
-        'id': '9pfsom1b',
-        'name': 'Bar',
-        'version': 0
-    },
-    'reference': {
-        'id': 'foo'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
 snapshots['test_edit[uvloop-] otu'] = {
     '_id': '6116cba1',
     'abbreviation': '',
@@ -343,6 +233,116 @@ snapshots['test_edit[uvloop-] history'] = {
     },
     'reference': {
         'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create_otu[uvloop--TMV] otu'] = {
+    '_id': 'TMV',
+    'abbreviation': '',
+    'isolates': [
+    ],
+    'last_indexed_version': None,
+    'lower_name': 'bar',
+    'name': 'Bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 0
+}
+
+snapshots['test_create_otu[uvloop--TMV] history'] = {
+    '_id': 'TMV.0',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created Bar',
+    'diff': {
+        '_id': 'TMV',
+        'abbreviation': '',
+        'isolates': [
+        ],
+        'last_indexed_version': None,
+        'lower_name': 'bar',
+        'name': 'Bar',
+        'reference': {
+            'id': 'foo'
+        },
+        'schema': [
+        ],
+        'verified': False,
+        'version': 0
+    },
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create',
+    'otu': {
+        'id': 'TMV',
+        'name': 'Bar',
+        'version': 0
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create_otu[uvloop-None-otu] otu'] = {
+    '_id': 'otu',
+    'abbreviation': None,
+    'isolates': [
+    ],
+    'last_indexed_version': None,
+    'lower_name': 'bar',
+    'name': 'Bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 0
+}
+
+snapshots['test_create_otu[uvloop-None-otu] history'] = {
+    '_id': 'otu.0',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created Bar',
+    'diff': {
+        '_id': 'otu',
+        'abbreviation': None,
+        'isolates': [
+        ],
+        'last_indexed_version': None,
+        'lower_name': 'bar',
+        'name': 'Bar',
+        'reference': {
+            'id': 'foo'
+        },
+        'schema': [
+        ],
+        'verified': False,
+        'version': 0
+    },
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create',
+    'otu': {
+        'id': 'otu',
+        'name': 'Bar',
+        'version': 0
+    },
+    'reference': {
+        'id': 'foo'
     },
     'user': {
         'id': 'bob'

--- a/tests/otus/snapshots/snap_test_fake.py
+++ b/tests/otus/snapshots/snap_test_fake.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_create_fake_otus[uvloop] otus'] = [
+    {
+        '_id': '2x6YnyMt',
+        'abbreviation': 'ABTV',
+        'isolates': [
+            {
+                'default': True,
+                'id': 'c2uyoYJd',
+                'source_name': 'A',
+                'source_type': 'Isolate'
+            }
+        ],
+        'last_indexed_version': None,
+        'lower_name': 'abaca bunchy top virus',
+        'name': 'Abaca bunchy top virus',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'schema': [
+        ],
+        'verified': True,
+        'version': 6
+    },
+    {
+        '_id': '7a1B1KtN',
+        'abbreviation': 'ASPV',
+        'isolates': [
+            {
+                'default': True,
+                'id': '902DuXz1',
+                'source_name': 'Z',
+                'source_type': 'Isolate'
+            }
+        ],
+        'last_indexed_version': None,
+        'lower_name': 'apple stem pitting virus',
+        'name': 'Apple stem pitting virus',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'schema': [
+        ],
+        'verified': True,
+        'version': 2
+    },
+    {
+        '_id': '4IR34Chh',
+        'abbreviation': 'TMV',
+        'isolates': [
+            {
+                'default': True,
+                'id': '9xFfqLFw',
+                'source_name': '1',
+                'source_type': 'Isolate'
+            },
+            {
+                'default': False,
+                'id': '8l0bRaiq',
+                'source_name': '2',
+                'source_type': 'Isolate'
+            }
+        ],
+        'last_indexed_version': None,
+        'lower_name': 'tobacco mosaic virus',
+        'name': 'Tobacco mosaic virus',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'schema': [
+        ],
+        'verified': True,
+        'version': 4
+    },
+    {
+        '_id': '7Rsub0Ci',
+        'abbreviation': 'LChV1',
+        'isolates': [
+            {
+                'default': True,
+                'id': '3R8uwP00',
+                'source_name': 'A',
+                'source_type': 'Isolate'
+            },
+            {
+                'default': False,
+                'id': '2d79qUCq',
+                'source_name': 'B',
+                'source_type': 'Isolate'
+            },
+            {
+                'default': False,
+                'id': '90Izf7jv',
+                'source_name': 'C',
+                'source_type': 'Isolate'
+            }
+        ],
+        'last_indexed_version': None,
+        'lower_name': 'little cherry virus 1',
+        'name': 'Little cherry virus 1',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'schema': [
+        ],
+        'verified': True,
+        'version': 6
+    }
+]
+
+snapshots['test_create_fake_otus[uvloop] sequences'] = [
+    {
+        '_id': '5NxTrGkY',
+        'accession': 'foo',
+        'definition': 'ABTV sequence 1',
+        'host': '',
+        'isolate_id': 'c2uyoYJd',
+        'otu_id': '2x6YnyMt',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': 'p0Th3uDp',
+        'accession': 'foo',
+        'definition': 'ABTV sequence 2',
+        'host': '',
+        'isolate_id': 'c2uyoYJd',
+        'otu_id': '2x6YnyMt',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': 'z1IIKKvq',
+        'accession': 'foo',
+        'definition': 'ABTV sequence 3',
+        'host': '',
+        'isolate_id': 'c2uyoYJd',
+        'otu_id': '2x6YnyMt',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': '9Zmo2yG4',
+        'accession': 'foo',
+        'definition': 'ABTV sequence 4',
+        'host': '',
+        'isolate_id': 'c2uyoYJd',
+        'otu_id': '2x6YnyMt',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': 'pWWE8Vpm',
+        'accession': 'foo',
+        'definition': 'ABTV sequence 5',
+        'host': '',
+        'isolate_id': 'c2uyoYJd',
+        'otu_id': '2x6YnyMt',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': '1LxB7Ddw',
+        'accession': 'bar',
+        'definition': 'ASPV sequence 1',
+        'host': '',
+        'isolate_id': '902DuXz1',
+        'otu_id': '7a1B1KtN',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': 't7ueOV9n',
+        'accession': 'bar',
+        'definition': 'TMV sequence 1',
+        'host': '',
+        'isolate_id': '9xFfqLFw',
+        'otu_id': '4IR34Chh',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': '6BUEdNcZ',
+        'accession': 'baz',
+        'definition': 'TMV sequence 1',
+        'host': '',
+        'isolate_id': '8l0bRaiq',
+        'otu_id': '4IR34Chh',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': 'C1gBTvcu',
+        'accession': 'bar',
+        'definition': 'LChV1 sequence 1',
+        'host': '',
+        'isolate_id': '3R8uwP00',
+        'otu_id': '7Rsub0Ci',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': '7UCa0nKm',
+        'accession': 'baz',
+        'definition': 'LChV1 sequence 1',
+        'host': '',
+        'isolate_id': '2d79qUCq',
+        'otu_id': '7Rsub0Ci',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    },
+    {
+        '_id': 'I4YTKnMk',
+        'accession': 'bat',
+        'definition': 'LChV1 sequence 1',
+        'host': '',
+        'isolate_id': '90Izf7jv',
+        'otu_id': '7Rsub0Ci',
+        'reference': {
+            'id': 'reference_1'
+        },
+        'segment': None,
+        'sequence': 'ATGAGAGACACATAG'
+    }
+]

--- a/tests/otus/snapshots/snap_test_isolates.py
+++ b/tests/otus/snapshots/snap_test_isolates.py
@@ -7,756 +7,6 @@ from snapshottest import GenericRepr, Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_add[uvloop-False-empty-False] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B as default',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    0,
-                    {
-                        'default': True,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-False-empty-False] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-False-empty-False] return_value'] = {
-    'default': True,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-False-empty-True] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B as default',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    0,
-                    {
-                        'default': True,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-False-empty-True] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-False-empty-True] return_value'] = {
-    'default': True,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-False-not_empty-False] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    1,
-                    {
-                        'default': False,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-False-not_empty-False] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': False,
-            'id': 'cab8b360',
-            'source_name': '8816-v2',
-            'source_type': 'isolate'
-        },
-        {
-            'default': False,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-False-not_empty-False] return_value'] = {
-    'default': False,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-False-not_empty-True] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B as default',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    1,
-                    {
-                        'default': True,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-False-not_empty-True] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': False,
-            'id': 'cab8b360',
-            'source_name': '8816-v2',
-            'source_type': 'isolate'
-        },
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-False-not_empty-True] return_value'] = {
-    'default': True,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-True-empty-False] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B as default',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    0,
-                    {
-                        'default': True,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-True-empty-False] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-True-empty-False] return_value'] = {
-    'default': True,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-True-empty-True] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B as default',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    0,
-                    {
-                        'default': True,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-True-empty-True] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-True-empty-True] return_value'] = {
-    'default': True,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-True-not_empty-False] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    1,
-                    {
-                        'default': False,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-True-not_empty-False] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': 'cab8b360',
-            'source_name': '8816-v2',
-            'source_type': 'isolate'
-        },
-        {
-            'default': False,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-True-not_empty-False] return_value'] = {
-    'default': False,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_add[uvloop-True-not_empty-True] history'] = {
-    '_id': '6116cba1.1',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Added Isolate B as default',
-    'diff': [
-        [
-            'change',
-            'version',
-            [
-                0,
-                1
-            ]
-        ],
-        [
-            'change',
-            [
-                'isolates',
-                0,
-                'default'
-            ],
-            [
-                True,
-                False
-            ]
-        ],
-        [
-            'add',
-            'isolates',
-            [
-                [
-                    1,
-                    {
-                        'default': True,
-                        'id': '9pf',
-                        'sequences': [
-                        ],
-                        'source_name': 'B',
-                        'source_type': 'isolate'
-                    }
-                ]
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'add_isolate',
-    'otu': {
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1
-    },
-    'reference': {
-        'id': 'hxn167'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_add[uvloop-True-not_empty-True] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': False,
-            'id': 'cab8b360',
-            'source_name': '8816-v2',
-            'source_type': 'isolate'
-        },
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': 'B',
-            'source_type': 'isolate'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_add[uvloop-True-not_empty-True] return_value'] = {
-    'default': True,
-    'id': '9pf',
-    'sequences': [
-    ],
-    'source_name': 'B',
-    'source_type': 'isolate'
-}
-
-snapshots['test_append[uvloop-False] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': 'cab8b360',
-            'source_name': '8816-v2',
-            'source_type': 'isolate'
-        },
-        {
-            'id': '9pf',
-            'source_name': '1',
-            'source_type': 'variant'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
-snapshots['test_append[uvloop-True] otu'] = {
-    '_id': '6116cba1',
-    'abbreviation': 'PVF',
-    'imported': True,
-    'isolates': [
-        {
-            'default': True,
-            'id': '9pf',
-            'source_name': '8816-v2',
-            'source_type': 'isolate'
-        },
-        {
-            'id': 'u3c',
-            'source_name': '1',
-            'source_type': 'variant'
-        }
-    ],
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
-    'name': 'Prunus virus F',
-    'reference': {
-        'id': 'hxn167'
-    },
-    'schema': [
-    ],
-    'verified': False,
-    'version': 1
-}
-
 snapshots['test_edit[uvloop] history'] = {
     '_id': '6116cba1.1',
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
@@ -1144,5 +394,1389 @@ snapshots['test_set_default[uvloop] return_value'] = {
     'sequences': [
     ],
     'source_name': 'A',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-True-empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-True-empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-True-empty-True] return_value'] = {
+    'default': True,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-True-empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-True-empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-True-empty-False] return_value'] = {
+    'default': True,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-True-not_empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': False,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': True,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-True-not_empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'change',
+            [
+                'isolates',
+                0,
+                'default'
+            ],
+            [
+                True,
+                False
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': True,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-True-not_empty-True] return_value'] = {
+    'default': True,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-True-not_empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': False,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-True-not_empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': False,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-True-not_empty-False] return_value'] = {
+    'default': False,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-False-empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-False-empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-False-empty-True] return_value'] = {
+    'default': True,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-False-empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-False-empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-False-empty-False] return_value'] = {
+    'default': True,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-False-not_empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': False,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': True,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-False-not_empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': True,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-False-not_empty-True] return_value'] = {
+    'default': True,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-None-False-not_empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': False,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': False,
+            'id': '9pf',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-None-False-not_empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': False,
+                        'id': '9pf',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-None-False-not_empty-False] return_value'] = {
+    'default': False,
+    'id': '9pf',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-True-empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-True-empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-True-empty-True] return_value'] = {
+    'default': True,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-True-empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-True-empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-True-empty-False] return_value'] = {
+    'default': True,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-True-not_empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': False,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': True,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-True-not_empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'change',
+            [
+                'isolates',
+                0,
+                'default'
+            ],
+            [
+                True,
+                False
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': True,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-True-not_empty-True] return_value'] = {
+    'default': True,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-True-not_empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': False,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-True-not_empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': False,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-True-not_empty-False] return_value'] = {
+    'default': False,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-False-empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-False-empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-False-empty-True] return_value'] = {
+    'default': True,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-False-empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': True,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-False-empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    0,
+                    {
+                        'default': True,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-False-empty-False] return_value'] = {
+    'default': True,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-False-not_empty-True] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': False,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': True,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-False-not_empty-True] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B as default',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': True,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-False-not_empty-True] return_value'] = {
+    'default': True,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
+    'source_type': 'isolate'
+}
+
+snapshots['test_add[uvloop-isolate-False-not_empty-False] otu'] = {
+    '_id': '6116cba1',
+    'abbreviation': 'PVF',
+    'imported': True,
+    'isolates': [
+        {
+            'default': False,
+            'id': 'cab8b360',
+            'source_name': '8816-v2',
+            'source_type': 'isolate'
+        },
+        {
+            'default': False,
+            'id': 'isolate',
+            'source_name': 'B',
+            'source_type': 'isolate'
+        }
+    ],
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Prunus virus F',
+    'reference': {
+        'id': 'hxn167'
+    },
+    'schema': [
+    ],
+    'verified': False,
+    'version': 1
+}
+
+snapshots['test_add[uvloop-isolate-False-not_empty-False] history'] = {
+    '_id': '6116cba1.1',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Added Isolate B',
+    'diff': [
+        [
+            'change',
+            'version',
+            [
+                0,
+                1
+            ]
+        ],
+        [
+            'add',
+            'isolates',
+            [
+                [
+                    1,
+                    {
+                        'default': False,
+                        'id': 'isolate',
+                        'sequences': [
+                        ],
+                        'source_name': 'B',
+                        'source_type': 'isolate'
+                    }
+                ]
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'add_isolate',
+    'otu': {
+        'id': '6116cba1',
+        'name': 'Prunus virus F',
+        'version': 1
+    },
+    'reference': {
+        'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_add[uvloop-isolate-False-not_empty-False] return_value'] = {
+    'default': False,
+    'id': 'isolate',
+    'sequences': [
+    ],
+    'source_name': 'B',
     'source_type': 'isolate'
 }

--- a/tests/otus/snapshots/snap_test_sequences.py
+++ b/tests/otus/snapshots/snap_test_sequences.py
@@ -7,362 +7,6 @@ from snapshottest import GenericRepr, Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_create[uvloop-False-False] 1'] = {
-    '_id': 'bar',
-    'isolates': [
-        {
-            'id': 'baz',
-            'source_name': 'A',
-            'source_type': 'isolate'
-        }
-    ],
-    'name': 'Bar Virus',
-    'reference': {
-        'id': 'foo'
-    },
-    'verified': True,
-    'version': 4
-}
-
-snapshots['test_create[uvloop-False-False] 2'] = {
-    '_id': '9pfsom1b',
-    'accession': 'abc123',
-    'definition': 'A made up sequence',
-    'host': 'Plant',
-    'isolate_id': 'baz',
-    'otu_id': 'bar',
-    'reference': {
-        'id': 'foo'
-    },
-    'segment': None,
-    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-}
-
-snapshots['test_create[uvloop-False-False] 3'] = {
-    '_id': 'bar.4',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Created new sequence abc123 in Isolate A',
-    'diff': [
-        [
-            'add',
-            [
-                'isolates',
-                0,
-                'sequences'
-            ],
-            [
-                [
-                    0,
-                    {
-                        '_id': '9pfsom1b',
-                        'accession': 'abc123',
-                        'definition': 'A made up sequence',
-                        'host': 'Plant',
-                        'isolate_id': 'baz',
-                        'otu_id': 'bar',
-                        'reference': {
-                            'id': 'foo'
-                        },
-                        'segment': None,
-                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-                    }
-                ]
-            ]
-        ],
-        [
-            'change',
-            'version',
-            [
-                3,
-                4
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'create_sequence',
-    'otu': {
-        'id': 'bar',
-        'name': 'Bar Virus',
-        'version': 4
-    },
-    'reference': {
-        'id': 'foo'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_create[uvloop-False-True] 1'] = {
-    '_id': 'bar',
-    'isolates': [
-        {
-            'id': 'baz',
-            'source_name': 'A',
-            'source_type': 'isolate'
-        }
-    ],
-    'name': 'Bar Virus',
-    'reference': {
-        'id': 'foo'
-    },
-    'verified': True,
-    'version': 4
-}
-
-snapshots['test_create[uvloop-False-True] 2'] = {
-    '_id': '9pfsom1b',
-    'accession': 'abc123',
-    'definition': 'A made up sequence',
-    'host': 'host',
-    'isolate_id': 'baz',
-    'otu_id': 'bar',
-    'reference': {
-        'id': 'foo'
-    },
-    'segment': None,
-    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-}
-
-snapshots['test_create[uvloop-False-True] 3'] = {
-    '_id': 'bar.4',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Created new sequence abc123 in Isolate A',
-    'diff': [
-        [
-            'add',
-            [
-                'isolates',
-                0,
-                'sequences'
-            ],
-            [
-                [
-                    0,
-                    {
-                        '_id': '9pfsom1b',
-                        'accession': 'abc123',
-                        'definition': 'A made up sequence',
-                        'host': 'host',
-                        'isolate_id': 'baz',
-                        'otu_id': 'bar',
-                        'reference': {
-                            'id': 'foo'
-                        },
-                        'segment': None,
-                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-                    }
-                ]
-            ]
-        ],
-        [
-            'change',
-            'version',
-            [
-                3,
-                4
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'create_sequence',
-    'otu': {
-        'id': 'bar',
-        'name': 'Bar Virus',
-        'version': 4
-    },
-    'reference': {
-        'id': 'foo'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_create[uvloop-True-False] 1'] = {
-    '_id': 'bar',
-    'isolates': [
-        {
-            'id': 'baz',
-            'source_name': 'A',
-            'source_type': 'isolate'
-        }
-    ],
-    'name': 'Bar Virus',
-    'reference': {
-        'id': 'foo'
-    },
-    'verified': True,
-    'version': 4
-}
-
-snapshots['test_create[uvloop-True-False] 2'] = {
-    '_id': '9pfsom1b',
-    'accession': 'abc123',
-    'definition': 'A made up sequence',
-    'host': 'Plant',
-    'isolate_id': 'baz',
-    'otu_id': 'bar',
-    'reference': {
-        'id': 'foo'
-    },
-    'segment': 'seg',
-    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-}
-
-snapshots['test_create[uvloop-True-False] 3'] = {
-    '_id': 'bar.4',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Created new sequence abc123 in Isolate A',
-    'diff': [
-        [
-            'add',
-            [
-                'isolates',
-                0,
-                'sequences'
-            ],
-            [
-                [
-                    0,
-                    {
-                        '_id': '9pfsom1b',
-                        'accession': 'abc123',
-                        'definition': 'A made up sequence',
-                        'host': 'Plant',
-                        'isolate_id': 'baz',
-                        'otu_id': 'bar',
-                        'reference': {
-                            'id': 'foo'
-                        },
-                        'segment': 'seg',
-                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-                    }
-                ]
-            ]
-        ],
-        [
-            'change',
-            'version',
-            [
-                3,
-                4
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'create_sequence',
-    'otu': {
-        'id': 'bar',
-        'name': 'Bar Virus',
-        'version': 4
-    },
-    'reference': {
-        'id': 'foo'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
-snapshots['test_create[uvloop-True-True] 1'] = {
-    '_id': 'bar',
-    'isolates': [
-        {
-            'id': 'baz',
-            'source_name': 'A',
-            'source_type': 'isolate'
-        }
-    ],
-    'name': 'Bar Virus',
-    'reference': {
-        'id': 'foo'
-    },
-    'verified': True,
-    'version': 4
-}
-
-snapshots['test_create[uvloop-True-True] 2'] = {
-    '_id': '9pfsom1b',
-    'accession': 'abc123',
-    'definition': 'A made up sequence',
-    'host': 'host',
-    'isolate_id': 'baz',
-    'otu_id': 'bar',
-    'reference': {
-        'id': 'foo'
-    },
-    'segment': 'seg',
-    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-}
-
-snapshots['test_create[uvloop-True-True] 3'] = {
-    '_id': 'bar.4',
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'description': 'Created new sequence abc123 in Isolate A',
-    'diff': [
-        [
-            'add',
-            [
-                'isolates',
-                0,
-                'sequences'
-            ],
-            [
-                [
-                    0,
-                    {
-                        '_id': '9pfsom1b',
-                        'accession': 'abc123',
-                        'definition': 'A made up sequence',
-                        'host': 'host',
-                        'isolate_id': 'baz',
-                        'otu_id': 'bar',
-                        'reference': {
-                            'id': 'foo'
-                        },
-                        'segment': 'seg',
-                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
-                    }
-                ]
-            ]
-        ],
-        [
-            'change',
-            'version',
-            [
-                3,
-                4
-            ]
-        ]
-    ],
-    'index': {
-        'id': 'unbuilt',
-        'version': 'unbuilt'
-    },
-    'method_name': 'create_sequence',
-    'otu': {
-        'id': 'bar',
-        'name': 'Bar Virus',
-        'version': 4
-    },
-    'reference': {
-        'id': 'foo'
-    },
-    'user': {
-        'id': 'bob'
-    }
-}
-
 snapshots['test_edit[uvloop-False] 1'] = {
     '_id': 'foo',
     'isolates': [
@@ -701,6 +345,718 @@ snapshots['test_remove[uvloop] 2'] = {
     },
     'reference': {
         'id': 'hxn167'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-foobar-True-True] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-foobar-True-True] sequences'] = {
+    '_id': 'foobar',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'host',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': 'seg',
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-foobar-True-True] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': 'foobar',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'host',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': 'seg',
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-foobar-True-False] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-foobar-True-False] sequences'] = {
+    '_id': 'foobar',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'Plant',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': 'seg',
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-foobar-True-False] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': 'foobar',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'Plant',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': 'seg',
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-foobar-False-True] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-foobar-False-True] sequences'] = {
+    '_id': 'foobar',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'host',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': None,
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-foobar-False-True] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': 'foobar',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'host',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': None,
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-foobar-False-False] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-foobar-False-False] sequences'] = {
+    '_id': 'foobar',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'Plant',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': None,
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-foobar-False-False] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': 'foobar',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'Plant',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': None,
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-None-True-True] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-None-True-True] sequences'] = {
+    '_id': '9pfsom1b',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'host',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': 'seg',
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-None-True-True] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': '9pfsom1b',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'host',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': 'seg',
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-None-True-False] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-None-True-False] sequences'] = {
+    '_id': '9pfsom1b',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'Plant',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': 'seg',
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-None-True-False] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': '9pfsom1b',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'Plant',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': 'seg',
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-None-False-True] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-None-False-True] sequences'] = {
+    '_id': '9pfsom1b',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'host',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': None,
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-None-False-True] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': '9pfsom1b',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'host',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': None,
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
+    },
+    'user': {
+        'id': 'bob'
+    }
+}
+
+snapshots['test_create[uvloop-None-False-False] otus'] = {
+    '_id': 'bar',
+    'isolates': [
+        {
+            'id': 'baz',
+            'source_name': 'A',
+            'source_type': 'isolate'
+        }
+    ],
+    'name': 'Bar Virus',
+    'reference': {
+        'id': 'foo'
+    },
+    'verified': True,
+    'version': 4
+}
+
+snapshots['test_create[uvloop-None-False-False] sequences'] = {
+    '_id': '9pfsom1b',
+    'accession': 'abc123',
+    'definition': 'A made up sequence',
+    'host': 'Plant',
+    'isolate_id': 'baz',
+    'otu_id': 'bar',
+    'reference': {
+        'id': 'foo'
+    },
+    'segment': None,
+    'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+}
+
+snapshots['test_create[uvloop-None-False-False] history'] = {
+    '_id': 'bar.4',
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'description': 'Created new sequence abc123 in Isolate A',
+    'diff': [
+        [
+            'add',
+            [
+                'isolates',
+                0,
+                'sequences'
+            ],
+            [
+                [
+                    0,
+                    {
+                        '_id': '9pfsom1b',
+                        'accession': 'abc123',
+                        'definition': 'A made up sequence',
+                        'host': 'Plant',
+                        'isolate_id': 'baz',
+                        'otu_id': 'bar',
+                        'reference': {
+                            'id': 'foo'
+                        },
+                        'segment': None,
+                        'sequence': 'ATGCGTGTACTGAGAGTATATTTATACCACAC'
+                    }
+                ]
+            ]
+        ],
+        [
+            'change',
+            'version',
+            [
+                3,
+                4
+            ]
+        ]
+    ],
+    'index': {
+        'id': 'unbuilt',
+        'version': 'unbuilt'
+    },
+    'method_name': 'create_sequence',
+    'otu': {
+        'id': 'bar',
+        'name': 'Bar Virus',
+        'version': 4
+    },
+    'reference': {
+        'id': 'foo'
     },
     'user': {
         'id': 'bob'

--- a/tests/otus/test_fake.py
+++ b/tests/otus/test_fake.py
@@ -1,0 +1,19 @@
+from virtool.fake.wrapper import FakerWrapper
+from virtool.otus.fake import create_fake_otus
+
+
+async def test_create_fake_otus(dbi, snapshot):
+    app = {
+        "db": dbi,
+        "data_path": "/foo",
+        "fake": FakerWrapper()
+    }
+
+    await create_fake_otus(
+        app,
+        "reference_1",
+        "bob"
+    )
+
+    snapshot.assert_match(await dbi.otus.find().to_list(None), "otus")
+    snapshot.assert_match(await dbi.sequences.find().to_list(None), "sequences")

--- a/tests/otus/test_sequences.py
+++ b/tests/otus/test_sequences.py
@@ -1,4 +1,5 @@
 import pytest
+
 import virtool.otus.sequences
 
 
@@ -80,7 +81,8 @@ async def test_check_segment_or_target(data_type, defined, missing, used, sequen
 
 @pytest.mark.parametrize("host", [True, False])
 @pytest.mark.parametrize("segment", [True, False])
-async def test_create(host, segment, mocker, snapshot, dbi, static_time, test_random_alphanumeric):
+@pytest.mark.parametrize("sequence_id", ["foobar", None])
+async def test_create(host, segment, sequence_id, snapshot, dbi, static_time, test_random_alphanumeric):
     """
 
     """
@@ -127,17 +129,13 @@ async def test_create(host, segment, mocker, snapshot, dbi, static_time, test_ra
         "bar",
         "baz",
         data,
-        "bob"
+        "bob",
+        sequence_id
     )
 
-    otu = await dbi.otus.find_one()
-    snapshot.assert_match(otu)
-
-    sequence = await dbi.sequences.find_one()
-    snapshot.assert_match(sequence)
-
-    history = await dbi.history.find_one()
-    snapshot.assert_match(history)
+    snapshot.assert_match(await dbi.otus.find_one(), "otus")
+    snapshot.assert_match(await dbi.sequences.find_one(), "sequences")
+    snapshot.assert_match(await dbi.history.find_one(), "history")
 
 
 @pytest.mark.parametrize("sequence", [True, False])

--- a/virtool/dev/fake.py
+++ b/virtool/dev/fake.py
@@ -21,12 +21,14 @@ import virtool.users.db
 import virtool.utils
 from virtool.hmm.fake import create_fake_hmms
 from virtool.jobs.utils import JobRights
+from virtool.otus.fake import create_fake_otus
 from virtool.types import App
 from virtool.uploads.models import Upload
 from virtool.utils import ensure_data_dir, random_alphanumeric
 
 logger = getLogger(__name__)
 
+REF_ID = "reference_1"
 USER_ID = "bob"
 
 
@@ -36,6 +38,7 @@ async def populate(app: App):
     await create_fake_analysis(app)
     await create_fake_jobs(app)
     await create_fake_hmms(app)
+    await create_fake_otus(app, REF_ID, USER_ID)
 
 
 async def remove_fake_data_path(app: App):
@@ -89,9 +92,7 @@ async def create_fake_user(app: App):
 
     """
     await virtool.users.db.create(app["db"], USER_ID, "hello_world", True)
-
     await virtool.users.db.edit(app["db"], "bob", administrator=True, force_reset=False)
-
     logger.debug("Created fake user")
 
 
@@ -170,7 +171,14 @@ async def create_fake_analysis(app: App):
         "subtraction_2",
     ]
 
-    file = await virtool.analyses.files.create_analysis_file(app["pg"], "analysis_2", "fasta", "result.fa", 123456)
+    file = await virtool.analyses.files.create_analysis_file(
+        app["pg"],
+        "analysis_2",
+        "fasta",
+        "result.fa",
+        123456
+    )
+
     await app["db"].analyses.insert_many([
         {
             "_id": "analysis_1",
@@ -259,10 +267,9 @@ async def create_fake_references(app: App):
         "virus",
         "A fake reference",
         "genome",
-        ref_id="reference_1",
+        ref_id=REF_ID,
         user_id=USER_ID
     )
 
     await app["db"].references.insert_one(document)
-
     logger.debug("Created fake reference")

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -126,7 +126,7 @@ async def create(req):
     if message:
         return bad_request(message)
 
-    document = await asyncio.shield(virtool.otus.db.create(
+    document = await asyncio.shield(virtool.otus.db.create_otu(
         req.app,
         ref_id,
         name,

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,34 +1,8 @@
 """
 Work with OTUs in the database.
 
-Schema:
-- _id (str) the unique ID for the OTU
-- abbreviation (str) the virus abbreviation
-- created_at (datetime) timestamp for creation of the OTU
-- imported (bool) true when the sample creation workflow has completed
-- isolates (List[Object]) a list of child isolates
-  - default (bool) set to true of the isolate is the default isolate for the OTU - ie. used as representative of species
-  - id (str) the instance-unique ID for the isolate
-  - source_type (str) the first part of the isolate name (eg. Isolate, Strain)
-  - source_ name (str) the last part of the isolate name (eg. A, China-1)
-- last_indexed_version (int) the last version of the OTU that was included in an index
-- lower_name (str) the OTU name transformed to lower case
-- name (str) the user-defined name for the OTU
-- reference (Object) describes the parent reference
-  - id (str) the reference ID
-- remote (Object)
-  - id (str) the foreign ID if the OTU was imported or remoted
-- schema (Array[Object]) ordered objects describing the virus genome
-  - molecule (str) the virus genome type (eg. ssDNA, dsRNA)
-  - name (str) the name of the segment (eg. RNA1, DNA-A)
-  - required (bool) true if the segment must be defined for an isolate to be created
-- user (Object) describes the creating user
-  - id (str) the user ID
-- verified (bool) true if OTU meets validation requirements
-- version (int) the version of the OTU - increments everytime the OTU or a child isolate or sequence changes
-
 """
-from typing import Union
+from typing import Optional, Union
 
 import pymongo.results
 
@@ -107,7 +81,7 @@ async def check_name_and_abbreviation(
     return False
 
 
-async def create(app, ref_id, name, abbreviation, user_id):
+async def create_otu(app, ref_id, name, abbreviation, user_id, otu_id: Optional[str] = None):
     """
     Create a new OTU.
 
@@ -116,12 +90,13 @@ async def create(app, ref_id, name, abbreviation, user_id):
     :param name: a name for the new OTU
     :param abbreviation: an abbreviation for the new OTU
     :param user_id: the ID of the requesting user
+    :param otu_id: an optional OTU ID to use
     :return: the joined OTU document
 
     """
     db = app["db"]
 
-    otu_id = await virtool.db.utils.get_new_id(db.otus)
+    otu_id = otu_id or await virtool.db.utils.get_new_id(db.otus)
 
     # Start building a otu document.
     document = {

--- a/virtool/otus/fake.py
+++ b/virtool/otus/fake.py
@@ -1,0 +1,121 @@
+from dataclasses import dataclass
+from typing import List
+
+import virtool.otus.isolates
+import virtool.otus.sequences
+from virtool.fake.wrapper import FakerWrapper
+from virtool.otus.db import create_otu
+from virtool.types import App
+
+
+@dataclass
+class FakeSequence:
+    accession: str
+    definition: str
+    sequence: str
+
+
+class FakeOTU:
+
+    def __init__(self, app: App, ref_id: str, user_id: str, document: dict):
+        self._app = app
+        self._ref_id = ref_id
+        self._user_id = user_id
+        self._document = document
+
+        self.otu_id = document["id"]
+        self._faker: FakerWrapper = self._app["fake"]
+
+    async def add_isolate(self, source_type, source_name, sequences: List[FakeSequence]):
+        isolate_data = {
+            "default": False,
+            "source_type": source_type,
+            "source_name": source_name
+        }
+
+        isolate_id = self._faker.get_mongo_id()
+
+        await virtool.otus.isolates.add(
+            self._app,
+            self.otu_id,
+            isolate_data,
+            self._user_id,
+            isolate_id
+        )
+
+        for sequence in sequences:
+            sequence_data = {
+                "accession": sequence.accession,
+                "definition": sequence.definition,
+                "sequence": sequence.sequence
+            }
+
+            await virtool.otus.sequences.create(
+                self._app,
+                self._ref_id,
+                self.otu_id,
+                isolate_id,
+                sequence_data,
+                self._user_id,
+                self._faker.get_mongo_id()
+            )
+
+
+class FakeOTUCreator:
+
+    def __init__(self, app: App, ref_id: str, user_id: str):
+        self._app = app
+        self._faker = app["fake"]
+        self._ref_id = ref_id
+        self._user_id = user_id
+
+    async def create(self, name: str, abbreviation: str):
+        otu_id = self._faker.get_mongo_id()
+
+        document = await create_otu(
+            self._app,
+            self._ref_id,
+            name,
+            abbreviation,
+            self._user_id,
+            otu_id
+        )
+
+        return FakeOTU(self._app, self._ref_id, self._user_id, document)
+
+
+async def create_fake_otus(app: App, ref_id: str, user_id: str):
+    """
+    Create a set of fake OTUs to populate the reference identified by ``ref_id``.
+
+    :param app: the application object
+    :param ref_id: the parent reference ID
+    :param user_id: the ID of the user creating the OTUs
+
+    """
+    fake_otu_creator = FakeOTUCreator(app, ref_id, user_id)
+
+    abtv = await fake_otu_creator.create("Abaca bunchy top virus", "ABTV")
+
+    await abtv.add_isolate("Isolate", "A", [
+        FakeSequence("foo", "ABTV sequence 1", "ATGAGAGACACATAG"),
+        FakeSequence("foo", "ABTV sequence 2", "ATGAGAGACACATAG"),
+        FakeSequence("foo", "ABTV sequence 3", "ATGAGAGACACATAG"),
+        FakeSequence("foo", "ABTV sequence 4", "ATGAGAGACACATAG"),
+        FakeSequence("foo", "ABTV sequence 5", "ATGAGAGACACATAG")
+    ])
+
+    aspv = await fake_otu_creator.create("Apple stem pitting virus", "ASPV")
+
+    await aspv.add_isolate("Isolate", "Z", [FakeSequence("bar", "ASPV sequence 1", "ATGAGAGACACATAG")])
+
+    tmv = await fake_otu_creator.create("Tobacco mosaic virus", "TMV")
+
+    await tmv.add_isolate("Isolate", "1", [FakeSequence("bar", "TMV sequence 1", "ATGAGAGACACATAG")])
+    await tmv.add_isolate("Isolate", "2", [FakeSequence("baz", "TMV sequence 1", "ATGAGAGACACATAG")])
+
+    lchv_1 = await fake_otu_creator.create("Little cherry virus 1", "LChV1")
+
+    await lchv_1.add_isolate("Isolate", "A", [FakeSequence("bar", "LChV1 sequence 1", "ATGAGAGACACATAG")])
+    await lchv_1.add_isolate("Isolate", "B", [FakeSequence("baz", "LChV1 sequence 1", "ATGAGAGACACATAG")])
+    await lchv_1.add_isolate("Isolate", "C", [FakeSequence("bat", "LChV1 sequence 1", "ATGAGAGACACATAG")])

--- a/virtool/otus/sequences.py
+++ b/virtool/otus/sequences.py
@@ -1,21 +1,8 @@
 """
 Database functions and utilities for sequences.
 
-Sequence Document Schema:
-- _id (str) unique ID for the sequence
-- definition (str) a wordy definition for the sequence - same as definitiion field from Genbank
-- host (str) a user-defined host - same as host feature field from Genbank
-- sequence (str) the nucleotide sequence
-- isolate_id (str) the ID of the parent isolate
-- accession (str) the user-defined accession for the sequence - should be a Genbank accession when possible
-- otu_id (str) the ID of the parent OTU
-- reference (Object) described the parent reference
-  - id (str) the reference ID
-- segment (str) the ID of the schema segment for this sequence
-- remote (str) the remote ID for the sequence if it was imported or remoted
-
 """
-from typing import Union
+from typing import Optional, Union
 
 import virtool.db.utils
 import virtool.history
@@ -24,6 +11,7 @@ import virtool.otus
 import virtool.otus.db
 import virtool.otus.utils
 import virtool.utils
+from virtool.types import App
 
 
 async def check_segment_or_target(
@@ -87,7 +75,15 @@ async def check_segment_or_target(
     return None
 
 
-async def create(app, ref_id: str, otu_id: str, isolate_id: str, data: dict, user_id: str):
+async def create(
+        app: App,
+        ref_id: str,
+        otu_id: str,
+        isolate_id: str,
+        data: dict,
+        user_id: str,
+        sequence_id: Optional[str] = None
+):
     """
     Create a new sequence document. Update the
 
@@ -97,6 +93,7 @@ async def create(app, ref_id: str, otu_id: str, isolate_id: str, data: dict, use
     :param isolate_id: the ID of the parent isolate
     :param data: source data for the new sequence
     :param user_id: the ID of the requesting user
+    :param sequence_id: optionally force a sequence ID
     :return: the new sequence
 
     """
@@ -118,6 +115,9 @@ async def create(app, ref_id: str, otu_id: str, isolate_id: str, data: dict, use
     }
 
     old = await virtool.otus.db.join(db, otu_id)
+
+    if sequence_id:
+        to_insert["_id"] = sequence_id
 
     sequence_document = await db.sequences.insert_one(to_insert)
 


### PR DESCRIPTION
* Update OTU, isolate, and sequence creation functions to accept forced `id`
* Add four OTUs with isolates and sequences when job API is started in fake mode
