### PR TITLE
Fix multiple backend errors

### DIFF
--- a/virtool/config.py
+++ b/virtool/config.py
@@ -183,17 +183,14 @@ def start_server(
         b2c_client_id=b2c_client_id,
         b2c_client_secret=b2c_client_secret,
         b2c_tenant=b2c_tenant,
-        b2c_user_flow=b2c_user_flow,        
-        data_path=ctx.obj["data_path"],
+        b2c_user_flow=b2c_user_flow,   
         host=host,        
         no_check_db=no_check_db,
         no_check_files=no_check_files,
         no_client=no_client,
         no_fetching=no_fetching,
         port=port,
-        proxy=ctx.obj["proxy"],
         use_b2c=use_b2c,
-        verbose=ctx.obj["verbose"]
     )
 
     logger.info("Starting in server mode")

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -15,7 +15,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from virtool.api.utils import paginate
 from virtool.configuration.config import Config
 from virtool.db.utils import get_new_id
-from virtool.history.db import get_contributors
 from virtool.indexes.models import IndexFile
 from virtool.users.db import attach_user
 
@@ -189,7 +188,7 @@ async def get_contributors(db, index_id: str) -> List[dict]:
     :return: a list of contributors to the index
 
     """
-    return await get_contributors(db, {"index.id": index_id})
+    return await virtool.history.db.get_contributors(db, {"index.id": index_id})
 
 
 async def get_current_id_and_version(db, ref_id: str) -> Tuple[str, int]:

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -301,6 +301,8 @@ async def create(req):
 
     sample_group_setting = settings.sample_group
 
+    group = "none"
+
     # Require a valid ``group`` field if the ``sample_group`` setting is ``users_primary_group``.
     if sample_group_setting == "force_choice":
         force_choice_error_message = await validate_force_choice_group(db, data)
@@ -314,10 +316,6 @@ async def create(req):
     # ``users_primary_group``.
     elif sample_group_setting == "users_primary_group":
         group = await virtool.db.utils.get_one_field(db.users, "primary_group", user_id)
-
-    # Make the owner group none if the setting is none.
-    elif sample_group_setting == "none":
-        group = "none"
 
     files = [
         {"id": upload["id"], "name": upload["name"], "size": upload["size"]}


### PR DESCRIPTION
Fix multiple errors:
* Error during calls to reference API during build index workflow run. Was due to infinite recursion in `get_contributors`.
* Remove duplicate declaration of attributes in settings dataclass.
* Make group `'none'` by default during sample creation to prevent error.