### PR TITLE
fix: prevent missing asynccontextmanager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ aioredis==1.3.1
 apipkg==1.5
 appdirs==1.4.3
 arrow==0.15.5
+async-generator==1.10
 async-timeout==3.0.1
 atomicwrites==1.3.0
 attrs==19.3.0
@@ -20,6 +21,7 @@ Cerberus==1.3.2
 certifi==2020.6.20
 cffi==1.14.0
 chardet==3.0.4
+charset-normalizer==2.0.12
 click==7.1.1
 coloredlogs==14.0
 configobj==5.0.6

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -1,13 +1,11 @@
-from pprint import pprint
-
-import arrow
 import asyncio
 import json
 import os
-from contextlib import asynccontextmanager
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import aiofiles
+import arrow
+from async_generator import asynccontextmanager
 
 import virtool.analyses.utils
 import virtool.bio


### PR DESCRIPTION
Use the `async-generator` package to provide this in Python 3.6.