### PR TITLE
chore: don't run start up tasks during tests

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -69,7 +69,7 @@ def create_app(
     test_db_connection_string,
     test_db_name,
 ):
-    def _create_app(dev: bool = False, base_url: str = ""):
+    def _create_app(dev: bool = False, base_url: str = "", no_tasks: bool = True):
         config = Config(
             base_url=base_url,
             db_connection_string=test_db_connection_string,
@@ -79,6 +79,7 @@ def create_app(
             no_check_db=True,
             no_check_files=True,
             no_fetching=True,
+            no_tasks=no_tasks,
             no_sentry=True,
             openfga_host="localhost:8080",
             openfga_scheme="http",
@@ -112,10 +113,11 @@ def spawn_client(
         dev=False,
         enable_api=False,
         groups=None,
+        no_tasks=True,
         permissions=None,
         use_b2c=False,
     ):
-        app = create_app(dev, base_url)
+        app = create_app(dev, base_url, no_tasks)
 
         if groups is not None:
             complete_groups = [

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -212,7 +212,7 @@
       'error': None,
       'id': 1,
       'progress': 0,
-      'step': 'load_file',
+      'step': 'import_reference',
       'type': 'import_reference',
     },
     'unbuilt_change_count': 0,

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio import gather
+from enum import Enum
 from pathlib import Path
 
 import pytest
@@ -12,7 +13,7 @@ from virtool_core.models.task import Task
 import virtool.utils
 from virtool.data.utils import get_data_from_app
 from virtool.pg.utils import get_row_by_id
-from virtool.references.tasks import UpdateRemoteReferenceTask
+from virtool.references.tasks import UpdateRemoteReferenceTask, ImportReferenceTask
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.tasks.models import Task as SQLTask
 
@@ -208,6 +209,9 @@ class TestCreate:
         )
 
         task_id = reference["task"]["id"]
+
+        import_reference_task = ImportReferenceTask(client.app, task_id)
+        await import_reference_task.run()
 
         while True:
             await asyncio.sleep(1)

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1,6 +1,5 @@
 import asyncio
 from asyncio import gather
-from enum import Enum
 from pathlib import Path
 
 import pytest

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1,5 +1,4 @@
 import asyncio
-from asyncio import gather
 from pathlib import Path
 
 import pytest
@@ -11,8 +10,7 @@ from virtool_core.models.task import Task
 
 import virtool.utils
 from virtool.data.utils import get_data_from_app
-from virtool.pg.utils import get_row_by_id
-from virtool.references.tasks import UpdateRemoteReferenceTask, ImportReferenceTask
+from virtool.references.tasks import UpdateRemoteReferenceTask
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.tasks.models import Task as SQLTask
 
@@ -206,25 +204,6 @@ class TestCreate:
         assert reference == snapshot(
             matcher=path_type({"id": (str,)}),
         )
-
-        task_id = reference["task"]["id"]
-
-        import_reference_task = ImportReferenceTask(client.app, task_id)
-        await import_reference_task.run()
-
-        while True:
-            await asyncio.sleep(1)
-
-            task: SQLTask = await get_row_by_id(pg, SQLTask, task_id)
-
-            if task.complete:
-                assert await gather(
-                    client.db.otus.count_documents({}),
-                    client.db.sequences.count_documents({}),
-                    client.db.history.count_documents({}),
-                ) == [20, 26, 20]
-
-                break
 
     async def test_clone_reference(
         self, pg, snapshot, spawn_client, test_files_path, tmpdir, fake2, static_time


### PR DESCRIPTION
Prevents snapshots from failing due to attached tasks