### PR TITLE
Include client source maps in docker image

### DIFF
--- a/client/webpack.production.config.babel.js
+++ b/client/webpack.production.config.babel.js
@@ -47,6 +47,8 @@ module.exports = {
     },
   },
 
+  devtool: "source-map",
+
   output: {
     path: path.resolve(__dirname, "./dist"),
     filename: "app.[hash:8].js",


### PR DESCRIPTION
Error reports sent to Sentry from frontend are unintelligible right now. Including source maps will allow us to resolve these issues.