### PR TITLE
Allow subtraction creation from developer dialog

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Virtool CI
+name: ci
 
 on:
   push:
@@ -33,12 +33,18 @@ jobs:
       image: virtool/external-tools:0.2.0
 
     steps:
-      - uses: actions/checkout@v2
-      - name: test
+      - name: Install LFS
+        run: |
+          apt-get update
+          apt-get install -y git-lfs
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: 'true'
+      - name: Test
         run: |
           pip install -qr requirements.txt
           pytest  -x --db-connection-string mongodb://mongo:27017 --redis-connection-string redis://redis:6379 --postgres-connection-string postgresql+asyncpg://virtool:virtool@postgres --cov --cov-report xml
-
       - name: Run codacy-coverage-reporter
         if: ${{ github.event_name == 'push' }}
         uses: codacy/codacy-coverage-reporter-action@master
@@ -50,11 +56,13 @@ jobs:
   client:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
         with:
           node-version: '14'
-      - name: test
+      - name: Test
         run: |
           cd client
           npm i
@@ -65,8 +73,9 @@ jobs:
     container:
       image: node:14-stretch
     steps:
-      - uses: actions/checkout@v2
-      - name: client
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test
         run: |
           cd client
           npm i

--- a/client/src/js/dev/components/Dialog.js
+++ b/client/src/js/dev/components/Dialog.js
@@ -40,6 +40,17 @@ export const DeveloperDialog = ({ show, onCommand, onHide }) => (
                 </Button>
             </DeveloperCommandControl>
         </DeveloperCommand>
+        <DeveloperCommand>
+            <DeveloperCommandLabel>
+                <h3>Create Subtraction</h3>
+                <p>Creates a subtraction that is ready for use.</p>
+            </DeveloperCommandLabel>
+            <DeveloperCommandControl>
+                <Button color="red" onClick={() => onCommand("create_subtraction")}>
+                    Create Subtraction
+                </Button>
+            </DeveloperCommandControl>
+        </DeveloperCommand>
     </Modal>
 );
 

--- a/tests/dev/test_fake.py
+++ b/tests/dev/test_fake.py
@@ -1,18 +1,13 @@
 from os.path import isdir
 
 from virtool.dev.fake import create_fake_analysis, create_fake_data_path, create_fake_jobs, \
-    create_fake_references, create_fake_user
+    create_fake_references
 
 
 def test_create_fake_data_path():
     path = create_fake_data_path()
     assert "virtool_fake_" in path
     assert isdir(path)
-
-
-async def test_create_fake_user(snapshot, app, dbi, static_time):
-    await create_fake_user(app)
-    snapshot.assert_match(await dbi.users.find_one({}, {"password": False}))
 
 
 async def test_create_fake_analysis(snapshot, app, dbi, static_time):

--- a/tests/subtractions/snapshots/snap_test_fake.py
+++ b/tests/subtractions/snapshots/snap_test_fake.py
@@ -15,6 +15,12 @@ snapshots['test_create_fake_subtractions[uvloop] 1'] = [
             'id': 1,
             'name': 'test.fa.gz'
         },
+        'gc': {
+            'a': 0.25,
+            'c': 0.25,
+            'g': 0.25,
+            't': 0.25
+        },
         'is_host': True,
         'name': 'subtraction_1',
         'nickname': '',

--- a/tests/users/snapshots/snap_test_fake.py
+++ b/tests/users/snapshots/snap_test_fake.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import GenericRepr, Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_create_fake_bob_user[uvloop] 1'] = {
+    '_id': 'bob',
+    'administrator': True,
+    'force_reset': False,
+    'groups': [
+    ],
+    'identicon': '81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9',
+    'invalidate_sessions': True,
+    'last_password_change': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'permissions': {
+        'cancel_job': False,
+        'create_ref': False,
+        'create_sample': False,
+        'modify_hmm': False,
+        'modify_subtraction': False,
+        'remove_file': False,
+        'remove_job': False,
+        'upload_file': False
+    },
+    'primary_group': '',
+    'settings': {
+        'quick_analyze_workflow': 'pathoscope_bowtie',
+        'show_ids': True,
+        'show_versions': True,
+        'skip_quick_analyze_dialog': True
+    }
+}

--- a/tests/users/test_fake.py
+++ b/tests/users/test_fake.py
@@ -1,0 +1,6 @@
+from virtool.users.fake import create_fake_bob_user
+
+
+async def test_create_fake_bob_user(snapshot, app, dbi, static_time):
+    await create_fake_bob_user(app)
+    snapshot.assert_match(await dbi.users.find_one({}, {"password": False}))

--- a/virtool/dev/api.py
+++ b/virtool/dev/api.py
@@ -1,17 +1,22 @@
 from logging import getLogger
 
 from virtool.api.response import no_content
+from virtool.fake.wrapper import FakerWrapper
 from virtool.http.routes import Routes
+from virtool.subtractions.fake import create_fake_fasta_upload, create_fake_finalized_subtraction
+from virtool.utils import random_alphanumeric
 
 logger = getLogger(__name__)
 
 routes = Routes()
 
+faker = FakerWrapper()
+
 
 @routes.post("/api/dev")
 async def dev(req):
     data = await req.json()
-
+    user_id = req["client"].user_id
     command = data.get("command")
 
     if command == "clear_users":
@@ -20,5 +25,19 @@ async def dev(req):
         await req.app["db"].keys.delete_many({})
 
         logger.debug("Cleared users")
+
+    if command == "create_subtraction":
+        upload_id, upload_name = await create_fake_fasta_upload(
+            req.app,
+            req["client"].user_id
+        )
+
+        await create_fake_finalized_subtraction(
+            req.app,
+            upload_id,
+            upload_name,
+            random_alphanumeric(8),
+            user_id
+        )
 
     return no_content()

--- a/virtool/dev/fake.py
+++ b/virtool/dev/fake.py
@@ -16,12 +16,14 @@ import virtool.references.db
 import virtool.subtractions.db
 import virtool.users.db
 import virtool.utils
+from virtool.fake.identifiers import USER_ID
 from virtool.hmm.fake import create_fake_hmms
 from virtool.indexes.fake import create_fake_indexes
 from virtool.jobs.utils import JobRights
 from virtool.otus.fake import create_fake_otus
 from virtool.subtractions.fake import create_fake_subtractions
 from virtool.types import App
+from virtool.users.fake import create_fake_bob_user
 from virtool.utils import ensure_data_dir, random_alphanumeric
 
 logger = getLogger(__name__)
@@ -31,7 +33,7 @@ REF_ID = "reference_1"
 
 async def populate(app: App):
     await create_fake_bob_user(app)
-    await create_fake_subtractions(app, USER_ID)
+    await create_fake_subtractions(app)
     await create_fake_analysis(app)
     await create_fake_jobs(app)
     await create_fake_hmms(app)

--- a/virtool/dev/fake.py
+++ b/virtool/dev/fake.py
@@ -27,11 +27,10 @@ from virtool.utils import ensure_data_dir, random_alphanumeric
 logger = getLogger(__name__)
 
 REF_ID = "reference_1"
-USER_ID = "bob"
 
 
 async def populate(app: App):
-    await create_fake_user(app)
+    await create_fake_bob_user(app)
     await create_fake_subtractions(app, USER_ID)
     await create_fake_analysis(app)
     await create_fake_jobs(app)
@@ -81,18 +80,6 @@ def create_fake_data_path() -> str:
     data_path = str(mkdtemp(prefix=f"virtool_fake_{random_alphanumeric()}_"))
     ensure_data_dir(data_path)
     return data_path
-
-
-async def create_fake_user(app: App):
-    """
-    Create a fake user called Bob.
-
-    :param app: the application object
-
-    """
-    await virtool.users.db.create(app["db"], USER_ID, "hello_world", True)
-    await virtool.users.db.edit(app["db"], "bob", administrator=True, force_reset=False)
-    logger.debug("Created fake user")
 
 
 async def create_fake_analysis(app: App):

--- a/virtool/subtractions/fake.py
+++ b/virtool/subtractions/fake.py
@@ -1,10 +1,14 @@
 from logging import getLogger
 from pathlib import Path
 from shutil import copytree
+from typing import Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import virtool.subtractions.db
+from virtool.fake.identifiers import USER_ID
+from virtool.fake.wrapper import FakerWrapper
+from virtool.subtractions.db import finalize
 from virtool.subtractions.files import create_subtraction_files
 from virtool.subtractions.utils import FILES
 from virtool.types import App
@@ -13,7 +17,7 @@ from virtool.uploads.models import Upload
 logger = getLogger(__name__)
 
 
-async def create_fake_subtractions(app: App, user_id: str):
+async def create_fake_subtractions(app: App):
     """
     Create fake subtractions and their associated uploads and subtraction files.
 
@@ -24,18 +28,43 @@ async def create_fake_subtractions(app: App, user_id: str):
 
     """
     db = app["db"]
-    fake = app["fake"]
-    pg = app["pg"]
+    fake: FakerWrapper = app["fake"]
 
-    subtractions_path = Path(app["settings"]["data_path"]) / "subtractions"
-    example_path = (
-        Path(__file__).parent.parent.parent
-        / "example/subtractions/arabidopsis_thaliana"
+    upload_id, upload_name = await create_fake_fasta_upload(app, USER_ID)
+
+    await create_fake_finalized_subtraction(
+        app,
+        upload_id,
+        upload_name,
+        fake.get_mongo_id(),
+        USER_ID
     )
 
-    copytree(example_path, subtractions_path / "subtraction_1", dirs_exist_ok=True)
+    await virtool.subtractions.db.create(
+        db,
+        USER_ID,
+        upload_name,
+        "subtraction_2",
+        "",
+        upload_id,
+        fake.get_mongo_id()
+    )
 
-    async with AsyncSession(pg) as session:
+    await virtool.subtractions.db.create(
+        db,
+        USER_ID,
+        upload_name,
+        "subtraction_unready",
+        "",
+        upload_id,
+        fake.get_mongo_id(),
+    )
+
+    logger.debug("Created fake subtractions")
+
+
+async def create_fake_fasta_upload(app: App, user_id: str) -> Tuple[int, str]:
+    async with AsyncSession(app["pg"]) as session:
         upload = Upload(name="test.fa.gz", type="subtraction", user=user_id)
 
         session.add(upload)
@@ -46,35 +75,53 @@ async def create_fake_subtractions(app: App, user_id: str):
 
         await session.commit()
 
-    subtraction_1 = await db.subtraction.insert_one(
-        {
-            "_id": fake.get_mongo_id(),
-            "name": "subtraction_1",
-            "nickname": "",
-            "deleted": False,
-            "is_host": True,
-            "ready": True,
-            "file": {"id": upload_id, "name": upload_name},
-            "user": {"id": user_id},
-        }
+    return upload_id, upload_name
+
+
+async def create_fake_finalized_subtraction(
+        app: App,
+        upload_id: int,
+        upload_name: str,
+        subtraction_id: str,
+        user_id: str
+):
+    db = app["db"]
+    pg = app["pg"]
+
+    document = await db.subtraction.insert_one({
+        "_id": subtraction_id,
+        "name": "subtraction_1",
+        "nickname": "",
+        "deleted": False,
+        "is_host": True,
+        "ready": True,
+        "file": {"id": upload_id, "name": upload_name},
+        "user": {"id": user_id},
+    })
+
+    subtractions_path = Path(app["settings"]["data_path"]) / "subtractions"
+
+    example_path = (
+            Path(__file__).parent.parent.parent / "example/subtractions/arabidopsis_thaliana"
     )
 
-    await virtool.subtractions.db.create(
-        db, user_id, upload_name, "subtraction_2", "", upload_id, fake.get_mongo_id()
-    )
-
-    await virtool.subtractions.db.create(
-        db,
-        user_id,
-        upload_name,
-        "subtraction_unready",
-        "",
-        upload_id,
-        fake.get_mongo_id(),
-    )
+    copytree(example_path, subtractions_path / subtraction_id, dirs_exist_ok=True)
 
     await create_subtraction_files(
-        pg, subtraction_1["_id"], FILES, subtractions_path / "subtraction_1"
+        pg,
+        document["_id"],
+        FILES,
+        subtractions_path / subtraction_id
     )
 
-    logger.debug("Created fake subtractions")
+    await finalize(
+        db,
+        pg,
+        subtraction_id,
+        {
+            "a": 0.25,
+            "t": 0.25,
+            "g": 0.25,
+            "c": 0.25
+        }
+    )

--- a/virtool/users/fake.py
+++ b/virtool/users/fake.py
@@ -1,0 +1,19 @@
+from logging import getLogger
+
+import virtool.users.db
+from virtool.fake.identifiers import USER_ID
+from virtool.types import App
+
+logger = getLogger(__name__)
+
+
+async def create_fake_bob_user(app: App):
+    """
+    Create a fake user called Bob.
+
+    :param app: the application object
+
+    """
+    await virtool.users.db.create(app["db"], USER_ID, "hello_world", True)
+    await virtool.users.db.edit(app["db"], "bob", administrator=True, force_reset=False)
+    logger.debug("Created fake user")


### PR DESCRIPTION
* Break up `create_fake_subtractions()` so parts can be reused for on-demand subtraction faking
* Fix issue where subtraction names were used instead of IDs for subtraction paths
* Allow creation of fake subtractions at `/api/dev` and add button in frontend to trigger
* Move fake user to `virtool.user.fake` from `virtool.dev.fake`