### PR TITLE
fix: prevent error when session expires mid request

### DIFF
--- a/virtool/users/sessions.py
+++ b/virtool/users/sessions.py
@@ -176,8 +176,10 @@ class SessionData(DataLayerPiece):
 
         :param session_id: the session id
         """
-
-        session = await self._get(session_id)
+        try:
+            session = await self._get(session_id)
+        except ResourceNotFoundError:
+            return session_id
 
         if session.reset is None:
             return session_id


### PR DESCRIPTION
Possible fix for vir-1664.

Unable to recreate reported error locally, but likely cause is the session expiring between request being authenticated and the reply being sent. (session information is deleted from redis upon expiry, causing a ResourceNotFound error when `clear_reset_session` attempts to retrieve the session from redis) Pretty tight window for this to happen but some views cause the UI to make a lot of API requests

