### PR TITLE
Accept None user group during sample creation

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -298,7 +298,7 @@ class TestCreate:
 
         assert await resp_is.bad_request(resp, "Sample name is already in use")
 
-    @pytest.mark.parametrize("group", [None, "", "diagnostics"])
+    @pytest.mark.parametrize("group", ["", "diagnostics", None])
     async def test_force_choice(self, spawn_client, pg: AsyncEngine, resp_is, group):
         """
         Test that when ``force_choice`` is enabled, a request with no group field passed results in
@@ -330,13 +330,13 @@ class TestCreate:
             {"_id": "diagnostics"},
         )
 
-        if group:
+        if group is None:
+            resp = await client.post("/api/samples", request_data)
+            assert await resp_is.bad_request(resp, "Group value required for sample creation")
+        else:
             request_data["group"] = group
             resp = await client.post("/api/samples", request_data)
             assert resp.status == 201
-        else:
-            resp = await client.post("/api/samples", request_data)
-            assert await resp_is.bad_request(resp, "Group value required for sample creation")
 
     async def test_group_dne(self, spawn_client, pg: AsyncEngine, resp_is):
         client = await spawn_client(authorize=True, permissions=["create_sample"])

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -298,10 +298,11 @@ class TestCreate:
 
         assert await resp_is.bad_request(resp, "Sample name is already in use")
 
-    async def test_force_choice(self, spawn_client, pg: AsyncEngine, resp_is):
+    @pytest.mark.parametrize("group", [None, "", "diagnostics"])
+    async def test_force_choice(self, spawn_client, pg: AsyncEngine, resp_is, group):
         """
         Test that when ``force_choice`` is enabled, a request with no group field passed results in
-        an error response.
+        an error response, that "" is accepted as a valid user group and that valid user groups are accepted as expected
 
         """
         client = await spawn_client(authorize=True, permissions=["create_sample"])
@@ -320,13 +321,22 @@ class TestCreate:
             session.add(upload)
             await session.commit()
 
-        resp = await client.post("/api/samples", {
+        request_data = {
             "name": "Foobar",
             "files": [1],
             "subtractions": ["apple"]
-        })
+        }
+        await client.db.groups.insert_one(
+            {"_id": "diagnostics"},
+        )
 
-        assert await resp_is.bad_request(resp, "Group value required for sample creation")
+        if group:
+            request_data["group"] = group
+            resp = await client.post("/api/samples", request_data)
+            assert resp.status == 201
+        else:
+            resp = await client.post("/api/samples", request_data)
+            assert await resp_is.bad_request(resp, "Group value required for sample creation")
 
     async def test_group_dne(self, spawn_client, pg: AsyncEngine, resp_is):
         client = await spawn_client(authorize=True, permissions=["create_sample"])

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -301,9 +301,6 @@ async def create(req):
         force_choice_error_message = await virtool.samples.db.validate_force_choice_group(db, data)
 
         if force_choice_error_message:
-            if "not found" in force_choice_error_message:
-                return bad_request(force_choice_error_message)
-
             return bad_request(force_choice_error_message)
 
         group = data["group"]

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -361,6 +361,9 @@ async def remove_samples(
 
 async def validate_force_choice_group(db, data: dict) -> Optional[str]:
     try:
+        if data["group"] == "":
+            return None
+
         if not await db.groups.count_documents({"_id": data["group"]}):
             return "Group does not exist"
 


### PR DESCRIPTION
* When force_group_choice is enabled, accept "" as a valid user group
* Update tests