### PR TITLE
docs: add oas summaries

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -66,7 +66,12 @@ class AccountView(PydanticView):
 
     async def patch(self, data: EditAccountSchema) -> Union[r200[Account], r400, r401]:
         """
-        Edit the user account.
+        Update the account.
+
+        Provide a ``password`` to update the account password. The ``old_password`` must
+        also be provided in the request.
+
+        The ``email`` address is not currently used, but will be in future releases.
 
         Status Codes:
             200: Successful Operation

--- a/virtool/custom_oas/oas/__main__.py
+++ b/virtool/custom_oas/oas/__main__.py
@@ -2,7 +2,6 @@ import argparse
 
 from virtool.custom_oas.oas.cmd import setup
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate Open API Specification")
     setup(parser)

--- a/virtool/custom_oas/oas/cmd.py
+++ b/virtool/custom_oas/oas/cmd.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib
 import json
+from pprint import pprint
 from typing import Dict, Protocol, Optional, Callable
 import sys
 
@@ -131,4 +132,22 @@ def show_oas(args: argparse.Namespace):
     """
     spec = args.base
     spec.update(generate_oas(args.apps))
+
+    for path in spec["paths"].values():
+        for operation in ("get", "patch", "post", "put", "delete"):
+            try:
+                operation_dict = path[operation]
+                description = operation_dict["description"]
+            except KeyError:
+                continue
+
+            split_description = description.split("\n")
+
+            operation_dict.update(
+                {
+                    "summary": split_description[0].strip().rstrip("."),
+                    "description": "\n".join(split_description[1:]).lstrip("\n"),
+                }
+            )
+
     print(args.formatter(spec), file=args.output)

--- a/virtool/custom_oas/oas/cmd.py
+++ b/virtool/custom_oas/oas/cmd.py
@@ -1,9 +1,8 @@
 import argparse
 import importlib
 import json
-from pprint import pprint
-from typing import Dict, Protocol, Optional, Callable
 import sys
+from typing import Dict, Protocol, Optional, Callable
 
 from virtool.custom_oas.oas.view import generate_oas
 

--- a/virtool/custom_oas/oas/view.py
+++ b/virtool/custom_oas/oas/view.py
@@ -1,24 +1,18 @@
-import typing
 import copy
+import typing
 from inspect import getdoc
 from itertools import count
 from typing import List, Type, Optional, get_type_hints
 
 from aiohttp.web import Response, json_response
 from aiohttp.web_app import Application
-from pydantic import BaseModel
-
-from aiohttp_pydantic.oas.struct import OpenApiSpec3, OperationObject, PathItem
-
-from aiohttp_pydantic.oas import docstring_parser
-
 from aiohttp_pydantic.injectors import _parse_func_signature
-
-from aiohttp_pydantic.utils import is_pydantic_base_model
-
-from aiohttp_pydantic.view import PydanticView, is_pydantic_view
-
+from aiohttp_pydantic.oas import docstring_parser
+from aiohttp_pydantic.oas.struct import OpenApiSpec3, OperationObject, PathItem
 from aiohttp_pydantic.oas.typing import is_status_code_type
+from aiohttp_pydantic.utils import is_pydantic_base_model
+from aiohttp_pydantic.view import PydanticView, is_pydantic_view
+from pydantic import BaseModel
 
 
 class _OASResponseBuilder:
@@ -76,15 +70,11 @@ class _OASResponseBuilder:
 
             if new_dict:
                 self._oas_operation.responses[status_code].content = {
-                    "application/json": {
-                        "schema": new_dict
-                    }
+                    "application/json": {"schema": new_dict}
                 }
             else:
                 self._oas_operation.responses[status_code].content = {
-                    "application/json": {
-                        "schema": schema
-                    }
+                    "application/json": {"schema": schema}
                 }
 
             desc = self._status_code_descriptions.get(int(status_code))
@@ -109,7 +99,7 @@ class _OASResponseBuilder:
 
 
 def _add_http_method_to_oas(
-        oas: OpenApiSpec3, oas_path: PathItem, http_method: str, view: Type[PydanticView]
+    oas: OpenApiSpec3, oas_path: PathItem, http_method: str, view: Type[PydanticView]
 ):
     http_method = http_method.lower()
     oas_operation: OperationObject = getattr(oas_path, http_method)
@@ -147,9 +137,9 @@ def _add_http_method_to_oas(
 
     indexes = count()
     for args_location, args in (
-            ("path", path_args.items()),
-            ("query", qs_args.items()),
-            ("header", header_args.items()),
+        ("path", path_args.items()),
+        ("query", qs_args.items()),
+        ("header", header_args.items()),
     ):
         for name, type_ in args:
             i = next(indexes)
@@ -180,9 +170,9 @@ def _add_http_method_to_oas(
 
 
 def generate_oas(
-        apps: List[Application],
-        version_spec: Optional[str] = None,
-        title_spec: Optional[str] = None,
+    apps: List[Application],
+    version_spec: Optional[str] = None,
+    title_spec: Optional[str] = None,
 ) -> dict:
     """
     Generate and return Open Api Specification from PydanticView in application.

--- a/virtool/history/api.py
+++ b/virtool/history/api.py
@@ -20,7 +20,10 @@ routes = virtool.http.routes.Routes()
 class ChangesView(PydanticView):
     async def get(self) -> Union[r200[List[GetHistoryResponse]], r422]:
         """
-        Get a list of change documents.
+        List history.
+
+        Returns a list of change documents.
+
         Status Codes:
             200: Successful Operation
             422: Invalid query

--- a/virtool/labels/api.py
+++ b/virtool/labels/api.py
@@ -8,7 +8,13 @@ import virtool.http.routes
 from virtool.api.response import EmptyRequest, NotFound, json_response
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
-from virtool.labels.oas import CreateLabelSchema, EditLabelSchema, CreateLabelResponse, GetLabelResponse, LabelResponse
+from virtool.labels.oas import (
+    CreateLabelSchema,
+    EditLabelSchema,
+    CreateLabelResponse,
+    GetLabelResponse,
+    LabelResponse,
+)
 
 routes = virtool.http.routes.Routes()
 
@@ -17,7 +23,10 @@ routes = virtool.http.routes.Routes()
 class LabelsView(PydanticView):
     async def get(self) -> Union[r200[List[GetLabelResponse]], r400]:
         """
-        List all sample labels.
+        List labels.
+
+        Lists all sample labels on the instance. Pagination is not supported; all labels are
+        included in the response.
 
         Status Codes:
             200: Successful operation
@@ -29,9 +38,13 @@ class LabelsView(PydanticView):
 
         return json_response([label.dict() for label in labels])
 
-    async def post(self, data: CreateLabelSchema) -> Union[r201[CreateLabelResponse], r400]:
+    async def post(
+        self, data: CreateLabelSchema
+    ) -> Union[r201[CreateLabelResponse], r400]:
         """
-        Create a sample label.
+        Create a label.
+
+        Creates a new sample label.
 
         The color must be a valid hexadecimal code.
 
@@ -59,7 +72,9 @@ class LabelsView(PydanticView):
 class LabelView(PydanticView):
     async def get(self) -> Union[r200[LabelResponse], r404]:
         """
-        Get the details for a sample label.
+        Get a label.
+
+        Retrieve the details for a sample label.
 
         Status Codes:
             200: Successful operation
@@ -74,9 +89,13 @@ class LabelView(PydanticView):
 
         return json_response(label.dict())
 
-    async def patch(self, data: EditLabelSchema) -> Union[r200[LabelResponse], r400, r404]:
+    async def patch(
+        self, data: EditLabelSchema
+    ) -> Union[r200[LabelResponse], r400, r404]:
         """
-        Edit an existing sample label.
+        Update a label.
+
+        Updates an existing sample label.
 
         Status codes:
             200: Successful operation
@@ -101,16 +120,18 @@ class LabelView(PydanticView):
 
     async def delete(self) -> Union[r204, r404]:
         """
-        Delete a sample label.
+        Delete a label.
+
+        Deletes an existing sample label.
 
         Status Codes:
             204: Successful operation
             404: Not found
         """
-        label_id = int(self.request.match_info["label_id"])
-
         try:
-            await get_data_from_req(self.request).labels.delete(label_id=label_id)
+            await get_data_from_req(self.request).labels.delete(
+                label_id=int(self.request.match_info["label_id"])
+            )
         except ResourceNotFoundError:
             raise NotFound()
 

--- a/virtool/labels/data.py
+++ b/virtool/labels/data.py
@@ -73,7 +73,6 @@ class LabelsData:
 
         async with AsyncSession(self._pg) as session:
             result = await session.execute(select(LabelSQL).filter_by(id=label_id))
-
             label = result.scalar()
 
         if label is None:
@@ -127,7 +126,9 @@ class LabelsData:
             if label is None:
                 raise ResourceNotFoundError()
 
-            await self._db.samples.update_many({"labels": label_id}, {"$pull": {"labels": label_id}})
+            await self._db.samples.update_many(
+                {"labels": label_id}, {"$pull": {"labels": label_id}}
+            )
 
             await session.delete(label)
             await session.commit()

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -78,7 +78,14 @@ routes = Routes()
 @routes.get("/samples")
 async def find(req):
     """
-    Find samples, filtering by data passed as URL parameters.
+    Find samples.
+
+    Finds, filters, and returns samples.
+
+    Providing a ``term`` filters samples by their ``name`` field. Partial matches are
+    supported.
+
+    Filtering is supported by `label` and `workflow`.
 
     """
     db = req.app["db"]
@@ -146,7 +153,9 @@ async def find(req):
 @routes.get("/samples/{sample_id}")
 async def get(req):
     """
-    Get a complete sample document.
+    Get a sample.
+
+    Retrieves the details for a sample.
 
     """
     sample_id = req.match_info["sample_id"]
@@ -231,7 +240,6 @@ async def create(req):
 
     subtractions = data.get("subtractions", [])
 
-    # Make sure each subtraction host was submitted and it exists.
     non_existent_subtractions = await virtool.mongo.utils.check_missing_ids(
         db.subtraction, subtractions
     )
@@ -349,6 +357,8 @@ async def create(req):
 )
 async def edit(req):
     """
+    Update a sample.
+
     Update specific fields in the sample document.
 
     """

--- a/virtool/settings/api.py
+++ b/virtool/settings/api.py
@@ -22,7 +22,9 @@ routes = Routes()
 class SettingsView(PydanticView):
     async def get(self) -> r200[GetSettingsResponse]:
         """
-        Get a complete document of the application settings.
+        Get settings.
+
+        Returns the complete application settings.
 
         Status Codes:
             200: Successful operation
@@ -36,7 +38,9 @@ class SettingsView(PydanticView):
         self, data: UpdateSettingsSchema
     ) -> Union[r200[UpdateSettingsResponse], r403]:
         """
-        Update application settings based on request data.
+        Update settings.
+
+        Updates the application settings.
 
         Status Codes:
             200: Successful operation

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -50,7 +50,12 @@ BASE_QUERY = {"deleted": False}
 class SubtractionsView(PydanticView):
     async def get(self) -> r200[List[GetSubtractionResponse]]:
         """
-        Find subtractions by id (name) or nickname.
+        Find subtractions.
+
+        Find subtractions by their ``name`` or ``nickname`` by providing a ``term`` as a
+        query parameter. Partial matches are supported.
+
+        This endpoint returns paginated results by default.
 
         Status Codes:
             200: Successful operation
@@ -104,7 +109,11 @@ class SubtractionsView(PydanticView):
         self, data: CreateSubtractionSchema
     ) -> Union[r201[CreateSubtractionResponse], r400, r403]:
         """
-        Add a new subtraction. Starts a 'CreateSubtraction' job process.
+        Create a subtraction.
+
+        Creates a new subtraction. A job is started to build the data necessary to make
+        the subtraction usable in analyses. The subtraction is usable when the
+        ``ready`` property is ``true``.
 
         Status Codes:
             201: Successful operation
@@ -163,7 +172,9 @@ class SubtractionsView(PydanticView):
 class SubtractionView(PydanticView):
     async def get(self) -> Union[r200[SubtractionResponse], r404]:
         """
-        Get a complete host document.
+        Get a subtraction.
+
+        Retrieves the details of a subtraction.
 
         Status Codes:
             200: Operation Successful
@@ -192,7 +203,9 @@ class SubtractionView(PydanticView):
         self, data: EditSubtractionSchema
     ) -> Union[r200[SubtractionResponse], r400, r403, r404]:
         """
-        Updates the nickname for an existing subtraction.
+        Update a subtraction.
+
+        Updates the name or nickname of an existing subtraction.
 
         Status Codes:
             200: Operation successful
@@ -225,7 +238,9 @@ class SubtractionView(PydanticView):
     @policy(PermissionsRoutePolicy(Permission.modify_subtraction))
     async def delete(self) -> Union[r204, r403, r404, r409]:
         """
-        Remove an existing subtraction.
+        Delete a subtraction.
+
+        Deletes an existing subtraction.
 
         Status Codes:
             204: No content

--- a/virtool/tasks/api.py
+++ b/virtool/tasks/api.py
@@ -16,7 +16,10 @@ routes = Routes()
 class TasksView(PydanticView):
     async def get(self) -> r200[List[GetTasksResponse]]:
         """
-        Get a list of all task documents in the database.
+        List all tasks.
+
+        Retrieves a list of all tasks active on the instance. Pagination is not
+        supported.
 
         Status Codes:
             200: Successful operation
@@ -30,7 +33,9 @@ class TasksView(PydanticView):
 class TaskView(PydanticView):
     async def get(self) -> Union[r200[TaskResponse], r400]:
         """
-        Get a complete task document.
+        Retrieve a task.
+
+        Get the details of a task.
 
         Status Codes:
             200: Successful operation

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -34,7 +34,9 @@ class UsersView(PydanticView):
     @policy(AdministratorRoutePolicy)
     async def get(self) -> Union[r200, r403]:
         """
-        Get a list of all user documents in the database.
+        List all users.
+
+        Returns a paginated list of all users in the instance.
 
         Status Codes:
             200: Successful operation
@@ -59,7 +61,10 @@ class UsersView(PydanticView):
     @policy(AdministratorRoutePolicy)
     async def post(self, data: CreateUserSchema) -> Union[r201[User], r400, r403]:
         """
-        Add a new user to the user database.
+        Create a user.
+
+        Creates a new user.
+
 
         Status Codes:
             201: Successful operation
@@ -92,7 +97,9 @@ class UserView(PydanticView):
     @policy(AdministratorRoutePolicy)
     async def get(self) -> Union[r200[User], r403, r404]:
         """
-        Gets the details of a user.
+        Retrieve a user.
+
+        Returns the details for a user.
 
         Status Codes:
             200: Success
@@ -113,9 +120,10 @@ class UserView(PydanticView):
         self, data: UpdateUserSchema
     ) -> Union[r200[User], r400, r403, r404, r409]:
         """
-        Updates the user with the passed parameters.
+        Update a user.
 
-        Users cannot modify their own administrative status.
+        Updates and existing user with the provided parameters.  Users cannot modify
+        their own administrative status.
 
         Status Codes:
             200: Successful operation
@@ -150,9 +158,9 @@ class UserView(PydanticView):
     @policy(AdministratorRoutePolicy)
     async def delete(self) -> Union[r204, r400, r403, r404]:
         """
-        Deletes a user.
+        Delete a user.
 
-        Users cannot delete their own accounts.
+        Deletes an existing user. Users cannot delete their own accounts.
 
         Status Codes:
             204: No content
@@ -178,10 +186,13 @@ class FirstUserView(PydanticView):
     @policy(PublicRoutePolicy)
     async def put(self, data: CreateFirstUserSchema) -> Union[r201[User], r400, r403]:
         """
-        Creates the first user for the instance.
+        Create a first user.
 
-        This endpoint will not work after the first is created. Authenticate as the
-        first user and use those credentials to continue interacting with the API.
+        Creates the first user for the instance. This endpoint will not succeed more
+        than once.
+
+        After calling this endpoint, authenticate as the first user and use those
+        credentials to continue interacting with the API.
 
         Status Codes:
             201: Successful operation


### PR DESCRIPTION
### `summary`
Modify OAS generation to generate a `summary` field. This will be used for the docs header for each endpoint.

The first line of the request handler docstring will be used as the `summary`. For example:

> List users.
>
> Lists all users on the instance.

### Docs
* Restructure many docstrings to provide good summaries.
* Expand and correct many docstrings.