### PR TITLE
Remove `files` field from samples

### DIFF
--- a/tests/indexes/snapshots/snap_test_api.py
+++ b/tests/indexes/snapshots/snap_test_api.py
@@ -254,25 +254,7 @@ snapshots['test_upload[uvloop-None] 1'] = {
     'type': 'bowtie2'
 }
 
-snapshots['test_upload[uvloop-404] 1'] = {
-    'id': 1,
-    'index': 'foo',
-    'name': 'reference.1.bt2',
-    'size': 7205747,
-    'type': 'bowtie2'
-}
-
 snapshots['test_upload[uvloop-None] 2'] = {
-    '_id': 'foo',
-    'reference': {
-        'id': 'bar'
-    },
-    'user': {
-        'id': 'test'
-    }
-}
-
-snapshots['test_upload[uvloop-404] 2'] = {
     '_id': 'foo',
     'reference': {
         'id': 'bar'

--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -686,13 +686,6 @@ snapshots['TestCreate.test[uvloop-none] 1'] = {
     'all_read': True,
     'all_write': True,
     'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'id': 1,
-            'name': 'test.fq.gz',
-            'size': 123456
-        }
-    ],
     'format': 'fastq',
     'group': 'none',
     'group_read': True,
@@ -732,13 +725,6 @@ snapshots['TestCreate.test[uvloop-none] 2'] = {
     'all_read': True,
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-        {
-            'id': 1,
-            'name': 'test.fq.gz',
-            'size': 123456
-        }
-    ],
     'format': 'fastq',
     'group': 'none',
     'group_read': True,
@@ -771,13 +757,6 @@ snapshots['TestCreate.test[uvloop-users_primary_group] 1'] = {
     'all_read': True,
     'all_write': True,
     'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'id': 1,
-            'name': 'test.fq.gz',
-            'size': 123456
-        }
-    ],
     'format': 'fastq',
     'group': 'technician',
     'group_read': True,
@@ -817,13 +796,6 @@ snapshots['TestCreate.test[uvloop-users_primary_group] 2'] = {
     'all_read': True,
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-        {
-            'id': 1,
-            'name': 'test.fq.gz',
-            'size': 123456
-        }
-    ],
     'format': 'fastq',
     'group': 'technician',
     'group_read': True,
@@ -856,13 +828,6 @@ snapshots['TestCreate.test[uvloop-force_choice] 1'] = {
     'all_read': True,
     'all_write': True,
     'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'id': 1,
-            'name': 'test.fq.gz',
-            'size': 123456
-        }
-    ],
     'format': 'fastq',
     'group': 'diagnostics',
     'group_read': True,
@@ -902,13 +867,6 @@ snapshots['TestCreate.test[uvloop-force_choice] 2'] = {
     'all_read': True,
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-        {
-            'id': 1,
-            'name': 'test.fq.gz',
-            'size': 123456
-        }
-    ],
     'format': 'fastq',
     'group': 'diagnostics',
     'group_read': True,

--- a/tests/samples/snapshots/snap_test_db.py
+++ b/tests/samples/snapshots/snap_test_db.py
@@ -147,8 +147,6 @@ snapshots['test_create_sample[uvloop] 1'] = {
     'all_read': True,
     'all_write': False,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': '',
     'group_read': True,

--- a/tests/samples/snapshots/snap_test_fake.py
+++ b/tests/samples/snapshots/snap_test_fake.py
@@ -12,8 +12,6 @@ snapshots['test_create_fake_unpaired[uvloop-False-True] 1'] = {
     'all_read': True,
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'blood',
     'group_read': True,
@@ -45,8 +43,6 @@ snapshots['test_create_fake_unpaired[uvloop-False-False] 1'] = {
     'all_read': True,
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'blood',
     'group_read': True,
@@ -80,8 +76,6 @@ snapshots['test_create_fake_samples[uvloop] 1'] = {
     'artifacts': [
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'blood',
     'group_read': True,
@@ -247,8 +241,6 @@ snapshots['test_create_fake_samples[uvloop] 2'] = {
     'artifacts': [
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'range',
     'group_read': True,
@@ -422,8 +414,6 @@ snapshots['test_create_fake_samples[uvloop] 3'] = {
     'all_read': True,
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'clearly',
     'group_read': True,
@@ -457,8 +447,6 @@ snapshots['test_create_fake_unpaired[uvloop-True-True] 1'] = {
     'artifacts': [
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'blood',
     'group_read': True,
@@ -624,8 +612,6 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
     'artifacts': [
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'files': [
-    ],
     'format': 'fastq',
     'group': 'blood',
     'group_read': True,

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -329,7 +329,7 @@ async def test_create_sample(dbi, mocker, snapshot, static_time, spawn_client):
 
     mocker.patch("virtool.db.utils.get_new_id", return_value="a2oj3gfd")
 
-    document = await virtool.samples.db.create_sample(dbi, "foo", "", "", "", "", "", [], [], "test", [], "bob", client.app["settings"])
+    document = await virtool.samples.db.create_sample(dbi, "foo", "", "", "", "", "", [], "test", [], "bob", client.app["settings"])
 
     snapshot.assert_match(document)
 

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -204,11 +204,11 @@ async def create_sample(
     locale: str,
     library_type: str,
     subtractions: List[str],
-    files: List[Dict[str, any]],
     notes: str,
     labels: List[int],
     user_id: str,
     settings: Dict[str, any],
+    paired=False,
     _id=None,
 ) -> Dict[str, any]:
     """
@@ -222,11 +222,12 @@ async def create_sample(
     :param locale: user-defined locale for the sample
     :param library_type: Type of library for a sample, defaults to None
     :param subtractions: IDs of default subtractions for the sample
-    :param files: list of upload IDs to associate with a sample
     :param notes: user-defined notes for the sample
     :param labels: IDs of labels associated with the sample
     :param user_id: the ID of the user that is creating the sample
     :param settings: the application settings
+    :param paired: Whether a sample is paired or not, defaults to False
+    :param _id: An id to assign to a sample instead of it being automatically generated
     :return: the newly inserted sample document
     """
     if _id is None:
@@ -249,7 +250,6 @@ async def create_sample(
         "group_write": settings.get("sample_group_write"),
         "all_read": settings.get("sample_all_read"),
         "all_write": settings.get("sample_all_write"),
-        "files": files,
         "labels": labels,
         "library_type": library_type,
         "subtractions": subtractions,
@@ -257,7 +257,7 @@ async def create_sample(
         "user": {"id": user_id},
         "group": group,
         "locale": locale,
-        "paired": len(files) == 2,
+        "paired": paired,
     }
 
     await db.samples.insert_one(document)

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -100,7 +100,6 @@ async def create_fake_sample(app: App, paired=False, finalized=False) -> dict:
         isolate="Isolate A1",
         locale="",
         subtractions=subtraction_ids,
-        files=[],
         notes=fake.text(50),
         library_type="normal",
         labels=[],


### PR DESCRIPTION
* Stop writing field in creation endpoint
* Change `create_sample` params and docstrings, refactor where used
* Update snapshots