### PR TITLE
refactor: accept models on json_response

### DIFF
--- a/virtool/api/json.py
+++ b/virtool/api/json.py
@@ -11,17 +11,24 @@ into JSON. The pretty dumper is used for formatting JSON for viewing in the brow
 import datetime
 import json
 
+from pydantic import BaseModel
+
 
 class CustomEncoder(json.JSONEncoder):
     """
-    A custom :class:`JSONEncoder` that converts :class:`datetime` objects to
-    ISO-formatting date strings.
+    A custom :class:`JSONEncoder` that:
+
+    - Converts :class:`datetime` objects to ISO-formatting date strings.
+    - Converts Pydantic data objects to dictionaries.
 
     """
 
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             return isoformat(obj)
+
+        if issubclass(type(obj), BaseModel):
+            return obj.dict()
 
         return json.JSONEncoder.default(self, obj)
 

--- a/virtool/api/response.py
+++ b/virtool/api/response.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from aiohttp.web import Response
 from aiohttp.web_exceptions import HTTPForbidden, HTTPNotFound, HTTPUnprocessableEntity
 
 
 def json_response(
-    data: object, status: int = 200, headers: Optional[dict] = None
+    data: Any, status: int = 200, headers: Optional[Dict[str, str]] = None
 ) -> Response:
     """
     Return a response object whose attached JSON dict will be formatted by middleware

--- a/virtool/groups/api.py
+++ b/virtool/groups/api.py
@@ -56,7 +56,7 @@ class GroupsView(PydanticView):
             raise HTTPBadRequest(text="Group already exists")
 
         return json_response(
-            GroupResponse.parse_obj(group).dict(),
+            GroupResponse.parse_obj(group),
             status=201,
             headers={"Location": f"/groups/{group.id}"},
         )
@@ -79,7 +79,7 @@ class GroupView(PydanticView):
         except ResourceNotFoundError:
             raise NotFound()
 
-        return json_response(GroupResponse.parse_obj(group).dict())
+        return json_response(GroupResponse.parse_obj(group))
 
     @policy(AdministratorRoutePolicy)
     async def patch(self, data: EditGroupSchema) -> Union[r200[GroupResponse], r404]:
@@ -100,7 +100,7 @@ class GroupView(PydanticView):
         except ResourceNotFoundError:
             raise NotFound()
 
-        return json_response(GroupResponse.parse_obj(group).dict())
+        return json_response(GroupResponse.parse_obj(group))
 
     @policy(AdministratorRoutePolicy)
     async def delete(self) -> Union[r204, r404]:

--- a/virtool/labels/api.py
+++ b/virtool/labels/api.py
@@ -65,7 +65,7 @@ class LabelsView(PydanticView):
 
         headers = {"Location": f"/labels/{label.id}"}
 
-        return json_response(label.dict(), status=201, headers=headers)
+        return json_response(label, status=201, headers=headers)
 
 
 @routes.view("/labels/{label_id}")
@@ -87,7 +87,7 @@ class LabelView(PydanticView):
         except ResourceNotFoundError:
             raise NotFound()
 
-        return json_response(label.dict())
+        return json_response(label)
 
     async def patch(
         self, data: EditLabelSchema
@@ -116,7 +116,7 @@ class LabelView(PydanticView):
         except ResourceConflictError:
             raise HTTPBadRequest(text="Label name already exists")
 
-        return json_response(label.dict())
+        return json_response(label)
 
     async def delete(self) -> Union[r204, r404]:
         """

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -86,7 +86,7 @@ class UsersView(PydanticView):
             raise HTTPBadRequest(text=str(err))
 
         return json_response(
-            user.dict(),
+            user,
             headers={"Location": f"/users/{user.id}"},
             status=201,
         )
@@ -113,7 +113,7 @@ class UserView(PydanticView):
         except ResourceNotFoundError:
             raise NotFound()
 
-        return json_response(user.dict())
+        return json_response(user)
 
     @policy(AdministratorRoutePolicy)
     async def patch(
@@ -153,7 +153,7 @@ class UserView(PydanticView):
         except ResourceNotFoundError:
             raise NotFound("User does not exist")
 
-        return json_response(user.dict())
+        return json_response(user)
 
     @policy(AdministratorRoutePolicy)
     async def delete(self) -> Union[r204, r400, r403, r404]:


### PR DESCRIPTION
You can now return responses from request handlers like:
```py
# Returns a `User` object. The class is a subclass of `BaseModel`.
user: User = get_user(...)

return json_response(user)
```
It also works for models nested in other data structures:
```py
# Returning a list of `User` objects.
return json_response([user, user])
```
It is not necessary to convert to `dict`:
```py
# This is no longer necessary.
return json_rseponse(user.dict())
```