### PR TITLE
Require count parameter. 

### DIFF
--- a/tests/subtractions/snapshots/snap_test_api.py
+++ b/tests/subtractions/snapshots/snap_test_api.py
@@ -117,6 +117,7 @@ snapshots['test_finalize_subtraction[uvloop-None] 1'] = {
         'n': 0.002,
         't': 0.319
     },
+    "count": 100,
     'id': 'foo',
     'linked_samples': [
     ],
@@ -151,5 +152,6 @@ snapshots['test_finalize_subtraction[uvloop-None] 2'] = {
     },
     'name': 'Foo',
     'nickname': 'Foo Subtraction',
+    "count": 100,
     'ready': True
 }

--- a/tests/subtractions/snapshots/snap_test_fake.py
+++ b/tests/subtractions/snapshots/snap_test_fake.py
@@ -10,6 +10,7 @@ snapshots = Snapshot()
 snapshots['test_create_fake_subtractions[uvloop] 1'] = [
     {
         '_id': '2x6YnyMt',
+        'count': 100,
         'deleted': False,
         'file': {
             'id': 1,

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -123,7 +123,7 @@ async def test_finalize_subtraction(error, spawn_job_client, snapshot, resp_is, 
         return
 
     if error == "422":
-        assert await resp_is.invalid_input(resp, {'gc': ['required field']})
+        assert await resp_is.invalid_input(resp, {'gc': ['required field'], 'count': ['required field']})
         return
 
     assert resp.status == 200

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -97,7 +97,8 @@ async def test_finalize_subtraction(error, spawn_job_client, snapshot, resp_is, 
             "g": 0.18,
             "c": 0.18,
             "n": 0.002
-        }
+        },
+        "count": 100,
     }
 
     client = await spawn_job_client(authorize=True)

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -122,7 +122,7 @@ async def test_finalize(dbi, pg):
         "n": 0.002
     }
 
-    document = await virtool.subtractions.db.finalize(dbi, pg, "foo", gc)
+    document = await virtool.subtractions.db.finalize(dbi, pg, "foo", gc, 100)
     assert document == {
         "_id": "foo",
         "name": "Foo",

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -133,5 +133,6 @@ async def test_finalize(dbi, pg):
             "c": 0.18,
             "n": 0.002
         },
-        "ready": True
+        "ready": True,
+        "count": 100
     }

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -299,7 +299,10 @@ async def remove(req):
 
 
 @routes.jobs_api.patch("/api/subtractions/{subtraction_id}")
-@schema({"gc": {"type": "dict", "required": True}})
+@schema({
+    "gc": {"type": "dict", "required": True},
+    "count": {"type": "int", "required": True}
+})
 async def finalize_subtraction(req: aiohttp.web.Request):
     """
     Sets the gc field for an subtraction and marks it as ready.
@@ -319,7 +322,7 @@ async def finalize_subtraction(req: aiohttp.web.Request):
     if "ready" in document and document["ready"]:
         return conflict("Subtraction has already been finalized")
 
-    finalized = await virtool.subtractions.db.finalize(db, pg, subtraction_id, data["gc"])
+    finalized = await virtool.subtractions.db.finalize(db, pg, subtraction_id, data["gc"], data["count"])
     with_computed = await attach_computed(req.app, finalized)
 
     return json_response(virtool.utils.base_processor(with_computed))

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -154,7 +154,10 @@ async def create(req):
 
     task_args = {
         "subtraction_id": subtraction_id,
-        "upload_id": upload_id
+        "files": [{
+            "id": upload_id,
+            "name": filename
+        }]
     }
 
     rights = JobRights()
@@ -301,7 +304,7 @@ async def remove(req):
 @routes.jobs_api.patch("/api/subtractions/{subtraction_id}")
 @schema({
     "gc": {"type": "dict", "required": True},
-    "count": {"type": "int", "required": True}
+    "count": {"type": "integer", "required": True}
 })
 async def finalize_subtraction(req: aiohttp.web.Request):
     """

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -183,7 +183,13 @@ async def delete(app: App, subtraction_id: str) -> int:
     return update_result.modified_count
 
 
-async def finalize(db, pg: AsyncEngine, subtraction_id: str, gc: Dict[str, float]) -> dict:
+async def finalize(
+    db,
+    pg: AsyncEngine,
+    subtraction_id: str,
+    gc: Dict[str, float],
+    count: int,
+) -> dict:
     """
     Finalize a subtraction by setting `ready` to True and updating the `gc` and `files` fields.
 
@@ -197,7 +203,8 @@ async def finalize(db, pg: AsyncEngine, subtraction_id: str, gc: Dict[str, float
     updated_document = await db.subtraction.find_one_and_update({"_id": subtraction_id}, {
         "$set": {
             "gc": gc,
-            "ready": True
+            "ready": True,
+            "count": count,
         }
     })
 

--- a/virtool/subtractions/fake.py
+++ b/virtool/subtractions/fake.py
@@ -100,8 +100,8 @@ async def create_fake_finalized_subtraction(
     })
 
     subtractions_path = (
-            app["settings"]["data_path"] 
-            / "subtractions" 
+            app["settings"]["data_path"]
+            / "subtractions"
             / subtraction_id.replace(" ", "_").lower()
     )
 
@@ -125,5 +125,6 @@ async def create_fake_finalized_subtraction(
             "t": 0.25,
             "g": 0.25,
             "c": 0.25
-        }
+        },
+        count=100
     )


### PR DESCRIPTION
- Require `count` field in `PATCH /api/subtractions/{id}` route.
- Update `task_args` to use `files` list instead of `upload_id`.
     - Allows `virtool_workflow`'s `input_files` fixture to work as intended. 

