### PR TITLE
Update error message for email formatting in cerberus schema check

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -261,6 +261,33 @@ numpy = ["numpy (>=1.11.0)"]
 tests = ["check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "mock (>=1.3.0)", "pydocstyle (>=1.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=2.8.0)", "tox (>=3.7.0)"]
 
 [[package]]
+name = "dnspython"
+version = "2.1.0"
+description = "DNS toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dnssec = ["cryptography (>=2.6)"]
+doh = ["requests", "requests-toolbelt"]
+idna = ["idna (>=2.1)"]
+curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
+trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
+
+[[package]]
+name = "email-validator"
+version = "1.1.3"
+description = "A robust email syntax and deliverability validation library for Python 2.x/3.x."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+dnspython = ">=1.15.0"
+idna = ">=2.0.0"
+
+[[package]]
 name = "et-xmlfile"
 version = "1.1.0"
 description = "An implementation of lxml.xmlfile for the standard library"
@@ -879,7 +906,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "89b78c263ba7664b4689c0a18223a145c6f69e08e235af9293e0808920d079c4"
+content-hash = "0a7765ed83647f66493ef594311e81bfe6e0a734c7f8a80f00b092d53296fc80"
 
 [metadata.files]
 aiodns = [
@@ -1204,6 +1231,14 @@ dictdiffer = [
     {file = "dictdiffer-0.8.1-py2.py3-none-any.whl", hash = "sha256:d79d9a39e459fe33497c858470ca0d2e93cb96621751de06d631856adfd9c390"},
     {file = "dictdiffer-0.8.1.tar.gz", hash = "sha256:1adec0d67cdf6166bda96ae2934ddb5e54433998ceab63c984574d187cc563d2"},
 ]
+dnspython = [
+    {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
+    {file = "dnspython-2.1.0.zip", hash = "sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4"},
+]
+email-validator = [
+    {file = "email_validator-1.1.3-py2.py3-none-any.whl", hash = "sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b"},
+    {file = "email_validator-1.1.3.tar.gz", hash = "sha256:aa237a65f6f4da067119b7df3f13e89c25c051327b2b5b66dc075f33d62480d7"},
+]
 et-xmlfile = [
     {file = "et_xmlfile-1.1.0-py3-none-any.whl", hash = "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"},
     {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
@@ -1335,12 +1370,22 @@ jinja2 = [
     {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1349,14 +1394,21 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1366,6 +1418,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1765,6 +1820,7 @@ wasmer = [
     {file = "wasmer-1.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a08be93aff695ce3be871994f726716b68bef36bd583bccad75778359cd273df"},
     {file = "wasmer-1.0.0-cp38-none-win_amd64.whl", hash = "sha256:8b13214b5dcc84d43f4c44e2309442497f19137561afada7f34babad89365355"},
     {file = "wasmer-1.0.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:1fada13fb536f44e12d7c98c557f5b7a55df94389d3cb90964193dcc8e16f0fa"},
+    {file = "wasmer-1.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f390a54e26775456602f21d5d7d62dbad487f6a1022cab4379d7eac2c812d7ce"},
     {file = "wasmer-1.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:04e5d51eed336be0e1bf1445aa032fc34466b77220c26732b8990df872f29e92"},
     {file = "wasmer-1.0.0-cp39-none-win_amd64.whl", hash = "sha256:690c5ed46a98e91bc638f52a25e5011c5baa1ef0581f414018eb7aa0e7f844bc"},
     {file = "wasmer-1.0.0-py3-none-any.whl", hash = "sha256:427e9c5e5301a453a09b8b9ceb8c793d85411b8f45e54c9c0d801566dd8d214e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ uvloop = "^0.15.2"
 aiojobs = "^0.3.0"
 Cerberus = "^1.3.4"
 PyYAML = "^5.4.1"
+email-validator = "^1.1.3"
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -50,8 +50,7 @@ async def test_edit(error, spawn_client, resp_is, static_time):
     resp = await client.patch("/api/account", data)
 
     if error == "email_error":
-        await resp_is.invalid_input(resp,  {'email': ["value does not match regex '^[a-zA-Z0-9_.+-]+@["
-                                                      "a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"]})
+        await resp_is.invalid_input(resp, {"email": ["Not a valid email"]})
 
     elif error == "password_length_error":
         await resp_is.bad_request(resp, f"Password does not meet minimum length requirement (8)")

--- a/tests/labels/test_api.py
+++ b/tests/labels/test_api.py
@@ -282,3 +282,24 @@ async def test_remove(error, spawn_client, pg_session, resp_is):
         return
 
     await resp_is.no_content(resp)
+
+
+@pytest.mark.parametrize("value", ["valid_hex_color", "invalid_hex_color"])
+async def test_is_valid_hex_color(value, spawn_client, resp_is):
+    """
+    Tests that when an invalid hex color is used, validators.is_valid_hex_color raises a 422 error.
+    """
+    client = await spawn_client(authorize=True)
+
+    data = {
+        "name": "test",
+        "color": "#fc5203" if value == "valid_hex_color" else "foo",
+        "description": "test"
+    }
+
+    resp = await client.patch("/api/labels/00", data=data)
+
+    if value == "valid_hex_color":
+        await resp_is.not_found(resp)
+    else:
+        await resp_is.invalid_input(resp, {'color': ['This is not a valid Hexadecimal color']})

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,47 @@
+from virtool.validators import is_valid_email, is_permission_dict, has_unique_segment_names, is_valid_hex_color
+
+
+async def test_is_permission_dict(mocker):
+    stub = mocker.stub()
+    is_permission_dict("permissions",
+                       {
+                           "cancel_job": True,
+                           "create_ref": True,
+                           "create_sample": True,
+                           "modify_hmm": True,
+                           "modify_subtraction": True,
+                           "remove_file": True,
+                           "remove_job": True,
+                           "upload_file": True,
+                           "foo": True
+                       },
+                       stub)
+    stub.assert_called_with("permissions", "keys must be valid permissions")
+
+
+async def test_has_unique_segment_names(mocker):
+    stub = mocker.stub()
+    has_unique_segment_names("collection",
+                             [
+                                 {
+                                     "name": "foo"
+                                 },
+                                 {
+                                     "name": "foo"
+                                 }
+                             ],
+                             stub
+                             )
+    stub.assert_called_with("collection", "list contains duplicate names")
+
+
+async def test_is_valid_hex_color(mocker):
+    stub = mocker.stub()
+    is_valid_hex_color("color", "abc123", stub)
+    stub.assert_called_with("color", "This is not a valid Hexadecimal color")
+
+
+async def test_email(mocker):
+    stub = mocker.stub()
+    is_valid_email("email", "-foo-bar-baz.!.@.gm-ail.com", stub)
+    stub.assert_called_with("email", "Not a valid email")

--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -50,7 +50,7 @@ async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
     "email": {
         "type": "string",
         "coerce": virtool.validators.strip,
-        "regex": r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+        "check_with": virtool.validators.is_valid_email
     },
     "old_password": {
         "type": "string"

--- a/virtool/validators.py
+++ b/virtool/validators.py
@@ -1,9 +1,10 @@
 import re
 
+from email_validator import validate_email, EmailSyntaxError
+
 import virtool.users.utils
 
 RE_HEX_COLOR = re.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
-RE_EMAIL = re.compile("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
 
 
 def strip(value: str) -> str:
@@ -33,5 +34,7 @@ def is_valid_hex_color(field, value, error):
 
 
 def is_valid_email(field, value, error):
-    if not RE_EMAIL.match(value):
+    try:
+        validate_email(value)
+    except EmailSyntaxError:
         error(field, "Not a valid email")

--- a/virtool/validators.py
+++ b/virtool/validators.py
@@ -3,6 +3,7 @@ import re
 import virtool.users.utils
 
 RE_HEX_COLOR = re.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
+RE_EMAIL = re.compile("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
 
 
 def strip(value: str) -> str:
@@ -29,3 +30,8 @@ def has_unique_segment_names(field, value, error):
 def is_valid_hex_color(field, value, error):
     if not RE_HEX_COLOR.match(value):
         error(field, "This is not a valid Hexadecimal color")
+
+
+def is_valid_email(field, value, error):
+    if not RE_EMAIL.match(value):
+        error(field, "Not a valid email")

--- a/virtool/validators.py
+++ b/virtool/validators.py
@@ -2,7 +2,7 @@ import re
 
 from email_validator import validate_email, EmailSyntaxError
 
-import virtool.users.utils
+from virtool.users.utils import PERMISSIONS
 
 RE_HEX_COLOR = re.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
 
@@ -18,22 +18,58 @@ def strip(value: str) -> str:
     return value.strip()
 
 
-def is_permission_dict(field, value, error):
-    if any(key not in virtool.users.utils.PERMISSIONS for key in value):
+def is_permission_dict(field: str, value: dict, error: callable):
+    """
+    Checks that all keys included in permissions dictionary are valid permissions.
+
+    If invalid key is found, error message is updated to "keys must be valid permissions"
+
+    :param field: permissions field to check
+    :param value: permissions dictionary value
+    :param error: points to the calling validator’s _error method
+    """
+    if any(key not in PERMISSIONS for key in value):
         error(field, "keys must be valid permissions")
 
 
-def has_unique_segment_names(field, value, error):
+def has_unique_segment_names(field: str, value: list, error: callable):
+    """
+    Checks that no duplicate names are used for segment names in list
+
+    If duplicate names are found, error message is updated to  "list contains duplicate names"
+
+    :param field: field to check
+    :param value: list value
+    :param error: points to the calling validator’s _error method
+    """
     if len({seg["name"] for seg in value}) != len(value):
         error(field, "list contains duplicate names")
 
 
-def is_valid_hex_color(field, value, error):
+def is_valid_hex_color(field: str, value: str, error: callable):
+    """
+    Checks that color is a valid Hexadecimal color, performs check using regex format comparison
+
+    If color is an invalid Hexadecimal color, error message is updated to "This is not a valid Hexadecimal color"
+
+    :param field: color field to check
+    :param value: color string value
+    :param error: points to the calling validator’s _error method
+    """
     if not RE_HEX_COLOR.match(value):
         error(field, "This is not a valid Hexadecimal color")
 
 
-def is_valid_email(field, value, error):
+def is_valid_email(field: str, value: str, error: callable):
+    """
+    Checks that email is a valid email according to email_validator.validate_email
+
+    If email is invalid, error message is updated to "Not a valid email"
+
+    :param field: email field to check
+    :param value: email string value
+    :param error: points to the calling validator’s _error method
+    """
     try:
         validate_email(value)
     except EmailSyntaxError:


### PR DESCRIPTION
Instead of writing separate custom validator, check for email formatting error in virtool.http.schema and update error message