### PR TITLE
Create unique constraints for sample reads uploads

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1107,7 +1107,7 @@ class TestUploadReads:
             data["file"] = open(path / "reads_2.fq.gz", "rb")
             resp_3 = await client.put("/api/samples/test/reads/reads_2.fq.gz", data=data)
 
-            assert await resp_is.conflict(resp_3, "Reads file is already associated with this sample")
+            assert await resp_is.conflict(resp_3, "Reads file name is already uploaded for this sample")
 
         assert resp.status == 201
         assert resp_2.status == 201

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -865,7 +865,7 @@ async def upload_reads(req):
     try:
         reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id, upload_id=upload)
     except exc.IntegrityError:
-        return conflict("Reads file is already associated with this sample")
+        return conflict("Reads file name is already uploaded for this sample")
 
     headers = {
         "Location": f"/api/samples/{sample_id}/reads/{reads['name_on_disk']}"

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, DateTime, Enum, Integer, String
-from sqlalchemy.sql.schema import ForeignKey
+from sqlalchemy.sql.schema import ForeignKey, UniqueConstraint
 
 from virtool.pg.utils import Base, SQLEnum
 
@@ -41,6 +41,7 @@ class SampleReads(Base):
 
     """
     __tablename__ = "sample_reads"
+    __table_args__ = (UniqueConstraint('sample', 'name'),)
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -41,7 +41,7 @@ class SampleReads(Base):
 
     """
     __tablename__ = "sample_reads"
-    __table_args__ = (UniqueConstraint('sample', 'name'),)
+    __table_args__ = (UniqueConstraint("sample", "name"),)
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)


### PR DESCRIPTION
* Add `UniqueConstraint` between `sample` and `name` in `SampleReads` model
* Catch resulting error in upload endpoint and return conflict response