### PR TITLE
fix: add task to relist waiting jobs

### DIFF
--- a/tests/administrators/test_api.py
+++ b/tests/administrators/test_api.py
@@ -188,3 +188,13 @@ class TestUpdateUser:
             body = await resp.json()
             assert body["force_reset"] is True
             assert body == snapshot
+
+
+@pytest.mark.apitest
+@pytest.mark.parametrize("name,status", [("relist_jobs", 202), ("foo", 400)])
+async def test_run_actions(spawn_client, fake2, snapshot, mongo, name, status):
+    client = await spawn_client(authorize=True, administrator=True)
+
+    resp = await client.put(f"/admin/actions", {"name": name})
+
+    assert resp.status == status

--- a/tests/administrators/test_api.py
+++ b/tests/administrators/test_api.py
@@ -195,6 +195,6 @@ class TestUpdateUser:
 async def test_run_actions(spawn_client, fake2, snapshot, mongo, name, status):
     client = await spawn_client(authorize=True, administrator=True)
 
-    resp = await client.put(f"/admin/actions", {"name": name})
+    resp = await client.put("/admin/actions", {"name": name})
 
     assert resp.status == status

--- a/tests/jobs/__snapshots__/test_tasks.ambr
+++ b/tests/jobs/__snapshots__/test_tasks.ambr
@@ -1,0 +1,20 @@
+# name: test_relist_jobs[preparing-False]
+  <class 'list'> [
+  ]
+---
+# name: test_relist_jobs[waiting-False]
+  <class 'list'> [
+    <class 'tuple'> (
+      'jobs_pathoscope_bowtie',
+      'fb085f7f',
+    ),
+  ]
+---
+# name: test_relist_jobs[waiting-True]
+  <class 'list'> [
+    <class 'tuple'> (
+      'jobs_pathoscope_bowtie',
+      'fb085f7f',
+    ),
+  ]
+---

--- a/tests/jobs/test_tasks.py
+++ b/tests/jobs/test_tasks.py
@@ -1,8 +1,7 @@
 import pytest
-
-from virtool.jobs.client import DummyJobsClient
 from virtool_core.models.job import JobState
 
+from virtool.jobs.client import DummyJobsClient
 from virtool.jobs.data import JobsData
 
 

--- a/tests/jobs/test_tasks.py
+++ b/tests/jobs/test_tasks.py
@@ -1,0 +1,43 @@
+import pytest
+
+from virtool.jobs.client import DummyJobsClient
+from virtool_core.models.job import JobState
+
+from virtool.jobs.data import JobsData
+
+
+async def sleep_patch():
+    pass
+
+
+@pytest.mark.parametrize(
+    "state,listed,",
+    [
+        (JobState.WAITING.value, False),
+        (JobState.PREPARING.value, False),
+        (JobState.WAITING.value, True),
+    ],
+)
+async def test_relist_jobs(fake2, pg, mongo, mocker, state, listed, snapshot):
+    """
+    Test that jobs are relisted in redis that are in the waiting state and are no longer in redis.
+
+    """
+
+    user = await fake2.users.create()
+    job = await fake2.jobs.create(user)
+    dummy_client = DummyJobsClient()
+
+    mocker.patch("virtool.jobs.data.asyncio.sleep", function=sleep_patch)
+
+    if listed:
+        await dummy_client.enqueue(job.workflow, job.id)
+        assert (await dummy_client.list()) == [job.id]
+
+    if state != JobState.WAITING.value:
+        await mongo.jobs.update_one({"_id": job.id}, {"$set": {"state": state}})
+
+    jobs_data = JobsData(dummy_client, mongo, pg)
+    await jobs_data.relist()
+
+    assert dummy_client.enqueued == snapshot

--- a/virtool/administrators/actions.py
+++ b/virtool/administrators/actions.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from typing import TYPE_CHECKING, Type
+
+from virtool.data.errors import ResourceError
+from virtool.jobs.tasks import RelistJobsTask
+from virtool.tasks.task import BaseTask
+
+if TYPE_CHECKING:
+    from virtool.data.layer import DataLayer
+
+
+class Action(ABC):
+    async def run(self, data_layer: "DataLayer", *args, **kwargs):
+        ...
+
+
+class TaskAction:
+    def __init__(self, task: Type[BaseTask]):
+        self.task = task
+
+    async def run(self, data_layer: "DataLayer", *args, **kwargs):
+        return await data_layer.tasks.create(self.task)
+
+
+actions = {"relist_jobs": TaskAction(RelistJobsTask)}
+
+
+def get_action_from_name(name: str) -> Action:
+    """
+    Derive an action from its name.
+
+    :param name: the name of the action
+    :return: the action
+    """
+    try:
+        return actions[name]
+    except KeyError:
+        raise ResourceError("Invalid action name")

--- a/virtool/administrators/api.py
+++ b/virtool/administrators/api.py
@@ -2,8 +2,9 @@ import asyncio
 from typing import Union, Optional
 
 from aiohttp.web_exceptions import HTTPForbidden, HTTPBadRequest
+from aiohttp.web_response import Response
 from aiohttp_pydantic import PydanticView
-from aiohttp_pydantic.oas.typing import r200, r404
+from aiohttp_pydantic.oas.typing import r200, r404, r202, r400
 from virtool_core.models.roles import AdministratorRole
 from virtool_core.utils import document_enum
 
@@ -13,11 +14,12 @@ from virtool.administrators.oas import (
     ListRolesResponse,
     UpdateUserRequest,
     UserResponse,
+    RunActionRequest,
 )
 from virtool.api.response import NotFound, json_response
 from virtool.authorization.client import AuthorizationClient
 from virtool.authorization.utils import get_authorization_client_from_req
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceNotFoundError, ResourceError
 from virtool.data.utils import get_data_from_req
 from virtool.http.policy import policy, AdministratorRoutePolicy
 from virtool.http.routes import Routes
@@ -185,3 +187,25 @@ class AdminRoleView(PydanticView):
             raise NotFound()
 
         return json_response(administrator, status=200)
+
+
+@routes.view("/admin/actions")
+class AdminActionsView(PydanticView):
+    @policy(AdministratorRoutePolicy(AdministratorRole.FULL))
+    async def put(self, data: RunActionRequest) -> Union[r202, r400]:
+        """
+        Initiate an action
+
+        Starts an action with the given name.
+
+        Status Codes:
+            200: Successful operation
+            404: User not found
+        """
+
+        try:
+            await get_data_from_req(self.request).administrators.run_action(data.name)
+        except ResourceError:
+            raise HTTPBadRequest(text="Invalid action name")
+
+        return Response(status=202)

--- a/virtool/administrators/data.py
+++ b/virtool/administrators/data.py
@@ -1,12 +1,14 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from virtool_core.models.roles import AdministratorRole
 from virtool_core.models.user import User, UserSearchResult
 
 import virtool
+from virtool.administrators.actions import get_action_from_name
 from virtool.administrators.db import update_legacy_administrator
 from virtool.administrators.oas import UpdateUserRequest
 from virtool.api.utils import paginate_aggregate, compose_regex_query
+from virtool.authorization.client import AuthorizationClient
 from virtool.authorization.relationships import AdministratorRoleAssignment
 from virtool.data.errors import (
     ResourceNotFoundError,
@@ -21,9 +23,6 @@ from virtool.users.db import (
     update_keys,
     compose_groups_update,
 )
-
-from virtool.authorization.client import AuthorizationClient
-
 
 PROJECTION = [
     "_id",
@@ -246,3 +245,14 @@ class AdministratorsData(DataLayerPiece):
             await self._authorization_client.add(
                 AdministratorRoleAssignment(user_id, AdministratorRole.FULL)
             )
+
+    async def run_action(self, name: str):
+        """
+        Run an action
+
+        Runs an action with the given name.
+
+        :param name: the name of the action to run
+        :return: the result of the action
+        """
+        return await get_action_from_name(name).run(self.data)

--- a/virtool/administrators/oas.py
+++ b/virtool/administrators/oas.py
@@ -5,6 +5,17 @@ from virtool_core.models.roles import AdministratorRole
 from virtool_core.models.validators import prevent_none
 
 
+class RunActionRequest(BaseModel):
+    """
+    Used when running an action on a task
+    """
+
+    name: str = Field(description="the action to run")
+
+    class Config:
+        schema_extra = {"example": {"name": "relist_jobs"}}
+
+
 class UpdateAdministratorRoleRequest(BaseModel):
     """
     Used when adding a user as an administrator

--- a/virtool/jobs/tasks.py
+++ b/virtool/jobs/tasks.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from tempfile import TemporaryDirectory
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
-from virtool.data.layer import DataLayer
 from virtool.tasks.task import BaseTask
+
+if TYPE_CHECKING:
+    from virtool.data.layer import DataLayer
 
 
 class TimeoutJobsTask(BaseTask):
@@ -20,7 +22,11 @@ class TimeoutJobsTask(BaseTask):
     name = "timeout_jobs"
 
     def __init__(
-        self, task_id: int, data: DataLayer, context: Dict, temp_dir: TemporaryDirectory
+        self,
+        task_id: int,
+        data: "DataLayer",
+        context: Dict,
+        temp_dir: TemporaryDirectory,
     ):
         super().__init__(task_id, data, context, temp_dir)
 
@@ -28,3 +34,28 @@ class TimeoutJobsTask(BaseTask):
 
     async def timeout_jobs(self):
         await self.data.jobs.timeout()
+
+
+class RelistJobsTask(BaseTask):
+    """
+    relist jobs in redis
+
+    Relists jobs in redis that are in the waiting state and are no longer in redis
+
+    """
+
+    name = "relist_jobs"
+
+    def __init__(
+        self,
+        task_id: int,
+        data: "DataLayer",
+        context: Dict,
+        temp_dir: TemporaryDirectory,
+    ):
+        super().__init__(task_id, data, context, temp_dir)
+
+        self.steps = [self.relist_jobs]
+
+    async def relist_jobs(self):
+        await self.data.jobs.relist()


### PR DESCRIPTION
Changes:
 - add new `relist_jobs` task that adds any jobs with the state `waiting` to the redis queue provided they are not already in it. 
   - To handle edge case where a task has been removed from the list but has not yet been set to preparing the task checks the list twice with a 10 second delay between. Only the values in both lists are added back to the redis list 
 - adds barebones `admin/actions` api route which allows invocation of new `relist_jobs` task via api request
   - Possible todos: Add more actions to the list of available ones, define a standard `action` data structure and return type, add action table storing when and who invoked an action, add `get` route to permit fetching of action data 