### PR TITLE
fix: prevent creation of invalid imported references

### DIFF
--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -835,7 +835,7 @@ async def insert_joined_otu(
             )
 
     for sequence in sequences:
-        await db.sequences.insert_one(sequence)
+        await db.sequences.insert_one(sequence, session=session)
 
     return document["_id"]
 

--- a/virtool/references/tasks.py
+++ b/virtool/references/tasks.py
@@ -169,7 +169,9 @@ class ImportReferenceTask(Task):
             for chunk in chunk_list(otus, 10):
                 chunk_otu_ids = await gather(
                     *[
-                        insert_joined_otu(self.db, otu, created_at, ref_id, user_id)
+                        insert_joined_otu(
+                            self.db, otu, created_at, ref_id, user_id, session
+                        )
                         for otu in chunk
                     ]
                 )


### PR DESCRIPTION
MongoDB sessions were not being used correctly. Make sure the session is used for all requests to MongoDB.