### PR TITLE
Rework naming for init and exit functions

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ import pytest
 from aiohttp.client import ClientSession
 from aiohttp.web import Application
 
-from virtool.startup import init_executors, init_http_client
+from virtool.startup import startup_executors, startup_http_client
 
 
 @pytest.fixture
@@ -17,20 +17,20 @@ async def fake_app():
 
     yield app
 
-    # Close real session created in `test_init_executors()`.
+    # Close real session created in `test_startup_executors()`.
     try:
         await app["client"].close()
     except TypeError:
         pass
 
 
-async def test_init_executors():
+async def test_startup_executors():
     """
     Test that an instance of :class:`.ThreadPoolExecutor` is added to ``app`` state and that it works.
     """
     app = Application()
 
-    await init_executors(app)
+    await startup_executors(app)
 
     assert isinstance(app["executor"], ThreadPoolExecutor)
 
@@ -42,18 +42,18 @@ async def test_init_executors():
     assert result == 14
 
 
-async def test_init_http_client(loop, fake_app):
-    await init_http_client(fake_app)
+async def test_startup_http_client(loop, fake_app):
+    await startup_http_client(fake_app)
 
     assert fake_app["version"] == "v1.2.3"
 
     assert isinstance(fake_app["client"], ClientSession)
 
 
-async def test_init_http_client_headers(loop, mocker, fake_app):
+async def test_startup_http_client_headers(loop, mocker, fake_app):
     m = mocker.patch("aiohttp.client.ClientSession")
 
-    await init_http_client(fake_app)
+    await startup_http_client(fake_app)
 
     headers = {
         "User-Agent": "virtool/v1.2.3"

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,10 +1,10 @@
 from sqlalchemy import text
 
 from virtool.startup import get_scheduler_from_app
-from virtool.shutdown import exit_client, exit_dispatcher, exit_executors, exit_scheduler, exit_redis, drop_fake_postgres
+from virtool.shutdown import shutdown_client, shutdown_dispatcher, shutdown_executors, shutdown_scheduler, shutdown_redis, drop_fake_postgres
 
 
-async def test_exit_client(spawn_client):
+async def test_shutdown_client(spawn_client):
     """
     Test that the HTTP async client is properly closed on shutdown.
 
@@ -12,12 +12,12 @@ async def test_exit_client(spawn_client):
     client = await spawn_client(authorize=True)
     app = client.app
 
-    await exit_client(app)
+    await shutdown_client(app)
 
     assert app["client"].closed
 
 
-async def test_exit_dispatcher(mocker, spawn_client):
+async def test_shutdown_dispatcher(mocker, spawn_client):
     """
     Test that the app's `Dispatcher` object is properly closed on shutdown.
 
@@ -27,12 +27,12 @@ async def test_exit_dispatcher(mocker, spawn_client):
 
     mock = mocker.patch('virtool.dispatcher.dispatcher.Dispatcher.close')
 
-    await exit_dispatcher(app)
+    await shutdown_dispatcher(app)
 
     assert mock.called
 
 
-async def test_exit_executors(mocker, spawn_client):
+async def test_shutdown_executors(mocker, spawn_client):
     """
     Test that the app's `ThreadPoolExecutor` is properly closed on shutdown.
 
@@ -42,13 +42,13 @@ async def test_exit_executors(mocker, spawn_client):
 
     mock = mocker.patch('concurrent.futures.process.ProcessPoolExecutor.shutdown')
 
-    await exit_executors(app)
+    await shutdown_executors(app)
 
     assert app["executor"]._shutdown
     assert mock.called
 
 
-async def test_exit_scheduler(spawn_client):
+async def test_shutdown_scheduler(spawn_client):
     """
     Test that the app's `aiojobs` scheduler is properly closed on shutdown.
 
@@ -58,16 +58,16 @@ async def test_exit_scheduler(spawn_client):
 
     scheduler = get_scheduler_from_app(app)
 
-    await exit_scheduler(app)
+    await shutdown_scheduler(app)
 
     assert scheduler.closed
 
 
-async def test_exit_redis(spawn_client):
+async def test_shutdown_redis(spawn_client):
     client = await spawn_client(authorize=True)
     app = client.app
 
-    await exit_redis(app)
+    await shutdown_redis(app)
 
     assert app["redis"].closed
 

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -13,10 +13,10 @@ import virtool.http.proxy
 import virtool.http.query
 from virtool.configuration.config import Config
 from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown
-from virtool.shutdown import exit_redis, exit_executors, exit_client, exit_scheduler, exit_dispatcher
-from virtool.startup import init_executors, init_db, init_events, init_redis, init_refresh, init_routes, init_sentry, \
-    init_settings, init_paths, init_tasks, init_postgres, init_version, init_dispatcher, init_client_path, \
-    init_http_client, init_jobs_client, init_task_runner, init_check_db, init_b2c
+from virtool.shutdown import shutdown_redis, shutdown_executors, shutdown_client, shutdown_scheduler, shutdown_dispatcher
+from virtool.startup import startup_executors, startup_db, startup_events, startup_redis, startup_refresh, startup_routes, startup_sentry, \
+    startup_settings, startup_paths, startup_tasks, startup_postgres, startup_version, startup_dispatcher, startup_client_path, \
+    startup_http_client, startup_jobs_client, startup_task_runner, startup_check_db, startup_b2c
 
 logger = logging.getLogger(__name__)
 
@@ -43,37 +43,37 @@ def create_app(config: Config):
     aiojobs.aiohttp.setup(app)
 
     app.on_startup.extend([
-        init_version,
-        init_events,
-        init_redis,
-        init_db,
-        init_postgres,
-        init_dispatcher,
-        init_settings,
-        init_client_path,
-        init_http_client,
-        init_paths,
-        init_routes,
-        init_executors,
-        init_task_runner,
-        init_tasks,
-        init_sentry,
-        init_check_db,
-        init_jobs_client,
-        init_refresh
+        startup_version,
+        startup_events,
+        startup_redis,
+        startup_db,
+        startup_postgres,
+        startup_dispatcher,
+        startup_settings,
+        startup_client_path,
+        startup_http_client,
+        startup_paths,
+        startup_routes,
+        startup_executors,
+        startup_task_runner,
+        startup_tasks,
+        startup_sentry,
+        startup_check_db,
+        startup_jobs_client,
+        startup_refresh
     ])
 
     if config.use_b2c:
-        app.on_startup.append(init_b2c)
+        app.on_startup.append(startup_b2c)
 
     app.on_response_prepare.append(virtool.http.csp.on_prepare)
 
     app.on_shutdown.extend([
-        exit_client,
-        exit_dispatcher,
-        exit_executors,
-        exit_scheduler,
-        exit_redis
+        shutdown_client,
+        shutdown_dispatcher,
+        shutdown_executors,
+        shutdown_scheduler,
+        shutdown_redis
     ])
 
     return app

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -8,12 +8,12 @@ import virtool.http.accept
 import virtool.http.errors
 import virtool.jobs.auth
 from virtool.dev.fake import drop_fake_mongo, remove_fake_data_path
-from virtool.jobs.routes import init_routes
+from virtool.jobs.routes import startup_routes
 from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown
 from virtool.configuration.config import Config
 from virtool.shutdown import drop_fake_postgres
-from virtool.startup import init_fake_config, init_redis, init_db, init_postgres, init_settings, init_executors, \
-    init_fake, init_events
+from virtool.startup import startup_fake_config, startup_redis, startup_db, startup_postgres, startup_settings, startup_executors, \
+    startup_fake, startup_events
 from virtool.types import App
 
 
@@ -33,15 +33,15 @@ async def create_app(config: Config):
     aiojobs.aiohttp.setup(app)
 
     app.on_startup.extend([
-        init_fake_config,
-        init_redis,
-        init_db,
-        init_postgres,
-        init_settings,
-        init_executors,
-        init_fake,
-        init_events,
-        init_routes,
+        startup_fake_config,
+        startup_redis,
+        startup_db,
+        startup_postgres,
+        startup_settings,
+        startup_executors,
+        startup_fake,
+        startup_events,
+        startup_routes,
     ])
 
     app.on_shutdown.extend([

--- a/virtool/jobs/routes.py
+++ b/virtool/jobs/routes.py
@@ -5,7 +5,7 @@ import virtool.indexes.api
 import virtool.routes
 
 
-async def init_routes(app: aiohttp.web.Application):
+async def startup_routes(app: aiohttp.web.Application):
     """Add routes to jobs API."""
     for routes in virtool.routes.ROUTES:
         app.add_routes(routes.jobs_api)

--- a/virtool/shutdown.py
+++ b/virtool/shutdown.py
@@ -8,7 +8,7 @@ from virtool.startup import get_scheduler_from_app
 logger = logging.getLogger(__name__)
 
 
-async def exit_client(app: Application):
+async def shutdown_client(app: Application):
     """
     Attempt to close the async HTTP client session.
 
@@ -22,7 +22,7 @@ async def exit_client(app: Application):
         pass
 
 
-async def exit_dispatcher(app: Application):
+async def shutdown_dispatcher(app: Application):
     """
     Attempt to close the app's `Dispatcher` object.
 
@@ -36,7 +36,7 @@ async def exit_dispatcher(app: Application):
         pass
 
 
-async def exit_executors(app: Application):
+async def shutdown_executors(app: Application):
     """
     Attempt to close the `ThreadPoolExecutor` and `ProcessPoolExecutor`.
 
@@ -53,7 +53,7 @@ async def exit_executors(app: Application):
         pass
 
 
-async def exit_scheduler(app: Application):
+async def shutdown_scheduler(app: Application):
     """
     Attempt to the close the app's `aiojobs` scheduler.
 
@@ -63,7 +63,7 @@ async def exit_scheduler(app: Application):
     await scheduler.close()
 
 
-async def exit_redis(app: Application):
+async def shutdown_redis(app: Application):
     """
     Attempt to close the app's `redis` instance.
 

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -83,7 +83,7 @@ def get_scheduler_from_app(app: Application) -> aiojobs.Scheduler:
     return scheduler
 
 
-async def init_check_db(app: Application):
+async def startup_check_db(app: Application):
     if app["config"].no_check_db:
         return logger.info("Skipping database checks")
 
@@ -102,7 +102,7 @@ async def init_check_db(app: Application):
     await virtool.db.mongo.create_indexes(db)
 
 
-async def init_client_path(app: Application):
+async def startup_client_path(app: Application):
     if not app["config"].no_client:
         app["client_path"] = await get_client_path()
 
@@ -113,7 +113,7 @@ async def init_client_path(app: Application):
         app.router.add_static("/static", app["client_path"])
 
 
-async def init_db(app: App):
+async def startup_db(app: App):
     """
     An application ``on_startup`` callback that attaches an instance of
     :class:`~AsyncIOMotorClient` and the ``db_name`` to the Virtool ``app`` object. Also
@@ -132,7 +132,7 @@ async def init_db(app: App):
     app["dispatcher_interface"] = dispatcher_interface
 
 
-async def init_dispatcher(app: Application):
+async def startup_dispatcher(app: Application):
     """
     An application ``on_startup`` callback that initializes a Virtool :class:`~.Dispatcher` object
     and attaches it to the ``app`` object.
@@ -157,7 +157,7 @@ async def init_dispatcher(app: Application):
     await get_scheduler_from_app(app).spawn(app["dispatcher"].run())
 
 
-async def init_events(app: Application):
+async def startup_events(app: Application):
     events = create_events()
 
     loop = asyncio.get_event_loop()
@@ -168,7 +168,7 @@ async def init_events(app: Application):
     app["events"] = events
 
 
-async def init_executors(app: Application):
+async def startup_executors(app: Application):
     """
     An application ``on_startup`` callback that initializes a :class:`~ThreadPoolExecutor` and
     attaches it to the ``app`` object.
@@ -197,13 +197,13 @@ async def init_executors(app: Application):
     app["process_executor"] = process_executor
 
 
-async def init_fake(app: Application):
+async def startup_fake(app: Application):
     if app["config"].fake:
         app["fake"] = FakerWrapper()
         await populate(app)
 
 
-async def init_fake_config(app: App):
+async def startup_fake_config(app: App):
     """
     If the ``fake`` config flag is set, patch the config so that the MongoDB and Postgres databases
     and the data directory are faked.
@@ -237,7 +237,7 @@ async def init_fake_config(app: App):
         app["config"].postgres_connection_string = f"{base_connection_string}/{name}"
 
 
-async def init_jobs_client(app: Application):
+async def startup_jobs_client(app: Application):
     """
     An application `on_startup` callback that initializes a Virtool
     :class:`virtool.job_manager.Manager` object and puts it in app state.
@@ -249,7 +249,7 @@ async def init_jobs_client(app: Application):
     app["jobs"] = JobsClient(app)
 
 
-async def init_http_client(app: Application):
+async def startup_http_client(app: Application):
     """
     Create an async HTTP client session for the server.
 
@@ -269,13 +269,13 @@ async def init_http_client(app: Application):
     app["client"] = aiohttp.client.ClientSession(headers=headers)
 
 
-async def init_paths(app: Application):
+async def startup_paths(app: Application):
     if app["config"].no_check_files is False:
         logger.info("Checking files")
         ensure_data_dir(app["config"].data_path)
 
 
-async def init_postgres(app: Application):
+async def startup_postgres(app: Application):
     """
      An application ``on_startup`` callback that attaches an instance of :class:`~AsyncConnection`
      to the Virtool ``app`` object.
@@ -290,7 +290,7 @@ async def init_postgres(app: Application):
     app["pg"] = await virtool.pg.utils.connect(postgres_connection_string)
 
 
-async def init_redis(app: typing.Union[dict, Application]):
+async def startup_redis(app: typing.Union[dict, Application]):
     redis_connection_string = app["config"].redis_connection_string
     logger.info("Connecting to Redis")
     redis = await virtool.redis.connect(redis_connection_string)
@@ -301,7 +301,7 @@ async def init_redis(app: typing.Union[dict, Application]):
     app["redis"] = redis
 
 
-async def init_refresh(app: Application):
+async def startup_refresh(app: Application):
     """
     Start async jobs for checking for new remote reference and HMM releases.
 
@@ -317,12 +317,12 @@ async def init_refresh(app: Application):
     await scheduler.spawn(refresh(app))
 
 
-async def init_routes(app: Application):
+async def startup_routes(app: Application):
     logger.debug("Setting up routes")
     setup_routes(app)
 
 
-async def init_sentry(app: typing.Union[dict, Application]):
+async def startup_sentry(app: typing.Union[dict, Application]):
     if (not app["config"].no_sentry
             and app["settings"].enable_sentry is not False
             and not app["config"].dev):
@@ -333,7 +333,7 @@ async def init_sentry(app: typing.Union[dict, Application]):
         logger.info("Skipped configuring Sentry")
 
 
-async def init_settings(app: typing.Union[dict, Application]):
+async def startup_settings(app: typing.Union[dict, Application]):
     """
     Draws settings from the settings database collection and populates `app["settings"`.
 
@@ -345,7 +345,7 @@ async def init_settings(app: typing.Union[dict, Application]):
     app["settings"] = await ensure(app["db"])
 
 
-async def init_version(app: typing.Union[dict, Application]):
+async def startup_version(app: typing.Union[dict, Application]):
     """
     Bind the application version to the application state `dict`.
 
@@ -369,7 +369,7 @@ async def init_version(app: typing.Union[dict, Application]):
     app["version"] = version
 
 
-async def init_b2c(app: Application):
+async def startup_b2c(app: Application):
     """
     Initiate connection to Azure AD B2C tenant.
 
@@ -398,7 +398,7 @@ async def init_b2c(app: Application):
     app["b2c"] = B2C(msal, authority)
 
 
-async def init_task_runner(app: Application):
+async def startup_task_runner(app: Application):
     """
     An application `on_startup` callback that initializes a Virtool
     :class:`virtool.tasks.runner.TaskRunner` object and puts it in app state.
@@ -414,7 +414,7 @@ async def init_task_runner(app: Application):
     await scheduler.spawn(TaskRunner(channel, app).run())
 
 
-async def init_tasks(app: Application):
+async def startup_tasks(app: Application):
     if app["config"].no_check_db:
         return logger.info("Skipping subtraction FASTA files checks")
 


### PR DESCRIPTION
Rename "init" -> "startup".

Rename "exit" -> "shutdown".