### PR TITLE
test: rerun flaky reference import tests

### DIFF
--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -44,6 +44,7 @@ class TestCreate:
         assert resp.headers["Location"] == snapshot
         assert await resp.json() == snapshot
 
+    @pytest.mark.flaky(reruns=2)
     async def test_import_reference(
         self, pg, snapshot, spawn_client, test_files_path, tmpdir
     ):

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -122,7 +122,6 @@ class ReferencesData(DataLayerPiece):
         )
 
     async def create(self, data: CreateReferenceSchema, user_id: str) -> Reference:
-
         settings = await self.data.settings.get_all()
 
         if data.clone_from:


### PR DESCRIPTION
The reference import API test is failing again.

This is caused by a MongoDB transaction error. It is unrelated to the collections being defined or not. I am adding back the flaky rerun mark that I removed in a recent PR.