### PR TITLE
refactor: rename mongo.core.DB to Mongo

### DIFF
--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -55,7 +55,7 @@ async def test_motor(test_db_connection_string, test_db_name, loop, request):
 
 @pytest.fixture
 def mongo(test_motor, mocker):
-    return virtool.mongo.core.DB(test_motor, mocker.stub(), FakeIdProvider())
+    return virtool.mongo.core.Mongo(test_motor, mocker.stub(), FakeIdProvider())
 
 
 @pytest.fixture(params=[True, False])

--- a/tests/messages/test_data.py
+++ b/tests/messages/test_data.py
@@ -5,11 +5,11 @@ from virtool.data.errors import ResourceConflictError
 from virtool.messages.data import MessagesData
 from virtool.messages.models import SQLInstanceMessage
 from virtool.messages.oas import CreateMessageRequest, UpdateMessageRequest
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 
 
 @pytest.fixture
-async def messages_data(pg: AsyncEngine, mongo: DB) -> MessagesData:
+async def messages_data(pg: AsyncEngine, mongo: Mongo) -> MessagesData:
     return MessagesData(pg, mongo)
 
 

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -21,7 +21,7 @@ from virtool.account.oas import (
 )
 from virtool.data.errors import ResourceError, ResourceNotFoundError
 from virtool.data.piece import DataLayerPiece
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.users.db import validate_credentials, fetch_complete_user
 from virtool.users.oas import UpdateUserRequest
@@ -42,7 +42,7 @@ PROJECTION = (
 
 
 class AccountData(DataLayerPiece):
-    def __init__(self, db: DB, redis: Redis):
+    def __init__(self, db: Mongo, redis: Redis):
         self._db = db
         self._redis = redis
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -41,7 +41,7 @@ from virtool.data.errors import (
     ResourceConflictError,
 )
 from virtool.data.piece import DataLayerPiece
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.mongo.utils import get_one_field
 from virtool.pg.utils import delete_row, get_row_by_id
@@ -70,7 +70,7 @@ EXCLUDED_FIELDS = {
 
 
 class AnalysisData(DataLayerPiece):
-    def __init__(self, db: DB, config, pg: AsyncEngine):
+    def __init__(self, db: Mongo, config, pg: AsyncEngine):
         self._db = db
         self._config = config
         self._pg = pg

--- a/virtool/blast/data.py
+++ b/virtool/blast/data.py
@@ -23,7 +23,7 @@ from virtool.data.piece import DataLayerPiece
 from virtool.types import Document
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 logger = getLogger(__name__)
 
@@ -33,7 +33,7 @@ class BLASTData(DataLayerPiece):
     A data layer piece for BLAST data.
     """
 
-    def __init__(self, client: ClientSession, mongo: "DB", pg: AsyncEngine):
+    def __init__(self, client: ClientSession, mongo: "Mongo", pg: AsyncEngine):
         self._client = client
         self._mongo = mongo
         self._pg = pg

--- a/virtool/data/factory.py
+++ b/virtool/data/factory.py
@@ -31,12 +31,12 @@ from virtool.users.data import UsersData
 from virtool.users.sessions import SessionData
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 
 def create_data_layer(
     authorization_client: AuthorizationClient,
-    mongo: "DB",
+    mongo: "Mongo",
     pg: AsyncEngine,
     config: Config,
     client,

--- a/virtool/dispatcher/dispatcher.py
+++ b/virtool/dispatcher/dispatcher.py
@@ -29,7 +29,7 @@ from virtool.dispatcher.fetchers import (
 )
 from virtool.dispatcher.listener import RedisDispatcherListener
 from virtool.dispatcher.operations import DELETE, INSERT, UPDATE
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 
 logger = getLogger(__name__)
 
@@ -57,7 +57,7 @@ class Fetchers:
 
 
 class Dispatcher:
-    def __init__(self, pg: AsyncEngine, db: DB, listener: RedisDispatcherListener):
+    def __init__(self, pg: AsyncEngine, db: Mongo, listener: RedisDispatcherListener):
         #: A dict of all active connections.
         self.db = db
         self._listener = listener

--- a/virtool/dispatcher/fetchers.py
+++ b/virtool/dispatcher/fetchers.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 import virtool.indexes.db
 import virtool.references.db
 import virtool.samples.db
-from virtool.mongo.core import Collection, DB
+from virtool.mongo.core import Collection, Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.dispatcher.change import Change
 from virtool.dispatcher.connection import Connection
@@ -148,7 +148,7 @@ class IndexesFetcher(AbstractFetcher):
 
 
 class LabelsFetcher(AbstractFetcher):
-    def __init__(self, pg: AsyncEngine, db: DB):
+    def __init__(self, pg: AsyncEngine, db: Mongo):
         self._pg = pg
         self._db = db
 
@@ -180,7 +180,7 @@ class LabelsFetcher(AbstractFetcher):
 
 
 class ReferencesFetcher(AbstractFetcher):
-    def __init__(self, db: DB):
+    def __init__(self, db: Mongo):
         self._db = db
 
     async def prepare(self, change: Change, connections: List[Connection]):
@@ -220,7 +220,7 @@ class ReferencesFetcher(AbstractFetcher):
 
 
 class SamplesFetcher(AbstractFetcher):
-    def __init__(self, pg: AsyncEngine, db: DB):
+    def __init__(self, pg: AsyncEngine, db: Mongo):
         self._pg = pg
         self._db = db
 

--- a/virtool/groups/data.py
+++ b/virtool/groups/data.py
@@ -18,11 +18,11 @@ from virtool.users.utils import generate_base_permissions
 from virtool.utils import base_processor
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 
 class GroupsData:
-    def __init__(self, authorization_client: AuthorizationClient, db: "DB"):
+    def __init__(self, authorization_client: AuthorizationClient, db: "Mongo"):
         self._authorization_client = authorization_client
         self._db = db
 

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -8,14 +8,14 @@ import virtool.utils
 from virtool.data.errors import ResourceNotFoundError, ResourceConflictError
 from virtool.errors import DatabaseError
 from virtool.history.db import DiffTransform, PROJECTION, patch_to_version
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.users.db import AttachUserTransform
 
 
 class HistoryData:
-    def __init__(self, data_path: Path, db: DB):
+    def __init__(self, data_path: Path, db: Mongo):
         self.data_path = data_path
         self._db = db
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -28,7 +28,7 @@ from virtool.types import Document
 from virtool.users.db import ATTACH_PROJECTION, AttachUserTransform
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 MOST_RECENT_PROJECTION = [
     "_id",
@@ -86,7 +86,7 @@ async def processor(db, document: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def add(
-    db: "DB",
+    db: "Mongo",
     data_path: Path,
     method_name: HistoryMethod,
     old: Optional[dict],

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -36,7 +36,7 @@ from virtool.indexes.db import (
 from virtool.indexes.models import SQLIndexFile
 from virtool.indexes.tasks import get_index_file_type_from_name, export_index
 from virtool.indexes.utils import join_index_path
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 
 from virtool.mongo.utils import id_exists, get_one_field
@@ -72,7 +72,7 @@ FIND_PIPELINE = [
 
 
 class IndexData:
-    def __init__(self, mongo: DB, config: Config, pg: AsyncEngine):
+    def __init__(self, mongo: Mongo, config: Config, pg: AsyncEngine):
         self._config = config
         self._mongo = mongo
         self._pg = pg

--- a/virtool/indexes/tasks.py
+++ b/virtool/indexes/tasks.py
@@ -10,7 +10,7 @@ from virtool.types import Document
 
 if TYPE_CHECKING:
     from virtool.data.layer import DataLayer
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 
 class EnsureIndexFilesTask(BaseTask):
@@ -106,7 +106,7 @@ def format_otu_for_export(otu: Document) -> Document:
 
 
 async def export_index(
-    data_path: Path, mongo: "DB", manifest: Dict[str, int]
+    data_path: Path, mongo: "Mongo", manifest: Dict[str, int]
 ) -> List[Document]:
     """
     Dump OTUs to a JSON-serializable data structure based on an index manifest.

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -22,7 +22,7 @@ from virtool.jobs import is_running_or_waiting
 from virtool.jobs.client import AbstractJobsClient, JOB_REMOVED_FROM_QUEUE
 from virtool.jobs.db import PROJECTION, fetch_complete_job
 from virtool.jobs.utils import JobRights, compose_status
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.mongo.utils import get_one_field
 from virtool.types import Document
@@ -30,7 +30,7 @@ from virtool.users.db import AttachUserTransform
 
 
 class JobsData:
-    def __init__(self, client: AbstractJobsClient, db: DB, pg: AsyncEngine):
+    def __init__(self, client: AbstractJobsClient, db: Mongo, pg: AsyncEngine):
         self._client = client
         self._db = db
         self._pg = pg

--- a/virtool/labels/data.py
+++ b/virtool/labels/data.py
@@ -9,13 +9,13 @@ from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.labels.db import SampleCountTransform
 from virtool.labels.models import Label as LabelSQL
 from virtool.labels.oas import UpdateLabelRequest
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.pg.utils import get_generic
 
 
 class LabelsData:
-    def __init__(self, db: DB, pg: AsyncEngine):
+    def __init__(self, db: Mongo, pg: AsyncEngine):
         self._db = db
         self._pg = pg
 

--- a/virtool/messages/data.py
+++ b/virtool/messages/data.py
@@ -6,13 +6,13 @@ from virtool.data.errors import ResourceNotFoundError, ResourceConflictError
 import virtool.utils
 from virtool.messages.models import SQLInstanceMessage
 from virtool.messages.oas import CreateMessageRequest, UpdateMessageRequest
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.users.db import AttachUserTransform
 
 
 class MessagesData:
-    def __init__(self, pg: AsyncEngine, mongo: DB):
+    def __init__(self, pg: AsyncEngine, mongo: Mongo):
         self._pg = pg
         self._mongo = mongo
 

--- a/virtool/mongo/core.py
+++ b/virtool/mongo/core.py
@@ -56,7 +56,7 @@ class Collection:
 
     def __init__(
         self,
-        mongo: "DB",
+        mongo: "Mongo",
         name: str,
         processor: Callable[[Any, Document], Awaitable[Document]],
         projection: Optional[Projection],
@@ -354,7 +354,7 @@ class Collection:
         return update_result
 
 
-class DB:
+class Mongo:
     def __init__(
         self,
         motor_client: AsyncIOMotorClient,

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -17,7 +17,7 @@ from virtool.history.utils import (
     compose_edit_description,
     compose_remove_description,
 )
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.mongo.utils import get_one_field
 from virtool.otus.db import increment_otu_version, update_otu_verification
@@ -30,7 +30,7 @@ from virtool.utils import base_processor
 
 
 class OTUData:
-    def __init__(self, mongo: DB, data_path: Path):
+    def __init__(self, mongo: Mongo, data_path: Path):
         self._mongo = mongo
         self._data_path = data_path
 

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -19,7 +19,7 @@ from virtool.types import Document
 from virtool.utils import base_processor, to_bool
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 PROJECTION = ["_id", "abbreviation", "name", "reference", "verified", "version"]
 
@@ -69,7 +69,7 @@ async def check_name_and_abbreviation(
 
 
 async def find(
-    mongo: "DB",
+    mongo: "Mongo",
     names: Optional[Union[bool, str]],
     term: Optional[str],
     req_query: Mapping,
@@ -150,7 +150,7 @@ async def join(
 
 
 async def bulk_join_query(
-    mongo: "DB",
+    mongo: "Mongo",
     query: dict,
     session: Optional[AsyncIOMotorClientSession] = None,
 ) -> List[Dict[str, Any]]:

--- a/virtool/references/bulk.py
+++ b/virtool/references/bulk.py
@@ -29,7 +29,7 @@ from virtool.tasks.progress import AccumulatingProgressHandlerWrapper
 from virtool.types import Document
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB, Collection
+    from virtool.mongo.core import Mongo, Collection
 
 WORKER_COUNT = 25
 
@@ -194,7 +194,7 @@ async def generate_bulk_id_buffer(
 class OTUDBBulkUpdater:
     def __init__(
         self,
-        mongo: "DB",
+        mongo: "Mongo",
         user_id: str,
         progress_tracker: AccumulatingProgressHandlerWrapper,
         task_queue: Queue,
@@ -314,7 +314,7 @@ class OTUUpdateBuffer(BaseDataBuffer):
         task_queue: Queue,
         update_db: OTUDBBulkUpdater,
         prepare_otu_update_buffer: BaseDataBuffer,
-        mongo: "DB",
+        mongo: "Mongo",
         ref_id: str,
         user_id: str,
         created_at: datetime,
@@ -345,7 +345,7 @@ class OTUUpdateBuffer(BaseDataBuffer):
         cls,
         task_queue: Queue,
         bulk_db_updater: OTUDBBulkUpdater,
-        mongo: "DB",
+        mongo: "Mongo",
         ref_id: str,
     ):
         async def func(otu_data: List[OTUData], session):
@@ -362,7 +362,7 @@ class OTUUpdateBuffer(BaseDataBuffer):
         cls,
         task_queue: Queue,
         bulk_db_updater: OTUDBBulkUpdater,
-        mongo: "DB",
+        mongo: "Mongo",
         user_id: str,
         data_path: Path,
     ):
@@ -403,7 +403,7 @@ class OTUUpdateBuffer(BaseDataBuffer):
 class BulkOTUUpdater:
     def __init__(
         self,
-        mongo: "DB",
+        mongo: "Mongo",
         ref_id: str,
         user_id: str,
         created_at: datetime,

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -54,7 +54,7 @@ from virtool.uploads.models import Upload as SQLUpload
 from virtool.users.db import AttachUserTransform, extend_user
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 PROJECTION = [
     "_id",
@@ -80,7 +80,7 @@ PROJECTION = [
 ]
 
 
-async def processor(mongo: "DB", document: Document) -> Document:
+async def processor(mongo: "Mongo", document: Document) -> Document:
     """
     Process a reference document to a form that can be dispatched or returned in a list.
 
@@ -124,7 +124,7 @@ async def processor(mongo: "DB", document: Document) -> Document:
     return document
 
 
-async def attach_computed(mongo: "DB", document: Document) -> Document:
+async def attach_computed(mongo: "Mongo", document: Document) -> Document:
     """
     Get all computed data for the specified reference and attach it to the passed
     ``document``.
@@ -172,7 +172,7 @@ async def attach_computed(mongo: "DB", document: Document) -> Document:
     return await apply_transforms(processed, [AttachUserTransform(mongo)])
 
 
-async def get_reference_users(mongo: "DB", document: Document) -> List[Document]:
+async def get_reference_users(mongo: "Mongo", document: Document) -> List[Document]:
     """
     Get a detailed list of users that have access to the specified reference.
 
@@ -255,7 +255,7 @@ async def check_right(req: Request, reference: Union[Dict, str], right: str) -> 
     return False
 
 
-async def check_source_type(mongo: "DB", ref_id: str, source_type: str) -> bool:
+async def check_source_type(mongo: "Mongo", ref_id: str, source_type: str) -> bool:
     """
     Check if the provided `source_type` is valid based on the current reference source
     type configuration.
@@ -310,7 +310,7 @@ def compose_base_find_query(user_id: str, administrator: bool, groups: list) -> 
 
 
 async def delete_group_or_user(
-    mongo: "DB", ref_id: str, subdocument_id: str, field: str
+    mongo: "Mongo", ref_id: str, subdocument_id: str, field: str
 ) -> Optional[str]:
     """
     Delete an existing group or user as decided by the `field` argument.
@@ -338,7 +338,7 @@ async def delete_group_or_user(
 
 
 async def edit_group_or_user(
-    mongo: "DB", ref_id: str, subdocument_id: str, field: str, data: Document
+    mongo: "Mongo", ref_id: str, subdocument_id: str, field: str, data: Document
 ) -> Optional[Document]:
     """
     Edit an existing group or user as decided by the `field` argument.
@@ -373,7 +373,7 @@ async def edit_group_or_user(
 
 
 async def fetch_and_update_release(
-    mongo: "DB", client, ref_id: str, ignore_errors: bool = False
+    mongo: "Mongo", client, ref_id: str, ignore_errors: bool = False
 ) -> dict:
     """
     Get the latest release for the GitHub repository identified by the passed `slug`.
@@ -444,7 +444,7 @@ async def fetch_and_update_release(
     return release
 
 
-async def get_contributors(mongo: "DB", ref_id: str) -> Optional[List[Document]]:
+async def get_contributors(mongo: "Mongo", ref_id: str) -> Optional[List[Document]]:
     """
     Return an list of contributors and their contribution count for a specific ref.
 
@@ -457,7 +457,7 @@ async def get_contributors(mongo: "DB", ref_id: str) -> Optional[List[Document]]
 
 
 async def get_internal_control(
-    mongo: "DB", internal_control_id: Optional[str], ref_id: str
+    mongo: "Mongo", internal_control_id: Optional[str], ref_id: str
 ) -> Optional[Document]:
     """
     Return a minimal dict describing the ref internal control given a `otu_id`.
@@ -481,7 +481,7 @@ async def get_internal_control(
     return {"id": internal_control_id, "name": name}
 
 
-async def get_latest_build(mongo: "DB", ref_id: str) -> Optional[Document]:
+async def get_latest_build(mongo: "Mongo", ref_id: str) -> Optional[Document]:
     """
     Return the latest index build for the ref.
 
@@ -502,7 +502,7 @@ async def get_latest_build(mongo: "DB", ref_id: str) -> Optional[Document]:
         )
 
 
-async def get_official_installed(mongo: "DB") -> bool:
+async def get_official_installed(mongo: "Mongo") -> bool:
     """
     Return a boolean indicating whether the official plant virus reference is installed.
 
@@ -517,7 +517,7 @@ async def get_official_installed(mongo: "DB") -> bool:
     )
 
 
-async def get_manifest(mongo: "DB", ref_id: str) -> Document:
+async def get_manifest(mongo: "Mongo", ref_id: str) -> Document:
     """
     Generate a dict of otu document version numbers keyed by the document id.
 
@@ -537,7 +537,7 @@ async def get_manifest(mongo: "DB", ref_id: str) -> Document:
     return manifest
 
 
-async def get_otu_count(mongo: "DB", ref_id: str) -> int:
+async def get_otu_count(mongo: "Mongo", ref_id: str) -> int:
     """
     Get the number of OTUs associated with the given `ref_id`.
 
@@ -549,7 +549,7 @@ async def get_otu_count(mongo: "DB", ref_id: str) -> int:
     return await mongo.otus.count_documents({"reference.id": ref_id})
 
 
-async def get_unbuilt_count(mongo: "DB", ref_id: str) -> int:
+async def get_unbuilt_count(mongo: "Mongo", ref_id: str) -> int:
     """
     Return a count of unbuilt history changes associated with a given `ref_id`.
 
@@ -564,7 +564,7 @@ async def get_unbuilt_count(mongo: "DB", ref_id: str) -> int:
 
 
 async def create_clone(
-    mongo: "DB",
+    mongo: "Mongo",
     settings: Settings,
     name: str,
     clone_from: str,
@@ -592,7 +592,7 @@ async def create_clone(
 
 
 async def create_document(
-    mongo: "DB",
+    mongo: "Mongo",
     settings: Settings,
     name: str,
     organism: Optional[str],
@@ -639,7 +639,7 @@ async def create_document(
 
 
 async def create_import(
-    mongo: "DB",
+    mongo: "Mongo",
     pg: AsyncEngine,
     settings: Settings,
     name: str,
@@ -749,7 +749,7 @@ async def download_and_parse_release(
 
 async def insert_change(
     data_path: Path,
-    mongo: "DB",
+    mongo: "Mongo",
     otu_id: str,
     verb: HistoryMethod,
     user_id: str,
@@ -794,7 +794,7 @@ async def insert_change(
 
 
 async def insert_joined_otu(
-    mongo: "DB",
+    mongo: "Mongo",
     otu: dict,
     created_at: datetime.datetime,
     ref_id: str,
@@ -884,7 +884,7 @@ async def update(
 
 
 async def prepare_update_joined_otu(
-    mongo: "DB", old, otu: Document, ref_id: str
+    mongo: "Mongo", old, otu: Document, ref_id: str
 ) -> Optional[OTUUpdate]:
     if not check_will_change(old, otu):
         return None
@@ -946,7 +946,7 @@ async def prepare_update_joined_otu(
 
 
 async def bulk_prepare_update_joined_otu(
-    mongo: "DB", otu_data: List[OTUData], ref_id: str, session
+    mongo: "Mongo", otu_data: List[OTUData], ref_id: str, session
 ) -> List[OTUUpdate]:
     sequence_ids = []
     for otu_item in otu_data:
@@ -1077,7 +1077,7 @@ def prepare_insert_otu(
     )
 
 
-async def prepare_remove_otu(mongo: "DB", otu_id: str, session) -> Optional[OTUDelete]:
+async def prepare_remove_otu(mongo: "Mongo", otu_id: str, session) -> Optional[OTUDelete]:
     """
     Remove an OTU.
 

--- a/virtool/references/transforms.py
+++ b/virtool/references/transforms.py
@@ -14,7 +14,7 @@ from virtool.users.db import AttachUserTransform
 from virtool.utils import get_safely, base_processor
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 
 class ImportedFromTransform(AbstractTransform):
@@ -23,7 +23,7 @@ class ImportedFromTransform(AbstractTransform):
 
     """
 
-    def __init__(self, mongo: DB, pg: AsyncEngine):
+    def __init__(self, mongo: Mongo, pg: AsyncEngine):
         self._mongo = mongo
         self._pg = pg
 
@@ -50,7 +50,7 @@ PROJECTION = ["_id", "name", "data_type"]
 
 
 class AttachReferenceTransform(AbstractTransform):
-    def __init__(self, mongo: "DB"):
+    def __init__(self, mongo: "Mongo"):
         self._mongo = mongo
 
     async def prepare_one(self, document: Document) -> Any:

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -35,7 +35,7 @@ from virtool.users.db import AttachUserTransform
 from virtool.utils import base_processor
 
 if TYPE_CHECKING:
-    from virtool.mongo.core import DB
+    from virtool.mongo.core import Mongo
 
 logger = logging.getLogger(__name__)
 
@@ -463,7 +463,7 @@ async def update_is_compressed(db, sample: Dict[str, Any]):
         )
 
 
-async def compress_sample_reads(db: "DB", config: Config, sample: Dict[str, Any]):
+async def compress_sample_reads(db: "Mongo", config: Config, sample: Dict[str, Any]):
     """
     Compress the reads for one legacy samples.
 
@@ -511,7 +511,7 @@ async def compress_sample_reads(db: "DB", config: Config, sample: Dict[str, Any]
         await to_thread(os.remove, path)
 
 
-async def move_sample_files_to_pg(db: "DB", pg: AsyncEngine, sample: Dict[str, any]):
+async def move_sample_files_to_pg(db: "Mongo", pg: AsyncEngine, sample: Dict[str, any]):
     """
     Creates a row in the `sample_reads` table for each file in a sample's `files` array.
 

--- a/virtool/settings/data.py
+++ b/virtool/settings/data.py
@@ -1,6 +1,6 @@
 from virtool_core.models.settings import Settings
 
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.settings.oas import UpdateSettingsRequest
 
 PROJECTION = {"_id": False}
@@ -8,7 +8,7 @@ PROJECTION = {"_id": False}
 
 class SettingsData:
     def __init__(self, db):
-        self._db: DB = db
+        self._db: Mongo = db
 
     async def get_all(self) -> Settings:
         """

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -35,7 +35,7 @@ from virtool.indexes.tasks import (
     EnsureIndexFilesTask,
 )
 from virtool.jobs.tasks import TimeoutJobsTask
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.identifier import RandomIdProvider
 from virtool.mongo.migrate import migrate
 from virtool.oidc.utils import JWKArgs
@@ -266,7 +266,7 @@ async def startup_databases(app: Application):
 
     app.update(
         {
-            "db": DB(mongo, dispatcher_interface.enqueue_change, RandomIdProvider()),
+            "db": Mongo(mongo, dispatcher_interface.enqueue_change, RandomIdProvider()),
             "dispatcher_interface": dispatcher_interface,
             "pg": pg,
             "authorization": AuthorizationClient(openfga_instance),

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -12,7 +12,7 @@ from virtool_core.utils import rm
 import virtool.utils
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.piece import DataLayerPiece
-from virtool.mongo.core import DB
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.uploads.db import finalize
 from virtool.uploads.models import Upload as SQLUpload
@@ -24,7 +24,7 @@ logger = getLogger("uploads")
 class UploadsData(DataLayerPiece):
     def __init__(self, config, db, pg):
         self._config = config
-        self._db: DB = db
+        self._db: Mongo = db
         self._pg: AsyncEngine = pg
 
     async def find(


### PR DESCRIPTION
Renamed the wrapper for AsyncioMotorDatabase to Mongo in virtool/mongo/core::DB; updated uses to match refactor