### PR TITLE
fix: only attach BLAST results for nuvs analyses

### DIFF
--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -232,6 +232,7 @@
       'handle': 'leeashley',
       'id': '7CtBo2yG',
     },
+    'workflow': 'pathoscope_bowtie',
   }
 ---
 # name: test_get[uvloop-None-True].1

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -158,6 +158,7 @@ async def test_get(
                 "user": {"id": user["_id"]},
                 "subtractions": ["apple", "plum"],
                 "results": {"hits": []},
+                "workflow": "pathoscope_bowtie",
             }
         ),
     )

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -141,10 +141,11 @@ async def get(req: Request) -> Response:
 
     document = await processor(db, document)
 
-    document = await apply_transforms(
-        document,
-        [AttachNuVsBLAST(pg)],
-    )
+    if document["workflow"] == "nuvs":
+        document = await apply_transforms(
+            document,
+            [AttachNuVsBLAST(pg)],
+        )
 
     return json_response(document, headers=headers)
 


### PR DESCRIPTION
Trying to do this for Pathoscope analyses results in an exception.