### PR TITLE
ci: publish images to ghcr

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   dockerhub:
     runs-on: ubuntu-20.04
@@ -27,3 +30,30 @@ jobs:
         with:
           push: true
           tags: virtool/virtool:${{ github.event.release.tag_name }}
+  ghcr:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+    if: github.repository_owner == 'Virtool'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GITHUB_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/virtool
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Start publishing to GHCR.

We will continue publishing to Dockerhub for the foreseeable future.