### PR TITLE
Include labels and user handle for samples sent via dispatcher

### DIFF
--- a/virtool/dispatcher/fetchers.py
+++ b/virtool/dispatcher/fetchers.py
@@ -232,7 +232,7 @@ class SamplesFetcher(AbstractFetcher):
 
         documents = [base_processor(document) for document in documents]
 
-        await apply_transforms(
+        documents = await apply_transforms(
             documents, [AttachLabelsTransform(self._pg), AttachUserTransform(self._db)]
         )
 


### PR DESCRIPTION
For some reason `SamplesFetcher` was calling `apply_transforms` but not storing the results. Quick one line fix to store the results of `apply_transforms` into documents.