### PR TITLE
fix: prevent 404 when downloading subtraction file

### DIFF
--- a/virtool/subtractions/utils.py
+++ b/virtool/subtractions/utils.py
@@ -37,7 +37,7 @@ def check_subtraction_file_type(file_name: str) -> str:
 
 
 def join_subtraction_path(config: Config, subtraction_id: str) -> Path:
-    return config.data_path / "subtractions" / subtraction_id.replace(" ", "_").lower()
+    return config.data_path / "subtractions" / subtraction_id.replace(" ", "_")
 
 
 def join_subtraction_index_path(config: Config, subtraction_id: str) -> Path:


### PR DESCRIPTION
Deriving subtraction file paths included lowercasing. Since IDs include cased characters now, this caused the files to not be found.