### PR TITLE
Use path context for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,10 @@ jobs:
   docker:
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: develop
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -17,6 +21,7 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: "docker/Dockerfile"
           push: true
           tags: virtool/virtool:nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "22 22 * * *"
 
 jobs:
   docker:


### PR DESCRIPTION
* Use path context so `develop` doesn't have to be default branch
* Schedule action off hour [to reduce waiting time](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events)