### PR TITLE
Replace `create_sample_reads_record()` with `create_reads_file()`

### DIFF
--- a/tests/samples/snapshots/snap_test_fake.py
+++ b/tests/samples/snapshots/snap_test_fake.py
@@ -208,24 +208,24 @@ snapshots['test_create_fake_samples[uvloop] 1'] = {
     },
     'reads': [
         {
-            'download_url': '/api/samples/2x6YnyMt/reads/read_1.fq.gz',
+            'download_url': '/api/samples/2x6YnyMt/reads/reads_1.fq.gz',
             'id': 1,
-            'name': 'read_1.fq.gz',
-            'name_on_disk': 'paired_1.fq.gz',
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
             'sample': '2x6YnyMt',
             'size': 35441105,
             'upload': None,
-            'uploaded_at': None
+            'uploaded_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         },
         {
-            'download_url': '/api/samples/2x6YnyMt/reads/read_2.fq.gz',
+            'download_url': '/api/samples/2x6YnyMt/reads/reads_2.fq.gz',
             'id': 2,
-            'name': 'read_2.fq.gz',
-            'name_on_disk': 'paired_2.fq.gz',
+            'name': 'reads_2.fq.gz',
+            'name_on_disk': 'reads_2.fq.gz',
             'sample': '2x6YnyMt',
             'size': 41550519,
             'upload': None,
-            'uploaded_at': None
+            'uploaded_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
     'ready': True,
@@ -397,11 +397,11 @@ snapshots['test_create_fake_samples[uvloop] 2'] = {
             'download_url': '/api/samples/LB1U6zCj/reads/reads.fq.gz',
             'id': 3,
             'name': 'reads.fq.gz',
-            'name_on_disk': 'single.fq.gz',
+            'name_on_disk': 'reads.fq.gz',
             'sample': 'LB1U6zCj',
             'size': 16700094,
             'upload': None,
-            'uploaded_at': None
+            'uploaded_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
     'ready': True,
@@ -579,24 +579,24 @@ snapshots['test_create_fake_unpaired[uvloop-True-True] 1'] = {
     },
     'reads': [
         {
-            'download_url': '/api/samples/sample_1/reads/read_1.fq.gz',
+            'download_url': '/api/samples/sample_1/reads/reads_1.fq.gz',
             'id': 1,
-            'name': 'read_1.fq.gz',
-            'name_on_disk': 'paired_1.fq.gz',
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
             'sample': 'sample_1',
             'size': 35441105,
             'upload': None,
-            'uploaded_at': None
+            'uploaded_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         },
         {
-            'download_url': '/api/samples/sample_1/reads/read_2.fq.gz',
+            'download_url': '/api/samples/sample_1/reads/reads_2.fq.gz',
             'id': 2,
-            'name': 'read_2.fq.gz',
-            'name_on_disk': 'paired_2.fq.gz',
+            'name': 'reads_2.fq.gz',
+            'name_on_disk': 'reads_2.fq.gz',
             'sample': 'sample_1',
             'size': 41550519,
             'upload': None,
-            'uploaded_at': None
+            'uploaded_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
     'ready': True,
@@ -746,11 +746,11 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
             'download_url': '/api/samples/sample_1/reads/reads.fq.gz',
             'id': 1,
             'name': 'reads.fq.gz',
-            'name_on_disk': 'single.fq.gz',
+            'name_on_disk': 'reads.fq.gz',
             'sample': 'sample_1',
             'size': 16700094,
             'upload': None,
-            'uploaded_at': None
+            'uploaded_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
     'ready': True,

--- a/tests/samples/snapshots/snap_test_fake.py
+++ b/tests/samples/snapshots/snap_test_fake.py
@@ -394,10 +394,10 @@ snapshots['test_create_fake_samples[uvloop] 2'] = {
     },
     'reads': [
         {
-            'download_url': '/api/samples/LB1U6zCj/reads/reads.fq.gz',
+            'download_url': '/api/samples/LB1U6zCj/reads/reads_1.fq.gz',
             'id': 3,
-            'name': 'reads.fq.gz',
-            'name_on_disk': 'reads.fq.gz',
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
             'sample': 'LB1U6zCj',
             'size': 16700094,
             'upload': None,
@@ -743,10 +743,10 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
     },
     'reads': [
         {
-            'download_url': '/api/samples/sample_1/reads/reads.fq.gz',
+            'download_url': '/api/samples/sample_1/reads/reads_1.fq.gz',
             'id': 1,
-            'name': 'reads.fq.gz',
-            'name_on_disk': 'reads.fq.gz',
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
             'sample': 'sample_1',
             'size': 16700094,
             'upload': None,

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -571,7 +571,7 @@ async def test_finalize(tmp_path, dbi, pg, pg_session):
     assert not (await virtool.pg.utils.get_row(pg, 1, SampleReads)).upload
 
 
-async def test_create_sample_reads_record(tmp_path, pg, pg_session):
+async def test_create_sample_reads_record(tmp_path, example_path, pg, pg_session):
     async def run_in_thread(func, *args):
         return func(*args)
 
@@ -585,7 +585,7 @@ async def test_create_sample_reads_record(tmp_path, pg, pg_session):
 
     test_dir = tmp_path / "samples" / "sample_1"
 
-    file_path = Path(sys.path[0]) / "tests" / "test_files" / "samples" / "reads_1.fq.gz"
+    file_path = example_path / "reads" / "paired_1.fq.gz"
 
     await virtool.samples.db.create_sample_reads_record(app, "sample_1", file_path, "reads_1.fq.gz")
 

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -47,5 +47,5 @@ async def test_create_fake_samples(app, snapshot, dbi, static_time):
     for sample in samples:
         snapshot.assert_match(sample)
 
-    assert os.listdir(app["settings"]["data_path"] / "samples" / "LB1U6zCj") == ["reads.fq.gz"]
+    assert os.listdir(app["settings"]["data_path"] / "samples" / "LB1U6zCj") == ["reads_1.fq.gz"]
     assert set(os.listdir(app["settings"]["data_path"] / "samples" / "2x6YnyMt")) == {"reads_1.fq.gz", "reads_2.fq.gz"}

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from virtool.samples.fake import create_fake_sample, create_fake_samples
 from virtool.fake.wrapper import FakerWrapper
@@ -44,3 +46,6 @@ async def test_create_fake_samples(app, snapshot, dbi, static_time):
 
     for sample in samples:
         snapshot.assert_match(sample)
+
+    assert os.listdir(app["settings"]["data_path"] / "samples" / "LB1U6zCj") == ["reads.fq.gz"]
+    assert set(os.listdir(app["settings"]["data_path"] / "samples" / "2x6YnyMt")) == {"reads_1.fq.gz", "reads_2.fq.gz"}

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -1,7 +1,8 @@
 import os
 
 import pytest
-from virtool.samples.fake import create_fake_sample, create_fake_samples
+
+from virtool.samples.fake import create_fake_sample, create_fake_samples, copy_reads_file, READ_FILES_PATH
 from virtool.fake.wrapper import FakerWrapper
 from virtool.samples.db import LIST_PROJECTION
 
@@ -49,3 +50,11 @@ async def test_create_fake_samples(app, snapshot, dbi, static_time):
 
     assert os.listdir(app["settings"]["data_path"] / "samples" / "LB1U6zCj") == ["reads_1.fq.gz"]
     assert set(os.listdir(app["settings"]["data_path"] / "samples" / "2x6YnyMt")) == {"reads_1.fq.gz", "reads_2.fq.gz"}
+
+
+async def test_copy_reads_file(app):
+    file_path = READ_FILES_PATH / "paired_1.fq.gz"
+
+    await copy_reads_file(app, file_path, "reads_1.fq.gz", "sample_1")
+
+    assert os.listdir(app["settings"]["data_path"] / "samples" / "sample_1") == ["reads_1.fq.gz"]

--- a/tests/samples/test_files.py
+++ b/tests/samples/test_files.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+from sqlalchemy import select
+
+from virtool.samples.files import create_reads_file
+from virtool.samples.models import SampleReads
+from virtool.samples.fake import READ_FILES_PATH
+
+
+@pytest.mark.parametrize("copy_file", [True, False])
+async def test_create_reads_file(copy_file, run_in_thread, tmp_path, pg, pg_session, static_time):
+    app = {
+        "pg": pg,
+        "settings": {
+            "data_path": tmp_path
+        },
+        "run_in_thread": run_in_thread
+    }
+
+    file_path = READ_FILES_PATH / "single.fq.gz"
+
+    if copy_file:
+        await create_reads_file(
+            app,
+            file_path.stat().st_size,
+            "reads.fq.gz",
+            "reads.fq.gz",
+            "sample_1",
+            path=file_path,
+            copy_file=True
+        )
+    else:
+        await create_reads_file(
+            app,
+            123456,
+            "reads_1.fq.gz",
+            "reads_1.fq.gz",
+            "sample_1",
+        )
+
+    async with pg_session as session:
+        result = (await session.execute(select(SampleReads).filter_by(id=1))).scalar()
+
+    if copy_file:
+        assert result.to_dict() == {
+            "id": 1,
+            "sample": "sample_1",
+            "name": "reads.fq.gz",
+            "name_on_disk": "reads.fq.gz",
+            "size": file_path.stat().st_size,
+            "upload": None,
+            "uploaded_at": static_time.datetime
+        }
+        assert os.listdir(app["settings"]["data_path"] / "samples" / "sample_1") == ["reads.fq.gz"]
+    else:
+        assert result.to_dict() == {
+            "id": 1,
+            "sample": "sample_1",
+            "name": "reads_1.fq.gz",
+            "name_on_disk": "reads_1.fq.gz",
+            "size": 123456,
+            "upload": None,
+            "uploaded_at": static_time.datetime
+        }

--- a/tests/samples/test_files.py
+++ b/tests/samples/test_files.py
@@ -1,65 +1,27 @@
-import os
-
-import pytest
 from sqlalchemy import select
 
 from virtool.samples.files import create_reads_file
 from virtool.samples.models import SampleReads
-from virtool.samples.fake import READ_FILES_PATH
 
 
-@pytest.mark.parametrize("copy_file", [True, False])
-async def test_create_reads_file(copy_file, run_in_thread, tmp_path, pg, pg_session, static_time):
-    app = {
-        "pg": pg,
-        "settings": {
-            "data_path": tmp_path
-        },
-        "run_in_thread": run_in_thread
-    }
-
-    file_path = READ_FILES_PATH / "single.fq.gz"
-
-    if copy_file:
-        await create_reads_file(
-            app,
-            file_path.stat().st_size,
-            "reads.fq.gz",
-            "reads.fq.gz",
-            "sample_1",
-            path=file_path,
-            copy_file=True
-        )
-    else:
-        await create_reads_file(
-            app,
-            123456,
-            "reads_1.fq.gz",
-            "reads_1.fq.gz",
-            "sample_1",
-        )
+async def test_create_reads_file(pg, pg_session, static_time):
+    await create_reads_file(
+        pg,
+        123456,
+        "reads_1.fq.gz",
+        "reads_1.fq.gz",
+        "sample_1",
+    )
 
     async with pg_session as session:
         result = (await session.execute(select(SampleReads).filter_by(id=1))).scalar()
 
-    if copy_file:
-        assert result.to_dict() == {
-            "id": 1,
-            "sample": "sample_1",
-            "name": "reads.fq.gz",
-            "name_on_disk": "reads.fq.gz",
-            "size": file_path.stat().st_size,
-            "upload": None,
-            "uploaded_at": static_time.datetime
-        }
-        assert os.listdir(app["settings"]["data_path"] / "samples" / "sample_1") == ["reads.fq.gz"]
-    else:
-        assert result.to_dict() == {
-            "id": 1,
-            "sample": "sample_1",
-            "name": "reads_1.fq.gz",
-            "name_on_disk": "reads_1.fq.gz",
-            "size": 123456,
-            "upload": None,
-            "uploaded_at": static_time.datetime
-        }
+    assert result.to_dict() == {
+        "id": 1,
+        "sample": "sample_1",
+        "name": "reads_1.fq.gz",
+        "name_on_disk": "reads_1.fq.gz",
+        "size": 123456,
+        "upload": None,
+        "uploaded_at": static_time.datetime
+    }

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -835,7 +835,6 @@ async def upload_reads(req):
 
     """
     db = req.app["db"]
-    pg = req.app["pg"]
 
     name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
@@ -861,7 +860,7 @@ async def upload_reads(req):
         logger.debug(f"Reads file upload aborted for {sample_id}")
         return aiohttp.web.Response(status=499)
     try:
-        reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id, upload_id=upload)
+        reads = await virtool.samples.files.create_reads_file(req.app, size, name, name, sample_id, upload_id=upload)
     except exc.IntegrityError:
         return conflict("Reads file name is already uploaded for this sample")
 
@@ -966,7 +965,6 @@ async def upload_reads_cache(req):
 
     """
     db = req.app["db"]
-    pg = req.app["pg"]
 
     name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
@@ -990,7 +988,7 @@ async def upload_reads_cache(req):
         logger.debug(f"Reads cache file upload aborted for {key}")
         return aiohttp.web.Response(status=499)
 
-    reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
+    reads = await virtool.samples.files.create_reads_file(req.app, size, name, name, sample_id)
 
     headers = {
         "Location": f"/api/samples/{sample_id}/caches/{key}/reads/{reads['id']}"

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -835,6 +835,7 @@ async def upload_reads(req):
 
     """
     db = req.app["db"]
+    pg = req.app["pg"]
 
     name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
@@ -860,7 +861,7 @@ async def upload_reads(req):
         logger.debug(f"Reads file upload aborted for {sample_id}")
         return aiohttp.web.Response(status=499)
     try:
-        reads = await virtool.samples.files.create_reads_file(req.app, size, name, name, sample_id, upload_id=upload)
+        reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id, upload_id=upload)
     except exc.IntegrityError:
         return conflict("Reads file name is already uploaded for this sample")
 
@@ -965,6 +966,7 @@ async def upload_reads_cache(req):
 
     """
     db = req.app["db"]
+    pg = req.app["pg"]
 
     name = req.match_info["name"]
     sample_id = req.match_info["sample_id"]
@@ -988,7 +990,7 @@ async def upload_reads_cache(req):
         logger.debug(f"Reads cache file upload aborted for {key}")
         return aiohttp.web.Response(status=499)
 
-    reads = await virtool.samples.files.create_reads_file(req.app, size, name, name, sample_id)
+    reads = await virtool.samples.files.create_reads_file(pg, size, name, name, sample_id)
 
     headers = {
         "Location": f"/api/samples/{sample_id}/caches/{key}/reads/{reads['id']}"

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -472,10 +472,10 @@ async def create_sample_reads_record(app: App,
 
         await session.commit()
 
-    reads_path = app["settings"]["data_path"] / "samples" / sample_id / name
+    reads_path = app["settings"]["data_path"] / "samples" / sample_id
     reads_path.mkdir(parents=True, exist_ok=True)
 
-    await app["run_in_thread"](shutil.copy, path, reads_path)
+    await app["run_in_thread"](shutil.copy, path, reads_path / name)
 
 
 async def move_sample_files_to_pg(app: App, sample: Dict[str, any]):

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -4,7 +4,7 @@ from typing import List
 from virtool.fake.identifiers import USER_ID
 from virtool.fake.wrapper import FakerWrapper
 from virtool.samples.db import create_sample, finalize
-from virtool.samples.db import create_sample_reads_record
+from virtool.samples.files import create_reads_file
 from virtool.types import App
 
 EXAMPLE_FILES_PATH = Path(__file__).parent.parent.parent / "example"
@@ -80,18 +80,26 @@ async def create_fake_sample(app: App, sample_id: str, user_id: str, paired=Fals
     if finalized is True:
         if paired:
             for n in (1, 2):
-                await create_sample_reads_record(
+                file_path = READ_FILES_PATH / f"paired_{n}.fq.gz"
+                await create_reads_file(
                     app,
-                    sample_id=sample_id,
-                    name=f"read_{n}.fq.gz",
-                    path=READ_FILES_PATH / f"paired_{n}.fq.gz",
+                    file_path.stat().st_size,
+                    f"reads_{n}.fq.gz",
+                    f"reads_{n}.fq.gz",
+                    sample_id,
+                    path=file_path,
+                    copy_file=True
                 )
         else:
-            await create_sample_reads_record(
+            file_path = READ_FILES_PATH / "single.fq.gz"
+            await create_reads_file(
                 app,
-                sample_id=sample_id,
-                name="reads.fq.gz",
-                path=READ_FILES_PATH / "single.fq.gz",
+                file_path.stat().st_size,
+                "reads.fq.gz",
+                "reads.fq.gz",
+                sample_id,
+                path=file_path,
+                copy_file=True
             )
 
     sample = await create_sample(

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -95,8 +95,8 @@ async def create_fake_sample(app: App, sample_id: str, user_id: str, paired=Fals
             await create_reads_file(
                 app,
                 file_path.stat().st_size,
-                "reads.fq.gz",
-                "reads.fq.gz",
+                "reads_1.fq.gz",
+                "reads_1.fq.gz",
                 sample_id,
                 path=file_path,
                 copy_file=True

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -82,24 +82,20 @@ async def create_fake_sample(app: App, sample_id: str, user_id: str, paired=Fals
             for n in (1, 2):
                 file_path = READ_FILES_PATH / f"paired_{n}.fq.gz"
                 await create_reads_file(
-                    app,
+                    pg,
                     file_path.stat().st_size,
                     f"reads_{n}.fq.gz",
                     f"reads_{n}.fq.gz",
                     sample_id,
-                    path=file_path,
-                    copy_file=True
                 )
         else:
             file_path = READ_FILES_PATH / "single.fq.gz"
             await create_reads_file(
-                app,
+                pg,
                 file_path.stat().st_size,
                 "reads_1.fq.gz",
                 "reads_1.fq.gz",
                 sample_id,
-                path=file_path,
-                copy_file=True
             )
 
     sample = await create_sample(

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -1,5 +1,3 @@
-import shutil
-from pathlib import Path
 from typing import Dict, List
 
 from sqlalchemy import select
@@ -9,7 +7,6 @@ import virtool.pg.utils
 import virtool.utils
 from virtool.caches.models import SampleArtifactCache, SampleReadsCache
 from virtool.samples.models import SampleArtifact, SampleReads
-from virtool.types import App
 from virtool.uploads.models import Upload
 
 

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -66,33 +66,29 @@ async def create_artifact_file(
 
 
 async def create_reads_file(
-    app: App,
+    pg: AsyncEngine,
     size: int,
     name: str,
     name_on_disk: str,
     sample_id: str,
     cache: bool = False,
     upload_id: int = None,
-    path: Path = None,
-    copy_file: bool = False
 ) -> Dict[str, any]:
     """
     Create a row in a SQL table that represents uploaded sample reads files.
 
-    :param app: The application object
+    :param pg: PostgreSQL AsyncEngine object
     :param size: Size of a newly uploaded file in bytes
     :param name: Name of the file (either `reads_1.fq.gz` or `reads_2.fq.gz`)
     :param name_on_disk: Name of the newly uploaded file on disk
     :param sample_id: ID that corresponds to a parent sample
     :param cache: Whether the row should be created in the `sample_reads_files` or `sample_reads_files_cache` table
     :param upload_id: ID for a row in the `uploads` table to pair with
-    :param path: The path to the reads file
-    :param copy_file: Whether the file should be copied to the data path.
 
     :return: List of dictionary representations of the newly created row(s)
     """
 
-    async with AsyncSession(app["pg"]) as session:
+    async with AsyncSession(pg) as session:
         reads = SampleReads() if not cache else SampleReadsCache()
 
         reads.sample, reads.name, reads.name_on_disk, reads.size, reads.uploaded_at = (
@@ -114,10 +110,4 @@ async def create_reads_file(
 
         await session.commit()
 
-    if path and copy_file:
-        reads_path = app["settings"]["data_path"] / "samples" / sample_id
-        reads_path.mkdir(parents=True, exist_ok=True)
-
-        await app["run_in_thread"](shutil.copy, path, reads_path / name)
-
-    return reads
+        return reads


### PR DESCRIPTION
- Add an option for copying files to data path in `create_reads_file()`
- Replace usage of `create_sample_reads_record()` with `create_reads_file()`
- Fix wrong reads filenames for fake samples
- Add tests