### PR TITLE
feat: enable decoupled running of tasks

### DIFF
--- a/tests/tasks/test_data.py
+++ b/tests/tasks/test_data.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.subtractions.tasks import AddSubtractionFilesTask
+from virtool.tasks.client import TasksClient
 from virtool.tasks.data import TasksData
 from virtool.tasks.models import Task
 from virtool.tasks.oas import TaskUpdate
@@ -13,7 +14,7 @@ from virtool.tasks.oas import TaskUpdate
 
 @pytest.fixture
 async def tasks_data(pg: AsyncEngine, redis: Redis) -> TasksData:
-    return TasksData(pg, redis)
+    return TasksData(pg, TasksClient(redis))
 
 
 async def test_find(

--- a/tests/tasks/test_task.py
+++ b/tests/tasks/test_task.py
@@ -1,14 +1,20 @@
 import os
-from asyncio import to_thread
+from asyncio import to_thread, wait_for
+from datetime import datetime
 from typing import TYPE_CHECKING, Dict
 
 import pytest
 from humanfriendly.testing import TemporaryDirectory
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from syrupy.matchers import path_type
 
+from virtool.config import Config
+from virtool.data.errors import ResourceError
 from virtool.pg.utils import get_row_by_id
+from virtool.tasks.client import TasksClient
 from virtool.tasks.models import Task as SQLTask
+from virtool.tasks.spawner import spawn
 from virtool.tasks.task import BaseTask
 from virtool.utils import get_temp_dir
 
@@ -118,6 +124,88 @@ async def test_run(error, task, pg: AsyncEngine):
     else:
         assert result["progress"] == 100
         assert not os.path.exists(task.temp_path)
+
+
+@pytest.fixture
+def test_channel():
+    return "test-task-channel"
+
+
+@pytest.fixture
+def task_spawner(
+    test_db_connection_string,
+    test_db_name,
+    pg_connection_string,
+    redis_connection_string,
+    mocker,
+    test_channel,
+):
+    async def func(task_name: str):
+        mocker.patch("virtool.tasks.client.REDIS_TASKS_LIST_KEY", test_channel)
+        config = Config(
+            base_url="",
+            db_connection_string=test_db_connection_string,
+            db_name=test_db_name,
+            dev=True,
+            force_version="v0.0.0",
+            no_sentry=True,
+            no_check_db=True,
+            no_check_files=True,
+            no_fetching=True,
+            openfga_host="localhost:8080",
+            openfga_scheme="http",
+            postgres_connection_string=pg_connection_string,
+            redis_connection_string=redis_connection_string,
+            fake=False,
+        )
+        await spawn(config, task_name)
+
+    return func
+
+
+@pytest.fixture
+def tasks_client(redis):
+    return TasksClient(redis)
+
+
+@pytest.mark.parametrize("valid_task", [True, False])
+async def test_spawn(
+    valid_task,
+    task_spawner,
+    tasks_client: TasksClient,
+    pg: AsyncEngine,
+    snapshot,
+):
+    task_name = "dummy_task" if valid_task else "nonexistent-task"
+
+    error = None
+
+    try:
+        await task_spawner(task_name)
+    except ResourceError as e:
+        error = e
+
+    if not valid_task:
+        assert error
+
+    if valid_task:
+        task_id = await wait_for(tasks_client.pop(), 2)
+
+        async with AsyncSession(pg) as session:
+            result = (
+                (
+                    await session.execute(
+                        select(SQLTask).filter_by(id=int(task_id), type=task_name)
+                    )
+                )
+                .scalar()
+                .to_dict()
+            )
+
+            assert result == snapshot(
+                matcher=path_type({"created_at": (datetime,)}),
+                name=f"test_spawn_task_{task_name}",
+            )
 
 
 async def test_progress_handler_set_progress(task: BaseTask, pg: AsyncEngine):

--- a/virtool/config/cli.py
+++ b/virtool/config/cli.py
@@ -8,6 +8,8 @@ import uvloop
 from virtool_core.logging import configure_logs
 
 import virtool.jobs.main
+import virtool.tasks.main
+import virtool.tasks.spawner
 from virtool.app import run_app
 from virtool.config.cls import Config
 
@@ -216,3 +218,38 @@ def start_jobs_api(ctx, port, host):
     )
 
     asyncio.get_event_loop().run_until_complete(virtool.jobs.main.run(config))
+
+
+@cli.command("tasks")
+@click.option("--host", default="localhost", help="The host to listen on", type=str)
+@click.option("--port", default=9950, help="The port to listen on", type=int)
+@click.pass_context
+def start_task_runner(ctx, host, port):
+    debug = ctx.obj["dev"] or ctx.obj["verbose"]
+    configure_logs(debug)
+
+    logger.info("Starting tasks worker")
+
+    config = Config(
+        **ctx.obj,
+        host=host,
+        port=port,
+    )
+
+    asyncio.get_event_loop().run_until_complete(virtool.tasks.main.run(config))
+
+
+@cli.command("spawn_task")
+@click.option("--task-name", help="Name of the task too spawn", type=str)
+@click.pass_context
+def spawn_task(ctx, task_name):
+    debug = ctx.obj["dev"] or ctx.obj["verbose"]
+    configure_logs(debug)
+
+    logger.info("Spawning task")
+
+    config = Config(**ctx.obj)
+
+    asyncio.get_event_loop().run_until_complete(
+        virtool.tasks.spawner.spawn(config, task_name)
+    )

--- a/virtool/data/factory.py
+++ b/virtool/data/factory.py
@@ -24,6 +24,7 @@ from virtool.references.data import ReferencesData
 from virtool.samples.data import SamplesData
 from virtool.settings.data import SettingsData
 from virtool.subtractions.data import SubtractionsData
+from virtool.tasks.client import TasksClient
 from virtool.tasks.data import TasksData
 from virtool.uploads.data import UploadsData
 from virtool.users.data import UsersData
@@ -64,7 +65,7 @@ def create_data_layer(
         SubtractionsData(config.base_url, config, db, pg),
         SessionData(redis),
         SettingsData(db),
-        TasksData(pg, redis),
+        TasksData(pg, TasksClient(redis)),
         UploadsData(config, db, pg),
         UsersData(db, pg),
     )

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -51,6 +51,7 @@ from virtool.subtractions.tasks import (
     AddSubtractionFilesTask,
     WriteSubtractionFASTATask,
 )
+from virtool.tasks.client import TasksClient
 from virtool.tasks.runner import TaskRunner
 from virtool.types import App
 from virtool.uploads.tasks import MigrateFilesTask
@@ -382,8 +383,8 @@ async def startup_task_runner(app: Application):
 
     if not get_config_from_app(app).no_tasks:
         scheduler = get_scheduler_from_app(app)
-        (channel,) = await app["redis"].subscribe("channel:tasks")
-        await scheduler.spawn(TaskRunner(app["data"], channel, app).run())
+        tasks_client = TasksClient(app["redis"])
+        await scheduler.spawn(TaskRunner(app["data"], tasks_client, app).run())
 
 
 async def startup_tasks(app: Application):

--- a/virtool/tasks/api.py
+++ b/virtool/tasks/api.py
@@ -4,12 +4,28 @@ from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r400
 
 from virtool.api.response import NotFound, json_response
+from virtool.data.errors import ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.http.routes import Routes
 from virtool.tasks.oas import GetTasksResponse, TaskResponse
-from virtool.data.errors import ResourceNotFoundError
 
 routes = Routes()
+
+
+class TasksRunnerView(PydanticView):
+    async def get(self) -> r200:
+        """
+        Root response for task runner. Used for checking if the server is alive.
+        Status Codes:
+            200: Successful operation
+        """
+        version = "unknown"
+        try:
+            version = self.request.app["version"]
+        except KeyError:
+            pass
+
+        return json_response({"version": version})
 
 
 @routes.view("/tasks")

--- a/virtool/tasks/client.py
+++ b/virtool/tasks/client.py
@@ -1,0 +1,46 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import List
+
+from aioredis import Redis
+
+REDIS_TASKS_LIST_KEY = "tasks"
+
+
+class AbstractTasksClient(ABC):
+    @abstractmethod
+    async def enqueue(self, task_type: str, task_id: int):
+        ...
+
+    @abstractmethod
+    async def pop(self) -> int:
+        ...
+
+
+class TasksClient(AbstractTasksClient):
+    def __init__(self, redis: Redis):
+        self.redis = redis
+
+    async def enqueue(self, task_type: str, task_id: int):
+        logging.info(task_id)
+        await self.redis.rpush(REDIS_TASKS_LIST_KEY, task_id)
+
+    async def pop(self) -> int:
+        result = await self.redis.blpop(REDIS_TASKS_LIST_KEY)
+
+        if result is not None:
+            return int(result[1])
+
+
+class DummyTasksClient(AbstractTasksClient):
+    def __init__(
+        self,
+        task_list: List = None,
+    ):
+        self.task_list = task_list or []
+
+    async def enqueue(self, task_type: str, task_id: int):
+        self.task_list.append(task_id)
+
+    async def pop(self) -> int:
+        return self.task_list.pop(0)

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -2,21 +2,22 @@ import asyncio
 from typing import List, Type, Optional, Dict
 
 from aioredis import Redis
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool_core.models.task import Task
 
 import virtool.utils
 from virtool.data.errors import ResourceNotFoundError
+from virtool.tasks.client import AbstractTasksClient
 from virtool.tasks.models import Task as SQLTask
 from virtool.tasks.oas import TaskUpdate
 from virtool.tasks.task import BaseTask
 
 
 class TasksData:
-    def __init__(self, pg: AsyncEngine, redis: Redis):
+    def __init__(self, pg: AsyncEngine, tasks_client: AbstractTasksClient):
         self._pg = pg
-        self._redis = redis
+        self._tasks_client = tasks_client
 
     async def find(self) -> List[Task]:
         """
@@ -110,7 +111,7 @@ class TasksData:
         async with AsyncSession(self._pg) as session:
             result = await session.execute(select(SQLTask).filter_by(id=task_id))
             task = result.scalar()
-            session.delete(task)
+            await session.delete(task)
 
             await session.commit()
 
@@ -139,7 +140,7 @@ class TasksData:
             task = Task(**task.to_dict())
             await session.commit()
 
-        await self._redis.publish("channel:tasks", task.id)
+        await self._tasks_client.enqueue(task.type, task.id)
 
         return task
 

--- a/virtool/tasks/main.py
+++ b/virtool/tasks/main.py
@@ -1,0 +1,103 @@
+import aiojobs
+import aiojobs.aiohttp
+from aiohttp import web
+from aiohttp.web import Application
+from sqlalchemy.util import asyncio
+
+import virtool.http.accept
+import virtool.http.errors
+from virtool.config import Config
+from virtool.dispatcher.events import DispatcherSQLEvents
+from virtool.process_utils import create_app_runner, wait_for_restart, wait_for_shutdown
+from virtool.shutdown import (
+    shutdown_client,
+    shutdown_executors,
+    shutdown_scheduler,
+    shutdown_redis,
+    shutdown_authorization_client,
+)
+from virtool.startup import (
+    startup_events,
+    startup_http_client,
+    startup_databases,
+    startup_paths,
+    startup_executors,
+    startup_data,
+    startup_task_runner,
+    startup_sentry,
+    startup_version,
+    startup_fake,
+    startup_fake_config,
+)
+from virtool.tasks.api import TasksRunnerView
+
+
+async def startup_dispatcher_SQL_listener(app: Application):
+    """
+
+
+    :param app: the app object
+
+    """
+    DispatcherSQLEvents(app["dispatcher_interface"].enqueue_change)
+
+
+async def create_app(config: Config):
+    """
+    Creates the Virtool application.
+
+    """
+    app = Application(
+        middlewares=[
+            virtool.http.accept.middleware,
+            virtool.http.errors.middleware,
+        ]
+    )
+
+    app["config"] = config
+    app["mode"] = "tasks_worker"
+
+    aiojobs.aiohttp.setup(app)
+
+    app.add_routes([web.view("/", TasksRunnerView)])
+
+    app.on_startup.extend(
+        [
+            startup_version,
+            startup_http_client,
+            startup_fake_config,
+            startup_events,
+            startup_databases,
+            startup_dispatcher_SQL_listener,
+            startup_paths,
+            startup_executors,
+            startup_fake,
+            startup_data,
+            startup_task_runner,
+            startup_sentry,
+        ]
+    )
+
+    app.on_shutdown.extend(
+        [
+            shutdown_authorization_client,
+            shutdown_client,
+            shutdown_executors,
+            shutdown_scheduler,
+            shutdown_redis,
+        ]
+    )
+
+    return app
+
+
+async def run(config: Config):
+    app = await create_app(config)
+    runner = await create_app_runner(app, config.host, config.port)
+    _, pending = await asyncio.wait(
+        [
+            wait_for_restart(runner, app["events"]),
+            wait_for_shutdown(runner, app["events"]),
+        ],
+        return_when=asyncio.FIRST_COMPLETED,
+    )

--- a/virtool/tasks/spawner.py
+++ b/virtool/tasks/spawner.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Type
+
+import aiojobs
+
+from virtool.config import Config
+from virtool.data.errors import ResourceError
+from virtool.data.utils import get_data_from_app
+from virtool.shutdown import (
+    shutdown_client,
+    shutdown_executors,
+    shutdown_scheduler,
+    shutdown_redis,
+    shutdown_authorization_client,
+)
+from virtool.startup import (
+    startup_events,
+    startup_http_client,
+    startup_databases,
+    startup_paths,
+    startup_executors,
+    startup_data,
+    startup_sentry,
+    startup_version,
+    startup_fake,
+    startup_fake_config,
+    startup_settings,
+)
+from virtool.tasks.task import BaseTask
+
+logger = logging.getLogger("task_spawner")
+
+
+async def create_app(config: Config):
+    """
+    Creates the Virtool application.
+
+    """
+
+    app = {"config": config, "mode": "task_spawner", "scheduler": aiojobs.Scheduler()}
+
+    on_startup = [
+        startup_version,
+        startup_http_client,
+        startup_fake_config,
+        startup_events,
+        startup_databases,
+        startup_paths,
+        startup_executors,
+        startup_fake,
+        startup_data,
+        startup_settings,
+        startup_sentry,
+    ]
+
+    for step in on_startup:
+        await step(app)
+
+    return app
+
+
+async def shutdown_app(app):
+    shutdown_steps = [
+        shutdown_authorization_client,
+        shutdown_client,
+        shutdown_executors,
+        shutdown_scheduler,
+        shutdown_redis,
+    ]
+
+    for step in shutdown_steps:
+        await step(app)
+
+
+def get_task_from_name(task_name: str) -> Type[BaseTask]:
+    matching_task = [cls for cls in BaseTask.__subclasses__() if cls.name == task_name]
+
+    if len(matching_task) != 1:
+        raise ResourceError("Invalid task name")
+
+    return matching_task[0]
+
+
+async def spawn(config: Config, task_name: str):
+    app = await create_app(config)
+
+    task = get_task_from_name(task_name)
+    logger.info("Spawning task %s", task.name)
+
+    await get_data_from_app(app).tasks.create(task)
+
+    await shutdown_app(app)


### PR DESCRIPTION
Changes:
 - add cli command "spawn_task" for spawning tasks
 - add cli command "tasks" for executing standalone task runner
 - use TaskClient for pushing and pulling tasks from redis
 - replace use of redis channel with redis list
 - add test for task spawner
 - add "/" base route for task runner

Notes:
 - Running api with `tasks` command starts up a task runner that will work through one task at a time from a list stored in redis
    - Task runners can be run independently or in conjunction with task runners running within the main api server
    - Tested for support up to 3 simultaneous task runners, no expected theoretical limit to the number of runners possible.
 - Running api with "spawn_tasks --task_name <TaskName>" will attempt to create a task of "TaskName" if such a task exists or return an error and exit
   - **NB:** When running the API with `--no-tasks` argument it is necessary to spawn routine jobs via this command, as the independent task runners make no assumptions about the number of other workers. Periodic tasks spawned by an API instance will be picked up by independent task runners.
 - Decoupled task runner is intended to be run in kubernetes. If running the api in docker or locally stick to the coupled task runner

