### PR TITLE
fix: prevent error when returning some samples

### DIFF
--- a/virtool/caches/db.py
+++ b/virtool/caches/db.py
@@ -93,23 +93,3 @@ async def remove(app: App, cache_id: str):
         await to_thread(rm, path, True)
     except FileNotFoundError:
         pass
-
-
-def lookup_caches(local_field: str = "_id", set_as: str = "caches") -> list[dict]:
-    """
-        Create a mongoDB aggregation pipeline step to look up nested caches.
-
-        :param local_field: cache id field to look up
-        :param set_as: desired name of the returned record
-        :return: mongoDB aggregation steps for use in an aggregation pipeline
-    """
-    return [
-        {
-            "$lookup": {
-                "from": "caches",
-                "localField": local_field,
-                "foreignField": "sample.id",
-                "as": set_as,
-            }
-        },
-    ]

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -9,11 +9,9 @@ from motor.motor_asyncio import AsyncIOMotorClientSession
 from pymongo.results import UpdateResult
 from sqlalchemy.ext.asyncio import AsyncEngine
 from virtool_core.models.samples import SampleSearchResult, Sample
-from virtool.mongo.core import Mongo
 
 import virtool.utils
 from virtool.api.utils import compose_regex_query
-from virtool.caches.db import lookup_caches
 from virtool.config.cls import Config
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.piece import DataLayerPiece
@@ -22,6 +20,7 @@ from virtool.jobs.client import JobsClient
 from virtool.jobs.db import lookup_minimal_job_by_id, create_job
 from virtool.jobs.utils import JobRights
 from virtool.labels.db import AttachLabelsTransform
+from virtool.mongo.core import Mongo
 from virtool.mongo.transforms import apply_transforms
 from virtool.mongo.utils import get_new_id, get_one_field
 from virtool.samples.checks import (
@@ -170,7 +169,6 @@ class SamplesData(DataLayerPiece):
                 {"$match": {"_id": sample_id}},
                 *lookup_nested_user_by_id(local_field="user.id"),
                 *lookup_nested_subtractions(local_field="subtractions"),
-                *lookup_caches(local_field="_id"),
                 *lookup_minimal_job_by_id(local_field="job.id"),
             ]
         ).to_list(length=1)
@@ -185,6 +183,7 @@ class SamplesData(DataLayerPiece):
             [ArtifactsAndReadsTransform(self._pg), AttachLabelsTransform(self._pg)],
         )
 
+        document["caches"] = []
         document["paired"] = len(document["reads"]) == 2
 
         return Sample(**document)


### PR DESCRIPTION
Caused by broken cache documents for the sample.

Always send an empty list and don't lookup associated caches. They are defunct anyway. This will be followed with a thorough removal of the cache functionality as it exists. It will be replaced in the future.