### PR TITLE
chore: add task API examples

### DIFF
--- a/virtool/tasks/api.py
+++ b/virtool/tasks/api.py
@@ -6,15 +6,15 @@ from aiohttp_pydantic.oas.typing import r200, r400
 import virtool.tasks.pg
 from virtool.api.response import NotFound, json_response
 from virtool.http.routes import Routes
-from virtool_core.models.task import TaskMinimal, Task
+
+from virtool.tasks.oas import GetTasksResponse, TaskResponse
 
 routes = Routes()
 
 
 @routes.view("/tasks")
 class TasksView(PydanticView):
-
-    async def get(self) -> r200[List[TaskMinimal]]:
+    async def get(self) -> r200[List[GetTasksResponse]]:
         """
         Get a list of all task documents in the database.
 
@@ -28,8 +28,7 @@ class TasksView(PydanticView):
 
 @routes.view("/tasks/{task_id}")
 class TaskView(PydanticView):
-
-    async def get(self) -> Union[r200[Task], r400]:
+    async def get(self) -> Union[r200[TaskResponse], r400]:
         """
         Get a complete task document.
 

--- a/virtool/tasks/oas.py
+++ b/virtool/tasks/oas.py
@@ -1,0 +1,37 @@
+from virtool_core.models.task import TaskMinimal, Task
+
+
+class GetTasksResponse(TaskMinimal):
+    class Config:
+        schema_extra = {
+            "example": [
+                {
+                    "complete": True,
+                    "context": {"user_id": "virtool"},
+                    "created_at": "2021-11-24T19:40:03.320000Z",
+                    "error": None,
+                    "file_size": None,
+                    "id": 2,
+                    "progress": 100,
+                    "step": "remove_referenced_otus",
+                    "type": "delete_reference",
+                }
+            ]
+        }
+
+
+class TaskResponse(Task):
+    class Config:
+        schema_extra = {
+            "example": {
+                "complete": True,
+                "context": {"user_id": "virtool"},
+                "created_at": "2021-11-24T19:40:03.320000Z",
+                "error": None,
+                "file_size": None,
+                "id": 2,
+                "progress": 100,
+                "step": "remove_referenced_otus",
+                "type": "delete_reference",
+            }
+        }


### PR DESCRIPTION
Sorry it turns out task did already have auto-docs so my bad for including it in the list, bit of a mix up. But it didnt have the examples stuff yet so i added that. 