### PR TITLE
Always use the get_sample() function for form API responses

### DIFF
--- a/tests/samples/snapshots/snap_test_api.py
+++ b/tests/samples/snapshots/snap_test_api.py
@@ -7,292 +7,19 @@ from snapshottest import GenericRepr, Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_find_analyses[uvloop-None-None] 1'] = {
-    'documents': [
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'id': 'test_1',
-            'index': {
-                'id': 'foo',
-                'version': 2
-            },
-            'job': {
-                'id': 'test'
-            },
-            'ready': True,
-            'reference': {
-                'id': 'baz',
-                'name': 'Baz'
-            },
-            'sample': {
-                'id': 'test'
-            },
-            'user': {
-                'id': 'bob'
-            },
-            'workflow': 'pathoscope_bowtie'
-        },
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'id': 'test_2',
-            'index': {
-                'id': 'foo',
-                'version': 2
-            },
-            'job': {
-                'id': 'test'
-            },
-            'ready': True,
-            'reference': {
-                'id': 'baz',
-                'name': 'Baz'
-            },
-            'sample': {
-                'id': 'test'
-            },
-            'user': {
-                'id': 'fred'
-            },
-            'workflow': 'pathoscope_bowtie'
-        },
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'id': 'test_3',
-            'index': {
-                'id': 'foo',
-                'version': 2
-            },
-            'job': {
-                'id': 'test'
-            },
-            'ready': True,
-            'reference': {
-                'id': 'foo',
-                'name': 'Foo'
-            },
-            'sample': {
-                'id': 'test'
-            },
-            'user': {
-                'id': 'fred'
-            },
-            'workflow': 'pathoscope_bowtie'
-        }
-    ],
-    'found_count': 3,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3
-}
-
-snapshots['test_find_analyses[uvloop-bob-None] 1'] = {
-    'documents': [
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'id': 'test_1',
-            'index': {
-                'id': 'foo',
-                'version': 2
-            },
-            'job': {
-                'id': 'test'
-            },
-            'ready': True,
-            'reference': {
-                'id': 'baz',
-                'name': 'Baz'
-            },
-            'sample': {
-                'id': 'test'
-            },
-            'user': {
-                'id': 'bob'
-            },
-            'workflow': 'pathoscope_bowtie'
-        }
-    ],
-    'found_count': 1,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3
-}
-
-snapshots['test_get_cache[uvloop-None] 1'] = {
-    'id': 'bar',
-    'key': 'abc123',
-    'program': 'skewer-0.2.2',
-    'sample': {
-        'id': 'foo'
-    }
-}
-
-snapshots['test_upload_reads_cache[uvloop-True] 1'] = {
-    'id': 2,
-    'key': 'aodp-abcdefgh',
-    'name': 'reads_2.fq.gz',
-    'name_on_disk': 'reads_2.fq.gz',
-    'sample': 'test',
-    'size': 9081,
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
-snapshots['test_get[uvloop-False-None] 1'] = {
-    'artifacts': [
-        {
-            'id': 1,
-            'name': 'reference.fa.gz',
-            'name_on_disk': 'reference.fa.gz',
-            'sample': 'test',
-            'size': None,
-            'type': 'fasta',
-            'uploaded_at': None
-        }
-    ],
-    'caches': [
-    ],
-    'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'download_url': '/download/samples/files/file_1.fq.gz',
-            'id': 'foo',
-            'name': 'Bar.fq.gz'
-        }
-    ],
-    'id': 'test',
-    'labels': [
-        {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug'
-        }
-    ],
-    'name': 'Test',
-    'paired': False,
-    'reads': [
-        {
-            'id': 1,
-            'name': 'reads_1.fq.gz',
-            'name_on_disk': 'reads_1.fq.gz',
-            'sample': 'test',
-            'size': None,
-            'upload': {
-                'created_at': None,
-                'id': 1,
-                'name': 'test',
-                'name_on_disk': None,
-                'ready': False,
-                'removed': False,
-                'removed_at': None,
-                'reserved': False,
-                'size': None,
-                'type': None,
-                'uploaded_at': None,
-                'user': None
-            },
-            'uploaded_at': None
-        }
-    ],
-    'ready': False,
-    'subtractions': [
-        {
-            'id': 'foo',
-            'name': 'Foo'
-        },
-        {
-            'id': 'bar',
-            'name': 'Bar'
-        }
-    ]
-}
-
-snapshots['test_get[uvloop-True-None] 1'] = {
-    'artifacts': [
-        {
-            'download_url': '/api/samples/test/artifacts/reference.fa.gz',
-            'id': 1,
-            'name': 'reference.fa.gz',
-            'name_on_disk': 'reference.fa.gz',
-            'sample': 'test',
-            'size': None,
-            'type': 'fasta',
-            'uploaded_at': None
-        }
-    ],
-    'caches': [
-    ],
-    'created_at': '2015-10-06T20:00:00Z',
-    'files': [
-        {
-            'download_url': '/download/samples/files/file_1.fq.gz',
-            'id': 'foo',
-            'name': 'Bar.fq.gz'
-        }
-    ],
-    'id': 'test',
-    'labels': [
-        {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug'
-        }
-    ],
-    'name': 'Test',
-    'paired': False,
-    'reads': [
-        {
-            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
-            'id': 1,
-            'name': 'reads_1.fq.gz',
-            'name_on_disk': 'reads_1.fq.gz',
-            'sample': 'test',
-            'size': None,
-            'upload': {
-                'created_at': None,
-                'id': 1,
-                'name': 'test',
-                'name_on_disk': None,
-                'ready': False,
-                'removed': False,
-                'removed_at': None,
-                'reserved': False,
-                'size': None,
-                'type': None,
-                'uploaded_at': None,
-                'user': None
-            },
-            'uploaded_at': None
-        }
-    ],
-    'ready': True,
-    'subtractions': [
-        {
-            'id': 'foo',
-            'name': 'Foo'
-        },
-        {
-            'id': 'bar',
-            'name': 'Bar'
-        }
-    ]
-}
-
-snapshots['TestCreate.test[uvloop-none] 1'] = {
+snapshots['TestCreate.test[uvloop-force_choice] 1'] = {
     'all_read': True,
     'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
     'created_at': '2015-10-06T20:00:00Z',
-    'format': 'fastq',
-    'group': 'none',
+    'group': 'diagnostics',
     'group_read': True,
     'group_write': True,
-    'hold': True,
-    'host': '',
     'id': '9pfsom1b',
     'is_legacy': False,
-    'isolate': '',
     'labels': [
         {
             'color': '#FF0000',
@@ -300,6 +27,35 @@ snapshots['TestCreate.test[uvloop-none] 1'] = {
             'id': 1,
             'name': 'bug'
         }
+    ],
+    'library_type': 'normal',
+    'name': 'Foobar',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': False,
+    'reads': [
+    ],
+    'ready': False,
+    'user': {
+        'id': 'test'
+    }
+}
+
+snapshots['TestCreate.test[uvloop-force_choice] 2'] = {
+    '_id': '9pfsom1b',
+    'all_read': True,
+    'all_write': True,
+    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
+    'format': 'fastq',
+    'group': 'diagnostics',
+    'group_read': True,
+    'group_write': True,
+    'hold': True,
+    'host': '',
+    'is_legacy': False,
+    'isolate': '',
+    'labels': [
+        1
     ],
     'library_type': 'normal',
     'locale': '',
@@ -313,6 +69,40 @@ snapshots['TestCreate.test[uvloop-none] 1'] = {
     'subtractions': [
         'apple'
     ],
+    'user': {
+        'id': 'test'
+    }
+}
+
+snapshots['TestCreate.test[uvloop-none] 1'] = {
+    'all_read': True,
+    'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'group': 'none',
+    'group_read': True,
+    'group_write': True,
+    'id': '9pfsom1b',
+    'is_legacy': False,
+    'labels': [
+        {
+            'color': '#FF0000',
+            'description': None,
+            'id': 1,
+            'name': 'bug'
+        }
+    ],
+    'library_type': 'normal',
+    'name': 'Foobar',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': False,
+    'reads': [
+    ],
+    'ready': False,
     'user': {
         'id': 'test'
     }
@@ -354,16 +144,16 @@ snapshots['TestCreate.test[uvloop-none] 2'] = {
 snapshots['TestCreate.test[uvloop-users_primary_group] 1'] = {
     'all_read': True,
     'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
     'created_at': '2015-10-06T20:00:00Z',
-    'format': 'fastq',
     'group': 'technician',
     'group_read': True,
     'group_write': True,
-    'hold': True,
-    'host': '',
     'id': '9pfsom1b',
     'is_legacy': False,
-    'isolate': '',
     'labels': [
         {
             'color': '#FF0000',
@@ -373,17 +163,13 @@ snapshots['TestCreate.test[uvloop-users_primary_group] 1'] = {
         }
     ],
     'library_type': 'normal',
-    'locale': '',
     'name': 'Foobar',
-    'notes': '',
     'nuvs': False,
     'paired': False,
     'pathoscope': False,
-    'quality': None,
-    'ready': False,
-    'subtractions': [
-        'apple'
+    'reads': [
     ],
+    'ready': False,
     'user': {
         'id': 'test'
     }
@@ -422,232 +208,6 @@ snapshots['TestCreate.test[uvloop-users_primary_group] 2'] = {
     }
 }
 
-snapshots['TestCreate.test[uvloop-force_choice] 1'] = {
-    'all_read': True,
-    'all_write': True,
-    'created_at': '2015-10-06T20:00:00Z',
-    'format': 'fastq',
-    'group': 'diagnostics',
-    'group_read': True,
-    'group_write': True,
-    'hold': True,
-    'host': '',
-    'id': '9pfsom1b',
-    'is_legacy': False,
-    'isolate': '',
-    'labels': [
-        {
-            'color': '#FF0000',
-            'description': None,
-            'id': 1,
-            'name': 'bug'
-        }
-    ],
-    'library_type': 'normal',
-    'locale': '',
-    'name': 'Foobar',
-    'notes': '',
-    'nuvs': False,
-    'paired': False,
-    'pathoscope': False,
-    'quality': None,
-    'ready': False,
-    'subtractions': [
-        'apple'
-    ],
-    'user': {
-        'id': 'test'
-    }
-}
-
-snapshots['TestCreate.test[uvloop-force_choice] 2'] = {
-    '_id': '9pfsom1b',
-    'all_read': True,
-    'all_write': True,
-    'created_at': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),
-    'format': 'fastq',
-    'group': 'diagnostics',
-    'group_read': True,
-    'group_write': True,
-    'hold': True,
-    'host': '',
-    'is_legacy': False,
-    'isolate': '',
-    'labels': [
-        1
-    ],
-    'library_type': 'normal',
-    'locale': '',
-    'name': 'Foobar',
-    'notes': '',
-    'nuvs': False,
-    'paired': False,
-    'pathoscope': False,
-    'quality': None,
-    'ready': False,
-    'subtractions': [
-        'apple'
-    ],
-    'user': {
-        'id': 'test'
-    }
-}
-
-snapshots['TestEdit.test[uvloop] 1'] = {
-    'id': 'test',
-    'labels': [
-        {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug'
-        }
-    ],
-    'name': 'test_sample',
-    'notes': 'This is a test.',
-    'subtractions': [
-        'foo'
-    ]
-}
-
-snapshots['TestEdit.test_name_exists[uvloop-False] 1'] = {
-    'id': 'foo',
-    'labels': [
-    ],
-    'name': 'Bar'
-}
-
-snapshots['TestEdit.test_label_exists[uvloop-True] 1'] = {
-    'id': 'foo',
-    'labels': [
-        {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug'
-        }
-    ],
-    'name': 'Foo'
-}
-
-snapshots['TestEdit.test_subtraction_exists[uvloop-True] 1'] = {
-    'id': 'test',
-    'labels': [
-    ],
-    'name': 'Test',
-    'subtractions': [
-        'foo',
-        'bar'
-    ]
-}
-
-snapshots['test_finalize[uvloop-quality] 1'] = {
-    'artifacts': [
-        {
-            'download_url': '/api/samples/test/artifacts/reference.fa.gz',
-            'id': 1,
-            'name': 'reference.fa.gz',
-            'name_on_disk': 'reference.fa.gz',
-            'sample': 'test',
-            'size': None,
-            'type': 'fasta',
-            'uploaded_at': None
-        }
-    ],
-    'id': 'test',
-    'quality': {
-    },
-    'reads': [
-        {
-            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
-            'id': 1,
-            'name': 'reads_1.fq.gz',
-            'name_on_disk': 'reads_1.fq.gz',
-            'sample': 'test',
-            'size': None,
-            'upload': None,
-            'uploaded_at': None
-        }
-    ],
-    'ready': True
-}
-
-snapshots['test_find_analyses[uvloop-Baz-None] 1'] = {
-    'documents': [
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'id': 'test_1',
-            'index': {
-                'id': 'foo',
-                'version': 2
-            },
-            'job': {
-                'id': 'test'
-            },
-            'ready': True,
-            'reference': {
-                'id': 'baz',
-                'name': 'Baz'
-            },
-            'sample': {
-                'id': 'test'
-            },
-            'user': {
-                'id': 'bob'
-            },
-            'workflow': 'pathoscope_bowtie'
-        },
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'id': 'test_2',
-            'index': {
-                'id': 'foo',
-                'version': 2
-            },
-            'job': {
-                'id': 'test'
-            },
-            'ready': True,
-            'reference': {
-                'id': 'baz',
-                'name': 'Baz'
-            },
-            'sample': {
-                'id': 'test'
-            },
-            'user': {
-                'id': 'fred'
-            },
-            'workflow': 'pathoscope_bowtie'
-        }
-    ],
-    'found_count': 2,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3
-}
-
-snapshots['test_upload_artifact[uvloop-None] 1'] = {
-    'id': 1,
-    'name': 'small.fq',
-    'name_on_disk': 'small.fq',
-    'sample': 'test',
-    'size': 3130756,
-    'type': 'fastq',
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
-snapshots['TestUploadReads.test_upload_reads[uvloop-True] 1'] = {
-    'id': 1,
-    'name': 'reads_1.fq.gz',
-    'name_on_disk': 'reads_1.fq.gz',
-    'sample': 'test',
-    'size': 9081,
-    'upload': 1,
-    'uploaded_at': '2015-10-06T20:00:00Z'
-}
-
 snapshots['TestCreateCache.test[uvloop-key] 1'] = {
     'created_at': '2015-10-06T20:00:00Z',
     'files': [
@@ -663,25 +223,128 @@ snapshots['TestCreateCache.test[uvloop-key] 1'] = {
     }
 }
 
-snapshots['test_upload_artifact_cache[uvloop-None] 1'] = {
-    'id': 1,
-    'key': 'aodp-abcdefgh',
-    'name': 'small.fq',
-    'name_on_disk': 'small.fq',
-    'sample': 'test',
-    'size': 3130756,
-    'type': 'fastq',
-    'uploaded_at': '2015-10-06T20:00:00Z'
+snapshots['TestEdit.test[uvloop] 1'] = {
+    'all_read': True,
+    'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
+    'id': 'test',
+    'labels': [
+        {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug'
+        }
+    ],
+    'name': 'test_sample',
+    'paired': False,
+    'reads': [
+    ],
+    'ready': True
 }
 
-snapshots['test_upload_reads_cache[uvloop-False] 1'] = {
+snapshots['TestEdit.test_label_exists[uvloop-True] 1'] = {
+    'all_read': True,
+    'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
+    'id': 'foo',
+    'labels': [
+        {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug'
+        }
+    ],
+    'name': 'Foo',
+    'paired': False,
+    'reads': [
+    ],
+    'ready': True
+}
+
+snapshots['TestEdit.test_name_exists[uvloop-False] 1'] = {
+    'all_read': True,
+    'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
+    'id': 'foo',
+    'labels': [
+    ],
+    'name': 'Bar',
+    'paired': False,
+    'reads': [
+    ],
+    'ready': True
+}
+
+snapshots['TestEdit.test_subtraction_exists[uvloop-True] 1'] = {
+    'all_read': True,
+    'all_write': True,
+    'artifacts': [
+    ],
+    'caches': [
+    ],
+    'id': 'test',
+    'labels': [
+    ],
+    'name': 'Test',
+    'paired': False,
+    'reads': [
+    ],
+    'ready': True
+}
+
+snapshots['TestUploadReads.test_upload_reads[uvloop-True] 1'] = {
     'id': 1,
-    'key': 'aodp-abcdefgh',
     'name': 'reads_1.fq.gz',
     'name_on_disk': 'reads_1.fq.gz',
     'sample': 'test',
     'size': 9081,
+    'upload': 1,
     'uploaded_at': '2015-10-06T20:00:00Z'
+}
+
+snapshots['test_finalize[uvloop-quality] 1'] = {
+    'artifacts': [
+        {
+            'download_url': '/api/samples/test/artifacts/reference.fa.gz',
+            'id': 1,
+            'name': 'reference.fa.gz',
+            'name_on_disk': 'reference.fa.gz',
+            'sample': 'test',
+            'size': None,
+            'type': 'fasta',
+            'uploaded_at': None
+        }
+    ],
+    'caches': [
+    ],
+    'id': 'test',
+    'labels': [
+    ],
+    'paired': False,
+    'reads': [
+        {
+            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
+            'id': 1,
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
+            'sample': 'test',
+            'size': None,
+            'upload': None,
+            'uploaded_at': None
+        }
+    ],
+    'ready': True
 }
 
 snapshots['test_finalize_cache[uvloop-quality] 1'] = {
@@ -693,85 +356,6 @@ snapshots['test_finalize_cache[uvloop-quality] 1'] = {
     'sample': {
         'id': 'test'
     }
-}
-
-snapshots['test_find[uvloop-None-None-None-None] 1'] = {
-    'documents': [
-        {
-            'created_at': '2015-10-06T22:00:00Z',
-            'host': '',
-            'id': 'cb400e6d',
-            'isolate': '',
-            'labels': [
-                {
-                    'color': '#0d321d',
-                    'description': 'This is a question',
-                    'id': 3,
-                    'name': 'Question'
-                }
-            ],
-            'name': '16SPP044',
-            'nuvs': False,
-            'pathoscope': False,
-            'ready': True,
-            'user': {
-                'id': 'fred'
-            }
-        },
-        {
-            'created_at': '2015-10-06T21:00:00Z',
-            'host': '',
-            'id': 'beb1eb10',
-            'isolate': 'Thing',
-            'labels': [
-                {
-                    'color': '#a83432',
-                    'description': 'This is a bug',
-                    'id': 1,
-                    'name': 'Bug'
-                },
-                {
-                    'color': '#03fc20',
-                    'description': 'This is a info',
-                    'id': 2,
-                    'name': 'Info'
-                }
-            ],
-            'name': '16GVP042',
-            'nuvs': False,
-            'pathoscope': False,
-            'ready': True,
-            'user': {
-                'id': 'bob'
-            }
-        },
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'host': '',
-            'id': '72bb8b31',
-            'isolate': 'Test',
-            'labels': [
-                {
-                    'color': '#a83432',
-                    'description': 'This is a bug',
-                    'id': 1,
-                    'name': 'Bug'
-                }
-            ],
-            'name': '16GVP043',
-            'nuvs': False,
-            'pathoscope': False,
-            'ready': True,
-            'user': {
-                'id': 'fred'
-            }
-        }
-    ],
-    'found_count': 3,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3
 }
 
 snapshots['test_find[uvloop-None-2-1-None] 1'] = {
@@ -863,8 +447,29 @@ snapshots['test_find[uvloop-None-2-2-None] 1'] = {
     'total_count': 3
 }
 
-snapshots['test_find[uvloop-gv-None-None-None] 1'] = {
+snapshots['test_find[uvloop-None-None-None-None] 1'] = {
     'documents': [
+        {
+            'created_at': '2015-10-06T22:00:00Z',
+            'host': '',
+            'id': 'cb400e6d',
+            'isolate': '',
+            'labels': [
+                {
+                    'color': '#0d321d',
+                    'description': 'This is a question',
+                    'id': 3,
+                    'name': 'Question'
+                }
+            ],
+            'name': '16SPP044',
+            'nuvs': False,
+            'pathoscope': False,
+            'ready': True,
+            'user': {
+                'id': 'fred'
+            }
+        },
         {
             'created_at': '2015-10-06T21:00:00Z',
             'host': '',
@@ -914,90 +519,7 @@ snapshots['test_find[uvloop-gv-None-None-None] 1'] = {
             }
         }
     ],
-    'found_count': 2,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3
-}
-
-snapshots['test_find[uvloop-sp-None-None-None] 1'] = {
-    'documents': [
-        {
-            'created_at': '2015-10-06T22:00:00Z',
-            'host': '',
-            'id': 'cb400e6d',
-            'isolate': '',
-            'labels': [
-                {
-                    'color': '#0d321d',
-                    'description': 'This is a question',
-                    'id': 3,
-                    'name': 'Question'
-                }
-            ],
-            'name': '16SPP044',
-            'nuvs': False,
-            'pathoscope': False,
-            'ready': True,
-            'user': {
-                'id': 'fred'
-            }
-        }
-    ],
-    'found_count': 1,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3
-}
-
-snapshots['test_find[uvloop-fred-None-None-None] 1'] = {
-    'documents': [
-        {
-            'created_at': '2015-10-06T22:00:00Z',
-            'host': '',
-            'id': 'cb400e6d',
-            'isolate': '',
-            'labels': [
-                {
-                    'color': '#0d321d',
-                    'description': 'This is a question',
-                    'id': 3,
-                    'name': 'Question'
-                }
-            ],
-            'name': '16SPP044',
-            'nuvs': False,
-            'pathoscope': False,
-            'ready': True,
-            'user': {
-                'id': 'fred'
-            }
-        },
-        {
-            'created_at': '2015-10-06T20:00:00Z',
-            'host': '',
-            'id': '72bb8b31',
-            'isolate': 'Test',
-            'labels': [
-                {
-                    'color': '#a83432',
-                    'description': 'This is a bug',
-                    'id': 1,
-                    'name': 'Bug'
-                }
-            ],
-            'name': '16GVP043',
-            'nuvs': False,
-            'pathoscope': False,
-            'ready': True,
-            'user': {
-                'id': 'fred'
-            }
-        }
-    ],
-    'found_count': 2,
+    'found_count': 3,
     'page': 1,
     'page_count': 1,
     'per_page': 25,
@@ -1132,4 +654,471 @@ snapshots['test_find[uvloop-None-None-None-labels9] 1'] = {
     'page_count': 1,
     'per_page': 25,
     'total_count': 3
+}
+
+snapshots['test_find[uvloop-fred-None-None-None] 1'] = {
+    'documents': [
+        {
+            'created_at': '2015-10-06T22:00:00Z',
+            'host': '',
+            'id': 'cb400e6d',
+            'isolate': '',
+            'labels': [
+                {
+                    'color': '#0d321d',
+                    'description': 'This is a question',
+                    'id': 3,
+                    'name': 'Question'
+                }
+            ],
+            'name': '16SPP044',
+            'nuvs': False,
+            'pathoscope': False,
+            'ready': True,
+            'user': {
+                'id': 'fred'
+            }
+        },
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'host': '',
+            'id': '72bb8b31',
+            'isolate': 'Test',
+            'labels': [
+                {
+                    'color': '#a83432',
+                    'description': 'This is a bug',
+                    'id': 1,
+                    'name': 'Bug'
+                }
+            ],
+            'name': '16GVP043',
+            'nuvs': False,
+            'pathoscope': False,
+            'ready': True,
+            'user': {
+                'id': 'fred'
+            }
+        }
+    ],
+    'found_count': 2,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3
+}
+
+snapshots['test_find[uvloop-gv-None-None-None] 1'] = {
+    'documents': [
+        {
+            'created_at': '2015-10-06T21:00:00Z',
+            'host': '',
+            'id': 'beb1eb10',
+            'isolate': 'Thing',
+            'labels': [
+                {
+                    'color': '#a83432',
+                    'description': 'This is a bug',
+                    'id': 1,
+                    'name': 'Bug'
+                },
+                {
+                    'color': '#03fc20',
+                    'description': 'This is a info',
+                    'id': 2,
+                    'name': 'Info'
+                }
+            ],
+            'name': '16GVP042',
+            'nuvs': False,
+            'pathoscope': False,
+            'ready': True,
+            'user': {
+                'id': 'bob'
+            }
+        },
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'host': '',
+            'id': '72bb8b31',
+            'isolate': 'Test',
+            'labels': [
+                {
+                    'color': '#a83432',
+                    'description': 'This is a bug',
+                    'id': 1,
+                    'name': 'Bug'
+                }
+            ],
+            'name': '16GVP043',
+            'nuvs': False,
+            'pathoscope': False,
+            'ready': True,
+            'user': {
+                'id': 'fred'
+            }
+        }
+    ],
+    'found_count': 2,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3
+}
+
+snapshots['test_find[uvloop-sp-None-None-None] 1'] = {
+    'documents': [
+        {
+            'created_at': '2015-10-06T22:00:00Z',
+            'host': '',
+            'id': 'cb400e6d',
+            'isolate': '',
+            'labels': [
+                {
+                    'color': '#0d321d',
+                    'description': 'This is a question',
+                    'id': 3,
+                    'name': 'Question'
+                }
+            ],
+            'name': '16SPP044',
+            'nuvs': False,
+            'pathoscope': False,
+            'ready': True,
+            'user': {
+                'id': 'fred'
+            }
+        }
+    ],
+    'found_count': 1,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3
+}
+
+snapshots['test_find_analyses[uvloop-Baz-None] 1'] = {
+    'documents': [
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'id': 'test_1',
+            'index': {
+                'id': 'foo',
+                'version': 2
+            },
+            'job': {
+                'id': 'test'
+            },
+            'ready': True,
+            'reference': {
+                'id': 'baz',
+                'name': 'Baz'
+            },
+            'sample': {
+                'id': 'test'
+            },
+            'user': {
+                'id': 'bob'
+            },
+            'workflow': 'pathoscope_bowtie'
+        },
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'id': 'test_2',
+            'index': {
+                'id': 'foo',
+                'version': 2
+            },
+            'job': {
+                'id': 'test'
+            },
+            'ready': True,
+            'reference': {
+                'id': 'baz',
+                'name': 'Baz'
+            },
+            'sample': {
+                'id': 'test'
+            },
+            'user': {
+                'id': 'fred'
+            },
+            'workflow': 'pathoscope_bowtie'
+        }
+    ],
+    'found_count': 2,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3
+}
+
+snapshots['test_find_analyses[uvloop-None-None] 1'] = {
+    'documents': [
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'id': 'test_1',
+            'index': {
+                'id': 'foo',
+                'version': 2
+            },
+            'job': {
+                'id': 'test'
+            },
+            'ready': True,
+            'reference': {
+                'id': 'baz',
+                'name': 'Baz'
+            },
+            'sample': {
+                'id': 'test'
+            },
+            'user': {
+                'id': 'bob'
+            },
+            'workflow': 'pathoscope_bowtie'
+        },
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'id': 'test_2',
+            'index': {
+                'id': 'foo',
+                'version': 2
+            },
+            'job': {
+                'id': 'test'
+            },
+            'ready': True,
+            'reference': {
+                'id': 'baz',
+                'name': 'Baz'
+            },
+            'sample': {
+                'id': 'test'
+            },
+            'user': {
+                'id': 'fred'
+            },
+            'workflow': 'pathoscope_bowtie'
+        },
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'id': 'test_3',
+            'index': {
+                'id': 'foo',
+                'version': 2
+            },
+            'job': {
+                'id': 'test'
+            },
+            'ready': True,
+            'reference': {
+                'id': 'foo',
+                'name': 'Foo'
+            },
+            'sample': {
+                'id': 'test'
+            },
+            'user': {
+                'id': 'fred'
+            },
+            'workflow': 'pathoscope_bowtie'
+        }
+    ],
+    'found_count': 3,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3
+}
+
+snapshots['test_find_analyses[uvloop-bob-None] 1'] = {
+    'documents': [
+        {
+            'created_at': '2015-10-06T20:00:00Z',
+            'id': 'test_1',
+            'index': {
+                'id': 'foo',
+                'version': 2
+            },
+            'job': {
+                'id': 'test'
+            },
+            'ready': True,
+            'reference': {
+                'id': 'baz',
+                'name': 'Baz'
+            },
+            'sample': {
+                'id': 'test'
+            },
+            'user': {
+                'id': 'bob'
+            },
+            'workflow': 'pathoscope_bowtie'
+        }
+    ],
+    'found_count': 1,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3
+}
+
+snapshots['test_get[uvloop-False-None] 1'] = {
+    'artifacts': [
+        {
+            'id': 1,
+            'name': 'reference.fa.gz',
+            'name_on_disk': 'reference.fa.gz',
+            'sample': 'test',
+            'size': None,
+            'type': 'fasta',
+            'uploaded_at': None
+        }
+    ],
+    'caches': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'id': 'test',
+    'labels': [
+        {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug'
+        }
+    ],
+    'name': 'Test',
+    'paired': False,
+    'reads': [
+        {
+            'id': 1,
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
+            'sample': 'test',
+            'size': None,
+            'upload': {
+                'created_at': None,
+                'id': 1,
+                'name': 'test',
+                'name_on_disk': None,
+                'ready': False,
+                'removed': False,
+                'removed_at': None,
+                'reserved': False,
+                'size': None,
+                'type': None,
+                'uploaded_at': None,
+                'user': None
+            },
+            'uploaded_at': None
+        }
+    ],
+    'ready': False
+}
+
+snapshots['test_get[uvloop-True-None] 1'] = {
+    'artifacts': [
+        {
+            'download_url': '/api/samples/test/artifacts/reference.fa.gz',
+            'id': 1,
+            'name': 'reference.fa.gz',
+            'name_on_disk': 'reference.fa.gz',
+            'sample': 'test',
+            'size': None,
+            'type': 'fasta',
+            'uploaded_at': None
+        }
+    ],
+    'caches': [
+    ],
+    'created_at': '2015-10-06T20:00:00Z',
+    'id': 'test',
+    'labels': [
+        {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug'
+        }
+    ],
+    'name': 'Test',
+    'paired': False,
+    'reads': [
+        {
+            'download_url': '/api/samples/test/reads/reads_1.fq.gz',
+            'id': 1,
+            'name': 'reads_1.fq.gz',
+            'name_on_disk': 'reads_1.fq.gz',
+            'sample': 'test',
+            'size': None,
+            'upload': {
+                'created_at': None,
+                'id': 1,
+                'name': 'test',
+                'name_on_disk': None,
+                'ready': False,
+                'removed': False,
+                'removed_at': None,
+                'reserved': False,
+                'size': None,
+                'type': None,
+                'uploaded_at': None,
+                'user': None
+            },
+            'uploaded_at': None
+        }
+    ],
+    'ready': True
+}
+
+snapshots['test_get_cache[uvloop-None] 1'] = {
+    'id': 'bar',
+    'key': 'abc123',
+    'program': 'skewer-0.2.2',
+    'sample': {
+        'id': 'foo'
+    }
+}
+
+snapshots['test_upload_artifact[uvloop-None] 1'] = {
+    'id': 1,
+    'name': 'small.fq',
+    'name_on_disk': 'small.fq',
+    'sample': 'test',
+    'size': 3130756,
+    'type': 'fastq',
+    'uploaded_at': '2015-10-06T20:00:00Z'
+}
+
+snapshots['test_upload_artifact_cache[uvloop-None] 1'] = {
+    'id': 1,
+    'key': 'aodp-abcdefgh',
+    'name': 'small.fq',
+    'name_on_disk': 'small.fq',
+    'sample': 'test',
+    'size': 3130756,
+    'type': 'fastq',
+    'uploaded_at': '2015-10-06T20:00:00Z'
+}
+
+snapshots['test_upload_reads_cache[uvloop-False] 1'] = {
+    'id': 1,
+    'key': 'aodp-abcdefgh',
+    'name': 'reads_1.fq.gz',
+    'name_on_disk': 'reads_1.fq.gz',
+    'sample': 'test',
+    'size': 9081,
+    'uploaded_at': '2015-10-06T20:00:00Z'
+}
+
+snapshots['test_upload_reads_cache[uvloop-True] 1'] = {
+    'id': 2,
+    'key': 'aodp-abcdefgh',
+    'name': 'reads_2.fq.gz',
+    'name_on_disk': 'reads_2.fq.gz',
+    'sample': 'test',
+    'size': 9081,
+    'uploaded_at': '2015-10-06T20:00:00Z'
 }

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -165,7 +165,7 @@ async def test_get(error, ready, mocker, snapshot, spawn_client, resp_is, static
                 }
             ],
             "labels": [1],
-            "subtractions": ["foo", "bar"]
+            "subtractions": ["foo", "bar"],
         })
 
         label = Label(id=1, name="Bug", color="#a83432", description="This is a bug")
@@ -287,7 +287,8 @@ class TestCreate:
             "lower_name": "foobar",
             "created_at": static_time.datetime,
             "nuvs": False,
-            "pathoscope": False
+            "pathoscope": False,
+            "ready": True,
         })
 
         resp = await client.post("/api/samples", {
@@ -448,7 +449,8 @@ class TestEdit:
             "all_read": True,
             "all_write": True,
             "labels": [2, 3],
-            "subtractions": ["apple"]
+            "ready": True,
+            "subtractions": ["apple"],
         })
 
         await client.db.subtraction.insert_one({
@@ -487,6 +489,7 @@ class TestEdit:
                 "name": "Foo",
                 "all_read": True,
                 "all_write": True,
+                "ready": True,
             }
         ]
 
@@ -494,7 +497,8 @@ class TestEdit:
             samples.append(
                 {
                     "_id": "bar",
-                    "name": "Bar"
+                    "name": "Bar",
+                    "ready": True,
                 }
             )
 
@@ -527,7 +531,8 @@ class TestEdit:
                 "name": "Foo",
                 "all_read": True,
                 "all_write": True,
-                "labels": [2, 3]
+                "labels": [2, 3],
+                "ready": True
             }
         )
         if exists:
@@ -562,6 +567,7 @@ class TestEdit:
             "name": "Test",
             "all_read": True,
             "all_write": True,
+            "ready": True,
             "subtractions": ["apple"]
         })
 
@@ -610,6 +616,7 @@ async def test_finalize(field, snapshot, spawn_job_client, resp_is, pg, pg_sessi
 
     await client.db.samples.insert_one({
         "_id": "test",
+        "ready": True
     })
 
     async with pg_session as session:
@@ -652,7 +659,8 @@ async def test_remove(
         await client.db.samples.insert_one({
             "_id": "test",
             "all_read": True,
-            "all_write": True
+            "all_write": True,
+            "ready": True,
         })
 
     m = mocker.stub(name="remove_samples")
@@ -702,7 +710,7 @@ async def test_job_remove(
             "_id": "test",
             "all_read": True,
             "all_write": True,
-            "ready": ready
+            "ready": ready,
         })
 
     mocker.patch("virtool.utils.rm", return_value=True)
@@ -738,7 +746,8 @@ async def test_find_analyses(error, term, snapshot, mocker, spawn_client, resp_i
             "_id": "test",
             "created_at": static_time.datetime,
             "all_read": True,
-            "all_write": True
+            "all_write": True,
+            "ready": True,
         })
 
     await client.db.analyses.insert_many([
@@ -896,7 +905,8 @@ async def test_analyze(error, mocker, spawn_client, static_time, resp_is,
             "name": "Test",
             "created_at": static_time.datetime,
             "all_read": True,
-            "all_write": True
+            "all_write": True,
+            "ready": True,
         })
 
     m_create = mocker.patch("virtool.analyses.db.create", new=make_mocked_coro(test_analysis))
@@ -1005,6 +1015,7 @@ async def test_upload_artifact(
 
     await client.db.samples.insert_one({
         "_id": "test",
+        "ready": True,
     })
 
     resp = await client.post(f"/api/samples/test/artifacts?name=small.fq&type={artifact_type}",
@@ -1047,6 +1058,7 @@ class TestUploadReads:
 
         await client.db.samples.insert_one({
             "_id": "test",
+            "ready": True,
         })
 
         await virtool.uploads.db.create(pg, "test", "reads")
@@ -1082,6 +1094,7 @@ class TestUploadReads:
 
         await client.db.samples.insert_one({
             "_id": "test",
+            "ready": True,
         })
 
         resp = await client.put("/api/samples/test/reads/reads_1.fq.gz", data=data)
@@ -1149,6 +1162,7 @@ async def test_download_reads(suffix, error, tmp_path, spawn_client, spawn_job_c
     if error != "404_sample":
         await client.db.samples.insert_one({
             "_id": "foo",
+            "ready": True,
         })
 
     sample_reads = SampleReads(id=1, sample="foo", name=file_name, name_on_disk=file_name)
@@ -1186,6 +1200,7 @@ async def test_download_artifact(error, tmp_path, spawn_job_client, pg):
     if error != "404_sample":
         await client.db.samples.insert_one({
             "_id": "foo",
+            "ready": True,
         })
 
     if error != "404_artifact":
@@ -1227,6 +1242,7 @@ class TestCreateCache:
         await client.db.samples.insert_one({
             "_id": "test",
             "paired": False,
+            "ready": True,
         })
 
         data = {key: "aodp-abcdefgh"}
@@ -1254,6 +1270,7 @@ class TestCreateCache:
         await client.db.samples.insert_one({
             "_id": "test",
             "paired": False,
+            "ready": True,
         })
 
         await client.db.caches.insert_one({
@@ -1299,6 +1316,7 @@ async def test_upload_artifact_cache(
 
     await client.db.samples.insert_one({
         "_id": "test",
+        "ready": True,
     })
 
     await client.db.caches.insert_one({
@@ -1349,6 +1367,7 @@ async def test_upload_reads_cache(paired, snapshot, static_time, spawn_job_clien
 
     await client.db.samples.insert_one({
         "_id": "test",
+        "ready": True,
     })
 
     await client.db.caches.insert_one({
@@ -1403,6 +1422,7 @@ async def test_download_reads_cache(error, spawn_job_client, pg, tmp_path):
     if error != "404_sample":
         await client.db.samples.insert_one({
             "_id": "foo",
+            "ready": True,
         })
 
     if error != "404_cache":
@@ -1458,6 +1478,7 @@ async def test_download_artifact_cache(error, spawn_job_client, pg: AsyncEngine,
     if error != "404_sample":
         await client.db.samples.insert_one({
             "_id": "foo",
+            "ready": True,
         })
 
     if error != "404_artifact":
@@ -1502,6 +1523,7 @@ async def test_finalize_cache(field, resp_is, snapshot, spawn_job_client):
 
     await client.db.samples.insert_one({
         "_id": "test",
+        "ready": True,
     })
 
     await client.db.caches.insert_one({

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -561,7 +561,7 @@ async def get_sample(app, sample_id: str):
     db = app["db"]
     pg = app["pg"]
 
-    document = await db.samples.find_one({"_id": sample_id})
+    document = await db.samples.find_one({"_id": sample_id}, projection=PROJECTION)
 
     if not document:
         raise ValueError("Sample {sample_id} does not exist.")


### PR DESCRIPTION
* Prevents variable response shapes for sample resources
* Update tests by providing required fields in fake data and rewriting some snapshots.

Fixes inconsistent `subtractions` field in responses noted by @OfficialArms.