### PR TITLE
Add version and server headers

### DIFF
--- a/virtool/app.py
+++ b/virtool/app.py
@@ -11,6 +11,7 @@ import virtool.http.errors
 import virtool.http.proxy
 import virtool.http.query
 from virtool.configuration.config import Config
+from virtool.http.headers import headers_middleware
 from virtool.process_utils import (create_app_runner, wait_for_restart,
                                    wait_for_shutdown)
 from virtool.shutdown import (shutdown_client, shutdown_dispatcher,
@@ -34,6 +35,7 @@ def create_app(config: Config):
 
     """
     middlewares = [
+        headers_middleware,
         virtool.http.auth.middleware,
         virtool.http.accept.middleware,
         virtool.http.errors.middleware,

--- a/virtool/http/headers.py
+++ b/virtool/http/headers.py
@@ -1,0 +1,14 @@
+from aiohttp.web import middleware
+
+
+@middleware
+async def headers_middleware(req, handler):
+    """
+    Middleware that adds the current version of the API to the response.
+
+    """
+    resp = await handler(req)
+    resp.headers["X-Virtool-Version"] = req.app["version"]
+    resp.headers["Server"] = "Virtool"
+
+    return resp


### PR DESCRIPTION
Include the `X-Virtool-Version` and `Server` HTTP headers in responses.

The `X-Virtool-Version` header was lost during the removal of client serving before `6.0.0`.