### PR TITLE
Base type

### DIFF
--- a/virtool/account/db.py
+++ b/virtool/account/db.py
@@ -21,7 +21,7 @@ PROJECTION = (
 )
 
 
-def compose_password_update(password: str) -> Dict[str]:
+def compose_password_update(password: str) -> Dict[str, Any]:
     """
     Compose an update dict for self-changing a users account password.
 

--- a/virtool/account/db.py
+++ b/virtool/account/db.py
@@ -21,7 +21,7 @@ PROJECTION = (
 )
 
 
-def compose_password_update(password: str) -> Dict[str, Any]:
+def compose_password_update(password: str) -> Dict[str]:
     """
     Compose an update dict for self-changing a users account password. This will disable forced
     reset and won't invalidate current sessions, unlike a password change by an administrator.
@@ -38,7 +38,7 @@ def compose_password_update(password: str) -> Dict[str, Any]:
     }
 
 
-async def get(db, user_id: str) -> Dict[str, Any]:
+async def get(db, user_id: str) -> Document:
     """
     Get appropriately projected user document by id.
 
@@ -75,7 +75,7 @@ async def get_alternate_id(db, name: str) -> str:
 
 async def create_api_key(
     db, name: str, permissions: Dict[str, bool], user_id: str
-) -> Dict[str, Any]:
+) -> Document:
     """
     Create a new API key for the account with the given `user_id`.
 

--- a/virtool/account/db.py
+++ b/virtool/account/db.py
@@ -4,9 +4,9 @@ Work with the current user account and its API keys.
 """
 from typing import Any, Dict
 
-import virtool.users.db
 import virtool.users.utils
 import virtool.utils
+from virtool.types import Document
 
 PROJECTION = (
     "_id",
@@ -23,8 +23,10 @@ PROJECTION = (
 
 def compose_password_update(password: str) -> Dict[str]:
     """
-    Compose an update dict for self-changing a users account password. This will disable forced
-    reset and won't invalidate current sessions, unlike a password change by an administrator.
+    Compose an update dict for self-changing a users account password.
+
+    This will disable forced reset and won't invalidate current sessions, unlike a
+    password change by an administrator.
 
     :param password: the new password
     :return: a password update
@@ -52,8 +54,8 @@ async def get(db, user_id: str) -> Document:
 
 async def get_alternate_id(db, name: str) -> str:
     """
-    Get an alternate id for an API key whose provided `name` is not unique. Appends an integer
-    suffix to the end of the `name`.
+    Get an alternate id for an API key whose provided `name` is not unique. Appends an
+    integer suffix to the end of the `name`.
 
     :param db: the application database object
     :param name: the API key name
@@ -79,10 +81,11 @@ async def create_api_key(
     """
     Create a new API key for the account with the given `user_id`.
 
-    API keys can only receive permissions possessed by the owner of the API key. If the owner is an
-    administrator, their key permissions will not be limited.
+    API keys can only receive permissions possessed by the owner of the API key. If the
+    owner is an administrator, their key permissions will not be limited.
 
-    Actions that require administrator status cannot be performed using API key authentication.
+    Actions that require administrator status cannot be performed using API key
+    authentication.
 
     :param db: the application database object
     :param name: a display name for the API key

--- a/virtool/api/json.py
+++ b/virtool/api/json.py
@@ -1,11 +1,11 @@
 """
 Code for working with JSON.
 
-:class:`CustomEncoder` is a custom JSON encoder that encodes :class:`datetime.datetime` objects
-into ISO formatted strings. Is is used mostly for encoding JSON API responses.
+:class:`CustomEncoder` is a custom JSON encoder that encodes :class:`datetime.datetime`
+objects into ISO formatted strings. It is used mostly for encoding JSON API responses.
 
-The :func:`dumps` and :func:`pretty_dumps` functions stringify Python data structures into JSON.
-The pretty dumper is used for formatting JSON for viewing in the browser.
+The :func:`dumps` and :func:`pretty_dumps` functions stringify Python data structures
+into JSON. The pretty dumper is used for formatting JSON for viewing in the browser.
 
 """
 import datetime
@@ -14,8 +14,8 @@ import json
 
 class CustomEncoder(json.JSONEncoder):
     """
-    A custom :class:`JSONEncoder` that converts :class:`datetime` objects to ISO-formatting date
-    strings.
+    A custom :class:`JSONEncoder` that converts :class:`datetime` objects to
+    ISO-formatting date strings.
 
     """
 
@@ -39,21 +39,23 @@ def isoformat(obj: datetime.datetime) -> str:
 
 def dumps(obj: object) -> str:
     """
-    A wrapper for :func:`json.dumps` is able to encode datetime objects in input. Used as `dumps`
-    argument for :func:`.json_response`.
+    A wrapper for :func:`json.dumps` is able to encode datetime objects in input.
+
+    Used as `dumps` argument for :func:`.json_response`.
 
     :param obj: a JSON-serializable object
     :return: a JSON string
+
     """
     return json.dumps(obj, cls=CustomEncoder)
 
 
 def pretty_dumps(obj: object) -> str:
     """
-    A wrapper for :func:`json.dumps` that applies pretty formatting to the output. Sorts keys and
-    adds indentation.
+    A wrapper for :func:`json.dumps` that applies pretty formatting to the output.
 
-    Used as ``dumps`` argument for :func:`.json_response`.
+    Sorts keys and adds indentation. Used as ``dumps`` argument for
+    :func:`.json_response`.
 
     :param obj: a JSON-serializable object
     :return: a JSON string

--- a/virtool/api/response.py
+++ b/virtool/api/response.py
@@ -8,8 +8,8 @@ def json_response(
     data: object, status: int = 200, headers: Optional[dict] = None
 ) -> Response:
     """
-    Return a response object whose attached JSON dict will be formatted by middleware depending on
-    the request's `Accept` header.
+    Return a response object whose attached JSON dict will be formatted by middleware
+    depending on the request's `Accept` header.
 
     :param data: the data to send in the response as JSON
     :param status: the HTTP status code for the response

--- a/virtool/api/utils.py
+++ b/virtool/api/utils.py
@@ -3,12 +3,11 @@ import math
 import re
 from typing import Dict, List, Optional, Tuple, Union
 
-import aiohttp.web
+from aiohttp.web import Request
 from multidict import MultiDictProxy
 
-import virtool.users.utils
-import virtool.utils
 from virtool.types import Projection
+from virtool.utils import coerce_list, to_bool
 
 
 def compose_exists_query(field: str) -> Dict[str, Dict[str, bool]]:
@@ -24,8 +23,8 @@ def compose_exists_query(field: str) -> Dict[str, Dict[str, bool]]:
 
 def compose_regex_query(term, fields: List[str]) -> Dict[str, List[Dict[str, dict]]]:
     """
-    Compose a MongoDB query that checks if the values of the passed `fields` match the passed
-    search `term`.
+    Compose a MongoDB query that checks if the values of the passed `fields` match the
+    passed search `term`.
 
     :param term: the term to search
     :param fields: the list of field to match against
@@ -36,7 +35,7 @@ def compose_regex_query(term, fields: List[str]) -> Dict[str, List[Dict[str, dic
         raise TypeError("Type of 'fields' must be one of 'list' or 'tuple'")
 
     # Stringify fields.
-    fields = [str(field) for field in virtool.utils.coerce_list(fields)]
+    fields = [str(field) for field in coerce_list(fields)]
 
     term = re.escape(term)
 
@@ -61,21 +60,22 @@ async def paginate(
 
     Uses a number of different queries to return search results.
 
-    The `db_query` is composed is passed in the function call. This is usually derived from user
-    input such as search terms and filter options. This documents matching query will count toward
-    the returned `found_count`.
+    The `db_query` is composed is passed in the function call. This is usually derived
+    from user input such as search terms and filter options. This documents matching
+    query will count toward the returned `found_count`.
 
-    The `url_query` is the raw query from the request URL. This value is used to derive the `page`
-    and `per_page` numbers used in paging the search results.
+    The `url_query` is the raw query from the request URL. This value is used to derive
+    the `page` and `per_page` numbers used in paging the search results.
 
-    The `base_query` is affects the `total_count` of documents in the collection returned to the
-    API client. An example where this is used is only ever returning documents that have a `ready`
-    field set to `True`. If the field is `False`, the client would never know the document existed.
+    The `base_query` is affects the `total_count` of documents in the collection
+    returned to the API client. An example where this is used is only ever returning
+    documents that have a `ready` field set to `True`. If the field is `False`, the
+    client would never know the document existed.
 
-    The function returns a dictionary containing the matching `documents` and metadata about the
-    search.
+    The function returns a dictionary containing the matching `documents` and metadata
+    about the search.
 
-    `total_count`: the total number of documents the API client should see are in the collection
+    `total_count`: the total number of unhidden documents in the collection
     `found_count`: the number of documents matching the search query (`db_query`)
     `page_count`: the number of pages given the passed `per_page` value
     `per_page`: the `documents` to return for each page request
@@ -137,7 +137,7 @@ async def paginate(
     }
 
 
-def get_query_bool(req: aiohttp.web.Request, key: str) -> bool:
+def get_query_bool(req: Request, key: str) -> bool:
     """
     Return a `bool` calculated from a URL query given its `key`.
 
@@ -148,6 +148,6 @@ def get_query_bool(req: aiohttp.web.Request, key: str) -> bool:
     """
     try:
         short = req.query[key]
-        return virtool.utils.to_bool(short)
+        return to_bool(short)
     except KeyError:
         return False

--- a/virtool/config/cli.py
+++ b/virtool/config/cli.py
@@ -1,16 +1,17 @@
 import asyncio
 import json
-import logging
+from logging import getLogger
 from pathlib import Path
 
 import click
 import uvloop
-import virtool.app
+
 import virtool.jobs.main
+from virtool.app import run_app
 from virtool.config.cls import Config
 from virtool.logs import configure_logs
 
-logger = logging.getLogger(__name__)
+logger = getLogger("config")
 
 
 def create_default_map():
@@ -173,7 +174,7 @@ def start_server(
     )
 
     logger.info("Starting in server mode")
-    asyncio.get_event_loop().run_until_complete(virtool.app.run_app(config))
+    asyncio.get_event_loop().run_until_complete(run_app(config))
 
 
 @cli.command("jobsAPI")

--- a/virtool/db/mongo.py
+++ b/virtool/db/mongo.py
@@ -1,16 +1,18 @@
-import logging
 import sys
+from logging import getLogger
 from typing import Callable, List
 
-import pymongo.errors
-import virtool.db.core
 from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import ASCENDING, DESCENDING
+from pymongo.errors import ServerSelectionTimeoutError
 from semver import VersionInfo
+
 from virtool.config.cls import Config
+from virtool.db.core import DB
 
 MINIMUM_MONGO_VERSION = "3.6.0"
 
-logger = logging.getLogger("mongo")
+logger = getLogger("mongo")
 
 
 async def connect(
@@ -29,7 +31,7 @@ async def connect(
 
     try:
         await db_client.list_database_names()
-    except pymongo.errors.ServerSelectionTimeoutError:
+    except ServerSelectionTimeoutError:
         logger.critical("Could not connect to MongoDB server")
         sys.exit(1)
 
@@ -37,12 +39,14 @@ async def connect(
 
     db = db_client[config.db_name]
 
-    return virtool.db.core.DB(db, enqueue_change)
+    return DB(db, enqueue_change)
 
 
 async def check_mongo_version(db: AsyncIOMotorClient) -> str:
     """
-    Check the MongoDB version. Log a critical error and exit if it is too old.
+    Check the MongoDB version.
+
+    Log a critical error and exit if it is too old. Return it otherwise.
 
     :param db: the application database object
     :return: the MongoDB version
@@ -66,6 +70,7 @@ async def get_mongo_version(db: AsyncIOMotorClient) -> str:
 
     :param db: the application database object
     :return: MongoDB server version in string format
+
     """
     return (await db.motor_client.client.server_info())["version"]
 
@@ -75,30 +80,29 @@ async def create_indexes(db):
     Create all MongoDB indexes.
 
     :param db: the application database object
+
     """
     await db.analyses.create_index("sample.id")
-    await db.analyses.create_index([("created_at", pymongo.DESCENDING)])
+    await db.analyses.create_index([("created_at", DESCENDING)])
     await db.caches.create_index(
-        [("key", pymongo.ASCENDING), ("sample.id", pymongo.ASCENDING)], unique=True
+        [("key", ASCENDING), ("sample.id", ASCENDING)], unique=True
     )
     await db.history.create_index("otu.id")
     await db.history.create_index("index.id")
     await db.history.create_index("created_at")
-    await db.history.create_index([("otu.name", pymongo.ASCENDING)])
-    await db.history.create_index([("otu.version", pymongo.DESCENDING)])
+    await db.history.create_index([("otu.name", ASCENDING)])
+    await db.history.create_index([("otu.version", DESCENDING)])
     await db.indexes.create_index(
-        [("version", pymongo.ASCENDING), ("reference.id", pymongo.ASCENDING)],
+        [("version", ASCENDING), ("reference.id", ASCENDING)],
         unique=True,
     )
     await db.keys.create_index("id", unique=True)
     await db.keys.create_index("user.id")
-    await db.otus.create_index(
-        [("_id", pymongo.ASCENDING), ("isolate.id", pymongo.ASCENDING)]
-    )
+    await db.otus.create_index([("_id", ASCENDING), ("isolate.id", ASCENDING)])
     await db.otus.create_index("name")
     await db.otus.create_index("nickname")
     await db.otus.create_index("abbreviation")
-    await db.samples.create_index([("created_at", pymongo.DESCENDING)])
+    await db.samples.create_index([("created_at", DESCENDING)])
     await db.sequences.create_index("otu_id")
     await db.sequences.create_index("name")
     await db.users.create_index("b2c_oid", unique=True, sparse=True)

--- a/virtool/db/utils.py
+++ b/virtool/db/utils.py
@@ -3,7 +3,7 @@ Utilities for working with MongoDB.
 
 """
 from contextlib import asynccontextmanager
-from typing import Any, Dict, Optional, Sequence, Union, Set
+from typing import Any, Dict, Optional, Sequence, Set, Union
 
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import InsertOne, UpdateOne
@@ -27,7 +27,8 @@ class BufferedBulkWriter:
         """
         Add a write request to the buffer.
 
-        If the buffer has reached ``batch_size`` all requests will be sent to MongoDB and the buffer will be emptied.
+        If the buffer has reached ``batch_size`` all requests will be sent to MongoDB
+        and the buffer will be emptied.
 
         :param request: the request to add to the buffer
 
@@ -52,7 +53,8 @@ async def buffered_bulk_writer(collection, batch_size=100):
     """
     A context manager for bulk writing to MongoDB.
 
-    Returns a :class:``BufferedBulkWriter`` object. Automatically flushes the buffer when the context manager exits.
+    Returns a :class:``BufferedBulkWriter`` object. Automatically flushes the buffer
+    when the context manager exits.
 
     :param collection: the MongoDB collection to write against
     :param batch_size: the number of requests to be sent in each bulk operation
@@ -124,8 +126,8 @@ async def check_missing_ids(
 
 async def get_new_id(collection, excluded: Optional[Sequence[str]] = None) -> str:
     """
-    Returns a new, unique, id that can be used for inserting a new document. Will not return any id
-    that is included in ``excluded``.
+    Returns a new, unique, id that can be used for inserting a new document. Will not
+    return any id that is included in ``excluded``.
 
     :param collection: the Mongo collection to get a new _id for
     :param excluded: a list of ids to exclude from the search

--- a/virtool/genbank/api.py
+++ b/virtool/genbank/api.py
@@ -2,9 +2,10 @@
 Provides request handlers for accessing GenBank through the web server.
 
 """
-import aiohttp
+from aiohttp import ClientConnectorError
+from aiohttp.web import HTTPBadGateway, Response
+
 import virtool.genbank.http
-from aiohttp.web import HTTPBadGateway
 from virtool.api.response import NotFound, json_response
 from virtool.http.routes import Routes
 
@@ -12,10 +13,10 @@ routes = Routes()
 
 
 @routes.get("/genbank/{accession}")
-async def get(req):
+async def get(req) -> Response:
     """
-    Retrieve the Genbank data associated with the given accession and transform it into a Virtool-style sequence
-    document.
+    Retrieve the Genbank data associated with the given accession and transform it into
+    a Virtool-style sequence document.
 
     """
     accession = req.match_info["accession"]
@@ -30,5 +31,5 @@ async def get(req):
 
         return json_response(data)
 
-    except aiohttp.ClientConnectorError:
+    except ClientConnectorError:
         raise HTTPBadGateway(text="Could not reach NCBI")

--- a/virtool/groups/api.py
+++ b/virtool/groups/api.py
@@ -1,8 +1,10 @@
 import pymongo.errors
+from aiohttp.web import Request, Response
+from aiohttp.web_exceptions import HTTPBadRequest, HTTPNoContent
+
 import virtool.groups.db
 import virtool.http.routes
 import virtool.validators
-from aiohttp.web_exceptions import HTTPBadRequest, HTTPNoContent
 from virtool.api.response import NotFound, json_response
 from virtool.http.schema import schema
 from virtool.users.utils import generate_base_permissions
@@ -12,7 +14,7 @@ routes = virtool.http.routes.Routes()
 
 
 @routes.get("/groups")
-async def find(req):
+async def find(req: Request) -> Response:
     """
     Get a list of all existing group documents.
 
@@ -32,7 +34,7 @@ async def find(req):
         }
     }
 )
-async def create(req):
+async def create(req: Request) -> Response:
     """
     Adds a new user group.
 
@@ -55,7 +57,7 @@ async def create(req):
 
 
 @routes.get("/groups/{group_id}")
-async def get(req):
+async def get(req: Request) -> Response:
     """
     Gets a complete group document.
 
@@ -78,7 +80,7 @@ async def get(req):
         }
     }
 )
-async def update_permissions(req):
+async def update_permissions(req: Request) -> Response:
     """
     Updates the permissions of a given group.
 
@@ -106,7 +108,7 @@ async def update_permissions(req):
 
 
 @routes.delete("/groups/{group_id}", admin=True)
-async def remove(req):
+async def remove(req: Request):
     """
     Remove a group.
 

--- a/virtool/labels/db.py
+++ b/virtool/labels/db.py
@@ -1,7 +1,9 @@
 from typing import Dict, Any
 
+from virtool.types import Document
 
-async def attach_sample_count(db, document: dict) -> Dict[str, Any]:
+
+async def attach_sample_count(db, document: dict) -> Document:
     """
     Attach the number of samples associated with the given label to the passed document.
 

--- a/virtool/pg/utils.py
+++ b/virtool/pg/utils.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional, Type, Union
 
 from sqlalchemy import select, text
 from sqlalchemy.engine.result import ScalarResult
@@ -64,11 +64,11 @@ async def create_models(engine):
         await conn.run_sync(Base.metadata.create_all)
 
 
-async def delete_row(pg: AsyncEngine, id_: int, model: Base):
+async def delete_row(pg: AsyncEngine, id_: int, model: Type[Base]):
     """
     Deletes a row in the `model` SQL model by its row `id_`.
 
-    :param pg: PostgreSQL AsyncEngine object
+    :param pg: the application AsyncEngine object
     :param id_: Row `id` to delete from the given SQL model
     :param model: Table to delete row from
     """
@@ -80,11 +80,11 @@ async def delete_row(pg: AsyncEngine, id_: int, model: Base):
             await session.commit()
 
 
-async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int) -> Optional[Base]:
+async def get_row_by_id(pg: AsyncEngine, model: Type[Base], id_: int) -> Optional[Base]:
     """
     Get a row from a SQL `model` by its `id`.
 
-    :param pg: PostgreSQL AsyncEngine object
+    :param pg: the application AsyncEngine object
     :param model: A model to retrieve a row from
     :param id_: An SQL row `id`
     :return: Row from the given SQL model
@@ -92,14 +92,14 @@ async def get_row_by_id(pg: AsyncEngine, model: Base, id_: int) -> Optional[Base
     return await get_row(pg, model, ("id", id_))
 
 
-async def get_row(pg: AsyncEngine, model: Base, match: tuple) -> Optional[Base]:
+async def get_row(pg: AsyncEngine, model: Type[Base], match: tuple) -> Optional[Base]:
     """
     Get a row from the SQL `model` that matches a query and column combination.
 
-    :param pg: PostgreSQL AsyncEngine object
-    :param model: A model to retrieve a row from
-    :param match: A (column, value) tuple to filter results by
-    :return: Row from the given SQL model
+    :param pg: the application AsyncEngine object
+    :param model: a model to retrieve a row from
+    :param match: a (column, value) tuple to filter results by
+    :return: row from the given SQL model
     """
     (column, value) = match
     async with AsyncSession(pg) as session:
@@ -110,14 +110,14 @@ async def get_row(pg: AsyncEngine, model: Base, match: tuple) -> Optional[Base]:
 
 async def get_rows(
     pg: AsyncEngine,
-    model: Base,
+    model: Type[Base],
     filter_: str = "name",
     query: Optional[Union[str, int, bool, SQLEnum]] = None,
 ) -> ScalarResult:
     """
     Get one or more rows from the `model` SQL model by its `filter_`. By default, rows will be fetched by their `name`.
 
-    :param pg: PostgreSQL AsyncEngine object
+    :param pg: the application AsyncEngine object
     :param query: A query to filter by
     :param model: A model to retrieve a row from
     :param filter_: A table column to search for a given `query`

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -2,13 +2,14 @@ import asyncio
 from asyncio.tasks import gather
 
 import aiohttp
+from aiohttp.web_exceptions import HTTPBadGateway, HTTPBadRequest, HTTPNoContent
+
 import virtool.db.utils
 import virtool.history.db
 import virtool.indexes.db
 import virtool.otus.db
 import virtool.references.db
 import virtool.utils
-from aiohttp.web_exceptions import HTTPBadGateway, HTTPBadRequest, HTTPNoContent
 from virtool.api.response import InsufficientRights, NotFound, json_response
 from virtool.api.utils import compose_regex_query, paginate
 from virtool.errors import DatabaseError, GitHubError
@@ -34,7 +35,7 @@ from virtool.references.tasks import (
     UpdateRemoteReferenceTask,
 )
 from virtool.uploads.models import Upload
-from virtool.users.db import attach_user, extend_user
+from virtool.users.db import extend_user
 from virtool.validators import strip
 
 routes = Routes()

--- a/virtool/types.py
+++ b/virtool/types.py
@@ -2,10 +2,12 @@
 Custom Types for Virtool
 
 """
-from typing import Union, Dict, Sequence, Any, Callable, Awaitable
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Dict, List, Sequence, Union
 
-import aiohttp.web
+from aiohttp.web import Application, Request, Response
 
-App = Union[aiohttp.web.Application, Dict[str, Any]]
+App = Union[Application, Dict[str, Any]]
+Document = Dict[str, Union[Dict, List, bool, str, int, float, datetime]]
 Projection = Union[Dict[str, bool], Sequence[str]]
-RouteHandler = Callable[[aiohttp.web.Request], Awaitable[aiohttp.web.Response]]
+RouteHandler = Callable[[Request], Awaitable[Response]]

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -1,11 +1,11 @@
 from asyncio import CancelledError
 from logging import getLogger
-from pathlib import Path
 
-import virtool.uploads.db
 from aiohttp.web_exceptions import HTTPBadRequest
 from aiohttp.web_fileresponse import FileResponse
 from aiohttp.web_response import Response
+
+import virtool.uploads.db
 from virtool.api.response import InvalidQuery, NotFound, json_response
 from virtool.http.routes import Routes
 from virtool.uploads.models import Upload, UploadType
@@ -114,7 +114,8 @@ async def download(req):
 @routes.delete("/uploads/{id}", permission="remove_file")
 async def delete(req):
     """
-    Set a row's `removed` and `removed_at` attribute in the `uploads` SQL table and delete its associated local file.
+    Set a row's `removed` and `removed_at` attribute in the `uploads` SQL table and
+    delete its associated local file.
 
     """
     pg = req.app["pg"]

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -27,7 +27,7 @@ async def create(
     :param pg: PostgreSQL AsyncEngine object
     :param name: The name of the upload
     :param upload_type: The type of upload (e.g. reads)
-    :param reserved: Whether the file should immediately be reserved (used for legacy samples)
+    :param reserved: Whether the file should immediately be reserved
     :param user: The id of the uploading user
     :return: Dictionary representation of new row in the `uploads` SQL table
     """
@@ -57,8 +57,9 @@ async def create(
 
 async def finalize(pg, size: int, id_: int, model: Type[Base]) -> Optional[dict]:
     """
-    Finalize row creation for tables that store uploaded files. Updates table with file information and sets `ready`
-    to `True`.
+    Finalize row creation for tables that store uploaded files.
+
+    Updates table with file information and sets `ready`    to `True`.
 
     :param pg: PostgreSQL AsyncEngine object
     :param size: Size of a newly uploaded file in bytes
@@ -85,8 +86,9 @@ async def finalize(pg, size: int, id_: int, model: Type[Base]) -> Optional[dict]
 
 async def find(pg, user: str = None, upload_type: str = None) -> List[dict]:
     """
-    Retrieves a list of `Upload` documents in the `uploads` SQL table. Can be given a list of filters to narrow down
-    results.
+    Retrieves a list of `Upload` documents in the `uploads` SQL table.
+
+    Can be given a list of filters to narrow down results.
 
     :param pg: PostgreSQL AsyncEngine object
     :param user: User id that corresponds to the user that uploaded the file
@@ -157,7 +159,9 @@ async def delete(req, pg: AsyncEngine, upload_id: int) -> Optional[dict]:
 
 async def delete_row(pg: AsyncEngine, upload_id: int) -> Optional[dict]:
     """
-    Set the `removed` and `removed_at` attributes in the given row. Returns a dictionary representation of that row.
+    Set the `removed` and `removed_at` attributes in the given row.
+
+    Returns a dictionary representation of that row.
 
     :param pg: PostgreSQL AsyncEngine object
     :param upload_id: Row `id` to set attributes for

--- a/virtool/uploads/models.py
+++ b/virtool/uploads/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, Enum, Integer, String, BigInteger
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Enum, Integer, String
 from sqlalchemy.orm import relationship
 
 from virtool.pg.base import Base
@@ -25,16 +25,16 @@ class Upload(Base):
 
     __tablename__ = "uploads"
 
-    id = Column(Integer, primary_key=True)
-    created_at = Column(DateTime)
-    name = Column(String)
-    name_on_disk = Column(String, unique=True)
-    ready = Column(Boolean, default=False, nullable=False)
-    reads = relationship("SampleReads", lazy="joined")
-    removed = Column(Boolean, default=False, nullable=False)
-    removed_at = Column(DateTime)
-    reserved = Column(Boolean, default=False, nullable=False)
-    size = Column(BigInteger)
-    type = Column(Enum(UploadType))
-    user = Column(String)
-    uploaded_at = Column(DateTime)
+    id: Column = Column(Integer, primary_key=True)
+    created_at: Column = Column(DateTime)
+    name: Column = Column(String)
+    name_on_disk: Column = Column(String, unique=True)
+    ready: Column = Column(Boolean, default=False, nullable=False)
+    reads: Column = relationship("SampleReads", lazy="joined")
+    removed: Column = Column(Boolean, default=False, nullable=False)
+    removed_at: Column = Column(DateTime)
+    reserved: Column = Column(Boolean, default=False, nullable=False)
+    size: Column = Column(BigInteger)
+    type: Column = Column(Enum(UploadType))
+    user: Column = Column(String)
+    uploaded_at: Column = Column(DateTime)


### PR DESCRIPTION
Clean up and format code. Fix typing problems using `Type` and a new `Document` type instead of `Dict[str, Any]`.