### PR TITLE
fix: revise b2c support for backend

### DIFF
--- a/tests/http/test_auth.py
+++ b/tests/http/test_auth.py
@@ -1,4 +1,5 @@
 from aiohttp import BasicAuth
+
 from virtool.utils import hash_key
 
 
@@ -16,7 +17,7 @@ class TestJobAuthentication:
 
     async def test_unauthenticated_root_fails(self, spawn_job_client):
         """
-        Check that an request against the root API URL
+        Check that a request against the root API URL
 
         """
         client = await spawn_job_client(authorize=False)
@@ -27,8 +28,9 @@ class TestJobAuthentication:
 
     async def test_protected_fails(self, dbi, spawn_client):
         """
-        Check that a request against GET /samples using job authentication fails. This URI is
-        not accessible to jobs.
+        Check that a request against GET /samples using job authentication fails.
+
+        This path is not accessible to jobs.
 
         """
         key = "bar"

--- a/tests/http/test_headers.py
+++ b/tests/http/test_headers.py
@@ -6,7 +6,7 @@ test_routes = RouteTableDef()
 
 
 @test_routes.get("/foo")
-def public_test_route(request: Request):
+def public_test_route(req: Request):
     headers = {"Location": "/foo", "Content-Location": "/bar"}
     return Response(status=200, headers=headers)
 


### PR DESCRIPTION
Recent decoupling of the front- and back-end has led to some changes in how B2C works in Virtool.

* Front-end handles login with B2C through pop-up.
* Login functionality is removed from backend.
* Back-end is registered as separate app and code has been updated accordingly.