### PR TITLE
fix: use correct content-type for file downloads

### DIFF
--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -395,5 +395,8 @@ async def download_subtraction_files(req: aiohttp.web.Request):
 
     return FileResponse(
         file_path,
-        headers={"Content-Length": file["size"], "Content-Type": "application/gzip"},
+        headers={
+            "Content-Length": file["size"],
+            "Content-Type": "application/octet-stream",
+        },
     )

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -110,12 +110,13 @@ async def download(req):
     if not upload_path.exists():
         raise NotFound("Uploaded file not found at expected location")
 
-    headers = {
-        "Content-Disposition": f"attachment; filename={upload.name}",
-        "Content-Type": "application/x-gzip",
-    }
-
-    return FileResponse(upload_path, headers=headers)
+    return FileResponse(
+        upload_path,
+        headers={
+            "Content-Disposition": f"attachment; filename={upload.name}",
+            "Content-Type": "application/octet-stream",
+        },
+    )
 
 
 @routes.delete("/uploads/{id}", permission="remove_file")


### PR DESCRIPTION
Files like `otus.json.gz` should use the `application/octet-stream` content-type instead of `application/gzip`.