### PR TITLE
fix: return analysis results as null until they are ready

### DIFF
--- a/tests/analyses/__snapshots__/test_db.ambr
+++ b/tests/analyses/__snapshots__/test_db.ambr
@@ -16,6 +16,7 @@
       'id': 'test_ref',
       'name': None,
     },
+    'results': None,
     'sample': <class 'dict'> {
       'id': 'test_sample',
     },
@@ -48,6 +49,7 @@
       'id': 'test_ref',
       'name': None,
     },
+    'results': None,
     'sample': <class 'dict'> {
       'id': 'test_sample',
     },
@@ -80,6 +82,7 @@
       'id': 'test_ref',
       'name': None,
     },
+    'results': None,
     'sample': <class 'dict'> {
       'id': 'test_sample',
     },
@@ -112,6 +115,7 @@
       'id': 'test_ref',
       'name': None,
     },
+    'results': None,
     'sample': <class 'dict'> {
       'id': 'test_sample',
     },

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -110,13 +110,9 @@ async def create(
     created_at = virtool.utils.timestamp()
 
     document = {
-        "ready": False,
         "created_at": created_at,
-        "updated_at": created_at,
-        "job": {"id": job_id},
         "files": [],
-        "workflow": workflow,
-        "sample": {"id": sample_id},
+        "job": {"id": job_id},
         "index": {"id": index_id, "version": index_version},
         "reference": {
             "id": ref_id,
@@ -124,10 +120,15 @@ async def create(
                 db.references, "name", ref_id
             ),
         },
+        "ready": False,
+        "results": None,
+        "sample": {"id": sample_id},
         "subtractions": subtractions,
+        "updated_at": created_at,
         "user": {
             "id": user_id,
         },
+        "workflow": workflow,
     }
 
     if analysis_id:


### PR DESCRIPTION
The `results` field is nullable but required. For new analysis, set the `results` field to `None` instead of not setting it at all.

A complementary commit has already been merged to **virtool-migration** that will set old unset `results` fields to `None`.