### PR TITLE
chore: remove use of function on startup

### DIFF
--- a/virtool/mongo/migrate.py
+++ b/virtool/mongo/migrate.py
@@ -25,7 +25,7 @@ async def migrate(app: App):
     :param app: the application object
 
     """
-    await gather(migrate_status(app["db"]), recalculate_all_workflow_tags(app["db"]))
+    await gather(migrate_status(app["db"]))
 
 
 async def recalculate_all_workflow_tags(mongo: Mongo):

--- a/virtool/mongo/migrate.py
+++ b/virtool/mongo/migrate.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from asyncio import gather
 from logging import getLogger
 from typing import TYPE_CHECKING
 
 from pymongo.errors import DuplicateKeyError
-
-from virtool.samples.db import recalculate_workflow_tags
-from virtool.types import App
-from virtool.utils import chunk_list
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -16,36 +11,7 @@ if TYPE_CHECKING:
 logger = getLogger("mongo")
 
 
-async def migrate(app: App):
-    """
-    Update all collections on application start.
-
-    Used for applying MongoDB schema and file storage changes.
-
-    :param app: the application object
-
-    """
-    await gather(migrate_status(app["db"]))
-
-
-async def recalculate_all_workflow_tags(mongo: Mongo):
-    """
-    Recalculate workflow tags for all samples. Works on multiple samples concurrently.
-
-    :param mongo: the application database object
-
-    """
-    logger.info("Recalculating samples workflow tags")
-
-    sample_ids = await mongo.samples.distinct("_id")
-
-    for chunk in chunk_list(sample_ids, 50):
-        await gather(
-            *[recalculate_workflow_tags(mongo, sample_id) for sample_id in chunk]
-        )
-
-
-async def migrate_status(mongo):
+async def migrate_status(mongo: Mongo):
     """
     Automatically update the status collection.
 

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -484,8 +484,6 @@ class SamplesData(DataLayerPiece):
                     )
 
     async def update_sample_workflows(self):
-        logger.info("Recalculating samples workflow tags")
-
         sample_ids = await self._mongo.samples.distinct("_id")
 
         for chunk in chunk_list(sample_ids, 50):

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -9,7 +9,7 @@ from aiohttp import ClientSession
 from aiojobs import Scheduler
 from msal import ClientApplication
 from pymongo.errors import CollectionInvalid
-from virtool_core.redis import connect_redis, periodically_ping_redis
+from virtool_core.redis import connect, periodically_ping_redis
 
 from virtool.authorization.client import AuthorizationClient
 from virtool.authorization.utils import connect_openfga
@@ -133,7 +133,7 @@ async def startup_databases(app: App):
     mongo, pg, redis, openfga_instance = await asyncio.gather(
         connect_mongo(config.mongodb_connection_string, config.mongodb_database),
         connect_pg(config.postgres_connection_string),
-        connect_redis(config.redis_connection_string),
+        connect(config.redis_connection_string),
         connect_openfga(
             config.openfga_host, config.openfga_scheme, config.openfga_store_name
         ),

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -94,7 +94,7 @@ async def startup_check_db(app: App):
     db = app["db"]
 
     logger.info("Checking database")
-    migrate_status(db)
+    await migrate_status(db)
 
     # Make sure the indexes collection exists before later trying to set an compound
     # index on it.

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -9,7 +9,7 @@ from aiohttp import ClientSession
 from aiojobs import Scheduler
 from msal import ClientApplication
 from pymongo.errors import CollectionInvalid
-from virtool_core.redis import connect, periodically_ping_redis
+from virtool_core.redis import connect_redis, periodically_ping_redis
 
 from virtool.authorization.client import AuthorizationClient
 from virtool.authorization.utils import connect_openfga
@@ -21,7 +21,7 @@ from virtool.migration.pg import check_data_revision_version
 from virtool.mongo.connect import connect_mongo
 from virtool.mongo.core import Mongo
 from virtool.mongo.identifier import RandomIdProvider
-from virtool.mongo.migrate import migrate
+from virtool.mongo.migrate import migrate_status
 from virtool.oidc.utils import JWKArgs
 from virtool.pg.utils import connect_pg
 from virtool.routes import setup_routes
@@ -94,7 +94,7 @@ async def startup_check_db(app: App):
     db = app["db"]
 
     logger.info("Checking database")
-    await migrate(app)
+    migrate_status(db)
 
     # Make sure the indexes collection exists before later trying to set an compound
     # index on it.
@@ -133,7 +133,7 @@ async def startup_databases(app: App):
     mongo, pg, redis, openfga_instance = await asyncio.gather(
         connect_mongo(config.mongodb_connection_string, config.mongodb_database),
         connect_pg(config.postgres_connection_string),
-        connect(config.redis_connection_string),
+        connect_redis(config.redis_connection_string),
         connect_openfga(
             config.openfga_host, config.openfga_scheme, config.openfga_store_name
         ),

--- a/virtool/tasks/spawner.py
+++ b/virtool/tasks/spawner.py
@@ -13,6 +13,7 @@ from virtool.analyses.tasks import StoreNuvsFilesTask
 from virtool.hmm.tasks import HMMRefreshTask
 from virtool.indexes.tasks import EnsureIndexFilesTask
 from virtool.jobs.tasks import TimeoutJobsTask
+from virtool.mongo.tasks import RecalculateWorkflowTagsTask
 from virtool.references.tasks import RefreshReferenceReleasesTask, CleanReferencesTask
 from virtool.samples.tasks import CompressSamplesTask, MoveSampleFilesTask
 from virtool.startup import get_scheduler_from_app
@@ -169,6 +170,7 @@ async def startup_task_spawner(app: App):
         (RefreshReferenceReleasesTask, 600),
         (StoreNuvsFilesTask, 3600),
         (TimeoutJobsTask, 3600),
+        (RecalculateWorkflowTagsTask, 3600),
     ]
 
     await scheduler.spawn(

--- a/virtool/tasks/spawner.py
+++ b/virtool/tasks/spawner.py
@@ -13,7 +13,7 @@ from virtool.analyses.tasks import StoreNuvsFilesTask
 from virtool.hmm.tasks import HMMRefreshTask
 from virtool.indexes.tasks import EnsureIndexFilesTask
 from virtool.jobs.tasks import TimeoutJobsTask
-from virtool.mongo.tasks import RecalculateWorkflowTagsTask
+from virtool.samples.tasks import UpdateSampleWorkflowsTask
 from virtool.references.tasks import RefreshReferenceReleasesTask, CleanReferencesTask
 from virtool.samples.tasks import CompressSamplesTask, MoveSampleFilesTask
 from virtool.startup import get_scheduler_from_app
@@ -170,7 +170,7 @@ async def startup_task_spawner(app: App):
         (RefreshReferenceReleasesTask, 600),
         (StoreNuvsFilesTask, 3600),
         (TimeoutJobsTask, 3600),
-        (RecalculateWorkflowTagsTask, 3600),
+        (UpdateSampleWorkflowsTask, 3600),
     ]
 
     await scheduler.spawn(

--- a/virtool/tasks/utils.py
+++ b/virtool/tasks/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from virtool_core.redis import connect_redis, periodically_ping_redis
+from virtool_core.redis import connect, periodically_ping_redis
 
 from virtool.pg.utils import connect_pg
 from virtool.config import get_config_from_app
@@ -21,7 +21,7 @@ async def startup_databases_for_spawner(app: App):
 
     pg, redis = await asyncio.gather(
         connect_pg(config.postgres_connection_string),
-        connect_redis(config.redis_connection_string),
+        connect(config.redis_connection_string),
     )
 
     await get_scheduler_from_app(app).spawn(periodically_ping_redis(redis))

--- a/virtool/tasks/utils.py
+++ b/virtool/tasks/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from virtool_core.redis import connect, periodically_ping_redis
+from virtool_core.redis import connect_redis, periodically_ping_redis
 
 from virtool.pg.utils import connect_pg
 from virtool.config import get_config_from_app
@@ -21,7 +21,7 @@ async def startup_databases_for_spawner(app: App):
 
     pg, redis = await asyncio.gather(
         connect_pg(config.postgres_connection_string),
-        connect(config.redis_connection_string),
+        connect_redis(config.redis_connection_string),
     )
 
     await get_scheduler_from_app(app).spawn(periodically_ping_redis(redis))


### PR DESCRIPTION
remove use of `recalculate_all_workflow_tags`
in `virtool/migrate::migrate`

add `RecalculateWorkflowTags` as a recurring task