### PR TITLE
update client side account creation to work with new id system

### DIFF
--- a/client/src/js/account/components/Profile.js
+++ b/client/src/js/account/components/Profile.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
 import { Icon, Label } from "../../base";
-import { getAccountAdministrator, getAccountId } from "../selectors";
+import { getAccountAdministrator, getAccountHandle } from "../selectors";
 import Email from "./Email";
 import ChangePassword from "./Password";
 
@@ -46,7 +46,7 @@ const AccountProfileHeader = styled.div`
     }
 `;
 
-export const AccountProfile = ({ id, groups, administrator }) => {
+export const AccountProfile = ({ handle, groups, administrator }) => {
     const groupLabels = map(groups, groupId => (
         <Label key={groupId}>
             <Icon name="users" /> {groupId}
@@ -68,7 +68,7 @@ export const AccountProfile = ({ id, groups, administrator }) => {
             <AccountProfileHeader>
                 <div>
                     <h3>
-                        {id}
+                        {handle}
                         {adminLabel}
                     </h3>
                     <AccountProfileGroups>{groupLabels}</AccountProfileGroups>
@@ -82,7 +82,7 @@ export const AccountProfile = ({ id, groups, administrator }) => {
 };
 
 export const mapStateToProps = state => ({
-    id: getAccountId(state),
+    handle: getAccountHandle(state),
     groups: state.account.groups,
     administrator: getAccountAdministrator(state)
 });

--- a/client/src/js/account/components/__tests__/Profile.test.js
+++ b/client/src/js/account/components/__tests__/Profile.test.js
@@ -5,7 +5,7 @@ describe("<AccountProfile />", () => {
 
     beforeEach(() => {
         props = {
-            id: "foo",
+            handle: "foo",
             groups: ["test"],
             administrator: false
         };
@@ -26,13 +26,13 @@ describe("<AccountProfile />", () => {
 describe("mapStateToProps()", () => {
     const state = {
         account: {
-            id: "foo",
+            handle: "foo",
             groups: ["test"],
             administrator: true
         }
     };
     const expected = {
-        id: "foo",
+        handle: "foo",
         groups: ["test"],
         administrator: true
     };

--- a/client/src/js/account/selectors.js
+++ b/client/src/js/account/selectors.js
@@ -3,3 +3,4 @@ import { get } from "lodash-es";
 export const getAccount = state => state.account;
 export const getAccountAdministrator = state => get(state, "account.administrator", false);
 export const getAccountId = state => state.account.id;
+export const getAccountHandle = state => state.account.handle;

--- a/client/src/js/users/actions.js
+++ b/client/src/js/users/actions.js
@@ -60,9 +60,9 @@ export const createUser = data => ({
     ...data
 });
 
-export const createFirstUser = (userId, password) => ({
+export const createFirstUser = (handle, password) => ({
     type: CREATE_FIRST_USER.REQUESTED,
-    userId,
+    handle,
     password
 });
 

--- a/client/src/js/users/api.js
+++ b/client/src/js/users/api.js
@@ -4,16 +4,16 @@ export const find = ({ term, page }) => Request.get("/api/users").query({ find: 
 
 export const get = ({ userId }) => Request.get(`/api/users/${userId}`);
 
-export const create = ({ userId, password, forceReset }) =>
+export const create = ({ handle, password, forceReset }) =>
     Request.post("/api/users").send({
-        user_id: userId,
+        handle,
         password,
         force_reset: forceReset
     });
 
-export const createFirst = ({ userId, password }) =>
+export const createFirst = ({ handle, password }) =>
     Request.put("/api/users/first").send({
-        user_id: userId,
+        handle,
         password
     });
 

--- a/client/src/js/users/components/Create.js
+++ b/client/src/js/users/components/Create.js
@@ -20,10 +20,10 @@ import { getTargetChange, routerLocationHasState } from "../../utils/utils";
 import { createUser } from "../actions";
 
 const getInitialState = () => ({
-    userId: "",
+    handle: "",
     password: "",
     forceReset: false,
-    errorUserId: "",
+    errorHandle: "",
     errorPassword: ""
 });
 
@@ -34,8 +34,8 @@ export class CreateUser extends React.PureComponent {
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
-        if (!prevState.errorUserId && nextProps.error) {
-            return { errorUserId: nextProps.error };
+        if (!prevState.errorHandle && nextProps.error) {
+            return { errorHandle: nextProps.error };
         }
         return null;
     }
@@ -68,9 +68,9 @@ export class CreateUser extends React.PureComponent {
 
         let hasError = false;
 
-        if (!this.state.userId) {
+        if (!this.state.handle) {
             hasError = true;
-            this.setState({ errorUserId: "Please specify a username" });
+            this.setState({ errorHandle: "Please specify a username" });
         }
 
         if (this.state.password.length < this.props.minimumPasswordLength) {
@@ -81,7 +81,7 @@ export class CreateUser extends React.PureComponent {
         }
 
         if (!hasError) {
-            this.props.onCreate(pick(this.state, ["userId", "password", "confirm", "forceReset"]));
+            this.props.onCreate(pick(this.state, ["handle", "password", "confirm", "forceReset"]));
         }
     };
 
@@ -98,8 +98,8 @@ export class CreateUser extends React.PureComponent {
                     <ModalBody>
                         <InputGroup>
                             <InputLabel>Username</InputLabel>
-                            <Input name="userId" value={this.state.userId} onChange={this.handleChange} />
-                            <InputError>{this.state.errorUserId}</InputError>
+                            <Input name="handle" value={this.state.handle} onChange={this.handleChange} />
+                            <InputError>{this.state.errorHandle}</InputError>
                         </InputGroup>
                         <InputGroup>
                             <InputLabel>Password</InputLabel>

--- a/client/src/js/users/components/Item.js
+++ b/client/src/js/users/components/Item.js
@@ -21,9 +21,9 @@ const StyledUserItem = styled(LinkBox)`
     }
 `;
 
-export const UserItem = ({ id, administrator }) => (
+export const UserItem = ({ id, handle, administrator }) => (
     <StyledUserItem to={`/administration/users/${id}`}>
-        <strong>{id}</strong>
+        <strong>{handle}</strong>
         {administrator && (
             <Label color="purple">
                 <Icon name="user-shield" /> Administrator
@@ -33,10 +33,11 @@ export const UserItem = ({ id, administrator }) => (
 );
 
 export const mapStateToProps = (state, ownProps) => {
-    const { id, administrator } = get(state, `users.documents[${ownProps.index}]`, null);
+    const { id, handle, administrator } = get(state, `users.documents[${ownProps.index}]`, null);
 
     return {
         id,
+        handle,
         administrator
     };
 };

--- a/client/src/js/users/components/__tests__/Create.test.js
+++ b/client/src/js/users/components/__tests__/Create.test.js
@@ -17,10 +17,10 @@ describe("<CreateUser />", () => {
 
         state = {
             errorPassword: "",
-            errorUserId: "",
+            errorHandle: "",
             forceReset: false,
             password: "",
-            userId: ""
+            handle: ""
         };
     });
 
@@ -39,7 +39,7 @@ describe("<CreateUser />", () => {
 
     it("should render when name has changed", () => {
         const e = {
-            target: { name: "userId", value: "bob" }
+            target: { name: "handle", value: "bob" }
         };
         const wrapper = shallow(<CreateUser {...props} error="Error" />);
         expect(wrapper).toMatchSnapshot();
@@ -72,13 +72,13 @@ describe("<CreateUser />", () => {
         expect(wrapper.state()).toEqual({ ...state, forceReset: true });
     });
 
-    it("should call handleSubmit when form is submitted and [!this.state.userId=true]", () => {
+    it("should call handleSubmit when form is submitted and [!this.state.Handle=true]", () => {
         const e = {
             preventDefault: jest.fn()
         };
         const wrapper = shallow(<CreateUser {...props} />);
         wrapper.find("form").simulate("submit", e);
-        expect(wrapper.state()).toEqual({ ...state, errorUserId: "Please specify a username" });
+        expect(wrapper.state()).toEqual({ ...state, errorHandle: "Please specify a username" });
     });
 
     it("should call handleSubmit when form is submitted and [this.state.password.length < this.props.minimumPasswordLength]", () => {
@@ -87,11 +87,11 @@ describe("<CreateUser />", () => {
         };
         props.minimumPasswordLength = 2;
         const wrapper = shallow(<CreateUser {...props} />);
-        wrapper.setState({ userId: "foo", password: "f", confirm: "f" });
+        wrapper.setState({ handle: "foo", password: "f", confirm: "f" });
         wrapper.find("form").simulate("submit", e);
         expect(wrapper.state()).toEqual({
             ...state,
-            userId: "foo",
+            handle: "foo",
             password: "f",
             confirm: "f",
             errorPassword: "Passwords must contain at least 2 characters"

--- a/client/src/js/users/components/__tests__/__snapshots__/Create.test.js.snap
+++ b/client/src/js/users/components/__tests__/__snapshots__/Create.test.js.snap
@@ -19,7 +19,7 @@ exports[`<CreateUser /> should render 1`] = `
           Username
         </Input__InputLabel>
         <Input
-          name="userId"
+          name="handle"
           onChange={[Function]}
           value=""
         />
@@ -69,7 +69,7 @@ exports[`<CreateUser /> should render when name has changed 1`] = `
           Username
         </Input__InputLabel>
         <Input
-          name="userId"
+          name="handle"
           onChange={[Function]}
           value=""
         />
@@ -121,7 +121,7 @@ exports[`<CreateUser /> should render when name has changed 2`] = `
           Username
         </Input__InputLabel>
         <Input
-          name="userId"
+          name="handle"
           onChange={[Function]}
           value="bob"
         />
@@ -173,7 +173,7 @@ exports[`<CreateUser /> should render when password has changed 1`] = `
           Username
         </Input__InputLabel>
         <Input
-          name="userId"
+          name="handle"
           onChange={[Function]}
           value=""
         />
@@ -225,7 +225,7 @@ exports[`<CreateUser /> should render when password has changed 2`] = `
           Username
         </Input__InputLabel>
         <Input
-          name="userId"
+          name="handle"
           onChange={[Function]}
           value=""
         />
@@ -277,7 +277,7 @@ exports[`<CreateUser /> should render with error 1`] = `
           Username
         </Input__InputLabel>
         <Input
-          name="userId"
+          name="handle"
           onChange={[Function]}
           value=""
         />

--- a/client/src/js/users/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/client/src/js/users/components/__tests__/__snapshots__/Item.test.js.snap
@@ -4,9 +4,7 @@ exports[`<UserItem /> should render when administrator=false] 1`] = `
 <Item__StyledUserItem
   to="/administration/users/bob"
 >
-  <strong>
-    bob
-  </strong>
+  <strong />
 </Item__StyledUserItem>
 `;
 
@@ -14,9 +12,7 @@ exports[`<UserItem /> should render when administrator=true] 1`] = `
 <Item__StyledUserItem
   to="/administration/users/bob"
 >
-  <strong>
-    bob
-  </strong>
+  <strong />
   <Label
     color="purple"
   >

--- a/client/src/js/wall/__tests__/FirstUser.test.js
+++ b/client/src/js/wall/__tests__/FirstUser.test.js
@@ -64,7 +64,7 @@ describe("mapDispatchToProps", () => {
         props.onSubmit("foo", "bar");
 
         expect(dispatch).toHaveBeenCalledWith({
-            userId: "foo",
+            handle: "foo",
             password: "bar",
             type: "CREATE_FIRST_USER_REQUESTED"
         });


### PR DESCRIPTION
Notes:

- Creating the first user and making additional users now works with the new ID system
- Where available in the sent data, the client side has been updated to show the user handle rather than ID.
- For api routes that pass only the user_id the client renders the user id. (random string generate by the server)
- Tests updated as needed to reflect the change from user id to handle in modified components