### PR TITLE
Split configuration from settings

### DIFF
--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-import virtool.users.utils
+from virtool.users.utils import PERMISSIONS, hash_password
 
 
 async def test_get(spawn_client, static_time):
@@ -16,7 +16,7 @@ async def test_get(spawn_client, static_time):
         "id": "test",
         "administrator": False,
         "last_password_change": static_time.iso,
-        "permissions": {p: False for p in virtool.users.utils.PERMISSIONS},
+        "permissions": {p: False for p in PERMISSIONS},
         "primary_group": "technician",
         "settings": {
             "quick_analyze_workflow": "pathoscope_bowtie",
@@ -37,7 +37,7 @@ async def test_get(spawn_client, static_time):
 async def test_edit(error, spawn_client, resp_is, static_time):
     client = await spawn_client(authorize=True)
 
-    client.app["settings"]["minimum_password_length"] = 8
+    client.app["settings"].minimum_password_length = 8
 
     data = {
         "email": "dev-at-virtool.ca" if error == "email_error" else "dev@virtool.ca",
@@ -274,7 +274,7 @@ class TestCreateAPIKey:
                 "id": "test"
             },
             "groups": [],
-            "permissions": {p: False for p in virtool.users.utils.PERMISSIONS}
+            "permissions": {p: False for p in PERMISSIONS}
         }
 
         assert await client.db.keys.find_one({"id": "foobar_1"}) == expected
@@ -314,7 +314,7 @@ class TestUpdateAPIKey:
                 "id": "test"
             },
             "groups": [],
-            "permissions": {p: False for p in virtool.users.utils.PERMISSIONS}
+            "permissions": {p: False for p in PERMISSIONS}
         }
 
         await client.db.keys.insert_one(expected)
@@ -532,7 +532,7 @@ async def test_login(spawn_client, create_user, resp_is, error, mocker):
     await client.db.users.insert_one({
         "user_id": "abc123",
         "handle": "foobar",
-        "password": virtool.users.utils.hash_password("p@ssword123")
+        "password": hash_password("p@ssword123")
     })
 
     data = {

--- a/tests/analyses/test_db.py
+++ b/tests/analyses/test_db.py
@@ -2,19 +2,16 @@ import pytest
 from aiohttp.test_utils import make_mocked_coro
 
 import virtool.analyses.db
+from virtool.analyses.db import BLAST, remove_nuvs_blast
 import virtool.analyses.format
 import virtool.tasks.pg
 
 
 @pytest.fixture
-def test_blast_obj(dbi, tmp_path):
-    settings = {
-        "data_path": tmp_path
-    }
-
-    return virtool.analyses.db.BLAST(
+def test_blast_obj(dbi, tmp_path, config):
+    return BLAST(
         dbi,
-        settings,
+        config,
         "foo",
         5,
         "ABC123"
@@ -25,7 +22,7 @@ class TestBLAST:
 
     def test_init(self, dbi, test_blast_obj, tmp_path):
         assert test_blast_obj.db == dbi
-        assert test_blast_obj.settings == {"data_path": tmp_path}
+        assert test_blast_obj.config.data_path == tmp_path
         assert test_blast_obj.analysis_id == "foo"
         assert test_blast_obj.sequence_index == 5
         assert test_blast_obj.rid == "ABC123"
@@ -79,7 +76,7 @@ class TestBLAST:
         await test_blast_obj.update(ready, result, error)
 
         if ready is None:
-            m_check_rid.assert_called_with(test_blast_obj.settings, test_blast_obj.rid)
+            m_check_rid.assert_called_with(test_blast_obj.config, test_blast_obj.rid)
         else:
             assert not m_check_rid.called
 
@@ -165,7 +162,7 @@ async def test_remove_nuvs_blast(snapshot, dbi, static_time):
         }
     ])
 
-    await virtool.analyses.db.remove_nuvs_blast(
+    await remove_nuvs_blast(
         dbi,
         "foo",
         5

--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -2,21 +2,16 @@ import json
 
 import pytest
 
-import virtool.analyses.format
-from virtool.analyses.format import transform_coverage_to_coordinates
+from virtool.analyses.format import transform_coverage_to_coordinates, load_results
 
 
 @pytest.mark.parametrize("loadable", [True, False])
-async def test_load_results(loadable, mocker, tmp_path):
+async def test_load_results(loadable, mocker, tmp_path, config):
     """
     Test that results are loaded from a `results.json` as expected. Check that the file loading action is not pursued
     if the results are stored in the analysis document.
 
     """
-    settings = {
-        "data_path": tmp_path
-    }
-
     results = {
         "foo": "bar",
         "bar": "baz"
@@ -38,7 +33,7 @@ async def test_load_results(loadable, mocker, tmp_path):
         return_value=str(results_file)
     )
 
-    result = await virtool.analyses.format.load_results(settings, document)
+    result = await load_results(config, document)
 
     if loadable:
         m_join_analysis_json_path.assert_called_with(

--- a/tests/analyses/test_tasks.py
+++ b/tests/analyses/test_tasks.py
@@ -16,7 +16,7 @@ async def test_store_nuvs_files_task(tmp_path, spawn_client, dbi, pg, pg_session
     test_dir.joinpath("hmm.tsv").write_text("HMM file")
     test_dir.joinpath("unmapped_otus.fq").write_text("FASTQ file")
 
-    client.app["settings"]["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
 
     await dbi.analyses.insert_one({
         "_id": "bar",
@@ -80,4 +80,5 @@ async def test_store_nuvs_files_task(tmp_path, spawn_client, dbi, pg, pg_session
         }
     ]
     assert set(os.listdir(tmp_path / "analyses" / "bar")) == {"assembly.fa.gz", "hmm.tsv", "unmapped_otus.fq.gz"}
+
     assert not (tmp_path / "samples" / "foo" / "analysis" / "bar").is_dir()

--- a/tests/caches/test_db.py
+++ b/tests/caches/test_db.py
@@ -62,13 +62,11 @@ async def test_get(exists, dbi):
 
 
 @pytest.mark.parametrize("exception", [False, True])
-async def test_remove(exception, dbi, tmp_path):
+async def test_remove(exception, dbi, tmp_path, config):
     app = {
         "db": dbi,
         "run_in_thread": make_mocked_coro(raise_exception=FileNotFoundError) if exception else make_mocked_coro(),
-        "settings": {
-            "data_path": tmp_path
-        }
+        "config": config
     }
 
     await dbi.caches.insert_one({"_id": "baz"})

--- a/tests/caches/test_migrate.py
+++ b/tests/caches/test_migrate.py
@@ -1,5 +1,6 @@
-import virtool.caches.migrate
 from aiohttp.test_utils import make_mocked_coro
+
+from virtool.caches.migrate import migrate_caches, add_missing_field, rename_hash_field
 
 
 async def test_migrate_caches(mocker, dbi):
@@ -13,18 +14,16 @@ async def test_migrate_caches(mocker, dbi):
         }
     }
 
-    await virtool.caches.migrate.migrate_caches(app)
+    await migrate_caches(app)
 
     m_add_missing_field.assert_called_with(app)
     m_rename_hash_field.assert_called_with(app)
 
 
-async def test_add_missing_field(snapshot, tmp_path, dbi):
+async def test_add_missing_field(snapshot, tmp_path, dbi, config):
     app = {
         "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "config": config
     }
 
     caches_dir = tmp_path / "caches"
@@ -57,7 +56,7 @@ async def test_add_missing_field(snapshot, tmp_path, dbi):
         }
     ])
 
-    await virtool.caches.migrate.add_missing_field(app)
+    await add_missing_field(app)
 
     snapshot.assert_match(await dbi.caches.find().to_list(None))
 
@@ -84,6 +83,6 @@ async def test_rename_hash_field(snapshot, dbi):
         }
     ])
 
-    await virtool.caches.migrate.rename_hash_field(app)
+    await rename_hash_field(app)
 
     snapshot.assert_match(await dbi.caches.find().to_list(None))

--- a/tests/caches/test_utils.py
+++ b/tests/caches/test_utils.py
@@ -1,11 +1,7 @@
-import virtool.caches.utils
+from virtool.caches.utils import join_cache_path
 
 
-def test_join_cache_path(tmp_path):
-    settings = {
-        "data_path": tmp_path
-    }
-
+def test_join_cache_path(tmp_path, config):
     cache_id = "bar"
 
-    assert virtool.caches.utils.join_cache_path(settings, cache_id) == tmp_path / "caches" / "bar"
+    assert join_cache_path(config, cache_id) == tmp_path / "caches" / "bar"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from tests.fixtures.labels import *
 from tests.fixtures.tasks import *
 from tests.fixtures.settings import *
 from tests.fixtures.subtractions import *
+from tests.fixtures.config import *
 
 
 def pytest_addoption(parser):

--- a/tests/fake/test_yaml_loading.py
+++ b/tests/fake/test_yaml_loading.py
@@ -1,11 +1,15 @@
-import pytest
-from virtool.fake.factory import load_test_case_from_yml
-from virtool.dev.fake import populate
 from pathlib import Path
+
+import pytest
+
+from virtool.dev.fake import populate
+from virtool.fake.factory import load_test_case_from_yml
+
 
 @pytest.fixture
 def example_test_case(test_files_path) -> Path:
     return test_files_path / "fake/test_case.yml"
+
 
 async def test_load_yml(app, run_in_thread, example_test_case):
     app["run_in_thread"] = run_in_thread
@@ -26,10 +30,11 @@ async def test_load_yml(app, run_in_thread, example_test_case):
     assert case.job.args["additional_arg"] is True
 
 
-async def test_populate_does_load_yaml(app, run_in_thread, example_test_case):
+async def test_populate_does_load_yaml(app, run_in_thread, example_test_case, tmp_path, config):
     app["run_in_thread"] = run_in_thread
-    app["config"] = {}
-    app["config"]["fake_path"] = example_test_case.parent
+
+    app["config"] = config
+    app["config"].fake_path = example_test_case.parent
     await populate(app)
 
     job = await app["db"].jobs.find_one({"_id": "test_case_1"})

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -6,7 +6,7 @@ from aiohttp.web_routedef import RouteTableDef
 
 import virtool.app
 import virtool.jobs.main
-import virtool.users.utils
+from virtool.configuration.config import Config
 from virtool.utils import hash_key
 
 
@@ -69,20 +69,22 @@ def create_app(
     def _create_app(
             dev=False,
     ):
-        return virtool.app.create_app({
-            "dev": dev,
-            "db_connection_string": test_db_connection_string,
-            "redis_connection_string": redis_connection_string,
-            "postgres_connection_string": pg_connection_string,
-            "db_name": test_db_name,
-            "fake": False,
-            "force_version": "v0.0.0",
-            "no_client": True,
-            "no_check_db": True,
-            "no_check_files": True,
-            "no_fetching": True,
-            "no_sentry": True
-        })
+        config = Config(
+            db_connection_string=test_db_connection_string,
+            db_name=test_db_name,
+            dev=dev,
+            force_version="v0.0.0",
+            no_check_db=True,
+            no_check_files=True,
+            no_fetching=True,
+            no_sentry=True,
+            no_client=True,
+            postgres_connection_string=pg_connection_string,
+            redis_connection_string=redis_connection_string,
+            fake=False,
+
+        )
+        return virtool.app.create_app(config)
 
     return _create_app
 
@@ -176,12 +178,14 @@ def spawn_job_client(
             auth = None
 
         app = await virtool.jobs.main.create_app(
-            db_connection_string=test_db_connection_string,
-            db_name=test_db_name,
-            dev=dev,
-            fake=False,
-            postgres_connection_string=pg_connection_string,
-            redis_connection_string=redis_connection_string,
+            Config(
+                db_connection_string=test_db_connection_string,
+                db_name=test_db_name,
+                dev=dev,
+                fake=False,
+                postgres_connection_string=pg_connection_string,
+                redis_connection_string=redis_connection_string
+            )
         )
 
         if add_route_table:

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture
+def config(tmp_path, mocker):
+    config = mocker.Mock()
+    config.data_path = tmp_path
+    return config

--- a/tests/fixtures/fake.py
+++ b/tests/fixtures/fake.py
@@ -2,17 +2,13 @@ import pytest
 
 from virtool.fake.wrapper import FakerWrapper
 
+
 @pytest.fixture
-def app(dbi, pg, tmp_path):
+def app(dbi, pg, tmp_path, config, settings):
     return {
         "db": dbi,
         "fake": FakerWrapper(),
         "pg": pg,
-        "settings": {
-            "default_source_types": [
-                "isolate",
-                "strain"
-            ],
-            "data_path": tmp_path
+        "settings": settings,
+        "config": config
         }
-    }

--- a/tests/fixtures/settings.py
+++ b/tests/fixtures/settings.py
@@ -1,5 +1,7 @@
 import pytest
 
+from virtool.settings.db import Settings
+
 
 @pytest.fixture()
 async def test_settings(dbi):
@@ -24,3 +26,8 @@ async def test_settings(dbi):
     }
 
     await dbi.settings.insert_one(settings)
+
+
+@pytest.fixture()
+def settings():
+    return Settings()

--- a/tests/genbank/test_api.py
+++ b/tests/genbank/test_api.py
@@ -1,4 +1,4 @@
-import aiohttp.client
+from aiohttp.client import ClientSession
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 
@@ -20,12 +20,12 @@ async def test_get(error, mocker, resp_is, spawn_client):
         return
 
     m_fetch.assert_called_with(
-        client.app["settings"],
+        client.app["config"],
         mocker.ANY,
         "NC_016574.1"
     )
 
-    assert isinstance(m_fetch.call_args[0][1], aiohttp.client.ClientSession)
+    assert isinstance(m_fetch.call_args[0][1], ClientSession)
 
     assert resp.status == 200
     assert await resp.json() == expected

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -1,19 +1,18 @@
 import datetime
-from aiohttp.test_utils import make_mocked_coro
 
 import pytest
+from aiohttp.test_utils import make_mocked_coro
 
 import virtool.history.db
 
 
 class TestAdd:
 
-    async def test(self, snapshot, dbi, static_time, test_otu_edit, test_change, tmp_path):
+    async def test(self, snapshot, dbi, static_time, test_otu_edit, test_change, tmp_path, config):
+
         app = {
             "db": dbi,
-            "settings": {
-                "data_path": tmp_path
-            }
+            "config": config
         }
 
         old, new = test_otu_edit
@@ -32,12 +31,10 @@ class TestAdd:
         snapshot.assert_match(change, "change")
         snapshot.assert_match(document, "document")
 
-    async def test_create(self, snapshot, dbi, static_time, test_otu_edit, test_change, tmp_path):
+    async def test_create(self, snapshot, dbi, static_time, test_otu_edit, test_change, tmp_path, config):
         app = {
             "db": dbi,
-            "settings": {
-                "data_path": tmp_path
-            }
+            "config": config
         }
 
         # There is no old document because this is a change document for a otu creation operation.
@@ -61,16 +58,14 @@ class TestAdd:
         snapshot.assert_match(change)
         snapshot.assert_match(document)
 
-    async def test_remove(self, snapshot, dbi, static_time, test_otu_edit, test_change, tmp_path):
+    async def test_remove(self, snapshot, dbi, static_time, test_otu_edit, test_change, tmp_path, config):
         """
         Test that the addition of a change due to otu removal inserts the expected change document.
 
         """
         app = {
             "db": dbi,
-            "settings": {
-                "data_path": tmp_path
-            }
+            "config": config
         }
 
         # There is no new document because this is a change document for a otu removal operation.
@@ -96,7 +91,7 @@ class TestAdd:
 
 
 @pytest.mark.parametrize("file", [True, False])
-async def test_get(file, mocker, snapshot, dbi, tmp_path):
+async def test_get(file, mocker, snapshot, dbi, tmp_path, config):
     await dbi.history.insert_one({
         "_id": "baz.2",
         "diff": "file" if file else {
@@ -108,9 +103,7 @@ async def test_get(file, mocker, snapshot, dbi, tmp_path):
 
     app = {
         "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "config": config
     }
 
     document = await virtool.history.db.get(app, "baz.2")

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -7,7 +7,7 @@ import pytest
 from aiohttp.test_utils import make_mocked_coro
 
 import virtool.errors
-import virtool.utils
+from virtool.utils import decompress_file
 
 
 async def test_find(mocker, spawn_client, hmm_document):
@@ -143,7 +143,7 @@ async def test_get(error, spawn_client, hmm_document, resp_is):
 
 async def test_get_hmm_annotations(spawn_job_client, tmp_path):
     client = await spawn_job_client(authorize=True)
-    client.settings["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
     db = client.app["db"]
 
     await db.hmm.insert_one({"_id": "foo"})
@@ -158,7 +158,7 @@ async def test_get_hmm_annotations(spawn_job_client, tmp_path):
         async with aiofiles.open(compressed_hmm_annotations, "wb") as f:
             await f.write(await response.read())
 
-        virtool.utils.decompress_file(compressed_hmm_annotations, decompressed_hmm_annotations)
+        decompress_file(compressed_hmm_annotations, decompressed_hmm_annotations)
 
         async with aiofiles.open(decompressed_hmm_annotations, "r") as f:
             hmms = json.loads(await f.read())
@@ -183,8 +183,8 @@ async def test_get_hmm_profiles(
     """
     client = await spawn_job_client(authorize=True)
 
-    client.app["settings"]["data_path"] = tmp_path
-    hmms_path = client.app["settings"]["data_path"] / "hmm"
+    client.app["config"].data_path = tmp_path
+    hmms_path = tmp_path / "hmm"
     profiles_path = hmms_path / "profiles.hmm"
 
     if data_exists:

--- a/tests/http/test_auth.py
+++ b/tests/http/test_auth.py
@@ -36,7 +36,7 @@ class TestJobAuthentication:
         key = "bar"
 
         client = await spawn_client(auth=BasicAuth("job-foo", key))
-        client.settings["enable_api"] = True
+        client.settings.enable_api = True
 
         await dbi.jobs.insert_one({
             "_id": "foo",

--- a/tests/indexes/test_tasks.py
+++ b/tests/indexes/test_tasks.py
@@ -15,7 +15,7 @@ async def test_add_index_files(spawn_client, pg_session, static_time, tmp_path, 
     - index document is ready to be populated
     """
     client = await spawn_client(authorize=True, administrator=True)
-    client.app["settings"]["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
 
     test_dir = tmp_path / "references" / "foo"
     test_dir.mkdir(parents=True)

--- a/tests/otus/test_isolates.py
+++ b/tests/otus/test_isolates.py
@@ -1,6 +1,6 @@
 import pytest
 
-import virtool.otus.isolates
+from virtool.otus.isolates import add, edit, set_default, remove
 
 
 @pytest.mark.parametrize("default", [True, False])
@@ -25,10 +25,7 @@ async def test_add(
 
     """
     app = {
-        "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "db": dbi
     }
 
     test_otu["isolates"][0]["default"] = existing_default
@@ -38,7 +35,7 @@ async def test_add(
 
     await dbi.otus.insert_one(test_otu)
 
-    return_value = await virtool.otus.isolates.add(
+    return_value = await add(
         app,
         "6116cba1",
         {
@@ -57,15 +54,12 @@ async def test_add(
 
 async def test_edit(dbi, snapshot, test_otu, static_time, tmp_path):
     app = {
-        "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "db": dbi
     }
 
     await dbi.otus.insert_one(test_otu)
 
-    await virtool.otus.isolates.edit(
+    await edit(
         app,
         "6116cba1",
         "cab8b360",
@@ -87,10 +81,7 @@ async def test_remove(isolate_id, dbi, snapshot, test_otu, test_sequence, static
 
     """
     app = {
-        "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "db": dbi
     }
 
     test_otu["isolates"].append({
@@ -103,7 +94,7 @@ async def test_remove(isolate_id, dbi, snapshot, test_otu, test_sequence, static
     await dbi.otus.insert_one(test_otu)
     await dbi.sequences.insert_one(test_sequence)
 
-    await virtool.otus.isolates.remove(
+    await remove(
         app,
         "6116cba1",
         isolate_id,
@@ -117,10 +108,7 @@ async def test_remove(isolate_id, dbi, snapshot, test_otu, test_sequence, static
 
 async def test_set_default(dbi, snapshot, test_otu, static_time, tmp_path):
     app = {
-        "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "db": dbi
     }
 
     test_otu["isolates"].append({
@@ -132,7 +120,7 @@ async def test_set_default(dbi, snapshot, test_otu, static_time, tmp_path):
 
     await dbi.otus.insert_one(test_otu)
 
-    return_value = await virtool.otus.isolates.set_default(
+    return_value = await set_default(
         app,
         "6116cba1",
         "bar",

--- a/tests/otus/test_sequences.py
+++ b/tests/otus/test_sequences.py
@@ -1,6 +1,6 @@
 import pytest
 
-import virtool.otus.sequences
+from virtool.otus.sequences import check_segment_or_target, create, edit, get, increment_otu_version, remove
 
 
 @pytest.mark.parametrize("data_type", ["genome", "barcode"])
@@ -49,7 +49,7 @@ async def test_check_segment_or_target(data_type, defined, missing, used, sequen
     if missing:
         data = dict()
 
-    message = await virtool.otus.sequences.check_segment_or_target(
+    message = await check_segment_or_target(
         dbi,
         "foo",
         "baz",
@@ -83,14 +83,8 @@ async def test_check_segment_or_target(data_type, defined, missing, used, sequen
 @pytest.mark.parametrize("segment", [True, False])
 @pytest.mark.parametrize("sequence_id", ["foobar", None])
 async def test_create(host, segment, sequence_id, snapshot, dbi, static_time, test_random_alphanumeric, tmp_path):
-    """
-
-    """
     app = {
         "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
     }
 
     data = {
@@ -123,7 +117,7 @@ async def test_create(host, segment, sequence_id, snapshot, dbi, static_time, te
         "version": 3
     })
 
-    await virtool.otus.sequences.create(
+    await create(
         app,
         "foo",
         "bar",
@@ -145,10 +139,7 @@ async def test_edit(sequence, snapshot, dbi, static_time, tmp_path):
 
     """
     app = {
-        "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "db": dbi
     }
 
     await dbi.otus.insert_one({
@@ -189,7 +180,7 @@ async def test_edit(sequence, snapshot, dbi, static_time, tmp_path):
     if sequence:
         data["sequence"] = "ATAGAG GAGTA\nAGAGTGA"
 
-    await virtool.otus.sequences.edit(
+    await edit(
         app,
         "foo",
         "bar",
@@ -228,7 +219,7 @@ async def test_get(missing, snapshot, dbi):
             "comment": "hello world"
         })
 
-    document = await virtool.otus.sequences.get(
+    document = await get(
         dbi,
         "foo",
         "bar",
@@ -245,7 +236,7 @@ async def test_increment_otu_version(dbi, snapshot):
         "verified": True
     })
 
-    await virtool.otus.sequences.increment_otu_version(dbi, "foo")
+    await increment_otu_version(dbi, "foo")
 
     otu = await dbi.otus.find_one()
     snapshot.assert_match(otu)
@@ -253,10 +244,7 @@ async def test_increment_otu_version(dbi, snapshot):
 
 async def test_remove(snapshot, dbi, test_otu, static_time, tmp_path):
     app = {
-        "db": dbi,
-        "settings": {
-            "data_path": tmp_path
-        }
+        "db": dbi
     }
 
     await dbi.otus.insert_one(test_otu)
@@ -272,7 +260,7 @@ async def test_remove(snapshot, dbi, test_otu, static_time, tmp_path):
         "isolate_id": "cab8b360"
     })
 
-    await virtool.otus.sequences.remove(
+    await remove(
         app,
         "6116cba1",
         "cab8b360",

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1,6 +1,7 @@
-import aiohttp.web
 import pytest
 from aiohttp.test_utils import make_mocked_coro
+from aiohttp.web import Request
+
 from virtool.references.tasks import UpdateRemoteReferenceTask
 
 
@@ -169,7 +170,7 @@ async def test_update(error, mocker, spawn_client, check_ref_right, id_exists, r
         "test"
     )
 
-    assert isinstance(m_update.call_args[0][0], aiohttp.web.Request)
+    assert isinstance(m_update.call_args[0][0], Request)
 
     assert resp.status == 201
 
@@ -214,7 +215,7 @@ async def test_create(data_type, mocker, snapshot, spawn_client, test_random_alp
         "isolate"
     ]
 
-    client.app["settings"]["default_source_types"] = default_source_type
+    client.app["settings"].default_source_types = default_source_type
 
     data = {
         "name": "Test Viruses",

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -2,21 +2,19 @@ import os
 
 import pytest
 
-from virtool.samples.fake import create_fake_sample, copy_reads_file, READ_FILES_PATH
 from virtool.fake.wrapper import FakerWrapper
 from virtool.samples.db import LIST_PROJECTION
+from virtool.samples.fake import create_fake_sample, copy_reads_file, READ_FILES_PATH
 
 
 @pytest.fixture
-def app(dbi, pg, run_in_thread, tmp_path):
+def app(dbi, pg, run_in_thread, tmp_path, config):
     return {
         "db": dbi,
         "fake": FakerWrapper(),
         "pg": pg,
         "run_in_thread": run_in_thread,
-        "settings": {
-            "data_path": tmp_path
-        },
+        "config": config
     }
 
 
@@ -45,5 +43,5 @@ async def test_copy_reads_file(app):
 
     await copy_reads_file(app, file_path, "reads_1.fq.gz", "sample_1")
 
-    assert os.listdir(app["settings"]["data_path"] /
+    assert os.listdir(app["config"].data_path /
                       "samples" / "sample_1") == ["reads_1.fq.gz"]

--- a/tests/settings/test_api.py
+++ b/tests/settings/test_api.py
@@ -35,7 +35,6 @@ async def test_update(spawn_client, test_settings):
     assert resp.status == 200
 
     assert await resp.json() == {
-        "_id": "settings",
         "default_source_types": ["isolate", "strain"],
         "enable_api": False,
         "enable_sentry": False,

--- a/tests/settings/test_db.py
+++ b/tests/settings/test_db.py
@@ -1,10 +1,10 @@
-import virtool.settings.db
+from virtool.settings.db import Settings, ensure
 
 
 async def test_ensure(dbi, test_settings):
-    settings = await virtool.settings.db.ensure(dbi)
+    settings = await ensure(dbi)
 
-    assert settings == {
+    assert settings == Settings(**{
         "default_source_types": ["isolate", "strain"],
         "enable_api": True,
         "enable_sentry": True,
@@ -17,4 +17,4 @@ async def test_ensure(dbi, test_settings):
         "sample_group_write": False,
         "sample_unique_names": True,
         "software_channel": "stable"
-    }
+    })

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -1,7 +1,7 @@
 import os
 
-import aiohttp.test_utils
 import pytest
+from aiohttp.test_utils import make_mocked_coro
 
 from virtool.subtractions.models import SubtractionFile
 
@@ -13,7 +13,7 @@ from virtool.subtractions.models import SubtractionFile
     {"name": "Bar", "nickname": "Bar Subtraction"}
 ])
 async def test_edit(data, mocker, snapshot, spawn_client):
-    mocker.patch("virtool.subtractions.db.get_linked_samples", aiohttp.test_utils.make_mocked_coro(12))
+    mocker.patch("virtool.subtractions.db.get_linked_samples", make_mocked_coro(12))
 
     client = await spawn_client(authorize=True, permissions=["modify_subtraction"])
 
@@ -43,7 +43,7 @@ async def test_upload(error, tmp_path, spawn_job_client, snapshot, resp_is, pg_s
         "file": open(path, "rb")
     }
 
-    client.app["settings"]["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
 
     subtraction = {
         "_id": "foo",
@@ -136,7 +136,7 @@ async def test_finalize_subtraction(error, spawn_job_client, snapshot, resp_is, 
 @pytest.mark.parametrize("exists", [True, False])
 async def test_job_remove(exists, ready, tmp_path, spawn_job_client, snapshot, resp_is):
     client = await spawn_job_client(authorize=True)
-    client.app["settings"]["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
 
     if exists:
         await client.db.subtraction.insert_one({
@@ -173,7 +173,7 @@ async def test_job_remove(exists, ready, tmp_path, spawn_job_client, snapshot, r
 async def test_download_subtraction_files(error, tmp_path, spawn_job_client, pg_session):
     client = await spawn_job_client(authorize=True)
 
-    client.app["settings"]["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
 
     test_dir = tmp_path / "subtractions" / "foo"
     test_dir.mkdir(parents=True)
@@ -218,8 +218,8 @@ async def test_download_subtraction_files(error, tmp_path, spawn_job_client, pg_
         assert fasta_resp.status == bowtie_resp.status == 404
         return
 
-    fasta_expected_path = client.app["settings"]["data_path"] / "subtractions" / "foo" / "subtraction.fa.gz"
-    bowtie_expected_path = client.app["settings"]["data_path"] / "subtractions" / "foo" / "subtraction.1.bt2"
+    fasta_expected_path = client.app["config"].data_path / "subtractions" / "foo" / "subtraction.fa.gz"
+    bowtie_expected_path = client.app["config"].data_path / "subtractions" / "foo" / "subtraction.1.bt2"
 
     assert fasta_expected_path.read_bytes() == await fasta_resp.content.read()
     assert bowtie_expected_path.read_bytes() == await bowtie_resp.content.read()

--- a/tests/subtractions/test_tasks.py
+++ b/tests/subtractions/test_tasks.py
@@ -8,7 +8,7 @@ from virtool.tasks.models import Task
 async def test_add_subtraction_files_task(tmp_path, spawn_client, dbi, pg_session,
                                           static_time):
     client = await spawn_client(authorize=True)
-    client.app["settings"]["data_path"] = tmp_path
+    client.app["config"].data_path = tmp_path
 
     test_dir = tmp_path / "subtractions" / "foo"
     test_dir.mkdir(parents=True)

--- a/tests/subtractions/test_utils.py
+++ b/tests/subtractions/test_utils.py
@@ -2,21 +2,18 @@ import os
 
 import pytest
 
-import virtool.subtractions.utils
+from virtool.subtractions.utils import join_subtraction_path, get_subtraction_files, rename_bowtie_files, \
+    check_subtraction_file_type
 
 
-def test_join_subtraction_path(tmp_path):
-    settings = {
-        "data_path": tmp_path
-    }
-
-    path = virtool.subtractions.utils.join_subtraction_path(settings, "bar")
+def test_join_subtraction_path(tmp_path, config):
+    path = join_subtraction_path(config, "bar")
 
     assert path == tmp_path / "subtractions" / "bar"
 
 
 async def test_get_subtraction_files(pg, test_subtraction_files):
-    files = await virtool.subtractions.utils.get_subtraction_files(pg, "foo")
+    files = await get_subtraction_files(pg, "foo")
 
     assert files == [
             {
@@ -55,16 +52,16 @@ def test_rename_bowtie_files(tmp_path):
     test_dir.joinpath("reference.2.bt2").write_text("Bowtie2 file")
     test_dir.joinpath("reference.3.bt2").write_text("Bowtie2 file")
 
-    virtool.subtractions.utils.rename_bowtie_files(test_dir)
+    rename_bowtie_files(test_dir)
     assert set(os.listdir(test_dir)) == {'subtraction.1.bt2', 'subtraction.2.bt2', 'subtraction.3.bt2'}
 
 
 @pytest.mark.parametrize("file_type", ["fasta", "bowtie2"])
 def test_check_subtraction_file_type(file_type):
     if file_type == "fasta":
-        result = virtool.subtractions.utils.check_subtraction_file_type("subtraction.fa.gz")
+        result = check_subtraction_file_type("subtraction.fa.gz")
         assert result == "fasta"
 
     if file_type == "bowtie2":
-        result = virtool.subtractions.utils.check_subtraction_file_type("subtraction.1.bt2")
+        result = check_subtraction_file_type("subtraction.1.bt2")
         assert result == "bowtie2"

--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -29,7 +29,7 @@ class TestUpload:
         """
         client = await spawn_client(authorize=True, permissions=["upload_file"])
 
-        client.app["settings"]["data_path"] = tmp_path
+        client.app["config"].data_path = tmp_path
 
         if upload_type:
             resp = await client.post_form(f"/api/uploads?type={upload_type}&name=Test.fq.gz", data=files)
@@ -96,7 +96,7 @@ class TestGet:
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        client.app["settings"]["data_path"] = tmp_path
+        client.app["config"].data_path = tmp_path
 
         if exists:
             await client.post_form("/api/uploads?name=test.fq.gz", data=files)
@@ -116,7 +116,7 @@ class TestGet:
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        client.app["settings"]["data_path"] = tmp_path
+        client.app["config"].data_path = tmp_path
 
         async with pg_session as session:
             session.add(Upload(name_on_disk="1-test.fq.gz", removed=exists))
@@ -136,7 +136,7 @@ class TestDelete:
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        client.app["settings"]["data_path"] = tmp_path
+        client.app["config"].data_path = tmp_path
         await client.post_form("/api/uploads?name=test.fq.gz", data=files)
 
         resp = await client.delete("/api/uploads/1")
@@ -153,7 +153,7 @@ class TestDelete:
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        client.app["settings"]["data_path"] = tmp_path
+        client.app["config"].data_path = tmp_path
 
         async with pg_session as session:
             session.add(Upload(name_on_disk="1-test.fq.gz", removed=exists))
@@ -176,7 +176,7 @@ class TestDelete:
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        client.app["settings"]["data_path"] = tmp_path
+        client.app["config"].data_path = tmp_path
 
         if exists:
             async with pg_session as session:

--- a/tests/users/test_api.py
+++ b/tests/users/test_api.py
@@ -136,7 +136,7 @@ async def test_create(error, spawn_client, create_user, resp_is, static_time, mo
             "_id": "abc123"
         })
 
-    client.app["settings"]["minimum_password_length"] = 8
+    client.app["settings"].minimum_password_length = 8
 
     data = {
         "handle": "fred",
@@ -200,7 +200,7 @@ async def test_edit(data, error, spawn_client, resp_is, static_time, create_user
 
     client = await spawn_client(authorize=True, administrator=True)
 
-    client.app["settings"]["minimum_password_length"] = 8
+    client.app["settings"].minimum_password_length = 8
 
     bob = None
 

--- a/virtool/api/response.py
+++ b/virtool/api/response.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 
-from aiohttp import web
+from aiohttp.web import Response
 from aiohttp.web_exceptions import HTTPForbidden, HTTPNotFound, HTTPUnprocessableEntity
 
 
-def json_response(data: object, status: int = 200, headers: Optional[dict] = None) -> web.Response:
+def json_response(data: object, status: int = 200, headers: Optional[dict] = None) -> Response:
     """
     Return a response object whose attached JSON dict will be formatted by middleware depending on
     the request's `Accept` header.
@@ -17,7 +17,7 @@ def json_response(data: object, status: int = 200, headers: Optional[dict] = Non
     """
     headers = headers or {}
 
-    resp = web.Response(status=status, headers=headers)
+    resp = Response(status=status, headers=headers)
     resp["json_data"] = data
 
     return resp

--- a/virtool/caches/db.py
+++ b/virtool/caches/db.py
@@ -7,7 +7,6 @@ from typing import Any, Dict
 
 import pymongo.errors
 
-import virtool.caches
 import virtool.utils
 from virtool.types import App
 
@@ -90,13 +89,13 @@ async def remove(app: App, cache_id: str):
 
     """
     db = app["db"]
-    settings = app["settings"]
+    config = app["config"]
 
     await db.caches.delete_one({
         "_id": cache_id
     })
 
-    path = settings["data_path"] / "caches" / cache_id
+    path = config.data_path / "caches" / cache_id
 
     try:
         await app["run_in_thread"](virtool.utils.rm, path, True)

--- a/virtool/caches/migrate.py
+++ b/virtool/caches/migrate.py
@@ -29,7 +29,7 @@ async def add_missing_field(app: App):
     """
     db = app["db"]
 
-    path = app["settings"]["data_path"] / "caches"
+    path = app["config"].data_path / "caches"
 
     found_cache_ids = os.listdir(path)
 

--- a/virtool/caches/utils.py
+++ b/virtool/caches/utils.py
@@ -3,16 +3,17 @@ Utilities used for working with cache files within analysis workflows.
 
 """
 from pathlib import Path
-from typing import Any, Dict
+
+from virtool.configuration.config import Config
 
 
-def join_cache_path(settings: Dict[str, Any], cache_id: str) -> Path:
+def join_cache_path(config: Config, cache_id: str) -> Path:
     """
-    Create a cache path string given the application settings and cache id.
+    Create a cache path string given the application configuration and cache id.
 
-    :param settings: the application settings
+    :param config: the application configuration
     :param cache_id: the id of the cache
     :return: a cache path
 
     """
-    return settings["data_path"] / "caches" / cache_id
+    return config.data_path / "caches" / cache_id

--- a/virtool/configuration/config.py
+++ b/virtool/configuration/config.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Config(object):
+    db_connection_string: str
+    db_name: str
+    dev: bool
+    postgres_connection_string: str
+    redis_connection_string: str
+    no_sentry: bool = False
+    no_fetching: bool = False
+    no_check_files: bool = False
+    no_check_db: bool = False
+    force_version: str = None
+    verbose: bool = False
+    data_path: Path = None
+    proxy: str = None
+    host: str = None
+    no_client: bool = False
+    port: int = 9950
+    fake: bool = False
+    fake_path: Path = None

--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -1,13 +1,13 @@
 import logging
 import sys
-from typing import Any, Callable, Dict, List
+from typing import Callable, List
 
 import pymongo.errors
 from motor.motor_asyncio import AsyncIOMotorClient
 from semver import VersionInfo
 
 import virtool.db.core
-import virtool.db.utils
+from virtool.configuration.config import Config
 
 MINIMUM_MONGO_VERSION = "3.6.0"
 
@@ -15,18 +15,18 @@ logger = logging.getLogger("mongo")
 
 
 async def connect(
-        config: Dict[str, Any],
+        config: Config,
         enqueue_change: Callable[[str, str, List[str]], None]
 ):
     """
     Connect to a MongoDB server and return an application database object.
 
-    :param config: the application's configuration dictionary
+    :param config: the application's configuration object
     :param enqueue_change: a function that can to report change to the database
 
     """
     db_client = AsyncIOMotorClient(
-        config["db_connection_string"],
+        config.db_connection_string,
         serverSelectionTimeoutMS=6000
     )
 
@@ -38,7 +38,7 @@ async def connect(
 
     await check_mongo_version(db_client)
 
-    db = db_client[config["db_name"]]
+    db = db_client[config.db_name]
 
     return virtool.db.core.DB(
         db,

--- a/virtool/dev/fake.py
+++ b/virtool/dev/fake.py
@@ -21,10 +21,10 @@ REF_ID = "reference_1"
 
 async def populate(app: App):
     await create_fake_bob_user(app)
-    for yml_file in Path(app["config"]["fake_path"]).iterdir():
+    for yml_file in Path(app["config"].fake_path).iterdir():
+        print(yml_file)
         if yml_file.suffix in (".yml", ".yaml"):
             await load_test_case_from_yml(app, yml_file)
-
 
 
 async def remove_fake_data_path(app: App):
@@ -35,10 +35,10 @@ async def remove_fake_data_path(app: App):
     :param app: the application object
 
     """
-    data_path = app["config"].get("data_path")
+    data_path = app["config"].data_path
 
     # Be extra sure this is a fake application directory we should remove.
-    if data_path and app["config"]["fake"] and "virtool_fake_" in data_path:
+    if data_path and app["config"].fake and "virtool_fake_" in data_path:
         rmtree(data_path)
         logger.debug(f"Removed fake data directory: {data_path}")
 
@@ -50,10 +50,10 @@ async def drop_fake_mongo(app: App):
     :param app: the application object
 
     """
-    db_name = app["config"]["db_name"]
+    db_name = app["config"].db_name
 
     # Be extra sure this is a fake database we should drop.
-    if "fake-" in db_name and app["config"]["fake"]:
+    if "fake-" in db_name and app["config"].fake:
         await app["db"].motor_client.client.drop_database(db_name)
         logger.debug(f"Dropped fake Mongo database: {db_name}")
 

--- a/virtool/fake/factory.py
+++ b/virtool/fake/factory.py
@@ -65,7 +65,7 @@ class TestCaseDataFactory:
         self.db = app["db"]
         self.pg = app["pg"]
         self.settings = app["settings"]
-        self.data_path = self.settings["data_path"]
+        self.data_path = app["config"].data_path
 
     async def analysis(
             self,
@@ -247,7 +247,6 @@ async def load_test_case_from_yml(app: App, path: str) -> WorkflowTestCase:
         if "hmms" in include:
             await factory.hmms()
 
-
     if "sample" in yml:
         test_case.sample = await factory.sample(**yml["sample"])
         job_args["sample_id"] = test_case.sample["_id"]
@@ -271,10 +270,8 @@ async def load_test_case_from_yml(app: App, path: str) -> WorkflowTestCase:
 
         job_args["analysis_id"] = test_case.analysis["_id"]
 
-
     if "job_args" in yml:
         job_args.update(yml["job_args"])
-
 
     test_case.job = await factory.job(args=job_args, workflow=workflow)
 

--- a/virtool/genbank/api.py
+++ b/virtool/genbank/api.py
@@ -6,11 +6,10 @@ import aiohttp
 from aiohttp.web import HTTPBadGateway
 
 import virtool.genbank.http
-import virtool.http.proxy
-import virtool.http.routes
+from virtool.http.routes import Routes
 from virtool.api.response import json_response, NotFound
 
-routes = virtool.http.routes.Routes()
+routes = Routes()
 
 
 @routes.get("/api/genbank/{accession}")
@@ -22,10 +21,10 @@ async def get(req):
     """
     accession = req.match_info["accession"]
     session = req.app["client"]
-    settings = req.app["settings"]
+    config = req.app["config"]
 
     try:
-        data = await virtool.genbank.http.fetch(settings, session, accession)
+        data = await virtool.genbank.http.fetch(config, session, accession)
 
         if data is None:
             raise NotFound()

--- a/virtool/genbank/http.py
+++ b/virtool/genbank/http.py
@@ -9,7 +9,7 @@ from typing import Union, Optional
 import Bio.SeqIO
 import aiohttp
 
-import virtool.http.proxy
+from virtool.http.proxy import ProxyRequest
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +19,11 @@ TOOL = "virtool"
 FETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 
 
-async def fetch(settings: dict, session: aiohttp.ClientSession, accession: Union[int, str]) -> Optional[dict]:
+async def fetch(config, session: aiohttp.ClientSession, accession: Union[int, str]) -> Optional[dict]:
     """
     Fetch the Genbank record for the passed `accession`. Returns `None` if the Genbank record can not be found.
 
-    :param settings: the application settings object
+    :param config: the application configuration object
     :param session: an aiohttp client session
     :param accession: the accession to fetch
     :return: parsed Genbank data
@@ -38,7 +38,7 @@ async def fetch(settings: dict, session: aiohttp.ClientSession, accession: Union
         "tool": TOOL
     }
 
-    async with virtool.http.proxy.ProxyRequest(settings, session.get, FETCH_URL, params=params) as resp:
+    async with ProxyRequest(config, session.get, FETCH_URL, params=params) as resp:
 
         body = await resp.text()
 

--- a/virtool/github.py
+++ b/virtool/github.py
@@ -5,7 +5,7 @@ from typing import Optional
 import aiohttp
 
 import virtool.errors
-import virtool.http.proxy
+from virtool.http.proxy import ProxyRequest
 import virtool.utils
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ def get_etag(release: Optional[dict]) -> Optional[str]:
 
 
 async def get_release(
-        settings: dict,
+        config,
         session: aiohttp.ClientSession,
         slug: str,
         etag: Optional[str] = None,
@@ -90,7 +90,7 @@ async def get_release(
     """
     GET data from a GitHub API url.
 
-    :param settings: the application settings object
+    :param config: the application config object
     :param session: the application HTTP client session
     :param slug: the slug for the GitHub repo
     :param etag: an ETag for the resource to be used with the `If-None-Match` header
@@ -105,7 +105,7 @@ async def get_release(
     if etag:
         headers["If-None-Match"] = etag
 
-    async with virtool.http.proxy.ProxyRequest(settings, session.get, url, headers=headers) as resp:
+    async with ProxyRequest(config, session.get, url, headers=headers) as resp:
         rate_limit_remaining = resp.headers.get("X-RateLimit-Remaining", "00")
         rate_limit = resp.headers.get("X-RateLimit-Limit", "00")
 

--- a/virtool/history/utils.py
+++ b/virtool/history/utils.py
@@ -143,7 +143,7 @@ def derive_otu_information(old: Optional[dict], new: Optional[dict]) -> Tuple[st
 
 def join_diff_path(data_path: Path, otu_id: str, otu_version: Union[int, str]) -> Path:
     """
-    Derive the path to a diff file based on the application `data_path` setting and the OTU ID and version.
+    Derive the path to a diff file based on the application `data_path` configuration and the OTU ID and version.
 
     :param data_path: the application data path
     :param otu_id: the OTU ID to join a diff path for
@@ -202,7 +202,7 @@ async def remove_diff_files(app, id_list: List[str]):
     :param id_list: a list of change IDs to remove diff files for
 
     """
-    data_path = app["settings"]["data_path"]
+    data_path = app["config"].data_path
 
     for change_id in id_list:
         otu_id, otu_version = change_id.split(".")

--- a/virtool/hmm/fake.py
+++ b/virtool/hmm/fake.py
@@ -11,7 +11,8 @@ from virtool.types import App
 async def create_fake_hmms(app: App):
     fake: FakerWrapper = app["fake"]
 
-    data_path = app["settings"]["data_path"]
+    data_path = app["config"].data_path
+
     hmms_path = data_path / "hmm"
 
     copy(example_path / "hmms/profiles.hmm", hmms_path)

--- a/virtool/http/proxy.py
+++ b/virtool/http/proxy.py
@@ -5,14 +5,15 @@ from aiohttp import web
 
 import virtool.errors
 from virtool.api.response import json_response
+from virtool.configuration.config import Config
 
 logger = getLogger(__name__)
 
 
 class ProxyRequest:
 
-    def __init__(self, settings, method, url, **kwargs):
-        self.proxy = settings["proxy"] or None
+    def __init__(self, config: Config, method, url, **kwargs):
+        self.proxy = config.proxy or None
         self.method = method
         self.url = url
         self.resp = None

--- a/virtool/http/utils.py
+++ b/virtool/http/utils.py
@@ -2,11 +2,10 @@ from pathlib import Path
 from typing import Callable, Union, Awaitable
 
 import aiofiles
-import aiohttp.web_response
+from aiohttp.web_response import Response
 
-import virtool.errors
-import virtool.http.proxy
 from virtool.errors import GitHubError
+from virtool.http.proxy import ProxyRequest
 from virtool.types import App
 
 
@@ -25,7 +24,7 @@ async def download_file(
     :param progress_handler: a callable that will be called with the current progress when it changes.
 
     """
-    async with virtool.http.proxy.ProxyRequest(app["settings"], app["client"].get, url) as resp:
+    async with ProxyRequest(app["config"], app["client"].get, url) as resp:
         if resp.status != 200:
             raise GitHubError("Could not download file")
 
@@ -42,9 +41,9 @@ async def download_file(
                     await progress_handler(len(chunk))
 
 
-def set_session_id_cookie(resp: aiohttp.web_response.Response, session_id: str):
+def set_session_id_cookie(resp: Response, session_id: str):
     resp.set_cookie("session_id", session_id, httponly=True, max_age=2600000)
 
 
-def set_session_token_cookie(resp: aiohttp.web_response.Response, session_token: str):
+def set_session_token_cookie(resp: Response, session_token: str):
     resp.set_cookie("session_token", session_token, httponly=True, max_age=2600000)

--- a/virtool/indexes/tasks.py
+++ b/virtool/indexes/tasks.py
@@ -36,7 +36,7 @@ class AddIndexFilesTask(Task):
             except KeyError:
                 index_id = index["_id"]
 
-                path = self.app["settings"]["data_path"] / "references" / index_id
+                path = self.app["config"].data_path / "references" / index_id
 
                 async with AsyncSession(self.app["pg"]) as session:
                     for file_path in sorted(path.iterdir()):

--- a/virtool/routes.py
+++ b/virtool/routes.py
@@ -71,7 +71,7 @@ def setup_routes(app):
 
     app.router.add_get("/ws", virtool.http.ws.root)
 
-    if app["config"]["dev"]:
+    if app["config"].dev:
         logger.info("Enabling development API")
         app.router.add_routes(virtool.dev.api.routes)
 

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -96,16 +96,16 @@ def join_legacy_read_path(sample_path: Path, suffix: int) -> Path:
     return sample_path / f"reads_{suffix}.fastq"
 
 
-def join_legacy_read_paths(settings: dict, sample):
+def join_legacy_read_paths(config, sample):
     """
     Create a list of paths for the read files associated with the `sample`.
 
-    :param settings: the application settings
+    :param config: the application configuration
     :param sample: the sample document
     :return: a list of sample read paths
 
     """
-    sample_path = join_sample_path(settings, sample["_id"])
+    sample_path = join_sample_path(config, sample["_id"])
 
     if not all(f["raw"] for f in sample["files"]):
         if sample["paired"]:
@@ -117,5 +117,5 @@ def join_legacy_read_paths(settings: dict, sample):
         return [join_legacy_read_path(sample_path, 1)]
 
 
-def join_sample_path(settings, sample_id) -> Path:
-    return settings["data_path"] / "samples" / sample_id
+def join_sample_path(config, sample_id) -> Path:
+    return config.data_path / "samples" / sample_id

--- a/virtool/settings/api.py
+++ b/virtool/settings/api.py
@@ -1,18 +1,18 @@
-import aiohttp.web
+from aiohttp.web import Response, Request
 
-import virtool.http.routes
 import virtool.settings.db
-import virtool.settings.schema
-import virtool.utils
 from virtool.api.response import json_response
+from virtool.http.routes import Routes
 from virtool.http.schema import schema
+from virtool.settings.db import Settings
+from virtool.settings.schema import SCHEMA
 
-routes = virtool.http.routes.Routes()
+routes = Routes()
 
 
 @routes.get("/api/settings")
 @routes.jobs_api.get("/api/settings")
-async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
+async def get(req: Request) -> Response:
     """
     Get a complete document of the application settings.
 
@@ -23,8 +23,8 @@ async def get(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
 
 @routes.patch("/api/settings", admin=True)
-@schema(virtool.settings.schema.SCHEMA)
-async def update(req: aiohttp.web.Request) -> aiohttp.web.Response:
+@schema(SCHEMA)
+async def update(req: Request) -> Response:
     """
     Update application settings based on request data.
 
@@ -35,6 +35,6 @@ async def update(req: aiohttp.web.Request) -> aiohttp.web.Response:
 
     settings = await virtool.settings.db.update(req.app["db"], data)
 
-    req.app["settings"].update(settings)
+    req.app["settings"] = Settings(**settings)
 
     return json_response(settings)

--- a/virtool/shutdown.py
+++ b/virtool/shutdown.py
@@ -1,14 +1,14 @@
 import logging
 
-import aiohttp.web
+from aiohttp.web import Application
 
-import virtool.startup
 from virtool.pg.base import Base
+from virtool.startup import get_scheduler_from_app
 
 logger = logging.getLogger(__name__)
 
 
-async def exit_client(app: aiohttp.web.Application):
+async def exit_client(app: Application):
     """
     Attempt to close the async HTTP client session.
 
@@ -22,7 +22,7 @@ async def exit_client(app: aiohttp.web.Application):
         pass
 
 
-async def exit_dispatcher(app: aiohttp.web.Application):
+async def exit_dispatcher(app: Application):
     """
     Attempt to close the app's `Dispatcher` object.
 
@@ -36,7 +36,7 @@ async def exit_dispatcher(app: aiohttp.web.Application):
         pass
 
 
-async def exit_executors(app: aiohttp.web.Application):
+async def exit_executors(app: Application):
     """
     Attempt to close the `ThreadPoolExecutor` and `ProcessPoolExecutor`.
 
@@ -53,17 +53,17 @@ async def exit_executors(app: aiohttp.web.Application):
         pass
 
 
-async def exit_scheduler(app: aiohttp.web.Application):
+async def exit_scheduler(app: Application):
     """
     Attempt to the close the app's `aiojobs` scheduler.
 
     :param app: The application object
     """
-    scheduler = virtool.startup.get_scheduler_from_app(app)
+    scheduler = get_scheduler_from_app(app)
     await scheduler.close()
 
 
-async def exit_redis(app: aiohttp.web.Application):
+async def exit_redis(app: Application):
     """
     Attempt to close the app's `redis` instance.
 
@@ -78,14 +78,14 @@ async def exit_redis(app: aiohttp.web.Application):
         pass
 
 
-async def drop_fake_postgres(app: aiohttp.web.Application):
+async def drop_fake_postgres(app: Application):
     """
     Drop a fake PostgreSQL database if the instance was run with the ``--fake`` option.
 
     :param app: the application object
 
     """
-    if app["config"]["fake"] and "fake_" in app["config"]["postgres_connection_string"]:
+    if app["config"].fake and "fake_" in app["config"].postgres_connection_string:
         async with app["pg"].begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
             logger.debug("Dropped fake PostgreSQL database.")

--- a/virtool/subtractions/fake.py
+++ b/virtool/subtractions/fake.py
@@ -49,7 +49,7 @@ async def create_fake_finalized_subtraction(
     })
 
     subtractions_path = (
-            app["settings"]["data_path"]
+            app["config"].data_path
             / "subtractions"
             / subtraction_id.replace(" ", "_").lower()
     )

--- a/virtool/subtractions/tasks.py
+++ b/virtool/subtractions/tasks.py
@@ -39,8 +39,6 @@ class AddSubtractionFilesTask(virtool.tasks.task.Task):
         Change Bowtie2 index name from 'reference' to 'subtraction'
 
         """
-        settings = self.app["settings"]
-
         await virtool.tasks.pg.update(
             self.pg,
             self.id,
@@ -48,7 +46,7 @@ class AddSubtractionFilesTask(virtool.tasks.task.Task):
         )
 
         async for subtraction in self.db.subtraction.find(ADD_SUBTRACTION_FILES_QUERY):
-            path = virtool.subtractions.utils.join_subtraction_path(settings, subtraction["_id"])
+            path = virtool.subtractions.utils.join_subtraction_path(self.app["config"], subtraction["_id"])
             await self.app["run_in_thread"](virtool.subtractions.utils.rename_bowtie_files, path)
 
     async def store_subtraction_files(self):
@@ -57,8 +55,6 @@ class AddSubtractionFilesTask(virtool.tasks.task.Task):
         subtraction
 
         """
-        settings = self.app["settings"]
-
         await virtool.tasks.pg.update(
             self.pg,
             self.id,
@@ -66,7 +62,7 @@ class AddSubtractionFilesTask(virtool.tasks.task.Task):
         )
 
         async for subtraction in self.db.subtraction.find(ADD_SUBTRACTION_FILES_QUERY):
-            path = virtool.subtractions.utils.join_subtraction_path(settings, subtraction["_id"])
+            path = virtool.subtractions.utils.join_subtraction_path(self.app["config"], subtraction["_id"])
             subtraction_files = list()
 
             for filename in sorted(os.listdir(path)):
@@ -101,12 +97,12 @@ class WriteSubtractionFASTATask(virtool.tasks.task.Task):
         ]
 
     async def generate_fasta_file(self):
-        settings = self.app["settings"]
+        config = self.app["config"]
         subtraction = self.context["subtraction"]
 
-        index_path = virtool.subtractions.utils.join_subtraction_index_path(settings, subtraction)
+        index_path = virtool.subtractions.utils.join_subtraction_index_path(config, subtraction)
         fasta_path = (
-            virtool.subtractions.utils.join_subtraction_path(settings, subtraction)
+            virtool.subtractions.utils.join_subtraction_path(config, subtraction)
             / "subtraction.fa"
         )
 
@@ -120,7 +116,7 @@ class WriteSubtractionFASTATask(virtool.tasks.task.Task):
         await proc.communicate()
 
         target_path = (
-            virtool.subtractions.utils.join_subtraction_path(settings, subtraction)
+            virtool.subtractions.utils.join_subtraction_path(config, subtraction)
             / "subtraction.fa.gz"
         )
 

--- a/virtool/subtractions/utils.py
+++ b/virtool/subtractions/utils.py
@@ -35,12 +35,12 @@ def check_subtraction_file_type(file_name: str) -> str:
         return "bowtie2"
 
 
-def join_subtraction_path(settings: dict, subtraction_id: str) -> Path:
-    return settings["data_path"] / "subtractions" / subtraction_id.replace(" ", "_").lower()
+def join_subtraction_path(config, subtraction_id: str) -> Path:
+    return config.data_path / "subtractions" / subtraction_id.replace(" ", "_").lower()
 
 
-def join_subtraction_index_path(settings: dict, subtraction_id: str) -> Path:
-    return join_subtraction_path(settings, subtraction_id) / "reference"
+def join_subtraction_index_path(config, subtraction_id: str) -> Path:
+    return join_subtraction_path(config, subtraction_id) / "reference"
 
 
 async def get_subtraction_files(pg: AsyncEngine, subtraction: str) -> List[dict]:

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -40,7 +40,7 @@ async def create(req):
 
     upload_id = upload["id"]
 
-    file_path = req.app["settings"]["data_path"] / "files" / upload["name_on_disk"]
+    file_path = req.app["config"].data_path / "files" / upload["name_on_disk"]
 
     try:
         size = await naive_writer(req, file_path)
@@ -106,7 +106,7 @@ async def get(req):
 
     # check if the file has been removed as a result of a `DELETE` request
 
-    upload_path = Path(req.app["settings"]["data_path"]) / "files" / upload.name_on_disk
+    upload_path = Path(req.app["config"].data_path / "files" / upload.name_on_disk)
 
     # check if the file has been manually removed by the user
     if not upload_path.exists():

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -1,15 +1,11 @@
 import logging
 from typing import Union, Optional, List, Dict, Type
-from virtool.pg.base import Base
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
 
-import virtool.tasks.pg
-import virtool.tasks.task
-import virtool.uploads.utils
 import virtool.utils
-
+from virtool.pg.base import Base
 from virtool.uploads.models import Upload
 
 logger = logging.getLogger("uploads")
@@ -153,7 +149,7 @@ async def delete(req, pg: AsyncEngine, upload_id: int) -> Optional[dict]:
     try:
         await req.app["run_in_thread"](
             virtool.utils.rm,
-            req.app["settings"]["data_path"] / "files" / upload["name_on_disk"]
+            req.app["config"].data_path / "files" / upload["name_on_disk"]
         )
     except FileNotFoundError:
         pass

--- a/virtool/users/checks.py
+++ b/virtool/users/checks.py
@@ -1,12 +1,12 @@
-import aiohttp.web
+from aiohttp.web import Request
 
 
-async def check_password_length(req: aiohttp.web.Request) -> str:
+async def check_password_length(req: Request) -> str:
     """
     Return error text if the password in the request does not meet application length requirements.
 
     """
-    minimum_password_length = req.app["settings"]["minimum_password_length"]
+    minimum_password_length = req.app["settings"].minimum_password_length
 
     if len(req["data"]["password"]) < minimum_password_length:
         return f"Password does not meet minimum length requirement ({minimum_password_length})"


### PR DESCRIPTION
Separate the `click` configuration information and settings stored in the database and store separately in `app["config"]` and `app["settings"]`. Create a data class for config information and a data class for settings. Update all references to settings and config to use new data classes.
