### PR TITLE
Log HTTP error details when making a request from the server

### DIFF
--- a/virtool/http/proxy.py
+++ b/virtool/http/proxy.py
@@ -1,8 +1,12 @@
+from logging import getLogger
+
 import aiohttp
 from aiohttp import web
 
 import virtool.errors
 from virtool.api.response import json_response
+
+logger = getLogger(__name__)
 
 
 class ProxyRequest:
@@ -23,6 +27,11 @@ class ProxyRequest:
 
         if self.resp.status == 407:
             raise virtool.errors.ProxyError("Proxy authentication failed")
+
+        if self.resp.status > 400:
+            logger.warning(
+                f"Error while making request to {self.resp.url}. {self.resp.status} - {await self.resp.text()}"
+            )
 
         return self.resp
 

--- a/virtool/http/utils.py
+++ b/virtool/http/utils.py
@@ -1,11 +1,12 @@
 from pathlib import Path
-from typing import Callable, Union
+from typing import Callable, Union, Awaitable
 
 import aiofiles
 import aiohttp.web_response
 
 import virtool.errors
 import virtool.http.proxy
+from virtool.errors import GitHubError
 from virtool.types import App
 
 
@@ -13,7 +14,7 @@ async def download_file(
         app: App,
         url: str,
         target_path: Path,
-        progress_handler: Callable[[Union[float, int]], int] = None
+        progress_handler: Callable[[Union[float, int]], Awaitable[int]] = None
 ):
     """
     Download the GitHub release at ``url`` to the location specified by ``target_path``.
@@ -26,7 +27,7 @@ async def download_file(
     """
     async with virtool.http.proxy.ProxyRequest(app["settings"], app["client"].get, url) as resp:
         if resp.status != 200:
-            raise virtool.errors.GitHubError("Could not download file")
+            raise GitHubError("Could not download file")
 
         async with aiofiles.open(target_path, "wb") as handle:
             while True:


### PR DESCRIPTION
Currently, it is impossible to tell why the HMM installation task is failing at release download.

Handle and log error codes in `ProxyRequest`. This should display the encountered error in the server log.