### PR TITLE
fix: return subtraction created_at in responses

### DIFF
--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -19,6 +19,7 @@ from virtool.types import App
 PROJECTION = [
     "_id",
     "count",
+    "created_at",
     "file",
     "ready",
     "job",


### PR DESCRIPTION
This is already returned in detailed responses. Return in listings.