### PR TITLE
fix: don't fetch github release on demand

### DIFF
--- a/tests/hmm/__snapshots__/test_api.ambr
+++ b/tests/hmm/__snapshots__/test_api.ambr
@@ -106,22 +106,6 @@
     'total_entropy': 101.49,
   }
 ---
-# name: test_get_release[uvloop-None][json]
-  <class 'dict'> {
-    'body': "- remove some annotations that didn't have corresponding profiles",
-    'content_type': 'application/gzip',
-    'download_url': 'https://github.com/virtool/virtool-hmm/releases/download/v0.2.1/vthmm.tar.gz',
-    'etag': 'W/"7bd9cdef79c82ab4d7e5cfff394cf81eaddc6f681b8202f2a7bdc65cbcc4aaea"',
-    'filename': 'vthmm.tar.gz',
-    'html_url': 'https://github.com/virtool/virtool-hmm/releases/tag/v0.2.1',
-    'id': 1230982,
-    'name': 'v0.2.1',
-    'newer': False,
-    'published_at': '2015-10-06T20:00:00Z',
-    'retrieved_at': '2015-10-06T20:00:00Z',
-    'size': 85904451,
-  }
----
 # name: test_get_release[uvloop][json]
   <class 'dict'> {
     'body': "- remove some annotations that didn't have corresponding profiles",

--- a/tests/hmm/__snapshots__/test_api.ambr
+++ b/tests/hmm/__snapshots__/test_api.ambr
@@ -122,6 +122,22 @@
     'size': 85904451,
   }
 ---
+# name: test_get_release[uvloop][json]
+  <class 'dict'> {
+    'body': "- remove some annotations that didn't have corresponding profiles",
+    'content_type': 'application/gzip',
+    'download_url': 'https://github.com/virtool/virtool-hmm/releases/download/v0.2.1/vthmm.tar.gz',
+    'etag': 'W/"7bd9cdef79c82ab4d7e5cfff394cf81eaddc6f681b8202f2a7bdc65cbcc4aaea"',
+    'filename': 'vthmm.tar.gz',
+    'html_url': 'https://github.com/virtool/virtool-hmm/releases/tag/v0.2.1',
+    'id': 1230982,
+    'name': 'v0.2.1',
+    'newer': False,
+    'published_at': '2015-10-06T20:00:00Z',
+    'retrieved_at': '2015-10-06T20:00:00Z',
+    'size': 85904451,
+  }
+---
 # name: test_get_status[uvloop][json]
   <class 'dict'> {
     'errors': <class 'list'> [

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -3,11 +3,7 @@ import shutil
 
 import aiofiles
 import pytest
-from aiohttp import ClientConnectorError
-from aiohttp.test_utils import make_mocked_coro
 from virtool_core.utils import decompress_file
-
-from virtool.errors import GitHubError
 
 
 @pytest.fixture
@@ -78,8 +74,7 @@ async def test_get_status(fake_hmm_status, snapshot, spawn_client, static_time):
     assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.parametrize("error", [None, "502_repo", "502_github", "404"])
-async def test_get_release(error, mocker, spawn_client, resp_is, snapshot, static_time):
+async def test_get_release(fake_hmm_status, spawn_client, snapshot):
     """
     Test that the endpoint returns the latest HMM release. Check that error responses are sent in all expected
     situations.
@@ -87,50 +82,7 @@ async def test_get_release(error, mocker, spawn_client, resp_is, snapshot, stati
     """
     client = await spawn_client(authorize=True)
 
-    m_fetch = make_mocked_coro(
-        None
-        if error == "404"
-        else {
-            "body": "- remove some annotations that didn't have corresponding profiles",
-            "content_type": "application/gzip",
-            "download_url": "https://github.com/virtool/virtool-hmm/releases/download/v0.2.1/vthmm.tar.gz",
-            "etag": 'W/"7bd9cdef79c82ab4d7e5cfff394cf81eaddc6f681b8202f2a7bdc65cbcc4aaea"',
-            "filename": "vthmm.tar.gz",
-            "html_url": "https://github.com/virtool/virtool-hmm/releases/tag/v0.2.1",
-            "id": 1230982,
-            "name": "v0.2.1",
-            "newer": False,
-            "published_at": static_time.datetime,
-            "retrieved_at": static_time.datetime,
-            "size": 85904451,
-        },
-    )
-
-    mocker.patch("virtool.hmm.db.fetch_and_update_release", new=m_fetch)
-
-    if error == "502_repo":
-        m_fetch.side_effect = GitHubError("404 Not found")
-
-    if error == "502_github":
-        m_fetch.side_effect = ClientConnectorError("foo", OSError("Bar"))
-
     resp = await client.get("/hmms/status/release")
-
-    m_fetch.assert_called_with(
-        client.app["config"], client.app["client"], client.db, "virtool/virtool-hmm"
-    )
-
-    if error == "404":
-        await resp_is.not_found(resp, "Not found")
-        return
-
-    if error == "502_repo":
-        await resp_is.bad_gateway(resp, "GitHub repository does not exist")
-        return
-
-    if error == "502_github":
-        await resp_is.bad_gateway(resp, "Could not reach GitHub")
-        return
 
     assert resp.status == 200
     assert await resp.json() == snapshot(name="json")

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -116,13 +116,13 @@ class ReleaseView(PydanticView):
             502: Cannot reach GitHub
         """
         try:
-            release = await get_data_from_req(self.request).hmms.get_release()
+            status = await get_data_from_req(self.request).hmms.get_status()
         except ResourceNotFoundError:
             raise NotFound
         except ResourceRemoteError as err:
             raise HTTPBadGateway(text=str(err))
 
-        return json_response(release)
+        return json_response(status.release)
 
 
 @routes.view("/hmms/status/updates")


### PR DESCRIPTION
Stop making requests to GitHub everytime a client makes a request to `GET /hmms/status/release`. This endpoint will now return the cached release.

Contacting GitHub for every API request will not scale well.