### PR TITLE
Make base SelectBox component accessible

### DIFF
--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -2,7 +2,10 @@ import styled from "styled-components";
 import { Box } from "./Box";
 import React from "react";
 
-export const StyledSelectBox = styled(Box)`
+export const SelectBox = styled(Box).attrs(props => ({
+    type: "button",
+    as: "button"
+}))`
     border: 1px ${props => (props.active ? props.theme.color.blue : props.theme.color.greyLight)} solid;
     border-radius: ${props => props.theme.borderRadius.sm};
     box-shadow: ${props => (props.active ? props.theme.boxShadow.inset : "none")};
@@ -18,11 +21,3 @@ export const StyledSelectBox = styled(Box)`
         padding-top: 5px;
     }
 `;
-
-export const SelectBox = props => {
-    return (
-        <StyledSelectBox {...props} type="button" as="button">
-            {props.children}
-        </StyledSelectBox>
-    );
-};

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -1,10 +1,15 @@
 import styled from "styled-components";
 import { Box } from "./Box";
+import {Button} from "./Button";
 
-export const SelectBox = styled(Box)`
+export const SelectBox = styled(Button)`
     border: 1px ${props => (props.active ? props.theme.color.blue : props.theme.color.greyLight)} solid;
     border-radius: ${props => props.theme.borderRadius.sm};
     box-shadow: ${props => (props.active ? props.theme.boxShadow.inset : "none")};
+    background: white;
+    width: 100%;
+    text-align: center;
+    white-space: normal;
 
     div {
         font-weight: ${props => props.theme.fontWeight.thick};

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -1,8 +1,7 @@
 import styled from "styled-components";
 import { Box } from "./Box";
-import React from "react";
 
-export const SelectBox = styled(Box).attrs(props => ({
+export const SelectBox = styled(Box).attrs(() => ({
     type: "button",
     as: "button"
 }))`

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -7,9 +7,7 @@ export const StyledSelectBox = styled(Box)`
     border-radius: ${props => props.theme.borderRadius.sm};
     box-shadow: ${props => (props.active ? props.theme.boxShadow.inset : "none")};
     background: white;
-    width: 100%;
     text-align: left;
-    white-space: normal;
     div {
         font-weight: ${props => props.theme.fontWeight.thick};
         padding-bottom: 5px;

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -20,7 +20,7 @@ export const StyledSelectBox = styled(Box)`
 `;
 
 export const SelectBox = props => {
-    let buttonType = props.type ? props.type : "button";
+    const buttonType = props.type ? props.type : "button";
     return (
         <StyledSelectBox {...props} type={buttonType} as="button">
             {props.children}

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -1,17 +1,15 @@
 import styled from "styled-components";
 import { Box } from "./Box";
-import { Button } from "./Button";
 import React from "react";
 
-export const SelectButton = styled.button`
+export const StyledSelectBox = styled(Box)`
     border: 1px ${props => (props.active ? props.theme.color.blue : props.theme.color.greyLight)} solid;
     border-radius: ${props => props.theme.borderRadius.sm};
     box-shadow: ${props => (props.active ? props.theme.boxShadow.inset : "none")};
     background: white;
     width: 100%;
-    text-align: center;
+    text-align: left;
     white-space: normal;
-
     div {
         font-weight: ${props => props.theme.fontWeight.thick};
         padding-bottom: 5px;
@@ -24,9 +22,10 @@ export const SelectButton = styled.button`
 `;
 
 export const SelectBox = props => {
+    let buttonType = props.type ? props.type : "button";
     return (
-        <SelectButton {...props} type={"button"}>
+        <StyledSelectBox {...props} type={buttonType} as="button">
             {props.children}
-        </SelectButton>
+        </StyledSelectBox>
     );
 };

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -6,7 +6,7 @@ export const StyledSelectBox = styled(Box)`
     border: 1px ${props => (props.active ? props.theme.color.blue : props.theme.color.greyLight)} solid;
     border-radius: ${props => props.theme.borderRadius.sm};
     box-shadow: ${props => (props.active ? props.theme.boxShadow.inset : "none")};
-    background: white;
+    background-color: ${props => props.theme.color.white};
     text-align: left;
     div {
         font-weight: ${props => props.theme.fontWeight.thick};
@@ -20,9 +20,8 @@ export const StyledSelectBox = styled(Box)`
 `;
 
 export const SelectBox = props => {
-    const buttonType = props.type ? props.type : "button";
     return (
-        <StyledSelectBox {...props} type={buttonType} as="button">
+        <StyledSelectBox {...props} type="button" as="button">
             {props.children}
         </StyledSelectBox>
     );

--- a/client/src/js/base/SelectBox.js
+++ b/client/src/js/base/SelectBox.js
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 import { Box } from "./Box";
-import {Button} from "./Button";
+import { Button } from "./Button";
+import React from "react";
 
-export const SelectBox = styled(Button)`
+export const SelectButton = styled.button`
     border: 1px ${props => (props.active ? props.theme.color.blue : props.theme.color.greyLight)} solid;
     border-radius: ${props => props.theme.borderRadius.sm};
     box-shadow: ${props => (props.active ? props.theme.boxShadow.inset : "none")};
@@ -21,3 +22,11 @@ export const SelectBox = styled(Button)`
         padding-top: 5px;
     }
 `;
+
+export const SelectBox = props => {
+    return (
+        <SelectButton {...props} type={"button"}>
+            {props.children}
+        </SelectButton>
+    );
+};


### PR DESCRIPTION
Changed select box to render as a button. Slight tweaks to the styling were required to keep the look consistent with the old div version. A helper function was also added to enable the default passing of a default button type to prevent the form from submitting automatically when an option is selected.