### PR TITLE
Create Parent Directories When Creating OTU JSON file.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,12 @@
 import datetime
+import gzip
+import json
 import os
 import shutil
 from pathlib import Path
 
 import arrow
 import pytest
-
 import virtool.utils
 
 
@@ -154,3 +155,25 @@ def test_to_bool(value, result):
 
     """
     assert virtool.utils.to_bool(value) == result
+
+
+def test_compress_json_with_gzip(tmpdir):
+    """
+    Test that `utils.compress_json_with_gzip` correctly compresses a JSON string.
+
+    """
+    data = json.dumps({"foo": "bar"})
+
+    target = Path(tmpdir) / "data.json.gz"
+    target_with_sub_paths = target.parent / "foo/bar/data.json.gz"
+
+    virtool.utils.compress_json_with_gzip(data, target)
+    virtool.utils.compress_json_with_gzip(data, target_with_sub_paths)
+
+    assert target.exists()
+    assert target_with_sub_paths.exists()
+
+    for _target in (target, target_with_sub_paths):
+        with gzip.open(_target, 'r') as f:
+            json_data = f.read().decode('utf-8')
+            assert json_data == data

--- a/virtool/utils.py
+++ b/virtool/utils.py
@@ -93,6 +93,9 @@ def compress_json_with_gzip(json_string: str, target: str):
     Compress the JSON string to a gzipped file at `target`.
 
     """
+    # gzip will fail to open the file if it's parent directory doesn't exist.
+    target = Path(target)
+    target.parent.mkdir(exist_ok=True, parents=True)
     with gzip.open(target, "wb") as f:
         f.write(bytes(json_string, "utf-8"))
 


### PR DESCRIPTION
The API route `/api/indexes/{id}/files/otus.json.gz` is failing due to a FileNotFound. 

This exception is raised from the `gzip` package when the `target` path has parent directories which do not exist. This PR ensures that new directories are created where required before creating the `otus.json.gz` file with `gzip.open`.