### PR TITLE
fix: use latest sentry sdk to ensure error reports work

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -969,7 +969,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.3.0"
+version = "1.5.7"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -991,6 +991,7 @@ flask = ["flask (>=0.11)", "blinker (>=1.1)"]
 httpx = ["httpx (>=0.16.0)"]
 pure_eval = ["pure-eval", "executing", "asttokens"]
 pyspark = ["pyspark (>=2.4.4)"]
+quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
 rq = ["rq (>=0.6)"]
 sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
@@ -2196,8 +2197,8 @@ semver = [
     {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.3.0.tar.gz", hash = "sha256:5210a712dd57d88d225c1fc3fe3a3626fee493637bcd54e204826cf04b8d769c"},
-    {file = "sentry_sdk-1.3.0-py2.py3-none-any.whl", hash = "sha256:6864dcb6f7dec692635e5518c2a5c80010adf673c70340817f1a1b713d65bb41"},
+    {file = "sentry-sdk-1.5.7.tar.gz", hash = "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"},
+    {file = "sentry_sdk-1.5.7-py2.py3-none-any.whl", hash = "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -1,20 +1,20 @@
 import logging
+from logging import getLogger
 
 import sentry_sdk
-import sentry_sdk.integrations.aiohttp
-import sentry_sdk.integrations.logging
+from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
-sentry_logging = sentry_sdk.integrations.logging.LoggingIntegration(
-    level=logging.INFO, event_level=logging.ERROR
-)
+logger = getLogger(__name__)
 
 
 def setup(server_version, dsn):
+    logger.info(f"Initializing Sentry with DSN {dsn[:20]}...")
     sentry_sdk.init(
         dsn=dsn,
         integrations=[
-            sentry_sdk.integrations.aiohttp.AioHttpIntegration(),
-            sentry_logging,
+            AioHttpIntegration(),
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
         ],
         release=server_version,
         traces_sample_rate=0.2,


### PR DESCRIPTION
* Use latest Sentry SDK.
* Clean up Sentry startup module.
* Log `INFO` when Sentry client is initialized.