### PR TITLE
fix: resolve errors on hmm endpoints

### DIFF
--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -34,7 +34,7 @@ def data_layer(dbi, config, mocker, pg: AsyncEngine, redis: Redis):
         SettingsData(dbi),
         HistoryData(config.data_path, dbi),
         ReferencesData(dbi, pg, config, mocker.Mock(spec=ClientSession)),
-        HmmData(mocker.Mock(spec=ClientSession), config, dbi),
+        HmmData(mocker.Mock(spec=ClientSession), config, dbi, pg),
         LabelsData(dbi, pg),
         JobsData(DummyJobsClient(), dbi, pg),
         OTUData({"db": dbi, "pg": pg}),
@@ -42,5 +42,5 @@ def data_layer(dbi, config, mocker, pg: AsyncEngine, redis: Redis):
         SubtractionsData(base_url, config, dbi, pg),
         UploadsData(config, dbi, pg),
         UsersData(dbi, pg),
-        TasksData(pg, redis)
+        TasksData(pg, redis),
     )

--- a/tests/tasks/__snapshots__/test_transforms.ambr
+++ b/tests/tasks/__snapshots__/test_transforms.ambr
@@ -1,0 +1,36 @@
+# name: test_attach_task_transform[uvloop]
+  <class 'list'> [
+    <class 'dict'> {
+      'id': 1,
+      'task': <class 'dict'> {
+        'complete': False,
+        'context': <class 'dict'> {
+        },
+        'count': 0,
+        'created_at': <class 'datetime'>,
+        'error': None,
+        'file_size': None,
+        'id': 3,
+        'progress': 0,
+        'step': 'add_index_files',
+        'type': 'add_index_files',
+      },
+    },
+    <class 'dict'> {
+      'id': 2,
+      'task': <class 'dict'> {
+        'complete': False,
+        'context': <class 'dict'> {
+        },
+        'count': 0,
+        'created_at': <class 'datetime'>,
+        'error': None,
+        'file_size': None,
+        'id': 4,
+        'progress': 0,
+        'step': 'add_subtraction_files',
+        'type': 'add_subtraction_files',
+      },
+    },
+  ]
+---

--- a/tests/tasks/__snapshots__/test_transforms.ambr
+++ b/tests/tasks/__snapshots__/test_transforms.ambr
@@ -34,3 +34,27 @@
     },
   ]
 ---
+# name: test_attach_task_transform_single[uvloop]
+  <class 'list'> [
+    <class 'dict'> {
+      'id': 1,
+      'task': <class 'dict'> {
+        'complete': False,
+        'context': <class 'dict'> {
+        },
+        'count': 0,
+        'created_at': <class 'datetime'>,
+        'error': None,
+        'file_size': None,
+        'id': 2,
+        'progress': 0,
+        'step': 'clone_reference',
+        'type': 'clone_reference',
+      },
+    },
+    <class 'dict'> {
+      'id': 2,
+      'task': None,
+    },
+  ]
+---

--- a/tests/tasks/test_transforms.py
+++ b/tests/tasks/test_transforms.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+from syrupy.matchers import path_type
+
+from virtool.mongo.transforms import apply_transforms
+from virtool.tasks.transforms import AttachTaskTransform
+
+
+async def test_attach_task_transform(fake2, pg: AsyncEngine, snapshot):
+    await fake2.tasks.create()
+    await fake2.tasks.create()
+    task_2 = await fake2.tasks.create()
+    task_3 = await fake2.tasks.create()
+
+    documents = [
+        {"id": 1, "task": {"id": task_2.id}},
+        {"id": 2, "task": {"id": task_3.id}},
+        {"id": 3, "task": None},
+        {
+            "id": 4,
+        },
+    ]
+
+    transformed = await apply_transforms(documents, [AttachTaskTransform(pg)])
+
+    assert transformed == snapshot(
+        matcher=path_type({".*created_at": (datetime,)}, regex=True)
+    )

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -16,11 +16,19 @@ from faker.providers import BaseProvider, python, color, lorem
 from virtool_core.models.group import Group
 from virtool_core.models.job import Job
 from virtool_core.models.label import Label
+from virtool_core.models.task import Task
 from virtool_core.models.user import User
 
 from virtool.data.layer import DataLayer
 from virtool.groups.oas import EditPermissionsSchema, EditGroupSchema
+from virtool.indexes.tasks import AddIndexFilesTask, AddIndexJSONTask
 from virtool.jobs.utils import WORKFLOW_NAMES, JobRights
+from virtool.references.tasks import (
+    CloneReferenceTask,
+    CleanReferencesTask,
+    DeleteReferenceTask,
+)
+from virtool.subtractions.tasks import AddSubtractionFilesTask
 from virtool.users.oas import UpdateUserSchema
 
 
@@ -51,6 +59,7 @@ class DataFaker:
         self.groups = GroupsFakerPiece(self)
         self.labels = LabelsFakerPiece(self)
         self.jobs = JobsFakerPiece(self)
+        self.tasks = TasksFakerPiece(self)
         self.users = UsersFakerPiece(self)
 
 
@@ -100,6 +109,25 @@ class LabelsFakerPiece(DataFakerPiece):
             self.faker.word().capitalize(),
             self.faker.hex_color(),
             self.faker.sentence(),
+        )
+
+
+class TasksFakerPiece(DataFakerPiece):
+    model = Task
+
+    async def create(self):
+        return await self.layer.tasks.register(
+            self.faker.random_element(
+                [
+                    AddIndexFilesTask,
+                    AddIndexJSONTask,
+                    AddSubtractionFilesTask,
+                    CloneReferenceTask,
+                    CleanReferencesTask,
+                    DeleteReferenceTask,
+                ]
+            ),
+            {},
         )
 
 

--- a/virtool/hmm/tasks.py
+++ b/virtool/hmm/tasks.py
@@ -42,7 +42,6 @@ class HMMInstallTask(Task):
         self.steps = [
             self.download,
             self.decompress,
-            self.purge,
             self.install_profiles,
             self.import_annotations,
         ]
@@ -51,6 +50,7 @@ class HMMInstallTask(Task):
 
     async def download(self):
         release = self.context["release"]
+
         await get_data_from_app(self.app).tasks.update(self.id, 0, step="download")
 
         tracker = await self.get_tracker(release["size"])
@@ -74,9 +74,6 @@ class HMMInstallTask(Task):
             decompress_tgz, self.temp_path / "hmm.tar.gz", self.temp_path
         )
 
-    async def purge(self):
-        await get_data_from_app(self.app).hmms.purge()
-
     async def install_profiles(self):
         tracker = await self.get_tracker()
 
@@ -94,7 +91,9 @@ class HMMInstallTask(Task):
 
     async def import_annotations(self):
         release = self.context["release"]
-        await get_data_from_app(self.app).tasks.update(self.id, step="import_annotations")
+        await get_data_from_app(self.app).tasks.update(
+            self.id, step="import_annotations"
+        )
 
         async with aiofiles.open(self.temp_path / "hmm" / "annotations.json", "r") as f:
             annotations = json.loads(await f.read())

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -139,7 +139,7 @@ async def startup_data(app: App):
         SettingsData(app["db"]),
         HistoryData(app["config"].data_path, app["db"]),
         ReferencesData(app["db"], app["pg"], app["config"], app["client"]),
-        HmmData(app["client"], app["config"], app["db"]),
+        HmmData(app["client"], app["config"], app["db"], app["pg"]),
         LabelsData(app["db"], app["pg"]),
         JobsData(JobsClient(app["redis"]), app["db"], app["pg"]),
         OTUData(app),
@@ -147,7 +147,7 @@ async def startup_data(app: App):
         SubtractionsData(app["config"].base_url, app["config"], app["db"], app["pg"]),
         UploadsData(app["config"], app["db"], app["pg"]),
         UsersData(app["db"], app["pg"]),
-        TasksData(app["pg"], app["redis"])
+        TasksData(app["pg"], app["redis"]),
     )
 
 
@@ -360,7 +360,7 @@ async def startup_version(app: typing.Union[dict, Application]):
         version = await determine_server_version()
 
     logger.info("Virtool %s", version)
-    logger.info("Mode: %s", app['mode'])
+    logger.info("Mode: %s", app["mode"])
 
     app["version"] = version
 

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -44,10 +44,10 @@ class TasksData:
                 await session.execute(select(SQLTask).filter_by(id=task_id))
             ).scalar()
 
-        if result is None:
-            raise ResourceNotFoundError
+        if result:
+            return Task(**result.to_dict())
 
-        return Task(**result.to_dict())
+        raise ResourceNotFoundError
 
     async def register(self, task_class: Type[TaskClass], context: dict = None) -> Task:
         """

--- a/virtool/tasks/runner.py
+++ b/virtool/tasks/runner.py
@@ -1,9 +1,6 @@
 import asyncio
 import logging
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
 import virtool.tasks.task
 from virtool.pg.utils import get_row_by_id
 from virtool.tasks.models import Task

--- a/virtool/tasks/runner.py
+++ b/virtool/tasks/runner.py
@@ -23,7 +23,7 @@ class TaskRunner:
 
                 await self.run_task(task_id)
 
-                logging.info(f"Task finished: {task_id}")
+                logging.info(f"Task finished: %s", task_id)
 
         except asyncio.CancelledError:
             logging.info("Stopped task runner")

--- a/virtool/tasks/runner.py
+++ b/virtool/tasks/runner.py
@@ -23,7 +23,7 @@ class TaskRunner:
 
                 await self.run_task(task_id)
 
-                logging.info(f"Task finished: %s", task_id)
+                logging.info("Finished task: %s", task_id)
 
         except asyncio.CancelledError:
             logging.info("Stopped task runner")
@@ -37,7 +37,7 @@ class TaskRunner:
         """
         task: Task = await get_row_by_id(self.app["pg"], Task, task_id)
 
-        logging.info(f"Task starting: {task.id} {task.type}")
+        logging.info(f"Starting task: %s %s", task.id, task.type)
 
         loop = asyncio.get_event_loop()
 

--- a/virtool/tasks/transforms.py
+++ b/virtool/tasks/transforms.py
@@ -1,0 +1,56 @@
+from typing import List, Dict, Any, Union
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.mongo.transforms import AbstractTransform
+from virtool.tasks.models import Task as SQLTask
+from virtool.types import Document
+from virtool.utils import get_safely
+
+
+class AttachTaskTransform(AbstractTransform):
+    """
+    Attaches more complete task data to a document with a `task.id` field.
+    """
+
+    def __init__(self, pg: AsyncEngine):
+        self._pg = pg
+
+    async def attach_one(self, document, prepared):
+        return {**document, "task": prepared}
+
+    async def attach_many(
+        self, documents: List[Document], prepared: Dict[int, Any]
+    ) -> List[Document]:
+        attached = []
+
+        for document in documents:
+            if task_id := get_safely(document, "task", "id"):
+                attached.append({**document, "task": prepared[task_id]})
+
+        return attached
+
+    async def prepare_one(self, document):
+        task_id = document["task"]["id"]
+
+        async with AsyncSession(self._pg) as session:
+            result = (
+                await session.execute(select(SQLTask).filter_by(id=task_id))
+            ).scalar()
+
+        return result.to_dict()
+
+    async def prepare_many(
+        self, documents: List[Document]
+    ) -> Dict[Union[int, str], Any]:
+        task_ids = {get_safely(document, "task", "id") for document in documents}
+        task_ids.discard(None)
+        task_ids = list(task_ids)
+
+        async with AsyncSession(self._pg) as session:
+            results = await session.execute(
+                select(SQLTask).filter(SQLTask.id.in_(task_ids))
+            )
+
+            return {task.id: task.to_dict() for task in results.scalars()}

--- a/virtool/utils.py
+++ b/virtool/utils.py
@@ -48,6 +48,24 @@ def base_processor(document: Optional[Dict]) -> Optional[Dict]:
     return document
 
 
+def get_safely(dct: Dict, *keys) -> Any:
+    """
+    Get values from nested dictionaries while returning ``None`` when a ``KeyError`` or
+    ``TypeError`` is raised.
+
+    """
+    for key in keys:
+        try:
+            dct = dct[key]
+        except (
+            KeyError,
+            TypeError,
+        ):
+            return None
+
+    return dct
+
+
 def chunk_list(lst: list, n: int):
     """Yield successive n-sized chunks from `lst`."""
     for i in range(0, len(lst), n):


### PR DESCRIPTION
* Add transform for attaching complete task data.
* Add task faking.
* Restore HMM install functionality.
* Don't purge during HMM install. This removes status.
* Add `get_safely` to get from nested dicts.