### PR TITLE
Uploads fixture support.

### DIFF
--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -87,6 +87,7 @@ async def find(req):
 
 
 @routes.get("/api/uploads/{id}")
+@routes.jobs_api.get("/api/uploads/{id}")
 async def get(req):
     """
     Downloads a file that corresponds to a row `id` in the `uploads` SQL table.

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -14,7 +14,7 @@ import virtool.utils
 from virtool.api.response import invalid_query, json_response, bad_request, not_found
 from virtool.uploads.models import Upload, UploadType
 
-logger = logging.getLogger("uploads")
+logger = logging.getLogger(__name__)
 
 routes = virtool.http.routes.Routes()
 


### PR DESCRIPTION
Add `/api/uploads/{id}` to jobs API for use in the `download_input_file` fixture introduced by PR [#206](https://github.com/virtool/virtool-workflow/pull/206) on `virtool_workflow`.