### PR TITLE
Change all usages of task to workflow

### DIFF
--- a/client/src/js/analyses/components/Create/WorkflowSelector.js
+++ b/client/src/js/analyses/components/Create/WorkflowSelector.js
@@ -2,7 +2,7 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../../base/MultiSelector";
-import { getTaskDisplayName } from "../../../utils/utils";
+import { getWorkflowDisplayName } from "../../../utils/utils";
 
 export const getCompatibleWorkflows = (dataType, hasHmm) => {
     if (dataType === "barcode") {
@@ -19,7 +19,7 @@ export const getCompatibleWorkflows = (dataType, hasHmm) => {
 export const WorkflowSelector = ({ dataType, hasError, hasHmm, workflows, onSelect }) => {
     const workflowItems = map(getCompatibleWorkflows(dataType, hasHmm), workflow => (
         <MultiSelectorItem key={workflow} name={workflow} value={workflow}>
-            {getTaskDisplayName(workflow)}
+            {getWorkflowDisplayName(workflow)}
         </MultiSelectorItem>
     ));
 

--- a/client/src/js/analyses/components/Create/__tests__/SubtractionSelector.test.js
+++ b/client/src/js/analyses/components/Create/__tests__/SubtractionSelector.test.js
@@ -1,7 +1,7 @@
 import React from "react";
-import { SubtractionSelector } from "../SubtractionSelector";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { SubtractionSelector } from "../SubtractionSelector";
 
 describe("<SubtractionSelector />", () => {
     let props;

--- a/client/src/js/analyses/components/Detail.js
+++ b/client/src/js/analyses/components/Detail.js
@@ -10,7 +10,7 @@ import {
     SubviewHeaderAttribution,
     SubviewHeaderTitle
 } from "../../base/index";
-import { getTaskDisplayName } from "../../utils/utils";
+import { getWorkflowDisplayName } from "../../utils/utils";
 import { clearAnalysis, getAnalysis } from "../actions";
 import AODPViewer from "./AODP/Viewer";
 import AnalysisCache from "./CacheLink";
@@ -57,7 +57,7 @@ export const AnalysisDetail = props => {
         <div>
             <SubviewHeader>
                 <SubviewHeaderTitle>
-                    {getTaskDisplayName(detail.workflow)} for {sampleName}
+                    {getWorkflowDisplayName(detail.workflow)} for {sampleName}
                     <AnalysisCache />
                 </SubviewHeaderTitle>
                 <SubviewHeaderAttribution>

--- a/client/src/js/analyses/components/Item.js
+++ b/client/src/js/analyses/components/Item.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
 import { Attribution, Icon, SlashList, SpacedBox } from "../../base";
 import { getCanModify } from "../../samples/selectors";
-import { getTaskDisplayName } from "../../utils/utils";
+import { getWorkflowDisplayName } from "../../utils/utils";
 import { removeAnalysis } from "../actions";
 import { AnalysisItemRightIcon } from "./RightIcon";
 
@@ -74,7 +74,7 @@ export const AnalysisItem = props => {
     return (
         <StyledAnalysisItem>
             <AnalysisItemTop>
-                <Link to={`/samples/${sampleId}/analyses/${id}`}>{getTaskDisplayName(workflow)}</Link>
+                <Link to={`/samples/${sampleId}/analyses/${id}`}>{getWorkflowDisplayName(workflow)}</Link>
                 <AnalysisItemRightIcon canModify={canModify} onRemove={onRemove} ready={ready} />
             </AnalysisItemTop>
             <Attribution user={user.id} time={created_at} />

--- a/client/src/js/jobs/__tests__/reducer.test.js
+++ b/client/src/js/jobs/__tests__/reducer.test.js
@@ -44,11 +44,11 @@ describe("Job Reducer", () => {
             documents: [
                 {
                     id: "foo",
-                    task: "test_job"
+                    workflow: "test_job"
                 },
                 {
                     id: "bar",
-                    task: "running_job"
+                    workflow: "running_job"
                 }
             ]
         };
@@ -56,7 +56,7 @@ describe("Job Reducer", () => {
             type: WS_UPDATE_JOB,
             data: {
                 id: "bar",
-                task: "finish_job"
+                workflow: "finish_job"
             }
         };
         const result = reducer(state, action);
@@ -65,11 +65,11 @@ describe("Job Reducer", () => {
             documents: [
                 {
                     id: "foo",
-                    task: "test_job"
+                    workflow: "test_job"
                 },
                 {
                     id: "bar",
-                    task: "finish_job"
+                    workflow: "finish_job"
                 }
             ]
         });

--- a/client/src/js/jobs/components/Detail.js
+++ b/client/src/js/jobs/components/Detail.js
@@ -13,11 +13,11 @@ import {
     ViewHeaderIcons,
     ViewHeaderTitle
 } from "../../base";
-import { getTaskDisplayName } from "../../utils/utils";
+import { getWorkflowDisplayName } from "../../utils/utils";
 import { getJob, removeJob } from "../actions";
 import JobError from "./Error";
 import JobSteps from "./Steps";
-import { TaskArgs } from "./TaskArgs";
+import { JobArgs } from "./JobArgs";
 
 const JobDetailBadge = styled(Badge)`
     text-transform: capitalize;
@@ -55,13 +55,13 @@ class JobDetail extends React.Component {
             color = "red";
         }
 
-        const taskName = getTaskDisplayName(detail.task);
+        const workflow = getWorkflowDisplayName(detail.workflow);
 
         return (
             <div>
-                <ViewHeader title={taskName}>
+                <ViewHeader title={workflow}>
                     <ViewHeaderTitle>
-                        {taskName} <JobDetailBadge color={color}>{latest.state}</JobDetailBadge>
+                        {workflow} <JobDetailBadge color={color}>{latest.state}</JobDetailBadge>
                         <ViewHeaderIcons>
                             <Icon color="red" name="trash" style={{ fontSize: "18px" }} onClick={this.handleClick} />
                         </ViewHeaderIcons>
@@ -69,7 +69,7 @@ class JobDetail extends React.Component {
                     <ViewHeaderAttribution time={detail.status[0].timestamp} user={detail.user.id} />
                 </ViewHeader>
 
-                <TaskArgs taskType={detail.task} taskArgs={detail.args} />
+                <JobArgs workflow={detail.workflow} args={detail.args} />
 
                 <JobSteps />
 

--- a/client/src/js/jobs/components/Item/Item.js
+++ b/client/src/js/jobs/components/Item/Item.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../../app/theme";
 import { AffixedProgressBar, Attribution, LinkBox } from "../../../base";
-import { getTaskDisplayName } from "../../../utils/utils";
+import { getWorkflowDisplayName } from "../../../utils/utils";
 import { cancelJob, removeJob } from "../../actions";
 import { JobAction } from "./Action";
 import { JobStatus } from "./Status";
@@ -32,7 +32,18 @@ const JobItemLinkBox = styled(LinkBox)`
     z-index: 10;
 `;
 
-export const JobItem = ({ id, task, state, progress, created_at, user, canCancel, canRemove, onCancel, onRemove }) => {
+export const JobItem = ({
+    id,
+    workflow,
+    state,
+    progress,
+    created_at,
+    user,
+    canCancel,
+    canRemove,
+    onCancel,
+    onRemove
+}) => {
     const handleCancel = useCallback(() => onCancel(id), [id, onCancel]);
     const handleRemove = useCallback(() => onRemove(id), [id, onRemove]);
 
@@ -56,7 +67,7 @@ export const JobItem = ({ id, task, state, progress, created_at, user, canCancel
 
                 <JobItemBody>
                     <JobItemHeader>
-                        <span>{getTaskDisplayName(task)}</span>
+                        <span>{getWorkflowDisplayName(workflow)}</span>
                         <JobStatus state={state} pad={canCancel || canRemove} />
                     </JobItemHeader>
                     <Attribution time={created_at} user={user.id} />

--- a/client/src/js/jobs/components/Item/__tests__/Item.test.js
+++ b/client/src/js/jobs/components/Item/__tests__/Item.test.js
@@ -7,7 +7,7 @@ describe("<JobItem />", () => {
         props = {
             id: "foo",
             progress: 1,
-            task: "build_index",
+            workflow: "build_index",
             created_at: "Foo",
             user: {
                 id: "bob"

--- a/client/src/js/jobs/components/JobArgs.js
+++ b/client/src/js/jobs/components/JobArgs.js
@@ -3,7 +3,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { BoxGroup, BoxGroupHeader, Table } from "../../base";
 
-const TaskArgsRow = ({ children, title }) => (
+const JobArgsRow = ({ children, title }) => (
     <tr>
         <th>{title}</th>
         <td>{children}</td>
@@ -12,68 +12,68 @@ const TaskArgsRow = ({ children, title }) => (
 
 export const AnalysisRows = ({ sample_id, analysis_id }) => (
     <React.Fragment>
-        <TaskArgsRow title="Sample">
+        <JobArgsRow title="Sample">
             <Link to={`/samples/${sample_id}`}>{sample_id}</Link>
-        </TaskArgsRow>
-        <TaskArgsRow title="Analysis">
+        </JobArgsRow>
+        <JobArgsRow title="Analysis">
             <Link to={`/samples/${sample_id}/analyses/${analysis_id}`}>{analysis_id}</Link>
-        </TaskArgsRow>
+        </JobArgsRow>
     </React.Fragment>
 );
 
 export const BuildIndexRows = ({ index_id, ref_id }) => (
     <React.Fragment>
-        <TaskArgsRow title="Reference">
+        <JobArgsRow title="Reference">
             <Link to={`/refs/${ref_id}`}>{ref_id}</Link>
-        </TaskArgsRow>
-        <TaskArgsRow title="Index">
+        </JobArgsRow>
+        <JobArgsRow title="Index">
             <Link to={`/refs/${ref_id}/indexes/${index_id}`}>{index_id}</Link>
-        </TaskArgsRow>
+        </JobArgsRow>
     </React.Fragment>
 );
 
 export const CreateSampleRows = ({ sample_id }) => (
     <React.Fragment>
-        <TaskArgsRow title="Sample">
+        <JobArgsRow title="Sample">
             <Link to={`/samples/${sample_id}`}>{sample_id}</Link>
-        </TaskArgsRow>
+        </JobArgsRow>
     </React.Fragment>
 );
 
 export const CreateSubtractionRows = ({ subtraction_id }) => (
-    <TaskArgsRow title="Subtraction">
+    <JobArgsRow title="Subtraction">
         <Link to={`/subtraction/${subtraction_id}`}>{subtraction_id}</Link>
-    </TaskArgsRow>
+    </JobArgsRow>
 );
 
 export const UpdateSampleRows = ({ sample_id }) => (
-    <TaskArgsRow title="Subtraction">
+    <JobArgsRow title="Subtraction">
         <Link to={`/samples/${sample_id}`}>{sample_id}</Link>
-    </TaskArgsRow>
+    </JobArgsRow>
 );
 
-export const TaskArgsRows = ({ taskType, taskArgs }) => {
-    switch (taskType) {
+export const JobArgsRows = ({ workflow, args }) => {
+    switch (workflow) {
         case "build_index":
-            return <BuildIndexRows {...taskArgs} />;
+            return <BuildIndexRows {...args} />;
 
         case "create_sample":
-            return <CreateSampleRows {...taskArgs} />;
+            return <CreateSampleRows {...args} />;
 
         case "create_subtraction":
-            return <CreateSubtractionRows {...taskArgs} />;
+            return <CreateSubtractionRows {...args} />;
 
         case "aodp":
         case "nuvs":
         case "pathoscope_bowtie":
-            return <AnalysisRows {...taskArgs} />;
+            return <AnalysisRows {...args} />;
 
         case "update_sample":
-            return <UpdateSampleRows {...taskArgs} />;
+            return <UpdateSampleRows {...args} />;
     }
 };
 
-export const TaskArgs = props => (
+export const JobArgs = props => (
     <BoxGroup>
         <BoxGroupHeader>
             <h2>Arguments</h2>
@@ -81,13 +81,13 @@ export const TaskArgs = props => (
         </BoxGroupHeader>
         <Table>
             <tbody>
-                <TaskArgsRows {...props} />
+                <JobArgsRows {...props} />
             </tbody>
         </Table>
     </BoxGroup>
 );
 
-TaskArgs.propTypes = {
-    taskType: PropTypes.string.isRequired,
-    taskArgs: PropTypes.object.isRequired
+JobArgs.propTypes = {
+    workflow: PropTypes.string.isRequired,
+    args: PropTypes.object.isRequired
 };

--- a/client/src/js/jobs/components/Step.js
+++ b/client/src/js/jobs/components/Step.js
@@ -47,8 +47,8 @@ const StyledJobStepDescription = styled.div`
     }
 `;
 
-export const JobStepDescription = ({ stage, state, task, timestamp }) => {
-    const { description, title } = getStepDescription(stage, state, task);
+export const JobStepDescription = ({ stage, state, workflow, timestamp }) => {
+    const { description, title } = getStepDescription(stage, state, workflow);
 
     return (
         <StyledJobStepDescription>
@@ -99,12 +99,12 @@ const StyledJobStep = styled(BoxGroupSection)`
     display: flex;
 `;
 
-const JobStep = ({ complete, step, task }) => (
+const JobStep = ({ complete, step, workflow }) => (
     <StyledJobStep>
         <JobStepIconContainer>
             <JobStepIcon state={step.state} complete={complete} />
         </JobStepIconContainer>
-        <JobStepDescription {...step} task={task} />
+        <JobStepDescription {...step} workflow={workflow} />
     </StyledJobStep>
 );
 

--- a/client/src/js/jobs/components/Steps.js
+++ b/client/src/js/jobs/components/Steps.js
@@ -4,21 +4,21 @@ import { connect } from "react-redux";
 import { BoxGroup } from "../../base";
 import JobStep from "./Step";
 
-export const JobSteps = ({ status, task }) => {
+export const JobSteps = ({ status, workflow }) => {
     const currentIndex = status.length - 1;
 
     const stepComponents = map(status, (step, index) => (
-        <JobStep key={index} complete={index < currentIndex} step={step} task={task} />
+        <JobStep key={index} complete={index < currentIndex} step={step} workflow={workflow} />
     ));
 
     return <BoxGroup>{stepComponents}</BoxGroup>;
 };
 
 export const mapStateToProps = state => {
-    const { status, task } = state.jobs.detail;
+    const { status, workflow } = state.jobs.detail;
     return {
         status,
-        task
+        workflow
     };
 };
 

--- a/client/src/js/jobs/components/Toolbar.js
+++ b/client/src/js/jobs/components/Toolbar.js
@@ -6,7 +6,7 @@ import { clearJobs, findJobs } from "../actions";
 
 export const JobsToolbar = ({ onClear, onFind, canRemove, term }) => (
     <Toolbar>
-        <SearchInput value={term} onChange={onFind} placeholder="User or task" />
+        <SearchInput value={term} onChange={onFind} placeholder="User or workflow" />
         {canRemove && (
             <Button onClick={() => onClear("finished")} tip="Clear Finished">
                 <Icon name="trash" />

--- a/client/src/js/jobs/components/__tests__/Step.test.js
+++ b/client/src/js/jobs/components/__tests__/Step.test.js
@@ -15,14 +15,14 @@ describe("<JobStepDescription />", () => {
         props = {
             stage: "bowtie_build",
             state: "running",
-            task: "create_subtraction"
+            workflow: "create_subtraction"
         };
     });
 
     it("renders and calls getStepDescription", () => {
         const wrapper = shallow(<JobStepDescription {...props} />);
-        const { stage, state, task } = props;
-        expect(getStepDescription).toHaveBeenCalledWith(stage, state, task);
+        const { stage, state, workflow } = props;
+        expect(getStepDescription).toHaveBeenCalledWith(stage, state, workflow);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/client/src/js/jobs/components/__tests__/Steps.test.js
+++ b/client/src/js/jobs/components/__tests__/Steps.test.js
@@ -4,7 +4,7 @@ describe("<JobSteps />", () => {
     it("should render", () => {
         const props = {
             status: [{ state: "waiting" }, { state: "running" }],
-            task: "bowtie_build"
+            workflow: "bowtie_build"
         };
         const wrapper = shallow(<JobSteps {...props} />);
         expect(wrapper).toMatchSnapshot();
@@ -15,20 +15,20 @@ describe("mapStateToProps", () => {
     it("should map state to props correctly", () => {
         const status = [{ state: "waiting" }, { state: "running" }];
 
-        const task = "bowtie_build";
+        const workflow = "bowtie_build";
 
         const props = mapStateToProps({
             jobs: {
                 detail: {
                     status,
-                    task
+                    workflow
                 }
             }
         });
 
         expect(props).toEqual({
             status,
-            task
+            workflow
         });
     });
 });

--- a/client/src/js/jobs/components/__tests__/TaskArgs.test.js
+++ b/client/src/js/jobs/components/__tests__/TaskArgs.test.js
@@ -3,11 +3,11 @@ import {
     BuildIndexRows,
     CreateSampleRows,
     CreateSubtractionRows,
-    TaskArgsRows,
+    JobArgsRows,
     UpdateSampleRows
-} from "../TaskArgs";
+} from "../JobArgs";
 
-const taskTypes = [
+const workflows = [
     "aodp",
     "build_index",
     "create_sample",
@@ -17,18 +17,14 @@ const taskTypes = [
     "update_sample"
 ];
 
-describe("<TaskArgs />", () => {
-    let props;
-
-    it.each(taskTypes)("renders <TaskArgsRows /> correctly when task type is %p", taskType => {
-        props = {
-            taskType,
-            taskArgs: {
-                sample_id: "123abc",
-                analysis_id: "test-analysis"
-            }
+describe("<JobArgs />", () => {
+    it.each(workflows)("renders <JobArgsRows /> correctly when workflow is %p", workflow => {
+        const args = {
+            sample_id: "123abc",
+            analysis_id: "test-analysis"
         };
-        const wrapper = shallow(<TaskArgsRows {...props} />);
+
+        const wrapper = shallow(<JobArgsRows workflow={workflow} args={args} />);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/client/src/js/jobs/components/__tests__/__snapshots__/Steps.test.js.snap
+++ b/client/src/js/jobs/components/__tests__/__snapshots__/Steps.test.js.snap
@@ -10,7 +10,7 @@ exports[`<JobSteps /> should render 1`] = `
         "state": "waiting",
       }
     }
-    task="bowtie_build"
+    workflow="bowtie_build"
   />
   <JobStep
     complete={false}
@@ -20,7 +20,7 @@ exports[`<JobSteps /> should render 1`] = `
         "state": "running",
       }
     }
-    task="bowtie_build"
+    workflow="bowtie_build"
   />
 </Box__BoxGroup>
 `;

--- a/client/src/js/jobs/components/__tests__/__snapshots__/TaskArgs.test.js.snap
+++ b/client/src/js/jobs/components/__tests__/__snapshots__/TaskArgs.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<AnalysisRows /> renders correctly 1`] = `
 <Fragment>
-  <TaskArgsRow
+  <JobArgsRow
     title="Sample"
   >
     <Link
@@ -10,8 +10,8 @@ exports[`<AnalysisRows /> renders correctly 1`] = `
     >
       bar
     </Link>
-  </TaskArgsRow>
-  <TaskArgsRow
+  </JobArgsRow>
+  <JobArgsRow
     title="Analysis"
   >
     <Link
@@ -19,13 +19,13 @@ exports[`<AnalysisRows /> renders correctly 1`] = `
     >
       foo
     </Link>
-  </TaskArgsRow>
+  </JobArgsRow>
 </Fragment>
 `;
 
 exports[`<BuildIndexRows /> renders correctly 1`] = `
 <Fragment>
-  <TaskArgsRow
+  <JobArgsRow
     title="Reference"
   >
     <Link
@@ -33,8 +33,8 @@ exports[`<BuildIndexRows /> renders correctly 1`] = `
     >
       foo
     </Link>
-  </TaskArgsRow>
-  <TaskArgsRow
+  </JobArgsRow>
+  <JobArgsRow
     title="Index"
   >
     <Link
@@ -42,13 +42,13 @@ exports[`<BuildIndexRows /> renders correctly 1`] = `
     >
       bar
     </Link>
-  </TaskArgsRow>
+  </JobArgsRow>
 </Fragment>
 `;
 
 exports[`<CreateSampleRows /> renders correctly 1`] = `
 <Fragment>
-  <TaskArgsRow
+  <JobArgsRow
     title="Sample"
   >
     <Link
@@ -56,12 +56,12 @@ exports[`<CreateSampleRows /> renders correctly 1`] = `
     >
       foo
     </Link>
-  </TaskArgsRow>
+  </JobArgsRow>
 </Fragment>
 `;
 
 exports[`<CreateSubtractionRows /> renders correctly 1`] = `
-<TaskArgsRow
+<JobArgsRow
   title="Subtraction"
 >
   <Link
@@ -69,52 +69,52 @@ exports[`<CreateSubtractionRows /> renders correctly 1`] = `
   >
     foo
   </Link>
-</TaskArgsRow>
+</JobArgsRow>
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "aodp" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "aodp" 1`] = `
 <AnalysisRows
   analysis_id="test-analysis"
   sample_id="123abc"
 />
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "build_index" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "build_index" 1`] = `
 <BuildIndexRows
   analysis_id="test-analysis"
   sample_id="123abc"
 />
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "create_sample" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "create_sample" 1`] = `
 <CreateSampleRows
   analysis_id="test-analysis"
   sample_id="123abc"
 />
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "create_subtraction" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "create_subtraction" 1`] = `
 <CreateSubtractionRows
   analysis_id="test-analysis"
   sample_id="123abc"
 />
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "nuvs" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "nuvs" 1`] = `
 <AnalysisRows
   analysis_id="test-analysis"
   sample_id="123abc"
 />
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "pathoscope_bowtie" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "pathoscope_bowtie" 1`] = `
 <AnalysisRows
   analysis_id="test-analysis"
   sample_id="123abc"
 />
 `;
 
-exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "update_sample" 1`] = `
+exports[`<JobArgs /> renders <JobArgsRows /> correctly when workflow is "update_sample" 1`] = `
 <UpdateSampleRows
   analysis_id="test-analysis"
   sample_id="123abc"
@@ -122,7 +122,7 @@ exports[`<TaskArgs /> renders <TaskArgsRows /> correctly when task type is "upda
 `;
 
 exports[`<UpdateSampleRows /> renders correctly 1`] = `
-<TaskArgsRow
+<JobArgsRow
   title="Subtraction"
 >
   <Link
@@ -130,5 +130,5 @@ exports[`<UpdateSampleRows /> renders correctly 1`] = `
   >
     foo
   </Link>
-</TaskArgsRow>
+</JobArgsRow>
 `;

--- a/client/src/js/jobs/components/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/client/src/js/jobs/components/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -4,7 +4,7 @@ exports[`<JobsToolbar /> should render when [canRemove=false] 1`] = `
 <Toolbar>
   <SearchInput
     onChange={[MockFunction]}
-    placeholder="User or task"
+    placeholder="User or workflow"
     value="foo"
   />
 </Toolbar>
@@ -14,7 +14,7 @@ exports[`<JobsToolbar /> should render when [canRemove=true] 1`] = `
 <Toolbar>
   <SearchInput
     onChange={[MockFunction]}
-    placeholder="User or task"
+    placeholder="User or workflow"
     value="foo"
   />
   <Button

--- a/client/src/js/jobs/utils.js
+++ b/client/src/js/jobs/utils.js
@@ -190,7 +190,7 @@ export const stepDescriptions = {
     nuvs: nuvsDescriptions
 };
 
-export const getStepDescription = (stage, state, task) => {
+export const getStepDescription = (stage, state, workflow) => {
     if (state === "waiting") {
         return {
             title: "Waiting",
@@ -212,7 +212,7 @@ export const getStepDescription = (stage, state, task) => {
         };
     }
 
-    return get(stepDescriptions, [task, stage], {
+    return get(stepDescriptions, [workflow, stage], {
         description: "",
         title: startCase(stage)
     });

--- a/client/src/js/samples/components/Create/__tests__/Create.test.js
+++ b/client/src/js/samples/components/Create/__tests__/Create.test.js
@@ -1,7 +1,7 @@
 import React from "react";
-import { CreateSample, mapDispatchToProps, mapStateToProps } from "../Create";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { CreateSample, mapDispatchToProps, mapStateToProps } from "../Create";
 
 describe("<CreateSample>", () => {
     const readFileName = "large";

--- a/client/src/js/samples/components/Filter/WorkflowFilter.js
+++ b/client/src/js/samples/components/Filter/WorkflowFilter.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { getBorder, getFontSize } from "../../../app/theme";
 import { Box, BoxTitle, Icon } from "../../../base";
-import { getTaskDisplayName } from "../../../utils/utils";
+import { getWorkflowDisplayName } from "../../../utils/utils";
 import { updateSearch } from "../../actions";
 import { getWorkflowsFromURL } from "../../selectors";
 import { workflowStates } from "../../utils";
@@ -67,7 +67,7 @@ const WorkflowFilterControl = ({ workflow, states, onChange }) => {
 
     return (
         <StyledWorkflowFilterControl>
-            <WorkflowFilterLabel>{getTaskDisplayName(workflow)}</WorkflowFilterLabel>
+            <WorkflowFilterLabel>{getWorkflowDisplayName(workflow)}</WorkflowFilterLabel>
             <WorkflowFilterControlButtons>
                 <WorkflowFilterControlButton
                     active={states.includes(workflowStates.NONE)}

--- a/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
+++ b/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
@@ -1,7 +1,7 @@
 import React from "react";
-import { SampleSubtractionSelector } from "../components/Selector";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { SampleSubtractionSelector } from "../components/Selector";
 
 describe("<SampleSubtractionSelector />", () => {
     let props;

--- a/client/src/js/utils/utils.js
+++ b/client/src/js/utils/utils.js
@@ -123,13 +123,13 @@ export const formatIsolateName = isolate => {
 };
 
 /**
- * Transforms a plain taskName (eg. pathoscope_bowtie) to a human-readable name (eg. PathoscopeBowtie).
+ * Transforms a plain workflow ID (eg. pathoscope_bowtie) to a human-readable name (eg. PathoscopeBowtie).
  *
  * @func
- * @param taskName {string} plain task name
- * @returns {string}
+ * @param workflow {string} plain workflow ID
+ * @returns {string} human-readable workflow name
  */
-export const getTaskDisplayName = taskName => get(taskDisplayNames, taskName, startCase(taskName));
+export const getWorkflowDisplayName = workflow => get(workflowDisplayNames, workflow, startCase(workflow));
 
 export const reportAPIError = action => window.captureException(action.error);
 
@@ -156,11 +156,11 @@ export const getTargetChange = target => ({
 });
 
 /**
- * Object that maps algorithm names (task names) to human-readable names.
+ * Object that maps workflow IDs to human-readable names.
  *
  * @type {object}
  */
-export const taskDisplayNames = {
+export const workflowDisplayNames = {
     aodp: "AODP",
     create_sample: "Create Sample",
     create_subtraction: "Create Subtraction",


### PR DESCRIPTION
* Types of jobs are now called workflows. Better put, jobs are instances of workflows.
* The front end has been updated to clarify the concepts around workflows and jobs.