### PR TITLE
Import references fixes

### DIFF
--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -634,7 +634,7 @@ async def create_import(
     created_at = virtool.utils.timestamp()
 
     document = await create_document(
-        pg,
+        db,
         settings,
         name or "Unnamed Import",
         None,

--- a/virtool/references/tasks.py
+++ b/virtool/references/tasks.py
@@ -3,11 +3,11 @@ import os
 import shutil
 from asyncio import gather
 from datetime import timedelta
+from logging import getLogger
 from pathlib import Path
 
 import aiohttp
 import arrow
-from pip._internal.utils._log import getLogger
 from semver import VersionInfo
 
 import virtool.tasks.pg


### PR DESCRIPTION
* Fix error caused by importing `getLogger` from `pip` instead of `logging`.
* Fix error during reference import due to bad `db` parameter.