### PR TITLE
fix: correct status error schema

### DIFF
--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -122,12 +122,12 @@ async def cancel(req):
                 "type": {"type": "string", "required": True},
                 "traceback": {
                     "type": "list",
-                    "items": [{"type": "string"}],
+                    "schema": {"type": "string"},
                     "required": True,
                 },
                 "details": {
                     "type": "list",
-                    "items": [{"type": "string"}],
+                    "schema": {"type": "string"},
                     "required": True,
                 },
             },


### PR DESCRIPTION
The "items" key for Cerberus enforces a set length on the list coming in. `"items": [{"type": "string"}]` expects a list containing a single string. This is causing a unexpected 422 error when workflows push a "error" status. 

This PR updates the schema to accept a variable length list of strings.