### PR TITLE
Timeout jobs module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 23.1.0
-  hooks:
-   - id: black
-- repo: https://github.com/PyCQA/isort
-  rev: 5.9.3
-  hooks:
-   - id: isort
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    - id: isort
+      args: [ "--profile", "black", "--filter-files" ]

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -34,6 +34,7 @@ from virtool.hmm.db import refresh
 from virtool.indexes.tasks import (
     EnsureIndexFilesTask,
 )
+from virtool.jobs.tasks import TimeoutJobsTask
 from virtool.mongo.core import DB
 from virtool.mongo.identifier import RandomIdProvider
 from virtool.mongo.migrate import migrate
@@ -412,5 +413,6 @@ async def startup_tasks(app: Application):
     await tasks_data.create(CompressSamplesTask)
     await tasks_data.create(MoveSampleFilesTask)
     await tasks_data.create(CleanReferencesTask)
+    await tasks_data.create(TimeoutJobsTask)
 
     await scheduler.spawn(tasks_data.create_periodically(MigrateFilesTask, 3600))


### PR DESCRIPTION
* Import `TimeoutJobsTask` and run on start when integrated jobs runner is enabled. Importing the task also fixes an error when it is run using `spawn_task`.
* Update pre-commit to avoid conflicts between isort and Black.