### PR TITLE
Improvements for tracking down errors causing HMM install failure

### DIFF
--- a/virtool/hmm/tasks.py
+++ b/virtool/hmm/tasks.py
@@ -66,13 +66,9 @@ class HMMInstallTask(virtool.tasks.task.Task):
                 path,
                 tracker.add
             )
-        except (aiohttp.ClientConnectorError, virtool.errors.GitHubError):
-            await virtool.tasks.pg.update(
-                self.pg,
-                self.id,
-                error="Could not download HMM data",
-                step="unpack"
-            )
+        except Exception as err:
+            logger.warning(f"Request for HMM release encountered exception: {err}")
+            await self.error("Could not download HMM data.")
 
     async def decompress(self):
         tracker = await self.get_tracker()
@@ -139,5 +135,5 @@ class HMMInstallTask(virtool.tasks.task.Task):
             }
         })
 
-        logger.debug("Update HMM status")
-        logger.debug("Finished HMM install task")
+    async def cleanup(self):
+        await purge(self.db, self.app["settings"])

--- a/virtool/http/proxy.py
+++ b/virtool/http/proxy.py
@@ -28,7 +28,7 @@ class ProxyRequest:
         if self.resp.status == 407:
             raise virtool.errors.ProxyError("Proxy authentication failed")
 
-        if self.resp.status > 400:
+        if self.resp.status >= 400:
             logger.warning(
                 f"Error while making request to {self.resp.url}. {self.resp.status} - {await self.resp.text()}"
             )


### PR DESCRIPTION
* Expand logging for errors that occur during the request to download the HMM data.
* Use task error handling to cleanup after a HMM installation task failure.