### PR TITLE
fix: don't report slow websocket transactions to sentry

### DIFF
--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -1,12 +1,25 @@
 import logging
 from logging import getLogger
-from typing import Optional
+from typing import Optional, Dict
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 logger = getLogger(__name__)
+
+
+def traces_sampler(sampling_context: Dict) -> float:
+    try:
+        transaction_name = sampling_context["transaction_context"]["name"]
+    except KeyError:
+        logger.warning("Could not determine Sentry transaction name")
+        transaction_name = None
+
+    if transaction_name == "virtool.http.ws.root":
+        return 0.0
+
+    return 0.2
 
 
 def setup(server_version: Optional[str], dsn: str):
@@ -18,5 +31,5 @@ def setup(server_version: Optional[str], dsn: str):
             LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
         ],
         release=server_version,
-        traces_sample_rate=0.2,
+        traces_sampler=traces_sampler,
     )


### PR DESCRIPTION
Since Websocket connections are long-lived, Sentry thinks these are very slow transactions.

Stop sending samples for these.