### PR TITLE
Copy example files into docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ COPY run.py /virtool/
 COPY virtool /virtool/virtool
 COPY static /virtool/static
 COPY templates /virtool/templates
+COPY example /virtool/example
 EXPOSE 9950
 ENTRYPOINT ["python", "run.py"]
 CMD ["server"]


### PR DESCRIPTION
The `virtool/virtool` image does not contain the example files which are required for integration tests.

- Adds `COPY example /virtool/example` to Dockerfile