### PR TITLE
Support login with Azure AD B2C

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -202,6 +202,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "charset-normalizer"
+version = "2.0.7"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
@@ -255,6 +266,25 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 toml = ["toml"]
 
 [[package]]
+name = "cryptography"
+version = "35.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.12"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
+docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+sdist = ["setuptools_rust (>=0.11.4)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+
+[[package]]
 name = "dictdiffer"
 version = "0.8.1"
 description = "Dictdiffer is a library that helps you to diff and patch dictionaries."
@@ -282,6 +312,21 @@ doh = ["requests", "requests-toolbelt"]
 idna = ["idna (>=2.1)"]
 curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
 trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+description = "ECDSA cryptographic signature library (pure python)"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
 
 [[package]]
 name = "email-validator"
@@ -426,6 +471,19 @@ pymongo = ">=3.11,<4"
 encryption = ["pymongo[encryption] (>=3.11,<4)"]
 
 [[package]]
+name = "msal"
+version = "1.16.0"
+description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cryptography = ">=0.6,<38"
+PyJWT = {version = ">=1.0.0,<3", extras = ["crypto"]}
+requests = ">=2.0.0,<3"
+
+[[package]]
 name = "multidict"
 version = "5.1.0"
 description = "multidict implementation"
@@ -497,6 +555,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pyasn1"
+version = "0.4.8"
+description = "ASN.1 types and codecs"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pycares"
 version = "4.0.0"
 description = "Python interface for c-ares"
@@ -517,6 +583,23 @@ description = "C parser in Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyjwt"
+version = "2.3.0"
+description = "JSON Web Token implementation in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cryptography = {version = ">=3.3.1", optional = true, markers = "extra == \"crypto\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.3.1)"]
+dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pymongo"
@@ -684,12 +767,60 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-jose"
+version = "3.3.0"
+description = "JOSE implementation in Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "!=0.15"
+pyasn1 = "*"
+rsa = "*"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pycrypto (>=2.6.0,<2.7.0)", "pyasn1"]
+pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)", "pyasn1"]
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
+name = "requests"
+version = "2.26.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "rsa"
+version = "4.7.2"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "semver"
@@ -877,7 +1008,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "cd0e80f3126e830e6e82ece1118a01b82b761ae61085ac9f11ede72c4c637a36"
+content-hash = "55f49b4a7f04cf70a163d20c8ab9dd4e16b1687dcd2371f105ecb7a27c38e0d4"
 
 [metadata.files]
 aiodns = [
@@ -1132,6 +1263,10 @@ chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
 ]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
+    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
+]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
@@ -1201,6 +1336,28 @@ coverage = [
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
+cryptography = [
+    {file = "cryptography-35.0.0-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:d57e0cdc1b44b6cdf8af1d01807db06886f10177469312fbde8f44ccbb284bc9"},
+    {file = "cryptography-35.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:ced40344e811d6abba00295ced98c01aecf0c2de39481792d87af4fa58b7b4d6"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:54b2605e5475944e2213258e0ab8696f4f357a31371e538ef21e8d61c843c28d"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7b7ceeff114c31f285528ba8b390d3e9cfa2da17b56f11d366769a807f17cbaa"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d69645f535f4b2c722cfb07a8eab916265545b3475fdb34e0be2f4ee8b0b15e"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2d0e0acc20ede0f06ef7aa58546eee96d2592c00f450c9acb89c5879b61992"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6"},
+    {file = "cryptography-35.0.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7eba2cebca600a7806b893cb1d541a6e910afa87e97acf2021a22b32da1df52d"},
+    {file = "cryptography-35.0.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d90f4711bf63e2fb21e8c8e51ed8189438e6b35a6d996201ebd98a26abbbe6"},
+    {file = "cryptography-35.0.0-cp36-abi3-win32.whl", hash = "sha256:c10c797ac89c746e488d2ee92bd4abd593615694ee17b2500578b63cad6b93a8"},
+    {file = "cryptography-35.0.0-cp36-abi3-win_amd64.whl", hash = "sha256:7075b304cd567694dc692ffc9747f3e9cb393cc4aa4fb7b9f3abd6f5c4e43588"},
+    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a688ebcd08250eab5bb5bca318cc05a8c66de5e4171a65ca51db6bd753ff8953"},
+    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99915d6ab265c22873f1b4d6ea5ef462ef797b4140be4c9d8b179915e0985c6"},
+    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:928185a6d1ccdb816e883f56ebe92e975a262d31cc536429041921f8cb5a62fd"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:22a38e96118a4ce3b97509443feace1d1011d0571fae81fc3ad35f25ba3ea999"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:abb5a361d2585bb95012a19ed9b2c8f412c5d723a9836418fab7aaa0243e67d2"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1ed82abf16df40a60942a8c211251ae72858b25b7421ce2497c2eb7a1cee817c"},
+    {file = "cryptography-35.0.0.tar.gz", hash = "sha256:9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d"},
+]
 dictdiffer = [
     {file = "dictdiffer-0.8.1-py2.py3-none-any.whl", hash = "sha256:d79d9a39e459fe33497c858470ca0d2e93cb96621751de06d631856adfd9c390"},
     {file = "dictdiffer-0.8.1.tar.gz", hash = "sha256:1adec0d67cdf6166bda96ae2934ddb5e54433998ceab63c984574d187cc563d2"},
@@ -1208,6 +1365,10 @@ dictdiffer = [
 dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
     {file = "dnspython-2.1.0.zip", hash = "sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4"},
+]
+ecdsa = [
+    {file = "ecdsa-0.17.0-py2.py3-none-any.whl", hash = "sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676"},
+    {file = "ecdsa-0.17.0.tar.gz", hash = "sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa"},
 ]
 email-validator = [
     {file = "email_validator-1.1.3-py2.py3-none-any.whl", hash = "sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b"},
@@ -1399,6 +1560,10 @@ motor = [
     {file = "motor-2.4.0-py3-none-any.whl", hash = "sha256:839c11a43897dbec8e5ba0e87a9c9b877239803126877b2efa5cef89aa6b687a"},
     {file = "motor-2.4.0.tar.gz", hash = "sha256:1196db507142ef8f00d953efa2f37b39335ef2d72af6ce4fbccfd870b65c5e9f"},
 ]
+msal = [
+    {file = "msal-1.16.0-py2.py3-none-any.whl", hash = "sha256:a421a43413335099228f1d9ad93f7491d7c7c40044108290e4923fe58f41a332"},
+    {file = "msal-1.16.0.tar.gz", hash = "sha256:240fb04dba46a27fd6a3178db8334412d0d02e0be85166f9e05bb45d03399084"},
+]
 multidict = [
     {file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f"},
     {file = "multidict-5.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf"},
@@ -1514,6 +1679,21 @@ py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
 pycares = [
     {file = "pycares-4.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:db5a533111a3cfd481e7e4fb2bf8bef69f4fa100339803e0504dd5aecafb96a5"},
     {file = "pycares-4.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fdff88393c25016f417770d82678423fc7a56995abb2df3d2a1e55725db6977d"},
@@ -1552,6 +1732,10 @@ pycares = [
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pyjwt = [
+    {file = "PyJWT-2.3.0-py3-none-any.whl", hash = "sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f"},
+    {file = "PyJWT-2.3.0.tar.gz", hash = "sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41"},
 ]
 pymongo = [
     {file = "pymongo-3.11.4-cp27-cp27m-macosx_10_14_intel.whl", hash = "sha256:b7efc7e7049ef366777cfd35437c18a4166bb50a5606a1c840ee3b9624b54fc9"},
@@ -1664,6 +1848,10 @@ python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
+python-jose = [
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
     {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
@@ -1694,6 +1882,14 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+requests = [
+    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
+    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+rsa = [
+    {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
+    {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
 ]
 semver = [
     {file = "semver-2.13.0-py2.py3-none-any.whl", hash = "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ aiojobs = "^0.3.0"
 Cerberus = "^1.3.4"
 PyYAML = "^5.4.1"
 email-validator = "^1.1.3"
+PyJWT = "^2.3.0"
+msal = "^1.16.0"
+python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -64,7 +64,7 @@ def create_app(
         pg_connection_string,
         redis_connection_string,
         test_db_connection_string,
-        test_db_name,
+        test_db_name
 ):
     def _create_app(
             dev=False,
@@ -81,9 +81,9 @@ def create_app(
             no_client=True,
             postgres_connection_string=pg_connection_string,
             redis_connection_string=redis_connection_string,
-            fake=False,
-
+            fake=False
         )
+
         return virtool.app.create_app(config)
 
     return _create_app
@@ -107,7 +107,8 @@ def spawn_client(
             dev=False,
             enable_api=False,
             groups=None,
-            permissions=None
+            permissions=None,
+            use_b2c=False
     ):
         app = create_app(dev)
 
@@ -135,6 +136,12 @@ def spawn_client(
                 "session_id": "foobar",
                 "session_token": "bar"
             }
+
+        elif use_b2c:
+            cookies = {
+                "id_token": "foobar"
+            }
+
         else:
             cookies = {
                 "session_id": "dne"

--- a/tests/oidc/test_api.py
+++ b/tests/oidc/test_api.py
@@ -1,0 +1,9 @@
+async def test_delete_tokens(spawn_client):
+    """
+    Assert that id_token cookie is deleted from response at /api/oidc/delete_tokens endpoint
+    """
+    client = await spawn_client(use_b2c=True)
+
+    resp = await client.get("/api/oidc/delete_tokens")
+
+    assert resp.cookies.get("id_token") is None

--- a/tests/users/__snapshots__/test_db.ambr
+++ b/tests/users/__snapshots__/test_db.ambr
@@ -176,6 +176,45 @@
     },
   }
 ---
+# name: test_find_or_create_b2c_user[uvloop-None]
+  <class 'dict'> {
+    '_id': 'foobar',
+    'administrator': False,
+    'b2c_display_name': 'bobby',
+    'b2c_family_name': 'bobbert',
+    'b2c_given_name': 'bob',
+    'b2c_oid': 'abc123',
+    'force_reset': False,
+    'groups': <class 'list'> [
+    ],
+    'handle': 'bob123',
+    'invalidate_sessions': False,
+    'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+    'permissions': <class 'dict'> {
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    },
+    'primary_group': '',
+    'settings': <class 'dict'> {
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    },
+  }
+---
+# name: test_find_or_create_b2c_user[uvloop-oid]
+  <class 'dict'> {
+    '_id': 'foobar',
+    'b2c_oid': 'abc123',
+  }
+---
 # name: test_update_sessions_and_keys[uvloop-False-False-False]
   <class 'dict'> {
     '_id': 'foobar',

--- a/tests/users/__snapshots__/test_tasks.ambr
+++ b/tests/users/__snapshots__/test_tasks.ambr
@@ -1,8 +1,8 @@
 # name: test_update_user_document_task[uvloop-ad_user]
   <class 'dict'> {
     '_id': 'abc123',
-    'ad_family_name': 'bar',
-    'ad_given_name': 'foo',
+    'b2c_family_name': 'bar',
+    'b2c_given_name': 'foo',
     'handle': 'foo',
   }
 ---

--- a/tests/users/test_tasks.py
+++ b/tests/users/test_tasks.py
@@ -10,8 +10,8 @@ async def test_update_user_document_task(spawn_client, snapshot, pg_session, sta
     if user == "ad_user":
         document = {
             "_id": "abc123",
-            "ad_given_name": "foo",
-            "ad_family_name": "bar"
+            "b2c_given_name": "foo",
+            "b2c_family_name": "bar"
         }
 
     elif user == "existing_user":

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -16,7 +16,7 @@ from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_
 from virtool.shutdown import exit_redis, exit_executors, exit_client, exit_scheduler, exit_dispatcher
 from virtool.startup import init_executors, init_db, init_events, init_redis, init_refresh, init_routes, init_sentry, \
     init_settings, init_paths, init_tasks, init_postgres, init_version, init_dispatcher, init_client_path, \
-    init_http_client, init_jobs_client, init_task_runner, init_check_db
+    init_http_client, init_jobs_client, init_task_runner, init_check_db, init_b2c
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,9 @@ def create_app(config: Config):
         init_jobs_client,
         init_refresh
     ])
+
+    if config.use_b2c:
+        app.on_startup.append(init_b2c)
 
     app.on_response_prepare.append(virtool.http.csp.on_prepare)
 

--- a/virtool/config.py
+++ b/virtool/config.py
@@ -8,8 +8,8 @@ import uvloop
 
 import virtool.app
 import virtool.jobs.main
-from virtool.logs import configure_logs
 from virtool.configuration.config import Config
+from virtool.logs import configure_logs
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +136,46 @@ def cli(ctx, data_path, db_connection_string, db_name, dev, force_version, no_se
     help="Start with automatic fetching disabled",
     is_flag=True
 )
+@click.option(
+    "--b2c-client-id",
+    help="Azure AD B2C client ID, required for --use-b2c",
+    type=str
+)
+@click.option(
+    "--b2c-client-secret",
+    help="Azure AD B2C client secret, required for --use-b2c",
+    type=str
+)
+@click.option(
+    "--b2c-tenant",
+    help="Azure AD B2C tenant name",
+    type=str
+)
+@click.option(
+    "--b2c-user-flow",
+    help="Azure AD B2C signupsignin user flow, required for --use-b2c",
+    type=str,
+)
+@click.option(
+    "--use-b2c",
+    help="Use Azure AD B2C for authentication",
+    is_flag=True
+)
 @click.pass_context
-def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fetching):
+def start_server(
+        ctx,
+        host,
+        port,
+        no_check_db,
+        no_check_files,
+        no_client,
+        no_fetching,
+        b2c_client_id,
+        b2c_client_secret,
+        b2c_tenant,
+        b2c_user_flow,
+        use_b2c
+):
     configure_logs(ctx.obj["dev"], ctx.obj["verbose"])
 
     config = Config(
@@ -156,7 +194,12 @@ def start_server(ctx, host, port, no_check_db, no_check_files, no_client, no_fet
         proxy=ctx.obj["proxy"],
         host=host,
         no_client=no_client,
-        port=port
+        port=port,
+        b2c_client_id=b2c_client_id,
+        b2c_client_secret=b2c_client_secret,
+        b2c_tenant=b2c_tenant,
+        b2c_user_flow=b2c_user_flow,
+        use_b2c=use_b2c
     )
 
     logger.info("Starting in server mode")

--- a/virtool/configuration/config.py
+++ b/virtool/configuration/config.py
@@ -22,3 +22,8 @@ class Config(object):
     port: int = 9950
     fake: bool = False
     fake_path: Path = None
+    b2c_client_id: str = None
+    b2c_client_secret: str = None
+    b2c_tenant: str = None
+    b2c_user_flow: str = None
+    use_b2c: bool = False

--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -103,5 +103,5 @@ async def create_indexes(db):
     await db.samples.create_index([("created_at", pymongo.DESCENDING)])
     await db.sequences.create_index("otu_id")
     await db.sequences.create_index("name")
-    await db.users.create_index("ad_oid", unique=True, sparse=True)
+    await db.users.create_index("b2c_oid", unique=True, sparse=True)
     await db.users.create_index("handle", unique=True, sparse=True)

--- a/virtool/db/utils.py
+++ b/virtool/db/utils.py
@@ -192,12 +192,12 @@ async def handle_exists(collection, handle: str) -> bool:
     return bool(await collection.count_documents({"handle": handle}))
 
 
-async def oid_exists(collection, ad_oid: str) -> bool:
+async def oid_exists(collection, b2c_oid: str) -> bool:
     """
-    Check if the Azure AD oid exists in the collection.
+    Check if the oid from Azure AD B2C exists in the collection.
 
     :param collection: the Mongo collection to check the oid against
-    :param ad_oid: the Azure AD oid to check for
+    :param b2c_oid: the Azure AD B2C oid to check for
     :return: does the oid exist
     """
-    return bool(await collection.count_documents({"ad_oid": ad_oid}))
+    return bool(await collection.count_documents({"b2c_oid": b2c_oid}))

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -4,20 +4,33 @@ import aiofiles
 import jinja2
 from aiohttp import BasicAuth
 from aiohttp import web
-from aiohttp.web import Request, Response
+from aiohttp.web import Request, Response, HTTPFound
 from aiohttp.web_exceptions import HTTPUnauthorized
+from jose import ExpiredSignatureError
+from jose.exceptions import JWTClaimsError, JWTError
 
 import virtool.errors
+import virtool.utils
 from virtool.http.client import UserClient
 from virtool.http.utils import set_session_id_cookie
+from virtool.oidc.utils import validate_token, update_jwk_args
+from virtool.users.db import B2CUserAttributes, find_or_create_b2c_user
 from virtool.users.sessions import get_session, create_session, clear_reset_code
-from virtool.utils import hash_key
+from virtool.utils import random_alphanumeric
 
 AUTHORIZATION_PROJECTION = [
     "user",
     "administrator",
     "groups",
     "permissions"
+]
+
+PUBLIC_ROUTES = [
+    "/api/oidc/acquire_tokens",
+    "/api/oidc/refresh_tokens",
+    "/api/oidc/delete_tokens",
+    "/api/account/login",
+    "/api/account/logout"
 ]
 
 
@@ -62,7 +75,7 @@ def decode_authorization(authorization: str) -> Tuple[str, str]:
     return auth.login, auth.password
 
 
-async def authenticate_with_key(req: Request, handler: Callable):
+async def authenticate_with_key(req: Request, handler: Callable) -> Response:
     """
     Authenticate the request with an API key or job key.
 
@@ -78,7 +91,7 @@ async def authenticate_with_key(req: Request, handler: Callable):
     return await authenticate_with_api_key(req, handler, holder_id, key)
 
 
-async def authenticate_with_api_key(req: Request, handler: Callable, user_id: str, key: str):
+async def authenticate_with_api_key(req: Request, handler: Callable, user_id: str, key: str) -> Response:
     db = req.app["db"]
 
     document = await db.keys.find_one({
@@ -102,11 +115,75 @@ async def authenticate_with_api_key(req: Request, handler: Callable, user_id: st
     return await handler(req)
 
 
+async def authenticate_with_b2c(req: Request, handler: Callable) -> Response:
+    """
+    Authenticate requests when req.app["config"].use_b2c is True.
+
+    If no id_token cookie is attached to request, redirect to /api/acquire_tokens
+
+    If id_token cookie is found, attempt to validate to gather user information from claims. If token is expired,
+    redirect to /api/refresh_tokens. If token is invalid for some other reason, redirect to /api/delete_tokens
+
+    find or create user based on token claims, then populate req["cient"] with user information and return the
+    response from the handler.
+
+    :param req: the request to handle
+    :param handler: the handler to call with the request if it is authenticated successfully
+
+    :return: the response
+    """
+    if req.cookies.get("id_token") is None:
+        auth_code_flow = await req.app["run_in_thread"](
+            req.app["b2c"].msal.initiate_auth_code_flow,
+            ["email"],
+            f"http://localhost:9950/api/oidc/acquire_tokens",
+            random_alphanumeric(8)
+        )
+        req.app["b2c"].auth_code_flow = auth_code_flow
+        return HTTPFound(auth_code_flow["auth_uri"])
+
+    try:
+        token_claims = await validate_token(req.app, req.cookies.get("id_token"))
+    except ExpiredSignatureError:
+        return HTTPFound("/api/oidc/refresh_tokens")
+    except (JWTClaimsError, JWTError):
+        await update_jwk_args(req.app, req.cookies.get("id_token"))
+        return HTTPFound("/api/oidc/delete_tokens")
+
+    user_attributes = B2CUserAttributes(
+        display_name=token_claims["name"],
+        given_name=token_claims["given_name"],
+        family_name=token_claims["family_name"],
+        oid=token_claims["oid"]
+    )
+
+    user_document = await find_or_create_b2c_user(req.app["db"], user_attributes)
+
+    req["client"] = UserClient(
+        db=req.app["db"],
+        administrator=user_document["administrator"],
+        force_reset=False,
+        groups=user_document["groups"],
+        permissions=user_document["permissions"],
+        user_id=user_document["_id"],
+        authenticated=True
+    )
+
+    return await handler(req)
+
+
 @web.middleware
-async def middleware(req, handler):
+async def middleware(req, handler) -> Response:
+    """
+    Handle requests based on client type and authentication status.
+
+    :param req: the request to handle
+    :param handler: the handler to call with the request if it is authenticated successfully
+    :return: the response
+    """
     db = req.app["db"]
 
-    if req.path == "/api/account/login" or req.path == "/api/account/logout":
+    if req.path in PUBLIC_ROUTES:
         req["client"] = UserClient(
             db=db,
             administrator=False,
@@ -122,6 +199,9 @@ async def middleware(req, handler):
     if req.headers.get("AUTHORIZATION"):
         if can_use_key(req):
             return await authenticate_with_key(req, handler)
+
+    if req.app["config"].use_b2c:
+        return await authenticate_with_b2c(req, handler)
 
     # Get session information from cookies.
     session_id = req.cookies.get("session_id")
@@ -186,7 +266,7 @@ async def index_handler(req: Request) -> Response:
     """
     requires_first_user = not await req.app["db"].users.count_documents({})
 
-    requires_login = req["client"].authenticated is False
+    requires_login = not req.app["config"].use_b2c and not req["client"].authenticated
 
     path = req.app["client_path"] / "index.html"
 

--- a/virtool/http/routes.py
+++ b/virtool/http/routes.py
@@ -5,6 +5,7 @@ from aiohttp.web_exceptions import HTTPUnauthorized
 from aiohttp.web_routedef import RouteTableDef
 
 from virtool.api.response import json_response
+from virtool.http.auth import PUBLIC_ROUTES
 from virtool.users.utils import PERMISSIONS
 
 
@@ -42,10 +43,10 @@ def protect(
         async def wrapped(req):
             client = req["client"]
 
-            if not public and not client.authenticated:
+            if not public and not client.authenticated and req.path not in PUBLIC_ROUTES:
                 raise HTTPUnauthorized(text="Requires authorization")
 
-            if client is None or not client.administrator:
+            if not client.authenticated or not client.administrator:
                 if admin:
                     return json_response({
                         "id": "not_permitted",

--- a/virtool/oidc/api.py
+++ b/virtool/oidc/api.py
@@ -1,0 +1,90 @@
+from urllib.parse import parse_qs
+
+import jwt
+from aiohttp.web import Request, Response
+from aiohttp.web_exceptions import HTTPFound
+
+from virtool.http.routes import Routes
+
+routes = Routes()
+
+
+@routes.get("/api/oidc/acquire_tokens", public=True)
+async def acquire_tokens(req: Request) -> Response:
+    """
+    Gather authentication response from auth uri query string. Fetch tokens from b2c authorization endpoint.
+
+    Once tokens are acquired, redirect user back to Virtool homepage.
+
+    If error occurs during token retrieval, delete tokens to restart process.
+
+    :param req: the request to handle
+    :return: the response
+    """
+    auth_response = {key: value[0] for key, value in parse_qs(req.url.query_string).items()}
+
+    try:
+        result = await req.app["run_in_thread"](
+            req.app["b2c"].msal.acquire_token_by_auth_code_flow,
+            req.app["b2c"].auth_code_flow,
+            auth_response
+        )
+    except ValueError:
+        return HTTPFound("/api/oidc/delete_tokens")
+
+    resp = HTTPFound("/")
+
+    if "id_token" in result:
+        resp.set_cookie("id_token", result.get("id_token"), httponly=True)
+
+    return resp
+
+
+@routes.get("/api/oidc/refresh_tokens", public=True)
+async def refresh_tokens(req: Request) -> Response:
+    """
+    Silently retrieve tokens for account in token cache.
+
+    Fetch oid value stored in expired ID token, then fetch fresh tokens from token cache for the account with the
+    correct local account ID value.
+
+    If no accounts are found, or correct account isn't found, then redirect to /api/delete_tokens
+
+    :param req: the request to handle
+    :return: the response
+    """
+    accounts = req.app["b2c"].msal.get_accounts()
+
+    if accounts:
+        # decode token without validation to fetch oid value
+        payload = jwt.decode(req.cookies.get("id_token"), options={"verify_signature": False})
+
+        user_account = [account for account in accounts if payload["oid"] == account["local_account_id"]][0]
+
+        if user_account:
+            result = await req.app["run_in_thread"](
+                req.app["b2c"].msal.acquire_token_silent,
+                [],
+                user_account,
+                req.app["b2c"].authority
+            )
+
+            if "id_token" in result:
+                resp = HTTPFound("/")
+                resp.set_cookie("id_token", result.get("id_token"), httponly=True)
+                return resp
+
+    return HTTPFound("/api/oidc/delete_tokens")
+
+
+@routes.get("/api/oidc/delete_tokens", public=True)
+async def delete_tokens(req: Request) -> Response:
+    """
+    Delete id_token cookie from response.
+
+    :param req: the request to handle
+    :return: the response
+    """
+    resp = HTTPFound("/")
+    resp.del_cookie("id_token")
+    return resp

--- a/virtool/oidc/utils.py
+++ b/virtool/oidc/utils.py
@@ -1,0 +1,76 @@
+import json
+from dataclasses import dataclass, asdict
+
+import jwt
+from aiohttp.web import Application
+from jose.jwt import decode, get_unverified_header
+
+
+@dataclass
+class JWKArgs:
+    kty: str
+    kid: str
+    use: str
+    n: str
+    e: str
+
+
+async def validate_token(app: Application, token: jwt) -> dict:
+    """
+    Validate token and return claims using JWK_ARGS environment variable.
+
+    :param token: JWT token to validate
+    :param app: the application object
+    :return: JWT claims
+    """
+
+    jwk_args = app["b2c"].jwk_args or await update_jwk_args(app, token)
+
+    return decode(
+        token,
+        asdict(jwk_args),
+        algorithms=["RS256"],
+        audience=app["config"].b2c_client_id
+    )
+
+
+async def update_jwk_args(app: Application, token: jwt) -> JWKArgs:
+    """
+    Update jwk_args and store in environment variable
+
+    :param token: JWT token to validate and decode
+    :param app: the app object
+    :return: jwk_args
+    """
+    header = await app["run_in_thread"](get_unverified_header, token)
+    authority = app["b2c"].authority
+    resp = await app["client"].get(f"{authority}/discovery/v2.0/keys", allow_redirects=True)
+    jwks = json.loads(await resp.text())
+
+    jwk = await get_matching_jwk(jwks, header["kid"])
+
+    jwk_args = JWKArgs(
+        kty=jwk["kty"],
+        kid=jwk["kid"],
+        use=jwk["use"],
+        n=jwk["n"],
+        e=jwk["e"]
+    )
+
+    app["b2c"].jwk_args = jwk_args
+
+    return jwk_args
+
+
+async def get_matching_jwk(jwks: dict, kid: str) -> dict:
+    """
+    Iterate through JSON web key set and return first key with matching KID from the token header.
+
+    :param jwks: JSON web key set
+    :param kid: Json web key ID from token header
+
+    :return: JWK with matching KID
+    """
+    for jwk in jwks["keys"]:
+        if jwk["kid"] == kid:
+            return jwk

--- a/virtool/routes.py
+++ b/virtool/routes.py
@@ -16,6 +16,7 @@ import virtool.http.ws
 import virtool.indexes.api
 import virtool.jobs.api
 import virtool.labels.api
+import virtool.oidc.api
 import virtool.otus.api
 import virtool.references.api
 import virtool.samples.api
@@ -61,7 +62,8 @@ ROUTES = (
     virtool.settings.api.routes,
     virtool.subtractions.api.routes,
     virtool.uploads.api.routes,
-    virtool.users.api.routes
+    virtool.users.api.routes,
+    virtool.oidc.api.routes
 )
 
 

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -4,6 +4,7 @@ import logging
 import signal
 import sys
 import typing
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
@@ -12,6 +13,7 @@ import aiojobs
 import aiojobs.aiohttp
 import pymongo.errors
 from aiohttp.web import Application
+from msal import ClientApplication
 
 import virtool.db.mongo
 import virtool.pg.utils
@@ -27,6 +29,7 @@ from virtool.fake.wrapper import FakerWrapper
 from virtool.hmm.db import refresh
 from virtool.indexes.tasks import AddIndexFilesTask
 from virtool.jobs.client import JobsClient
+from virtool.oidc.utils import JWKArgs
 from virtool.pg.testing import create_test_database
 from virtool.references.db import refresh_remotes
 from virtool.references.tasks import CreateIndexJSONTask, DeleteReferenceTask
@@ -45,6 +48,14 @@ from virtool.utils import random_alphanumeric, get_client_path, ensure_data_dir
 from virtool.version import determine_server_version
 
 logger = logging.getLogger("startup")
+
+
+@dataclass
+class B2C:
+    msal: ClientApplication
+    authority: str
+    jwk_args: JWKArgs = None
+    auth_code_flow: dict = None
 
 
 def create_events() -> dict:
@@ -347,6 +358,35 @@ async def init_version(app: typing.Union[dict, Application]):
     logger.info(f"Mode: {app['mode']}")
 
     app["version"] = version
+
+
+async def init_b2c(app: Application):
+    """
+    Initiate connection to Azure AD B2C tenant.
+
+    :param app: Application object
+    """
+    b2c_tenant = app["config"].b2c_tenant
+    b2c_user_flow = app["config"].b2c_user_flow
+
+    if not all([
+        app["config"].b2c_client_id,
+        app["config"].b2c_client_secret,
+        b2c_tenant,
+        b2c_user_flow
+    ]):
+        logger.fatal("Required B2C client information not provided for --use-b2c option")
+        sys.exit(1)
+
+    authority = f"https://{b2c_tenant}.b2clogin.com/{b2c_tenant}.onmicrosoft.com/{b2c_user_flow}"
+
+    msal = ClientApplication(
+        client_id=app["config"].b2c_client_id,
+        authority=authority,
+        client_credential=app["config"].b2c_client_secret
+    )
+
+    app["b2c"] = B2C(msal, authority)
 
 
 async def init_task_runner(app: Application):

--- a/virtool/users/tasks.py
+++ b/virtool/users/tasks.py
@@ -9,7 +9,7 @@ class UpdateUserDocumentsTask(Task):
     """
     Update user documents that don't contain a "handle" field.
 
-    For AD users with ad_given_name and ad_family_name included in their user document, generate handle.
+    For B2C users with b2c_given_name and b2c_family_name included in their user document, generate handle.
 
     For all other users use existing _id values as handle.
 
@@ -27,11 +27,11 @@ class UpdateUserDocumentsTask(Task):
         async for document in self.db.users.find({"handle": {"$exists": False}}):
             user_id = document["_id"]
 
-            if "ad_given_name" in document and "ad_family_name" in document:
+            if "b2c_given_name" in document and "b2c_family_name" in document:
                 handle = await virtool.users.db.generate_handle(
                     self.db,
-                    document["ad_given_name"],
-                    document["ad_family_name"]
+                    document["b2c_given_name"],
+                    document["b2c_family_name"]
                 )
             else:
                 handle = user_id


### PR DESCRIPTION
When server is started with --use-b2c option, prompt user login or account creation with B2C.

Retrieve ID token for user once they have logged in via B2C and refresh tokens when they've expired.

Once tokens are retrieved from B2C, create corresponding user document in virtool database.

Add new tests and error handling for B2C operations.