### PR TITLE
Return dev mode value in root API response

### DIFF
--- a/tests/http/snapshots/snap_test_root.py
+++ b/tests/http/snapshots/snap_test_root.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_get[uvloop] 1'] = {
+    'dev': False,
+    'endpoints': {
+        'account': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/account',
+            'url': '/api/account'
+        },
+        'analyses': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/analyses',
+            'url': '/api/analyses'
+        },
+        'genbank': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/genbank',
+            'url': '/api/genbank'
+        },
+        'groups': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/groups',
+            'url': '/api/groups'
+        },
+        'history': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/history',
+            'url': '/api/history'
+        },
+        'hmm': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/hmm',
+            'url': '/api/hmm'
+        },
+        'indexes': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/indexes',
+            'url': '/api/indexes'
+        },
+        'jobs': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/jobs',
+            'url': '/api/jobs'
+        },
+        'otus': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/otus',
+            'url': '/api/otus'
+        },
+        'references': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/refs',
+            'url': '/api/references'
+        },
+        'samples': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/samples',
+            'url': '/api/samples'
+        },
+        'settings': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/settings',
+            'url': '/api/settings'
+        },
+        'subtraction': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/subtraction',
+            'url': '/api/subtraction'
+        },
+        'tasks': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/tasks',
+            'url': '/api/tasks'
+        },
+        'users': {
+            'doc': 'https://www.virtool.ca/docs/developer/api/users',
+            'url': '/api/users'
+        }
+    },
+    'version': 'v0.0.0'
+}

--- a/tests/http/test_root.py
+++ b/tests/http/test_root.py
@@ -1,0 +1,5 @@
+async def test_get(spawn_client, snapshot):
+    client = await spawn_client(authorize=True)
+    resp = await client.get("/api")
+
+    snapshot.assert_match(await resp.json())

--- a/virtool/http/root.py
+++ b/virtool/http/root.py
@@ -16,64 +16,66 @@ async def get(req):
     app_data = {"endpoints": {
             "account": {
                 "url": "/api/account",
-                "doc": f"{API_URL_ROOT}_account.html"
+                "doc": f"{API_URL_ROOT}/account"
             },
             "analyses": {
                 "url": "/api/analyses",
-                "doc": f"{API_URL_ROOT}_analyses.html"
+                "doc": f"{API_URL_ROOT}/analyses"
             },
             "genbank": {
                 "url": "/api/genbank",
-                "doc": f"{API_URL_ROOT}_genbank.html"
+                "doc": f"{API_URL_ROOT}/genbank"
             },
             "groups": {
                 "url": "/api/groups",
-                "doc": f"{API_URL_ROOT}_groups.html"
+                "doc": f"{API_URL_ROOT}/groups"
             },
             "history": {
                 "url": "/api/history",
-                "doc": f"{API_URL_ROOT}_history.html"
+                "doc": f"{API_URL_ROOT}/history"
             },
             "hmm": {
                 "url": "/api/hmm",
-                "doc": f"{API_URL_ROOT}_hmm.html"
+                "doc": f"{API_URL_ROOT}/hmm"
             },
             "indexes": {
                 "url": "/api/indexes",
-                "doc": f"{API_URL_ROOT}_indexes.html"
+                "doc": f"{API_URL_ROOT}/indexes"
             },
             "jobs": {
                 "url": "/api/jobs",
-                "doc": f"{API_URL_ROOT}_jobs.html"
+                "doc": f"{API_URL_ROOT}/jobs"
             },
             "otus": {
                 "url": "/api/otus",
-                "doc": f"{API_URL_ROOT}_otus.html"
+                "doc": f"{API_URL_ROOT}/otus"
             },
             "references": {
                 "url": "/api/references",
-                "doc": f"{API_URL_ROOT}_references.html"
+                "doc": f"{API_URL_ROOT}/refs"
             },
             "samples": {
                 "url": "/api/samples",
-                "doc": f"{API_URL_ROOT}_samples.html"
+                "doc": f"{API_URL_ROOT}/samples"
             },
             "settings": {
                 "url": "/api/settings",
-                "doc": f"{API_URL_ROOT}_settings.html"
+                "doc": f"{API_URL_ROOT}/settings"
             },
             "subtraction": {
                 "url": "/api/subtraction",
-                "doc": f"{API_URL_ROOT}_subtraction.html"
+                "doc": f"{API_URL_ROOT}/subtraction"
             },
             "tasks": {
                 "url": "/api/tasks",
-                "doc": f"{API_URL_ROOT}_tasks.html"
+                "doc": f"{API_URL_ROOT}/tasks"
             },
             "users": {
                 "url": "/api/users",
-                "doc": f"{API_URL_ROOT}_users.html"
-            }}}
+                "doc": f"{API_URL_ROOT}/users"
+            }},
+        "dev": req.app["config"].dev
+    }
 
     try:
         app_data["version"] = req.app["version"]


### PR DESCRIPTION
Update documentation links in virtool.http.root. Add test to ensure that dev is included in the response from the GET /api request handler.