### PR TITLE
Updated `ready` prop to be dependent on `state.settings.data`

### DIFF
--- a/client/src/js/app/Main.js
+++ b/client/src/js/app/Main.js
@@ -80,8 +80,8 @@ export const Main = ({ ready, onLoad }) => {
     return <LoadingPlaceholder />;
 };
 
-export const mapStateToProps = ({ account: { ready }, settings: { data } }) => ({
-    ready: ready && Boolean(data)
+export const mapStateToProps = state => ({
+    ready: state.account.ready && Boolean(state.settings.data)
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/client/src/js/app/Main.js
+++ b/client/src/js/app/Main.js
@@ -1,4 +1,3 @@
-import { keys } from "lodash-es";
 import React, { lazy, Suspense, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
@@ -46,7 +45,7 @@ export const Main = ({ ready, onLoad }) => {
 
     if (ready) {
         return (
-            <div>
+            <React.Fragment>
                 <Helmet>
                     <title>Virtool</title>
                     <meta charSet="utf-8" />
@@ -74,15 +73,15 @@ export const Main = ({ ready, onLoad }) => {
 
                 <DevDialog />
                 <UploadOverlay />
-            </div>
+            </React.Fragment>
         );
     }
 
     return <LoadingPlaceholder />;
 };
 
-export const mapStateToProps = state => ({
-    ready: state.account.ready && Boolean(keys(state.settings).length)
+export const mapStateToProps = ({ account: { ready }, settings: { data } }) => ({
+    ready: ready && Boolean(data)
 });
 
 export const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
`State.account.data` was previously not considered to determine the value of the ready prop. This lead to issues where other components that depended on that data, like the sample creation page, would attempt to access it before it had been loaded.