### PR TITLE
fix: prevent `QueueFull` errors

### DIFF
--- a/virtool/data/events.py
+++ b/virtool/data/events.py
@@ -160,7 +160,6 @@ class EventPublisher:
                         }
                     ),
                 )
-                await asyncio.sleep(0.1)
         except CancelledError:
             pass
 


### PR DESCRIPTION
Stop sleeping between publishing events. This causes problems when events are rapidly fired.