### PR TITLE
Fix jobs API tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --aiohttp-loop uvloop --capture tee-sys
+asyncio_mode = auto

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -1108,9 +1108,9 @@
       },
       <class 'dict'> {
         'archived': False,
-        'created_at': '2020-11-02T04:27:01Z',
+        'created_at': '2021-09-26T08:48:49Z',
         'id': 'fczq56va',
-        'progress': 100,
+        'progress': 97,
         'stage': 'second',
         'state': 'running',
         'user': <class 'dict'> {
@@ -1325,9 +1325,9 @@
       },
       <class 'dict'> {
         'archived': True,
-        'created_at': '2020-02-07T23:59:24Z',
-        'id': '3cvzfiqz',
-        'progress': 85,
+        'created_at': '2022-06-27T21:51:28Z',
+        'id': '03cvzfiq',
+        'progress': 100,
         'stage': 'first',
         'state': 'cancelled',
         'user': <class 'dict'> {
@@ -1335,13 +1335,13 @@
           'handle': 'bob',
           'id': 'test',
         },
-        'workflow': 'create_subtraction',
+        'workflow': 'create_sample',
       },
       <class 'dict'> {
         'archived': False,
-        'created_at': '2020-11-02T04:27:01Z',
+        'created_at': '2021-09-26T08:48:49Z',
         'id': 'fczq56va',
-        'progress': 100,
+        'progress': 97,
         'stage': 'second',
         'state': 'running',
         'user': <class 'dict'> {
@@ -1486,9 +1486,9 @@
       },
       <class 'dict'> {
         'archived': True,
-        'created_at': '2020-02-07T23:59:24Z',
-        'id': '3cvzfiqz',
-        'progress': 85,
+        'created_at': '2022-06-27T21:51:28Z',
+        'id': '03cvzfiq',
+        'progress': 100,
         'stage': 'first',
         'state': 'cancelled',
         'user': <class 'dict'> {
@@ -1496,7 +1496,7 @@
           'handle': 'bob',
           'id': 'test',
         },
-        'workflow': 'create_subtraction',
+        'workflow': 'create_sample',
       },
     ],
   }
@@ -1535,9 +1535,9 @@
       },
       <class 'dict'> {
         'archived': False,
-        'created_at': '2020-11-02T04:27:01Z',
+        'created_at': '2021-09-26T08:48:49Z',
         'id': 'fczq56va',
-        'progress': 100,
+        'progress': 97,
         'stage': 'second',
         'state': 'running',
         'user': <class 'dict'> {
@@ -1584,9 +1584,9 @@
       },
       <class 'dict'> {
         'archived': False,
-        'created_at': '2020-11-02T04:27:01Z',
+        'created_at': '2021-09-26T08:48:49Z',
         'id': 'fczq56va',
-        'progress': 100,
+        'progress': 97,
         'stage': 'second',
         'state': 'running',
         'user': <class 'dict'> {

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -79,15 +79,20 @@ async def test_acquire(
     assert await dbi.jobs.find_one() == snapshot
 
 
-async def test_archive(
-    dbi, fake, jobs_data: JobsData, pg, snapshot, static_time
-):
+async def test_archive(dbi, fake, jobs_data: JobsData, pg, snapshot, static_time):
     user = await fake.users.insert()
 
     status = compose_status("waiting", None)
 
     await dbi.jobs.insert_one(
-        {"_id": "foo", "status": [status], "archived": False, "acquired": False, "key": None, "user": {"id": user["_id"]}}
+        {
+            "_id": "foo",
+            "status": [status],
+            "archived": False,
+            "acquired": False,
+            "key": None,
+            "user": {"id": user["_id"]},
+        }
     )
 
     assert await jobs_data.archive("foo") == snapshot

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -144,7 +144,7 @@ class JobsData:
             ),
         }
 
-    async def find(self, query: Mapping):
+    async def find(self, query: MultiDictProxy):
         """
         :param query:
         :return:


### PR DESCRIPTION
* Add `asyncio_mode` to `pytest.ini`. This is required for upgrades to asyncio testing packages.
* Update snapshots for `test_jobs_find_beta`. Fake data for these somehow became disordered.