### PR TITLE
Groups API fixes

### DIFF
--- a/virtool/groups/api.py
+++ b/virtool/groups/api.py
@@ -42,7 +42,13 @@ class GroupsView(PydanticView):
         self, data: CreateGroupRequest
     ) -> Union[r201[CreateGroupResponse], r400]:
         """
-        Create a new group. New groups have no permissions.
+        Create a group.
+
+        Creates a new group with the given name.
+
+        The ``group_id`` parameter is deprecated and will no longer be accepted in a
+        future major release. For now, ``group_id`` will be used as ``name`` if it is
+        provided.
 
         Status Codes:
             201: Successful operation
@@ -84,7 +90,9 @@ class GroupView(PydanticView):
         self, group_id: str, /, data: UpdateGroupRequest
     ) -> Union[r200[GroupResponse], r404]:
         """
-        Update the permissions of a group.
+        Update a group.
+
+        Updates a group's name or permissions.
 
         Permissions that are not included in the ``permissions`` object will retain
         their previous setting.

--- a/virtool/groups/oas.py
+++ b/virtool/groups/oas.py
@@ -82,14 +82,10 @@ class UpdateGroupRequest(BaseModel):
     Used when updating permissions and/or group `name`.
     """
 
-    permissions: UpdatePermissionsRequest = Field(
-        description="a permission update comprising an object keyed by permissions "
-        "with boolean values",
-        default={},
-    )
+    name: Optional[constr(min_length=1)] = Field(description="a name for the group")
 
-    name: Optional[constr(min_length=1)] = Field(
-        description="a name for the group", default=None
+    permissions: Optional[UpdatePermissionsRequest] = Field(
+        description="a permission update comprising an object keyed by permissions with boolean values"
     )
 
     class Config:

--- a/virtool/groups/oas.py
+++ b/virtool/groups/oas.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, Field, constr, root_validator
 from virtool_core.models.group import Group, GroupMinimal
 
 
@@ -24,11 +24,20 @@ class CreateGroupRequest(BaseModel):
     """
 
     name: constr(strip_whitespace=True, min_length=1) = Field(
-        description="a name for the group", alias="group_id"
+        description="a name for the group"
     )
 
     class Config:
         schema_extra = {"example": {"group_id": "research"}}
+
+    @root_validator(pre=True)
+    def convert_group_id_to_name(cls, values):
+        try:
+            values["name"] = values.pop("group_id")
+        except KeyError:
+            pass
+
+        return values
 
 
 class CreateGroupResponse(Group):


### PR DESCRIPTION
* Accept `name` for creation while still supporting `group_id`. Only `group_id` was being accepted.
* Update and improve docs.