### PR TITLE
fix: restore broken jobs api downloads

### DIFF
--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -10,6 +10,7 @@ from aiohttp_pydantic.oas.typing import r200, r201, r204, r401, r403, r404
 from pydantic import Field, conint
 
 from virtool.api.response import InvalidQuery, json_response, NotFound
+from virtool.config import get_config_from_req
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.http.policy import PermissionsRoutePolicy, policy
@@ -34,7 +35,7 @@ class UploadsView(PydanticView):
         per_page: conint(ge=1, le=100) = 25,
         upload_type: Optional[str] = None,
         ready: Optional[bool] = None,
-        paginate: Optional[bool] = False
+        paginate: Optional[bool] = False,
     ) -> r200[List[GetUploadsResponse]]:
         """
         List uploads.
@@ -180,9 +181,7 @@ async def download(req):
     except ResourceNotFoundError:
         raise NotFound
 
-    upload_path = await get_data_from_req(req).uploads.get_upload_path(
-        upload.name_on_disk
-    )
+    upload_path = await get_upload_path(get_config_from_req(req), upload.name_on_disk)
 
     return FileResponse(
         upload_path,


### PR DESCRIPTION
Downloads from `/uploads/:id` are broken. The responsible reference to a non-existent method has been fixed.