### PR TITLE
fix: prevent broken create-subtraction jobs

### DIFF
--- a/tests/subtractions/__snapshots__/test_api.ambr
+++ b/tests/subtractions/__snapshots__/test_api.ambr
@@ -22,6 +22,42 @@
     },
   }
 ---
+# name: test_create[uvloop][job]
+  <class 'dict'> {
+    '_id': 'bf1b993c',
+    'acquired': False,
+    'archived': False,
+    'args': <class 'dict'> {
+      'files': <class 'list'> [
+        <class 'dict'> {
+          'id': 1,
+          'name': 'palm.fa.gz',
+        },
+      ],
+      'subtraction_id': 'abc123',
+    },
+    'key': None,
+    'ping': None,
+    'rights': <class 'dict'> {
+    },
+    'state': 'waiting',
+    'status': <class 'list'> [
+      <class 'dict'> {
+        'error': None,
+        'progress': 0,
+        'stage': None,
+        'state': 'waiting',
+        'step_description': None,
+        'step_name': None,
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      },
+    ],
+    'user': <class 'dict'> {
+      'id': 'test',
+    },
+    'workflow': 'create_subtraction',
+  }
+---
 # name: test_edit[uvloop-False-data0]
   <class 'dict'> {
     'count': 11,

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -380,4 +380,8 @@ async def test_create(fake2, pg, spawn_client, mocker, snapshot, static_time):
 
     resp = await client.post("/subtractions", data)
 
+    assert resp.status == 201
+
     assert await resp.json() == snapshot
+
+    assert await client.db.jobs.find_one() == snapshot(name="job")

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -117,7 +117,7 @@ class SubtractionsData(DataLayerPiece):
         if upload is None:
             raise ResourceNotFoundError("Upload does not exist")
 
-        await self._mongo.subtraction.insert_one(
+        document = await self._mongo.subtraction.insert_one(
             {
                 "_id": subtraction_id
                 or await virtool.mongo.utils.get_new_id(self._mongo.subtraction),
@@ -137,17 +137,19 @@ class SubtractionsData(DataLayerPiece):
             }
         )
 
+        subtraction = await self.get(document["_id"])
+
         await self.data.jobs.create(
             "create_subtraction",
             {
-                "subtraction_id": subtraction_id,
+                "subtraction_id": subtraction.id,
                 "files": [{"id": upload.id, "name": upload.name}],
             },
             user_id,
             JobRights(),
         )
 
-        return await self.get(subtraction_id)
+        return subtraction
 
     async def get(self, subtraction_id: str) -> Subtraction:
         document = await self._mongo.subtraction.find_one(subtraction_id)


### PR DESCRIPTION
The subtraction id was not being passed to the job args correctly.