### PR TITLE
feat: return more user data in API responses

### DIFF
--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -26,6 +26,11 @@
     'sample': <class 'dict'> {
       'id': 'sample1',
     },
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'workflow': 'test_workflow',
   }
 ---
@@ -38,6 +43,9 @@
     },
     'sample': <class 'dict'> {
       'id': 'sample1',
+    },
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
     },
     'workflow': 'test_workflow',
   }
@@ -64,7 +72,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -87,7 +97,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -110,7 +122,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -154,6 +168,11 @@
         'name': 'Apple',
       },
     ],
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'workflow': 'pathoscope_bowtie',
   }
 ---
@@ -162,6 +181,11 @@
     'created_at': '2015-10-06T20:00:00Z',
     'formatted': True,
     'id': 'foo',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_get[uvloop-None-True].1
@@ -187,15 +211,12 @@
       'id': 'baz',
     },
     'subtractions': <class 'list'> [
-      <class 'dict'> {
-        'id': 'plum',
-        'name': 'Plum',
-      },
-      <class 'dict'> {
-        'id': 'apple',
-        'name': 'Apple',
-      },
+      'plum',
+      'apple',
     ],
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'workflow': 'pathoscope_bowtie',
   }
 ---

--- a/tests/dispatcher/test_fetchers.py
+++ b/tests/dispatcher/test_fetchers.py
@@ -1,7 +1,8 @@
 import pytest
-
 from virtool.dispatcher.change import Change
-from virtool.dispatcher.fetchers import IndexesFetcher, SimpleMongoFetcher, LabelsFetcher, UploadsFetcher, TasksFetcher
+from virtool.dispatcher.fetchers import (IndexesFetcher, LabelsFetcher,
+                                         SimpleMongoFetcher, TasksFetcher,
+                                         UploadsFetcher)
 from virtool.dispatcher.operations import DELETE, INSERT, UPDATE
 from virtool.uploads.models import UploadType
 
@@ -42,7 +43,8 @@ class TestSimpleMongoFetcher:
         ])
 
         if use_projection:
-            fetcher = SimpleMongoFetcher(dbi.hmm, projection=["name", "include"])
+            fetcher = SimpleMongoFetcher(
+                dbi.hmm, projection=["name", "include"])
         else:
             fetcher = SimpleMongoFetcher(dbi.hmm)
 
@@ -311,7 +313,7 @@ class TestUploadsFetcher:
                 'reserved': False,
                 "size": None,
                 "type": UploadType.reads,
-                "user": "danny",
+                "user": "7CtBo2yG",
                 "uploaded_at": None
             },
             "interface": "uploads",

--- a/tests/fake/test_yaml_loading.py
+++ b/tests/fake/test_yaml_loading.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from virtool.dev.fake import populate
 from virtool.fake.factory import load_test_case_from_yml
 
@@ -11,7 +10,9 @@ def example_test_case(test_files_path) -> Path:
     return test_files_path / "fake/test_case.yml"
 
 
-async def test_load_yml(app, run_in_thread, example_test_case):
+async def test_load_yml(app, fake, run_in_thread, example_test_case):
+    await fake.users.insert()
+
     app["run_in_thread"] = run_in_thread
     case = await load_test_case_from_yml(app, example_test_case)
 

--- a/tests/fixtures/fake.py
+++ b/tests/fixtures/fake.py
@@ -1,6 +1,118 @@
-import pytest
+from abc import ABC, abstractmethod
 
+import pytest
+from attr import dataclass
+from faker.proxy import Faker
 from virtool.fake.wrapper import FakerWrapper
+
+
+class AbstractFakeDataGenerator(ABC):
+
+    @abstractmethod
+    def create() -> dict:
+        ...
+
+    @abstractmethod
+    async def insert() -> dict:
+        ...
+
+    @abstractmethod
+    async def get_id() -> str:
+        ...
+
+
+class FakeJobGenerator(AbstractFakeDataGenerator):
+
+    def __init__(self, fake_generator, db):
+        self.generator = fake_generator
+
+        self._db = db
+        self._faker = Faker()
+
+    async def create(self) -> dict:
+        return {
+            "acquired": self._faker.pybool(),
+            "workflow": "nuvs",
+            "args": {},
+            "key": None,
+            "rights": {},
+            "state": "waiting",
+            "status": [
+                {
+                    "state": "waiting",
+                    "stage": None,
+                    "error": None,
+                    "progress": 0,
+                    "timestamp": self._faker.date_time()
+                }
+            ],
+            "user": {
+                "id": await self.generator.users.get_id()
+            }
+        }
+
+    async def insert(self) -> dict:
+        document = await self.create()
+        await self._db.jobs.insert_one(document)
+        return document
+
+    async def get_id(self):
+        id_list = await self._db.jobs.distinct("_id")
+
+        if id_list:
+            return self._faker.random_element(id_list)
+
+        document = await self.insert()
+
+        return document["_id"]
+
+
+class FakeUserGenerator(AbstractFakeDataGenerator):
+
+    def __init__(self, fake_generator, db):
+        self.generator = fake_generator
+
+        self._db = db
+        self._faker = FakerWrapper()
+
+    async def create(self):
+        profile = self._faker.profile()
+
+        return {
+            "_id": self._faker.get_mongo_id(),
+            "groups": [
+                "technicians",
+                "bosses"
+            ],
+            "handle": profile["username"],
+            "primary_group": "technicians",
+            "username": profile["username"],
+            "permissions": [],
+            "administrator": False,
+            "created_at": self._faker.date_time()
+        }
+
+    async def insert(self):
+        document = await self.create()
+        await self._db.users.insert_one(document)
+        return document
+
+    async def get_id(self):
+        id_list = await self._db.users.distinct("_id")
+
+        if id_list:
+            return self._faker.random_element(id_list)
+
+        document = await self.insert()
+
+        return document["_id"]
+
+
+class FakeGenerator:
+
+    def __init__(self, db):
+        self.jobs = FakeJobGenerator(self, db)
+        self.users = FakeUserGenerator(self, db)
 
 
 @pytest.fixture
@@ -11,4 +123,9 @@ def app(dbi, pg, tmp_path, config, settings):
         "pg": pg,
         "settings": settings,
         "config": config
-        }
+    }
+
+
+@pytest.fixture
+def fake(dbi):
+    return FakeGenerator(dbi)

--- a/tests/fixtures/uploads.py
+++ b/tests/fixtures/uploads.py
@@ -1,16 +1,33 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-
 from virtool.uploads.models import Upload
 
 
 @pytest.fixture
-async def test_uploads(pg, static_time):
-    upload_1 = Upload(id=1, name="test.fq.gz", type="reads", user="danny")
-    upload_2 = Upload(id=2, name="test.fq.gz", type="reference", user="lester")
-    upload_3 = Upload(id=3, name="test.fq.gz", user="jake")
+async def test_uploads(pg, fake, static_time):
+    user_1 = await fake.users.insert()
+    user_2 = await fake.users.insert()
+
+    upload_1 = Upload(
+        id=1,
+        name="test.fq.gz",
+        type="reads",
+        user=user_1["_id"]
+    )
+
+    upload_2 = Upload(
+        id=2,
+        name="test.fq.gz",
+        type="reference",
+        user=user_1["_id"]
+    )
+
+    upload_3 = Upload(
+        id=3,
+        name="test.fq.gz",
+        user=user_2["_id"]
+    )
 
     async with AsyncSession(pg) as session:
         session.add_all([upload_1, upload_2, upload_3])
-
         await session.commit()

--- a/tests/history/__snapshots__/test_api.ambr
+++ b/tests/history/__snapshots__/test_api.ambr
@@ -19,6 +19,8 @@
           'id': 'hxn167',
         },
         'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'bob',
           'id': 'test',
         },
       },
@@ -40,6 +42,8 @@
           'id': 'hxn167',
         },
         'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'bob',
           'id': 'test',
         },
       },
@@ -61,6 +65,8 @@
           'id': 'hxn167',
         },
         'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'bob',
           'id': 'test',
         },
       },
@@ -117,6 +123,8 @@
       'id': 'hxn167',
     },
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
   }

--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -322,12 +322,22 @@
       'foo': 'bar',
     },
     'id': 'baz.2',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_get[uvloop-True]
   <class 'dict'> {
     'diff': 'loaded',
     'id': 'baz.2',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_get_most_recent_change[uvloop-False]

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -30,7 +30,7 @@ async def test_get(error, snapshot, resp_is, spawn_client, test_changes, static_
 
     change_id = "baz.1" if error else "6116cba1.1"
 
-    resp = await client.get("/api/history/" + change_id)
+    resp = await client.get(f"/api/history/{change_id}")
 
     if error:
         await resp_is.not_found(resp)

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -84,16 +84,23 @@ class TestAdd:
 
 
 @pytest.mark.parametrize("file", [True, False])
-async def test_get(file, mocker, snapshot, dbi, tmp_path, config):
+async def test_get(file, mocker, snapshot, dbi, fake, tmp_path, config):
+    user = await fake.users.insert()
+
     await dbi.history.insert_one({
         "_id": "baz.2",
         "diff": "file" if file else {
             "foo": "bar"
+        },
+        "user": {
+            "id": user["_id"]
         }
     })
 
-    mocker.patch("virtool.history.utils.read_diff_file",
-                 make_mocked_coro(return_value="loaded"))
+    mocker.patch(
+        "virtool.history.utils.read_diff_file",
+        make_mocked_coro(return_value="loaded")
+    )
 
     app = {
         "db": dbi,

--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -1,5 +1,6 @@
 # name: TestCreate.test[True-uvloop]
   <class 'dict'> {
+    'change_count': 1,
     'created_at': '2015-10-06T20:00:00Z',
     'has_files': True,
     'has_json': False,
@@ -8,11 +9,14 @@
       'id': 'u3cuwaoq',
     },
     'manifest': 'manifest',
+    'modified_otu_count': 0,
     'ready': False,
     'reference': <class 'dict'> {
       'id': 'foo',
     },
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
     'version': 9,
@@ -98,6 +102,7 @@
 ---
 # name: test_finalize[uvloop-None]
   <class 'dict'> {
+    'change_count': 0,
     'files': <class 'list'> [
       <class 'dict'> {
         'download_url': '/api/indexes/test_index/files/reference.json.gz',
@@ -165,9 +170,15 @@
       },
     ],
     'id': 'test_index',
+    'modified_otu_count': 0,
     'ready': True,
     'reference': <class 'dict'> {
       'id': 'hxn167',
+    },
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
   }
 ---
@@ -214,7 +225,9 @@
           'id': 'bar',
         },
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'version': 1,
       },
@@ -232,7 +245,9 @@
           'id': 'foo',
         },
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'version': 0,
       },
@@ -356,7 +371,9 @@
     ],
     'ready': False,
     'user': <class 'dict'> {
-      'id': 'test',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
     'version': 0,
   }
@@ -378,7 +395,7 @@
       'id': 'bar',
     },
     'user': <class 'dict'> {
-      'id': 'test',
+      'id': '7CtBo2yG',
     },
   }
 ---

--- a/tests/indexes/__snapshots__/test_db.ambr
+++ b/tests/indexes/__snapshots__/test_db.ambr
@@ -124,3 +124,15 @@
     },
   }
 ---
+# name: test_processor[uvloop]
+  <class 'dict'> {
+    'change_count': 5,
+    'id': 'baz',
+    'modified_otu_count': 2,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
+  }
+---

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -9,10 +9,14 @@
       'username': 'igboyes',
       'workflow': 'nuvs',
     },
+    'created_at': '2015-10-06T20:00:00Z',
     'id': '4c530449',
     'key': 'key',
     'mem': 16,
     'proc': 10,
+    'progress': 1.0,
+    'stage': 'import_results',
+    'state': 'complete',
     'status': <class 'list'> [
       <class 'dict'> {
         'error': None,
@@ -44,12 +48,14 @@
       },
     ],
     'user': <class 'dict'> {
-      'id': 'igboyes',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
     'workflow': 'build_index',
   }
 ---
-# name: test_cancel[uvloop]
+# name: test_cancel[uvloop-None]
   <class 'dict'> {
     'acquired': False,
     'args': <class 'dict'> {
@@ -60,10 +66,13 @@
       'username': 'igboyes',
       'workflow': 'nuvs',
     },
+    'created_at': '2015-10-06T20:00:00Z',
     'id': '4c530449',
     'mem': 16,
     'proc': 10,
-    'state': 'cancelling',
+    'progress': 0.091,
+    'stage': 'mk_analysis_dir',
+    'state': 'running',
     'status': <class 'list'> [
       <class 'dict'> {
         'error': None,
@@ -88,7 +97,9 @@
       },
     ],
     'user': <class 'dict'> {
-      'id': 'igboyes',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
     'workflow': 'build_index',
   }
@@ -104,9 +115,13 @@
       'username': 'igboyes',
       'workflow': 'nuvs',
     },
+    'created_at': '2015-10-06T20:00:00Z',
     'id': '4c530449',
     'mem': 16,
     'proc': 10,
+    'progress': 1.0,
+    'stage': 'import_results',
+    'state': 'complete',
     'status': <class 'list'> [
       <class 'dict'> {
         'error': None,
@@ -138,7 +153,9 @@
       },
     ],
     'user': <class 'dict'> {
-      'id': 'igboyes',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
     'workflow': 'build_index',
   }

--- a/tests/jobs/__snapshots__/test_db.ambr
+++ b/tests/jobs/__snapshots__/test_db.ambr
@@ -113,8 +113,40 @@
     'progress': 1.0,
     'stage': 'import_results',
     'state': 'complete',
+    'status': <class 'list'> [
+      <class 'dict'> {
+        'error': None,
+        'progress': 0,
+        'stage': None,
+        'state': 'waiting',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+      <class 'dict'> {
+        'error': None,
+        'progress': 0,
+        'stage': None,
+        'state': 'running',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+      <class 'dict'> {
+        'error': None,
+        'progress': 0.091,
+        'stage': 'mk_analysis_dir',
+        'state': 'running',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+      <class 'dict'> {
+        'error': None,
+        'progress': 1.0,
+        'stage': 'import_results',
+        'state': 'complete',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+    ],
     'user': <class 'dict'> {
-      'id': 'igboyes',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
     'workflow': 'build_index',
   }

--- a/tests/jobs/test_db.py
+++ b/tests/jobs/test_db.py
@@ -12,11 +12,17 @@ status = {
 }
 
 
-async def test_processor(snapshot, dbi, static_time, test_job):
+async def test_processor(snapshot, dbi, fake, static_time, test_job):
     """
     Test that the dispatch processor properly formats a raw job document into a dispatchable format.
 
     """
+    user = await fake.users.insert()
+
+    test_job["user"] = {
+        "id": user["_id"]
+    }
+
     assert await virtool.jobs.db.processor(dbi, test_job) == snapshot
 
 

--- a/tests/labels/test_api.py
+++ b/tests/labels/test_api.py
@@ -10,10 +10,19 @@ class TestFind:
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        label_1 = Label(id=1, name="Bug", color="#a83432",
-                        description="This is a bug")
-        label_2 = Label(id=2, name="Question", color="#03fc20",
-                        description="This is a question")
+        label_1 = Label(
+            id=1,
+            name="Bug",
+            color="#a83432",
+            description="This is a bug"
+        )
+
+        label_2 = Label(
+            id=2,
+            name="Question",
+            color="#03fc20",
+            description="This is a question"
+        )
 
         await client.db.samples.insert_many([
             {

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -111,7 +111,7 @@ class TestCreate:
         assert await client.db.otus.find_one() == snapshot
         assert await client.db.history.find_one() == snapshot
 
-    @ pytest.mark.parametrize("error,message", [
+    @pytest.mark.parametrize("error,message", [
         (None, None),
         ("400_name_exists", "Name already exists"),
         ("400_abbr_exists", "Abbreviation already exists"),
@@ -171,7 +171,7 @@ class TestCreate:
 
 class TestEdit:
 
-    @ pytest.mark.parametrize("data, existing_abbreviation, description", [
+    @pytest.mark.parametrize("data, existing_abbreviation, description", [
         # Name, ONLY.
         (
             {
@@ -285,7 +285,7 @@ class TestEdit:
         assert await client.db.otus.find_one() == snapshot
         assert await client.db.history.find_one() == snapshot
 
-    @ pytest.mark.parametrize("data,message", [
+    @pytest.mark.parametrize("data,message", [
         (
             {
                 "name": "Tobacco mosaic virus",
@@ -345,7 +345,7 @@ class TestEdit:
 
         await resp_is.bad_request(resp, message)
 
-    @ pytest.mark.parametrize("old_name,old_abbreviation,data", [
+    @pytest.mark.parametrize("old_name,old_abbreviation,data", [
         (
             "Tobacco mosaic otu",
             "TMV",
@@ -493,7 +493,7 @@ async def test_get_isolate(error, snapshot, spawn_client, resp_is, test_otu, tes
 
 class TestAddIsolate:
 
-    @ pytest.mark.parametrize("default", [True, False])
+    @pytest.mark.parametrize("default", [True, False])
     async def test_default(self, default, mocker, snapshot, spawn_client, check_ref_right, resp_is, test_otu,
                            test_random_alphanumeric):
         """

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -58,12 +58,6 @@
 # name: test_create[uvloop-barcode].1
   <class 'dict'> {
     'contributors': <class 'list'> [
-      <class 'dict'> {
-        'bob': 4,
-      },
-      <class 'dict'> {
-        'fred': 10,
-      },
     ],
     'created_at': '2015-10-06T20:00:00Z',
     'data_type': 'barcode',
@@ -71,17 +65,11 @@
     'groups': <class 'list'> [
     ],
     'id': '9pfsom1b',
-    'internal_control': <class 'dict'> {
-      'id': 'foo',
-      'name': 'Foo virus',
-    },
-    'latest_build': <class 'dict'> {
-      'created_at': '2015-10-06T20:00:00Z',
-      'id': 'foo',
-    },
+    'internal_control': None,
+    'latest_build': None,
     'name': 'Test Viruses',
     'organism': 'virus',
-    'otu_count': 22,
+    'otu_count': 0,
     'restrict_source_types': False,
     'source_types': <class 'list'> [
       'strain',
@@ -89,8 +77,10 @@
     ],
     'targets': <class 'list'> [
     ],
-    'unbuilt_change_count': 5,
+    'unbuilt_change_count': 0,
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
     'users': <class 'list'> [
@@ -110,12 +100,6 @@
 # name: test_create[uvloop-genome].1
   <class 'dict'> {
     'contributors': <class 'list'> [
-      <class 'dict'> {
-        'bob': 4,
-      },
-      <class 'dict'> {
-        'fred': 10,
-      },
     ],
     'created_at': '2015-10-06T20:00:00Z',
     'data_type': 'genome',
@@ -123,24 +107,20 @@
     'groups': <class 'list'> [
     ],
     'id': '9pfsom1b',
-    'internal_control': <class 'dict'> {
-      'id': 'foo',
-      'name': 'Foo virus',
-    },
-    'latest_build': <class 'dict'> {
-      'created_at': '2015-10-06T20:00:00Z',
-      'id': 'foo',
-    },
+    'internal_control': None,
+    'latest_build': None,
     'name': 'Test Viruses',
     'organism': 'virus',
-    'otu_count': 22,
+    'otu_count': 0,
     'restrict_source_types': False,
     'source_types': <class 'list'> [
       'strain',
       'isolate',
     ],
-    'unbuilt_change_count': 5,
+    'unbuilt_change_count': 0,
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
     'users': <class 'list'> [
@@ -205,6 +185,11 @@
       },
     ],
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
         'id': 'bob',
@@ -225,6 +210,9 @@
         'required': True,
       },
     ],
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
         'id': 'bob',
@@ -244,6 +232,11 @@
     'name': 'Bar',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
         'id': 'bob',
@@ -257,6 +250,9 @@
     'data_type': 'genome',
     'description': 'This is a test reference.',
     'name': 'Bar',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
         'id': 'bob',

--- a/tests/references/__snapshots__/test_db.ambr
+++ b/tests/references/__snapshots__/test_db.ambr
@@ -10,9 +10,14 @@
     'name': 'Tester',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -22,11 +27,14 @@
     '_id': 'foo',
     'data_type': 'genome',
     'description': 'This is a test reference.',
-    'internal_control': None,
+    'internal_control': '',
     'name': 'Tester',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -45,9 +53,14 @@
     'name': 'Tester',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -57,11 +70,14 @@
     '_id': 'foo',
     'data_type': 'genome',
     'description': 'This is a test reference.',
-    'internal_control': None,
+    'internal_control': '',
     'name': 'Tester',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -78,9 +94,14 @@
     'name': 'Tester',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -94,9 +115,12 @@
       'id': 'bar',
     },
     'name': 'Tester',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -115,9 +139,14 @@
     'name': 'Tester',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -131,9 +160,12 @@
       'id': 'bar',
     },
     'name': 'Tester',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -150,9 +182,14 @@
     'name': 'Tester',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -162,11 +199,14 @@
     '_id': 'foo',
     'data_type': 'genome',
     'description': 'This is a test reference.',
-    'internal_control': None,
+    'internal_control': 'baz',
     'name': 'Tester',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -185,9 +225,14 @@
     'name': 'Tester',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -197,13 +242,14 @@
     '_id': 'foo',
     'data_type': 'genome',
     'description': 'This is a test reference.',
-    'internal_control': <class 'dict'> {
-      'id': 'baz',
-    },
+    'internal_control': 'baz',
     'name': 'Tester',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
       },
     ],
   }
@@ -219,6 +265,11 @@
     'name': 'Bar',
     'otu_count': 0,
     'unbuilt_change_count': 0,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
         'id': 'bob',
@@ -234,6 +285,9 @@
       'id': 'bar',
     },
     'name': 'Bar',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
     'users': <class 'list'> [
       <class 'dict'> {
         'id': 'bob',

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -45,6 +45,8 @@
       },
     ],
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
   }
@@ -130,6 +132,8 @@
       },
     ],
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
   }
@@ -215,6 +219,8 @@
       },
     ],
     'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
       'id': 'test',
     },
   }
@@ -301,6 +307,11 @@
         'name': 'Foo',
       },
     ],
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: TestEdit.test_label_exists[uvloop-True]
@@ -325,6 +336,11 @@
     'reads': <class 'list'> [
     ],
     'ready': True,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: TestEdit.test_name_exists[uvloop-False]
@@ -343,6 +359,11 @@
     'reads': <class 'list'> [
     ],
     'ready': True,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: TestEdit.test_subtraction_exists[uvloop-True]
@@ -371,6 +392,11 @@
         'name': 'Bar',
       },
     ],
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: TestUploadReads.test_upload_reads[uvloop-True]
@@ -443,6 +469,11 @@
       },
     ],
     'ready': True,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_finalize_cache[uvloop-quality]
@@ -455,6 +486,63 @@
     'sample': <class 'dict'> {
       'id': 'test',
     },
+  }
+---
+# name: test_find[uvloop-LB1U-None-None-None]
+  <class 'dict'> {
+    'documents': <class 'list'> [
+      <class 'dict'> {
+        'created_at': '2015-10-06T22:00:00Z',
+        'host': '',
+        'id': 'cb400e6d',
+        'isolate': '',
+        'labels': <class 'list'> [
+          <class 'dict'> {
+            'color': '#0d321d',
+            'description': 'This is a question',
+            'id': 3,
+            'name': 'Question',
+          },
+        ],
+        'name': '16SPP044',
+        'nuvs': False,
+        'pathoscope': False,
+        'ready': True,
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
+        },
+      },
+      <class 'dict'> {
+        'created_at': '2015-10-06T20:00:00Z',
+        'host': '',
+        'id': '72bb8b31',
+        'isolate': 'Test',
+        'labels': <class 'list'> [
+          <class 'dict'> {
+            'color': '#a83432',
+            'description': 'This is a bug',
+            'id': 1,
+            'name': 'Bug',
+          },
+        ],
+        'name': '16GVP043',
+        'nuvs': False,
+        'pathoscope': False,
+        'ready': True,
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
+        },
+      },
+    ],
+    'found_count': 2,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3,
   }
 ---
 # name: test_find[uvloop-None-2-1-None]
@@ -478,7 +566,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
       <class 'dict'> {
@@ -505,7 +595,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
       },
     ],
@@ -537,7 +629,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
     ],
@@ -569,7 +663,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
       <class 'dict'> {
@@ -596,7 +692,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
       },
       <class 'dict'> {
@@ -617,7 +715,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
     ],
@@ -649,7 +749,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
     ],
@@ -681,7 +783,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
       <class 'dict'> {
@@ -708,7 +812,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
       },
     ],
@@ -751,64 +857,13 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
     ],
     'found_count': 1,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
-  }
----
-# name: test_find[uvloop-fred-None-None-None]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-      <class 'dict'> {
-        'created_at': '2015-10-06T22:00:00Z',
-        'host': '',
-        'id': 'cb400e6d',
-        'isolate': '',
-        'labels': <class 'list'> [
-          <class 'dict'> {
-            'color': '#0d321d',
-            'description': 'This is a question',
-            'id': 3,
-            'name': 'Question',
-          },
-        ],
-        'name': '16SPP044',
-        'nuvs': False,
-        'pathoscope': False,
-        'ready': True,
-        'user': <class 'dict'> {
-          'id': 'fred',
-        },
-      },
-      <class 'dict'> {
-        'created_at': '2015-10-06T20:00:00Z',
-        'host': '',
-        'id': '72bb8b31',
-        'isolate': 'Test',
-        'labels': <class 'list'> [
-          <class 'dict'> {
-            'color': '#a83432',
-            'description': 'This is a bug',
-            'id': 1,
-            'name': 'Bug',
-          },
-        ],
-        'name': '16GVP043',
-        'nuvs': False,
-        'pathoscope': False,
-        'ready': True,
-        'user': <class 'dict'> {
-          'id': 'fred',
-        },
-      },
-    ],
-    'found_count': 2,
     'page': 1,
     'page_count': 1,
     'per_page': 25,
@@ -842,7 +897,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
       },
       <class 'dict'> {
@@ -863,7 +920,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
     ],
@@ -895,7 +954,9 @@
         'pathoscope': False,
         'ready': True,
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
       },
     ],
@@ -928,7 +989,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -951,7 +1014,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -985,7 +1050,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'bob',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -1008,7 +1075,9 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
         },
         'workflow': 'pathoscope_bowtie',
       },
@@ -1031,46 +1100,14 @@
           'id': 'test',
         },
         'user': <class 'dict'> {
-          'id': 'fred',
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
         },
         'workflow': 'pathoscope_bowtie',
       },
     ],
     'found_count': 3,
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
-  }
----
-# name: test_find_analyses[uvloop-bob-None]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-      <class 'dict'> {
-        'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_1',
-        'index': <class 'dict'> {
-          'id': 'foo',
-          'version': 2,
-        },
-        'job': <class 'dict'> {
-          'id': 'test',
-        },
-        'ready': True,
-        'reference': <class 'dict'> {
-          'id': 'baz',
-          'name': 'Baz',
-        },
-        'sample': <class 'dict'> {
-          'id': 'test',
-        },
-        'user': <class 'dict'> {
-          'id': 'bob',
-        },
-        'workflow': 'pathoscope_bowtie',
-      },
-    ],
-    'found_count': 1,
     'page': 1,
     'page_count': 1,
     'per_page': 25,
@@ -1146,6 +1183,11 @@
         'name': 'Bar',
       },
     ],
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_get[uvloop-True-None]
@@ -1219,6 +1261,11 @@
         'name': 'Bar',
       },
     ],
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_get_cache[uvloop-None]

--- a/tests/samples/__snapshots__/test_db.ambr
+++ b/tests/samples/__snapshots__/test_db.ambr
@@ -266,6 +266,11 @@
       },
     ],
     'ready': True,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_update_is_compressed[uvloop]

--- a/tests/samples/__snapshots__/test_fake.ambr
+++ b/tests/samples/__snapshots__/test_fake.ambr
@@ -26,7 +26,7 @@
     'subtractions': <class 'list'> [
     ],
     'user': <class 'dict'> {
-      'id': 'bob',
+      'id': '7CtBo2yG',
     },
   }
 ---
@@ -58,7 +58,7 @@
     'subtractions': <class 'list'> [
     ],
     'user': <class 'dict'> {
-      'id': 'bob',
+      'id': '7CtBo2yG',
     },
   }
 ---
@@ -219,7 +219,9 @@
     'subtractions': <class 'list'> [
     ],
     'user': <class 'dict'> {
-      'id': 'bob',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
   }
 ---
@@ -390,7 +392,9 @@
     'subtractions': <class 'list'> [
     ],
     'user': <class 'dict'> {
-      'id': 'bob',
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
     },
   }
 ---

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -24,13 +24,16 @@ async def test_create_fake_unpaired(
     paired,
     finalized,
     app,
+    fake,
     snapshot,
     static_time
 ):
+    user = await fake.users.insert()
+
     fake_sample = await create_fake_sample(
         app,
         "sample_1",
-        "bob",
+        user["_id"],
         paired=paired,
         finalized=finalized
     )

--- a/tests/subtractions/__snapshots__/test_api.ambr
+++ b/tests/subtractions/__snapshots__/test_api.ambr
@@ -1,4 +1,4 @@
-# name: test_edit[uvloop-data0]
+# name: test_edit[uvloop-False-data0]
   <class 'dict'> {
     'files': <class 'list'> [
     ],
@@ -8,14 +8,14 @@
     'nickname': 'Foo Subtraction',
   }
 ---
-# name: test_edit[uvloop-data0].1
+# name: test_edit[uvloop-False-data0].1
   <class 'dict'> {
     '_id': 'foo',
     'name': 'Bar',
     'nickname': 'Foo Subtraction',
   }
 ---
-# name: test_edit[uvloop-data1]
+# name: test_edit[uvloop-False-data1]
   <class 'dict'> {
     'files': <class 'list'> [
     ],
@@ -25,14 +25,14 @@
     'nickname': 'Bar Subtraction',
   }
 ---
-# name: test_edit[uvloop-data1].1
+# name: test_edit[uvloop-False-data1].1
   <class 'dict'> {
     '_id': 'foo',
     'name': 'Foo',
     'nickname': 'Bar Subtraction',
   }
 ---
-# name: test_edit[uvloop-data2]
+# name: test_edit[uvloop-False-data2]
   <class 'dict'> {
     'files': <class 'list'> [
     ],
@@ -42,14 +42,14 @@
     'nickname': '',
   }
 ---
-# name: test_edit[uvloop-data2].1
+# name: test_edit[uvloop-False-data2].1
   <class 'dict'> {
     '_id': 'foo',
     'name': 'Foo',
     'nickname': '',
   }
 ---
-# name: test_edit[uvloop-data3]
+# name: test_edit[uvloop-False-data3]
   <class 'dict'> {
     'files': <class 'list'> [
     ],
@@ -59,11 +59,111 @@
     'nickname': 'Bar Subtraction',
   }
 ---
-# name: test_edit[uvloop-data3].1
+# name: test_edit[uvloop-False-data3].1
   <class 'dict'> {
     '_id': 'foo',
     'name': 'Bar',
     'nickname': 'Bar Subtraction',
+  }
+---
+# name: test_edit[uvloop-True-data0]
+  <class 'dict'> {
+    'files': <class 'list'> [
+    ],
+    'id': 'foo',
+    'linked_samples': 12,
+    'name': 'Bar',
+    'nickname': 'Foo Subtraction',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data0].1
+  <class 'dict'> {
+    '_id': 'foo',
+    'name': 'Bar',
+    'nickname': 'Foo Subtraction',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data1]
+  <class 'dict'> {
+    'files': <class 'list'> [
+    ],
+    'id': 'foo',
+    'linked_samples': 12,
+    'name': 'Foo',
+    'nickname': 'Bar Subtraction',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data1].1
+  <class 'dict'> {
+    '_id': 'foo',
+    'name': 'Foo',
+    'nickname': 'Bar Subtraction',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data2]
+  <class 'dict'> {
+    'files': <class 'list'> [
+    ],
+    'id': 'foo',
+    'linked_samples': 12,
+    'name': 'Foo',
+    'nickname': '',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data2].1
+  <class 'dict'> {
+    '_id': 'foo',
+    'name': 'Foo',
+    'nickname': '',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data3]
+  <class 'dict'> {
+    'files': <class 'list'> [
+    ],
+    'id': 'foo',
+    'linked_samples': 12,
+    'name': 'Bar',
+    'nickname': 'Bar Subtraction',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_edit[uvloop-True-data3].1
+  <class 'dict'> {
+    '_id': 'foo',
+    'name': 'Bar',
+    'nickname': 'Bar Subtraction',
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_finalize_subtraction[uvloop-None]
@@ -108,6 +208,11 @@
     'name': 'Foo',
     'nickname': 'Foo Subtraction',
     'ready': True,
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_finalize_subtraction[uvloop-None].1
@@ -124,6 +229,9 @@
     'name': 'Foo',
     'nickname': 'Foo Subtraction',
     'ready': True,
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
   }
 ---
 # name: test_job_remove[uvloop-True-False]

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -74,7 +74,7 @@ async def test_unlink_default_subtractions(dbi):
     ]
 
 
-@ pytest.mark.parametrize("subtraction_id", [None, "abc"])
+@pytest.mark.parametrize("subtraction_id", [None, "abc"])
 async def test_create(subtraction_id, snapshot, dbi, test_random_alphanumeric):
     user_id = "test"
     filename = "subtraction.fa.gz"

--- a/tests/uploads/__snapshots__/test_api.ambr
+++ b/tests/uploads/__snapshots__/test_api.ambr
@@ -1,6 +1,24 @@
-# name: TestFind.test[uvloop-danny-None]
+# name: TestFind.test[uvloop-None]
   <class 'dict'> {
     'documents': <class 'list'> [
+      <class 'dict'> {
+        'created_at': None,
+        'id': 2,
+        'name': 'test.fq.gz',
+        'name_on_disk': None,
+        'ready': False,
+        'removed': False,
+        'removed_at': None,
+        'reserved': False,
+        'size': None,
+        'type': 'reference',
+        'uploaded_at': None,
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
+        },
+      },
       <class 'dict'> {
         'created_at': None,
         'id': 1,
@@ -13,40 +31,12 @@
         'size': None,
         'type': 'reads',
         'uploaded_at': None,
-        'user': 'danny',
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
+        },
       },
-    ],
-  }
----
-# name: TestFind.test[uvloop-danny-reads]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-      <class 'dict'> {
-        'created_at': None,
-        'id': 1,
-        'name': 'test.fq.gz',
-        'name_on_disk': None,
-        'ready': False,
-        'removed': False,
-        'removed_at': None,
-        'reserved': False,
-        'size': None,
-        'type': 'reads',
-        'uploaded_at': None,
-        'user': 'danny',
-      },
-    ],
-  }
----
-# name: TestFind.test[uvloop-danny-reference]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-    ],
-  }
----
-# name: TestFind.test[uvloop-jake-None]
-  <class 'dict'> {
-    'documents': <class 'list'> [
       <class 'dict'> {
         'created_at': None,
         'id': 3,
@@ -59,24 +49,40 @@
         'size': None,
         'type': None,
         'uploaded_at': None,
-        'user': 'jake',
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'johnsoncynthia',
+          'id': 'LB1U6zCj',
+        },
       },
     ],
   }
 ---
-# name: TestFind.test[uvloop-jake-reads]
+# name: TestFind.test[uvloop-reads]
   <class 'dict'> {
     'documents': <class 'list'> [
+      <class 'dict'> {
+        'created_at': None,
+        'id': 1,
+        'name': 'test.fq.gz',
+        'name_on_disk': None,
+        'ready': False,
+        'removed': False,
+        'removed_at': None,
+        'reserved': False,
+        'size': None,
+        'type': 'reads',
+        'uploaded_at': None,
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
+        },
+      },
     ],
   }
 ---
-# name: TestFind.test[uvloop-jake-reference]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-    ],
-  }
----
-# name: TestFind.test[uvloop-lester-None]
+# name: TestFind.test[uvloop-reference]
   <class 'dict'> {
     'documents': <class 'list'> [
       <class 'dict'> {
@@ -91,33 +97,11 @@
         'size': None,
         'type': 'reference',
         'uploaded_at': None,
-        'user': 'lester',
-      },
-    ],
-  }
----
-# name: TestFind.test[uvloop-lester-reads]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-    ],
-  }
----
-# name: TestFind.test[uvloop-lester-reference]
-  <class 'dict'> {
-    'documents': <class 'list'> [
-      <class 'dict'> {
-        'created_at': None,
-        'id': 2,
-        'name': 'test.fq.gz',
-        'name_on_disk': None,
-        'ready': False,
-        'removed': False,
-        'removed_at': None,
-        'reserved': False,
-        'size': None,
-        'type': 'reference',
-        'uploaded_at': None,
-        'user': 'lester',
+        'user': <class 'dict'> {
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': '7CtBo2yG',
+        },
       },
     ],
   }
@@ -135,7 +119,11 @@
     'size': 9081,
     'type': 'hmm',
     'uploaded_at': '2015-10-06T20:00:00Z',
-    'user': 'test',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
+      'id': 'test',
+    },
   }
 ---
 # name: TestUpload.test[uvloop-reads]
@@ -151,7 +139,11 @@
     'size': 9081,
     'type': 'reads',
     'uploaded_at': '2015-10-06T20:00:00Z',
-    'user': 'test',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
+      'id': 'test',
+    },
   }
 ---
 # name: TestUpload.test[uvloop-reference]
@@ -167,7 +159,11 @@
     'size': 9081,
     'type': 'reference',
     'uploaded_at': '2015-10-06T20:00:00Z',
-    'user': 'test',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
+      'id': 'test',
+    },
   }
 ---
 # name: TestUpload.test[uvloop-subtraction]
@@ -183,6 +179,10 @@
     'size': 9081,
     'type': 'subtraction',
     'uploaded_at': '2015-10-06T20:00:00Z',
-    'user': 'test',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'bob',
+      'id': 'test',
+    },
   }
 ---

--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -66,19 +66,21 @@ class TestUpload:
 
 
 class TestFind:
-    @pytest.mark.parametrize("type_", ["reads", "reference", None])
-    @pytest.mark.parametrize("user", ["danny", "lester", "jake"])
-    async def test(self, spawn_client, snapshot, type_, user, test_uploads):
+
+    @pytest.mark.parametrize("upload_type", ["reads", "reference", None])
+    async def test(self, upload_type, spawn_client, snapshot, test_uploads):
         """
         Test `GET /api/uploads` to assure that it returns the correct `upload` documents.
 
         """
         client = await spawn_client(authorize=True, administrator=True)
 
-        if type_:
-            resp = await client.get(f"/api/uploads?type={type_}&user={user}")
-        else:
-            resp = await client.get(f"/api/uploads?user={user}")
+        url = f"/api/uploads"
+
+        if upload_type:
+            url += f"?type={upload_type}"
+
+        resp = await client.get(url)
 
         assert resp.status == 200
         assert await resp.json() == snapshot

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -3,13 +3,15 @@ Work with analyses in the database.
 
 """
 import asyncio
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import virtool.bio
 import virtool.db.utils
 import virtool.utils
-from virtool.indexes.db import get_current_id_and_version
 from virtool.configuration.config import Config
+from virtool.indexes.db import get_current_id_and_version
+from virtool.subtractions.db import attach_subtractions
+from virtool.users.db import attach_user
 
 PROJECTION = (
     "_id",
@@ -108,6 +110,21 @@ class BLAST:
         })
 
         return data, document
+
+
+async def processor(db, document: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Process an analysis document by attaching user and subtraction data.
+
+    :param db: the application database object
+    :param document: the analysis document
+    :return: the processed analysis document
+
+    """
+    processed = await attach_subtractions(db, document)
+    processed = await attach_user(db, processed)
+
+    return virtool.utils.base_processor(processed)
 
 
 async def create(

--- a/virtool/dev/fake.py
+++ b/virtool/dev/fake.py
@@ -9,10 +9,11 @@ from logging import getLogger
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
+
+from virtool.fake.factory import load_test_case_from_yml
 from virtool.types import App
 from virtool.users.fake import create_fake_bob_user
 from virtool.utils import ensure_data_dir, random_alphanumeric
-from virtool.fake.factory import load_test_case_from_yml
 
 logger = getLogger(__name__)
 
@@ -22,7 +23,6 @@ REF_ID = "reference_1"
 async def populate(app: App):
     await create_fake_bob_user(app)
     for yml_file in Path(app["config"].fake_path).iterdir():
-        print(yml_file)
         if yml_file.suffix in (".yml", ".yaml"):
             await load_test_case_from_yml(app, yml_file)
 

--- a/virtool/fake/wrapper.py
+++ b/virtool/fake/wrapper.py
@@ -3,7 +3,7 @@ A wrapper for the `fake` package that adds some Virtool-specific functionality.
 
 """
 from faker import Faker
-from faker.providers import address, misc, lorem, python
+from faker.providers import address, date_time, lorem, misc, profile, python
 
 
 class FakerWrapper:
@@ -14,6 +14,8 @@ class FakerWrapper:
         self.fake.add_provider(misc)
         self.fake.add_provider(lorem)
         self.fake.add_provider(python)
+        self.fake.add_provider(date_time)
+        self.fake.add_provider(profile)
 
         self.country = self.fake.country
 
@@ -24,6 +26,9 @@ class FakerWrapper:
         self.integer = self.fake.pyint
         self.list = self.fake.pylist
         self.boolean = self.fake.pybool
+        self.profile = self.fake.profile
+        self.date_time = self.fake.date_time
+        self.random_element = self.fake.random_element
 
     def get_mongo_id(self) -> str:
         """

--- a/virtool/history/api.py
+++ b/virtool/history/api.py
@@ -1,9 +1,8 @@
-from aiohttp.web import HTTPNoContent, HTTPConflict
-
 import virtool.history.db
 import virtool.http.routes
 import virtool.references.db
-from virtool.api.response import json_response, InsufficientRights, NotFound
+from aiohttp.web import HTTPConflict, HTTPNoContent
+from virtool.api.response import InsufficientRights, NotFound, json_response
 from virtool.errors import DatabaseError
 
 routes = virtool.http.routes.Routes()

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -1,10 +1,9 @@
 import logging
-from typing import Union, Optional, List, Dict, Type
-
-from sqlalchemy import select, update
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from typing import Dict, List, Optional, Type, Union
 
 import virtool.utils
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.pg.base import Base
 from virtool.uploads.models import Upload
 
@@ -197,9 +196,9 @@ async def release(pg: AsyncEngine, upload_ids: Union[int, List[int]]):
     async with AsyncSession(pg) as session:
         await session.execute(
             update(Upload)
-                .where(query)
-                .values(reserved=False)
-                .execution_options(synchronize_session="fetch")
+            .where(query)
+            .values(reserved=False)
+            .execution_options(synchronize_session="fetch")
         )
 
         await session.commit()
@@ -218,9 +217,9 @@ async def reserve(pg: AsyncEngine, upload_ids: Union[int, List[int]]):
         query = Upload.id.in_(upload_ids)
 
     async with AsyncSession(pg) as session:
-        await session.execute(update(Upload).
-                              where(query).values(reserved=True).
-                              execution_options(synchronize_session="fetch")
-                              )
-
+        await session.execute(
+            update(Upload).
+            where(query).values(reserved=True).
+            execution_options(synchronize_session="fetch")
+        )
         await session.commit()


### PR DESCRIPTION
Return more user data than just `user.id` from relevant API endpoints.

This is necessary because user IDs will now be automatically generated and the `handle` field will be used for user display.