### PR TITLE
Always send created_at in job websocket messages

### DIFF
--- a/virtool/db/core.py
+++ b/virtool/db/core.py
@@ -54,6 +54,7 @@ class Collection:
     ):
         self.name = name
         self._collection = collection
+        self.database = collection.database
         self._enqueue_change = enqueue_change
         self.processor = processor
         self.projection = projection

--- a/virtool/dispatcher/dispatcher.py
+++ b/virtool/dispatcher/dispatcher.py
@@ -65,7 +65,7 @@ class Dispatcher:
             SimpleMongoFetcher(db.history, virtool.history.db.LIST_PROJECTION),
             SimpleMongoFetcher(db.hmm, virtool.hmm.db.PROJECTION),
             IndexesFetcher(db),
-            SimpleMongoFetcher(db.jobs, virtool.jobs.db.PROJECTION),
+            SimpleMongoFetcher(db.jobs, virtool.jobs.db.PROJECTION, virtool.jobs.db.processor),
             LabelsFetcher(pg, db),
             SimpleMongoFetcher(db.otus, virtool.otus.db.PROJECTION),
             TasksFetcher(pg),


### PR DESCRIPTION
Issue was caused by jobs processor not being called on outgoing documents. This pull request fixes errors in the frontend due to invalid time values.

* Allow easy access to motor database object from `Collection.database`.
* Take an optional `processor` argument when defining `Fetcher` objects. This function argument will be called on the outgoing document. If none is defined the `base_processor` is called as before.
* Use the jobs processor for job websocket dispatches.