### PR TITLE
Fix Nightly Build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /build
 RUN pip install --user poetry
 COPY pyproject.toml ./pyproject.toml
 COPY poetry.lock ./poetry.lock
-RUN /root/.local/bin/poetry export > requirements.txt
+RUN /root/.local/bin/poetry export --without-hashes > requirements.txt
 RUN pip install --user -r requirements.txt
 COPY . . 
 RUN pip install --user .


### PR DESCRIPTION
Pip requires versions to be pinned using `==` when hashes are given in the `requirements.txt` file. The `Dockerfile` has been changed to use `poetry export --without-hashes` which should resolve the build issues.