### PR TITLE
Send custom code on websocket authentication failure

### DIFF
--- a/tests/dispatcher/test_connection.py
+++ b/tests/dispatcher/test_connection.py
@@ -33,5 +33,5 @@ async def test_send(ws):
 
 
 async def test_close(ws):
-    await ws.close()
+    await ws.close(1000)
     ws._ws.close.assert_called()

--- a/virtool/dispatcher/connection.py
+++ b/virtool/dispatcher/connection.py
@@ -28,9 +28,9 @@ class Connection:
             if "Cannot write to closing transport" not in str(err):
                 raise
 
-            await self.close()
+            await self.close(1002)
 
-    async def close(self, code: Union[int, str] = None):
+    async def close(self, code: int):
         """
         Closes the underlying websocket connection.
         :param code: closure code to send to the client

--- a/virtool/dispatcher/connection.py
+++ b/virtool/dispatcher/connection.py
@@ -30,8 +30,9 @@ class Connection:
 
             await self.close()
 
-    async def close(self):
+    async def close(self, code: Union[int, str] = None):
         """
         Closes the underlying websocket connection.
+        :param code: closure code to send to the client
         """
-        await self._ws.close()
+        await self._ws.close(code=code)

--- a/virtool/dispatcher/dispatcher.py
+++ b/virtool/dispatcher/dispatcher.py
@@ -110,7 +110,7 @@ class Dispatcher:
         try:
             async for change in self._listener:
                 await self._dispatch(change)
-                logger.debug(f"Received change: {change.target}")
+                logger.debug("Received change: %s", change.target)
         except CancelledError:
             pass
 
@@ -126,7 +126,7 @@ class Dispatcher:
 
         """
         self._connections.append(connection)
-        logger.debug(f"Added connection to dispatcher: {connection.user_id}")
+        logger.debug("Added connection to dispatcher: %s", connection.user_id)
 
     def remove_connection(self, connection: Connection):
         """
@@ -137,7 +137,7 @@ class Dispatcher:
         """
         try:
             self._connections.remove(connection)
-            logger.debug(f"Removed connection from dispatcher: {connection.user_id}")
+            logger.debug("Removed connection from dispatcher: %s", connection.user_id)
         except ValueError:
             pass
 
@@ -159,7 +159,7 @@ class Dispatcher:
         try:
             fetcher = getattr(self._fetchers, change.interface)
         except AttributeError:
-            logger.warning(f"Unknown dispatch interface: {change.interface}")
+            logger.warning("Unknown dispatch interface: %s", change.interface)
             return
 
         if change.operation not in (DELETE, INSERT, UPDATE):
@@ -176,7 +176,7 @@ class Dispatcher:
                 ):
                     self.remove_connection(connection)
 
-        logger.debug(f"Dispatcher sent messages for {change.target}")
+        logger.debug("Dispatcher sent messages for %s", change.target)
 
     async def close(self):
         """
@@ -186,6 +186,6 @@ class Dispatcher:
         logger.debug("Closing dispatcher")
 
         for connection in self._connections:
-            await connection.close()
+            await connection.close(1001)
 
         logger.debug("Closed dispatcher")

--- a/virtool/http/policy.py
+++ b/virtool/http/policy.py
@@ -68,6 +68,12 @@ class PublicRoutePolicy(DefaultRoutePolicy):
     allow_unauthenticated = True
 
 
+class WebSocketRoutePolicy(DefaultRoutePolicy):
+    """Any client can access the route."""
+
+    allow_unauthenticated = True
+
+
 def policy(route_policy: Union[DefaultRoutePolicy, Type[DefaultRoutePolicy]]):
     def decorator(func):
         try:

--- a/virtool/http/policy.py
+++ b/virtool/http/policy.py
@@ -69,8 +69,7 @@ class PublicRoutePolicy(DefaultRoutePolicy):
 
 
 class WebSocketRoutePolicy(DefaultRoutePolicy):
-    """Any client can access the route."""
-
+    """Only for use with websocket, accessible by any client"""
     allow_unauthenticated = True
 
 


### PR DESCRIPTION
Changes:
  - Adds new authentication policy that allows any client through but still collects authentication information
  - If authentication fails the server will immediately close the connection with a custom closure code.