### PR TITLE
Fix 500 error when creating analysis

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -891,7 +891,7 @@ async def test_analyze(error, mocker, spawn_client, static_time, resp_is,
             "all_write": True
         })
 
-    m_new = mocker.patch("virtool.analyses.db.create", new=make_mocked_coro(test_analysis))
+    m_create = mocker.patch("virtool.analyses.db.create", new=make_mocked_coro(test_analysis))
 
     resp = await client.post("/api/samples/test/analyses", data={
         "workflow": "pathoscope_bowtie",
@@ -923,8 +923,8 @@ async def test_analyze(error, mocker, spawn_client, static_time, resp_is,
 
     assert await resp.json() == test_analysis
 
-    m_new.assert_called_with(
-        client.app,
+    m_create.assert_called_with(
+        client.db,
         "test",
         "foo",
         ["bar"],

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -700,9 +700,8 @@ async def analyze(req):
 
     job_id = await virtool.db.utils.get_new_id(db.jobs)
 
-    # Generate a unique _id for the analysis entry
     document = await virtool.analyses.db.create(
-        req.app,
+        req.app["db"],
         sample_id,
         ref_id,
         subtractions,


### PR DESCRIPTION
The function `virtool.analyses.db.create` was not being passed the correct arguments.