### PR TITLE
Remove usage of `sample["files"]` in sample remove endpoint

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -13,6 +13,7 @@ import virtool.samples.db
 import virtool.uploads.db
 from virtool.caches.models import SampleArtifactCache, SampleReadsCache
 from virtool.labels.models import Label
+from virtool.samples.files import create_reads_file
 from virtool.samples.models import SampleReads, SampleArtifact
 from virtool.uploads.models import Upload
 
@@ -731,12 +732,12 @@ async def test_job_remove(
 
     if exists:
         file = await virtool.uploads.db.create(pg, "test", "reads", reserved=True)
+        await create_reads_file(pg, 0, "test", "test", "test", upload_id=1)
 
         await client.db.samples.insert_one({
             "_id": "test",
             "all_read": True,
             "all_write": True,
-            "files": [file["id"]],
             "ready": ready
         })
 


### PR DESCRIPTION
I'm not sure if this is the correct strategy here, but I assumed that the document in `jobs` wouldn't persist beyond `create_sample` so I did not have it check for `ids` in `task_args`.