### PR TITLE
Fix hanging Welcome component

### DIFF
--- a/client/src/js/home/components/Welcome.js
+++ b/client/src/js/home/components/Welcome.js
@@ -1,9 +1,7 @@
-import { get } from "lodash-es";
 import React from "react";
-import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize } from "../../app/theme";
-import { Box, Container, ExternalLink, LoadingPlaceholder, NarrowContainer } from "../../base";
+import { Box, Container, ExternalLink, NarrowContainer } from "../../base";
 import { Support } from "./Support";
 
 const StyledWelcome = styled(NarrowContainer)`
@@ -24,33 +22,22 @@ const StyledWelcome = styled(NarrowContainer)`
     }
 `;
 
-export const Welcome = ({ mongoVersion, version }) => {
-    if (!mongoVersion || !version) {
-        return <LoadingPlaceholder />;
-    }
+export const Welcome = () => (
+    <Container>
+        <StyledWelcome>
+            <Box>
+                <h1>Virtool {window.virtool.version}</h1>
+                <p>Viral infection diagnostics using next-generation sequencing</p>
 
-    return (
-        <Container>
-            <StyledWelcome>
-                <Box>
-                    <h1>Virtool {version}</h1>
-                    <p>Viral infection diagnostics using next-generation sequencing</p>
+                <strong>
+                    <ExternalLink href="http://www.virtool.ca/">Website</ExternalLink>
+                    <ExternalLink href="https://github.com/virtool/virtool">Github</ExternalLink>
+                </strong>
+            </Box>
 
-                    <strong>
-                        <ExternalLink href="http://www.virtool.ca/">Website</ExternalLink>
-                        <ExternalLink href="https://github.com/virtool/virtool">Github</ExternalLink>
-                    </strong>
-                </Box>
+            <Support />
+        </StyledWelcome>
+    </Container>
+);
 
-                <Support />
-            </StyledWelcome>
-        </Container>
-    );
-};
-
-export const mapStateToProps = state => ({
-    mongoVersion: get(state.updates, "mongo_version"),
-    version: get(state.updates, "version")
-});
-
-export default connect(mapStateToProps, null)(Welcome);
+export default Welcome;

--- a/client/src/js/home/components/__tests__/Welcome.test.js
+++ b/client/src/js/home/components/__tests__/Welcome.test.js
@@ -1,40 +1,11 @@
-import { Welcome, mapStateToProps } from "../Welcome";
+import { Welcome } from "../Welcome";
 
 describe("<Welcome />", () => {
-    let props;
-
-    beforeEach(() => {
-        props = {
-            mongoVersion: "3.6.3",
+    it("should render", () => {
+        window.virtool = {
             version: "v1.2.3"
         };
-    });
-
-    it("should render", () => {
-        const wrapper = shallow(<Welcome {...props} />);
+        const wrapper = shallow(<Welcome version="v1.2.3" />);
         expect(wrapper).toMatchSnapshot();
-    });
-
-    it.each([
-        ["3.6.3", null],
-        [null, "v1.2.3"],
-        [null, null]
-    ])("should render LoadingPlaceholder when version information is (%p, %p)", (mongoVersion, version) => {
-        props.mongoVersion = mongoVersion;
-        props.version = version;
-        const wrapper = shallow(<Welcome {...props} />);
-        expect(wrapper).toMatchSnapshot();
-    });
-});
-
-describe("mapStateToProps", () => {
-    it("should return props", () => {
-        const state = {
-            updates: {
-                version: "foo"
-            }
-        };
-        const result = mapStateToProps(state);
-        expect(result).toEqual({ version: "foo" });
     });
 });

--- a/client/src/js/home/components/__tests__/__snapshots__/Welcome.test.js.snap
+++ b/client/src/js/home/components/__tests__/__snapshots__/Welcome.test.js.snap
@@ -28,9 +28,3 @@ exports[`<Welcome /> should render 1`] = `
   </Welcome__StyledWelcome>
 </Container>
 `;
-
-exports[`<Welcome /> should render LoadingPlaceholder when version information is ("3.6.3", null) 1`] = `<LoadingPlaceholder />`;
-
-exports[`<Welcome /> should render LoadingPlaceholder when version information is (null, "v1.2.3") 1`] = `<LoadingPlaceholder />`;
-
-exports[`<Welcome /> should render LoadingPlaceholder when version information is (null, null) 1`] = `<LoadingPlaceholder />`;


### PR DESCRIPTION
* Remove `mongoVersion` logic. This is not necessary in 5.0.0 and is probably not great security-wise.
* Get `version` from `window.virtool` instead of the Redux store, where it no longer exists.