### PR TITLE
fix: generate export files for indexes in the background

### DIFF
--- a/tests/fixtures/references.py
+++ b/tests/fixtures/references.py
@@ -20,7 +20,7 @@ def check_ref_right(mocker, request):
 def reference(static_time):
     return {
         "_id": "3tt0w336",
-        "created_at": static_time,
+        "created_at": static_time.datetime,
         "data_type": "genome",
         "description": "",
         "name": "Original",

--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -105,20 +105,20 @@
     'change_count': 0,
     'files': <class 'list'> [
       <class 'dict'> {
-        'download_url': '/indexes/test_index/files/reference.json.gz',
-        'id': 1,
-        'index': 'test_index',
-        'name': 'reference.json.gz',
-        'size': None,
-        'type': 'json',
-      },
-      <class 'dict'> {
         'download_url': '/indexes/test_index/files/reference.fa.gz',
-        'id': 2,
+        'id': 1,
         'index': 'test_index',
         'name': 'reference.fa.gz',
         'size': None,
         'type': 'fasta',
+      },
+      <class 'dict'> {
+        'download_url': '/indexes/test_index/files/reference.json.gz',
+        'id': 2,
+        'index': 'test_index',
+        'name': 'reference.json.gz',
+        'size': None,
+        'type': 'json',
       },
       <class 'dict'> {
         'download_url': '/indexes/test_index/files/reference.1.bt2',

--- a/tests/indexes/__snapshots__/test_tasks.ambr
+++ b/tests/indexes/__snapshots__/test_tasks.ambr
@@ -1,20 +1,30 @@
 # name: test_add_index_files[uvloop-DNE]
   <class 'list'> [
-    <IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=4096)>,
-    <IndexFile(id=2, name=reference.fa.gz, index=foo, type=fasta, size=4096)>,
+    <IndexFile(id=1, name=reference.1.bt2, index=index, type=bowtie2, size=12)>,
+    <IndexFile(id=2, name=reference.fa.gz, index=index, type=fasta, size=10)>,
   ]
 ---
 # name: test_add_index_files[uvloop-empty]
   <class 'list'> [
-    <IndexFile(id=1, name=reference.1.bt2, index=foo, type=bowtie2, size=4096)>,
-    <IndexFile(id=2, name=reference.fa.gz, index=foo, type=fasta, size=4096)>,
+    <IndexFile(id=1, name=reference.1.bt2, index=index, type=bowtie2, size=12)>,
+    <IndexFile(id=2, name=reference.fa.gz, index=index, type=fasta, size=10)>,
   ]
 ---
 # name: test_add_index_files[uvloop-full]
   <class 'list'> [
+    <IndexFile(id=1, name=reference.1.bt2, index=index, type=bowtie2, size=12)>,
+    <IndexFile(id=2, name=reference.fa.gz, index=index, type=fasta, size=10)>,
   ]
 ---
 # name: test_add_index_files[uvloop-not_ready]
   <class 'list'> [
   ]
+---
+# name: test_add_index_json[uvloop]
+  <class 'list'> [
+    <IndexFile(id=1, name=reference.json.gz, index=index_1, type=json, size=321)>,
+  ]
+---
+# name: test_add_index_json[uvloop][json]
+  '{"data_type": "genome", "organism": "virus", "otus": [{"_id": "6116cba1", "name": "Prunus virus F", "abbreviation": "PVF", "isolates": [{"id": "cab8b360", "default": true, "source_name": "8816-v2", "source_type": "isolate", "sequences": [{"_id": "KX269872", "accession": "KX269872", "definition": "Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.", "host": "sweet cherry", "sequence": "TGTTTAAGAGATTAAACAACCGCTTTC", "segment": null}]}], "schema": []}], "targets": null}'
 ---

--- a/tests/indexes/test_tasks.py
+++ b/tests/indexes/test_tasks.py
@@ -1,7 +1,12 @@
+import gzip
+from pathlib import Path
+
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from virtool.indexes.models import IndexFile
-from virtool.indexes.tasks import AddIndexFilesTask
+from virtool.indexes.tasks import AddIndexFilesTask, AddIndexJSONTask
 from virtool.tasks.models import Task
 
 
@@ -20,17 +25,18 @@ async def test_add_index_files(
     client = await spawn_client(authorize=True, administrator=True)
     client.app["config"].data_path = tmp_path
 
-    test_dir = tmp_path / "references" / "foo"
+    test_dir = tmp_path / "references" / "ref" / "index"
     test_dir.mkdir(parents=True)
     test_dir.joinpath("reference.fa.gz").write_text("FASTA file")
     test_dir.joinpath("reference.1.bt2").write_text("Bowtie2 file")
 
     index = {
-        "_id": "foo",
+        "_id": "index",
         "name": "Foo",
         "nickname": "Foo Index",
         "deleted": False,
         "ready": True,
+        "reference": {"id": "ref"},
     }
 
     if files == "empty":
@@ -65,3 +71,67 @@ async def test_add_index_files(
 
     async with pg_session as session:
         assert (await session.execute(select(IndexFile))).scalars().all() == snapshot
+
+
+async def test_add_index_json(
+    pg,
+    reference,
+    spawn_client,
+    snapshot,
+    static_time,
+    test_otu,
+    test_sequence,
+    tmp_path,
+):
+    client = await spawn_client(authorize=True, administrator=True)
+    client.app["config"].data_path = Path(tmp_path)
+
+    test_sequence["accession"] = "KX269872"
+
+    await client.db.otus.insert_one(test_otu)
+    await client.db.sequences.insert_one(test_sequence)
+
+    ref_id = test_otu["reference"]["id"]
+
+    await client.db.references.insert_one({**reference, "_id": ref_id})
+    await client.db.indexes.insert_one(
+        {
+            "_id": "index_1",
+            "deleted": False,
+            "manifest": {test_otu["_id"]: test_otu["version"]},
+            "ready": True,
+            "reference": {"id": ref_id},
+        }
+    )
+
+    index_dir = tmp_path / "references" / ref_id / "index_1"
+    index_dir.mkdir(parents=True)
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            Task(
+                id=1,
+                complete=False,
+                context={},
+                count=0,
+                progress=0,
+                step="add_index_json_file",
+                type="add_index_json",
+                created_at=static_time.datetime,
+            )
+        )
+        await session.commit()
+
+    task = AddIndexJSONTask(client.app, 1)
+
+    await task.run()
+
+    async with AsyncSession(pg) as session:
+        assert (
+            await session.execute(
+                select(IndexFile).where(IndexFile.name == "reference.json.gz")
+            )
+        ).scalars().all() == snapshot
+
+    with gzip.open(Path(index_dir) / "reference.json.gz", "rt") as f:
+        assert f.read() == snapshot(name="json")

--- a/tests/references/test_utils.py
+++ b/tests/references/test_utils.py
@@ -1,5 +1,18 @@
 import pytest
-import virtool.references.utils
+
+from virtool.references.utils import (
+    detect_duplicate_abbreviation,
+    detect_duplicate_ids,
+    detect_duplicate_isolate_ids,
+    detect_duplicate_name,
+    detect_duplicate_sequence_ids,
+    detect_duplicates,
+    get_import_schema,
+    get_isolate_schema,
+    get_otu_schema,
+    get_owner_user,
+    get_sequence_schema,
+)
 
 
 @pytest.mark.parametrize("empty", [True, False])
@@ -14,7 +27,7 @@ def test_detect_duplicate_abbreviation(in_seen, empty, test_otu):
     if empty:
         test_otu["abbreviation"] = ""
 
-    virtool.references.utils.detect_duplicate_abbreviation(test_otu, duplicates, seen)
+    detect_duplicate_abbreviation(test_otu, duplicates, seen)
 
     if in_seen or not empty:
         assert seen == {"PVF"}
@@ -35,7 +48,7 @@ def test_detect_duplicate_ids(seen, test_otu):
     if seen:
         seen_ids.add("6116cba1")
 
-    virtool.references.utils.detect_duplicate_ids(test_otu, duplicate_ids, seen_ids)
+    detect_duplicate_ids(test_otu, duplicate_ids, seen_ids)
 
     assert duplicate_ids == ({"6116cba1"} if seen else set())
     assert seen_ids == {"6116cba1"}
@@ -52,9 +65,7 @@ def test_detect_duplicate_isolate_ids(has_dups, test_otu):
 
     duplicate_isolate_ids = dict()
 
-    virtool.references.utils.detect_duplicate_isolate_ids(
-        test_otu, duplicate_isolate_ids
-    )
+    detect_duplicate_isolate_ids(test_otu, duplicate_isolate_ids)
 
     if has_dups:
         assert duplicate_isolate_ids == {
@@ -78,7 +89,7 @@ def test_detect_duplicate_name(seen, transform, test_otu):
 
     duplicates = set()
 
-    virtool.references.utils.detect_duplicate_name(test_otu, duplicates, seen_names)
+    detect_duplicate_name(test_otu, duplicates, seen_names)
 
     if seen:
         assert duplicates == {test_otu["name"]}
@@ -103,7 +114,7 @@ def test_detect_duplicate_sequence_ids(intra, seen, test_merged_otu):
 
     duplicate_sequence_ids = set()
 
-    virtool.references.utils.detect_duplicate_sequence_ids(
+    detect_duplicate_sequence_ids(
         test_merged_otu, duplicate_sequence_ids, seen_sequence_ids
     )
 
@@ -121,7 +132,7 @@ def test_detect_duplicates(strict, test_merged_otu):
 
     otu_list[0]["isolates"].append(otu_list[0]["isolates"][0])
 
-    result = virtool.references.utils.detect_duplicates(otu_list, strict=strict)
+    result = detect_duplicates(otu_list, strict=strict)
 
     if strict:
         assert result == [
@@ -170,7 +181,7 @@ def test_detect_duplicates(strict, test_merged_otu):
 
 @pytest.mark.parametrize("require_meta", [True, False])
 def test_get_import_schema(require_meta):
-    assert virtool.references.utils.get_import_schema(require_meta) == {
+    assert get_import_schema(require_meta) == {
         "data_type": {"type": "string", "required": require_meta},
         "organism": {"type": "string", "required": require_meta},
         "otus": {"type": "list", "required": True},
@@ -179,7 +190,7 @@ def test_get_import_schema(require_meta):
 
 @pytest.mark.parametrize("require_id", [True, False])
 def test_get_isolate_schema(require_id):
-    assert virtool.references.utils.get_isolate_schema(require_id) == {
+    assert get_isolate_schema(require_id) == {
         "id": {"type": "string", "required": require_id},
         "source_type": {"type": "string", "required": True},
         "source_name": {"type": "string", "required": True},
@@ -190,7 +201,7 @@ def test_get_isolate_schema(require_id):
 
 @pytest.mark.parametrize("require_id", [True, False])
 def test_get_otu_schema(require_id):
-    assert virtool.references.utils.get_otu_schema(require_id) == {
+    assert get_otu_schema(require_id) == {
         "_id": {"type": "string", "required": require_id},
         "abbreviation": {"type": "string"},
         "name": {"type": "string", "required": True},
@@ -199,7 +210,7 @@ def test_get_otu_schema(require_id):
 
 
 def test_get_owner_user():
-    assert virtool.references.utils.get_owner_user("fred") == {
+    assert get_owner_user("fred") == {
         "id": "fred",
         "build": True,
         "modify": True,
@@ -210,7 +221,7 @@ def test_get_owner_user():
 
 @pytest.mark.parametrize("require_id", [True, False])
 def test_get_sequence_schema(require_id):
-    assert virtool.references.utils.get_sequence_schema(require_id) == {
+    assert get_sequence_schema(require_id) == {
         "_id": {"type": "string", "required": require_id},
         "accession": {"type": "string", "required": True},
         "definition": {"type": "string", "required": True},

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -29,9 +29,6 @@ async def test_create_fake_unpaired(
         app, "sample_1", user["_id"], paired=paired, finalized=finalized
     )
 
-    print(sorted(list(set(LIST_PROJECTION))))
-    print(sorted(list(set(fake_sample.keys()))))
-
     assert set(LIST_PROJECTION) <= set(fake_sample.keys())
 
     if finalized is True:

--- a/virtool/indexes/tasks.py
+++ b/virtool/indexes/tasks.py
@@ -1,54 +1,201 @@
+import json
+from typing import Dict, List
+
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from virtool.history.db import patch_to_version
 from virtool.indexes.db import FILES
 from virtool.indexes.models import IndexFile, IndexType
-from virtool.tasks.pg import update
+from virtool.indexes.utils import join_index_path
 from virtool.tasks.task import Task
-from virtool.types import App
-from virtool.utils import file_stats
+from virtool.types import App, Document
+from virtool.utils import compress_json_with_gzip, file_stats
 
 
 class AddIndexFilesTask(Task):
     """
-    Add a 'files' field to index documents to list what files can be downloaded for that index.
+    Add a 'files' field to index documents to list what files can be downloaded for that
+    index.
     """
 
     task_type = "add_index_files"
 
     def __init__(self, app: App, task_id: int):
         super().__init__(app, task_id)
-
         self.steps = [self.store_index_files]
 
     async def store_index_files(self):
-        await update(self.pg, self.id, step="store_index_files")
+        async for index in self.db.indexes.find({"ready": True}):
+            index_id = index["_id"]
 
-        async for index in self.db.indexes.find():
-            try:
-                if index["ready"] and not index["files"]:
-                    raise KeyError
+            index_path = join_index_path(
+                self.app["config"].data_path, index["reference"]["id"], index_id
+            )
 
-            except KeyError:
-                index_id = index["_id"]
+            async with AsyncSession(self.app["pg"]) as session:
+                first = (
+                    await session.execute(
+                        select(IndexFile).where(IndexFile.index == index_id)
+                    )
+                ).first()
 
-                path = self.app["config"].data_path / "references" / index_id
+                if first:
+                    continue
 
-                async with AsyncSession(self.app["pg"]) as session:
-                    for file_path in sorted(path.iterdir()):
+                session.add_all(
+                    [
+                        IndexFile(
+                            name=path.name,
+                            index=index_id,
+                            type=get_index_file_type_from_name(path.name),
+                            size=file_stats(path)["size"],
+                        )
+                        for path in sorted(index_path.iterdir())
+                        if path.name in FILES
+                    ]
+                )
 
-                        if file_path.name in FILES:
-                            size = file_stats(path)["size"]
+                await session.commit()
 
-                            session.add(
-                                IndexFile(
-                                    name=file_path.name,
-                                    index=index_id,
-                                    type=get_index_file_type_from_name(file_path.name),
-                                    size=size,
-                                )
-                            )
 
-                    await session.commit()
+class AddIndexJSONTask(Task):
+    task_type = "add_index_json"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.steps = [self.add_index_json_file]
+
+    async def add_index_json_file(self):
+        async for index in self.db.indexes.find({"ready": True}):
+            index_id = index["_id"]
+            ref_id = index["reference"]["id"]
+            manifest = index["manifest"]
+
+            async with AsyncSession(self.pg) as session:
+                path = join_index_path(self.app["config"].data_path, ref_id, index_id)
+
+                index_json_path = path / "reference.json.gz"
+
+                if index_json_path.is_file():
+                    continue
+
+                index_data = await export_index(self.app, manifest)
+
+                reference = await self.db.references.find_one(
+                    ref_id, ["data_type", "organism", "targets"]
+                )
+
+                json_string = json.dumps(
+                    {
+                        "data_type": reference["data_type"],
+                        "organism": reference["organism"],
+                        "otus": index_data,
+                        "targets": reference.get("targets"),
+                    }
+                )
+
+                await self.run_in_thread(
+                    compress_json_with_gzip, json_string, index_json_path
+                )
+
+                session.add(
+                    IndexFile(
+                        name="reference.json.gz",
+                        index=index_id,
+                        type="json",
+                        size=file_stats(index_json_path)["size"],
+                    ),
+                )
+
+                await session.commit()
+
+
+def format_sequence_for_export(sequence: Document) -> Document:
+    """
+    Prepare a raw sequence document for export.
+
+    If the sequence has a remote ID use this as the `_id` for export. This makes the
+    sequence compatible with the original remote reference.
+
+    :param sequence: a sequence document
+    :return: the formatted sequence document
+    """
+    try:
+        sequence_id = sequence["remote"]["id"]
+    except KeyError:
+        sequence_id = sequence["_id"]
+
+    cleaned_sequence = {
+        "_id": sequence_id,
+        "accession": sequence["accession"],
+        "definition": sequence["definition"],
+        "host": sequence["host"],
+        "sequence": sequence["sequence"],
+    }
+
+    for key in ["segment", "target"]:
+        try:
+            return {**cleaned_sequence, key: sequence[key]}
+        except KeyError:
+            pass
+
+    return cleaned_sequence
+
+
+def format_otu_for_export(otu: Document) -> Document:
+    """
+    Prepare a raw, joined OTU for export.
+
+    If the OTU has a remote ID use this as the `_id` for export. This makes the OTU
+    compatible with the original remote reference.
+
+    :param otu: a joined OTU document
+    :return: the formatted, joined OTU document
+    """
+    try:
+        otu_id = otu["remote"]["id"]
+    except KeyError:
+        otu_id = otu["_id"]
+
+    isolates = [
+        {
+            "id": isolate["id"],
+            "default": isolate["default"],
+            "source_name": isolate["source_name"],
+            "source_type": isolate["source_type"],
+            "sequences": [
+                format_sequence_for_export(sequence)
+                for sequence in isolate["sequences"]
+            ],
+        }
+        for isolate in otu["isolates"]
+    ]
+
+    return {
+        "_id": otu_id,
+        "name": otu["name"],
+        "abbreviation": otu["abbreviation"],
+        "isolates": isolates,
+        "schema": otu["schema"],
+    }
+
+
+async def export_index(app: App, manifest: Dict[str, int]) -> List[Document]:
+    """
+    Dump OTUs to a JSON-serializable data structure based on an index manifest.
+
+    :param app: the application object
+    :param manifest: the index manifest
+    :return: JSON-serializable OTU data
+    """
+    otu_list = []
+
+    for otu_id, otu_version in manifest.items():
+        _, joined, _ = await patch_to_version(app, otu_id, otu_version)
+        otu_list.append(format_otu_for_export(joined))
+
+    return otu_list
 
 
 def get_index_file_type_from_name(name: str) -> IndexType:

--- a/virtool/indexes/utils.py
+++ b/virtool/indexes/utils.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 def check_index_file_type(file_name: str) -> str:
     """
     Get the index file type based on the extension of given `file_name`
@@ -12,3 +15,18 @@ def check_index_file_type(file_name: str) -> str:
         return "json"
     else:
         return "bowtie2"
+
+
+def join_index_path(data_path: Path, reference_id: str, index_id: str) -> Path:
+    """
+    Return the path to an index.
+
+    :param data_path: the application data path
+    :param reference_id: the ID of the parent reference
+    :param index_id: the ID of the index
+    :return: the index path
+    """
+    return data_path / "references" / reference_id / index_id
+
+
+OTU_KEYS = ["name", "abbreviation", "schema"]

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -28,7 +28,6 @@ from virtool.pg.utils import get_row
 from virtool.references.utils import (
     RIGHTS,
     check_will_change,
-    clean_export_list,
     get_owner_user,
     load_reference_file,
 )
@@ -735,23 +734,6 @@ async def edit(db, ref_id: str, data: dict) -> dict:
         )
 
     return document
-
-
-async def export(app: App, ref_id: str) -> list:
-    db = app["db"]
-
-    otu_list = list()
-
-    query = {"reference.id": ref_id, "last_indexed_version": {"$ne": None}}
-
-    async for document in db.otus.find(query):
-        _, joined, _ = await virtool.history.db.patch_to_version(
-            app, document["_id"], document["last_indexed_version"]
-        )
-
-        otu_list.append(joined)
-
-    return clean_export_list(otu_list)
 
 
 async def insert_change(

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -9,8 +9,6 @@ import virtool.otus.utils
 
 ISOLATE_KEYS = ["id", "source_type", "source_name", "default"]
 
-OTU_KEYS = ["name", "abbreviation", "schema"]
-
 RIGHTS = ["build", "modify", "modify_otu", "remove"]
 
 SEQUENCE_KEYS = ["accession", "definition", "host", "sequence"]
@@ -57,7 +55,8 @@ def check_will_change(old: dict, imported: dict) -> bool:
         if old[key] != imported[key]:
             return True
 
-    # Will change if isolate ids have changed, meaning an isolate has been added or removed.
+    # Will change if isolate ids have changed, meaning an isolate has been added or
+    # removed.
     if {i["id"] for i in old["isolates"]} != {i["id"] for i in imported["isolates"]}:
         return True
 
@@ -95,58 +94,6 @@ def check_will_change(old: dict, imported: dict) -> bool:
                     return True
 
     return False
-
-
-def clean_export_list(otus: List[dict]) -> List[dict]:
-    cleaned = list()
-
-    otu_keys = OTU_KEYS + ["_id"]
-    sequence_keys = SEQUENCE_KEYS + ["_id"]
-
-    for otu in otus:
-        try:
-            otu["_id"] = otu["remote"]["id"]
-        except KeyError:
-            pass
-
-        for isolate in otu["isolates"]:
-            for sequence in isolate["sequences"]:
-                try:
-                    sequence["_id"] = sequence["remote"]["id"]
-                except KeyError:
-                    pass
-
-        cleaned.append(clean_otu(otu, otu_keys, sequence_keys))
-
-    return cleaned
-
-
-def clean_otu(otu: dict, otu_keys: list = None, sequence_keys: list = None) -> dict:
-    otu_keys = otu_keys or OTU_KEYS
-    sequence_keys = sequence_keys or SEQUENCE_KEYS
-
-    cleaned = {key: otu.get(key) for key in otu_keys}
-
-    cleaned.update({"isolates": list(), "schema": otu.get("schema", list())})
-
-    for isolate in otu["isolates"]:
-        cleaned_isolate = {key: isolate[key] for key in ISOLATE_KEYS}
-        cleaned_isolate["sequences"] = list()
-
-        for sequence in isolate["sequences"]:
-            cleaned_sequence = {key: sequence[key] for key in sequence_keys}
-
-            for key in ["segment", "target"]:
-                try:
-                    cleaned_sequence[key] = sequence[key]
-                except KeyError:
-                    pass
-
-            cleaned_isolate["sequences"].append(cleaned_sequence)
-
-        cleaned["isolates"].append(cleaned_isolate)
-
-    return cleaned
 
 
 def detect_duplicate_abbreviation(joined: dict, duplicates: set, seen: set):
@@ -340,7 +287,8 @@ def get_sequence_schema(require_id: bool) -> dict:
 
 def load_reference_file(path: str) -> dict:
     """
-    Load a list of merged otus documents from a file associated with a Virtool reference file.
+    Load a list of merged otus documents from a file associated with a Virtool reference
+    file.
 
     :param path: the path to the otus.json.gz file
 

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -31,7 +31,10 @@ from virtool.dispatcher.events import DispatcherSQLEvents
 from virtool.dispatcher.listener import RedisDispatcherListener
 from virtool.fake.wrapper import FakerWrapper
 from virtool.hmm.db import refresh
-from virtool.indexes.tasks import AddIndexFilesTask
+from virtool.indexes.tasks import (
+    AddIndexFilesTask,
+    AddIndexJSONTask,
+)
 from virtool.jobs.client import JobsClient
 from virtool.oidc.utils import JWKArgs
 from virtool.pg.testing import create_test_database
@@ -39,7 +42,6 @@ from virtool.redis import periodically_ping_redis
 from virtool.references.db import refresh_remotes
 from virtool.references.tasks import (
     CleanReferencesTask,
-    CreateIndexJSONTask,
     DeleteReferenceTask,
 )
 from virtool.routes import setup_routes
@@ -432,12 +434,10 @@ async def startup_tasks(app: Application):
             WriteSubtractionFASTATask, context={"subtraction": subtraction}
         )
 
-    logger.info("Checking index JSON files")
-
-    await app["tasks"].add(CreateIndexJSONTask)
+    await app["tasks"].add(AddIndexFilesTask)
+    await app["tasks"].add(AddIndexJSONTask)
     await app["tasks"].add(DeleteReferenceTask, context={"user_id": "virtool"})
     await app["tasks"].add(AddSubtractionFilesTask)
-    await app["tasks"].add(AddIndexFilesTask)
     await app["tasks"].add(StoreNuvsFilesTask)
     await app["tasks"].add(CompressSamplesTask)
     await app["tasks"].add(MoveSampleFilesTask)


### PR DESCRIPTION
* Add a task to generate JSON exports for indexes where missing.
* Refactor old index export code.
* Move index-centric code from references to indexes subpackage.