### PR TITLE
fix: prevent invalid input error during upload

### DIFF
--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -554,4 +554,6 @@ async def test_login(spawn_client, create_user, resp_is, error, mocker):
     if error == "wrong_handle" or error == "wrong_password":
         await resp_is.bad_request(resp, "Invalid username or password")
         return
+
     assert resp.status == 201
+    assert await resp.json() == {"reset": False}

--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -336,9 +336,11 @@ async def login(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
     # Re-render the login page with an error message if the username doesn't correlate to a user_id value in the
     # database and/or password are invalid.
-    user_id = await db.users.find_one({"handle": handle})
-    if not user_id or not await validate_credentials(db, user_id, password):
+    document = await db.users.find_one({"handle": handle})
+    if not document or not await validate_credentials(db, document["_id"], password):
         raise HTTPBadRequest(text="Invalid username or password")
+
+    user_id = document["_id"]
 
     session_id = req.cookies.get("session_id")
 


### PR DESCRIPTION
Accept user handle for account login, use handle to retrieve user document.

Use user_id to create session instead of entire user document.