### PR TITLE
Improve apiCall() generator function

### DIFF
--- a/client/src/js/administration/__tests__/reducer.test.js
+++ b/client/src/js/administration/__tests__/reducer.test.js
@@ -33,9 +33,11 @@ describe("Settings Reducer", () => {
         const state = { data: { boo: 1, foo: "bar" } };
         const action = {
             type: UPDATE_SETTINGS.SUCCEEDED,
-            update: {
-                foo: "baz",
-                bar: "baz"
+            context: {
+                update: {
+                    foo: "baz",
+                    bar: "baz"
+                }
             }
         };
         const result = reducer(state, action);

--- a/client/src/js/administration/reducer.js
+++ b/client/src/js/administration/reducer.js
@@ -12,7 +12,7 @@ export default function settingsReducer(state = initialState, action) {
         case UPDATE_SETTINGS.SUCCEEDED:
             return {
                 ...state,
-                data: { ...state.data, ...action.update }
+                data: { ...state.data, ...action.context.update }
             };
 
         default:

--- a/client/src/js/analyses/__tests__/reducer.test.js
+++ b/client/src/js/analyses/__tests__/reducer.test.js
@@ -307,8 +307,10 @@ describe("Analyses Reducer", () => {
         };
         const action = {
             type: BLAST_NUVS.SUCCEEDED,
-            analysisId: "testid",
-            sequenceIndex: 3,
+            context: {
+                analysisId: "testid",
+                sequenceIndex: 3
+            },
             data: {}
         };
         const result = reducer(state, action);

--- a/client/src/js/analyses/reducer.js
+++ b/client/src/js/analyses/reducer.js
@@ -194,7 +194,8 @@ export default function analysesReducer(state = initialState, action) {
             });
 
         case BLAST_NUVS.SUCCEEDED:
-            return setNuvsBLAST(state, action.analysisId, action.sequenceIndex, action.data);
+            const { analysisId, sequenceIndex } = action.context;
+            return setNuvsBLAST(state, analysisId, sequenceIndex, action.data);
 
         default:
             return state;

--- a/client/src/js/analyses/sagas.js
+++ b/client/src/js/analyses/sagas.js
@@ -49,7 +49,5 @@ export function* blastNuvs(action) {
 }
 
 export function* removeAnalysis(action) {
-    yield apiCall(analysesAPI.remove, action, REMOVE_ANALYSIS, {
-        id: action.analysisId
-    });
+    yield apiCall(analysesAPI.remove, action, REMOVE_ANALYSIS);
 }

--- a/client/src/js/files/__tests__/reducer.test.js
+++ b/client/src/js/files/__tests__/reducer.test.js
@@ -86,13 +86,13 @@ describe("filesReducer()", () => {
         const action = {
             type: FIND_FILES.SUCCEEDED,
             data: { documents: [] },
-            fileType: "test"
+            context: { fileType: "test" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
             ...action.data,
-            fileType: action.fileType
+            fileType: "test"
         });
     });
 

--- a/client/src/js/files/reducer.js
+++ b/client/src/js/files/reducer.js
@@ -101,7 +101,7 @@ export default function fileReducer(state = initialState, action) {
         case FIND_FILES.SUCCEEDED:
             return {
                 ...updateDocuments(state, action, "uploaded_at", true),
-                fileType: action.fileType
+                fileType: action.context.fileType
             };
 
         case UPLOAD.REQUESTED:

--- a/client/src/js/hmm/sagas.js
+++ b/client/src/js/hmm/sagas.js
@@ -30,7 +30,7 @@ export function* getHmm(action) {
 }
 
 export function* purgeHmms(action) {
-    const resp = yield apiCall(hmmsAPI.purge, action, PURGE_HMMS, {}, extraFunc);
+    const resp = yield apiCall(hmmsAPI.purge, action, PURGE_HMMS);
 
     if (resp.ok) {
         yield put(push("/hmm"));

--- a/client/src/js/indexes/sagas.js
+++ b/client/src/js/indexes/sagas.js
@@ -66,7 +66,7 @@ export function* listReadyIndexes(action) {
 }
 
 export function* createIndex(action) {
-    const response = yield apiCall(indexesAPI.create, action, CREATE_INDEX, {});
+    const response = yield apiCall(indexesAPI.create, action, CREATE_INDEX);
 
     if (response.ok) {
         yield put(pushState({ rebuild: false }));

--- a/client/src/js/otus/sagas.js
+++ b/client/src/js/otus/sagas.js
@@ -52,8 +52,11 @@ export function* getOTUHistory(action) {
 }
 
 export function* createOTU(action) {
-    const extraFunc = { closeModal: put(push({ state: { createOTU: false } })) };
-    yield apiCall(otusAPI.create, action, CREATE_OTU, {}, extraFunc);
+    const resp = yield apiCall(otusAPI.create, action, CREATE_OTU);
+
+    if (resp.ok) {
+        yield put(push({ state: { createOTU: false } }));
+    }
 }
 
 export function* editOTU(action) {
@@ -65,10 +68,11 @@ export function* setIsolateAsDefault(action) {
 }
 
 export function* removeOTU(action) {
-    const extraFunc = {
-        goBack: put(push(`/refs/${action.refId}/otus`))
-    };
-    yield apiCall(otusAPI.remove, action, REMOVE_OTU, {}, extraFunc);
+    const resp = yield apiCall(otusAPI.remove, action, REMOVE_OTU);
+
+    if (resp.ok) {
+        yield put(push(`/refs/${action.refId}/otus`));
+    }
 }
 
 export function* addIsolate(action) {

--- a/client/src/js/references/__tests__/reducer.test.js
+++ b/client/src/js/references/__tests__/reducer.test.js
@@ -235,8 +235,10 @@ describe("References Reducer", () => {
         beforeEach(() => {
             action = {
                 type: REMOVE_REFERENCE_USER.SUCCEEDED,
-                refId: "foo",
-                userId: "bar"
+                context: {
+                    refId: "foo",
+                    userId: "bar"
+                }
             };
             state = {
                 detail: {
@@ -256,7 +258,7 @@ describe("References Reducer", () => {
         });
 
         it("when store and action ref ids don't match", () => {
-            action.refId = "boo";
+            action.context.refId = "boo";
             const result = reducer(state, action);
             expect(result).toEqual(state);
         });
@@ -330,8 +332,10 @@ describe("References Reducer", () => {
         beforeEach(() => {
             action = {
                 type: REMOVE_REFERENCE_GROUP.SUCCEEDED,
-                refId: "foobar",
-                groupId: "bar"
+                context: {
+                    refId: "foobar",
+                    groupId: "bar"
+                }
             };
 
             state = {
@@ -355,7 +359,7 @@ describe("References Reducer", () => {
         });
 
         it("when store and action ref ids don't match", () => {
-            action.refId = "bid";
+            action.context.refId = "bid";
             const result = reducer(state, action);
             expect(result).toEqual(state);
         });

--- a/client/src/js/references/reducer.js
+++ b/client/src/js/references/reducer.js
@@ -174,13 +174,15 @@ export default function referenceReducer(state = initialState, action) {
             return state;
 
         case REMOVE_REFERENCE_USER.SUCCEEDED:
-            if (action.refId === state.detail.id) {
+            if (action.context.refId === state.detail.id) {
+                const userId = action.context.userId;
+
                 return {
                     ...state,
-                    pendingRemoveUsers: without(state.pendingRemoveUsers, action.userId),
+                    pendingRemoveUsers: without(state.pendingRemoveUsers, userId),
                     detail: {
                         ...state.detail,
-                        users: reject(state.detail.users, { id: action.userId })
+                        users: reject(state.detail.users, { id: userId })
                     }
                 };
             }
@@ -216,14 +218,16 @@ export default function referenceReducer(state = initialState, action) {
             return state;
 
         case REMOVE_REFERENCE_GROUP.SUCCEEDED:
-            if (action.refId === state.detail.id) {
+            if (action.context.refId === state.detail.id) {
+                const groupId = action.context.groupId;
+
                 return {
                     ...state,
-                    pendingRemoveGroups: without(state.pendingRemoveGroups, action.groupId),
+                    pendingRemoveGroups: without(state.pendingRemoveGroups, groupId),
                     detail: {
                         ...state.detail,
                         groups: reject(state.detail.groups, {
-                            id: action.groupId
+                            id: groupId
                         })
                     }
                 };

--- a/client/src/js/samples/sagas.js
+++ b/client/src/js/samples/sagas.js
@@ -108,6 +108,7 @@ export function* getSample(action) {
 
 export function* createSample(action) {
     const resp = yield apiCall(samplesAPI.create, action, CREATE_SAMPLE);
+
     if (resp.ok) {
         yield put(push("/samples"));
     }
@@ -126,6 +127,9 @@ export function* updateSampleRights(action) {
 }
 
 export function* removeSample(action) {
-    yield apiCall(samplesAPI.remove, action, REMOVE_SAMPLE);
-    yield put(push("/samples"));
+    const resp = yield apiCall(samplesAPI.remove, action, REMOVE_SAMPLE);
+
+    if (resp.ok) {
+        yield put(push("/samples"));
+    }
 }

--- a/client/src/js/subtraction/sagas.js
+++ b/client/src/js/subtraction/sagas.js
@@ -22,8 +22,11 @@ export function* getSubtraction(action) {
 }
 
 export function* createSubtraction(action) {
-    yield apiCall(subtractionAPI.create, action, CREATE_SUBTRACTION, {});
-    yield put(pushState({ createSubtraction: false }));
+    const resp = yield apiCall(subtractionAPI.create, action, CREATE_SUBTRACTION);
+
+    if (resp.ok) {
+        yield put(pushState({ createSubtraction: false }));
+    }
 }
 
 export function* shortlistSubtractions(action) {
@@ -31,13 +34,19 @@ export function* shortlistSubtractions(action) {
 }
 
 export function* editSubtraction(action) {
-    yield apiCall(subtractionAPI.edit, action, EDIT_SUBTRACTION);
-    yield put(pushState({ editSubtraction: false }));
+    const resp = yield apiCall(subtractionAPI.edit, action, EDIT_SUBTRACTION);
+
+    if (resp.ok) {
+        yield put(pushState({ editSubtraction: false }));
+    }
 }
 
 export function* removeSubtraction(action) {
-    yield apiCall(subtractionAPI.remove, action, REMOVE_SUBTRACTION);
-    yield put(push("/subtraction"));
+    const resp = yield apiCall(subtractionAPI.remove, action, REMOVE_SUBTRACTION);
+
+    if (resp.ok) {
+        yield put(push("/subtraction"));
+    }
 }
 
 export function* watchSubtraction() {

--- a/client/src/js/users/sagas.js
+++ b/client/src/js/users/sagas.js
@@ -15,11 +15,11 @@ function* getUser(action) {
 }
 
 function* createUser(action) {
-    const extraFunc = {
-        closeModal: put(pushState({ createUser: false }))
-    };
+    const resp = yield apiCall(usersAPI.create, action, CREATE_USER);
 
-    yield apiCall(usersAPI.create, action, CREATE_USER, {}, extraFunc);
+    if (resp.ok) {
+        yield put(pushState({ createUser: false }));
+    }
 }
 
 function* createFirstUser(action) {
@@ -31,10 +31,11 @@ function* editUser(action) {
 }
 
 function* removeUser(action) {
-    const extraFunc = {
-        goBack: put(push("/administration/users"))
-    };
-    yield apiCall(usersAPI.remove, action, REMOVE_USER, {}, extraFunc);
+    const resp = yield apiCall(usersAPI.remove, action, REMOVE_USER);
+
+    if (resp.ok) {
+        yield put(push("/administration/users"));
+    }
 }
 
 export function* watchUsers() {

--- a/client/src/js/utils/sagas.js
+++ b/client/src/js/utils/sagas.js
@@ -6,7 +6,7 @@
 import { replace } from "connected-react-router";
 import { get, includes } from "lodash-es";
 import { matchPath } from "react-router-dom";
-import { all, put } from "redux-saga/effects";
+import { put } from "redux-saga/effects";
 import { LOGOUT } from "../app/actionTypes";
 import { createFindURL } from "./utils";
 
@@ -21,16 +21,12 @@ import { createFindURL } from "./utils";
  * @param apiMethod {function} the function to call with ``action``
  * @param action {object} an action to pass to ``apiMethod``
  * @param actionType {object} a request-style action type
- * @param extra {object} extra properties to assign to the SUCCEEDED action
+ * @param context {object} data to assign to the `context` property of the action
  */
-export function* apiCall(apiMethod, action, actionType, extra = {}, extraFunctions) {
+export function* apiCall(apiMethod, action, actionType, context = {}) {
     try {
         const response = yield apiMethod(action);
-        yield put({ type: actionType.SUCCEEDED, data: response.body, ...extra });
-        if (extraFunctions) {
-            yield all(extraFunctions);
-        }
-
+        yield put({ type: actionType.SUCCEEDED, data: response.body, context });
         return response;
     } catch (error) {
         const statusCode = get(error, "response.statusCode");

--- a/client/src/js/utils/sagas.js
+++ b/client/src/js/utils/sagas.js
@@ -5,7 +5,6 @@
  */
 import { replace } from "connected-react-router";
 import { get, includes } from "lodash-es";
-import { matchPath } from "react-router-dom";
 import { put } from "redux-saga/effects";
 import { LOGOUT } from "../app/actionTypes";
 import { createFindURL } from "./utils";
@@ -44,31 +43,6 @@ export function* apiCall(apiMethod, action, actionType, context = {}) {
         }
 
         throw error;
-    }
-}
-
-/**
- * Executes an API call that uses Virtool's find implementation when the browser URL matches to ``path``.
- *
- * This generator is intended to be used in a saga triggered by ``LOCATION_CHANGE`` from ``connected-react-router``. If the
- * ``path`` matches the current browser URL and API request will be sent to the server with the search parameter
- * (if any) appended to the request URL.
- *
- * The actual API call is made using {@link apiCall}.
- *
- * @generator
- * @param path {string} the path that, when matched, will allow find calls
- * @param apiMethod {function} the API function to call
- * @param action {object} the action to pass to the ``apiMethod``
- * @param actionType {object} the request-style action type to dispatch when the call completes
- */
-export function* apiFind(path, apiMethod, action, actionType) {
-    const { pathname } = action.payload;
-
-    const match = matchPath(pathname, { path, exact: true });
-
-    if (match) {
-        yield apiCall(apiMethod, {}, actionType);
     }
 }
 


### PR DESCRIPTION
* Improve `apiCall()` generator function.
  * Get rid of `extraFunctions` callback argument. Instead these have moved to the functions that call `apiCall()` in the first place. This is a much more understandable pattern that has been partially implemented for a while.
  * Change the `extra` argument to `context`. Previously, properties in the `extra` object were attached to the `SUCCEEDED` action. Now the `context` argument object will be attached to the `SUCCEEDED` action as the `context` property. This naming is better an the origin of the context values is more clear than it was when they were directly attached to the action object.
* Remove unused `apiFind()` function.