### PR TITLE
ci: fix ghcr builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/virtool
+          images: ${{ env.REGISTRY }}/virtool/virtool
       - name: Build and Push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Fix image path. It had a missing `/virtool`.