### PR TITLE
Don't depend on commitlint for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           npx webpack --config webpack.production.config.babel.js
   release:
     runs-on: ubuntu-20.04
-    needs: [server, client, commitlint]
+    needs: [server, client]
     if: github.event_name == 'push'
     steps:
       - name: Checkout


### PR DESCRIPTION
This is preventing releases on push because commitlint is skipped for pushes.