### PR TITLE
fix: fix path error during hmm installation

### DIFF
--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -172,6 +172,7 @@ class HmmsData(DataLayerDomain):
             )
 
             try:
+                await to_thread(self.profiles_path.mkdir, parents=True, exist_ok=True)
                 await to_thread(
                     shutil.move, str(hmm_temp_profile_path), str(self.profiles_path)
                 )


### PR DESCRIPTION
The HMM profile path didn't exist. Added a `path.mkdir` call to create the directory before copying in the profiles file.