### PR TITLE
Use `subtractions` key instead of `subtraction_ids`

### DIFF
--- a/client/src/js/analyses/api.js
+++ b/client/src/js/analyses/api.js
@@ -9,7 +9,7 @@ export const analyze = ({ sampleId, refId, subtractionIds, workflow }) =>
     Request.post(`/api/samples/${sampleId}/analyses`).send({
         workflow,
         ref_id: refId,
-        subtraction_ids: subtractionIds
+        subtractions: subtractionIds
     });
 
 export const blastNuvs = ({ analysisId, sequenceIndex }) =>

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -714,7 +714,8 @@ async def analyze(req):
         "ref_id": ref_id,
         "sample_id": sample_id,
         "sample_name": sample["name"],
-        "index_id": document["index"]["id"]
+        "index_id": document["index"]["id"],
+        "subtractions": subtractions
     }
 
     rights = JobRights()


### PR DESCRIPTION
- Use key `subtractions` in POST request
- Add subtractions to `job_args` for pathoscope workflow