### PR TITLE
fix failing tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           docker network create openfga
           docker run -d --name postgres --network=openfga -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:14.5
-          docker run --rm --network=openfga openfga/openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
-          docker run -d --name openfga --network=openfga -p 8080:8080 openfga/openfga run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable' --playground-enabled=false
+          docker run --rm --network=openfga openfga/openfga:v0.2.5 migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
+          docker run -d --name openfga --network=openfga -p 8080:8080 openfga/openfga:v0.2.5 run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable' --playground-enabled=false
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:
@@ -126,8 +126,8 @@ jobs:
         run: |
           docker network create openfga
           docker run -d --name postgres --network=openfga -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:14.5
-          docker run --rm --network=openfga openfga/openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
-          docker run -d --name openfga --network=openfga -p 8080:8080 openfga/openfga run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable' --playground-enabled=false
+          docker run --rm --network=openfga openfga/openfga:v0.2.5 migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable'
+          docker run -d --name openfga --network=openfga -p 8080:8080 openfga/openfga:v0.2.5 run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@postgres:5432/postgres?sslmode=disable' --playground-enabled=false
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -3698,6 +3698,7 @@
           }),
           'workflow': 'jobs_aodp',
         }),
+        'ml': None,
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
@@ -3749,6 +3750,7 @@
           }),
           'workflow': 'jobs_aodp',
         }),
+        'ml': None,
         'ready': True,
         'reference': dict({
           'data_type': 'genome',


### PR DESCRIPTION
* The latest version of OpenFGA is bugged. I have pinned the image to `0.2.5` like we use in production.
* Fixed two snapshots still broken from addition of `ml` field to analyses.