### PR TITLE
Document transformation pipelines

### DIFF
--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -26,6 +26,8 @@
     'sample': <class 'dict'> {
       'id': 'sample1',
     },
+    'subtractions': <class 'list'> [
+    ],
     'user': <class 'dict'> {
       'administrator': False,
       'handle': 'leeashley',
@@ -44,6 +46,8 @@
     'sample': <class 'dict'> {
       'id': 'sample1',
     },
+    'subtractions': <class 'list'> [
+    ],
     'user': <class 'dict'> {
       'id': '7CtBo2yG',
     },
@@ -71,6 +75,8 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -96,6 +102,12 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+          <class 'dict'> {
+            'id': 'foo',
+            'name': 'Malus domestica',
+          },
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -121,6 +133,8 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -181,6 +195,16 @@
     'created_at': '2015-10-06T20:00:00Z',
     'formatted': True,
     'id': 'foo',
+    'subtractions': <class 'list'> [
+      <class 'dict'> {
+        'id': 'apple',
+        'name': 'Apple',
+      },
+      <class 'dict'> {
+        'id': 'plum',
+        'name': 'Plum',
+      },
+    ],
     'user': <class 'dict'> {
       'administrator': False,
       'handle': 'leeashley',

--- a/tests/analyses/__snapshots__/test_db.ambr
+++ b/tests/analyses/__snapshots__/test_db.ambr
@@ -739,7 +739,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'files': <class 'list'> [
     ],
-    'id': '9pfsom1b',
+    'id': 'test_analysis',
     'index': <class 'dict'> {
       'id': 'test_index',
       'version': 11,
@@ -768,7 +768,7 @@
 ---
 # name: test_create[uvloop-test_analysis].1
   <class 'dict'> {
-    '_id': '9pfsom1b',
+    '_id': 'test_analysis',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'files': <class 'list'> [
     ],

--- a/tests/analyses/__snapshots__/test_db.ambr
+++ b/tests/analyses/__snapshots__/test_db.ambr
@@ -672,10 +672,10 @@
 ---
 # name: test_create[uvloop-None]
   <class 'dict'> {
-    '_id': '9pfsom1b',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'files': <class 'list'> [
     ],
+    'id': '9pfsom1b',
     'index': <class 'dict'> {
       'id': 'test_index',
       'version': 11,
@@ -736,10 +736,10 @@
 ---
 # name: test_create[uvloop-test_analysis]
   <class 'dict'> {
-    '_id': 'test_analysis',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'files': <class 'list'> [
     ],
+    'id': '9pfsom1b',
     'index': <class 'dict'> {
       'id': 'test_index',
       'version': 11,
@@ -768,7 +768,7 @@
 ---
 # name: test_create[uvloop-test_analysis].1
   <class 'dict'> {
-    '_id': 'test_analysis',
+    '_id': '9pfsom1b',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'files': <class 'list'> [
     ],

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 from faker import Faker
+
 from tests.fixtures.fake import FakeGenerator
 from virtool.analyses.files import create_analysis_file
 from virtool.analyses.models import AnalysisFile
@@ -35,7 +36,12 @@ async def test_find(snapshot, mocker, fake, spawn_client, resp_is, static_time):
             "all_read": True,
             "all_write": True,
             "user": {"id": user["_id"]},
+            "labels": [],
         }
+    )
+
+    await client.db.subtraction.insert_one(
+        {"_id": "foo", "name": "Malus domestica", "nickname": "Apple"}
     )
 
     await client.db.analyses.insert_many(
@@ -50,6 +56,7 @@ async def test_find(snapshot, mocker, fake, spawn_client, resp_is, static_time):
                 "user": {"id": user["_id"]},
                 "sample": {"id": "test"},
                 "reference": {"id": "baz", "name": "Baz"},
+                "subtractions": [],
                 "foobar": True,
             },
             {
@@ -62,6 +69,7 @@ async def test_find(snapshot, mocker, fake, spawn_client, resp_is, static_time):
                 "user": {"id": user["_id"]},
                 "sample": {"id": "test"},
                 "reference": {"id": "baz", "name": "Baz"},
+                "subtractions": ["foo"],
                 "foobar": True,
             },
             {
@@ -74,6 +82,7 @@ async def test_find(snapshot, mocker, fake, spawn_client, resp_is, static_time):
                 "user": {"id": user["_id"]},
                 "sample": {"id": "test"},
                 "reference": {"id": "foo", "name": "Foo"},
+                "subtractions": [],
                 "foobar": False,
             },
         ]
@@ -126,8 +135,9 @@ async def test_get(
                 "group": "tech",
                 "group_read": True,
                 "group_write": True,
+                "labels": [],
                 "subtractions": ["apple", "plum"],
-                "user": {"id": "fred"},
+                "user": {"id": user["_id"]},
             }
         )
 
@@ -143,6 +153,7 @@ async def test_get(
                 "created_at": static_time.datetime,
                 "formatted": True,
                 "user": {"id": user["_id"]},
+                "subtractions": ["apple", "plum"],
             }
         ),
     )
@@ -468,6 +479,7 @@ async def test_finalize(fake, snapshot, spawn_job_client, faker, error, resp_is)
         "workflow": "test_workflow",
         "user": {"id": user["_id"]},
         "ready": error == 409,
+        "subtractions": [],
     }
 
     patch_json = {"results": {"result": "TEST_RESULT"}}
@@ -530,6 +542,7 @@ async def test_finalize_large(fake, spawn_job_client, faker):
             "workflow": "test_workflow",
             "user": {"id": user["_id"]},
             "ready": False,
+            "subtractions": [],
         }
     )
 

--- a/tests/dispatcher/test_fetchers.py
+++ b/tests/dispatcher/test_fetchers.py
@@ -1,4 +1,6 @@
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+
 from virtool.dispatcher.change import Change
 from virtool.dispatcher.fetchers import (
     IndexesFetcher,
@@ -8,7 +10,6 @@ from virtool.dispatcher.fetchers import (
     UploadsFetcher,
 )
 from virtool.dispatcher.operations import DELETE, INSERT, UPDATE
-from virtool.uploads.models import UploadType
 
 
 @pytest.fixture
@@ -173,7 +174,7 @@ class TestIndexesFetcher:
 
 
 class TestLabelsFetcher:
-    async def test_auto_delete(self, connections, dbi, pg, ws):
+    async def test_auto_delete(self, connections, dbi, pg: AsyncEngine, ws):
         fetcher = LabelsFetcher(pg, dbi)
 
         pairs = list()
@@ -197,7 +198,13 @@ class TestLabelsFetcher:
             pairs.append(pair)
 
         message = {
-            "data": {"id": 1, "name": "Legacy", "color": None, "description": None},
+            "data": {
+                "id": 1,
+                "name": "Legacy",
+                "count": 0,
+                "color": None,
+                "description": None,
+            },
             "interface": "labels",
             "operation": operation,
         }

--- a/tests/labels/__snapshots__/test_db.ambr
+++ b/tests/labels/__snapshots__/test_db.ambr
@@ -1,12 +1,74 @@
-# name: test_attach_sample_count[uvloop]
-  <class 'tuple'> (
+# name: test_label_attacher[uvloop-documents0]
+  <class 'dict'> {
+    'id': 'foo',
+    'labels': <class 'list'> [
+      <class 'dict'> {
+        'color': '#a83432',
+        'description': 'This is a bug',
+        'id': 1,
+        'name': 'Bug',
+      },
+      <class 'dict'> {
+        'color': '#03fc20',
+        'description': 'This is a question',
+        'id': 2,
+        'name': 'Question',
+      },
+    ],
+    'name': 'Foo',
+  }
+---
+# name: test_label_attacher[uvloop-documents1]
+  <class 'list'> [
     <class 'dict'> {
-      'color': '#a83432',
-      'count': 1,
-      'description': 'This is a bug',
-      'id': 1,
-      'name': 'Bug',
+      'id': 'foo',
+      'labels': <class 'list'> [
+        <class 'dict'> {
+          'color': '#03fc20',
+          'description': 'This is a question',
+          'id': 2,
+          'name': 'Question',
+        },
+      ],
+      'name': 'Foo',
     },
+    <class 'dict'> {
+      'id': 'bar',
+      'labels': <class 'list'> [
+        <class 'dict'> {
+          'color': '#a83432',
+          'description': 'This is a bug',
+          'id': 1,
+          'name': 'Bug',
+        },
+        <class 'dict'> {
+          'color': '#03fc20',
+          'description': 'This is a question',
+          'id': 2,
+          'name': 'Question',
+        },
+      ],
+      'name': 'Bar',
+    },
+    <class 'dict'> {
+      'id': 'baz',
+      'labels': <class 'list'> [
+      ],
+      'name': 'Baz',
+    },
+  ]
+---
+# name: test_sample_count_attacher[uvloop-labels0]
+  <class 'dict'> {
+    'color': '#a83432',
+    'count': 1,
+    'description': 'This is a bug',
+    'id': 1,
+    'name': 'Bug',
+  }
+---
+# name: test_sample_count_attacher[uvloop-labels1]
+  <class 'list'> [
     <class 'dict'> {
       'color': '#03fc20',
       'count': 2,
@@ -21,5 +83,5 @@
       'id': 3,
       'name': 'Info',
     },
-  )
+  ]
 ---

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -336,6 +336,8 @@
     'reads': <class 'list'> [
     ],
     'ready': True,
+    'subtractions': <class 'list'> [
+    ],
     'user': <class 'dict'> {
       'administrator': False,
       'handle': 'leeashley',
@@ -359,6 +361,8 @@
     'reads': <class 'list'> [
     ],
     'ready': True,
+    'subtractions': <class 'list'> [
+    ],
     'user': <class 'dict'> {
       'administrator': False,
       'handle': 'leeashley',
@@ -469,6 +473,8 @@
       },
     ],
     'ready': True,
+    'subtractions': <class 'list'> [
+    ],
     'user': <class 'dict'> {
       'administrator': False,
       'handle': 'leeashley',
@@ -988,6 +994,8 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -1013,6 +1021,12 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+          <class 'dict'> {
+            'id': 'foo',
+            'name': 'Malus domestica',
+          },
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -1049,6 +1063,8 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -1074,6 +1090,12 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+          <class 'dict'> {
+            'id': 'foo',
+            'name': 'Malus domestica',
+          },
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'leeashley',
@@ -1099,6 +1121,12 @@
         'sample': <class 'dict'> {
           'id': 'test',
         },
+        'subtractions': <class 'list'> [
+          <class 'dict'> {
+            'id': 'foo',
+            'name': 'Malus domestica',
+          },
+        ],
         'user': <class 'dict'> {
           'administrator': False,
           'handle': 'johnsoncynthia',

--- a/tests/samples/__snapshots__/test_db.ambr
+++ b/tests/samples/__snapshots__/test_db.ambr
@@ -182,7 +182,6 @@
 ---
 # name: test_create_sample[uvloop]
   <class 'dict'> {
-    '_id': 'a2oj3gfd',
     'all_read': True,
     'all_write': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
@@ -192,6 +191,7 @@
     'group_write': False,
     'hold': True,
     'host': '',
+    'id': 'a2oj3gfd',
     'is_legacy': False,
     'isolate': '',
     'labels': <class 'list'> [
@@ -246,9 +246,9 @@
 ---
 # name: test_finalize[uvloop]
   <class 'dict'> {
-    '_id': 'test',
     'artifacts': <class 'list'> [
     ],
+    'id': 'test',
     'quality': <class 'dict'> {
       'count': 10000000,
       'gc': 43,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -7,11 +7,11 @@ from aiohttp.test_utils import make_mocked_coro
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.caches.db
+import virtool.pg.utils
 import virtool.uploads.db
 from virtool.caches.models import SampleArtifactCache, SampleReadsCache
 from virtool.caches.utils import join_cache_path
 from virtool.labels.models import Label
-from virtool.pg.utils import get_row_by_id
 from virtool.samples.db import check_name
 from virtool.samples.files import create_reads_file
 from virtool.samples.models import SampleArtifact, SampleReads
@@ -124,7 +124,7 @@ async def test_find(
         label_query = "&label=".join(str(label) for label in labels)
         query.append(f"label={label_query}")
 
-    if len(query):
+    if query:
         path += "?{}".format("&".join(query))
 
     resp = await client.get(path)

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from virtool.fake.wrapper import FakerWrapper
 from virtool.samples.db import LIST_PROJECTION
 from virtool.samples.fake import READ_FILES_PATH, copy_reads_file, create_fake_sample
@@ -27,6 +28,9 @@ async def test_create_fake_unpaired(
     fake_sample = await create_fake_sample(
         app, "sample_1", user["_id"], paired=paired, finalized=finalized
     )
+
+    print(sorted(list(set(LIST_PROJECTION))))
+    print(sorted(list(set(fake_sample.keys()))))
 
     assert set(LIST_PROJECTION) <= set(fake_sample.keys())
 

--- a/tests/subtractions/__snapshots__/test_db.ambr
+++ b/tests/subtractions/__snapshots__/test_db.ambr
@@ -1,3 +1,49 @@
+# name: test_attach_subtractions[uvloop-documents0]
+  <class 'dict'> {
+    'id': 'sub_1',
+    'subtractions': <class 'list'> [
+      <class 'dict'> {
+        'id': 'foo',
+        'name': 'Foo',
+      },
+      <class 'dict'> {
+        'id': 'bar',
+        'name': 'Bar',
+      },
+    ],
+  }
+---
+# name: test_attach_subtractions[uvloop-documents1]
+  <class 'list'> [
+    <class 'dict'> {
+      'id': 'sub_1',
+      'subtractions': <class 'list'> [
+        <class 'dict'> {
+          'id': 'foo',
+          'name': 'Foo',
+        },
+        <class 'dict'> {
+          'id': 'bar',
+          'name': 'Bar',
+        },
+      ],
+    },
+    <class 'dict'> {
+      'id': 'sub_2',
+      'subtractions': <class 'list'> [
+        <class 'dict'> {
+          'id': 'foo',
+          'name': 'Foo',
+        },
+      ],
+    },
+    <class 'dict'> {
+      'id': 'sub_3',
+      'subtractions': <class 'list'> [
+      ],
+    },
+  ]
+---
 # name: test_create[uvloop-None]
   <class 'dict'> {
     '_id': '9pfsom1b',

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -23,7 +23,6 @@ async def test_edit(data, has_user, mocker, snapshot, fake, spawn_client):
 
     if has_user:
         user = await fake.users.insert()
-
         document["user"] = {"id": user["_id"]}
 
     client = await spawn_client(authorize=True, permissions=["modify_subtraction"])

--- a/tests/users/__snapshots__/test_db.ambr
+++ b/tests/users/__snapshots__/test_db.ambr
@@ -1,3 +1,41 @@
+# name: test_attach_user_transform[uvloop-False]
+  <class 'dict'> {
+    '_id': 'bar',
+    'user': <class 'dict'> {
+      'administrator': False,
+      'handle': 'leeashley',
+      'id': '7CtBo2yG',
+    },
+  }
+---
+# name: test_attach_user_transform[uvloop-True]
+  <class 'list'> [
+    <class 'dict'> {
+      '_id': 'bar',
+      'user': <class 'dict'> {
+        'administrator': False,
+        'handle': 'leeashley',
+        'id': '7CtBo2yG',
+      },
+    },
+    <class 'dict'> {
+      '_id': 'foo',
+      'user': <class 'dict'> {
+        'administrator': False,
+        'handle': 'johnsoncynthia',
+        'id': 'LB1U6zCj',
+      },
+    },
+    <class 'dict'> {
+      '_id': 'baz',
+      'user': <class 'dict'> {
+        'administrator': False,
+        'handle': 'leeashley',
+        'id': '7CtBo2yG',
+      },
+    },
+  ]
+---
 # name: test_create[uvloop-False-False]
   <class 'dict'> {
     '_id': 'abc123',

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -93,7 +93,8 @@ class BLAST:
 
     async def sleep(self):
         """
-        Sleep for the current interval and increase the interval by 5 seconds after sleeping.
+        Sleep for the current interval and increase the interval by 5 seconds after
+        sleeping.
 
         """
         await asyncio.sleep(self.interval)
@@ -103,7 +104,8 @@ class BLAST:
         self, ready: bool, result: Optional[dict], error: Optional[str]
     ) -> Tuple[dict, dict]:
         """
-        Update the BLAST data. Returns the BLAST data and the complete analysis document.
+        Update the BLAST data. Returns the BLAST data and the complete analysis
+        document.
 
         :param ready: indicates whether the BLAST request is complete
         :param result: the formatted result of a successful BLAST request
@@ -187,30 +189,29 @@ async def create(
 
     created_at = virtool.utils.timestamp()
 
-    document = await db.analyses.insert_one(
-        {
-            "ready": False,
-            "created_at": created_at,
-            "updated_at": created_at,
-            "job": {"id": job_id},
-            "files": [],
-            "workflow": workflow,
-            "sample": {"id": sample_id},
-            "index": {"id": index_id, "version": index_version},
-            "reference": {
-                "id": ref_id,
-                "name": await virtool.db.utils.get_one_field(
-                    db.references, "name", ref_id
-                ),
-            },
-            "subtractions": subtractions,
-            "user": {
-                "id": user_id,
-            },
-        }
-    )
+    document = {
+        "ready": False,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "job": {"id": job_id},
+        "files": [],
+        "workflow": workflow,
+        "sample": {"id": sample_id},
+        "index": {"id": index_id, "version": index_version},
+        "reference": {
+            "id": ref_id,
+            "name": await virtool.db.utils.get_one_field(db.references, "name", ref_id),
+        },
+        "subtractions": subtractions,
+        "user": {
+            "id": user_id,
+        },
+    }
 
-    return base_processor(document)
+    if analysis_id:
+        document["_id"] = analysis_id
+
+    return base_processor(await db.analyses.insert_one(document))
 
 
 async def update_nuvs_blast(

--- a/virtool/db/transforms.py
+++ b/virtool/db/transforms.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+from asyncio import gather
+from typing import Any, Dict, List, Union
+
+from virtool.types import Document
+
+
+class AbstractTransform(ABC):
+    @abstractmethod
+    async def attach_one(self, document: Document, prepared: Any) -> Document:
+        ...
+
+    async def attach_many(
+        self, documents: List[Document], prepared: Dict[str, Any]
+    ) -> List[Document]:
+        return [
+            await self.attach_one(document, prepared[document["id"]])
+            for document in documents
+        ]
+
+    @abstractmethod
+    async def prepare_one(self, document: Document) -> Any:
+        ...
+
+    async def prepare_many(
+        self, documents: List[Document]
+    ) -> Dict[Union[int, str], Any]:
+        return {
+            document["id"]: await self.prepare_one(document) for document in documents
+        }
+
+
+async def apply_transforms(
+    documents: Union[Document, List[Document]], pipeline: List[AbstractTransform]
+):
+    """
+    Apply a list of transforms to one or more documents.
+
+    :param documents: a single document or list of documents
+    :param pipeline: a list of transforms to apply
+    :return: one transformed document or a list of transformed documents
+    """
+    if isinstance(documents, list):
+        all_prepared = await gather(
+            *[transform.prepare_many(documents) for transform in pipeline]
+        )
+
+        for transform, prepared in zip(pipeline, all_prepared):
+            documents = await transform.attach_many(documents, prepared)
+
+        return documents
+
+    for transform in pipeline:
+        documents = await transform.attach_one(
+            documents, await transform.prepare_one(documents)
+        )
+
+    return documents

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -2,7 +2,6 @@
 Work with OTU history in the database.
 
 """
-from asyncio.tasks import gather
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -199,10 +198,8 @@ async def get_contributors(db, query: dict) -> List[dict]:
 
     contributors = [{"id": c["_id"], "count": c["count"]} async for c in cursor]
 
-    projection = {**ATTACH_PROJECTION, "_id": True}
-
     users = await db.users.find(
-        {"_id": {"$in": [c["id"] for c in contributors]}}, projection=projection
+        {"_id": {"$in": [c["id"] for c in contributors]}}, projection=ATTACH_PROJECTION
     ).to_list(None)
 
     users = {u.pop("_id"): u for u in users}

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -264,10 +264,10 @@ async def get_next_version(db, ref_id: str) -> int:
 
 async def get_unbuilt_stats(db, ref_id: Optional[str] = None) -> dict:
     """
-    Get the number of unbuilt changes and number of OTUs affected by those changes. Used to populate the metadata for a
-    index find request.
+    Get the number of unbuilt changes and number of OTUs affected by those changes.
 
-    Can search against a specific reference or all references.
+    Used to populate the metadata for an index find request. Can search against a
+    specific reference or all references.
 
     :param db: the application database client
     :param ref_id: the ref id to search unbuilt changes for
@@ -306,7 +306,8 @@ async def reset_history(db, index_id: str):
 
 async def get_patched_otus(db, config: Config, manifest: Dict[str, int]) -> List[dict]:
     """
-    Get joined OTUs patched to a specific version based on a manifest of OTU ids and versions.
+    Get joined OTUs patched to a specific version based on a manifest of OTU ids and
+    versions.
 
     :param db: the job database client
     :param config: the application configuration
@@ -362,7 +363,7 @@ async def attach_files(pg: AsyncEngine, base_url: str, document: dict) -> dict:
     """
     Attach a list of index files under `files` field.
 
-    :param pg: the application PostgreSQL client
+    :param pg: the application Postgres client
     :param base_url: the application base URL
     :param document: an index document
 
@@ -376,10 +377,12 @@ async def attach_files(pg: AsyncEngine, base_url: str, document: dict) -> dict:
     files = []
 
     for index_file in [row.to_dict() for row in rows]:
+        location = f"/indexes/{index_id}/files/{index_file['name']}"
+
         files.append(
             {
                 **index_file,
-                "download_url": f"{base_url}/indexes/{index_id}/files/{index_file['name']}",
+                "download_url": str(base_url) + location,
             }
         )
 

--- a/virtool/jobs/db.py
+++ b/virtool/jobs/db.py
@@ -1,5 +1,6 @@
 """
-Constants and utility functions for interacting with the jobs collection in the application database.
+Constants and utility functions for interacting with the jobs collection in the
+application database.
 
 """
 from asyncio import gather
@@ -141,13 +142,15 @@ async def acquire(db, job_id: str) -> Dict[str, Any]:
 
 async def processor(db, document: dict) -> dict:
     """
-    The default document processor for job documents. Transforms projected job documents to a structure that can be
-    dispatches to clients.
+    The default document processor for job documents.
+
+    Transforms projected job documents to a structure that can be dispatches to clients.
 
     1. Removes the ``status`` and ``args`` fields from the job document.
     2. Adds a ``username`` field.
     3. Adds a ``created_at`` date taken from the first status entry in the job document.
-    4. Adds ``state`` and ``progress`` fields derived from the most recent ``status`` entry in the job document.
+    4. Adds ``state`` and ``progress`` fields derived from the most recent ``status``
+       entry in the job document.
 
     :param db: the application database object
     :param document: a document to process

--- a/virtool/labels/db.py
+++ b/virtool/labels/db.py
@@ -1,14 +1,63 @@
-from typing import Dict, Any
+from typing import Any, Awaitable, List
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.db.transforms import AbstractTransform
+from virtool.labels.models import Label
 from virtool.types import Document
 
 
-async def attach_sample_count(db, document: dict) -> Document:
+class AttachLabelsTransform(AbstractTransform):
+    def __init__(self, pg: AsyncEngine):
+        self._pg = pg
+
+    async def _fetch_labels(self, label_ids: List[int]) -> List[Document]:
+        async with AsyncSession(self._pg) as session:
+            results = await session.execute(
+                select(Label).filter(Label.id.in_(label_ids))
+            )
+
+        return [label.to_dict() for label in results.scalars()]
+
+    async def attach_one(self, document: Document, prepared: Any) -> Document:
+        return {**document, "labels": prepared}
+
+    async def prepare_one(self, document):
+        if document.get("labels"):
+            return await self._fetch_labels(document["labels"])
+
+        return []
+
+    async def prepare_many(self, documents):
+        label_ids = {
+            label_id
+            for document in documents
+            if document.get("labels")
+            for label_id in document["labels"]
+        }
+
+        labels_by_id = {
+            label["id"]: label for label in await self._fetch_labels(list(label_ids))
+        }
+
+        return {
+            document["id"]: [labels_by_id[label_id] for label_id in document["labels"]]
+            for document in documents
+        }
+
+
+class SampleCountTransform(AbstractTransform):
     """
     Attach the number of samples associated with the given label to the passed document.
 
     """
-    return {
-        **document,
-        "count": await db.samples.count_documents({"labels": document["id"]}),
-    }
+
+    def __init__(self, db):
+        self._db = db
+
+    async def attach_one(self, document: Document, prepared: int) -> Document:
+        return {**document, "count": prepared}
+
+    async def prepare_one(self, document) -> Awaitable[Any]:
+        return await self._db.samples.count_documents({"labels": document["id"]})

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -107,8 +107,10 @@ async def get(req):
 @routes.get("/refs/{ref_id}/release")
 async def get_release(req):
     """
-    Get the latest update from GitHub and return it. Also updates the reference document. This is the only way of doing
-    so without waiting for an automatic refresh every 10 minutes.
+    Get the latest update from GitHub and return it.
+
+    Also updates the reference document. This is the only way of doing so without
+    waiting for an automatic refresh every 10 minutes.
 
     """
     db = req.app["db"]

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -12,6 +12,7 @@ import virtool.references.db
 import virtool.utils
 from virtool.api.response import InsufficientRights, NotFound, json_response
 from virtool.api.utils import compose_regex_query, paginate
+from virtool.db.transforms import apply_transforms
 from virtool.errors import DatabaseError, GitHubError
 from virtool.github import format_release
 from virtool.http.routes import Routes
@@ -35,7 +36,7 @@ from virtool.references.tasks import (
     UpdateRemoteReferenceTask,
 )
 from virtool.uploads.models import Upload
-from virtool.users.db import extend_user
+from virtool.users.db import AttachUserTransform, extend_user
 from virtool.validators import strip
 
 routes = Routes()
@@ -71,6 +72,8 @@ async def find(req):
         base_query=base_query,
         projection=virtool.references.db.PROJECTION,
     )
+
+    await apply_transforms(data["documents"], [AttachUserTransform(db)])
 
     documents, official_installed = await gather(
         gather(*[virtool.references.db.processor(db, d) for d in data["documents"]]),

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -1,58 +1,6 @@
 """
 Work with references in the database
 
-Schema:
-- _id (str) the instance-unique reference ID
-- cloned_from (Object) describes the reference this one was cloned from (can be null)
-  - id (str) the ID of the source reference
-  - name (str) the name of the source reference at the time of cloning
-- created_at (datetime) when the reference was created
-- data_type (Enum["genome", "barcode"]) the type of data stored in the reference
-- description (str) a user-defined description for the the reference
-- groups (List[Object]) describes groups assigned to the reference and their rights
-  - id (str) the group ID
-  - build (bool) the group can create new builds of the reference
-  - modify (bool) the group can modify the non-OTU reference data
-  - modify_otu (bool) the group can modify OTUs
-  - remove (bool) the group can remove the reference
-- groups (List[Object]) describes users assigned to the reference and their rights
-  - id (str) the user ID
-  - build (bool) the user can create new builds of the reference
-  - modify (bool) the user can modify the non-OTU reference data
-  - modify_otu (bool) the user can modify OTUs
-  - remove (bool) the user can remove the reference
-- internal_control (str) the ID for an OTU that is used as an internal control in the lab
-- name (str) the reference name
-- organism (str) the organism represented in the reference (eg. virus, bacteria, fungus)
-- task (Object) a task associated with a current reference operation
-  - id (str) the task ID
-- release (Object) describes the latest remote reference release
-  - body (str) the Markdown-formatted release body from GitHub
-  - content_type (str) release content type - should always be application/gzip
-  - download_url (str) the GitHUB URL at which the reference release can be downloaded
-  - etag (str) the release ETag - allows caching of the release check result
-  - filename (str) the name of the release file
-  - html_url (str) the URL to the web page for the release on GitHub
-  - id (str) the unique ID for the release from GitHub
-  - name (str) the name of the release (eg. v1.4.0)
-  - newer (bool) true if there is a newer release available
-  - published_at (datetime) when the release was published on GitHub
-  - retrieved_at (datetime) when teh release was retrieved from GitHub
-  - size (int) size of the release file in bytes
-- remotes_from (Object) describes where the reference remotes from (can be null)
-  - errors (Array) errors related to the remote reference
-  - slug (str) the GitHub repository slug for the reference
-- restrict_source_types (bool) restricts the source types users may use when creating isolates
-- source_types (Array[str]) a set of allowable source types
-- updates (Array[Object]) a history of updates applied to the remote reference
-  - SHARES FIELDS WITH release
-  - user (Object) describes the user that applied the update
-    - id (str) the user ID
-- updating (bool) the remote reference is being updated
-- user (Object) describes the creating user
-  - id (str) the user ID
-
-
 """
 import asyncio
 import datetime
@@ -155,7 +103,8 @@ async def processor(db, document: dict) -> dict:
 
 async def attach_computed(db, document: dict) -> dict:
     """
-    Get all computed data for the specified reference and attach it to the passed `document`.
+    Get all computed data for the specified reference and attach it to the passed
+    ``document``.
 
     :param db: the application database client
     :param document: the document to attached computed data to
@@ -283,7 +232,8 @@ async def check_right(req: Request, reference: dict, right: str) -> bool:
 
 async def check_source_type(db, ref_id: str, source_type: str) -> bool:
     """
-    Check if the provided `source_type` is valid based on the current reference source type configuration.
+    Check if the provided `source_type` is valid based on the current reference source
+    type configuration.
 
     :param db: the application database client
     :param ref_id: the reference context
@@ -366,8 +316,9 @@ async def edit_group_or_user(
     db, ref_id: str, subdocument_id: str, field: str, data: dict
 ) -> Optional[dict]:
     """
-    Edit an existing group or user as decided by the `field` argument. Returns `None` if the reference, group, or user
-    does not exist.
+    Edit an existing group or user as decided by the `field` argument.
+
+    Returns `None` if the reference, group, or user does not exist.
 
     :param db: the application database client
     :param ref_id: the id of the reference to modify
@@ -400,11 +351,13 @@ async def fetch_and_update_release(
     app, ref_id: str, ignore_errors: bool = False
 ) -> dict:
     """
-    Get the latest release for the GitHub repository identified by the passed `slug`. If a release is found, update the
-    reference identified by the passed `ref_id` and return the release.
+    Get the latest release for the GitHub repository identified by the passed `slug`.
 
-    Exceptions can be ignored during the GitHub request. Error information will still be written to the reference
-    document.
+    If a release is found, update the reference identified by the passed `ref_id` and
+    return the release.
+
+    Exceptions can be ignored during the GitHub request. Error information will still
+    be written to the reference document.
 
     :param app: the application object
     :param ref_id: the id of the reference to update
@@ -543,8 +496,10 @@ async def get_official_installed(db) -> bool:
 
 async def get_manifest(db, ref_id: str) -> dict:
     """
-    Generate a dict of otu document version numbers keyed by the document id. This is used to make sure only changes
-    made at the time the index rebuild was started are included in the build.
+    Generate a dict of otu document version numbers keyed by the document id.
+
+    This is used to make sure only changes made at the time the index rebuild was
+    started are included in the build.
 
     :param db: the application database client
     :param ref_id: the id of the reference to get the current index for
@@ -729,7 +684,8 @@ async def create_remote(
         "remotes_from": {"errors": [], "slug": remote_from},
         # The latest available release on GitHub.
         "release": dict(release, retrieved_at=created_at),
-        # The update history for the reference. We put the release being installed as the first history item.
+        # The update history for the reference. We put the release being installed as
+        # the first history item.
         "updates": [
             virtool.github.create_update_subdocument(
                 release, False, user_id, created_at
@@ -813,7 +769,8 @@ async def insert_change(
     """
     db = app["db"]
 
-    # Join the otu document into a complete otu record. This will be used for recording history.
+    # Join the otu document into a complete otu record. This will be used for recording
+    # history.
     joined = await join(db, otu_id)
 
     name = joined["name"]

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -1,4 +1,4 @@
-import asyncio.tasks
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -255,7 +255,8 @@ async def create(req):
 
     group = "none"
 
-    # Require a valid ``group`` field if the ``sample_group`` setting is ``users_primary_group``.
+    # Require a valid ``group`` field if the ``sample_group`` setting is
+    # ``users_primary_group``.
     if sample_group_setting == "force_choice":
         force_choice_error_message = await validate_force_choice_group(db, data)
 
@@ -388,8 +389,9 @@ async def edit(req):
 @schema({"quality": {"type": "dict", "required": True}})
 async def finalize(req):
     """
-    Finalize a sample that is being created using the Jobs API by setting a sample's quality field
-    and `ready` to `True`
+    Finalize a sample.
+
+    Set the sample's quality field and the `ready` field to `True`.
 
     """
     data = req["data"]
@@ -433,7 +435,8 @@ async def set_rights(req):
 
     user_id = req["client"].user_id
 
-    # Only update the document if the connected user owns the samples or is an administrator.
+    # Only update the document if the connected user owns the samples or is an
+    # administrator.
     if not req["client"].administrator and user_id != await get_sample_owner(
         db, sample_id
     ):
@@ -483,8 +486,9 @@ async def remove(req):
 @routes.jobs_api.delete("/samples/{sample_id}")
 async def job_remove(req):
     """
-    Remove a sample document and all associated analyses. Only usable in the Jobs API and when
-    samples are unfinalized.
+    Remove a sample document and all associated analyses.
+
+    Only usable in the Jobs API and when samples are unfinalized.
 
     """
     db = req.app["db"]
@@ -658,7 +662,8 @@ async def analyze(req):
 @routes.jobs_api.delete("/samples/{sample_id}/caches/{cache_key}")
 async def cache_job_remove(req: aiohttp.web.Request):
     """
-    Remove a cache document. Only usable in the Jobs API and when caches are unfinalized.
+    Remove a cache document. Only usable in the Jobs API and when caches are
+    unfinalized.
 
     """
     db = req.app["db"]

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -152,7 +152,7 @@ async def check_rights(db, sample_id: str, client, write: bool = True) -> bool:
 
 def compose_sample_workflow_query(url_query: MultiDictProxy) -> Optional[dict]:
     """
-    Compose a MongoDB query for filtering samples by completed workflow (ie. workflow tags).
+    Compose a MongoDB query for filtering samples by completed workflow.
 
     :param url_query: a URL query string to compose the workflow query from
     :return: a MongoDB query for filtering by workflow
@@ -261,7 +261,8 @@ async def create_sample(
 
 async def get_sample_owner(db, sample_id: str) -> Optional[str]:
     """
-    A Shortcut function for getting the owner user id of a sample given its ``sample_id``.
+    A Shortcut function for getting the owner user id of a sample given its
+    ``sample_id``.
 
     :param db: the application database client
     :param sample_id: the id of the sample to get the owner for
@@ -300,8 +301,9 @@ async def recalculate_workflow_tags(db, sample_id: str) -> dict:
 
 async def remove_samples(db, config: Config, id_list: List[str]) -> DeleteResult:
     """
-    Complete removes the samples identified by the document ids in ``id_list``. In order, it:
+    Complete removes the samples identified by the document ids in ``id_list``.
 
+    In order, it:
     - removes all analyses associated with the sample from the analyses collection
     - removes the sample from the samples collection
     - removes the sample directory from the file system
@@ -360,8 +362,8 @@ def check_is_legacy(sample: Dict[str, Any]) -> bool:
 
 async def update_is_compressed(db, sample: Dict[str, Any]):
     """
-    Update the ``is_compressed`` field for the passed ``sample`` in the database if all of its
-    files are compressed.
+    Update the ``is_compressed`` field for the passed ``sample`` in the database if all
+    of its files are compressed.
 
     :param db: the application database
     :param sample: the sample document
@@ -433,9 +435,10 @@ async def compress_sample_reads(app: App, sample: Dict[str, Any]):
 
 async def move_sample_files_to_pg(app: App, sample: Dict[str, any]):
     """
-    Creates a row in the `sample_reads` table for each file in a sample's `files` array, and
-    creates a row in the `uploads` table for information stored in a file's `from` field. The rows
-    are then linked via a SQL relationship.
+    Creates a row in the `sample_reads` table for each file in a sample's `files` array.
+
+    Also, creates a row in the `uploads` table for information stored in a file's
+    `from` field with a relation to the `SampleRead`.
 
     :param app: the application object
     :param sample: the sample document

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from sqlalchemy.exc import IntegrityError
+
 from virtool.example import example_path
 from virtool.fake.wrapper import FakerWrapper
 from virtool.samples.db import create_sample, finalize
@@ -133,6 +134,8 @@ async def create_fake_sample(
             run_in_thread=app["run_in_thread"],
             data_path=app["config"].data_path,
         )
+
+    sample["_id"] = sample.pop("id")
 
     return sample
 

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -59,9 +59,11 @@ class AttachSubtractionTransform(AbstractTransform):
 
 async def attach_computed(app: App, subtraction: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Attach the ``linked_samples`` and ``files`` fields to the passed subtraction document.
+    Attach the ``linked_samples`` and ``files`` fields to the passed subtraction
+    document.
 
-    Queries MongoDB and SQL to find the required data. Returns a new document dictionary.
+    Queries MongoDB and SQL to find the required data. Returns a new document
+    dictionary.
 
     :param app: the application object
     :param subtraction: the subtraction document to attach to
@@ -87,8 +89,8 @@ async def attach_computed(app: App, subtraction: Dict[str, Any]) -> Dict[str, An
 
 async def check_subtraction_fasta_files(db, config: Config) -> list:
     """
-    Check subtraction directories for files and set 'has_file' to boolean based on whether .fa.gz
-    exists.
+    Check subtraction directories for files and set 'has_file' to boolean based on
+    whether a ``.fa.gz`` file exists.
 
     :param db: the application database client
     :param config: the application configuration
@@ -176,7 +178,8 @@ async def finalize(
     count: int,
 ) -> dict:
     """
-    Finalize a subtraction by setting `ready` to True and updating the `gc` and `files` fields.
+    Finalize a subtraction by setting `ready` to True and updating the `gc` and `files`
+    fields.
 
     :param db: the application database client
     :param pg: the PostgreSQL AsyncEngine object


### PR DESCRIPTION
This PR tries to better structure transforming documents (or rows) before returning them in API responses.

There is opportunity to use this structure to improve other code. It is also open to change.

Each transform class has two stages:

### Prepare
Prepare the data to be attached to the document. This typically involves getting data from other Mongo, Postgres, or the 
filesystem.

Multiple transforms can be prepared concurrently. This is the big improvement versus the case-by-case methods used 
previously.

If there is a list documents to transform, transforms can be written to avoid duplication of requests. For example, not fetching the same label multiple times from Postgres when attaching user data to 25 sample documents.

### Attach

The prepared data is attached to the documents in the order the transforms are defined in the `apply_pipeline()` function.