### PR TITLE
Prevent overflow when showing API key

### DIFF
--- a/client/src/js/account/components/API/Create.js
+++ b/client/src/js/account/components/API/Create.js
@@ -39,8 +39,8 @@ const StyledCreateAPIKey = styled(ModalBody)`
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin-left: 90px;
-    margin-right: 90px;
+    padding-left: 10px;
+    padding-right: 10px;
     text-align: center;
 
     strong {


### PR DESCRIPTION
Change log:

- Reduced margin in API/Create.js. API keys now fits nicely within the standard size modal window.