### PR TITLE
Allow fake sample creation from frontend

### DIFF
--- a/client/src/js/dev/components/Dialog.js
+++ b/client/src/js/dev/components/Dialog.js
@@ -42,6 +42,17 @@ export const DeveloperDialog = ({ show, onCommand, onHide }) => (
         </DeveloperCommand>
         <DeveloperCommand>
             <DeveloperCommandLabel>
+                <h3>Create Sample</h3>
+                <p>Creates a sample that is ready for use.</p>
+            </DeveloperCommandLabel>
+            <DeveloperCommandControl>
+                <Button color="red" onClick={() => onCommand("create_sample")}>
+                    Create Sample
+                </Button>
+            </DeveloperCommandControl>
+        </DeveloperCommand>
+        <DeveloperCommand>
+            <DeveloperCommandLabel>
                 <h3>Create Subtraction</h3>
                 <p>Creates a subtraction that is ready for use.</p>
             </DeveloperCommandLabel>

--- a/tests/samples/snapshots/snap_test_fake.py
+++ b/tests/samples/snapshots/snap_test_fake.py
@@ -13,7 +13,7 @@ snapshots['test_create_fake_unpaired[uvloop-False-True] 1'] = {
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'enough',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -24,8 +24,8 @@ snapshots['test_create_fake_unpaired[uvloop-False-True] 1'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'such serious',
-    'notes': 'American whole magazine truth stop whose.',
+    'name': 'Fake SAMPLE_1',
+    'notes': 'Serious inside else memory if six.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
@@ -44,7 +44,7 @@ snapshots['test_create_fake_unpaired[uvloop-False-False] 1'] = {
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'enough',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -55,8 +55,8 @@ snapshots['test_create_fake_unpaired[uvloop-False-False] 1'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'such serious',
-    'notes': 'American whole magazine truth stop whose.',
+    'name': 'Fake SAMPLE_1',
+    'notes': 'Serious inside else memory if six.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
@@ -77,7 +77,7 @@ snapshots['test_create_fake_samples[uvloop] 1'] = {
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'enough',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -88,20 +88,20 @@ snapshots['test_create_fake_samples[uvloop] 1'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'such serious',
-    'notes': 'American whole magazine truth stop whose.',
+    'name': 'Fake SAMPLE_UNPAIRED_FINALIZED',
+    'notes': 'Serious inside else memory if six.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
     'quality': {
-        'all_read': True,
-        'all_write': True,
+        'all_read': False,
+        'all_write': False,
         'bases': [
             [
-                32,
-                32,
                 31,
                 32,
+                31,
+                31,
                 32
             ],
             [
@@ -113,77 +113,68 @@ snapshots['test_create_fake_samples[uvloop] 1'] = {
             ],
             [
                 31,
-                31,
-                31,
-                32,
-                31
-            ],
-            [
                 32,
                 32,
-                31,
                 32,
                 31
             ],
             [
                 31,
                 31,
-                31,
+                32,
                 31,
                 32
+            ],
+            [
+                32,
+                31,
+                32,
+                31,
+                31
             ]
         ],
         'composition': [
             [
-                67,
-                31,
-                28,
-                1
-            ],
-            [
-                87,
-                76,
-                1,
-                1
-            ],
-            [
-                54,
-                75,
-                1,
-                1
-            ],
-            [
-                36,
-                58,
-                64,
-                1
-            ],
-            [
-                85,
-                83,
-                1,
-                1
-            ],
-            [
+                19,
                 90,
-                46,
+                1,
+                1
+            ],
+            [
+                29,
+                6,
+                74,
+                1
+            ],
+            [
+                82,
+                69,
+                1,
+                1
+            ],
+            [
+                78,
+                88,
                 1,
                 1
             ]
         ],
-        'count': 4926171705,
+        'count': 8997239604,
         'encoding': '''Sanger / Illumina 1.9
 ''',
-        'gc': 87,
-        'group_read': True,
+        'gc': 90,
+        'group_read': False,
         'group_write': False,
         'hold': False,
         'length': [
-            22,
-            19
+            42,
+            78
         ],
-        'paired': False,
+        'paired': True,
         'sequences': [
+            3909,
+            8896,
+            1494,
             5243,
             1786,
             9031,
@@ -200,7 +191,20 @@ snapshots['test_create_fake_samples[uvloop] 1'] = {
             1471,
             2450,
             1314,
-            8594
+            8594,
+            8549,
+            3525,
+            9497,
+            7382,
+            5855,
+            5313,
+            7969,
+            3119,
+            265,
+            1919,
+            6095,
+            5448,
+            1018
         ]
     },
     'reads': [
@@ -231,7 +235,7 @@ snapshots['test_create_fake_samples[uvloop] 2'] = {
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'painting',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -242,104 +246,96 @@ snapshots['test_create_fake_samples[uvloop] 2'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'drug rule',
-    'notes': 'Relate head color international.',
+    'name': 'Fake SAMPLE_PAIRED_FINALIZED',
+    'notes': 'Have wonder already against.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
     'quality': {
         'all_read': True,
-        'all_write': True,
+        'all_write': False,
         'bases': [
             [
                 31,
                 32,
                 31,
+                31,
+                31
+            ],
+            [
                 32,
+                32,
+                32,
+                31,
+                31
+            ],
+            [
+                32,
+                31,
+                31,
+                32,
+                31
+            ],
+            [
+                32,
+                32,
+                32,
+                31,
                 31
             ],
             [
                 31,
                 31,
                 31,
-                31,
-                31
-            ],
-            [
                 32,
-                31,
-                31,
-                31,
                 32
-            ],
-            [
-                31,
-                32,
-                31,
-                31,
-                31
-            ],
-            [
-                32,
-                32,
-                32,
-                31,
-                31
             ]
         ],
         'composition': [
             [
+                82,
                 58,
-                9,
-                34,
+                1,
+                1
+            ],
+            [
+                49,
+                91,
+                1,
+                1
+            ],
+            [
+                87,
+                73,
+                1,
+                1
+            ],
+            [
+                54,
+                5,
+                52,
                 1
             ],
             [
                 90,
-                21,
-                1,
-                1
-            ],
-            [
-                58,
-                68,
-                1,
-                1
-            ],
-            [
-                63,
-                72,
-                1,
-                1
-            ],
-            [
-                78,
-                97,
+                73,
                 1,
                 1
             ]
         ],
-        'count': 317824271,
+        'count': 2917784004,
         'encoding': '''Sanger / Illumina 1.9
 ''',
-        'gc': 24,
+        'gc': 79,
         'group_read': False,
-        'group_write': True,
-        'hold': False,
+        'group_write': False,
+        'hold': True,
         'length': [
-            25,
-            91
+            79,
+            64
         ],
         'paired': True,
         'sequences': [
-            645,
-            6410,
-            4262,
-            7704,
-            3332,
-            2592,
-            5608,
-            1920,
             2864,
             7727,
             9324,
@@ -357,12 +353,7 @@ snapshots['test_create_fake_samples[uvloop] 2'] = {
             6789,
             24,
             5478,
-            3922,
-            7342,
-            9308,
-            516,
-            9297,
-            766
+            3922
         ]
     },
     'reads': [
@@ -401,7 +392,7 @@ snapshots['test_create_fake_samples[uvloop] 3'] = {
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'Republican',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -412,8 +403,8 @@ snapshots['test_create_fake_samples[uvloop] 3'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'anyone state',
-    'notes': 'Could yourself plan base rise would.',
+    'name': 'Fake SAMPLE_UNPAIRED',
+    'notes': 'Land those traditional page. This manager fine.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
@@ -434,7 +425,7 @@ snapshots['test_create_fake_unpaired[uvloop-True-True] 1'] = {
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'enough',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -445,20 +436,20 @@ snapshots['test_create_fake_unpaired[uvloop-True-True] 1'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'such serious',
-    'notes': 'American whole magazine truth stop whose.',
+    'name': 'Fake SAMPLE_1',
+    'notes': 'Serious inside else memory if six.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
     'quality': {
-        'all_read': True,
-        'all_write': True,
+        'all_read': False,
+        'all_write': False,
         'bases': [
             [
-                32,
-                32,
                 31,
                 32,
+                31,
+                31,
                 32
             ],
             [
@@ -470,77 +461,68 @@ snapshots['test_create_fake_unpaired[uvloop-True-True] 1'] = {
             ],
             [
                 31,
-                31,
-                31,
-                32,
-                31
-            ],
-            [
                 32,
                 32,
-                31,
                 32,
                 31
             ],
             [
                 31,
                 31,
-                31,
+                32,
                 31,
                 32
+            ],
+            [
+                32,
+                31,
+                32,
+                31,
+                31
             ]
         ],
         'composition': [
             [
-                67,
-                31,
-                28,
-                1
-            ],
-            [
-                87,
-                76,
-                1,
-                1
-            ],
-            [
-                54,
-                75,
-                1,
-                1
-            ],
-            [
-                36,
-                58,
-                64,
-                1
-            ],
-            [
-                85,
-                83,
-                1,
-                1
-            ],
-            [
+                19,
                 90,
-                46,
+                1,
+                1
+            ],
+            [
+                29,
+                6,
+                74,
+                1
+            ],
+            [
+                82,
+                69,
+                1,
+                1
+            ],
+            [
+                78,
+                88,
                 1,
                 1
             ]
         ],
-        'count': 4926171705,
+        'count': 8997239604,
         'encoding': '''Sanger / Illumina 1.9
 ''',
-        'gc': 87,
-        'group_read': True,
+        'gc': 90,
+        'group_read': False,
         'group_write': False,
         'hold': False,
         'length': [
-            22,
-            19
+            42,
+            78
         ],
-        'paired': False,
+        'paired': True,
         'sequences': [
+            3909,
+            8896,
+            1494,
             5243,
             1786,
             9031,
@@ -557,7 +539,20 @@ snapshots['test_create_fake_unpaired[uvloop-True-True] 1'] = {
             1471,
             2450,
             1314,
-            8594
+            8594,
+            8549,
+            3525,
+            9497,
+            7382,
+            5855,
+            5313,
+            7969,
+            3119,
+            265,
+            1919,
+            6095,
+            5448,
+            1018
         ]
     },
     'reads': [
@@ -598,7 +593,7 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
     ],
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'enough',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -609,20 +604,20 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'such serious',
-    'notes': 'American whole magazine truth stop whose.',
+    'name': 'Fake SAMPLE_1',
+    'notes': 'Serious inside else memory if six.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
     'quality': {
-        'all_read': True,
-        'all_write': True,
+        'all_read': False,
+        'all_write': False,
         'bases': [
             [
-                32,
-                32,
                 31,
                 32,
+                31,
+                31,
                 32
             ],
             [
@@ -634,77 +629,68 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
             ],
             [
                 31,
-                31,
-                31,
-                32,
-                31
-            ],
-            [
                 32,
                 32,
-                31,
                 32,
                 31
             ],
             [
                 31,
                 31,
-                31,
+                32,
                 31,
                 32
+            ],
+            [
+                32,
+                31,
+                32,
+                31,
+                31
             ]
         ],
         'composition': [
             [
-                67,
-                31,
-                28,
-                1
-            ],
-            [
-                87,
-                76,
-                1,
-                1
-            ],
-            [
-                54,
-                75,
-                1,
-                1
-            ],
-            [
-                36,
-                58,
-                64,
-                1
-            ],
-            [
-                85,
-                83,
-                1,
-                1
-            ],
-            [
+                19,
                 90,
-                46,
+                1,
+                1
+            ],
+            [
+                29,
+                6,
+                74,
+                1
+            ],
+            [
+                82,
+                69,
+                1,
+                1
+            ],
+            [
+                78,
+                88,
                 1,
                 1
             ]
         ],
-        'count': 4926171705,
+        'count': 8997239604,
         'encoding': '''Sanger / Illumina 1.9
 ''',
-        'gc': 87,
-        'group_read': True,
+        'gc': 90,
+        'group_read': False,
         'group_write': False,
         'hold': False,
         'length': [
-            22,
-            19
+            42,
+            78
         ],
-        'paired': False,
+        'paired': True,
         'sequences': [
+            3909,
+            8896,
+            1494,
             5243,
             1786,
             9031,
@@ -721,7 +707,20 @@ snapshots['test_create_fake_unpaired[uvloop-True-False] 1'] = {
             1471,
             2450,
             1314,
-            8594
+            8594,
+            8549,
+            3525,
+            9497,
+            7382,
+            5855,
+            5313,
+            7969,
+            3119,
+            265,
+            1919,
+            6095,
+            5448,
+            1018
         ]
     },
     'reads': [
@@ -750,7 +749,7 @@ snapshots['test_create_fake_samples[uvloop] 4'] = {
     'all_write': True,
     'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
     'format': 'fastq',
-    'group': 'technology',
+    'group': 'none',
     'group_read': True,
     'group_write': True,
     'hold': True,
@@ -761,8 +760,8 @@ snapshots['test_create_fake_samples[uvloop] 4'] = {
     ],
     'library_type': 'normal',
     'locale': '',
-    'name': 'more best',
-    'notes': 'Part cup few read. Beyond take however ball.',
+    'name': 'Fake SAMPLE_PAIRED',
+    'notes': 'Would I question first.',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,

--- a/virtool/dev/api.py
+++ b/virtool/dev/api.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from virtool.api.response import no_content
 from virtool.fake.wrapper import FakerWrapper
 from virtool.http.routes import Routes
-from virtool.samples.fake import create_fake_samples
+from virtool.samples.fake import create_fake_sample
 from virtool.subtractions.fake import create_fake_fasta_upload, create_fake_finalized_subtraction
 from virtool.utils import random_alphanumeric
 
@@ -42,6 +42,12 @@ async def dev(req):
         )
 
     if command == "create_sample":
-        await create_fake_samples(req.app)
+        await create_fake_sample(
+            req.app,
+            random_alphanumeric(8),
+            req["client"].user_id,
+            False,
+            True
+        )
 
     return no_content()

--- a/virtool/dispatcher/fetchers.py
+++ b/virtool/dispatcher/fetchers.py
@@ -243,7 +243,7 @@ class SamplesFetcher(AbstractFetcher):
                     yield connection, {
                         "interface": change.interface,
                         "operation": change.operation,
-                        "data": document
+                        "data": base_processor(document)
                     }
 
 

--- a/virtool/fake/wrapper.py
+++ b/virtool/fake/wrapper.py
@@ -3,18 +3,22 @@ A wrapper for the `fake` package that adds some Virtool-specific functionality.
 
 """
 from faker import Faker
-from faker.providers import misc, lorem, python
+from faker.providers import address, misc, lorem, python
 
 
 class FakerWrapper:
     def __init__(self):
         self.fake = Faker()
         self.fake.seed_instance(0)
+        self.fake.add_provider(address)
         self.fake.add_provider(misc)
         self.fake.add_provider(lorem)
         self.fake.add_provider(python)
 
+        self.country = self.fake.country
+
         self.text = self.fake.text
+        self.word = self.fake.word
         self.words = self.fake.words
 
         self.integer = self.fake.pyint


### PR DESCRIPTION
This feature required some changes to the backend.

* Add fake sample creation button to developer dialog.
* The sample changes being dispatched to the client had an `_id` field instead of `id`. This was fixed by ensuring the `base_processor` is called on outgoing messages.
* Retrofitted `create_fake_sample` for use in handle dev API requests. Change `name` to be more informative to frontend users (**Fake 123ABC**; includes ID in name) and don't fail when there is no application level `FakerWrapper` object.