### PR TITLE
Clean up timed out remote ref updates

### DIFF
--- a/tests/references/__snapshots__/test_tasks.ambr
+++ b/tests/references/__snapshots__/test_tasks.ambr
@@ -1,0 +1,82 @@
+# name: test_clean_references_task[uvloop-clean]
+  <class 'dict'> {
+    '_id': 'foo',
+    'installed': <class 'dict'> {
+      'name': 'v1.2.1',
+    },
+    'remotes_from': <class 'dict'> {
+      'slug': 'virtool/ref-plant-viruses',
+    },
+    'updates': <class 'list'> [
+    ],
+    'updating': False,
+  }
+---
+# name: test_clean_references_task[uvloop-no_updates]
+  <class 'dict'> {
+    '_id': 'foo',
+    'installed': <class 'dict'> {
+      'name': 'v1.2.1',
+    },
+    'remotes_from': <class 'dict'> {
+      'slug': 'virtool/ref-plant-viruses',
+    },
+    'updates': <class 'list'> [
+    ],
+    'updating': True,
+  }
+---
+# name: test_clean_references_task[uvloop-ready]
+  <class 'dict'> {
+    '_id': 'foo',
+    'installed': <class 'dict'> {
+      'name': 'v1.2.1',
+    },
+    'remotes_from': <class 'dict'> {
+      'slug': 'virtool/ref-plant-viruses',
+    },
+    'updates': <class 'list'> [
+      <class 'dict'> {
+        'name': 'v1.2.2',
+        'ready': True,
+      },
+    ],
+    'updating': True,
+  }
+---
+# name: test_clean_references_task[uvloop-too_new]
+  <class 'dict'> {
+    '_id': 'foo',
+    'installed': <class 'dict'> {
+      'name': 'v1.2.1',
+    },
+    'remotes_from': <class 'dict'> {
+      'slug': 'virtool/ref-plant-viruses',
+    },
+    'updates': <class 'list'> [
+      <class 'dict'> {
+        'created_at': datetime.datetime(2020, 1, 1, 21, 20),
+        'name': 'v1.2.2',
+        'ready': False,
+      },
+    ],
+    'updating': True,
+  }
+---
+# name: test_clean_references_task[uvloop-too_old]
+  <class 'dict'> {
+    '_id': 'foo',
+    'installed': <class 'dict'> {
+      'name': 'v1.2.1',
+    },
+    'remotes_from': <class 'dict'> {
+      'slug': 'virtool/ref-plant-viruses',
+    },
+    'updates': <class 'list'> [
+      <class 'dict'> {
+        'name': 'v1.2.0',
+      },
+    ],
+    'updating': True,
+  }
+---

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -1,0 +1,77 @@
+import arrow
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.references.tasks import CleanReferencesTask
+from virtool.tasks.models import Task
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        None,
+        {"name": "v1.2.0"},
+        {"name": "v1.2.2", "ready": True},
+        {
+            "name": "v1.2.2",
+            "created_at": arrow.get("2020-01-01T21:20:00").datetime,
+            "ready": False,
+        },
+        {
+            "name": "v1.2.2",
+            "created_at": arrow.get("2020-01-01T21:00:00").datetime,
+            "ready": False,
+        },
+    ],
+    ids=["no_updates", "too_old", "ready", "too_new", "clean"],
+)
+async def test_clean_references_task(
+    update, dbi, mocker, pg, snapshot, spawn_client, static_time
+):
+    """
+    Test the following situations:
+
+    * no updates have been applied to the references (`[]`)
+    * the latest update is older than the installed version
+    * the latest update is ready indicating the update was successful
+    * the latest update subdocument was created recently and shouldn't be removed
+    * the latest update subdocument is old and not ready (timed out)
+    """
+    mocker.patch("arrow.utcnow", return_value=arrow.get("2020-01-01T21:25:00"))
+
+    client = await spawn_client(authorize=True)
+
+    task = Task(
+        id=1,
+        complete=False,
+        context={},
+        count=0,
+        progress=0,
+        step="clean_timed_out_updates",
+        type="clean_references",
+        created_at=static_time.datetime,
+    )
+
+    async with AsyncSession(pg) as session:
+        session.add(task)
+        await session.commit()
+
+    updates = []
+
+    if update:
+        updates.append(update)
+
+    await dbi.references.insert_one(
+        {
+            "_id": "foo",
+            "updates": updates,
+            "installed": {"name": "v1.2.1"},
+            "updating": True,
+            "remotes_from": {"slug": "virtool/ref-plant-viruses"},
+        }
+    )
+
+    clean_references_task = CleanReferencesTask(client.app, 1)
+    await clean_references_task.run()
+
+    assert await dbi.references.find_one({}) == snapshot

--- a/virtool/tasks/api.py
+++ b/virtool/tasks/api.py
@@ -1,9 +1,8 @@
-import virtool.http.routes
 import virtool.tasks.pg
-import virtool.utils
 from virtool.api.response import NotFound, json_response
+from virtool.http.routes import Routes
 
-routes = virtool.http.routes.Routes()
+routes = Routes()
 
 
 @routes.get("/tasks")

--- a/virtool/tasks/pg.py
+++ b/virtool/tasks/pg.py
@@ -1,7 +1,6 @@
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-import virtool.db.utils
 import virtool.utils
 from virtool.tasks.models import Task
 
@@ -31,13 +30,13 @@ async def get(pg: AsyncEngine, task_id: int) -> dict:
     :return: a task record
 
     """
-    document = dict()
     async with AsyncSession(pg) as session:
         result = (await session.execute(select(Task).filter_by(id=task_id))).scalar()
-    if result:
-        document = result.to_dict()
 
-    return document
+    if result:
+        return result.to_dict()
+
+    return {}
 
 
 async def register(pg, task_class, context: dict = None) -> dict:

--- a/virtool/tasks/task.py
+++ b/virtool/tasks/task.py
@@ -1,4 +1,4 @@
-import logging
+from logging import getLogger
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,7 +7,7 @@ import virtool.tasks.models
 import virtool.tasks.pg
 from virtool.utils import get_temp_dir
 
-logger = logging.getLogger("task")
+logger = getLogger("task")
 
 
 class Task:
@@ -135,8 +135,10 @@ class ProgressTracker:
 
     async def add(self, value: int) -> int:
         """
-        Add value to progress, the value will be automatically convert to progress based on the value and file size,
-        and update to the SQL database.
+        Add value to progress.
+
+        The value will be automatically convert to progress based on the value and file
+        size, and update to the SQL database.
 
         :param value: the value to be added to progress.
         :return: the new progress after update.

--- a/virtool/tasks/task.py
+++ b/virtool/tasks/task.py
@@ -28,6 +28,9 @@ class Task:
         self.errored = False
         self.temp_dir = get_temp_dir()
 
+    def __str__(self):
+        return f"<{type(self).__name__} id={self.id} step={self.step.__name__}>"
+
     async def init_db(self):
         self.document = await virtool.tasks.pg.get(self.pg, self.id)
         self.context = self.document["context"]
@@ -45,6 +48,7 @@ class Task:
             try:
                 await func()
             except Exception as err:
+                logger.exception(f"Encountered error in {self}")
                 await self.error(str(err))
 
         if not self.errored:


### PR DESCRIPTION
Remote reference updates can time out of the application Redis connection fails before the update task is started.

I added a task to clean this up.