### PR TITLE
Add JSON serializer to postgres instance

### DIFF
--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
+from virtool.api.json import pretty_dumps
 from virtool.pg.base import Base
 
 logger = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ async def connect(postgres_connection_string: str) -> AsyncEngine:
         sys.exit(1)
 
     try:
-        pg = create_async_engine(postgres_connection_string)
+        pg = create_async_engine(postgres_connection_string, json_serializer=pretty_dumps)
 
         await check_version(pg)
         await create_models(pg)

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -1410,7 +1410,7 @@ async def create_remote(db, settings: dict, release: dict, remote_from: str, use
 
 
 async def download_and_parse_release(app, url: str, task_id: str, progress_handler: callable):
-    pg = app["postgres"]
+    pg = app["pg"]
 
     with virtool.utils.get_temp_dir() as tempdir:
         temp_path = str(tempdir)


### PR DESCRIPTION
* Add a `dumps` callable to use for SQL columns that use `JSON` or `JSONB` types. This callable uses an encoder that properly converts `datetime` objects.