### PR TITLE
Create unique constraints for sample artifacts

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -294,7 +294,7 @@ async def test_upload_file(error, files, resp_is, spawn_job_client, static_time,
 
         assert os.listdir(tmp_path / "analyses") == ["1-reference.fa"]
 
-        assert await virtool.pg.utils.get_row(pg, 1, AnalysisFile)
+        assert await virtool.pg.utils.get_row_by_id(pg, AnalysisFile, 1)
 
     elif error == 400:
         assert await resp_is.bad_request(resp, "Unsupported analysis file format")

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -17,7 +17,7 @@ from virtool.indexes.db import FILES
 from virtool.indexes.models import IndexFile
 from virtool.indexes.utils import check_index_file_type
 
-OTUS_JSON_PATH = Path(sys.path[0]) / "tests/test_files/index/otus.json.gz"
+OTUS_JSON_PATH = Path.cwd() / "tests/test_files/index/otus.json.gz"
 
 
 async def test_find(mocker, snapshot, spawn_client, static_time):
@@ -519,7 +519,7 @@ async def test_delete_index(spawn_job_client, error):
 @pytest.mark.parametrize("error", [None, "409", "404_index", "404_file"])
 async def test_upload(error, tmp_path, spawn_job_client, snapshot, resp_is, pg_session):
     client = await spawn_job_client(authorize=True)
-    path = Path(sys.path[0]) / "tests" / "test_files" / "index" / "reference.1.bt2"
+    path = Path.cwd() / "tests" / "test_files" / "index" / "reference.1.bt2"
 
     files = {
         "file": open(path, "rb")

--- a/tests/pg/snapshots/snap_test_utils.py
+++ b/tests/pg/snapshots/snap_test_utils.py
@@ -7,10 +7,12 @@ from snapshottest import GenericRepr, Snapshot
 
 snapshots = Snapshot()
 
+snapshots['test_get_row[uvloop] 1'] = GenericRepr('<IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=1234567)>')
+
+snapshots['test_get_row_by_id[uvloop] 1'] = GenericRepr('<IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=1234567)>')
+
 snapshots['test_get_rows[uvloop] 1'] = [
     GenericRepr('<IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=1234567)>'),
     GenericRepr('<IndexFile(id=2, name=reference.2.bt2, index=foo, type=bowtie2, size=1234567)>'),
     GenericRepr('<IndexFile(id=3, name=reference.3.bt2, index=foo, type=bowtie2, size=1234567)>')
 ]
-
-snapshots['test_get_row[uvloop] 1'] = GenericRepr('<IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=1234567)>')

--- a/tests/pg/snapshots/snap_test_utils.py
+++ b/tests/pg/snapshots/snap_test_utils.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import GenericRepr, Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_get_rows[uvloop] 1'] = [
+    GenericRepr('<IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=1234567)>'),
+    GenericRepr('<IndexFile(id=2, name=reference.2.bt2, index=foo, type=bowtie2, size=1234567)>'),
+    GenericRepr('<IndexFile(id=3, name=reference.3.bt2, index=foo, type=bowtie2, size=1234567)>')
+]
+
+snapshots['test_get_row[uvloop] 1'] = GenericRepr('<IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=1234567)>')

--- a/tests/pg/test_utils.py
+++ b/tests/pg/test_utils.py
@@ -25,7 +25,18 @@ async def test_delete_row(pg, pg_session):
     assert result is None
 
 
-async def test_get_rows(pg, pg_session):
+async def test_get_row(snapshot, pg, pg_session):
+    index_1 = IndexFile(id=1, name="reference.1.bt2", index="foo", type="bowtie2", size=1234567)
+
+    async with pg_session as session:
+        session.add(index_1)
+        await session.commit()
+
+    result = await virtool.pg.utils.get_row(pg, IndexFile, "index", "foo")
+
+    snapshot.assert_match(result)
+
+async def test_get_rows(snapshot, pg, pg_session):
     index_1 = IndexFile(id=1, name="reference.1.bt2", index="foo", type="bowtie2", size=1234567)
     index_2 = IndexFile(id=2, name="reference.2.bt2", index="foo", type="bowtie2", size=1234567)
     index_3 = IndexFile(id=3, name="reference.3.bt2", index="foo", type="bowtie2", size=1234567)
@@ -36,4 +47,4 @@ async def test_get_rows(pg, pg_session):
 
     results = await virtool.pg.utils.get_rows(pg, IndexFile, "index", "foo")
 
-    assert len(results.all()) == 3
+    snapshot.assert_match(results.all())

--- a/tests/pg/test_utils.py
+++ b/tests/pg/test_utils.py
@@ -25,6 +25,18 @@ async def test_delete_row(pg, pg_session):
     assert result is None
 
 
+async def test_get_row_by_id(snapshot, pg, pg_session):
+    index_1 = IndexFile(id=1, name="reference.1.bt2", index="foo", type="bowtie2", size=1234567)
+
+    async with pg_session as session:
+        session.add(index_1)
+        await session.commit()
+
+    result = await virtool.pg.utils.get_row_by_id(pg, IndexFile, 1)
+
+    snapshot.assert_match(result)
+
+
 async def test_get_row(snapshot, pg, pg_session):
     index_1 = IndexFile(id=1, name="reference.1.bt2", index="foo", type="bowtie2", size=1234567)
 
@@ -32,9 +44,10 @@ async def test_get_row(snapshot, pg, pg_session):
         session.add(index_1)
         await session.commit()
 
-    result = await virtool.pg.utils.get_row(pg, IndexFile, "index", "foo")
+    result = await virtool.pg.utils.get_row(pg, IndexFile, ("foo", "index"))
 
     snapshot.assert_match(result)
+
 
 async def test_get_rows(snapshot, pg, pg_session):
     index_1 = IndexFile(id=1, name="reference.1.bt2", index="foo", type="bowtie2", size=1234567)

--- a/tests/pg/test_utils.py
+++ b/tests/pg/test_utils.py
@@ -20,7 +20,7 @@ async def test_delete_row(pg, pg_session):
     await virtool.pg.utils.delete_row(pg, 1, IndexFile)
 
     async with pg_session as session:
-        result = (await session.execute(select(IndexFile).filter_by(id=1))).scalar()
+        result = await virtool.pg.utils.get_row_by_id(pg, IndexFile, 1)
 
     assert result is None
 

--- a/tests/pg/test_utils.py
+++ b/tests/pg/test_utils.py
@@ -44,7 +44,7 @@ async def test_get_row(snapshot, pg, pg_session):
         session.add(index_1)
         await session.commit()
 
-    result = await virtool.pg.utils.get_row(pg, IndexFile, ("foo", "index"))
+    result = await virtool.pg.utils.get_row(pg, IndexFile, ("index", "foo"))
 
     snapshot.assert_match(result)
 

--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -938,16 +938,6 @@ snapshots['TestEdit.test_name_exists[uvloop-False] 1'] = {
     'name': 'Bar'
 }
 
-snapshots['test_upload_artifacts[uvloop-fastq] 1'] = {
-    'id': 1,
-    'name': 'small.fq',
-    'name_on_disk': '1-small.fq',
-    'sample': 'test',
-    'size': 3130756,
-    'type': 'fastq',
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
 snapshots['TestUploadReads.test_upload_reads[uvloop-True] 1'] = {
     'id': 1,
     'name': 'reads_1.fq.gz',
@@ -955,16 +945,6 @@ snapshots['TestUploadReads.test_upload_reads[uvloop-True] 1'] = {
     'sample': 'test',
     'size': 9081,
     'upload': 1,
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
-snapshots['test_upload_artifact_cache[uvloop-fastq] 1'] = {
-    'id': 1,
-    'name': 'small.fq',
-    'name_on_disk': '1-small.fq',
-    'sample': 'test',
-    'size': 3130756,
-    'type': 'fastq',
     'uploaded_at': '2015-10-06T20:00:00Z'
 }
 
@@ -1208,4 +1188,24 @@ snapshots['test_find[uvloop-None-None-None-label_filter10-None-None] 1'] = {
     'page_count': 1,
     'per_page': 25,
     'total_count': 3
+}
+
+snapshots['test_upload_artifact_cache[uvloop-None] 1'] = {
+    'id': 1,
+    'name': 'small.fq',
+    'name_on_disk': '1-small.fq',
+    'sample': 'test',
+    'size': 3130756,
+    'type': 'fastq',
+    'uploaded_at': '2015-10-06T20:00:00Z'
+}
+
+snapshots['test_upload_artifacts[uvloop-None] 1'] = {
+    'id': 1,
+    'name': 'small.fq',
+    'name_on_disk': '1-small.fq',
+    'sample': 'test',
+    'size': 3130756,
+    'type': 'fastq',
+    'uploaded_at': '2015-10-06T20:00:00Z'
 }

--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -7,146 +7,6 @@ from snapshottest import GenericRepr, Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_get[uvloop-True-None] 1'] = {
-    'artifacts': [
-        {
-            'download_url': '/api/samples/test/artifacts/1-reference.fa.gz',
-            'id': 1,
-            'name': 'reference.fa.gz',
-            'name_on_disk': '1-reference.fa.gz',
-            'sample': 'test',
-            'size': None,
-            'type': 'fasta',
-            'uploaded_at': None
-        }
-    ],
-    'caches': [
-    ],
-    'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'download_url': '/download/samples/files/file_1.fq.gz',
-            'id': 'foo',
-            'name': 'Bar.fq.gz'
-        }
-    ],
-    'id': 'test',
-    'labels': [
-        {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug'
-        }
-    ],
-    'name': 'Test',
-    'reads': [
-        {
-            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
-            'id': 1,
-            'name': 'reads_1.fq.gz',
-            'name_on_disk': 'reads_1.fq.gz',
-            'sample': 'test',
-            'size': None,
-            'upload': {
-                'created_at': None,
-                'id': 1,
-                'name': 'test',
-                'name_on_disk': None,
-                'ready': False,
-                'removed': False,
-                'removed_at': None,
-                'reserved': False,
-                'size': None,
-                'type': None,
-                'uploaded_at': None,
-                'user': None
-            },
-            'uploaded_at': None
-        }
-    ],
-    'ready': True,
-    'subtractions': [
-        {
-            'id': 'foo',
-            'name': 'Foo'
-        },
-        {
-            'id': 'bar',
-            'name': 'Bar'
-        }
-    ]
-}
-
-snapshots['test_get[uvloop-False-None] 1'] = {
-    'artifacts': [
-        {
-            'id': 1,
-            'name': 'reference.fa.gz',
-            'name_on_disk': '1-reference.fa.gz',
-            'sample': 'test',
-            'size': None,
-            'type': 'fasta',
-            'uploaded_at': None
-        }
-    ],
-    'caches': [
-    ],
-    'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'download_url': '/download/samples/files/file_1.fq.gz',
-            'id': 'foo',
-            'name': 'Bar.fq.gz'
-        }
-    ],
-    'id': 'test',
-    'labels': [
-        {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug'
-        }
-    ],
-    'name': 'Test',
-    'reads': [
-        {
-            'id': 1,
-            'name': 'reads_1.fq.gz',
-            'name_on_disk': 'reads_1.fq.gz',
-            'sample': 'test',
-            'size': None,
-            'upload': {
-                'created_at': None,
-                'id': 1,
-                'name': 'test',
-                'name_on_disk': None,
-                'ready': False,
-                'removed': False,
-                'removed_at': None,
-                'reserved': False,
-                'size': None,
-                'type': None,
-                'uploaded_at': None,
-                'user': None
-            },
-            'uploaded_at': None
-        }
-    ],
-    'ready': False,
-    'subtractions': [
-        {
-            'id': 'foo',
-            'name': 'Foo'
-        },
-        {
-            'id': 'bar',
-            'name': 'Bar'
-        }
-    ]
-}
-
 snapshots['test_find_analyses[uvloop-None-None] 1'] = {
     'documents': [
         {
@@ -622,37 +482,6 @@ snapshots['test_find[uvloop-fred-None-None-None-d_range6-meta6] 1'] = {
     'page_count': 1,
     'per_page': 25,
     'total_count': 3
-}
-
-snapshots['test_finalize[uvloop-quality] 1'] = {
-    'artifacts': [
-        {
-            'download_url': '/api/samples/test/artifacts/1-reference.fa.gz',
-            'id': 1,
-            'name': 'reference.fa.gz',
-            'name_on_disk': '1-reference.fa.gz',
-            'sample': 'test',
-            'size': None,
-            'type': 'fasta',
-            'uploaded_at': None
-        }
-    ],
-    'id': 'test',
-    'quality': {
-    },
-    'reads': [
-        {
-            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
-            'id': 1,
-            'name': 'reads_1.fq.gz',
-            'name_on_disk': 'reads_1.fq.gz',
-            'sample': 'test',
-            'size': None,
-            'upload': None,
-            'uploaded_at': None
-        }
-    ],
-    'ready': True
 }
 
 snapshots['test_get_cache[uvloop-None] 1'] = {
@@ -1190,20 +1019,191 @@ snapshots['test_find[uvloop-None-None-None-label_filter10-None-None] 1'] = {
     'total_count': 3
 }
 
-snapshots['test_upload_artifact_cache[uvloop-None] 1'] = {
+snapshots['test_get[uvloop-True-None] 1'] = {
+    'artifacts': [
+        {
+            'download_url': '/api/samples/test/artifacts/reference.fa.gz',
+            'id': 1,
+            'name': 'reference.fa.gz',
+            'name_on_disk': 'reference.fa.gz',
+            'sample': 'test',
+            'size': None,
+            'type': 'fasta',
+            'uploaded_at': None
+        }
+    ],
+    'caches': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'files': [
+        {
+            'download_url': '/download/samples/files/file_1.fq.gz',
+            'id': 'foo',
+            'name': 'Bar.fq.gz'
+        }
+    ],
+    'id': 'test',
+    'labels': [
+        {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug'
+        }
+    ],
+    'name': 'Test',
+    'reads': [
+        {
+            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
+            'id': 1,
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
+            'sample': 'test',
+            'size': None,
+            'upload': {
+                'created_at': None,
+                'id': 1,
+                'name': 'test',
+                'name_on_disk': None,
+                'ready': False,
+                'removed': False,
+                'removed_at': None,
+                'reserved': False,
+                'size': None,
+                'type': None,
+                'uploaded_at': None,
+                'user': None
+            },
+            'uploaded_at': None
+        }
+    ],
+    'ready': True,
+    'subtractions': [
+        {
+            'id': 'foo',
+            'name': 'Foo'
+        },
+        {
+            'id': 'bar',
+            'name': 'Bar'
+        }
+    ]
+}
+
+snapshots['test_get[uvloop-False-None] 1'] = {
+    'artifacts': [
+        {
+            'id': 1,
+            'name': 'reference.fa.gz',
+            'name_on_disk': 'reference.fa.gz',
+            'sample': 'test',
+            'size': None,
+            'type': 'fasta',
+            'uploaded_at': None
+        }
+    ],
+    'caches': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'files': [
+        {
+            'download_url': '/download/samples/files/file_1.fq.gz',
+            'id': 'foo',
+            'name': 'Bar.fq.gz'
+        }
+    ],
+    'id': 'test',
+    'labels': [
+        {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug'
+        }
+    ],
+    'name': 'Test',
+    'reads': [
+        {
+            'id': 1,
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
+            'sample': 'test',
+            'size': None,
+            'upload': {
+                'created_at': None,
+                'id': 1,
+                'name': 'test',
+                'name_on_disk': None,
+                'ready': False,
+                'removed': False,
+                'removed_at': None,
+                'reserved': False,
+                'size': None,
+                'type': None,
+                'uploaded_at': None,
+                'user': None
+            },
+            'uploaded_at': None
+        }
+    ],
+    'ready': False,
+    'subtractions': [
+        {
+            'id': 'foo',
+            'name': 'Foo'
+        },
+        {
+            'id': 'bar',
+            'name': 'Bar'
+        }
+    ]
+}
+
+snapshots['test_finalize[uvloop-quality] 1'] = {
+    'artifacts': [
+        {
+            'download_url': '/api/samples/test/artifacts/reference.fa.gz',
+            'id': 1,
+            'name': 'reference.fa.gz',
+            'name_on_disk': 'reference.fa.gz',
+            'sample': 'test',
+            'size': None,
+            'type': 'fasta',
+            'uploaded_at': None
+        }
+    ],
+    'id': 'test',
+    'quality': {
+    },
+    'reads': [
+        {
+            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
+            'id': 1,
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
+            'sample': 'test',
+            'size': None,
+            'upload': None,
+            'uploaded_at': None
+        }
+    ],
+    'ready': True
+}
+
+snapshots['test_upload_artifacts[uvloop-None] 1'] = {
     'id': 1,
     'name': 'small.fq',
-    'name_on_disk': '1-small.fq',
+    'name_on_disk': 'small.fq',
     'sample': 'test',
     'size': 3130756,
     'type': 'fastq',
     'uploaded_at': '2015-10-06T20:00:00Z'
 }
 
-snapshots['test_upload_artifacts[uvloop-None] 1'] = {
+snapshots['test_upload_artifact_cache[uvloop-None] 1'] = {
     'id': 1,
     'name': 'small.fq',
-    'name_on_disk': '1-small.fq',
+    'name_on_disk': 'small.fq',
     'sample': 'test',
     'size': 3130756,
     'type': 'fastq',

--- a/tests/samples/snapshots/snap_test_tasks.py
+++ b/tests/samples/snapshots/snap_test_tasks.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_move_sample_files_task[uvloop-True-True-True] 1'] = {
+    '_id': 'foo',
+    'is_compressed': True,
+    'is_legacy': True
+}
+
+snapshots['test_move_sample_files_task[uvloop-True-True-False] 1'] = {
+    '_id': 'foo',
+    'is_compressed': True,
+    'is_legacy': False
+}
+
+snapshots['test_move_sample_files_task[uvloop-True-False-True] 1'] = {
+    '_id': 'foo',
+    'files': [
+        {
+            'download_url': '/download/samples/oictwh/reads_1.fq.gz',
+            'from': {
+                'id': 'vorbsrmz-17TFP120_S21_R1_001.fastq.gz',
+                'name': 'vorbsrmz-17TFP120_S21_R1_001.fastq.gz',
+                'size': 239801249712,
+                'uploaded_at': None
+            },
+            'name': 'reads_1.fq.gz',
+            'raw': True,
+            'size': 213889231
+        },
+        {
+            'download_url': '/download/samples/oictwh/reads_2.fq.gz',
+            'from': {
+                'id': 'vorbsrmz-17TFP120_S21_R1_002.fastq.gz',
+                'name': 'vorbsrmz-17TFP120_S21_R1_002.fastq.gz',
+                'size': 239801249712,
+                'uploaded_at': None
+            },
+            'name': 'reads_2.fq.gz',
+            'raw': True,
+            'size': 213889231
+        }
+    ],
+    'is_compressed': False,
+    'is_legacy': True
+}
+
+snapshots['test_move_sample_files_task[uvloop-True-False-False] 1'] = {
+    '_id': 'foo',
+    'is_compressed': False,
+    'is_legacy': False
+}
+
+snapshots['test_move_sample_files_task[uvloop-False-True-True] 1'] = {
+    '_id': 'foo',
+    'is_compressed': True,
+    'is_legacy': True
+}
+
+snapshots['test_move_sample_files_task[uvloop-False-True-False] 1'] = {
+    '_id': 'foo',
+    'is_compressed': True,
+    'is_legacy': False
+}
+
+snapshots['test_move_sample_files_task[uvloop-False-False-True] 1'] = {
+    '_id': 'foo',
+    'files': [
+        {
+            'download_url': '/download/samples/oictwh/reads_1.fq.gz',
+            'from': {
+                'id': 'vorbsrmz-17TFP120_S21_R1_001.fastq.gz',
+                'name': 'vorbsrmz-17TFP120_S21_R1_001.fastq.gz',
+                'size': 239801249712,
+                'uploaded_at': None
+            },
+            'name': 'reads_1.fq.gz',
+            'raw': True,
+            'size': 213889231
+        }
+    ],
+    'is_compressed': False,
+    'is_legacy': True
+}
+
+snapshots['test_move_sample_files_task[uvloop-False-False-False] 1'] = {
+    '_id': 'foo',
+    'is_compressed': False,
+    'is_legacy': False
+}

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -221,7 +221,7 @@ async def test_get(error, ready, mocker, snapshot, spawn_client, resp_is, static
         })
 
         label_1 = Label(id=1, name="Bug", color="#a83432", description="This is a bug")
-        artifact = SampleArtifact(name="reference.fa.gz", sample="test", type="fasta", name_on_disk="1-reference.fa.gz")
+        artifact = SampleArtifact(name="reference.fa.gz", sample="test", type="fasta", name_on_disk="reference.fa.gz")
         reads = SampleReads(name="reads_1.fq.gz", name_on_disk="reads_1.fq.gz", sample="test")
         upload = Upload(name="test")
         async with pg_session as session:
@@ -650,7 +650,7 @@ async def test_finalize(field, snapshot, spawn_job_client, resp_is, pg, pg_sessi
 
     async with pg_session as session:
         upload = Upload(name="test", name_on_disk="test.fq.gz")
-        artifact = SampleArtifact(name="reference.fa.gz", sample="test", type="fasta", name_on_disk="1-reference.fa.gz")
+        artifact = SampleArtifact(name="reference.fa.gz", sample="test", type="fasta", name_on_disk="reference.fa.gz")
         reads = SampleReads(name="reads_1.fq.gz", name_on_disk="reads_1.fq.gz", sample="test")
 
         upload.reads.append(reads)
@@ -1052,7 +1052,7 @@ async def test_upload_artifacts(
     if not error:
         assert resp.status == 201
         snapshot.assert_match(await resp.json())
-        assert os.listdir(sample_file_path) == ["1-small.fq"]
+        assert os.listdir(sample_file_path) == ["small.fq"]
     elif error == 400:
         assert await resp_is.bad_request(resp, "Unsupported sample artifact type")
 
@@ -1209,7 +1209,7 @@ async def test_download_artifact(error, tmp_path, spawn_job_client, pg):
     if error != "404_file":
         path = (tmp_path / "samples" / "foo")
         path.mkdir(parents=True)
-        path.joinpath("1-fastqc.txt").write_text("test")
+        path.joinpath("fastqc.txt").write_text("test")
 
     if error != "404_sample":
         await client.db.samples.insert_one({
@@ -1221,7 +1221,6 @@ async def test_download_artifact(error, tmp_path, spawn_job_client, pg):
             id=1,
             sample="foo",
             name="fastqc.txt",
-            name_on_disk="1-fastqc.txt",
             type="fastq"
         )
 
@@ -1232,7 +1231,7 @@ async def test_download_artifact(error, tmp_path, spawn_job_client, pg):
 
     resp = await client.get("/api/samples/foo/artifacts/fastqc.txt")
 
-    expected_path = client.app["settings"]["data_path"] / "samples" / "foo" / "1-fastqc.txt"
+    expected_path = client.app["settings"]["data_path"] / "samples" / "foo" / "fastqc.txt"
 
     if error:
         assert resp.status == 404
@@ -1351,7 +1350,7 @@ async def test_upload_artifact_cache(
     if not error:
         assert resp.status == 201
         snapshot.assert_match(await resp.json())
-        assert os.listdir(cache_path) == ["1-small.fq"]
+        assert os.listdir(cache_path) == ["small.fq"]
     elif error == 400:
         assert await resp_is.bad_request(resp, "Unsupported sample artifact type")
 

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1107,7 +1107,7 @@ class TestUploadReads:
         client = await spawn_job_client(authorize=True)
 
         client.app["settings"]["data_path"] = tmp_path
-        sample_file_path = Path(client.app["settings"]["data_path"]) / "samples" / "test"
+        sample_file_path = client.app["settings"]["data_path"] / "samples" / "test"
 
         await client.db.samples.insert_one({
             "_id": "test",

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -664,7 +664,7 @@ async def test_finalize(field, snapshot, spawn_job_client, resp_is, pg, pg_sessi
         assert resp.status == 200
         snapshot.assert_match(await resp.json())
         assert not await virtool.uploads.db.get(pg, 1)
-        assert not (await virtool.pg.utils.get_row(pg, 1, SampleReads)).upload
+        assert not (await virtool.pg.utils.get_row_by_id(pg, SampleReads, 1)).upload
     else:
         assert resp.status == 422
         assert await resp_is.invalid_input(resp, {"quality": ['required field']})

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -17,7 +17,7 @@ from virtool.labels.models import Label
 from virtool.samples.models import SampleReads
 from virtool.uploads.models import Upload
 
-FASTQ_PATH = Path(sys.path[0]) / "tests/test_files/test.fq"
+FASTQ_PATH = Path.cwd() / "tests/test_files/test.fq"
 
 
 class TestCalculateWorkflowTags:

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -568,7 +568,7 @@ async def test_finalize(tmp_path, dbi, pg, pg_session):
         ]
     }
     assert not await virtool.uploads.db.get(pg, 1)
-    assert not (await virtool.pg.utils.get_row(pg, 1, SampleReads)).upload
+    assert not (await virtool.pg.utils.get_row_by_id(pg, SampleReads, 1)).upload
 
 
 async def test_create_sample_reads_record(tmp_path, pg, pg_session):

--- a/tests/subtractions/test_fake.py
+++ b/tests/subtractions/test_fake.py
@@ -21,7 +21,7 @@ async def test_create_fake_subtractions(app, example_path, snapshot, static_time
     snapshot.assert_match(await app["db"].subtraction.find().to_list(None))
 
     for file_name in FILES:
-        assert await get_row(app["pg"], file_name, SubtractionFile, "name")
+        assert await get_row(app["pg"], SubtractionFile, (file_name, "name"))
 
         is_fasta = "fa.gz" in file_name
 

--- a/tests/subtractions/test_fake.py
+++ b/tests/subtractions/test_fake.py
@@ -21,7 +21,7 @@ async def test_create_fake_subtractions(app, example_path, snapshot, static_time
     snapshot.assert_match(await app["db"].subtraction.find().to_list(None))
 
     for file_name in FILES:
-        assert await get_row(app["pg"], SubtractionFile, (file_name, "name"))
+        assert await get_row(app["pg"], SubtractionFile, ("name", file_name))
 
         is_fasta = "fa.gz" in file_name
 

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -245,7 +245,7 @@ async def download_analysis_result(req: aiohttp.web.Request) -> Union[aiohttp.we
     pg = req.app["pg"]
     upload_id = int(req.match_info["upload_id"])
 
-    analysis_file = await virtool.pg.utils.get_row(pg, upload_id, AnalysisFile)
+    analysis_file = await virtool.pg.utils.get_row(pg, AnalysisFile, query=upload_id)
 
     if not analysis_file:
         return not_found()

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -245,7 +245,7 @@ async def download_analysis_result(req: aiohttp.web.Request) -> Union[aiohttp.we
     pg = req.app["pg"]
     upload_id = int(req.match_info["upload_id"])
 
-    analysis_file = await virtool.pg.utils.get_row(pg, AnalysisFile, query=upload_id)
+    analysis_file = await virtool.pg.utils.get_row_by_id(pg, AnalysisFile, upload_id)
 
     if not analysis_file:
         return not_found()

--- a/virtool/caches/api.py
+++ b/virtool/caches/api.py
@@ -32,15 +32,3 @@ async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
         return not_found()
 
     return json_response(cache)
-
-
-@routes.jobs_api.get("/api/caches/{key}/artifacts/{filename}")
-async def download_artifacts_cache(req: aiohttp.web.Request) -> aiohttp.web.Response:
-    db = req.app["db"]
-    pg = req.app["pg"]
-
-    key = req.match_info["key"]
-    filename = req.match_info["filename"]
-
-    if not await db.caches.count_documents({"key": key}):
-        return not_found()

--- a/virtool/caches/api.py
+++ b/virtool/caches/api.py
@@ -32,3 +32,15 @@ async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
         return not_found()
 
     return json_response(cache)
+
+
+@routes.jobs_api.get("/api/caches/{key}/artifacts/{filename}")
+async def download_artifacts_cache(req: aiohttp.web.Request) -> aiohttp.web.Response:
+    db = req.app["db"]
+    pg = req.app["pg"]
+
+    key = req.match_info["key"]
+    filename = req.match_info["filename"]
+
+    if not await db.caches.count_documents({"key": key}):
+        return not_found()

--- a/virtool/caches/models.py
+++ b/virtool/caches/models.py
@@ -11,6 +11,7 @@ class SampleArtifactCache(Base):
 
     """
     __tablename__ = "sample_artifacts_cache"
+    __table_args__ = (UniqueConstraint("sample", "name"),)
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -112,7 +112,7 @@ async def get_row(
     async with AsyncSession(pg) as session:
         row = (
             await session.execute(
-                select(model).filter(getattr(model, column) == query)
+                select(model).filter(getattr(model, column) == value)
             )
         ).scalar()
 

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -80,25 +80,39 @@ async def delete_row(pg: AsyncEngine, id_: int, model: Base):
         await session.commit()
 
 
-async def get_row(
-        pg: AsyncEngine,
-        model: Base,
-        filter_: str = "id",
-        query: Optional[Union[str, int, bool, SQLEnum]] = None,
-) -> Optional[Base]:
+async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int):
     """
-    Get a row from the `model` SQL model by its `filter_`. By default, a row will be fetched by its `id`.
+    Get a row from a SQL `model` by its `id`.
 
     :param pg: PostgreSQL AsyncEngine object
-    :param query: A query to filter by
     :param model: A model to retrieve a row from
-    :param filter_: A table column to search for a given `query`
+    :param id_: An SQL row `id`
     :return: Row from the given SQL model
     """
     async with AsyncSession(pg) as session:
+        row = (await session.execute(select(model).filter(getattr(model, "id") == id_))).scalar()
+
+    return row
+
+
+async def get_row(
+        pg: AsyncEngine,
+        model: Base,
+        match: tuple
+) -> Optional[Base]:
+    """
+    Get a row from the SQL `model` that matches a query and column combination.
+
+    :param pg: PostgreSQL AsyncEngine object
+    :param model: A model to retrieve a row from
+    :param match: A (query, column) tuple to filter results by
+    :return: Row from the given SQL model
+    """
+    (query, column) = match
+    async with AsyncSession(pg) as session:
         row = (
             await session.execute(
-                select(model).filter(getattr(model, filter_) == query)
+                select(model).filter(getattr(model, column) == query)
             )
         ).scalar()
 
@@ -109,7 +123,7 @@ async def get_rows(
         pg: AsyncEngine,
         model: Base,
         filter_: str = "name",
-        query: Optional[Union[str, int, bool, SQLEnum]] = None,
+        query: Optional[Union[str, int, bool, SQLEnum]] = None
 ) -> Optional[Base]:
     """
     Get one or more rows from the `model` SQL model by its `filter_`. By default, rows will be fetched by their `name`.

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -108,7 +108,7 @@ async def get_row(
     :param match: A (query, column) tuple to filter results by
     :return: Row from the given SQL model
     """
-    (value, column) = match
+    (column, value) = match
     async with AsyncSession(pg) as session:
         row = (
             await session.execute(

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -70,14 +70,11 @@ async def delete_row(pg: AsyncEngine, id_: int, model: Base):
     :param model: Table to delete row from
     """
     async with AsyncSession(pg) as session:
-        row = (await session.execute(select(model).filter(model.id == id_))).scalar()
+        row = await get_row_by_id(pg, model, id_)
 
-        if not row:
-            return None
-
-        await session.delete(row)
-
-        await session.commit()
+        if row:
+            await session.delete(row)
+            await session.commit()
 
 
 async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int):

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -110,13 +110,7 @@ async def get_row(
     """
     (column, value) = match
     async with AsyncSession(pg) as session:
-        row = (
-            await session.execute(
-                select(model).filter(getattr(model, column) == value)
-            )
-        ).scalar()
-
-    return row
+        return (await session.execute(select(model).filter(getattr(model, column) == value))).scalar()
 
 
 async def get_rows(
@@ -138,6 +132,4 @@ async def get_rows(
         statement = select(model).filter(
             getattr(model, filter_).ilike(f"%{query}%")) if query else select(model)
 
-        rows = (await session.execute(statement)).scalars()
-
-    return rows
+        return (await session.execute(statement)).scalars()

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Optional, Union
 
 from sqlalchemy import select, text
+from sqlalchemy.engine.result import ScalarResult
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from virtool.api.json import pretty_dumps
@@ -77,7 +78,7 @@ async def delete_row(pg: AsyncEngine, id_: int, model: Base):
             await session.commit()
 
 
-async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int):
+async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int) -> Optional[Base]:
     """
     Get a row from a SQL `model` by its `id`.
 
@@ -112,7 +113,7 @@ async def get_rows(
         model: Base,
         filter_: str = "name",
         query: Optional[Union[str, int, bool, SQLEnum]] = None
-) -> Optional[Base]:
+) -> ScalarResult:
     """
     Get one or more rows from the `model` SQL model by its `filter_`. By default, rows will be fetched by their `name`.
 

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -89,10 +89,7 @@ async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int):
     :param id_: An SQL row `id`
     :return: Row from the given SQL model
     """
-    async with AsyncSession(pg) as session:
-        row = (await session.execute(select(model).filter(getattr(model, "id") == id_))).scalar()
-
-    return row
+    return await get_row(pg, model, ("id", id_))
 
 
 async def get_row(

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -100,7 +100,7 @@ async def get_row(
 
     :param pg: PostgreSQL AsyncEngine object
     :param model: A model to retrieve a row from
-    :param match: A (query, column) tuple to filter results by
+    :param match: A (column, value) tuple to filter results by
     :return: Row from the given SQL model
     """
     (column, value) = match

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -108,7 +108,7 @@ async def get_row(
     :param match: A (query, column) tuple to filter results by
     :return: Row from the given SQL model
     """
-    (query, column) = match
+    (value, column) = match
     async with AsyncSession(pg) as session:
         row = (
             await session.execute(

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -82,9 +82,9 @@ async def delete_row(pg: AsyncEngine, id_: int, model: Base):
 
 async def get_row(
         pg: AsyncEngine,
-        query: Union[str, int, bool, SQLEnum],
         model: Base,
         filter_: str = "id",
+        query: Optional[Union[str, int, bool, SQLEnum]] = None,
 ) -> Optional[Base]:
     """
     Get a row from the `model` SQL model by its `filter_`. By default, a row will be fetched by its `id`.

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -352,7 +352,7 @@ async def create(req):
         }
 
     elif import_from:
-        if not await virtool.pg.utils.get_row(pg, Upload, filter_="name_on_disk", query=import_from):
+        if not await virtool.pg.utils.get_row(pg, Upload, (import_from, "name_on_disk")):
             return not_found("File not found")
 
         path = req.app["settings"]["data_path"] / "files" / import_from

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -352,7 +352,7 @@ async def create(req):
         }
 
     elif import_from:
-        if not await virtool.pg.utils.get_row(pg, import_from, Upload, filter_="name_on_disk"):
+        if not await virtool.pg.utils.get_row(pg, Upload, filter_="name_on_disk", query=import_from):
             return not_found("File not found")
 
         path = req.app["settings"]["data_path"] / "files" / import_from

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -352,7 +352,7 @@ async def create(req):
         }
 
     elif import_from:
-        if not await virtool.pg.utils.get_row(pg, Upload, (import_from, "name_on_disk")):
+        if not await virtool.pg.utils.get_row(pg, Upload, ("name_on_disk", import_from)):
             return not_found("File not found")
 
         path = req.app["settings"]["data_path"] / "files" / import_from

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -669,7 +669,7 @@ async def create_import(db, pg: AsyncEngine, settings: dict, name: str, descript
         user_id=user_id
     )
 
-    upload = await virtool.pg.utils.get_row(pg, import_from, Upload, filter_="name_on_disk")
+    upload = await virtool.pg.utils.get_row(pg, Upload, filter_="name_on_disk", query=import_from)
 
     document["imported_from"] = upload.to_dict()
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -669,7 +669,7 @@ async def create_import(db, pg: AsyncEngine, settings: dict, name: str, descript
         user_id=user_id
     )
 
-    upload = await virtool.pg.utils.get_row(pg, Upload, filter_="name_on_disk", query=import_from)
+    upload = await virtool.pg.utils.get_row(pg, Upload, (import_from, "name_on_disk"))
 
     document["imported_from"] = upload.to_dict()
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -669,7 +669,7 @@ async def create_import(db, pg: AsyncEngine, settings: dict, name: str, descript
         user_id=user_id
     )
 
-    upload = await virtool.pg.utils.get_row(pg, Upload, (import_from, "name_on_disk"))
+    upload = await virtool.pg.utils.get_row(pg, Upload, ("name_on_disk", import_from))
 
     document["imported_from"] = upload.to_dict()
 

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -807,7 +807,7 @@ async def upload_artifact(req):
     try:
         size = await virtool.uploads.utils.naive_writer(req, artifact_file_path)
     except asyncio.CancelledError:
-        logger.debug(f"Artifact file upload aborted: {sample_id}")
+        logger.debug(f"Artifact file upload aborted for sample: {sample_id}")
         await req.app["run_in_thread"](os.remove, artifact_file_path)
         return aiohttp.web.Response(status=499)
 

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -789,8 +789,6 @@ async def upload_artifact(req):
     sample_id = req.match_info["sample_id"]
     artifact_type = req.query.get("type")
 
-    artifact_file_path = Path(virtool.samples.utils.join_sample_path(req.app["settings"], sample_id))
-
     if not await db.samples.find_one(sample_id):
         return not_found()
 
@@ -801,31 +799,25 @@ async def upload_artifact(req):
 
     name = req.query.get("name")
 
+    artifact_file_path = virtool.samples.utils.join_sample_path(req.app["settings"], sample_id) / name
+
     if artifact_type and artifact_type not in ArtifactType.to_list():
         return bad_request("Unsupported sample artifact type")
 
     try:
-        artifact = await virtool.samples.files.create_artifact_file(pg, name, sample_id, artifact_type)
+        size = await virtool.uploads.utils.naive_writer(req, artifact_file_path)
+    except asyncio.CancelledError:
+        logger.debug(f"Artifact file upload aborted: {sample_id}")
+        await req.app["run_in_thread"](os.remove, artifact_file_path)
+        return aiohttp.web.Response(status=499)
+
+    try:
+        artifact = await virtool.samples.files.create_artifact_file(pg, name, name, sample_id, size, artifact_type)
     except exc.IntegrityError:
         return conflict("Artifact file has already been uploaded for this sample")
 
-    file_id = artifact["id"]
-
-    artifact_file_path = artifact_file_path / artifact["name_on_disk"]
-
-    try:
-        size = await virtool.uploads.utils.naive_writer(req, artifact_file_path)
-    except asyncio.CancelledError:
-        logger.debug(f"Artifact file upload aborted: {file_id}")
-        await req.app["run_in_thread"](os.remove, artifact_file_path)
-        await virtool.pg.utils.delete_row(pg, file_id, SampleArtifact)
-
-        return aiohttp.web.Response(status=499)
-
-    artifact = await virtool.uploads.db.finalize(pg, size, file_id, SampleArtifact)
-
     headers = {
-        "Location": f"/api/samples/{sample_id}/artifact/{file_id}"
+        "Location": f"/api/samples/{sample_id}/artifact/{name}"
     }
 
     return json_response(artifact, status=201, headers=headers)
@@ -851,7 +843,7 @@ async def upload_reads(req):
     if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         return bad_request("File name is not an accepted reads file")
 
-    reads_path = Path(virtool.samples.utils.join_sample_path(req.app["settings"], sample_id)) / name
+    reads_path = virtool.samples.utils.join_sample_path(req.app["settings"], sample_id) / name
 
     if not await db.samples.find_one(sample_id):
         return not_found()
@@ -924,8 +916,6 @@ async def upload_artifacts_cache(req):
     key = req.match_info["key"]
     artifact_type = req.query.get("type")
 
-    cache_path = Path(virtool.caches.utils.join_cache_path(req.app["settings"], key))
-
     if not await db.caches.count_documents({"key": key, "sample.id": sample_id}):
         return not_found()
 
@@ -936,30 +926,25 @@ async def upload_artifacts_cache(req):
 
     name = req.query.get("name")
 
+    cache_path = virtool.caches.utils.join_cache_path(req.app["settings"], key) / name
+
     if artifact_type and artifact_type not in ArtifactType.to_list():
         return bad_request("Unsupported sample artifact type")
 
     try:
-        artifact = await virtool.samples.files.create_artifact_file(pg, name, sample_id, artifact_type, cache=True)
+        size = await virtool.uploads.utils.naive_writer(req, cache_path)
+    except asyncio.CancelledError:
+        logger.debug(f"Artifact file cache upload aborted: {sample_id}")
+        await req.app["run_in_thread"](os.remove, cache_path)
+        return aiohttp.web.Response(status=499)
+
+    try:
+        artifact = await virtool.samples.files.create_artifact_file(pg, name, name, sample_id, size, artifact_type, cache=True)
     except exc.IntegrityError:
         return conflict("Artifact file has already been uploaded for this sample cache")
 
-    upload_id = artifact["id"]
-
-    cache_path = cache_path / artifact["name_on_disk"]
-
-    try:
-        size = await virtool.uploads.utils.naive_writer(req, cache_path)
-    except asyncio.CancelledError:
-        logger.debug(f"Artifact file upload aborted: {upload_id}")
-        await req.app["run_in_thread"](os.remove, cache_path)
-        await virtool.pg.utils.delete_row(pg, upload_id, SampleArtifactCache)
-        return aiohttp.web.Response(status=499)
-
-    artifact = await virtool.uploads.db.finalize(pg, size, upload_id, SampleArtifactCache)
-
     headers = {
-        "Location": f"/api/samples/{sample_id}/caches/{key}/{upload_id}"
+        "Location": f"/api/samples/{sample_id}/caches/{key}/artifacts/{name}"
     }
 
     return json_response(artifact, status=201, headers=headers)
@@ -981,7 +966,7 @@ async def upload_reads_cache(req):
     if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         return bad_request("File name is not an accepted reads file")
 
-    cache_path = Path(virtool.caches.utils.join_cache_path(req.app["settings"], key)) / name
+    cache_path = virtool.caches.utils.join_cache_path(req.app["settings"], key) / name
 
     if not await db.caches.count_documents({"key": key, "sample.id": sample_id}):
         return not_found("Cache doesn't exist with given key")
@@ -1090,7 +1075,7 @@ async def download_artifact(req: aiohttp.web.Request):
 
     artifact = result.to_dict()
 
-    file_path = req.app["settings"]["data_path"] / "samples" / sample_id / artifact["name_on_disk"]
+    file_path = req.app["settings"]["data_path"] / "samples" / sample_id / artifact["name"]
 
     if not os.path.isfile(file_path):
         return virtool.api.response.not_found()

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -934,7 +934,7 @@ async def upload_artifacts_cache(req):
     try:
         size = await virtool.uploads.utils.naive_writer(req, cache_path)
     except asyncio.CancelledError:
-        logger.debug(f"Artifact file cache upload aborted: {sample_id}")
+        logger.debug(f"Artifact file cache upload aborted for sample: {sample_id}")
         await req.app["run_in_thread"](os.remove, cache_path)
         return aiohttp.web.Response(status=499)
 

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -32,7 +32,7 @@ async def get_existing_reads(
 
 
 async def create_artifact_file(
-    pg: AsyncEngine, name: str, sample: str, artifact_type: str, cache: bool = False
+    pg: AsyncEngine, name: str, name_on_disk: str, sample: str, size: int, artifact_type: str, cache: bool = False
 ) -> Dict[str, any]:
     """
     Create a row in an SQL table that represents uploaded sample artifact files. A row is created in either the
@@ -48,12 +48,17 @@ async def create_artifact_file(
     async with AsyncSession(pg) as session:
         artifact = SampleArtifact() if not cache else SampleArtifactCache()
 
-        artifact.sample, artifact.name, artifact.type = sample, name, artifact_type
+        artifact.name, artifact.name_on_disk, artifact.sample, artifact.size, artifact.type, artifact.uploaded_at = (
+            name,
+            name_on_disk,
+            sample,
+            size,
+            artifact_type,
+            virtool.utils.timestamp()
+        )
 
         session.add(artifact)
         await session.flush()
-
-        artifact.name_on_disk = f"{artifact.id}-{artifact.name}"
 
         artifact = artifact.to_dict()
 

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -32,7 +32,7 @@ async def get_existing_reads(
 
 
 async def create_artifact_file(
-    pg: AsyncEngine, name: str, name_on_disk: str, sample: str, size: int, artifact_type: str, cache: bool = False
+    pg: AsyncEngine, name: str, name_on_disk: str, sample: str, artifact_type: str, cache: bool = False
 ) -> Dict[str, any]:
     """
     Create a row in an SQL table that represents uploaded sample artifact files. A row is created in either the
@@ -48,13 +48,11 @@ async def create_artifact_file(
     async with AsyncSession(pg) as session:
         artifact = SampleArtifact() if not cache else SampleArtifactCache()
 
-        artifact.name, artifact.name_on_disk, artifact.sample, artifact.size, artifact.type, artifact.uploaded_at = (
+        artifact.name, artifact.name_on_disk, artifact.sample, artifact.type = (
             name,
             name_on_disk,
             sample,
-            size,
-            artifact_type,
-            virtool.utils.timestamp()
+            artifact_type
         )
 
         session.add(artifact)

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -59,7 +59,7 @@ async def create_artifact_file(
 
         await session.commit()
 
-        return artifact
+    return artifact
 
 
 async def create_reads_file(
@@ -106,4 +106,4 @@ async def create_reads_file(
 
         await session.commit()
 
-        return reads
+    return reads

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -48,12 +48,10 @@ async def create_artifact_file(
     async with AsyncSession(pg) as session:
         artifact = SampleArtifact() if not cache else SampleArtifactCache()
 
-        artifact.name, artifact.name_on_disk, artifact.sample, artifact.type = (
-            name,
-            name_on_disk,
-            sample,
-            artifact_type
-        )
+        artifact.name = name
+        artifact.name_on_disk = name_on_disk
+        artifact.sample = sample
+        artifact.type = artifact_type
 
         session.add(artifact)
         await session.flush()

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -25,6 +25,7 @@ class SampleArtifact(Base):
 
     """
     __tablename__ = "sample_artifacts"
+    __table_args__ = (UniqueConstraint("sample", "name"),)
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -133,7 +133,7 @@ async def create(req):
     nickname = data["nickname"]
     upload_id = data["upload_id"]
 
-    file = await virtool.pg.utils.get_row(pg, upload_id, Upload)
+    file = await virtool.pg.utils.get_row(pg, Upload, query=upload_id)
 
     if file is None:
         return bad_request("File does not exist")

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -133,7 +133,7 @@ async def create(req):
     nickname = data["nickname"]
     upload_id = data["upload_id"]
 
-    file = await virtool.pg.utils.get_row(pg, Upload, query=upload_id)
+    file = await virtool.pg.utils.get_row_by_id(pg, Upload, upload_id)
 
     if file is None:
         return bad_request("File does not exist")

--- a/virtool/subtractions/fake.py
+++ b/virtool/subtractions/fake.py
@@ -100,7 +100,7 @@ async def create_fake_finalized_subtraction(
         "user": {"id": user_id},
     })
 
-    subtractions_path = Path(app["settings"]["data_path"]) / "subtractions"
+    subtractions_path = app["settings"]["data_path"] / "subtractions"
 
     subtractions_example_path = example_path / "subtractions" / "arabidopsis_thaliana"
 

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -42,7 +42,7 @@ async def create(req):
 
     upload_id = upload["id"]
 
-    file_path = Path(req.app["settings"]["data_path"]) / "files" / upload["name_on_disk"]
+    file_path = req.app["settings"]["data_path"] / "files" / upload["name_on_disk"]
 
     try:
         size = await virtool.uploads.utils.naive_writer(req, file_path)

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -153,7 +153,7 @@ async def delete(req, pg: AsyncEngine, upload_id: int) -> Optional[dict]:
     try:
         await req.app["run_in_thread"](
             virtool.utils.rm,
-            Path(req.app["settings"]["data_path"]) / "files" / upload["name_on_disk"]
+            req.app["settings"]["data_path"] / "files" / upload["name_on_disk"]
         )
     except FileNotFoundError:
         pass

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 from typing import Union, Optional, List, Dict, Type
+from virtool.pg.base import Base
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
@@ -63,7 +64,7 @@ async def create(pg: AsyncEngine, name: str, upload_type: str, reserved: bool = 
         return upload
 
 
-async def finalize(pg, size: int, id_: int, table: Type[any]) -> Optional[dict]:
+async def finalize(pg, size: int, id_: int, model: Base) -> Optional[dict]:
     """
     Finalize row creation for tables that store uploaded files. Updates table with file information and sets `ready`
     to `True`.
@@ -75,7 +76,7 @@ async def finalize(pg, size: int, id_: int, table: Type[any]) -> Optional[dict]:
     :return: Dictionary representation of new row in `table`
     """
     async with AsyncSession(pg) as session:
-        upload = (await session.execute(select(table).filter_by(id=id_))).scalar()
+        upload = (await session.execute(select(model).filter_by(id=id_))).scalar()
 
         if not upload:
             return None


### PR DESCRIPTION
- Create constraints for `SampleArtifact` and `SampleArtifactCache` models
- Change artifact file naming convention to match reads by dropping usage of row `id`
- Add `get_row_by_id` to differentiate from `get_row`, which is now passed a tuple to filter results through
