### PR TITLE
Add nightly.yml GitHub action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,29 @@
+name: nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "22 22 * * *"
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: "docker/Dockerfile"
+          push: true
+          tags: virtool/virtool:nightly
+      - name: Image Digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Runs a nightly build that can also be triggered manually.

Merging this into `master` because workflows in non-default branches cannot be manually triggered.