### PR TITLE
Add deterministically generated custom user icons

### DIFF
--- a/client/src/js/account/components/Profile.js
+++ b/client/src/js/account/components/Profile.js
@@ -3,7 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
-import { Icon, Label } from "../../base";
+import { Icon, InitialIcon, Label, StyledInitialIcon } from "../../base";
 import { getAccountAdministrator, getAccountHandle } from "../selectors";
 import Email from "./Email";
 import ChangePassword from "./Password";
@@ -24,7 +24,9 @@ const AccountProfileHeader = styled.div`
     align-items: center;
     display: flex;
     margin-bottom: 15px;
-
+    > ${StyledInitialIcon} {
+        flex: 0 0 auto;
+    }
     > div {
         flex: 2 0 auto;
         margin-left: 15px;
@@ -66,6 +68,7 @@ export const AccountProfile = ({ handle, groups, administrator }) => {
     return (
         <div>
             <AccountProfileHeader>
+                <InitialIcon handle={handle} size="xxl" />
                 <div>
                     <h3>
                         {handle}

--- a/client/src/js/account/components/__tests__/__snapshots__/Profile.test.js.snap
+++ b/client/src/js/account/components/__tests__/__snapshots__/Profile.test.js.snap
@@ -3,6 +3,10 @@
 exports[`<AccountProfile /> should render when administrator 1`] = `
 <div>
   <Profile__AccountProfileHeader>
+    <InitialIcon
+      handle="foo"
+      size="xxl"
+    />
     <div>
       <h3>
         foo
@@ -41,6 +45,10 @@ exports[`<AccountProfile /> should render when administrator 1`] = `
 exports[`<AccountProfile /> should render when not administrator 1`] = `
 <div>
   <Profile__AccountProfileHeader>
+    <InitialIcon
+      handle="foo"
+      size="xxl"
+    />
     <div>
       <h3>
         foo

--- a/client/src/js/base/Attribution.js
+++ b/client/src/js/base/Attribution.js
@@ -1,11 +1,13 @@
 import { capitalize } from "lodash-es";
 import React from "react";
 import styled from "styled-components";
+import { InitialIcon } from "./InitialIcon";
 import { RelativeTime } from "./RelativeTime";
 
 export const UnstyledAttribution = ({ className, time, user, verb = "created" }) => {
     return (
         <span className={className}>
+            {user ? <InitialIcon size="md" handle={user} /> : null}
             <span>{user}</span>
             <span>{user ? verb : capitalize(verb)}</span>
             <RelativeTime time={time} />
@@ -20,5 +22,8 @@ export const Attribution = styled(UnstyledAttribution)`
 
     *:not(:first-child) {
         margin-left: 3px;
+    }
+    .InitialIcon {
+        margin-right: 5px;
     }
 `;

--- a/client/src/js/base/InitialIcon.js
+++ b/client/src/js/base/InitialIcon.js
@@ -1,0 +1,39 @@
+import { reduce } from "lodash-es";
+import React, { useMemo } from "react";
+import styled from "styled-components";
+import { getColor, getFontSize, getFontWeight, theme } from "../app/theme";
+
+const iconSize = {
+    xs: "20px",
+    sm: "24px",
+    md: "28px",
+    lg: "32px",
+    xl: "48px",
+    xxl: "64px"
+};
+const getIconSize = size => iconSize[size];
+
+export const StyledInitialIcon = styled.span`
+    border-radius: 50%;
+    display: flex;
+    flex: 0 0 auto;
+    justify-content: center;
+    align-items: center;
+    height: ${props => getIconSize(props.size)};
+    width: ${props => getIconSize(props.size)};
+    font-size: ${props => getFontSize(props.size)};
+    font-weight: ${getFontWeight("thick")};
+    color: ${getColor({ color: "white", theme })};
+    background: ${props => `hsl(${props.hash}, 83%, 21%);`};
+`;
+
+const colorHash = (hash, newChar) => (hash << 5) - newChar.charCodeAt(0);
+
+export const InitialIcon = ({ handle, size }) => {
+    const hash = useMemo(() => reduce(handle.split(""), colorHash, 0) % 360, [handle]);
+    return (
+        <StyledInitialIcon hash={hash} size={size} className="InitialIcon">
+            {handle.slice(0, 2).toUpperCase()}
+        </StyledInitialIcon>
+    );
+};

--- a/client/src/js/base/index.js
+++ b/client/src/js/base/index.js
@@ -16,6 +16,7 @@ export * from "./Dropdown";
 export * from "./Dropdown";
 export * from "./ExternalLink";
 export * from "./Icon";
+export * from "./InitialIcon";
 export * from "./Input";
 export * from "./Key";
 export * from "./Label";

--- a/client/src/js/indexes/components/Contributors.js
+++ b/client/src/js/indexes/components/Contributors.js
@@ -2,15 +2,22 @@ import { map, sortBy } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
-import { Badge, BoxGroup, BoxGroupHeader, BoxGroupSection, NoneFoundSection } from "../../base";
+import { Badge, BoxGroup, BoxGroupHeader, BoxGroupSection, InitialIcon, NoneFoundSection } from "../../base";
 
 const StyledContributor = styled(BoxGroupSection)`
     display: flex;
-    justify-content: space-between;
+    align-items: center;
+    .InitialIcon {
+        margin-right: 5px;
+    }
+    ${Badge} {
+        margin-left: auto;
+    }
 `;
 
 export const Contributor = ({ id, count }) => (
     <StyledContributor key={id}>
+        <InitialIcon handle={id} size="md" />
         {id}
         <Badge>
             {count} change{count === 1 ? "" : "s"}

--- a/client/src/js/indexes/components/__tests__/__snapshots__/Contributors.test.js.snap
+++ b/client/src/js/indexes/components/__tests__/__snapshots__/Contributors.test.js.snap
@@ -4,6 +4,10 @@ exports[`<Contributor /> should render when count is 1 1`] = `
 <Contributors__StyledContributor
   key="bob"
 >
+  <InitialIcon
+    handle="bob"
+    size="md"
+  />
   bob
   <Badge>
     1
@@ -16,6 +20,10 @@ exports[`<Contributor /> should render when count is 5 1`] = `
 <Contributors__StyledContributor
   key="bob"
 >
+  <InitialIcon
+    handle="bob"
+    size="md"
+  />
   bob
   <Badge>
     5

--- a/client/src/js/references/components/Detail/AddMember.js
+++ b/client/src/js/references/components/Detail/AddMember.js
@@ -5,14 +5,15 @@ import styled from "styled-components";
 import {
     BoxGroup,
     BoxGroupSection,
-    ModalBody,
+    InitialIcon,
     Input,
     InputContainer,
     InputGroup,
     InputIcon,
     Modal,
-    NoneFoundSection,
-    ModalHeader
+    ModalBody,
+    ModalHeader,
+    NoneFoundSection
 } from "../../../base";
 import { listGroups } from "../../../groups/actions";
 import { findUsers } from "../../../users/actions";
@@ -37,13 +38,20 @@ const getInitialState = () => ({
 
 const StyledAddMemberItem = styled(BoxGroupSection)`
     display: flex;
-
-    img {
+    align-items: center;
+    div {
         margin-right: 8px;
+    }
+    .InitialIcon {
+        margin-right: 3px;
     }
 `;
 
-const AddMemberItem = ({ id, onClick }) => <StyledAddMemberItem onClick={onClick}>{id}</StyledAddMemberItem>;
+const AddMemberItem = ({ id, onClick }) => (
+    <StyledAddMemberItem onClick={onClick}>
+        <InitialIcon size="md" handle={id} /> {id}
+    </StyledAddMemberItem>
+);
 
 const AddReferenceMemberHeader = styled(ModalHeader)`
     text-transform: capitalize;

--- a/client/src/js/references/components/Detail/MemberItem.js
+++ b/client/src/js/references/components/Detail/MemberItem.js
@@ -1,18 +1,17 @@
 import PropTypes from "prop-types";
 import React, { useCallback } from "react";
 import styled from "styled-components";
-import { BoxGroupSection, FlexItem, Icon } from "../../../base";
-import GroupIcon from "../../../groups/components/Icon";
+import { BoxGroupSection, FlexItem, Icon, InitialIcon } from "../../../base";
 
 const StyledMemberItem = styled(BoxGroupSection)`
     align-items: center;
     display: flex;
 `;
 
-const MemberItemIcon = () => {
+const MemberItemIcon = ({ id }) => {
     return (
         <FlexItem grow={0} shrink={0} style={{ paddingRight: "8px" }}>
-            <GroupIcon />
+            <InitialIcon handle={id} size="md" />
         </FlexItem>
     );
 };
@@ -44,7 +43,7 @@ const MemberItem = ({ canModify, id, onEdit, onRemove }) => {
 
     return (
         <StyledMemberItem>
-            <MemberItemIcon />
+            <MemberItemIcon id={id} />
             {id}
             {icons}
         </StyledMemberItem>

--- a/client/src/js/references/components/Detail/__tests__/__snapshots__/MemberItem.test.js.snap
+++ b/client/src/js/references/components/Detail/__tests__/__snapshots__/MemberItem.test.js.snap
@@ -2,14 +2,18 @@
 
 exports[`<MemberItem /> should render 1`] = `
 <MemberItem__StyledMemberItem>
-  <MemberItemIcon />
+  <MemberItemIcon
+    id="bob"
+  />
   bob
 </MemberItem__StyledMemberItem>
 `;
 
 exports[`<MemberItem /> should render with [canModify=true] 1`] = `
 <MemberItem__StyledMemberItem>
-  <MemberItemIcon />
+  <MemberItemIcon
+    id="bob"
+  />
   bob
   <MemberItem__MemberItemIcons>
     <Icon

--- a/client/src/js/users/components/Detail.js
+++ b/client/src/js/users/components/Detail.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
-import { Alert, device, Icon, LoadingPlaceholder, RemoveBanner } from "../../base";
+import { Alert, device, Icon, InitialIcon, LoadingPlaceholder, RemoveBanner } from "../../base";
 import { listGroups } from "../../groups/actions";
 import { getUser, removeUser } from "../actions";
 import { getCanModifyUser } from "../selectors";
@@ -40,7 +40,9 @@ const UserDetailTitle = styled.div`
     font-size: ${getFontSize("xl")};
     font-weight: ${getFontWeight("bold")};
     margin-left: 15px;
-
+    .InitialIcon {
+        margin-right: 8px;
+    }
     a {
         font-size: ${getFontSize("md")};
         margin-left: auto;
@@ -74,13 +76,14 @@ export class UserDetail extends React.Component {
             return <LoadingPlaceholder />;
         }
 
-        const { id, administrator } = this.props.detail;
+        const { handle, administrator } = this.props.detail;
 
         return (
             <div>
                 <UserDetailHeader>
                     <UserDetailTitle>
-                        <span>{id}</span>
+                        <InitialIcon size="xl" handle={handle} />
+                        <span>{handle}</span>
                         {administrator ? <AdminIcon name="user-shield" color="blue" /> : null}
                         <Link to="/administration/users">Back To List</Link>
                     </UserDetailTitle>

--- a/client/src/js/users/components/Item.js
+++ b/client/src/js/users/components/Item.js
@@ -3,7 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
-import { Icon, Label, LinkBox } from "../../base";
+import { Icon, InitialIcon, Label, LinkBox } from "../../base";
 
 const StyledUserItem = styled(LinkBox)`
     display: flex;
@@ -23,6 +23,7 @@ const StyledUserItem = styled(LinkBox)`
 
 export const UserItem = ({ id, handle, administrator }) => (
     <StyledUserItem to={`/administration/users/${id}`}>
+        <InitialIcon size="md" handle={handle} />
         <strong>{handle}</strong>
         {administrator && (
             <Label color="purple">

--- a/client/src/js/users/components/__tests__/Detail.test.js
+++ b/client/src/js/users/components/__tests__/Detail.test.js
@@ -17,6 +17,7 @@ describe("<UserDetail />", () => {
             error: [],
             detail: {
                 id: "bob",
+                handle: "bob",
                 administrator: true
             },
             onGetUser: jest.fn(),

--- a/client/src/js/users/components/__tests__/Item.test.js
+++ b/client/src/js/users/components/__tests__/Item.test.js
@@ -5,8 +5,9 @@ describe("<UserItem />", () => {
 
     beforeEach(() => {
         props = {
-            id: "bob",
-            administrator: false
+            id: "b8vkclwp",
+            administrator: false,
+            handle: "bob"
         };
     });
 

--- a/client/src/js/users/components/__tests__/__snapshots__/Detail.test.js.snap
+++ b/client/src/js/users/components/__tests__/__snapshots__/Detail.test.js.snap
@@ -4,6 +4,10 @@ exports[`<UserDetail /> should render 1`] = `
 <div>
   <Detail__UserDetailHeader>
     <Detail__UserDetailTitle>
+      <InitialIcon
+        handle="bob"
+        size="xl"
+      />
       <span>
         bob
       </span>
@@ -39,6 +43,10 @@ exports[`<UserDetail /> should render when [administrator=false] 1`] = `
 <div>
   <Detail__UserDetailHeader>
     <Detail__UserDetailTitle>
+      <InitialIcon
+        handle="bob"
+        size="xl"
+      />
       <span>
         bob
       </span>
@@ -70,6 +78,10 @@ exports[`<UserDetail /> should render when [canModifyUser=false] 1`] = `
 <div>
   <Detail__UserDetailHeader>
     <Detail__UserDetailTitle>
+      <InitialIcon
+        handle="bob"
+        size="xl"
+      />
       <span>
         bob
       </span>

--- a/client/src/js/users/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/client/src/js/users/components/__tests__/__snapshots__/Item.test.js.snap
@@ -2,17 +2,29 @@
 
 exports[`<UserItem /> should render when administrator=false] 1`] = `
 <Item__StyledUserItem
-  to="/administration/users/bob"
+  to="/administration/users/b8vkclwp"
 >
-  <strong />
+  <InitialIcon
+    handle="bob"
+    size="md"
+  />
+  <strong>
+    bob
+  </strong>
 </Item__StyledUserItem>
 `;
 
 exports[`<UserItem /> should render when administrator=true] 1`] = `
 <Item__StyledUserItem
-  to="/administration/users/bob"
+  to="/administration/users/b8vkclwp"
 >
-  <strong />
+  <InitialIcon
+    handle="bob"
+    size="md"
+  />
+  <strong>
+    bob
+  </strong>
   <Label
     color="purple"
   >


### PR DESCRIPTION
Changes:

- Created new base component `InitialIcon` which when passed the user handle and a size renders a circle of deterministically generated hue with the first two letters of the users name within.
    - `InitialIcon` Expects to be handed the users handle, but id is substituted where handle is not accessible
    - Only color is determined using hsl type where only hue is generated per user. saturation and lightness are kept constant prevent stylistic conflicts with color scheme of the page
- Integrated `InitialIcon` where `identicon` was used previously. 
  - `IntitialIcon` now renders with every instance of the `Attribution` base where a user handle is passed
  - Added `InitialIcon` to `indexes/components/Contributors`
- Updated tests as needed to accommodate the new page element