### PR TITLE
Remove progress multiplication by 100 in client

### DIFF
--- a/client/src/js/hmm/components/Installer.js
+++ b/client/src/js/hmm/components/Installer.js
@@ -41,7 +41,7 @@ const StyledHMMInstaller = styled(Box)`
 
 export const HMMInstaller = ({ installed, task }) => {
     if (task && !installed) {
-        const progress = task.progress * 100;
+        const progress = task.progress;
         const step = replace(task.step, "_", " ");
 
         return (

--- a/client/src/js/hmm/components/__tests__/Installer.test.js
+++ b/client/src/js/hmm/components/__tests__/Installer.test.js
@@ -6,7 +6,7 @@ describe("<HMMInstaller />", () => {
     beforeEach(() => {
         props = {
             releaseId: "foo",
-            task: { progress: "foo", step: "bar" },
+            task: { progress: 45, step: "bar" },
             installed: false
         };
     });

--- a/client/src/js/hmm/components/__tests__/__snapshots__/Installer.test.js.snap
+++ b/client/src/js/hmm/components/__tests__/__snapshots__/Installer.test.js.snap
@@ -1,30 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<HMMInstaller /> should render when [this.props.task exists] and [this.props.installed=true] 1`] = `
-<Installer__StyledHMMInstaller>
-  <Icon
-    faStyle="fas"
-    fixedWidth={false}
-    name="info-circle"
-  />
-  <div>
-    <h3>
-      No HMM data available.
-    </h3>
-    <p>
-      You can download and install the official HMM data automatically from our
-      <ExternalLink
-        href="https://github.com/virtool/virtool-hmm"
-      >
-         GitHub repository
-      </ExternalLink>
-      .
-    </p>
-    <Connect(InstallOption) />
-  </div>
-</Installer__StyledHMMInstaller>
-`;
-
 exports[`<HMMInstaller /> should render when [this.props.task = undefined] and [this.props.installed = false] 1`] = `
 <Installer__StyledHMMInstaller>
   <Icon
@@ -79,7 +54,7 @@ exports[`<HMMInstaller /> should render when [this.props.task exists] and [this.
 <Installer__HMMInstalling>
   <ProgressBar__AffixedProgressBar
     color="blue"
-    now={NaN}
+    now={45}
   />
   <div>
     <h3>

--- a/client/src/js/jobs/components/Item/Item.js
+++ b/client/src/js/jobs/components/Item/Item.js
@@ -47,8 +47,6 @@ export const JobItem = ({
     const handleCancel = useCallback(() => onCancel(id), [id, onCancel]);
     const handleRemove = useCallback(() => onRemove(id), [id, onRemove]);
 
-    const progressValue = progress * 100;
-
     let progressColor = "green";
 
     if (state === "running") {
@@ -63,7 +61,7 @@ export const JobItem = ({
     return (
         <JobItemContainer>
             <JobItemLinkBox to={`/jobs/${id}`}>
-                <AffixedProgressBar now={progressValue} color={progressColor} />
+                <AffixedProgressBar now={progress} color={progressColor} />
 
                 <JobItemBody>
                     <JobItemHeader>

--- a/client/src/js/jobs/components/Item/__tests__/Item.test.js
+++ b/client/src/js/jobs/components/Item/__tests__/Item.test.js
@@ -6,7 +6,7 @@ describe("<JobItem />", () => {
     beforeEach(() => {
         props = {
             id: "foo",
-            progress: 1,
+            progress: 100,
             workflow: "build_index",
             created_at: "Foo",
             user: {

--- a/client/src/js/references/components/Detail/Remote.js
+++ b/client/src/js/references/components/Detail/Remote.js
@@ -111,7 +111,7 @@ const StyledUpgrade = styled(BoxGroupSection)`
 
 const Upgrade = ({ progress }) => (
     <StyledUpgrade>
-        <AffixedProgressBar color="green" now={progress * 100} />
+        <AffixedProgressBar color="green" now={progress} />
         <Icon name="arrow-alt-circle-up" />
         <strong>Updating</strong>
     </StyledUpgrade>


### PR DESCRIPTION
Since progress was previously provided a decimal values between 0 and 1, components and tests had to reflected to update the change to 1-100 integer values.