### PR TITLE
Improve GitHub request logging

### DIFF
--- a/virtool/github.py
+++ b/virtool/github.py
@@ -123,4 +123,4 @@ async def get_release(
             return None
 
         else:
-            raise virtool.errors.GitHubError(f"Encountered error {resp.status}")
+            raise virtool.errors.GitHubError(f"Encountered error {resp.status} {await resp.json()}")

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -121,6 +121,8 @@ async def install(req):
     if await db.status.count_documents({"_id": "hmm", "updates.ready": False}):
         raise HTTPConflict(text="Install already in progress")
 
+    await virtool.hmm.db.fetch_and_update_release(req.app)
+
     release = await get_one_field(db.status, "release", "hmm")
 
     if release is None:


### PR DESCRIPTION
Installing HMMs is not working in Azure for @BlakeASmith. May be due to previous request to GitHub being blocked by fiewall. To resolve or investigate this:
* Log response body JSON when requests to GitHub fail
* Fetch the latest HMM release every time an install request is made. Don't rely on a previously fetched (or failed) request for release.