### PR TITLE
ci: add test patterns to .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,9 @@
 version = 1
 
+test_patterns = [
+  "tests/**"
+]
+
 [[analyzers]]
 name = "test-coverage"
 enabled = true


### PR DESCRIPTION
Stop DeepSource from complaining about `assert` in tests.