### PR TITLE
Restore support for exporting analysis results as csv and xlsx

### DIFF
--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -376,7 +376,7 @@ async def download_analysis_document(req: Request) -> Response:
         "Content-Type": content_type,
     }
 
-    return Response(text=formatted, headers=headers)
+    return Response(body=formatted, headers=headers)
 
 
 @routes.put("/analyses/{analysis_id}/{sequence_index}/blast")

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -246,7 +246,7 @@ async def format_analysis_to_excel(app: App, document: Dict[str, Any]) -> bytes:
     :return: the formatted Excel workbook
 
     """
-    depths = calculate_median_depths(document["hits"])
+    depths = calculate_median_depths(document["results"]["hits"])
 
     formatted = await format_analysis(app, document)
 
@@ -266,7 +266,7 @@ async def format_analysis_to_excel(app: App, document: Dict[str, Any]) -> bytes:
 
     rows = list()
 
-    for otu in formatted["results"]:
+    for otu in formatted["results"]["hits"]:
         for isolate in otu["isolates"]:
             for sequence in isolate["sequences"]:
                 row = [
@@ -302,7 +302,7 @@ async def format_analysis_to_csv(app: App, document: Dict[str, Any]) -> str:
     :return: the formatted CSV data
 
     """
-    depths = calculate_median_depths(document["hits"])
+    depths = calculate_median_depths(document["results"]["hits"])
 
     formatted = await format_analysis(app, document)
 
@@ -312,7 +312,7 @@ async def format_analysis_to_csv(app: App, document: Dict[str, Any]) -> str:
 
     writer.writerow(CSV_HEADERS)
 
-    for otu in formatted["results"]:
+    for otu in formatted["results"]["hits"]:
         for isolate in otu["isolates"]:
             for sequence in isolate["sequences"]:
                 row = [


### PR DESCRIPTION
Small fixes. Seems likely that the `document` dict changed shape at some point and this was missed in the updates. Also changed the the formatted response to be sent in body rather than text, as the text field does not accept the byte format used for the .xlsx files. 

Final csv file (in excel)
![image](https://user-images.githubusercontent.com/59776400/152019731-047ef651-67a0-4dbe-9ec0-d64b37504074.png)

Final xlsx file (in excel)
![image](https://user-images.githubusercontent.com/59776400/152019578-95b85f35-0443-4e48-9b5b-e3f593804db5.png)

(Input is a pathoscope run on reads_1.fq.gz and reads_2.fq.gz combined)