### PR TITLE
feat: add 'preparing' job state for acquired jobs

### DIFF
--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -53,6 +53,8 @@
         'progress': 0,
         'stage': None,
         'state': 'waiting',
+        'step_description': None,
+        'step_name': None,
         'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
       },
     ],

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -630,9 +630,9 @@
     'key': 'key',
     'mem': 16,
     'proc': 10,
-    'progress': 1.0,
-    'stage': 'import_results',
-    'state': 'complete',
+    'progress': 3,
+    'stage': None,
+    'state': 'preparing',
     'status': <class 'list'> [
       <class 'dict'> {
         'error': None,
@@ -660,6 +660,15 @@
         'progress': 1.0,
         'stage': 'import_results',
         'state': 'complete',
+        'timestamp': '2015-10-06T20:00:00Z',
+      },
+      <class 'dict'> {
+        'error': None,
+        'progress': 3,
+        'stage': None,
+        'state': 'preparing',
+        'step_description': None,
+        'step_name': None,
         'timestamp': '2015-10-06T20:00:00Z',
       },
     ],

--- a/tests/jobs/__snapshots__/test_client.ambr
+++ b/tests/jobs/__snapshots__/test_client.ambr
@@ -1,0 +1,48 @@
+# name: test_cancel_waiting[uvloop-create_sample]
+  <class 'dict'> {
+    '_id': 'foo',
+    'state': 'waiting',
+    'status': <class 'list'> [
+      <class 'dict'> {
+        'error': None,
+        'progress': 0.33,
+        'stage': 'foo',
+        'state': 'running',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+      <class 'dict'> {
+        'error': None,
+        'progress': 0.33,
+        'stage': 'foo',
+        'state': 'cancelled',
+        'step_description': None,
+        'step_name': None,
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+    ],
+  }
+---
+# name: test_cancel_waiting[uvloop-nuvs]
+  <class 'dict'> {
+    '_id': 'foo',
+    'state': 'waiting',
+    'status': <class 'list'> [
+      <class 'dict'> {
+        'error': None,
+        'progress': 0.33,
+        'stage': 'foo',
+        'state': 'running',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+      <class 'dict'> {
+        'error': None,
+        'progress': 0.33,
+        'stage': 'foo',
+        'state': 'cancelled',
+        'step_description': None,
+        'step_name': None,
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+    ],
+  }
+---

--- a/tests/jobs/__snapshots__/test_db.ambr
+++ b/tests/jobs/__snapshots__/test_db.ambr
@@ -1,3 +1,39 @@
+# name: test_acquire[uvloop]
+  <class 'dict'> {
+    'acquired': True,
+    'id': 'foo',
+    'key': 'key',
+    'status': <class 'list'> [
+      <class 'dict'> {
+        'error': None,
+        'progress': 3,
+        'stage': None,
+        'state': 'preparing',
+        'step_description': None,
+        'step_name': None,
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+    ],
+  }
+---
+# name: test_acquire[uvloop].1
+  <class 'dict'> {
+    '_id': 'foo',
+    'acquired': True,
+    'key': 'hashed',
+    'status': <class 'list'> [
+      <class 'dict'> {
+        'error': None,
+        'progress': 3,
+        'stage': None,
+        'state': 'preparing',
+        'step_description': None,
+        'step_name': None,
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+    ],
+  }
+---
 # name: test_cancel[uvloop]
   <class 'dict'> {
     '_id': 'foo',
@@ -15,6 +51,8 @@
         'progress': 0.33,
         'stage': 'foo',
         'state': 'cancelled',
+        'step_description': None,
+        'step_name': None,
         'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
       },
     ],
@@ -48,6 +86,8 @@
         'progress': 0,
         'stage': None,
         'state': 'waiting',
+        'step_description': None,
+        'step_name': None,
         'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
       },
     ],
@@ -85,6 +125,8 @@
         'progress': 0,
         'stage': None,
         'state': 'waiting',
+        'step_description': None,
+        'step_name': None,
         'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
       },
     ],

--- a/tests/jobs/test_db.py
+++ b/tests/jobs/test_db.py
@@ -1,6 +1,7 @@
 from unittest.mock import call
 
 import pytest
+
 import virtool.jobs.db
 from virtool.jobs.client import JobsClient
 from virtool.jobs.db import acquire, create, force_delete_jobs
@@ -64,20 +65,13 @@ async def test_create(
     assert await dbi.jobs.find_one() == snapshot
 
 
-async def test_acquire(dbi, mocker):
+async def test_acquire(dbi, mocker, snapshot, static_time):
     mocker.patch("virtool.utils.generate_key", return_value=("key", "hashed"))
 
     await dbi.jobs.insert_one({"_id": "foo", "acquired": False, "key": None})
 
-    result = await acquire(dbi, "foo")
-
-    assert await dbi.jobs.find_one() == {
-        "_id": "foo",
-        "acquired": True,
-        "key": "hashed",
-    }
-
-    assert result == {"id": "foo", "acquired": True, "key": "key"}
+    assert await acquire(dbi, "foo") == snapshot
+    assert await dbi.jobs.find_one() == snapshot
 
 
 async def test_force_delete_jobs(dbi, mocker, tmp_path):


### PR DESCRIPTION
Jobs will add a status item record they go from being queued (waiting) to being acquired by a job runner (preparing).

I took this approach as it involves no additional request from a workflow other than acquiring the job.