### PR TITLE
Prevent incorrect usage of user_handle during api key authentication

### DIFF
--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -66,18 +66,18 @@ async def authenticate_with_key(req: Request, handler: Callable) -> Response:
 
 
 async def authenticate_with_api_key(
-    req: Request, handler: Callable, user_id: str, key: str
+    req: Request, handler: Callable, handle: str, key: str
 ) -> Response:
     db = req.app["db"]
 
     document, user = await asyncio.gather(
         db.keys.find_one({"_id": hash_key(key)}, ["permissions", "user"]),
         db.users.find_one(
-            {"handle": user_id}, ["administrator", "groups", "permissions"]
+            {"handle": handle}, ["administrator", "groups", "permissions"]
         ),
     )
 
-    if not document or document["user"]["id"] != user["_id"]:
+    if not document or not user or document["user"]["id"] != user["_id"]:
         raise HTTPUnauthorized(text="Invalid authorization header")
 
     req["client"] = UserClient(

--- a/virtool/http/auth.py
+++ b/virtool/http/auth.py
@@ -86,7 +86,7 @@ async def authenticate_with_api_key(
         force_reset=False,
         groups=user["groups"],
         permissions=document["permissions"],
-        user_id=user_id,
+        user_id=user["_id"],
         authenticated=True,
     )
 


### PR DESCRIPTION
One line fix that prevents issues caused by the `user_id` field of `req["client"]` being populated by the users `handle` rather than `id`