### PR TITLE
fix: update sentry error reporting

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -969,7 +969,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.5.7"
+version = "1.5.11"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -2197,8 +2197,8 @@ semver = [
     {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.5.7.tar.gz", hash = "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"},
-    {file = "sentry_sdk-1.5.7-py2.py3-none-any.whl", hash = "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49"},
+    {file = "sentry-sdk-1.5.11.tar.gz", hash = "sha256:6c01d9d0b65935fd275adc120194737d1df317dce811e642cbf0394d0d37a007"},
+    {file = "sentry_sdk-1.5.11-py2.py3-none-any.whl", hash = "sha256:c17179183cac614e900cbd048dab03f49a48e2820182ec686c25e7ce46f8548f"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -1,5 +1,6 @@
 import logging
 from logging import getLogger
+from typing import Optional
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -8,7 +9,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 logger = getLogger(__name__)
 
 
-def setup(server_version, dsn):
+def setup(server_version: Optional[str], dsn: str):
     logger.info(f"Initializing Sentry with DSN {dsn[:20]}...")
     sentry_sdk.init(
         dsn=dsn,


### PR DESCRIPTION
* Update SDK.
* Add typing to Sentry `setup()` function.

This commit is in service of getting release tracking working.