### PR TITLE
GHCR version and credential fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Write VERSION file
-        run: |
-          echo ${{ github.event.release.tag_name }} > "VERSION"
+        run: echo ${{ github.event.release.tag_name }} > VERSION
       - name: Update pyproject.toml version
-        run: |
-          sed -i 's/0\.0\.0/${{ github.event.release.tag_name }}/' pyproject.toml
+        run: sed -i 's/0\.0\.0/${{ github.event.release.tag_name }}/' pyproject.toml
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -39,6 +37,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Write VERSION file
+        run: echo ${{ github.event.release.tag_name }} > VERSION
+      - name: Update pyproject.toml version
+        run: sed -i 's/0\.0\.0/${{ github.event.release.tag_name }}/' pyproject.toml
       - name: Login to Registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.GITHUB_USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Extract Metadata
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --user .
 FROM virtool/external-tools:0.2.0
 WORKDIR /virtool
 COPY --from=server /root/.local /root/.local
-COPY run.py VERSION* /virtool/
+COPY run.py pyproject.toml VERSION* /virtool/
 COPY virtool /virtool/virtool
 COPY example /virtool/example
 EXPOSE 9950

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -5,7 +5,6 @@ import signal
 import sys
 import typing
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Dict
 from urllib.parse import urlparse, urlunparse
 
@@ -349,13 +348,12 @@ async def startup_version(app: typing.Union[dict, Application]):
     :param app: the application object
 
     """
-
     force_version = app["config"].force_version
 
     if force_version:
         version = force_version
     else:
-        version = await determine_server_version(Path(sys.path[0]))
+        version = await determine_server_version()
 
     logger.info(f"Virtool {version}")
     logger.info(f"Mode: {app['mode']}")

--- a/virtool/version.py
+++ b/virtool/version.py
@@ -10,20 +10,16 @@ logger = logging.getLogger("app")
 
 
 async def determine_server_version(install_path: Optional[Path] = Path.cwd()):
-    loop = asyncio.get_event_loop()
-
-    version = await loop.run_in_executor(None, determine_server_version_from_git)
+    version = await asyncio.get_event_loop().run_in_executor(
+        None, determine_server_version_from_git
+    )
 
     if version:
         return version
 
     try:
-        version_file_path = install_path / "VERSION"
-
-        async with aiofiles.open(version_file_path, "r") as version_file:
-            content = await version_file.read()
-            return content.rstrip()
-
+        async with aiofiles.open(install_path / "VERSION", "r") as version_file:
+            return (await version_file.read()).rstrip()
     except FileNotFoundError:
         logger.critical("Could not determine software version.")
         return "Unknown"


### PR DESCRIPTION
* Fix GitHub credential issue during image publish. Secret was misspelled.
* Write version information to GHCR image build. It was only being done for Dockerhub images.
* Copy `pyproject.toml` to image during build.
* Clean-up version determination code.