### PR TITLE
feat: remove job deletion endpoints

### DIFF
--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -40,28 +40,6 @@ async def test_find_beta(users, archived, state, fake, snapshot, spawn_client):
 
 
 @pytest.mark.apitest
-@pytest.mark.parametrize("job_filter", [None, "finished", "complete", "failed"])
-async def test_delete(job_filter, fake2, spawn_client, test_job, resp_is, snapshot):
-    client = await spawn_client(authorize=True, permissions=[Permission.remove_job])
-
-    user = await fake2.users.create()
-
-    test_job["user"] = {"id": user.id}
-
-    await client.db.jobs.insert_one(test_job)
-
-    url = "/jobs"
-
-    if job_filter:
-        url += f"?filter={job_filter}"
-
-    resp = await client.delete(url)
-
-    assert resp.status == 200
-    assert await resp.json() == snapshot
-
-
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(error, fake2, snapshot, spawn_client, test_job, resp_is):
     client = await spawn_client(authorize=True)

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -443,26 +443,6 @@ class JobsData:
 
         return JobStatus(**document["status"][-1])
 
-    async def clear(self, complete: bool = False, failed: bool = False):
-        or_list = []
-
-        if complete:
-            or_list = OR_COMPLETE
-
-        if failed:
-            or_list += OR_FAILED
-
-        if len(or_list) == 0:
-            return []
-
-        query = {"$or": or_list}
-
-        removed = await self._db.jobs.distinct("_id", query)
-
-        await self._db.jobs.delete_many(query)
-
-        return removed
-
     async def delete(self, job_id: str):
         """
         Delete a job by its ID.


### PR DESCRIPTION
Jobs can no longer be deleted singly or in bulk. Removes two API endpoints:
* `DELETE /jobs`
* `DELETE /jobs/:id`

Jobs should be archived to remove them from the foreground views.