### PR TITLE
Use aiohttp's Web Exceptions

### DIFF
--- a/virtool/http/errors.py
+++ b/virtool/http/errors.py
@@ -1,6 +1,6 @@
 from typing import Callable
+
 from aiohttp import web
-from aiohttp.web_exceptions import HTTPNotFound
 
 from virtool.api.response import json_response
 from virtool.templates import setup_template_env
@@ -11,10 +11,11 @@ from virtool.utils import get_static_hash
 async def middleware(req: web.Request, handler: Callable):
     try:
         resp = await handler(req)
-        return resp
 
-    except HTTPNotFound:
-        return handle_404(req)
+        if not req.path.startswith("/api") and resp.status == 404:
+            return handle_404(req)
+
+        return resp
 
     except web.HTTPException as ex:
         data = {

--- a/virtool/http/errors.py
+++ b/virtool/http/errors.py
@@ -1,38 +1,33 @@
 from typing import Callable
-
 from aiohttp import web
+from aiohttp.web_exceptions import HTTPNotFound
 
-import virtool.templates
-import virtool.utils
-from virtool.api.response import not_found
+from virtool.api.response import json_response
+from virtool.templates import setup_template_env
+from virtool.utils import get_static_hash
 
 
 @web.middleware
 async def middleware(req: web.Request, handler: Callable):
-    is_api_call = req.path.startswith("/api")
-
     try:
-        response = await handler(req)
+        resp = await handler(req)
+        return resp
 
-        if not is_api_call and response.status == 404:
-            return handle_404(req)
-
-        return response
+    except HTTPNotFound:
+        return handle_404(req)
 
     except web.HTTPException as ex:
-        if is_api_call:
-            return not_found()
-
-        if ex.status == 404:
-            return handle_404(req)
-
-        raise
+        data = {
+            "id": "_".join(ex.reason.lower().split(" ")),
+            "message": ex.text
+        }
+        return json_response(data, ex.status)
 
 
 def handle_404(req: web.Request):
-    template = virtool.templates.setup_template_env.get_template("error_404.html")
+    template = setup_template_env.get_template("error_404.html")
 
-    static_hash = virtool.utils.get_static_hash(req)
+    static_hash = get_static_hash(req)
 
     html = template.render(hash=static_hash)
 

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import aiohttp.web
 import aiojobs.aiohttp
 
+import virtool.http.errors
 import virtool.http.accept
 import virtool.jobs.auth
 from virtool.dev.fake import drop_fake_mongo, remove_fake_data_path
@@ -16,10 +17,11 @@ from virtool.types import App
 
 
 async def create_app(**config):
-    """Crate the :class:`aiohttp.web.Application` for the jobs API process."""
+    """Create the :class:`aiohttp.web.Application` for the jobs API process."""
     middlewares = [
         virtool.http.accept.middleware,
         virtool.jobs.auth.middleware,
+        virtool.http.errors.middleware
     ]
 
     app: aiohttp.web.Application = aiohttp.web.Application(middlewares=middlewares)


### PR DESCRIPTION
 Update `virtool.http.errors.middleware` to return a `web.Response` object with a JSON body 
* "id" value is a snake-case message produced from the "reason" field of the exception. For example the HTTPNotFound error would have "Not Found" as its reason, which would be converted to "not_found".
* "message" is the text passed in when the error is raised. For example when helper functions are used, the message was passed in as `return not_found("Release not found")` and now the text will be given as `raise HTTPNotFound(text="Release not found")`. 

