### PR TITLE
Return user data in reference API responses

### DIFF
--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -85,7 +85,9 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
         'build': True,
+        'handle': 'bob',
         'id': 'test',
         'modify': True,
         'modify_otu': True,
@@ -125,7 +127,9 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
         'build': True,
+        'handle': 'bob',
         'id': 'test',
         'modify': True,
         'modify_otu': True,
@@ -166,7 +170,33 @@
     ],
   }
 ---
-# name: test_edit[uvloop-None-barcode]
+# name: test_edit[uvloop-None-barcode][db]
+  <class 'dict'> {
+    '_id': 'foo',
+    'data_type': 'barcode',
+    'description': 'This is a test reference.',
+    'name': 'Bar',
+    'targets': <class 'list'> [
+      <class 'dict'> {
+        'description': '',
+        'name': 'CPN60',
+        'required': True,
+      },
+    ],
+    'user': <class 'dict'> {
+      'id': '7CtBo2yG',
+    },
+    'users': <class 'list'> [
+      <class 'dict'> {
+        'id': 'LB1U6zCj',
+      },
+      <class 'dict'> {
+        'id': 'w20Amyfb',
+      },
+    ],
+  }
+---
+# name: test_edit[uvloop-None-barcode][resp]
   <class 'dict'> {
     'contributors': <class 'list'> [
     ],
@@ -192,35 +222,38 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'administrator': False,
+        'handle': 'johnsoncynthia',
+        'id': 'LB1U6zCj',
+      },
+      <class 'dict'> {
+        'administrator': False,
+        'handle': 'danagray',
+        'id': 'w20Amyfb',
       },
     ],
   }
 ---
-# name: test_edit[uvloop-None-barcode].1
+# name: test_edit[uvloop-None-genome][db]
   <class 'dict'> {
     '_id': 'foo',
-    'data_type': 'barcode',
+    'data_type': 'genome',
     'description': 'This is a test reference.',
     'name': 'Bar',
-    'targets': <class 'list'> [
-      <class 'dict'> {
-        'description': '',
-        'name': 'CPN60',
-        'required': True,
-      },
-    ],
     'user': <class 'dict'> {
       'id': '7CtBo2yG',
     },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'id': 'LB1U6zCj',
+      },
+      <class 'dict'> {
+        'id': 'w20Amyfb',
       },
     ],
   }
 ---
-# name: test_edit[uvloop-None-genome]
+# name: test_edit[uvloop-None-genome][resp]
   <class 'dict'> {
     'contributors': <class 'list'> [
     ],
@@ -239,23 +272,14 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'administrator': False,
+        'handle': 'johnsoncynthia',
+        'id': 'LB1U6zCj',
       },
-    ],
-  }
----
-# name: test_edit[uvloop-None-genome].1
-  <class 'dict'> {
-    '_id': 'foo',
-    'data_type': 'genome',
-    'description': 'This is a test reference.',
-    'name': 'Bar',
-    'user': <class 'dict'> {
-      'id': '7CtBo2yG',
-    },
-    'users': <class 'list'> [
       <class 'dict'> {
-        'id': 'bob',
+        'administrator': False,
+        'handle': 'danagray',
+        'id': 'w20Amyfb',
       },
     ],
   }

--- a/tests/references/__snapshots__/test_db.ambr
+++ b/tests/references/__snapshots__/test_db.ambr
@@ -17,6 +17,8 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
         'id': 'LB1U6zCj',
       },
     ],
@@ -60,6 +62,8 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
         'id': 'LB1U6zCj',
       },
     ],
@@ -101,6 +105,8 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
         'id': 'LB1U6zCj',
       },
     ],
@@ -146,6 +152,8 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
         'id': 'LB1U6zCj',
       },
     ],
@@ -189,6 +197,8 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
         'id': 'LB1U6zCj',
       },
     ],
@@ -232,6 +242,8 @@
     },
     'users': <class 'list'> [
       <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
         'id': 'LB1U6zCj',
       },
     ],

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -235,7 +235,9 @@ async def test_create(data_type, mocker, snapshot, spawn_client, test_random_alp
 async def test_edit(data_type, error, mocker, snapshot, fake, spawn_client, resp_is):
     client = await spawn_client(authorize=True)
 
-    user = await fake.users.insert()
+    user_1 = await fake.users.insert()
+    user_2 = await fake.users.insert()
+    user_3 = await fake.users.insert()
 
     if error != "404":
         await client.db.references.insert_one({
@@ -243,18 +245,13 @@ async def test_edit(data_type, error, mocker, snapshot, fake, spawn_client, resp
             "data_type": data_type,
             "name": "Foo",
             "user": {
-                "id": user["_id"]
+                "id": user_1["_id"]
             },
             "users": [
-                {
-                    "id": "bob"
-                }
+                {"id": user_2["_id"]},
+                {"id": user_3["_id"]}
             ]
         })
-
-    await client.db.users.insert_one({
-        "_id": "bob"
-    })
 
     data = {
         "name": "Bar",
@@ -318,8 +315,8 @@ async def test_edit(data_type, error, mocker, snapshot, fake, spawn_client, resp
         await resp_is.insufficient_rights(resp)
         return
 
-    assert await resp.json() == snapshot
-    assert await client.db.references.find_one() == snapshot
+    assert await resp.json() == snapshot(name="resp")
+    assert await client.db.references.find_one() == snapshot(name="db")
 
 
 @pytest.mark.parametrize("error", [None, "400_dne", "400_exists", "404"])

--- a/tests/users/test_db.py
+++ b/tests/users/test_db.py
@@ -1,12 +1,13 @@
 import hashlib
 
 import pytest
-from aiohttp.test_utils import make_mocked_coro
-
 import virtool.errors
-from virtool.users.db import compose_force_reset_update, compose_groups_update, compose_password_update, \
-    compose_primary_group_update, validate_credentials, update_sessions_and_keys, create, edit
-from virtool.users.db import generate_handle, find_or_create_b2c_user, B2CUserAttributes
+from aiohttp.test_utils import make_mocked_coro
+from virtool.users.db import (B2CUserAttributes, compose_force_reset_update,
+                              compose_groups_update, compose_password_update,
+                              compose_primary_group_update, create, edit,
+                              find_or_create_b2c_user, generate_handle,
+                              update_sessions_and_keys, validate_credentials)
 from virtool.users.utils import hash_password
 from virtool.utils import random_alphanumeric
 

--- a/virtool/users/db.py
+++ b/virtool/users/db.py
@@ -1,8 +1,7 @@
-from logging import BASIC_FORMAT
-from logging import Logger
 import random
 from asyncio.tasks import gather
 from dataclasses import dataclass
+from logging import BASIC_FORMAT, Logger
 from typing import Any, Dict, List, Optional, Union
 
 import virtool.utils
@@ -48,16 +47,6 @@ class B2CUserAttributes:
         self.display_name = display_name
         self.given_name = given_name
         self.family_name = family_name
-
-
-class AttachUsers:
-
-    def __init__(self, db):
-        self._db = db
-        self._cache = dict()
-
-    def __call__(self, documents):
-        pass
 
 
 async def attach_user(db, document: Dict[str, Any]) -> Dict[str, Any]:
@@ -108,6 +97,19 @@ async def attach_users(db, documents: List[Dict[str, Any]]) -> List[Dict[str, An
     return await gather(
         *[attach_user(db, document) for document in documents]
     )
+
+
+async def extend_user(db, user: Dict[str, Any]) -> Dict[str, Any]:
+    user_id = user["id"]
+
+    user_data = await db.users.find_one(user_id, ATTACH_PROJECTION)
+
+    extended = {
+        **user,
+        **user_data,
+    }
+
+    return extended
 
 
 def compose_force_reset_update(force_reset: Optional[bool]) -> dict:


### PR DESCRIPTION
This will allow user handles to be rendered in frontend. Currently on the user `id` is returned in the `users` field.