### PR TITLE
Replace usage of semver.compare with VersionInfo

### DIFF
--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -3,8 +3,8 @@ import sys
 from typing import Any, Callable, Dict, List
 
 import pymongo.errors
-import semver
 from motor.motor_asyncio import AsyncIOMotorClient
+from semver import VersionInfo
 
 import virtool.db.core
 import virtool.db.utils
@@ -55,7 +55,7 @@ async def check_mongo_version(db: AsyncIOMotorClient) -> str:
     """
     mongo_version = await get_mongo_version(db)
 
-    if semver.compare(mongo_version, MINIMUM_MONGO_VERSION) == -1:
+    if VersionInfo.parse(mongo_version) < VersionInfo.parse(MINIMUM_MONGO_VERSION):
         logger.critical(
             f"Virtool requires MongoDB {MINIMUM_MONGO_VERSION}. Found {mongo_version}."
         )

--- a/virtool/hmm/utils.py
+++ b/virtool/hmm/utils.py
@@ -1,11 +1,12 @@
 from pathlib import Path
+from typing import Optional
 
-import semver
+from semver import VersionInfo
 
 import virtool.github
 
 
-def format_hmm_release(updated: dict, release: dict, installed: dict) -> dict:
+def format_hmm_release(updated: Optional[dict], release: dict, installed: dict) -> Optional[dict]:
     # The release dict will only be replaced if there is a 200 response from GitHub. A 304 indicates the release
     # has not changed and `None` is returned from `get_release()`.
     if updated is None:
@@ -15,8 +16,8 @@ def format_hmm_release(updated: dict, release: dict, installed: dict) -> dict:
 
     formatted["newer"] = bool(
         release is None or installed is None or (
-                installed and
-                semver.compare(formatted["name"].lstrip("v"), installed["name"].lstrip("v")) == 1
+            installed and
+            VersionInfo.parse(formatted["name"].lstrip("v")) > VersionInfo.parse(installed["name"].lstrip("v"))
         )
     )
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -61,8 +61,8 @@ from typing import List, Union, Optional
 
 import aiohttp
 import pymongo
-import semver
 from aiohttp import web
+from semver import VersionInfo
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
 import virtool.api
@@ -401,7 +401,7 @@ async def fetch_and_update_release(app, ref_id: str, ignore_errors: bool = False
 
         release["newer"] = bool(
             installed and
-            semver.compare(release["name"].lstrip("v"), installed["name"].lstrip("v")) == 1
+            VersionInfo.parse(release["name"].lstrip("v")) > VersionInfo.parse(installed["name"].lstrip("v"))
         )
 
         release["retrieved_at"] = retrieved_at


### PR DESCRIPTION
The `semver.compare` function is deprecated. This commit replaces it with `VersionInfo` objects and equality operators.