### PR TITLE
feat: start writing users to postgres

### DIFF
--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -1,6 +1,10 @@
 import asyncio
 import os
 
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.ext.asyncio import AsyncEngine
+
 from virtool.analyses.models import SQLAnalysisFile
 from virtool.blast.models import SQLNuVsBlast
 from virtool.caches.models import SQLSampleReadsCache, SQLSampleArtifactCache
@@ -14,11 +18,6 @@ from virtool.samples.models import SQLSampleReads, SQLSampleArtifact
 from virtool.spaces.models import SQLSpace
 from virtool.subtractions.models import SQLSubtractionFile
 from virtool.uploads.models import SQLUpload
-
-from alembic import context
-from sqlalchemy import engine_from_config, pool
-from sqlalchemy.ext.asyncio import AsyncEngine
-
 from virtool.users.pg import SQLUser, SQLUserGroup
 
 config = context.config

--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -19,6 +19,8 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from virtool.users.pg import SQLUser, SQLUserGroup
+
 config = context.config
 
 # Interpret the config file for Python logging.
@@ -48,6 +50,8 @@ __models__ = (
     SQLSpace,
     SQLSubtractionFile,
     SQLUpload,
+    SQLUser,
+    SQLUserGroup,
 )
 
 

--- a/assets/alembic/versions/5df816cef12f_update_user_schema.py
+++ b/assets/alembic/versions/5df816cef12f_update_user_schema.py
@@ -1,0 +1,86 @@
+"""update user schema
+
+Revision ID: 5df816cef12f
+Revises: 77be1d95da09
+Create Date: 2024-01-04 01:39:59.377946+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "5df816cef12f"
+down_revision = "77be1d95da09"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Upgrade the schema for the final implementation of users.
+
+    * Bring back the `settings` field as a JSONB column.
+    * Drop the `administrator` and `primary_key_id` columns and associated constraint.
+    * Drop the `user_group_associations` table and replace it with `user_groups`. Add a
+      unique index on `user_groups` for the `primary` and `user_id` columns to ensure
+      that each user has only one primary group.
+    *
+
+    """
+    op.create_table(
+        "user_groups",
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column("primary", sa.Boolean(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("group_id", "user_id"),
+    )
+    op.create_index(
+        "primary_group_unique",
+        "user_groups",
+        ["primary", "user_id"],
+        unique=True,
+        postgresql_where=False,
+    )
+    op.drop_table("user_group_associations")
+    op.add_column(
+        "users",
+        sa.Column("settings", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    )
+    op.alter_column("users", "b2c_oid", existing_type=sa.VARCHAR(), nullable=True)
+    op.drop_constraint("users_primary_group_fkey", "users", type_="foreignkey")
+    op.drop_column("users", "primary_group_id")
+    op.drop_column("users", "administrator")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("administrator", sa.BOOLEAN(), autoincrement=False, nullable=False),
+    )
+    op.add_column(
+        "users",
+        sa.Column("primary_group_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "users_primary_group_fkey", "users", "groups", ["primary_group_id"], ["id"]
+    )
+    op.alter_column("users", "b2c_oid", existing_type=sa.VARCHAR(), nullable=False)
+    op.drop_column("users", "settings")
+    op.create_table(
+        "user_group_associations",
+        sa.Column("user_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("group_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["group_id"], ["groups.id"], name="user_group_associations_group_id_fkey"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], name="user_group_associations_user_id_fkey"
+        ),
+    )
+    op.drop_index(
+        "primary_group_unique", table_name="user_groups", postgresql_where=False
+    )
+    op.drop_table("user_groups")

--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -1025,22 +1025,6 @@
     dict({
       'in': 'body',
       'loc': list([
-        'show_ids',
-      ]),
-      'msg': 'Value may not be null',
-      'type': 'value_error',
-    }),
-    dict({
-      'in': 'body',
-      'loc': list([
-        'skip_quick_analyze_dialog',
-      ]),
-      'msg': 'Value may not be null',
-      'type': 'value_error',
-    }),
-    dict({
-      'in': 'body',
-      'loc': list([
         'quick_analyze_workflow',
       ]),
       'msg': 'Value may not be null',
@@ -1049,7 +1033,23 @@
     dict({
       'in': 'body',
       'loc': list([
+        'show_ids',
+      ]),
+      'msg': 'Value may not be null',
+      'type': 'value_error',
+    }),
+    dict({
+      'in': 'body',
+      'loc': list([
         'show_versions',
+      ]),
+      'msg': 'Value may not be null',
+      'type': 'value_error',
+    }),
+    dict({
+      'in': 'body',
+      'loc': list([
+        'skip_quick_analyze_dialog',
       ]),
       'msg': 'Value may not be null',
       'type': 'value_error',

--- a/tests/account/__snapshots__/test_data.ambr
+++ b/tests/account/__snapshots__/test_data.ambr
@@ -95,3 +95,71 @@
     }),
   })
 # ---
+# name: test_update[email][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'email': 'hello@world.com',
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: test_update[email][pg]
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+# ---
+# name: test_update[password and email][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'email': 'hello@world.com',
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: test_update[password and email][pg]
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+# ---
+# name: test_update[password][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: test_update[password][pg]
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+# ---

--- a/tests/administrators/test_api.py
+++ b/tests/administrators/test_api.py
@@ -288,7 +288,6 @@ class TestUpdateUser:
         resp = await client.patch(
             f"/admin/users/{user.id}", {"primary_group": group.id}
         )
-
         assert resp.status == 200 if is_member else 400
         assert await resp.json() == snapshot(matcher=_last_password_change_matcher)
 

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -453,6 +453,7 @@ async def test_upload_file(
 
             assert resp.status == 201
             assert await resp.json() == snapshot
+
             assert sorted(os.listdir(tmp_path / "analyses")) == [
                 "1-reference.fa",
                 "2-reference.fa",

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -110,23 +110,28 @@ async def pg(engine: AsyncEngine):
     async with AsyncSession(engine) as session:
         await session.execute(
             text(
-                """TRUNCATE TABLE analysis_files,
-                                groups,
-                                labels,
-                                sample_artifacts,
-                                subtraction_files,
-                                sample_artifacts_cache,
-                                sample_reads_cache,
-                                index_files,
-                                instance_messages,
-                                ml_models,
-                                ml_model_releases,
-                                uploads,
-                                nuvs_blast,
-                                sample_reads,
-                                spaces,
-                                revisions,
-                                tasks RESTART IDENTITY"""
+                """
+                TRUNCATE TABLE analysis_files,
+                    groups,
+                    index_files,
+                    instance_messages,
+                    labels,
+                    sample_artifacts,
+                    sample_artifacts_cache,
+                    sample_reads_cache,
+                    subtraction_files,
+                    ml_model_releases,
+                    ml_models,
+                    nuvs_blast,
+                    revisions,
+                    sample_reads,
+                    spaces,
+                    tasks,
+                    uploads,
+                    user_groups,
+                    users
+                RESTART IDENTITY
+                """
             )
         )
         await session.commit()

--- a/tests/fixtures/snapshot_date.py
+++ b/tests/fixtures/snapshot_date.py
@@ -45,6 +45,7 @@ def snapshot_recent(snapshot):
             mapping={
                 ".*applied_at": (datetime.datetime, str, Any),
                 ".*created_at": (datetime.datetime, str, Any),
+                ".*last_password_change": (datetime.datetime, str, Any),
                 ".*updated_at": (datetime.datetime, str, Any),
                 ".*uploaded_at": (datetime.datetime, str, Any),
             },

--- a/tests/groups/test_mongo.py
+++ b/tests/groups/test_mongo.py
@@ -1,6 +1,5 @@
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
-
 from virtool.fake.next import DataFaker
 from virtool.groups.mongo import update_member_users_and_api_keys
 from virtool.groups.pg import SQLGroup

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -190,5 +190,12 @@
       'name': 'repair schema',
       'revision': '77be1d95da09',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 28,
+      'name': 'update user schema',
+      'revision': '5df816cef12f',
+    }),
   ])
 # ---

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -1920,13 +1920,13 @@
   dict({
     'body': '''
       The release consists of a gzipped JSON file containing:
-      
+
       - a `data_type` field with value _genome_
       - an `organism` field with value _virus_
       - the `version` name (eg. *v0.2.0*)
       - a timestamp with the key `created_at`
       - virus data compatible for import into Virtool v2.0.0+
-      
+
       Scripts have been updated to follow upcoming convention changes in Virtool v3.0.0.
     ''',
     'content_type': 'application/gzip',

--- a/tests/users/__snapshots__/test_api.ambr
+++ b/tests/users/__snapshots__/test_api.ambr
@@ -455,7 +455,11 @@
       'remove_job': False,
       'upload_file': False,
     }),
-    'primary_group': None,
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'musicians',
+    }),
   })
 # ---
 # name: test_get[404]

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -1,8 +1,8 @@
 # serializer version: 1
-# name: TestCreate.test_force_reset[False]
+# name: TestCreate.test_first
   dict({
     'active': True,
-    'administrator_role': None,
+    'administrator_role': <AdministratorRole.FULL: 'full'>,
     'b2c': None,
     'b2c_display_name': None,
     'b2c_family_name': None,
@@ -12,7 +12,7 @@
     'groups': list([
     ]),
     'handle': 'bill',
-    'last_password_change': datetime,
+    'last_password_change': 'approximately_now_datetime',
     'permissions': dict({
       'cancel_job': False,
       'create_ref': False,
@@ -26,7 +26,209 @@
     'primary_group': None,
   })
 # ---
-# name: TestCreate.test_force_reset[True]
+# name: TestCreate.test_first[mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'bill',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_first[pg]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': False,
+    'groups': [],
+    'handle': 'bill',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_force_reset[false][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'bill',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_force_reset[false][obj]
+  dict({
+    'active': True,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'bill',
+    'last_password_change': 'approximately_now_datetime',
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': None,
+  })
+# ---
+# name: TestCreate.test_force_reset[false][pg]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': False,
+    'groups': [],
+    'handle': 'bill',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_force_reset[not_specified][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'bill',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_force_reset[not_specified][obj]
+  dict({
+    'active': True,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'bill',
+    'last_password_change': 'approximately_now_datetime',
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': None,
+  })
+# ---
+# name: TestCreate.test_force_reset[not_specified][pg]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': False,
+    'groups': [],
+    'handle': 'bill',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_force_reset[true][mongo]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': True,
+    'groups': list([
+    ]),
+    'handle': 'bill',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestCreate.test_force_reset[true][obj]
   dict({
     'active': True,
     'administrator_role': None,
@@ -39,7 +241,7 @@
     'groups': list([
     ]),
     'handle': 'bill',
-    'last_password_change': datetime,
+    'last_password_change': 'approximately_now_datetime',
     'permissions': dict({
       'cancel_job': False,
       'create_ref': False,
@@ -53,7 +255,297 @@
     'primary_group': None,
   })
 # ---
-# name: TestCreate.test_no_force_reset
+# name: TestCreate.test_force_reset[true][pg]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': True,
+    'groups': [],
+    'handle': 'bill',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_force_reset[mongo_1]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_force_reset[mongo_2]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': True,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': True,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_force_reset[mongo_3]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': True,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_force_reset[pg_1]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': False,
+    'groups': [],
+    'handle': 'leeashley',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_force_reset[pg_2]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': True,
+    'groups': [],
+    'handle': 'leeashley',
+    'id': 1,
+    'invalidate_sessions': True,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_force_reset[pg_3]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': False,
+    'groups': [],
+    'handle': 'leeashley',
+    'id': 1,
+    'invalidate_sessions': True,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_groups[mongo_1]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+      1,
+      3,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_groups[mongo_2]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+      2,
+      1,
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_groups[mongo_3]
+  dict({
+    '_id': 'bf1b993c',
+    'active': True,
+    'force_reset': False,
+    'groups': list([
+    ]),
+    'handle': 'leeashley',
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': None,
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_groups[obj_1]
+  dict({
+    'active': True,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+      dict({
+        'id': 3,
+        'legacy_id': None,
+        'name': 'oceanographers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': 'approximately_now_datetime',
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': None,
+  })
+# ---
+# name: TestUpdate.test_groups[obj_2]
+  dict({
+    'active': True,
+    'administrator_role': None,
+    'b2c': None,
+    'b2c_display_name': None,
+    'b2c_family_name': None,
+    'b2c_given_name': None,
+    'b2c_oid': None,
+    'force_reset': False,
+    'groups': list([
+      dict({
+        'id': 2,
+        'legacy_id': None,
+        'name': 'actors',
+      }),
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'gaffers',
+      }),
+    ]),
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': 'approximately_now_datetime',
+    'permissions': dict({
+      'cancel_job': False,
+      'create_ref': False,
+      'create_sample': False,
+      'modify_hmm': False,
+      'modify_subtraction': False,
+      'remove_file': False,
+      'remove_job': False,
+      'upload_file': False,
+    }),
+    'primary_group': None,
+  })
+# ---
+# name: TestUpdate.test_groups[obj_3]
   dict({
     'active': True,
     'administrator_role': None,
@@ -65,8 +557,9 @@
     'force_reset': False,
     'groups': list([
     ]),
-    'handle': 'bill',
-    'last_password_change': datetime,
+    'handle': 'leeashley',
+    'id': 'bf1b993c',
+    'last_password_change': 'approximately_now_datetime',
     'permissions': dict({
       'cancel_job': False,
       'create_ref': False,
@@ -80,16 +573,46 @@
     'primary_group': None,
   })
 # ---
-# name: TestCreate.test_no_force_reset[mongo]
+# name: TestUpdate.test_groups[pg_1]
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=oceanographers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
+# ---
+# name: TestUpdate.test_groups[pg_2]
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=2, legacy_id=None, name=actors, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=gaffers, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
+# ---
+# name: TestUpdate.test_groups[pg_3]
+  dict({
+    'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
+    'force_reset': False,
+    'groups': [],
+    'handle': 'leeashley',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
+    }),
+  })
+# ---
+# name: TestUpdate.test_groups_unset_primary[mongo]
   dict({
     '_id': 'bf1b993c',
     'active': True,
     'force_reset': False,
     'groups': list([
     ]),
-    'handle': 'bill',
+    'handle': 'laura56',
     'invalidate_sessions': False,
-    'last_password_change': datetime,
+    'last_password_change': 'approximately_now_datetime',
     'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
@@ -99,10 +622,9 @@
     }),
   })
 # ---
-# name: TestCreate.test_no_force_reset[obj]
+# name: TestUpdate.test_groups_unset_primary[obj]
   dict({
     'active': True,
-    'administrator': False,
     'administrator_role': None,
     'b2c': None,
     'b2c_display_name': None,
@@ -112,8 +634,9 @@
     'force_reset': False,
     'groups': list([
     ]),
-    'handle': 'bill',
-    'last_password_change': datetime,
+    'handle': 'laura56',
+    'id': 'bf1b993c',
+    'last_password_change': 'approximately_now_datetime',
     'permissions': dict({
       'cancel_job': False,
       'create_ref': False,
@@ -127,98 +650,28 @@
     'primary_group': None,
   })
 # ---
-# name: TestUpdate.test_administrator[False][mongo]
+# name: TestUpdate.test_groups_unset_primary[pg]
   dict({
-    '_id': 'bf1b993c',
     'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
     'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'leeashley',
+    'groups': [],
+    'handle': 'laura56',
+    'id': 1,
     'invalidate_sessions': False,
-    'last_password_change': datetime,
-    'primary_group': None,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
-  })
-# ---
-# name: TestUpdate.test_administrator[False][obj]
-  dict({
-    'active': True,
-    'administrator_role': <AdministratorRole.FULL: 'full'>,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_administrator[True][mongo]
-  dict({
-    '_id': 'bf1b993c',
-    'active': True,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'leeashley',
-    'invalidate_sessions': False,
-    'last_password_change': datetime,
-    'primary_group': None,
-    'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
-      'show_ids': True,
-      'show_versions': True,
-      'skip_quick_analyze_dialog': True,
-    }),
-  })
-# ---
-# name: TestUpdate.test_administrator[True][obj]
-  dict({
-    'active': True,
-    'administrator_role': <AdministratorRole.FULL: 'full'>,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'leeashley',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
   })
 # ---
 # name: TestUpdate.test_password[db]
@@ -231,7 +684,7 @@
     ]),
     'handle': 'laura56',
     'invalidate_sessions': True,
-    'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+    'last_password_change': 'approximately_now_datetime',
     'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
@@ -260,7 +713,7 @@
     ]),
     'handle': 'laura56',
     'id': 'bf1b993c',
-    'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+    'last_password_change': 'approximately_now_datetime',
     'permissions': dict({
       'cancel_job': False,
       'create_ref': False,
@@ -274,17 +727,22 @@
     'primary_group': None,
   })
 # ---
-# name: TestUpdate.test_set_groups[mongo_1]
+# name: TestUpdate.test_password[pg]
   dict({
-    '_id': 'bf1b993c',
     'active': True,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
+    'b2c_oid': None,
+    'email': '',
     'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'qtaylor',
-    'invalidate_sessions': False,
-    'last_password_change': datetime,
-    'primary_group': None,
+    'groups': [<SQLGroup(id=1, legacy_id=None, name=musicians, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>],
+    'handle': 'laura56',
+    'id': 1,
+    'invalidate_sessions': True,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [],
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -293,39 +751,18 @@
     }),
   })
 # ---
-# name: TestUpdate.test_set_groups[mongo_2]
+# name: TestUpdate.test_primary_group_when_member[mongo]
   dict({
     '_id': 'bf1b993c',
     'active': True,
     'force_reset': False,
     'groups': list([
-      2,
-    ]),
-    'handle': 'qtaylor',
-    'invalidate_sessions': False,
-    'last_password_change': datetime,
-    'primary_group': None,
-    'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
-      'show_ids': True,
-      'show_versions': True,
-      'skip_quick_analyze_dialog': True,
-    }),
-  })
-# ---
-# name: TestUpdate.test_set_groups[mongo_3]
-  dict({
-    '_id': 'bf1b993c',
-    'active': True,
-    'force_reset': False,
-    'groups': list([
-      2,
       1,
     ]),
-    'handle': 'qtaylor',
+    'handle': 'laura56',
     'invalidate_sessions': False,
-    'last_password_change': datetime,
-    'primary_group': None,
+    'last_password_change': 'approximately_now_datetime',
+    'primary_group': 1,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -334,26 +771,7 @@
     }),
   })
 # ---
-# name: TestUpdate.test_set_groups[mongo_4]
-  dict({
-    '_id': 'bf1b993c',
-    'active': True,
-    'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'qtaylor',
-    'invalidate_sessions': False,
-    'last_password_change': datetime,
-    'primary_group': None,
-    'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
-      'show_ids': True,
-      'show_versions': True,
-      'skip_quick_analyze_dialog': True,
-    }),
-  })
-# ---
-# name: TestUpdate.test_set_groups[obj_1]
+# name: TestUpdate.test_primary_group_when_member[obj]
   dict({
     'active': True,
     'administrator_role': None,
@@ -364,81 +782,15 @@
     'b2c_oid': None,
     'force_reset': False,
     'groups': list([
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[obj_2]
-  dict({
-    'active': True,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 2,
-        'legacy_id': None,
-        'name': 'hydrogeologists',
-      }),
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
-    }),
-    'primary_group': None,
-  })
-# ---
-# name: TestUpdate.test_set_groups[obj_3]
-  dict({
-    'active': True,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
-    'b2c_oid': None,
-    'force_reset': False,
-    'groups': list([
-      dict({
-        'id': 2,
-        'legacy_id': None,
-        'name': 'hydrogeologists',
-      }),
       dict({
         'id': 1,
         'legacy_id': None,
         'name': 'musicians',
       }),
     ]),
-    'handle': 'qtaylor',
+    'handle': 'laura56',
     'id': 'bf1b993c',
-    'last_password_change': datetime,
+    'last_password_change': 'approximately_now_datetime',
     'permissions': dict({
       'cancel_job': False,
       'create_ref': False,
@@ -449,35 +801,410 @@
       'remove_job': False,
       'upload_file': False,
     }),
-    'primary_group': None,
+    'primary_group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'musicians',
+    }),
   })
 # ---
-# name: TestUpdate.test_set_groups[obj_4]
+# name: TestUpdate.test_primary_group_when_member[pg]
   dict({
     'active': True,
-    'administrator_role': None,
-    'b2c': None,
-    'b2c_display_name': None,
-    'b2c_family_name': None,
-    'b2c_given_name': None,
+    'b2c_display_name': '',
+    'b2c_family_name': '',
+    'b2c_given_name': '',
     'b2c_oid': None,
+    'email': '',
     'force_reset': False,
-    'groups': list([
-    ]),
-    'handle': 'qtaylor',
-    'id': 'bf1b993c',
-    'last_password_change': datetime,
-    'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
+    'groups': [<SQLGroup(id=1, legacy_id=None, name=musicians, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>],
+    'handle': 'laura56',
+    'id': 1,
+    'invalidate_sessions': False,
+    'last_password_change': 'approximately_now_datetime',
+    'legacy_id': 'bf1b993c',
+    'primary_group': [<SQLGroup(id=1, legacy_id=None, name=musicians, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>],
+    'settings': dict({
+      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'show_ids': True,
+      'show_versions': True,
+      'skip_quick_analyze_dialog': True,
     }),
-    'primary_group': None,
+  })
+# ---
+# name: test_find[False-None]
+  dict({
+    'found_count': 1,
+    'items': list([
+      dict({
+        'active': True,
+        'administrator_role': None,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+        ]),
+        'handle': 'diamond21',
+        'id': '7cf872dc',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': None,
+      }),
+    ]),
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[False-missing-handle]
+  dict({
+    'found_count': 0,
+    'items': list([
+    ]),
+    'page': 1,
+    'page_count': 0,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[False-test_user]
+  dict({
+    'found_count': 0,
+    'items': list([
+    ]),
+    'page': 1,
+    'page_count': 0,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[None-None]
+  dict({
+    'found_count': 3,
+    'items': list([
+      dict({
+        'active': True,
+        'administrator_role': None,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+        ]),
+        'handle': 'diamond21',
+        'id': '7cf872dc',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+      dict({
+        'active': True,
+        'administrator_role': <AdministratorRole.FULL: 'full'>,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+        ]),
+        'handle': 'juliewilliams',
+        'id': 'fb085f7f',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+      dict({
+        'active': True,
+        'administrator_role': <AdministratorRole.BASE: 'base'>,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+          dict({
+            'id': 2,
+            'legacy_id': None,
+            'name': 'hydrogeologists',
+          }),
+          dict({
+            'id': 1,
+            'legacy_id': None,
+            'name': 'musicians',
+          }),
+        ]),
+        'handle': 'test_user',
+        'id': 'bf1b993c',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+    ]),
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[None-missing-handle]
+  dict({
+    'found_count': 0,
+    'items': list([
+    ]),
+    'page': 1,
+    'page_count': 0,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[None-test_user]
+  dict({
+    'found_count': 1,
+    'items': list([
+      dict({
+        'active': True,
+        'administrator_role': <AdministratorRole.BASE: 'base'>,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+          dict({
+            'id': 2,
+            'legacy_id': None,
+            'name': 'hydrogeologists',
+          }),
+          dict({
+            'id': 1,
+            'legacy_id': None,
+            'name': 'musicians',
+          }),
+        ]),
+        'handle': 'test_user',
+        'id': 'bf1b993c',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+    ]),
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[True-None]
+  dict({
+    'found_count': 2,
+    'items': list([
+      dict({
+        'active': True,
+        'administrator_role': <AdministratorRole.FULL: 'full'>,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+        ]),
+        'handle': 'juliewilliams',
+        'id': 'fb085f7f',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+      dict({
+        'active': True,
+        'administrator_role': <AdministratorRole.BASE: 'base'>,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+          dict({
+            'id': 2,
+            'legacy_id': None,
+            'name': 'hydrogeologists',
+          }),
+          dict({
+            'id': 1,
+            'legacy_id': None,
+            'name': 'musicians',
+          }),
+        ]),
+        'handle': 'test_user',
+        'id': 'bf1b993c',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+    ]),
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[True-missing-handle]
+  dict({
+    'found_count': 0,
+    'items': list([
+    ]),
+    'page': 1,
+    'page_count': 0,
+    'per_page': 25,
+    'total_count': 3,
+  })
+# ---
+# name: test_find[True-test_user]
+  dict({
+    'found_count': 1,
+    'items': list([
+      dict({
+        'active': True,
+        'administrator_role': <AdministratorRole.BASE: 'base'>,
+        'b2c': None,
+        'b2c_display_name': None,
+        'b2c_family_name': None,
+        'b2c_given_name': None,
+        'b2c_oid': None,
+        'force_reset': False,
+        'groups': list([
+          dict({
+            'id': 2,
+            'legacy_id': None,
+            'name': 'hydrogeologists',
+          }),
+          dict({
+            'id': 1,
+            'legacy_id': None,
+            'name': 'musicians',
+          }),
+        ]),
+        'handle': 'test_user',
+        'id': 'bf1b993c',
+        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
+        'permissions': dict({
+          'cancel_job': False,
+          'create_ref': False,
+          'create_sample': False,
+          'modify_hmm': False,
+          'modify_subtraction': False,
+          'remove_file': False,
+          'remove_job': False,
+          'upload_file': False,
+        }),
+        'primary_group': dict({
+          'id': 1,
+          'legacy_id': None,
+          'name': 'musicians',
+        }),
+      }),
+    ]),
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 3,
   })
 # ---
 # name: test_find_or_create_b2c_user[False]
@@ -534,353 +1261,6 @@
       'upload_file': False,
     }),
     'primary_group': None,
-  })
-# ---
-# name: test_find_users[False-None]
-  dict({
-    'found_count': 1,
-    'items': list([
-      dict({
-        'active': True,
-        'administrator_role': None,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-        ]),
-        'handle': 'diamond21',
-        'id': '7cf872dc',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-    ]),
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[False-missing-handle]
-  dict({
-    'found_count': 0,
-    'items': list([
-    ]),
-    'page': 1,
-    'page_count': 0,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[False-test_user]
-  dict({
-    'found_count': 0,
-    'items': list([
-    ]),
-    'page': 1,
-    'page_count': 0,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[None-None]
-  dict({
-    'found_count': 3,
-    'items': list([
-      dict({
-        'active': True,
-        'administrator_role': None,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-        ]),
-        'handle': 'diamond21',
-        'id': '7cf872dc',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-      dict({
-        'active': True,
-        'administrator_role': <AdministratorRole.FULL: 'full'>,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-        ]),
-        'handle': 'juliewilliams',
-        'id': 'fb085f7f',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-      dict({
-        'active': True,
-        'administrator_role': <AdministratorRole.BASE: 'base'>,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-          dict({
-            'id': 2,
-            'legacy_id': None,
-            'name': 'hydrogeologists',
-          }),
-          dict({
-            'id': 1,
-            'legacy_id': None,
-            'name': 'musicians',
-          }),
-        ]),
-        'handle': 'test_user',
-        'id': 'bf1b993c',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-    ]),
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[None-missing-handle]
-  dict({
-    'found_count': 0,
-    'items': list([
-    ]),
-    'page': 1,
-    'page_count': 0,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[None-test_user]
-  dict({
-    'found_count': 1,
-    'items': list([
-      dict({
-        'active': True,
-        'administrator_role': <AdministratorRole.BASE: 'base'>,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-          dict({
-            'id': 2,
-            'legacy_id': None,
-            'name': 'hydrogeologists',
-          }),
-          dict({
-            'id': 1,
-            'legacy_id': None,
-            'name': 'musicians',
-          }),
-        ]),
-        'handle': 'test_user',
-        'id': 'bf1b993c',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-    ]),
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[True-None]
-  dict({
-    'found_count': 2,
-    'items': list([
-      dict({
-        'active': True,
-        'administrator_role': <AdministratorRole.FULL: 'full'>,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-        ]),
-        'handle': 'juliewilliams',
-        'id': 'fb085f7f',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-      dict({
-        'active': True,
-        'administrator_role': <AdministratorRole.BASE: 'base'>,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-          dict({
-            'id': 2,
-            'legacy_id': None,
-            'name': 'hydrogeologists',
-          }),
-          dict({
-            'id': 1,
-            'legacy_id': None,
-            'name': 'musicians',
-          }),
-        ]),
-        'handle': 'test_user',
-        'id': 'bf1b993c',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-    ]),
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[True-missing-handle]
-  dict({
-    'found_count': 0,
-    'items': list([
-    ]),
-    'page': 1,
-    'page_count': 0,
-    'per_page': 25,
-    'total_count': 3,
-  })
-# ---
-# name: test_find_users[True-test_user]
-  dict({
-    'found_count': 1,
-    'items': list([
-      dict({
-        'active': True,
-        'administrator_role': <AdministratorRole.BASE: 'base'>,
-        'b2c': None,
-        'b2c_display_name': None,
-        'b2c_family_name': None,
-        'b2c_given_name': None,
-        'b2c_oid': None,
-        'force_reset': False,
-        'groups': list([
-          dict({
-            'id': 2,
-            'legacy_id': None,
-            'name': 'hydrogeologists',
-          }),
-          dict({
-            'id': 1,
-            'legacy_id': None,
-            'name': 'musicians',
-          }),
-        ]),
-        'handle': 'test_user',
-        'id': 'bf1b993c',
-        'last_password_change': datetime.datetime(2015, 10, 6, 20, 0),
-        'permissions': dict({
-          'cancel_job': False,
-          'create_ref': False,
-          'create_sample': False,
-          'modify_hmm': False,
-          'modify_subtraction': False,
-          'remove_file': False,
-          'remove_job': False,
-          'upload_file': False,
-        }),
-        'primary_group': None,
-      }),
-    ]),
-    'page': 1,
-    'page_count': 1,
-    'per_page': 25,
-    'total_count': 3,
   })
 # ---
 # name: test_set_administrator_role[None][obj]

--- a/tests/users/__snapshots__/test_db.ambr
+++ b/tests/users/__snapshots__/test_db.ambr
@@ -1,42 +1,4 @@
 # serializer version: 1
-# name: test_attach_user_transform[False]
-  dict({
-    '_id': 'bar',
-    'user': dict({
-      'administrator': False,
-      'handle': 'leeashley',
-      'id': 'bf1b993c',
-    }),
-  })
-# ---
-# name: test_attach_user_transform[True]
-  list([
-    dict({
-      '_id': 'bar',
-      'user': dict({
-        'administrator': False,
-        'handle': 'leeashley',
-        'id': 'bf1b993c',
-      }),
-    }),
-    dict({
-      '_id': 'foo',
-      'user': dict({
-        'administrator': False,
-        'handle': 'zclark',
-        'id': 'fb085f7f',
-      }),
-    }),
-    dict({
-      '_id': 'baz',
-      'user': dict({
-        'administrator': False,
-        'handle': 'leeashley',
-        'id': 'bf1b993c',
-      }),
-    }),
-  ])
-# ---
 # name: test_update_keys[False-False-False]
   dict({
     '_id': 'foobar',

--- a/tests/users/test_api.py
+++ b/tests/users/test_api.py
@@ -1,10 +1,14 @@
 import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy import SnapshotAssertion
+from tests.fixtures.client import ClientSpawner
 from virtool_core.models.enums import Permission
 from virtool_core.models.roles import SpaceSampleRole, SpaceReferenceRole
 
-from tests.fixtures.client import ClientSpawner
 from virtool.authorization.relationships import UserRoleAssignment
+from virtool.data.topg import both_transactions
+from virtool.users.pg import SQLUser
 from virtool.data.layer import DataLayer
 from virtool.data.utils import get_data_from_app
 from virtool.fake.next import DataFaker
@@ -324,6 +328,7 @@ async def test_create_first_user(
     first_user_exists: bool,
     status: int,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     spawn_client: ClientSpawner,
     static_time,
@@ -334,7 +339,9 @@ async def test_create_first_user(
     client = await spawn_client()
 
     if not first_user_exists:
-        await mongo.users.delete_many({})
+        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+            await pg_session.execute(delete(SQLUser))
+            await mongo.users.delete_many({}, session=mongo_session)
 
     resp = await client.put(
         "/users/first", {"handle": "fred", "password": "hello_world"}

--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -98,7 +98,7 @@ class AccountView(PydanticView):
 
 
 @routes.view("/account/settings")
-class SettingsView(PydanticView):
+class AccountsSettingsView(PydanticView):
     async def get(self) -> r200[AccountSettingsResponse] | r401:
         """
         Get account settings.
@@ -110,7 +110,7 @@ class SettingsView(PydanticView):
             401: Requires authorization
         """
         account_settings = await get_data_from_req(self.request).account.get_settings(
-            "settings", self.request["client"].user_id
+            self.request["client"].user_id
         )
 
         return json_response(AccountSettingsResponse.parse_obj(account_settings))
@@ -129,7 +129,7 @@ class SettingsView(PydanticView):
             401: Requires Authorization
         """
         settings = await get_data_from_req(self.request).account.update_settings(
-            data, "settings", self.request["client"].user_id
+            data, self.request["client"].user_id
         )
 
         return json_response(AccountSettingsResponse.parse_obj(settings))

--- a/virtool/account/oas.py
+++ b/virtool/account/oas.py
@@ -17,15 +17,6 @@ class UpdateAccountRequest(BaseModel):
     old_password: str | None = Field(description="the old password for verification")
     password: str | None = Field(description="the new password")
 
-    class Config:
-        schema_extra = {
-            "example": {
-                "email": "dev@virtool.ca",
-                "password": "foo_bar_1",
-                "old_password": "hello_world",
-            }
-        }
-
     @root_validator
     def check_password(cls, values: Union[str, constr]):
         """
@@ -47,9 +38,17 @@ class UpdateAccountRequest(BaseModel):
 
         return values
 
-    _email_validation = validator("email", allow_reuse=True)(check_email)
-
+    _email_validator = validator("email", allow_reuse=True)(check_email)
     _prevent_none = prevent_none("*")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "email": "dev@virtool.ca",
+                "password": "foo_bar_1",
+                "old_password": "hello_world",
+            }
+        }
 
 
 class UpdateAccountResponse(Account):
@@ -88,17 +87,17 @@ class UpdateSettingsRequest(BaseModel):
     Fields for updating a user account's settings.
     """
 
-    show_ids: Optional[bool] = Field(
-        description="show document ids in client where possible"
-    )
-    skip_quick_analyze_dialog: Optional[bool] = Field(
-        description="don’t show the quick analysis dialog"
-    )
-    quick_analyze_workflow: Optional[QuickAnalyzeWorkflow] = Field(
+    quick_analyze_workflow: QuickAnalyzeWorkflow | None = Field(
         description="workflow to use for quick analysis"
     )
-    show_versions: Optional[bool] = Field(
+    show_ids: bool | None = Field(
+        description="show document ids in client where possible"
+    )
+    show_versions: bool | None = Field(
         description="show document versions in client where possible"
+    )
+    skip_quick_analyze_dialog: bool | None = Field(
+        description="don’t show the quick analysis dialog"
     )
 
     class Config:
@@ -151,7 +150,7 @@ class CreateAPIKeyResponse(APIKey):
 
 
 class UpdateKeyRequest(BaseModel):
-    permissions: Optional[PermissionsUpdate] = Field(
+    permissions: PermissionsUpdate | None = Field(
         description="a permission update comprising an object keyed by permissions "
         "with boolean values"
     )
@@ -159,7 +158,7 @@ class UpdateKeyRequest(BaseModel):
     class Config:
         schema_extra = {"example": {"permissions": {"modify_subtraction": True}}}
 
-    _prevent_none = prevent_none("permissions")
+    _prevent_none = prevent_none("*")
 
 
 class APIKeyResponse(APIKey):
@@ -187,7 +186,7 @@ class APIKeyResponse(APIKey):
 class CreateLoginRequest(BaseModel):
     username: constr(min_length=1) = Field(description="account username")
     password: constr(min_length=1) = Field(description="account password")
-    remember: Optional[bool] = Field(
+    remember: bool | None = Field(
         default=False,
         description="value determining whether the session will last for 1 month or "
         "1 hour",
@@ -202,7 +201,7 @@ class CreateLoginRequest(BaseModel):
             }
         }
 
-    _prevent_none = prevent_none("remember")
+    _prevent_none = prevent_none("*")
 
 
 class LoginResponse(BaseModel):
@@ -213,6 +212,8 @@ class LoginResponse(BaseModel):
 class ResetPasswordRequest(BaseModel):
     password: str
     reset_code: str
+
+    _prevent_none = prevent_none("*")
 
     class Config:
         schema_extra = {

--- a/virtool/api/logging.py
+++ b/virtool/api/logging.py
@@ -1,0 +1,13 @@
+from aiohttp.web import Request, middleware
+from structlog import get_logger
+
+logger = get_logger("http")
+
+
+@middleware
+async def logging_middleware(req: Request, handler):
+    resp = await handler(req)
+
+    logger.info("handled request", method=req.method, path=req.path, status=resp.status)
+
+    return resp

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -1,3 +1,5 @@
+import logging.config
+
 import aiohttp.web
 import aiojobs
 import aiojobs.aiohttp
@@ -7,6 +9,7 @@ from virtool.api.accept import accept_middleware
 from virtool.api.authentication import authentication_middleware
 from virtool.api.errors import error_middleware
 from virtool.api.headers import headers_middleware, on_prepare_location
+from virtool.api.logging import logging_middleware
 from virtool.api.policy import route_policy_middleware
 from virtool.config.cls import Config
 from virtool.flags import FeatureFlags, feature_flag_middleware
@@ -35,7 +38,15 @@ from virtool.startup import (
 
 
 def create_app_without_startup():
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": True,
+        }
+    )
+
     middlewares = [
+        logging_middleware,
         headers_middleware,
         error_middleware,
         authentication_middleware,
@@ -57,6 +68,7 @@ def create_app(config: Config):
 
     """
     middlewares = [
+        logging_middleware,
         headers_middleware,
         accept_middleware,
         error_middleware,
@@ -109,4 +121,4 @@ def create_app(config: Config):
 
 def run_api_server(config: Config):
     app = create_app(config)
-    aiohttp.web.run_app(app=app, host=config.host, port=config.port)
+    aiohttp.web.run_app(app=app, host=config.host, port=config.port, access_log=None)

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -102,7 +102,7 @@ def create_data_layer(
     jobs_client = JobsClient(redis)
 
     data_layer = DataLayer(
-        AccountData(mongo, redis, authorization_client, pg),
+        AccountData(authorization_client, mongo, pg, redis),
         AdministratorsData(authorization_client, mongo, pg),
         AnalysisData(mongo, config, pg),
         BLASTData(client, mongo, pg),

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -465,7 +465,8 @@ class UsersFakerPiece(DataFakerPiece):
             return await self._layer.users.update(
                 user.id,
                 UpdateUserRequest(
-                    groups=list({group.id for group in groups} | {primary_group.id})
+                    groups=list({group.id for group in groups} | {primary_group.id}),
+                    primary_group=primary_group.id,
                 ),
             )
 

--- a/virtool/migration/pg.py
+++ b/virtool/migration/pg.py
@@ -9,7 +9,7 @@ from structlog import get_logger
 from virtool.migration.cls import AppliedRevision
 from virtool.pg.base import Base
 
-REQUIRED_VIRTOOL_REVISION = "011389a5ae19"
+REQUIRED_VIRTOOL_REVISION = "5df816cef12f"
 
 logger = get_logger("migration")
 

--- a/virtool/users/oas.py
+++ b/virtool/users/oas.py
@@ -8,10 +8,10 @@ class CreateFirstUserRequest(BaseModel):
     """
 
     handle: constr(strip_whitespace=True, min_length=1) = Field(
-        description="The unique handle for the user."
+        description="the unique handle for the user"
     )
 
-    password: constr(min_length=1) = Field(description="The password for the user.")
+    password: constr(min_length=1) = Field(description="the password for the user")
 
 
 class CreateUserRequest(CreateFirstUserRequest):
@@ -20,28 +20,28 @@ class CreateUserRequest(CreateFirstUserRequest):
     """
 
     force_reset: bool = Field(
-        default=True, description="Forces a password reset next time the user logs in"
+        default=True, description="forces a password reset next time the user logs in"
     )
 
 
 class UpdateUserRequest(BaseModel):
     active: bool | None = Field(description="make a user active or not")
 
-    groups: list[int | str] | None = Field(
-        description="sets the IDs of groups the user belongs to"
-    )
-
     force_reset: bool | None = Field(
         description="forces a password reset next time the user logs in"
+    )
+
+    groups: list[int | str] | None = Field(
+        description="sets the IDs of groups the user belongs to"
     )
 
     password: str | None = Field(description="the new password")
 
     primary_group: int | None = Field(
-        description="Sets the ID of the user's primary group"
+        description="set the ID of the user's primary group"
     )
 
-    _prevent_none = prevent_none("force_reset", "groups", "password")
+    _prevent_none = prevent_none("active", "force_reset", "groups", "password")
 
 
 class PermissionsResponse(BaseModel):

--- a/virtool/users/pg.py
+++ b/virtool/users/pg.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+
+from sqlalchemy import Index, ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.associationproxy import AssociationProxy
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from virtool.groups.pg import SQLGroup
+from virtool.pg.base import Base
+
+
+class SQLUserGroup(Base):
+    __tablename__ = "user_groups"
+
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("groups.id", ondelete="CASCADE"), primary_key=True
+    )
+    primary: Mapped[bool] = mapped_column(default=False)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+
+    group: Mapped["SQLGroup"] = relationship(lazy="joined")
+    user: Mapped["SQLUser"] = relationship(back_populates="user_group_associations")
+
+    __table_args__ = (
+        Index(
+            "primary_group_unique",
+            primary,
+            user_id,
+            unique=True,
+            postgresql_where=(primary is True),
+        ),
+    )
+
+
+class SQLUser(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    active: Mapped[bool] = mapped_column(default=True)
+    b2c_display_name: Mapped[str] = mapped_column(default="")
+    b2c_given_name: Mapped[str] = mapped_column(default="")
+    b2c_family_name: Mapped[str] = mapped_column(default="")
+    b2c_oid: Mapped[str | None]
+    email: Mapped[str] = mapped_column(default="", nullable=False)
+    force_reset: Mapped[bool] = mapped_column(default=False)
+    handle: Mapped[str]
+    invalidate_sessions: Mapped[bool] = mapped_column(default=False)
+    last_password_change: Mapped[datetime]
+    legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    password: Mapped[bytes | None]
+    settings: Mapped[dict] = mapped_column(JSONB)
+
+    user_group_associations: Mapped[list[SQLUserGroup]] = relationship(
+        back_populates="user", cascade="all, delete-orphan", lazy="joined"
+    )
+
+    groups: AssociationProxy[list[SQLGroup]] = AssociationProxy(
+        "user_group_associations",
+        "group",
+        creator=lambda group: SQLUserGroup(group=group),
+    )
+
+    primary_group_association: Mapped[SQLUserGroup] = relationship(
+        back_populates="user",
+        lazy="joined",
+        primaryjoin="and_(user_groups.c.user_id == SQLUser.id, user_groups.c.primary == True)",
+        viewonly=True,
+    )
+
+    primary_group: AssociationProxy[SQLGroup] = AssociationProxy(
+        "primary_group_association",
+        "group",
+    )
+
+    def to_dict(self):
+        return {
+            **super().to_dict(),
+            "groups": self.groups,
+            "primary_group": self.primary_group,
+        }
+
+    def __repr__(self):
+        params = ", ".join(
+            f"{column}='{type(value).__name__ if column == 'last_password_change' else value}'"
+            for column, value in self.to_dict().items()
+            if column not in ["password"]
+        )
+
+        return f"<{self.__class__.__name__}({params})>"

--- a/virtool/users/settings.py
+++ b/virtool/users/settings.py
@@ -1,0 +1,8 @@
+"""Default user settings."""
+
+DEFAULT_USER_SETTINGS = {
+    "skip_quick_analyze_dialog": True,
+    "show_ids": True,
+    "show_versions": True,
+    "quick_analyze_workflow": "pathoscope_bowtie",
+}


### PR DESCRIPTION
created own PR to allow for review functions to work better

The old line wasn't working for test_force_reset as the SQLUser did not store force reset without it being a column or mapped_column. See picture below, and note that all b2c is not stored in the SQLUser as well.

![image](https://github.com/virtool/virtool/assets/63571383/4ef812ef-98ef-4116-a52b-6857d92ac287)


The Mapped[bool] is only a type hint that is really only useful to the reader, unless it gets checked with mypy or other static analysis tools.

The mapped_column does work to pass the test and not fail any other existing test.


Did you want me to make all columns mapped?