### PR TITLE
Setup Sentry performance monitoring

### DIFF
--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -16,5 +16,6 @@ def setup(server_version):
     sentry_sdk.init(
         dsn=DSN,
         integrations=[sentry_sdk.integrations.aiohttp.AioHttpIntegration(), sentry_logging],
-        release=server_version
+        release=server_version,
+        traces_sample_rate=0.2
     )


### PR DESCRIPTION
* Set `traces_sample_rate` to 0.2 to sample 20% of transactions