### PR TITLE
Prevent nightly build from running on forks.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'Virtool'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Only run the nightly build if the repository owner is the `Virtool` organisation. 

Avoids an annoying notification on the fork when the build fails every day due to missing secrets.