### PR TITLE
Fixed subtraction and reference multiSelect lists rendering improperly when the list is empty

### DIFF
--- a/client/src/js/analyses/components/Create/ReferenceSelector.js
+++ b/client/src/js/analyses/components/Create/ReferenceSelector.js
@@ -34,7 +34,7 @@ export const ReferenceSelector = ({ hasError, indexes, selected, onChange }) => 
     if (!referenceComponents.length) {
         return (
             <NoneFoundBox noun="references">
-                <Link to="/subtraction">Import one</Link>.
+                <Link to="/refs">Import one</Link>.
             </NoneFoundBox>
         );
     }

--- a/client/src/js/analyses/components/Create/ReferenceSelector.js
+++ b/client/src/js/analyses/components/Create/ReferenceSelector.js
@@ -33,7 +33,7 @@ export const ReferenceSelector = ({ hasError, indexes, selected, onChange }) => 
 
     if (!referenceComponents.length) {
         return (
-            <NoneFoundBox noun={"references"}>
+            <NoneFoundBox noun="references">
                 <Link to="/subtraction">Import one</Link>.
             </NoneFoundBox>
         );

--- a/client/src/js/analyses/components/Create/ReferenceSelector.js
+++ b/client/src/js/analyses/components/Create/ReferenceSelector.js
@@ -2,8 +2,9 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
-import { Label } from "../../../base";
+import { Label, NoneFoundBox } from "../../../base";
 import { MultiSelector, MultiSelectorItem } from "../../../base/MultiSelector";
+import { Link } from "react-router-dom";
 
 const StyledReferenceSelectorItem = styled(MultiSelectorItem)`
     > span:last-child {
@@ -29,6 +30,14 @@ export const ReferenceSelector = ({ hasError, indexes, selected, onChange }) => 
             version={index.version}
         />
     ));
+
+    if (!referenceComponents.length) {
+        return (
+            <NoneFoundBox noun={"references"}>
+                <Link to="/subtraction">Import one</Link>.
+            </NoneFoundBox>
+        );
+    }
 
     return (
         <React.Fragment>

--- a/client/src/js/base/MultiSelector.js
+++ b/client/src/js/base/MultiSelector.js
@@ -18,7 +18,7 @@ const StyledMultiSelectorItem = styled(SelectBoxGroupSection)`
     user-select: none;
 `;
 
-export const MultiSelectorItem = ({ children, className, name, value }) => {
+export const MultiSelectorItem = ({ children, className, name, value, disabled }) => {
     const { selected, onSelect } = useContext(MultiSelectorContext);
     const active = selected.includes(value);
 
@@ -30,6 +30,7 @@ export const MultiSelectorItem = ({ children, className, name, value }) => {
             name={name}
             type="button"
             onClick={() => onSelect(value)}
+            disabled={disabled}
         >
             <Checkbox checked={active} /> {children}
         </StyledMultiSelectorItem>

--- a/client/src/js/base/MultiSelector.js
+++ b/client/src/js/base/MultiSelector.js
@@ -56,7 +56,7 @@ export const MultiSelector = ({ children, error, noun, selected, onChange }) => 
                 onSelect: handleSelect
             }}
         >
-            {children ? <MultiSelectorList error={error}>{children}</MultiSelectorList> : content}
+            {!!children.length ? <MultiSelectorList error={error}>{children}</MultiSelectorList> : content}
             {error && <MultiSelectorError>{error}</MultiSelectorError>}
         </MultiSelectorContext.Provider>
     );

--- a/client/src/js/base/MultiSelector.js
+++ b/client/src/js/base/MultiSelector.js
@@ -56,7 +56,7 @@ export const MultiSelector = ({ children, error, noun, selected, onChange }) => 
                 onSelect: handleSelect
             }}
         >
-            {!!children.length ? <MultiSelectorList error={error}>{children}</MultiSelectorList> : content}
+            {children.length ? <MultiSelectorList error={error}>{children}</MultiSelectorList> : content}
             {error && <MultiSelectorError>{error}</MultiSelectorError>}
         </MultiSelectorContext.Provider>
     );

--- a/client/src/js/base/MultiSelector.js
+++ b/client/src/js/base/MultiSelector.js
@@ -18,7 +18,7 @@ const StyledMultiSelectorItem = styled(SelectBoxGroupSection)`
     user-select: none;
 `;
 
-export const MultiSelectorItem = ({ children, className, name, value, disabled }) => {
+export const MultiSelectorItem = ({ children, className, name, value }) => {
     const { selected, onSelect } = useContext(MultiSelectorContext);
     const active = selected.includes(value);
 
@@ -30,7 +30,6 @@ export const MultiSelectorItem = ({ children, className, name, value, disabled }
             name={name}
             type="button"
             onClick={() => onSelect(value)}
-            disabled={disabled}
         >
             <Checkbox checked={active} /> {children}
         </StyledMultiSelectorItem>

--- a/client/src/js/base/NoneFound.js
+++ b/client/src/js/base/NoneFound.js
@@ -46,9 +46,9 @@ const StyledNoneFoundBox = styled(Box)`
     min-height: 30px;
 `;
 
-export const NoneFoundBox = ({ noun }) => (
+export const NoneFoundBox = ({ noun, children }) => (
     <StyledNoneFoundBox as={Box}>
-        <Icon name="info-circle" /> No {noun} found
+        <Icon name="info-circle" /> No {noun} found. &nbsp; {children}
     </StyledNoneFoundBox>
 );
 

--- a/client/src/js/base/NoneFound.js
+++ b/client/src/js/base/NoneFound.js
@@ -53,6 +53,7 @@ export const NoneFoundBox = ({ noun, children }) => (
 );
 
 NoneFoundBox.propTypes = {
+    children: PropTypes.node,
     noun: PropTypes.string.isRequired
 };
 

--- a/client/src/js/base/__tests__/__snapshots__/NoneFound.test.js.snap
+++ b/client/src/js/base/__tests__/__snapshots__/NoneFound.test.js.snap
@@ -56,7 +56,7 @@ exports[`<NoneFoundBox /> should render with [noun='boxes' 1`] = `
   />
    No 
   boxes
-   found
+   found.   
 </NoneFound__StyledNoneFoundBox>
 `;
 

--- a/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
+++ b/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
@@ -43,7 +43,7 @@ describe("<SampleSubtractionSelector />", () => {
 
     it("should render no subtractions found message iff appropriate", () => {
         const modProps = { ...props, subtractions: [] };
-        const testMessage = "No Subtractions Found.";
+        const testMessage = /No subtractions Found/i;
 
         renderWithProviders(<SampleSubtractionSelector {...props} />);
         expect(screen.queryByText(testMessage)).toBeNull();

--- a/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
+++ b/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SampleSubtractionSelector } from "../components/Selector";
+import { BrowserRouter } from "react-router-dom";
 
 describe("<SampleSubtractionSelector />", () => {
     let props;
@@ -41,14 +42,22 @@ describe("<SampleSubtractionSelector />", () => {
         expect(clickedValue).toEqual([props.subtractions[0].id]);
     });
 
+    const WrappedSampleSubtractionSelector = props => {
+        return (
+            <BrowserRouter>
+                <SampleSubtractionSelector {...props}> </SampleSubtractionSelector>
+            </BrowserRouter>
+        );
+    };
+
     it("should render no subtractions found message iff appropriate", () => {
         const modProps = { ...props, subtractions: [] };
         const testMessage = /No subtractions Found/i;
 
-        renderWithProviders(<SampleSubtractionSelector {...props} />);
+        renderWithProviders(<WrappedSampleSubtractionSelector {...props} />);
         expect(screen.queryByText(testMessage)).toBeNull();
 
-        renderWithProviders(<SampleSubtractionSelector {...modProps} />);
+        renderWithProviders(<WrappedSampleSubtractionSelector {...modProps} />);
         expect(screen.queryByText(testMessage)).toBeInTheDocument();
     });
 });

--- a/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
+++ b/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import {getByText, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SampleSubtractionSelector } from "../components/Selector";
 
@@ -39,5 +39,17 @@ describe("<SampleSubtractionSelector />", () => {
         expect(clickedValue).toEqual(null);
         userEvent.click(screen.getByText(props.subtractions[0].name));
         expect(clickedValue).toEqual([props.subtractions[0].id]);
+    });
+
+    it("should render no subtractions found message iff appropriate", () => {
+        const modProps = { ...props, subtractions: [] };
+        const testMessage = "No Subtractions Found."
+
+        renderWithProviders(<SampleSubtractionSelector {...props} />);
+        expect(screen.queryByText(testMessage)).toBeNull();
+
+        renderWithProviders(<SampleSubtractionSelector {...modProps} />);
+        expect(screen.queryByText(testMessage)).toBeInTheDocument();
+
     });
 });

--- a/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
+++ b/client/src/js/subtraction/__tests__/SampleSubtractionSelector.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {getByText, screen} from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SampleSubtractionSelector } from "../components/Selector";
 
@@ -43,13 +43,12 @@ describe("<SampleSubtractionSelector />", () => {
 
     it("should render no subtractions found message iff appropriate", () => {
         const modProps = { ...props, subtractions: [] };
-        const testMessage = "No Subtractions Found."
+        const testMessage = "No Subtractions Found.";
 
         renderWithProviders(<SampleSubtractionSelector {...props} />);
         expect(screen.queryByText(testMessage)).toBeNull();
 
         renderWithProviders(<SampleSubtractionSelector {...modProps} />);
         expect(screen.queryByText(testMessage)).toBeInTheDocument();
-
     });
 });

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -13,7 +13,7 @@ export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, 
     ));
     if (!subtractions.length) {
         return (
-            <NoneFoundBox noun={"subtractions"}>
+            <NoneFoundBox noun="subtractions">
                 <BrowserRouter>
                     <Link to="/subtraction"> Create one</Link>.
                 </BrowserRouter>

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -2,7 +2,7 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../base/MultiSelector";
-import { Link, BrowserRouter } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { NoneFoundBox } from "../../base/NoneFound";
 
 export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, onChange }) => {
@@ -14,9 +14,7 @@ export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, 
     if (!subtractions.length) {
         return (
             <NoneFoundBox noun="subtractions">
-                <BrowserRouter>
-                    <Link to="/subtraction"> Create one</Link>.
-                </BrowserRouter>
+                <Link to="/subtraction"> Create one</Link>.
             </NoneFoundBox>
         );
     }

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -2,7 +2,7 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../base/MultiSelector";
-import { Link } from "react-router-dom";
+import { Link, BrowserRouter } from "react-router-dom";
 import { NoneFoundBox } from "../../base/NoneFound";
 
 export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, onChange }) => {
@@ -13,8 +13,10 @@ export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, 
     ));
     if (!subtractions.length) {
         return (
-            <NoneFoundBox noun={noun}>
-                <Link to="/subtraction"> Create one</Link>.
+            <NoneFoundBox noun={"subtractions"}>
+                <BrowserRouter>
+                    <Link to="/subtraction"> Create one</Link>.
+                </BrowserRouter>
             </NoneFoundBox>
         );
     }

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -2,18 +2,36 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../base/MultiSelector";
+import { Icon } from "../../base";
+import { Link } from "react-router-dom";
 
 export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, onChange }) => {
-    const subtractionComponents = map(subtractions, ({ name, id }) => (
+    let subtractionComponents = map(subtractions, ({ name, id }) => (
         <MultiSelectorItem key={id} name={name} value={id} id={id}>
             <span>{name}</span>
         </MultiSelectorItem>
     ));
 
+    if (!subtractions.length) {
+        subtractionComponents = (
+            <MultiSelectorItem disabled={true}>
+                <span>{"N/A"}</span>
+            </MultiSelectorItem>
+        );
+    }
+
     return (
-        <MultiSelector name={name} noun={noun} selected={selected} onChange={onChange}>
-            {subtractionComponents}
-        </MultiSelector>
+        <div>
+            <MultiSelector name={name} noun={noun} selected={selected} onChange={onChange}>
+                {subtractionComponents}
+            </MultiSelector>
+            {!subtractions.length && (
+                <div>
+                    <Icon name="info-circle" /> No Subtractions Found.
+                    <Link to="/subtraction"> Create some</Link>
+                </div>
+            )}
+        </div>
     );
 };
 

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -2,8 +2,8 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../base/MultiSelector";
-import { Box, Icon } from "../../base";
 import { Link, BrowserRouter } from "react-router-dom";
+import { Box, Icon } from "../../base";
 
 export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, onChange }) => {
     const subtractionComponents = map(subtractions, ({ name, id }) => (

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -2,8 +2,8 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../base/MultiSelector";
-import { Link, BrowserRouter } from "react-router-dom";
-import { Box, Icon } from "../../base";
+import { Link } from "react-router-dom";
+import { NoneFoundBox } from "../../base/NoneFound";
 
 export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, onChange }) => {
     const subtractionComponents = map(subtractions, ({ name, id }) => (
@@ -13,14 +13,9 @@ export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, 
     ));
     if (!subtractions.length) {
         return (
-            <div>
-                <Box>
-                    <Icon name="info-circle" /> <span> No Subtractions Found. </span>
-                    <BrowserRouter>
-                        <Link to="/subtraction"> Create one</Link>.
-                    </BrowserRouter>
-                </Box>
-            </div>
+            <NoneFoundBox noun={noun}>
+                <Link to="/subtraction"> Create one</Link>.
+            </NoneFoundBox>
         );
     }
     return (

--- a/client/src/js/subtraction/components/Selector.js
+++ b/client/src/js/subtraction/components/Selector.js
@@ -2,36 +2,31 @@ import { map } from "lodash-es";
 import PropTypes from "prop-types";
 import React from "react";
 import { MultiSelector, MultiSelectorItem } from "../../base/MultiSelector";
-import { Icon } from "../../base";
-import { Link } from "react-router-dom";
+import { Box, Icon } from "../../base";
+import { Link, BrowserRouter } from "react-router-dom";
 
 export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, onChange }) => {
-    let subtractionComponents = map(subtractions, ({ name, id }) => (
+    const subtractionComponents = map(subtractions, ({ name, id }) => (
         <MultiSelectorItem key={id} name={name} value={id} id={id}>
             <span>{name}</span>
         </MultiSelectorItem>
     ));
-
     if (!subtractions.length) {
-        subtractionComponents = (
-            <MultiSelectorItem disabled={true}>
-                <span>{"N/A"}</span>
-            </MultiSelectorItem>
+        return (
+            <div>
+                <Box>
+                    <Icon name="info-circle" /> <span> No Subtractions Found. </span>
+                    <BrowserRouter>
+                        <Link to="/subtraction"> Create one</Link>.
+                    </BrowserRouter>
+                </Box>
+            </div>
         );
     }
-
     return (
-        <div>
-            <MultiSelector name={name} noun={noun} selected={selected} onChange={onChange}>
-                {subtractionComponents}
-            </MultiSelector>
-            {!subtractions.length && (
-                <div>
-                    <Icon name="info-circle" /> No Subtractions Found.
-                    <Link to="/subtraction"> Create some</Link>
-                </div>
-            )}
-        </div>
+        <MultiSelector name={name} noun={noun} selected={selected} onChange={onChange}>
+            {subtractionComponents}
+        </MultiSelector>
     );
 };
 


### PR DESCRIPTION
Changes:

1. After a few revisions ended up fixing VIR-948 by having the SubtractionSelector component directly return a NoneFoundBox if there are no subtractions to be listed. 
2. Added similar code to ReferenceSelector to create a properly formed error message
3. NoneFoundBox was modified to accept and directly render props.children to permit inclusion of links to the correct pages. Assumes that the child will be an inline element otherwise formatting will be off
4. Changed the content checking ternary operator in MultiSelector so that it checks the truthiness of children.length rather than children



