### PR TITLE
Use full logging for jobs API

### DIFF
--- a/virtool/config.py
+++ b/virtool/config.py
@@ -13,6 +13,7 @@ import virtool.jobs.main
 import virtool.logs
 import virtool.redis
 import virtool.utils
+from virtool.logs import configure_logs
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +142,7 @@ def cli(ctx, data_path, db_connection_string, db_name, dev, force_version, no_se
 )
 @click.pass_context
 def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fetching):
-    virtool.logs.configure_server(ctx.obj["dev"], ctx.obj["verbose"])
+    configure_logs(ctx.obj["dev"], ctx.obj["verbose"])
 
     config = {
         **ctx.obj,
@@ -180,7 +181,10 @@ def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fet
 @click.pass_context
 def start_jobs_api(ctx, fake_path, port, host):
     """Start a Virtool Jobs API server"""
+    configure_logs(ctx.obj["dev"], ctx.obj["verbose"])
+
     logger.info("Starting jobs API process")
+
     asyncio.get_event_loop().run_until_complete(
         virtool.jobs.main.run(
             fake=fake_path is not None,

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -1,78 +1,28 @@
-import logging.handlers
-from logging import Logger
+from logging import INFO, DEBUG, captureWarnings
 
 import coloredlogs
 
 
-def get_log_format(verbose: bool) -> str:
+def configure_logs(dev: bool, verbose: bool):
     """
-    Return a log format given `verbose`, which indicates whether the instance should adopt verbose logging.
+    Configure logging for Virtool.
 
-    :param verbose: the log format should be verbose
-
-    """
-    if verbose:
-        return "{asctime:<20} {module:<11} {levelname:<8} {message} ({name}:{funcName}:{lineno})"
-
-    return "{asctime:<20} {module:<11} {levelname:<8} {message}"
-
-
-def configure_server(dev: bool, verbose: bool) -> Logger:
-    """
-    Configure and return a logger for a server instance.
-    Logs are written to the `server.log` file in the run directory.
-    Configures the logging level and installs colored logs. If `dev` or `verbose` is `True`, the logger will record
-    additional source path information in the log and write logs at the `DEBUG` level.
-    :param dev: the logger should produce verbose logs
-    :param verbose: the logger should produce verbose logs
-    """
-    logger = configure_base_logger(dev, verbose)
-
-    handler = logging.handlers.RotatingFileHandler(
-        "server.log", maxBytes=1000000, backupCount=3
-    )
-
-    handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
-
-    logger.addHandler(handler)
-
-    return logger
-
-
-def configure_base_logger(dev: bool, verbose: bool) -> Logger:
-    """
-    Return a base class:`Logger` object that can be used for both runner and server instances.
-
-    Configures the logging level and installs colored logs. If `dev` or `verbose` is `True`, the logger will record
-    additional source path information in the log and write logs at the `DEBUG` level.
-
-    :param dev: the logger should produce verbose logs
-    :param verbose: the logger should produce verbose logs
+    * Use colored logging.
+    * Set short or long line formatting based on configuration options.
+    * Set logging level based on ``dev`` configuration option.
 
     """
     verbose = dev or verbose
 
-    logging_level = logging.DEBUG if verbose else logging.INFO
+    log_format = "{asctime:<20} {module:<11} {levelname:<8} {message}"
 
-    logging.captureWarnings(True)
+    if verbose:
+        log_format += " ({name}:{funcName}:{lineno})"
 
-    coloredlogs.install(level=logging_level, fmt=get_log_format(verbose), style="{")
+    captureWarnings(True)
 
-    logger = logging.getLogger()
-
-    return logger
-
-
-def configure_jobs_api_server(dev: bool, verbose: bool) -> Logger:
-    """Configure logging for the jobs API server."""
-    logger = configure_base_logger(dev, verbose)
-
-    handler = logging.handlers.RotatingFileHandler(
-        "jobs_api_server.log", maxBytes=1000000, backupCount=3
+    coloredlogs.install(
+        level=DEBUG if verbose else INFO,
+        fmt=log_format,
+        style="{"
     )
-
-    handler.setFormatter(logging.Formatter(get_log_format(verbose), style="{"))
-
-    logger.addHandler(handler)
-
-    return logger


### PR DESCRIPTION
Write more complete logs for the jobs API. Logging was previously not configured at all, which makes it hard to diagnose issues.

Also:
* Simplify `configure_logs` for Virtool. This was unnecessarily bloated.
* Stop writing logs to file. This makes no sense when we are running only Virtool in containers or in development.