### PR TITLE
fix: restore remote reference install functionality

### DIFF
--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -708,7 +708,7 @@ async def download_and_parse_release(
 
         await virtool.tasks.pg.update(pg, task_id, step="unpack")
 
-        return run_in_thread(load_reference_file, download_path)
+        return await run_in_thread(load_reference_file, download_path)
 
 
 async def edit(db, ref_id: str, data: dict) -> dict:

--- a/virtool/tasks/task.py
+++ b/virtool/tasks/task.py
@@ -45,6 +45,9 @@ class Task:
             self.step = func
 
             await virtool.tasks.pg.update(self.pg, self.id, step=self.step.__name__)
+
+            logger.info(f"Starting task step '{self.task_type}.{func.__name__}'")
+
             try:
                 await func()
             except Exception as err:


### PR DESCRIPTION
* Add missing `await`.
* Log a message at the beginning of each task step.