### PR TITLE
Stop login loop on refresh

### DIFF
--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -232,7 +232,4 @@ async def middleware(req, handler) -> Response:
 
     set_session_id_cookie(resp, session_id)
 
-    if req.path == "/":
-        resp.del_cookie("session_token")
-
     return resp


### PR DESCRIPTION
The `session_token` cookie was being deleted on any request to `/`.

Removed the offending lines to prevent this behaviour.