### PR TITLE
Add nightly build action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: virtool/virtool:nightly
+      - name: Image Digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Builds a Docker image and pushes to Dockerhub with the `nightly` tag.