### PR TITLE
feat: require all new samples to have unique names

### DIFF
--- a/tests/fixtures/settings.py
+++ b/tests/fixtures/settings.py
@@ -5,19 +5,19 @@ import pytest
 async def test_settings(mongo):
     await mongo.settings.delete_one({"_id": "settings"})
 
-    settings = {
-        "_id": "settings",
-        "default_source_types": ["isolate", "strain"],
-        "enable_api": True,
-        "enable_sentry": True,
-        "hmm_slug": "virtool/virtool-hmm",
-        "minimum_password_length": 8,
-        "sample_all_read": True,
-        "sample_all_write": False,
-        "sample_group": "none",
-        "sample_group_read": True,
-        "sample_group_write": False,
-        "sample_unique_names": True,
-    }
-
-    await mongo.settings.insert_one(settings)
+    await mongo.settings.insert_one(
+        {
+            "_id": "settings",
+            "default_source_types": ["isolate", "strain"],
+            "enable_api": True,
+            "enable_sentry": True,
+            "hmm_slug": "virtool/virtool-hmm",
+            "minimum_password_length": 8,
+            "sample_all_read": True,
+            "sample_all_write": False,
+            "sample_group": "none",
+            "sample_group_read": True,
+            "sample_group_write": False,
+            "sample_unique_names": True,
+        }
+    )

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -354,10 +354,6 @@ class TestCreate:
             authorize=True, permissions=[Permission.create_sample]
         )
 
-        await get_data_from_app(client.app).settings.update(
-            UpdateSettingsRequest(sample_unique_names=True)
-        )
-
         async with AsyncSession(pg) as session:
             session.add(test_upload)
 
@@ -405,9 +401,7 @@ class TestCreate:
                     {"_id": "diagnostics", "name": "Diagnostics"},
                 ),
                 get_data_from_app(client.app).settings.update(
-                    UpdateSettingsRequest(
-                        sample_group="force_choice", sample_unique_names=True
-                    )
+                    UpdateSettingsRequest(sample_group="force_choice")
                 ),
                 client.db.subtraction.insert_one({"_id": "apple", "name": "Apple"}),
             )
@@ -428,7 +422,7 @@ class TestCreate:
         )
 
         await get_data_from_app(client.app).settings.update(
-            UpdateSettingsRequest(sample_group="force_choice", sample_unique_names=True)
+            UpdateSettingsRequest(sample_group="force_choice")
         )
 
         async with AsyncSession(pg) as session:
@@ -438,7 +432,7 @@ class TestCreate:
                 session.commit(),
                 get_data_from_app(client.app).settings.update(
                     UpdateSettingsRequest(
-                        sample_group="force_choice", sample_unique_names=True
+                        sample_group="force_choice",
                     )
                 ),
                 client.db.subtraction.insert_one({"_id": "apple", "name": "Apple"}),
@@ -484,10 +478,6 @@ class TestCreate:
             authorize=True, permissions=[Permission.create_sample]
         )
 
-        await get_data_from_app(client.app).settings.update(
-            UpdateSettingsRequest(sample_unique_names=True)
-        )
-
         await client.db.subtraction.insert_one(
             {
                 "_id": "apple",
@@ -502,15 +492,12 @@ class TestCreate:
         resp = await client.post(
             "/samples", {"name": "Foobar", "files": [1, 2], "subtractions": ["apple"]}
         )
+
         await resp_is.bad_request(resp, "File does not exist")
 
     async def test_label_dne(self, spawn_client, pg: AsyncEngine, resp_is, test_upload):
         client = await spawn_client(
             authorize=True, permissions=[Permission.create_sample]
-        )
-
-        await get_data_from_app(client.app).settings.update(
-            UpdateSettingsRequest(sample_unique_names=True)
         )
 
         async with AsyncSession(pg) as session:

--- a/tests/settings/test_data.py
+++ b/tests/settings/test_data.py
@@ -10,7 +10,7 @@ async def settings_data(mongo) -> SettingsData:
     return SettingsData(mongo)
 
 
-async def test_ensure(mongo, settings_data, snapshot, test_settings):
+async def test_ensure(mongo, settings_data: SettingsData, snapshot, test_settings):
     settings = await settings_data.ensure()
 
     assert settings == Settings(

--- a/virtool/samples/checks.py
+++ b/virtool/samples/checks.py
@@ -8,20 +8,18 @@ from virtool.samples.utils import check_labels
 
 
 async def check_name_is_in_use(
-    db,
-    settings,
+    mongo,
     name: str,
     sample_id: Optional[str] = None,
     session: Optional[AsyncIOMotorClientSession] = None,
 ):
-    if settings.sample_unique_names:
-        query = {"name": name}
+    query = {"name": name}
 
-        if sample_id:
-            query["_id"] = {"$ne": sample_id}
+    if sample_id:
+        query["_id"] = {"$ne": sample_id}
 
-        if await db.samples.count_documents(query, session=session):
-            raise ResourceConflictError("Sample name is already in use")
+    if await mongo.samples.count_documents(query, limit=1, session=session) != 0:
+        raise ResourceConflictError("Sample name is already in use")
 
 
 async def check_subtractions_do_not_exist(

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -193,7 +193,7 @@ class SamplesData(DataLayerPiece):
         settings = await self.data.settings.get_all()
 
         await wait_for_checks(
-            check_name_is_in_use(self._db, settings, data.name),
+            check_name_is_in_use(self._db, data.name),
             check_labels_do_not_exist(self._pg, data.labels),
             check_subtractions_do_not_exist(self._db, data.subtractions),
         )
@@ -287,15 +287,12 @@ class SamplesData(DataLayerPiece):
     ) -> UpdateResult:
         data = data.dict(exclude_unset=True)
 
-        settings = await self.data.settings.get_all()
-
         aws = []
 
         if "name" in data:
             aws.append(
                 check_name_is_in_use(
                     self._db,
-                    settings,
                     data["name"],
                     sample_id=sample_id,
                     session=session,

--- a/virtool/settings/oas.py
+++ b/virtool/settings/oas.py
@@ -16,7 +16,7 @@ class GetSettingsResponse(Settings):
                 "sample_group": "force_choice",
                 "sample_group_read": True,
                 "sample_group_write": True,
-                "sample_unique_names": False,
+                "sample_unique_names": True,
             }
         }
 
@@ -27,7 +27,6 @@ class UpdateSettingsRequest(BaseModel):
     sample_group_write: bool = False
     sample_all_read: bool = True
     sample_all_write: bool = False
-    sample_unique_names: bool = True
     hmm_slug: constr(strip_whitespace=True) = "virtool/virtool-hmm"
     enable_api: bool = False
     enable_sentry: bool = True
@@ -45,6 +44,6 @@ class UpdateSettingsResponse(Settings):
                 "hmm_slug": "virtool/virtool-hmm",
                 "minimum_passsword_length": 12,
                 "sample_all_read": False,
-                "sample_unique_names": False,
+                "sample_unique_names": True,
             }
         }


### PR DESCRIPTION
From now on all sample names need to be unique.

The `unique_sample_names` setting will always be `True` and will no longer be changeable.