### PR TITLE
Update user document for AAD

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -109,7 +109,7 @@ def spawn_client(
     ):
         app = create_app(dev)
 
-        user_document = create_user("test", administrator, groups, permissions)
+        user_document = create_user(user_id="test", administrator=administrator, groups=groups, permissions=permissions)
         await dbi.users.insert_one(user_document)
 
         if authorize:

--- a/tests/fixtures/users.py
+++ b/tests/fixtures/users.py
@@ -6,7 +6,8 @@ from virtool.users.utils import PERMISSIONS
 @pytest.fixture
 def bob(no_permissions, static_time):
     return {
-        "_id": "bob",
+        "_id": "abc123",
+        "handle": "bob",
         "administrator": False,
         "force_reset": False,
         "groups": [
@@ -29,12 +30,13 @@ def bob(no_permissions, static_time):
 
 @pytest.fixture
 def create_user(static_time):
-    def func(name="test", administrator=False, groups=None, permissions=None):
+    def func(user_id="test", handle="bob", administrator=False, groups=None, permissions=None):
 
         permissions = permissions or list()
 
         return {
-            "_id": name,
+            "_id": user_id,
+            "handle": handle,
             "administrator": administrator,
             "identicon": "identicon",
             "permissions": {perm: perm in permissions for perm in PERMISSIONS},

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -21,8 +21,8 @@ async def test_add_group_or_user(error, field, rights, dbi, static_time):
     ref_id = "foo"
 
     subdocuments = [
-        {**RIGHTS, "id": "bar"},
-        {**RIGHTS, "id": "baz"}
+        {**RIGHTS, "id": "bar", "handle": "foo"},
+        {**RIGHTS, "id": "baz", "handle": "boo"}
     ]
 
     if error != "missing":
@@ -33,9 +33,9 @@ async def test_add_group_or_user(error, field, rights, dbi, static_time):
         })
 
     if error != "missing_member":
-        for _id in ["bar", "buzz"]:
+        for (_id, handle) in [("bar", "foo"), ("buzz", "boo")]:
             await dbi.groups.insert_one({"_id": _id})
-            await dbi.users.insert_one({"_id": _id})
+            await dbi.users.insert_one({"_id": _id, "handle": handle})
 
     subdocument_id = "bar" if error == "duplicate" else "buzz"
 

--- a/tests/users/snapshots/snap_test_fake.py
+++ b/tests/users/snapshots/snap_test_fake.py
@@ -8,11 +8,12 @@ from snapshottest import GenericRepr, Snapshot
 snapshots = Snapshot()
 
 snapshots['test_create_fake_bob_user[uvloop] 1'] = {
-    '_id': 'bob',
+    '_id': 'abc123',
     'administrator': True,
     'force_reset': False,
     'groups': [
     ],
+    'handle': 'bob',
     'identicon': '81b637d8fcd2c6da6359e6963113a1170de795e4b725b84d1e0b4cfd9ec58ce9',
     'invalidate_sessions': True,
     'last_password_change': GenericRepr('datetime.datetime(2015, 10, 6, 20, 0)'),

--- a/tests/users/test_fake.py
+++ b/tests/users/test_fake.py
@@ -1,6 +1,7 @@
 from virtool.users.fake import create_fake_bob_user
 
 
-async def test_create_fake_bob_user(snapshot, app, dbi, static_time):
+async def test_create_fake_bob_user(snapshot, app, dbi, static_time, mocker):
+    mocker.patch("virtool.db.utils.get_new_id", return_value="abc123")
     await create_fake_bob_user(app)
     snapshot.assert_match(await dbi.users.find_one({}, {"password": False}))

--- a/tests/users/test_tasks.py
+++ b/tests/users/test_tasks.py
@@ -1,0 +1,54 @@
+import pytest
+
+from virtool.tasks.models import Task
+from virtool.users.tasks import UpdateUserDocumentsTask
+
+
+@pytest.mark.parametrize("user", ["ad_user", "existing_user", "user_with_handle"])
+async def test_update_user_document_task(spawn_client, pg_session, static_time, mocker, user):
+    client = await spawn_client()
+
+    if user == "ad_user":
+        document = {
+            "_id": "abc123",
+            "ad_given_name": "foo",
+            "ad_family_name": "bar"
+        }
+        expected = "foo"
+
+    elif user == "existing_user":
+        document = {
+            "_id": "abc123"
+        }
+        expected = "abc123"
+
+    else:
+        document = {
+            "_id": "abc123",
+            "handle": "bar"
+        }
+
+    await client.db.users.insert_one(document)
+    mocker.patch("virtool.users.db.generate_handle", return_value="foo")
+
+    if user != "user_with_handle":
+        document["handle"] = expected
+
+    task = Task(
+        id=1,
+        complete=False,
+        context={},
+        count=0,
+        progress=0,
+        step="rename_index_files",
+        type="add_subtraction_files",
+        created_at=static_time.datetime
+    )
+
+    async with pg_session as session:
+        session.add(task)
+        await session.commit()
+
+    add_index_files_task = UpdateUserDocumentsTask(client.app, 1)
+    await add_index_files_task.run()
+    assert await client.db.users.find_one({"_id": "abc123"}) == document

--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -103,3 +103,5 @@ async def create_indexes(db):
     await db.samples.create_index([("created_at", pymongo.DESCENDING)])
     await db.sequences.create_index("otu_id")
     await db.sequences.create_index("name")
+    await db.users.create_index("ad_oid", unique=True, sparse=True)
+    await db.users.create_index("handle", unique=True)

--- a/virtool/db/utils.py
+++ b/virtool/db/utils.py
@@ -177,6 +177,27 @@ async def id_exists(collection, id_: str) -> bool:
     :param collection: the Mongo collection to check the _id against
     :param id_: the _id to check for
     :return: does the id exist
-
     """
     return bool(await collection.count_documents({"_id": id_}))
+
+
+async def handle_exists(collection, handle: str) -> bool:
+    """
+    Check if the document handle exists in the collection.
+
+    :param collection: the Mongo collection to check the handle against
+    :param handle: the handle to check for
+    :return: does the id exist
+    """
+    return bool(await collection.count_documents({"handle": handle}))
+
+
+async def oid_exists(collection, ad_oid: str) -> bool:
+    """
+    Check if the Azure AD oid exists in the collection.
+
+    :param collection: the Mongo collection to check the oid against
+    :param ad_oid: the Azure AD oid to check for
+    :return: does the oid exist
+    """
+    return bool(await collection.count_documents({"ad_oid": ad_oid}))

--- a/virtool/fake/identifiers.py
+++ b/virtool/fake/identifiers.py
@@ -1,3 +1,4 @@
 """Shared fake data IDs."""
 
-USER_ID = "bob"
+USER_ID = "abc123"
+USER_HANDLE = "bob"

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -41,6 +41,7 @@ from virtool.tasks.client import TasksClient
 from virtool.tasks.runner import TaskRunner
 from virtool.types import App
 from virtool.uploads.tasks import MigrateFilesTask
+from virtool.users.tasks import UpdateUserDocumentsTask
 from virtool.utils import random_alphanumeric, get_client_path, ensure_data_dir
 from virtool.version import determine_server_version
 
@@ -393,5 +394,6 @@ async def init_tasks(app: aiohttp.web.Application):
     await app["tasks"].add(StoreNuvsFilesTask)
     await app["tasks"].add(CompressSamplesTask)
     await app["tasks"].add(MoveSampleFilesTask)
+    await app["tasks"].add(UpdateUserDocumentsTask)
 
     await scheduler.spawn(app["tasks"].add_periodic(MigrateFilesTask, 3600))

--- a/virtool/users/fake.py
+++ b/virtool/users/fake.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
 import virtool.users.db
-from virtool.fake.identifiers import USER_ID
+from virtool.fake.identifiers import USER_HANDLE
 from virtool.types import App
 
 logger = getLogger(__name__)
@@ -14,6 +14,6 @@ async def create_fake_bob_user(app: App):
     :param app: the application object
 
     """
-    await virtool.users.db.create(app["db"], USER_ID, "hello_world", True)
-    await virtool.users.db.edit(app["db"], "bob", administrator=True, force_reset=False)
+    user_document = await virtool.users.db.create(app["db"], "hello_world", USER_HANDLE, True)
+    await virtool.users.db.edit(app["db"], user_document["_id"], administrator=True, force_reset=False)
     logger.debug("Created fake user")

--- a/virtool/users/tasks.py
+++ b/virtool/users/tasks.py
@@ -1,0 +1,58 @@
+from virtool.tasks.pg import update
+from virtool.tasks.task import Task
+from virtool.types import App
+from virtool.users.db import PROJECTION
+import virtool.users.db
+
+
+class UpdateUserDocumentsTask(Task):
+    """
+    Update user documents that don't contain a "handle" field.
+
+    For AD users with ad_given_name and ad_family_name included in their user document, generate handle.
+
+    For all other users use existing _id values as handle.
+    """
+    task_type = "update_user_documents"
+
+    def __init__(self, app: App, task_id: int):
+        super().__init__(app, task_id)
+
+        self.steps = [
+            self.update_user_documents
+        ]
+
+    async def update_user_documents(self):
+        tracker = await self.get_tracker()
+
+        await update(
+            self.pg,
+            self.id,
+            step="update_user_documents"
+        )
+
+        async for document in self.db.users.find({"handle": {"$exists": False}}):
+            user_id = document["_id"]
+            if "ad_given_name" in document and "ad_family_name" in document:
+                handle = await virtool.users.db.generate_handle(
+                    self.db,
+                    document["ad_given_name"],
+                    document["ad_family_name"]
+                )
+            else:
+                handle = user_id
+
+            await self.db.users.find_one_and_update({"_id": user_id}, {
+                    "$set": {
+                        "handle": handle
+                    }
+                },
+                projection=PROJECTION
+            )
+
+            await update(
+                self.pg,
+                self.id,
+                progress=tracker.step_completed,
+                step="update_user_documents"
+            )


### PR DESCRIPTION
* Start using random strings for user ID
* Add `handle` field to user documents
* Write `virtool.users.db.generate_handle()` to create handle from ID token claims for AD users
* Add AD derived fields to user document including `ad_oid`, `ad_display_name`, `ad_given_name`, `ad_family_name`, `ad_email`
* Add mongo indexes for `ad_oid` and `handle` fields
* Write `UpdateUserDocumentTask` to add handle to all existing user documents on startup
* Update supporting code to differentiate between handle and user_id
* Update tests 