### PR TITLE
feat: speed up openfga tests

### DIFF
--- a/tests/fixtures/authorization.py
+++ b/tests/fixtures/authorization.py
@@ -7,7 +7,11 @@ from openfga_sdk import TupleKey, WriteRequest, TupleKeys, ApiException
 
 from virtool.authorization.client import AuthorizationClient
 from virtool.authorization.permissions import ResourceType
-from virtool.authorization.utils import write_openfga_authorization_model, delete_tuples
+from virtool.authorization.utils import (
+    write_openfga_authorization_model,
+    delete_tuples,
+    get_or_create_openfga_store,
+)
 
 
 @pytest.fixture
@@ -18,21 +22,17 @@ async def authorization_client(openfga_store_name: str) -> AuthorizationClient:
 
     api_instance = openfga_sdk.OpenFgaApi(openfga_sdk.ApiClient(configuration))
 
-    response = await api_instance.create_store(
-        openfga_sdk.CreateStoreRequest(name=openfga_store_name)
+    configuration.store_id = await get_or_create_openfga_store(
+        api_instance, openfga_store_name
     )
 
-    configuration.store_id = response.id
-
     await write_openfga_authorization_model(api_instance)
-
-    yield AuthorizationClient(api_instance)
 
     await delete_tuples(api_instance, ResourceType.SPACE, 0)
 
     await delete_tuples(api_instance, ResourceType.APP, "virtool")
 
-    await api_instance.delete_store()
+    return AuthorizationClient(api_instance)
 
 
 @pytest.fixture

--- a/virtool/authorization/utils.py
+++ b/virtool/authorization/utils.py
@@ -121,6 +121,9 @@ async def write_openfga_authorization_model(api_instance: OpenFgaApi):
     """
     response = await api_instance.read_authorization_models()
 
+    if response.authorization_models:
+        return
+
     model = {
         "type_definitions": [
             {
@@ -1363,14 +1366,6 @@ async def write_openfga_authorization_model(api_instance: OpenFgaApi):
         ],
         "schema_version": "1.1",
     }
-
-    if (
-        response.authorization_models
-        and response.authorization_models[0].type_definitions
-        == model["type_definitions"]
-    ):
-        logger.info("OpenFGA authorization model is up-to-date.")
-        return
 
     await api_instance.write_authorization_model(model)
 


### PR DESCRIPTION
No longer deletes the store after testing. Deletes existing tuples at the start of tests rather than during cleanup.

No longer checks to see if the authorization model is updated before writing the new one. The old code was not functioning properly and it was harder than expected to find a working solution. It will be significantly easier to do this once the model is created in the migration, so I am removing it for now.