### PR TITLE
fix: prevent sample create failure by allowing larger file size values

### DIFF
--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Enum
+from sqlalchemy import BigInteger, Column, DateTime, Enum, Integer, String
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
@@ -33,5 +33,5 @@ class AnalysisFile(Base):
     format = Column(Enum(AnalysisFormat))
     name = Column(String)
     name_on_disk = Column(String, unique=True)
-    size = Column(Integer)
+    size = Column(BigInteger)
     uploaded_at = Column(DateTime)

--- a/virtool/caches/models.py
+++ b/virtool/caches/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Enum, Integer, String
+from sqlalchemy import BigInteger, Column, DateTime, Enum, Integer, String
 from sqlalchemy.sql.schema import UniqueConstraint
 
 from virtool.pg.base import Base
@@ -19,7 +19,7 @@ class SampleArtifactCache(Base):
     name = Column(String, nullable=False)
     name_on_disk = Column(String)
     sample = Column(String, nullable=False)
-    size = Column(Integer)
+    size = Column(BigInteger)
     type = Column(Enum(ArtifactType), nullable=False)
     uploaded_at = Column(DateTime)
 
@@ -38,5 +38,5 @@ class SampleReadsCache(Base):
     name = Column(String(length=13), nullable=False)
     name_on_disk = Column(String, nullable=False)
     sample = Column(String, nullable=False)
-    size = Column(Integer)
+    size = Column(BigInteger)
     uploaded_at = Column(DateTime)

--- a/virtool/indexes/models.py
+++ b/virtool/indexes/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Enum, Integer, String, UniqueConstraint
+from sqlalchemy import BigInteger, Column, Enum, Integer, String, UniqueConstraint
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
@@ -28,4 +28,4 @@ class IndexFile(Base):
     name = Column(String, nullable=False)
     index = Column(String, nullable=False)
     type = Column(Enum(IndexType))
-    size = Column(Integer)
+    size = Column(BigInteger)

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Enum, Integer, String
+from sqlalchemy import BigInteger, Column, DateTime, Enum, Integer, String
 from sqlalchemy.sql.schema import ForeignKey, UniqueConstraint
 
 from virtool.pg.base import Base
@@ -33,7 +33,7 @@ class SampleArtifact(Base):
     sample = Column(String, nullable=False)
     name = Column(String, nullable=False)
     name_on_disk = Column(String)
-    size = Column(Integer)
+    size = Column(BigInteger)
     type = Column(Enum(ArtifactType), nullable=False)
     uploaded_at = Column(DateTime)
 
@@ -51,6 +51,6 @@ class SampleReads(Base):
     sample = Column(String, nullable=False)
     name = Column(String(length=13), nullable=False)
     name_on_disk = Column(String, nullable=False)
-    size = Column(Integer)
+    size = Column(BigInteger)
     upload = Column(Integer, ForeignKey("uploads.id"))
     uploaded_at = Column(DateTime)

--- a/virtool/subtractions/models.py
+++ b/virtool/subtractions/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Enum, Integer, String, UniqueConstraint
+from sqlalchemy import BigInteger, Column, Enum, Integer, String, UniqueConstraint
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
@@ -27,4 +27,4 @@ class SubtractionFile(Base):
     name = Column(String)
     subtraction = Column(String)
     type = Column(Enum(SubtractionType))
-    size = Column(Integer)
+    size = Column(BigInteger)


### PR DESCRIPTION
The size columns for a number of SQL-based file models are still using `Integer`, which causes an exception when the file sizes exceed the capacity of `Integer`.

Change all to `BigInteger`. This is fine as the migration has been applied.