### PR TITLE
fix: restore oas spec as github release asset

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,7 @@
     "@semantic-release/release-notes-generator",
     ["@semantic-release/github", {
      "assets": [
-        {"path": "virtool/spec/oas.json", "label": "oas specification"}
+        {"path": "virtool/spec/openapi.json", "label": "openapi.json"}
         ]
     }]
   ],


### PR DESCRIPTION
I noticed the Open API specification wasn't being attached as a release asset anymore, so this should fix it.