### PR TITLE
Resolve failing tests in tests.http.auth

### DIFF
--- a/tests/http/test_auth.py
+++ b/tests/http/test_auth.py
@@ -3,17 +3,6 @@ from aiohttp import BasicAuth
 from virtool.utils import hash_key
 
 
-async def test_receives_session_id(mocker, spawn_client):
-    mocker.patch("secrets.token_hex", return_value="foobar")
-
-    client = await spawn_client()
-
-    resp = await client.get("/api")
-
-    assert resp.status == 401
-    assert client.has_cookie("session_id", "foobar")
-
-
 class TestJobAuthentication:
 
     async def test_root_succeeds(self, dbi, spawn_job_client):

--- a/tests/http/test_auth.py
+++ b/tests/http/test_auth.py
@@ -16,39 +16,23 @@ async def test_receives_session_id(mocker, spawn_client):
 
 class TestJobAuthentication:
 
-    async def test_root_succeeds(self, dbi, spawn_client):
+    async def test_root_succeeds(self, dbi, spawn_job_client):
         """
         Check that a request against the job accessible root URL (GET /api) succeeds.
 
         """
-        key = "bar"
-
-        client = await spawn_client(auth=BasicAuth("job-foo", key))
-        client.settings["enable_api"] = True
-
-        await dbi.jobs.insert_one({
-            "_id": "foo",
-            "key": hash_key(key)
-        })
+        client = await spawn_job_client(authorize=True)
 
         resp = await client.get("/api")
 
         assert resp.status == 200
 
-    async def test_unauthenticated_root_fails(self, dbi, spawn_client):
+    async def test_unauthenticated_root_fails(self, dbi, spawn_job_client):
         """
         Check that an request against the root API URL
 
         """
-        key = "bar"
-
-        client = await spawn_client(auth=BasicAuth("job-foo", "no_good"))
-        client.settings["enable_api"] = True
-
-        await dbi.jobs.insert_one({
-            "_id": "foo",
-            "key": hash_key(key)
-        })
+        client = await spawn_job_client(authorize=False)
 
         resp = await client.get("/api")
 
@@ -72,4 +56,4 @@ class TestJobAuthentication:
 
         resp = await client.get("/api/samples")
 
-        assert resp.status == 403
+        assert resp.status == 401

--- a/virtool/http/root.py
+++ b/virtool/http/root.py
@@ -13,8 +13,7 @@ async def get(req):
     Returns a generic message. Used during testing for acquiring a ``session_id``.
 
     """
-    return json_response({
-        "endpoints": {
+    app_data = {"endpoints": {
             "account": {
                 "url": "/api/account",
                 "doc": f"{API_URL_ROOT}_account.html"
@@ -74,7 +73,11 @@ async def get(req):
             "users": {
                 "url": "/api/users",
                 "doc": f"{API_URL_ROOT}_users.html"
-            }
-        },
-        "version": req.app["version"]
-    })
+            }}}
+
+    try:
+        app_data["version"] = req.app["version"]
+    except KeyError:
+        pass
+
+    return json_response(app_data)


### PR DESCRIPTION
Tests in `tests.http.auth` were never recruited by pytest because the module name didn't begin with "test_". Tests all failed when ran, this PR is to resolve those failing tests.