### PR TITLE
Add more logging for remote ref creation

### DIFF
--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio.tasks import gather
+from logging import getLogger
 
 import aiohttp
 import virtool.db.utils
@@ -27,6 +28,8 @@ from virtool.references.tasks import (CloneReferenceTask, DeleteReferenceTask,
 from virtool.uploads.models import Upload
 from virtool.users.db import attach_user
 from virtool.validators import strip
+
+logger = getLogger(__name__)
 
 routes = Routes()
 
@@ -400,14 +403,14 @@ async def create(req):
                 remote_from,
                 release_id=release_id
             )
-
-        except aiohttp.ClientConnectionError:
+        except aiohttp.ClientConnectionError as exc:
+            logger.exception(exc)
             raise HTTPBadGateway(text="Could not reach GitHub")
-
         except GitHubError as err:
             if "404" in str(err):
                 raise HTTPBadGateway(
-                    text="Could not retrieve latest GitHub release")
+                    text="Could not retrieve latest GitHub release"
+                )
 
             raise
 


### PR DESCRIPTION
Remote reference creation is failing with `502` due to a GitHub connection problem. Add more logging to try to diagnose this.