### PR TITLE
fix: rename ml model download

### DIFF
--- a/virtool/ml/api.py
+++ b/virtool/ml/api.py
@@ -56,7 +56,7 @@ class MLModelFileView(PydanticView):
         return FileResponse(
             file_descriptor.path,
             headers={
-                "Content-Disposition": "attachment; filename='model.tar.gz'",
+                "Content-Disposition": "attachment; filename=model.tar.gz",
                 "Content-Type": "application/octet-stream",
             },
         )


### PR DESCRIPTION
removed single quotes around filename.