### PR TITLE
Change "task" to "workflow" in job documents

### DIFF
--- a/tests/fixtures/jobs.py
+++ b/tests/fixtures/jobs.py
@@ -81,7 +81,7 @@ def test_job(dbi, static_time):
                 "progress": 1.0
             }
         ],
-        "task": "build_index",
+        "workflow": "build_index",
         "user": {
             "id": "igboyes"
         }

--- a/tests/indexes/snapshots/snap_test_api.py
+++ b/tests/indexes/snapshots/snap_test_api.py
@@ -40,7 +40,7 @@ snapshots['TestCreate.test[True-uvloop] 1'] = {
             'timestamp': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
-    'task': 'build_index',
+    'workflow': 'build_index',
     'user': {
         'id': 'test'
     }

--- a/tests/indexes/snapshots/snap_test_api.py
+++ b/tests/indexes/snapshots/snap_test_api.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import GenericRepr, Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['TestCreate.test[True-uvloop] 1'] = {

--- a/tests/jobs/snapshots/snap_test_api.py
+++ b/tests/jobs/snapshots/snap_test_api.py
@@ -51,7 +51,7 @@ snapshots['test_acquire[uvloop-None] 1'] = {
             'timestamp': '2015-10-06T20:00:00Z'
         }
     ],
-    'task': 'build_index',
+    'workflow': 'build_index',
     'user': {
         'id': 'igboyes'
     }
@@ -94,7 +94,7 @@ snapshots['test_cancel[uvloop] 1'] = {
             'timestamp': '2015-10-06T20:00:00Z'
         }
     ],
-    'task': 'build_index',
+    'workflow': 'build_index',
     'user': {
         'id': 'igboyes'
     }
@@ -143,7 +143,7 @@ snapshots['test_get[uvloop-None] 1'] = {
             'timestamp': '2015-10-06T20:00:00Z'
         }
     ],
-    'task': 'build_index',
+    'workflow': 'build_index',
     'user': {
         'id': 'igboyes'
     }

--- a/tests/jobs/snapshots/snap_test_db.py
+++ b/tests/jobs/snapshots/snap_test_db.py
@@ -58,7 +58,7 @@ snapshots['test_create[uvloop-False] 1'] = {
             'timestamp': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
-    'task': 'create_sample',
+    'workflow': 'create_sample',
     'user': {
         'id': 'bob'
     }
@@ -94,7 +94,7 @@ snapshots['test_create[uvloop-True] 1'] = {
             'timestamp': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)')
         }
     ],
-    'task': 'create_sample',
+    'workflow': 'create_sample',
     'user': {
         'id': 'bob'
     }
@@ -118,7 +118,7 @@ snapshots['test_processor[uvloop] 1'] = {
     'progress': 1.0,
     'stage': 'import_results',
     'state': 'complete',
-    'task': 'build_index',
+    'workflow': 'build_index',
     'user': {
         'id': 'igboyes'
     }

--- a/tests/jobs/test_client.py
+++ b/tests/jobs/test_client.py
@@ -17,24 +17,24 @@ async def test_init(dbi, redis, jobs_client):
     assert jobs_client.redis == redis
 
 
-@pytest.mark.parametrize("workflow_name", ["nuvs", "create_sample"])
-async def test_enqueue(workflow_name, dbi, redis, jobs_client):
+@pytest.mark.parametrize("workflow", ["nuvs", "create_sample"])
+async def test_enqueue(workflow, dbi, redis, jobs_client):
     await dbi.jobs.insert_one({
         "_id": "foo",
-        "task": workflow_name
+        "workflow": workflow
     })
 
     await jobs_client.enqueue("foo")
 
-    key = f"jobs_{workflow_name}"
+    key = f"jobs_{workflow}"
 
     assert await redis.llen(key) == 1
     assert await redis.lpop(key, encoding="utf-8") == "foo"
 
 
-@pytest.mark.parametrize("workflow_name", ["nuvs", "create_sample"])
-async def test_cancel_waiting(workflow_name, dbi, redis, jobs_client, static_time):
-    await redis.rpush(f"jobs_{workflow_name}", "foo")
+@pytest.mark.parametrize("workflow", ["nuvs", "create_sample"])
+async def test_cancel_waiting(workflow, dbi, redis, jobs_client, static_time):
+    await redis.rpush(f"jobs_{workflow}", "foo")
 
     list_keys = ["jobs_nuvs", "jobs_create_sample"]
 

--- a/virtool/fake/factory.py
+++ b/virtool/fake/factory.py
@@ -3,23 +3,23 @@ import shutil
 from typing import List
 
 import virtool.indexes.db
-import virtool.references.db
-import virtool.subtractions.db
 import virtool.jobs.db
-import virtool.utils
-from virtool.jobs.utils import JobRights
-from virtool.otus.fake import create_fake_otus
+import virtool.subtractions.db
 from virtool.analyses.files import create_analysis_file
 from virtool.example import example_path
+from virtool.fake.identifiers import USER_ID
 from virtool.fake.wrapper import FakerWrapper
 from virtool.hmm.fake import create_fake_hmms
 from virtool.indexes.fake import INDEX_FILES
 from virtool.indexes.files import create_index_file
+from virtool.jobs.utils import JobRights
+from virtool.otus.fake import create_fake_otus
+from virtool.references.db import create_document
 from virtool.samples.fake import create_fake_sample
 from virtool.subtractions.fake import (create_fake_fasta_upload,
                                        create_fake_finalized_subtraction)
-from virtool.fake.identifiers import USER_ID
 from virtool.types import App
+from virtool.utils import timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class TestCaseDataFactory:
         document = {
             "_id": id_,
             "workflow": workflow,
-            "created_at": virtool.utils.timestamp(),
+            "created_at": timestamp(),
             "ready": ready,
             "job": {
                 "id": self.job_id
@@ -128,7 +128,7 @@ class TestCaseDataFactory:
 
     async def reference(self) -> dict:
         id_ = self.fake.get_mongo_id()
-        document = await virtool.references.db.create_document(
+        document = await create_document(
             db=self.db,
             settings=self.settings,
             ref_id=id_,

--- a/virtool/fake/factory.py
+++ b/virtool/fake/factory.py
@@ -186,7 +186,7 @@ class TestCaseDataFactory:
     async def job(self, workflow: str, args: dict, rights=JobRights()):
         return await virtool.jobs.db.create(
             db=self.db,
-            workflow_name=workflow,
+            workflow=workflow,
             job_args=args,
             user_id=self.user_id,
             job_id=self.job_id,

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -1,18 +1,17 @@
 import os
 
-import virtool.api.utils
-import virtool.http.routes
 import virtool.jobs.db
 import virtool.users.db
 import virtool.utils
 from virtool.api.response import bad_request, conflict, json_response, no_content, \
     not_found
+from virtool.api.utils import compose_regex_query, paginate
 from virtool.db.utils import get_one_field
+from virtool.http.routes import Routes
 from virtool.http.schema import schema
 from virtool.jobs.db import PROJECTION
-from virtool.utils import base_processor
 
-routes = virtool.http.routes.Routes()
+routes = Routes()
 
 
 @routes.get("/api/jobs")
@@ -28,9 +27,9 @@ async def find(req):
     db_query = dict()
 
     if term:
-        db_query.update(virtool.api.utils.compose_regex_query(term, ["workflow", "user.id"]))
+        db_query.update(compose_regex_query(term, ["workflow", "user.id"]))
 
-    data = await virtool.api.utils.paginate(
+    data = await paginate(
         db.jobs,
         db_query,
         req.query,
@@ -85,7 +84,7 @@ async def acquire(req):
 
     document = await virtool.jobs.db.acquire(db, job_id)
 
-    return json_response(base_processor(document))
+    return json_response(virtool.utils.base_processor(document))
 
 
 @routes.put("/api/jobs/{job_id}/cancel", permission="cancel_job")

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -28,7 +28,7 @@ async def find(req):
     db_query = dict()
 
     if term:
-        db_query.update(virtool.api.utils.compose_regex_query(term, ["task", "user.id"]))
+        db_query.update(virtool.api.utils.compose_regex_query(term, ["workflow", "user.id"]))
 
     data = await virtool.api.utils.paginate(
         db.jobs,

--- a/virtool/jobs/client.py
+++ b/virtool/jobs/client.py
@@ -24,9 +24,9 @@ class JobsClient:
         self.redis = app["redis"]
 
     async def enqueue(self, job_id):
-        task = await get_one_field(self.db.jobs, "task", job_id)
+        workflow = await get_one_field(self.db.jobs, "workflow", job_id)
 
-        await self.redis.rpush(f"jobs_{task}", job_id)
+        await self.redis.rpush(f"jobs_{workflow}", job_id)
 
         logger.debug(f"Enqueued job: {job_id}")
 

--- a/virtool/jobs/db.py
+++ b/virtool/jobs/db.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional
 
 import virtool.utils
 from virtool.jobs.utils import JobRights
-from virtool.utils import base_processor
 
 OR_COMPLETE = [
     {"status.state": "complete"}
@@ -56,7 +55,7 @@ async def cancel(db, job_id: str) -> dict:
                 "timestamp": virtool.utils.timestamp()
             }
         }
-    }, projection=virtool.jobs.db.PROJECTION)
+    }, projection=PROJECTION)
 
 
 async def clear(db, complete: bool = False, failed: bool = False):
@@ -149,7 +148,7 @@ async def acquire(db, job_id: str) -> Dict[str, Any]:
 
     document["key"] = key
 
-    return base_processor(document)
+    return virtool.utils.base_processor(document)
 
 
 async def processor(db, document: dict) -> dict:

--- a/virtool/jobs/db.py
+++ b/virtool/jobs/db.py
@@ -20,7 +20,7 @@ OR_FAILED = [
 #: A projection for minimal representations of jobs suitable for search results.
 LIST_PROJECTION = [
     "_id",
-    "task",
+    "workflow",
     "status",
     "proc",
     "mem",
@@ -83,7 +83,7 @@ async def clear(db, complete: bool = False, failed: bool = False):
 
 async def create(
         db,
-        workflow_name: str,
+        workflow: str,
         job_args: Dict[str, Any],
         user_id: str,
         rights: JobRights,
@@ -93,7 +93,7 @@ async def create(
     Create, insert, and return a job document.
 
     :param db: the application database object
-    :param workflow_name: the name of the workflow to run
+    :param workflow: the name of the workflow to run
     :param job_args: the arguments required to run the job
     :param user_id: the user that started the job
     :param rights: the rights the job will have on Virtool resources
@@ -102,7 +102,7 @@ async def create(
     """
     document = {
         "acquired": False,
-        "task": workflow_name,
+        "workflow": workflow,
         "args": job_args,
         "key": None,
         "rights": rights.as_dict(),

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -8,7 +8,6 @@ import virtool.http.accept
 import virtool.jobs.auth
 from virtool.dev.fake import drop_fake_mongo, remove_fake_data_path
 from virtool.jobs.routes import init_routes
-from virtool.logs import configure_jobs_api_server
 from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown
 from virtool.shutdown import drop_fake_postgres
 from virtool.startup import init_fake_config, init_redis, init_db, init_postgres, init_settings, init_executors, \
@@ -73,7 +72,7 @@ async def start_aiohttp_server(
     return app, runner
 
 
-async def run(dev: bool, verbose: bool, **config):
+async def run(**config):
     """
     Run the jobs API server.
 
@@ -81,7 +80,6 @@ async def run(dev: bool, verbose: bool, **config):
     :param verbose: Same effect as :obj:`dev`
     :param config: Any other configuration options as keyword arguments
     """
-    logger = configure_jobs_api_server(dev, verbose)
     app, runner = await start_aiohttp_server(**config)
 
     _, pending = await asyncio.wait(

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -89,5 +89,5 @@ async def run(dev: bool, verbose: bool, **config):
         return_when=asyncio.FIRST_COMPLETED,
     )
 
-    for task in pending:
-        task.cancel()
+    for job in pending:
+        job.cancel()

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -6,12 +6,13 @@ import aiojobs.aiohttp
 
 import virtool.http.accept
 import virtool.jobs.auth
-import virtool.jobs.routes
-import virtool.logs
-import virtool.shutdown
-import virtool.startup
 from virtool.dev.fake import drop_fake_mongo, remove_fake_data_path
+from virtool.jobs.routes import init_routes
+from virtool.logs import configure_jobs_api_server
 from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown
+from virtool.shutdown import drop_fake_postgres
+from virtool.startup import init_fake_config, init_redis, init_db, init_postgres, init_settings, init_executors, \
+    init_fake, init_events
 from virtool.types import App
 
 
@@ -30,21 +31,21 @@ async def create_app(**config):
     aiojobs.aiohttp.setup(app)
 
     app.on_startup.extend([
-        virtool.startup.init_fake_config,
-        virtool.startup.init_redis,
-        virtool.startup.init_db,
-        virtool.startup.init_postgres,
-        virtool.startup.init_settings,
-        virtool.startup.init_executors,
-        virtool.startup.init_fake,
-        virtool.startup.init_events,
-        virtool.jobs.routes.init_routes,
+        init_fake_config,
+        init_redis,
+        init_db,
+        init_postgres,
+        init_settings,
+        init_executors,
+        init_fake,
+        init_events,
+        init_routes,
     ])
 
     app.on_shutdown.extend([
         shutdown,
         drop_fake_mongo,
-        virtool.shutdown.drop_fake_postgres,
+        drop_fake_postgres,
         remove_fake_data_path,
     ])
 
@@ -80,7 +81,7 @@ async def run(dev: bool, verbose: bool, **config):
     :param verbose: Same effect as :obj:`dev`
     :param config: Any other configuration options as keyword arguments
     """
-    logger = virtool.logs.configure_jobs_api_server(dev, verbose)
+    logger = configure_jobs_api_server(dev, verbose)
     app, runner = await start_aiohttp_server(**config)
 
     _, pending = await asyncio.wait(


### PR DESCRIPTION
Update naming and documentation for "task" field in MongoDB job documents.