### PR TITLE
Prevent updating job status after job is terminated

### DIFF
--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -276,7 +276,7 @@ class JobsData:
         if status is None:
             raise ResourceNotFoundError
 
-        if status[-1]["state"] in ("complete", "cancelled", "error"):
+        if status[-1]["state"] in ("complete", "cancelled", "error", "terminated"):
             raise ResourceConflictError("Job is finished")
 
         return await self._db.jobs.find_one_and_update(


### PR DESCRIPTION
Small change:

 - Adds "terminated" to the list of status which cannot be written over
 - Adds test to check that the "complete", "cancelled", "error", and "terminated" job states all prevent being written over