### PR TITLE
Fix `QueueFull` in task runner

### DIFF
--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -155,6 +155,7 @@ async def startup_databases(app: App):
 
 
 async def startup_events(app: App):
+    """Create and run the event publisher."""
     app["events"] = EventPublisher(app["redis"])
     await get_scheduler_from_app(app).spawn(app["events"].run())
 

--- a/virtool/tasks/api.py
+++ b/virtool/tasks/api.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import List
 
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r400
@@ -13,9 +13,14 @@ routes = Routes()
 
 
 class TaskServicesRootView(PydanticView):
+    """The only endpoint for the task runner and spawner services."""
+
     async def get(self) -> r200:
         """
-        Root response for task runner. Used for checking if the server is alive.
+        Root response for task runner.
+
+        Used for checking if the server is alive.
+
         Status Codes:
             200: Successful operation
         """
@@ -45,7 +50,7 @@ class TasksView(PydanticView):
 
 @routes.view("/tasks/{task_id}")
 class TaskView(PydanticView):
-    async def get(self, task_id: int, /) -> Union[r200[TaskResponse], r400]:
+    async def get(self, task_id: int, /) -> r200[TaskResponse] | r400:
         """
         Retrieve a task.
 


### PR DESCRIPTION
The issue was due to exceptions being raised in the event publisher and preventing further event from being published.

* Handle exceptions that interrupt `EventPublisher.run()`.
* Add more logging for event publisher.
* Fix up some docstrings and typing.
* Use `logger` (from `getLogger`) instead of `logging`.