### PR TITLE
ci: fix poetry export error in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM library/python:3.8-buster as server
 WORKDIR /build
-RUN pip install --user poetry
+RUN pip install --user poetry==1.1.14
 COPY pyproject.toml ./pyproject.toml
 COPY poetry.lock ./poetry.lock
 RUN /root/.local/bin/poetry export --without-hashes > requirements.txt


### PR DESCRIPTION
Pinned Poetry at 1.1.14 in the Dockerfile.

It looks like Poetry logging is being written to stdout for the `export` subcommand in `1.2.0`.