### PR TITLE
fix: restore server functionality when using integrated task runner

### DIFF
--- a/virtool/tasks/client.py
+++ b/virtool/tasks/client.py
@@ -26,10 +26,11 @@ class TasksClient(AbstractTasksClient):
         await self.redis.rpush(REDIS_TASKS_LIST_KEY, task_id)
 
     async def pop(self) -> int:
-        result = await self.redis.blpop(REDIS_TASKS_LIST_KEY)
+        with await self.redis as redis:
+            result = await redis.blpop(REDIS_TASKS_LIST_KEY)
 
-        if result is not None:
-            return int(result[1])
+            if result is not None:
+                return int(result[1])
 
 
 class DummyTasksClient(AbstractTasksClient):


### PR DESCRIPTION
Fixed problem with `blpop` blocking other requests by running the connection in `exclusive mode`. (prevents other requests from trying to use the same blocked connection from the pool)

Relevant docs: https://aioredis.readthedocs.io/en/v1.2.0/migration.html#blocking-operations-and-connection-sharing