### PR TITLE
fix: prevent error when fetching otu

### DIFF
--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -224,7 +224,7 @@ async def get_most_recent_change(
 
     """
     return await db.history.find_one(
-        {"otu.id": otu_id, "index.id": "unbuilt"},
+        {"otu.id": otu_id},
         MOST_RECENT_PROJECTION,
         sort=[("otu.version", -1)],
         session=session,


### PR DESCRIPTION
Include built changes in otu `most_recent_change` field.

This was causing the error when the `None` value field had user information attached to it. The field had a `None` value when the most recent change had been built into an index.