### PR TITLE
Removed ZIndex property of Icon in Item.js to fix overlay problem

### DIFF
--- a/client/src/js/samples/components/Item/Item.js
+++ b/client/src/js/samples/components/Item/Item.js
@@ -94,7 +94,7 @@ class SampleItem extends React.Component {
                     <Icon
                         color="green"
                         name="chart-area"
-                        style={{ fontSize: "17px", zIndex: 10000 }}
+                        style={{ fontSize: "17px"}}
                         tip="Quick Analyze"
                         tipPlacement="left"
                         onClick={this.handleQuickAnalyze}

--- a/client/src/js/samples/components/Item/Item.js
+++ b/client/src/js/samples/components/Item/Item.js
@@ -94,7 +94,7 @@ class SampleItem extends React.Component {
                     <Icon
                         color="green"
                         name="chart-area"
-                        style={{ fontSize: "17px"}}
+                        style={{ fontSize: "17px" }}
                         tip="Quick Analyze"
                         tipPlacement="left"
                         onClick={this.handleQuickAnalyze}


### PR DESCRIPTION
The quick analysis Icon was appearing on the top layer because it had the zIndex property set to 10000. Removing this property still allowed it to render properly where it should but stopped the icon from appearing over top of the quick analysis window.