### PR TITLE
Sample request handlers

### DIFF
--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -81,8 +81,6 @@ async def find(req):
     if not v.validate(dict(req.query)):
         return invalid_query(v.errors)
 
-    query = v.document
-
     queries = list()
 
     term = req.query.get("find")


### PR DESCRIPTION
Renamed request handler functions for the sample API. The handler function naming didn't make a lot of sense in terms of referring to caches and reads or artifacts.

The ordering of similar handlers for creating or getting reads and artifacts for samples and caches was inconsistent. They have been reordered to be more parallel.

Unused `query` variable was removed from `find()` handler.