### PR TITLE
fix: restore otu filtering

### DIFF
--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -275,11 +275,11 @@ class ReferenceUpdatesView(PydanticView):
 class ReferenceOTUsView(PydanticView):
     async def get(
         self,
+        ref_id: str,
+        /,
         find: Optional[str],
         verified: Optional[bool],
         names: Optional[Union[bool, str]],
-        ref_id: str,
-        /,
     ) -> Union[r200[FindOTUsResponse], r404]:
         """
         Find OTUs.


### PR DESCRIPTION
All parameters were marked as path parameters when most should have been query parameters.

relevant docs: https://github.com/Maillol/aiohttp-pydantic

Also restores filtering by verification

