### PR TITLE
Restore filtering by workflow in samples view

### DIFF
--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -89,7 +89,7 @@ class SamplesView(PydanticView):
         label: List[int] = Field(default_factory=lambda: []),
         page: conint(gt=0) = 1,
         per_page: conint(ge=1, le=100) = 25,
-        workflows: Optional[List[str]] = Field(default_factory=lambda: []),
+        workflows: List[str] = Field(default_factory=lambda: []),
     ) -> Union[r200[SampleSearchResult], r400]:
         """
         Find samples, filtering by data passed as URL parameters


### PR DESCRIPTION
Setting `workflows` as `Optional` seems to prevent aiohttp-pydantic from correctly parsing the incoming parameters as a list. Changed to conform with how the docs for aiohttp-pydantic suggest handling list parameters.