### PR TITLE
Don't interrupt all background tasks when one fails

### DIFF
--- a/virtool/tasks/models.py
+++ b/virtool/tasks/models.py
@@ -5,7 +5,7 @@ from virtool.pg.base import Base
 
 
 class Task(Base):
-    __tablename__ = 'tasks'
+    __tablename__ = "tasks"
 
     id = Column(Integer, primary_key=True)
     complete = Column(Boolean, default=False)

--- a/virtool/tasks/task.py
+++ b/virtool/tasks/task.py
@@ -48,7 +48,10 @@ class Task:
                 step=self.step.__name__
             )
 
-            await func()
+            try:
+                await func()
+            except Exception as err:
+                await self.error(str(err))
 
         if not self.errored:
             await virtool.tasks.pg.complete(self.pg, self.id)

--- a/virtool/users/tasks.py
+++ b/virtool/users/tasks.py
@@ -12,6 +12,7 @@ class UpdateUserDocumentsTask(Task):
     For AD users with ad_given_name and ad_family_name included in their user document, generate handle.
 
     For all other users use existing _id values as handle.
+
     """
     task_type = "update_user_documents"
 
@@ -23,16 +24,9 @@ class UpdateUserDocumentsTask(Task):
         ]
 
     async def update_user_documents(self):
-        tracker = await self.get_tracker()
-
-        await update(
-            self.pg,
-            self.id,
-            step="update_user_documents"
-        )
-
         async for document in self.db.users.find({"handle": {"$exists": False}}):
             user_id = document["_id"]
+
             if "ad_given_name" in document and "ad_family_name" in document:
                 handle = await virtool.users.db.generate_handle(
                     self.db,
@@ -48,11 +42,4 @@ class UpdateUserDocumentsTask(Task):
                     }
                 },
                 projection=PROJECTION
-            )
-
-            await update(
-                self.pg,
-                self.id,
-                progress=tracker.step_completed,
-                step="update_user_documents"
             )


### PR DESCRIPTION
* Remove unnecessary task updates and tracker in UpdateUserDocumentsTask`.
* Simplify task row retrieval in task runner.
* Log task type in addition to id when starting.
* Catch and log exceptions in tasks instead of letting them stop the runner.