### PR TITLE
fix: ensure all records are returned in reference search

### DIFF
--- a/tests/tasks/__snapshots__/test_transforms.ambr
+++ b/tests/tasks/__snapshots__/test_transforms.ambr
@@ -32,6 +32,14 @@
         'type': 'clone_reference',
       },
     },
+    <class 'dict'> {
+      'id': 3,
+      'task': None,
+    },
+    <class 'dict'> {
+      'id': 4,
+      'task': None,
+    },
   ]
 ---
 # name: test_attach_task_transform_single[uvloop]

--- a/virtool/tasks/transforms.py
+++ b/virtool/tasks/transforms.py
@@ -26,8 +26,11 @@ class AttachTaskTransform(AbstractTransform):
         attached = []
 
         for document in documents:
-            if task_id := get_safely(document, "task", "id"):
-                attached.append({**document, "task": prepared[task_id]})
+            task_id = get_safely(document, "task", "id")
+
+            attached.append(
+                {**document, "task": prepared[task_id] if task_id else None}
+            )
 
         return attached
 


### PR DESCRIPTION
Fix bug where references without `task.id` are not returned in search results.