### PR TITLE
Add even more GitHub logging

### DIFF
--- a/virtool/github.py
+++ b/virtool/github.py
@@ -106,11 +106,16 @@ async def get_release(
     if etag:
         headers["If-None-Match"] = etag
 
-    async with ProxyRequest(config, session.get, url, headers=headers) as resp:
+    logger.debug(f"Making GitHub request to {url}")
+
+    async with ProxyRequest(config, session.get, url, headers=headers) as resp:        
         rate_limit_remaining = resp.headers.get("X-RateLimit-Remaining", "00")
         rate_limit = resp.headers.get("X-RateLimit-Limit", "00")
 
-        logger.debug(f"Fetched release: {slug}/{release_id} ({resp.status} - {rate_limit_remaining}/{rate_limit})")
+        if rate_limit / rate_limit_remaining < 2:
+            logger.warning(f"Less than half of GitHub remaining ({rate_limit_remaining} of {rate_limit})")
+
+        logger.debug(f"Fetched release: {slug}/{release_id} ({resp.status})")
 
         if resp.status == 200:
             data = await resp.json()


### PR DESCRIPTION
Requests to GitHub are still failing in Azure. Add detailed lifecycle logging to the request.