### PR TITLE
Spawner logging

### DIFF
--- a/virtool/config/cli.py
+++ b/virtool/config/cli.py
@@ -189,7 +189,7 @@ def spawn_task(task_name: str, **kwargs):
     """Create and queue a task instance of the given name."""
     configure_logs(False)
 
-    logger.info("Spawning task")
+    logger.info("Spawning task %s", task_name)
 
     asyncio.get_event_loop().run_until_complete(
         spawn(TaskSpawnerConfig(**kwargs), task_name)

--- a/virtool/config/cli.py
+++ b/virtool/config/cli.py
@@ -204,7 +204,8 @@ def tasks_spawner(**kwargs):
     """
     Schedule all periodically run tasks on hardcoded schedules
     """
+    configure_logs(False)
 
-    logger.info("Periodic Task spawner")
+    logger.info("Starting task spawner")
 
     run_task_spawner(PeriodicTaskSpawnerConfig(**kwargs, base_url=""))

--- a/virtool/tasks/main.py
+++ b/virtool/tasks/main.py
@@ -52,7 +52,7 @@ async def create_task_runner_app(config: TaskRunnerConfig):
     )
 
     app["config"] = config
-    app["mode"] = "tasks_worker"
+    app["mode"] = "task_runner"
 
     aiojobs.aiohttp.setup(app)
 

--- a/virtool/tasks/spawner.py
+++ b/virtool/tasks/spawner.py
@@ -191,7 +191,7 @@ async def create_task_spawner_app(config: PeriodicTaskSpawnerConfig):
     )
 
     app["config"] = config
-    app["mode"] = "periodic_task_spawner"
+    app["mode"] = "task_spawner"
 
     aiojobs.aiohttp.setup(app)
 

--- a/virtool/tasks/spawner.py
+++ b/virtool/tasks/spawner.py
@@ -53,9 +53,7 @@ from virtool.startup import (
 )
 from virtool.tasks.api import TaskServicesRootView
 
-logging.basicConfig(level=logging.DEBUG)
-
-logger = logging.getLogger("periodic_task_spawner")
+logger = logging.getLogger("spawner")
 
 
 @dataclass
@@ -131,7 +129,7 @@ class TaskSpawnerService:
         """
         if check_interval_exceeded(task.interval, task.last_triggered):
             await self._tasks_datalayer.create(task.task)
-            logger.info("Spawning task %s", task.task)
+            logger.info("Spawning task %s", task.task.name)
             task.last_triggered = timestamp()
         return task
 


### PR DESCRIPTION
* Use standard logging configuration for task spawner.
* Use consistent wording for task services: task runner (`task_runner`), task spawner (`task_spawner`).