### PR TITLE
Fix for user page not correctly showing error message when there are no groups

### DIFF
--- a/client/src/js/users/components/Groups.js
+++ b/client/src/js/users/components/Groups.js
@@ -25,7 +25,7 @@ export class UserGroups extends React.Component {
             <UserGroup key={id} id={id} toggled={includes(this.props.memberGroups, id)} onClick={this.handleEdit} />
         ));
 
-        if (!groupComponents) {
+        if (!groupComponents.length) {
             groupComponents = <NoneFoundSection key="noneFound" noun="groups" />;
         }
 

--- a/client/src/js/users/components/__tests__/__snapshots__/Groups.test.js.snap
+++ b/client/src/js/users/components/__tests__/__snapshots__/Groups.test.js.snap
@@ -35,6 +35,11 @@ exports[`<UserGroups /> should render NoneFound when [documents=[]] 1`] = `
   <label>
     Groups
   </label>
-  <Groups__UserGroupsList />
+  <Groups__UserGroupsList>
+    <NoneFoundSection
+      key="noneFound"
+      noun="groups"
+    />
+  </Groups__UserGroupsList>
 </div>
 `;


### PR DESCRIPTION
Super small fix. Changed the ternary operator in Groups.js to check the truthiness of the length rather than the array itself. Previously implemented errors message now renders as expected.