### PR TITLE
feat(perf): speed up analysis find operations

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -31,7 +31,13 @@ def create_files(test_files_path, tmp_path):
 
 
 @pytest.mark.apitest
-async def test_find(snapshot, mocker, fake2, spawn_client, static_time):
+async def test_find(
+    mocker,
+    fake2: DataFaker,
+    snapshot: SnapshotAssertion,
+    spawn_client: ClientSpawner,
+    static_time,
+):
     mocker.patch("virtool.samples.utils.get_sample_rights", return_value=(True, True))
 
     client = await spawn_client(authenticated=True)
@@ -55,6 +61,9 @@ async def test_find(snapshot, mocker, fake2, spawn_client, static_time):
                 "created_at": static_time.datetime,
                 "all_read": True,
                 "all_write": True,
+                "group": "none",
+                "group_read": False,
+                "group_write": False,
                 "user": {"id": user_1.id},
                 "labels": [],
             }

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -2028,6 +2028,122 @@
     }),
   })
 # ---
+# name: test_find_analyses
+  dict({
+    'documents': list([
+      dict({
+        'created_at': '2015-10-06T20:00:00Z',
+        'id': 'test_1',
+        'index': dict({
+          'id': 'foo',
+          'version': 2,
+        }),
+        'job': dict({
+          'archived': False,
+          'created_at': '2015-10-06T20:00:00Z',
+          'id': '3cbb22cc',
+          'progress': 50,
+          'stage': 'JURZHTCWaKMqqBTFitpK',
+          'state': 'timeout',
+          'user': dict({
+            'administrator': False,
+            'handle': 'leeashley',
+            'id': 'fb085f7f',
+          }),
+          'workflow': 'jobs_aodp',
+        }),
+        'ml': None,
+        'ready': True,
+        'reference': dict({
+          'data_type': 'genome',
+          'id': 'baz',
+          'name': 'Baz',
+        }),
+        'sample': dict({
+          'id': 'test',
+        }),
+        'subtractions': list([
+        ]),
+        'updated_at': '2015-10-06T20:00:00Z',
+        'user': dict({
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': 'fb085f7f',
+        }),
+        'workflow': 'pathoscope_bowtie',
+      }),
+      dict({
+        'created_at': '2015-10-06T20:00:00Z',
+        'id': 'test_2',
+        'index': dict({
+          'id': 'foo',
+          'version': 2,
+        }),
+        'job': None,
+        'ml': None,
+        'ready': True,
+        'reference': dict({
+          'data_type': 'genome',
+          'id': 'baz',
+          'name': 'Baz',
+        }),
+        'sample': dict({
+          'id': 'test',
+        }),
+        'subtractions': list([
+          dict({
+            'id': 'foo',
+            'name': 'Malus domestica',
+          }),
+        ]),
+        'updated_at': '2015-10-06T20:00:00Z',
+        'user': dict({
+          'administrator': False,
+          'handle': 'leeashley',
+          'id': 'fb085f7f',
+        }),
+        'workflow': 'pathoscope_bowtie',
+      }),
+      dict({
+        'created_at': '2015-10-06T20:00:00Z',
+        'id': 'test_3',
+        'index': dict({
+          'id': 'foo',
+          'version': 2,
+        }),
+        'job': None,
+        'ml': None,
+        'ready': True,
+        'reference': dict({
+          'data_type': 'genome',
+          'id': 'foo',
+          'name': 'Foo',
+        }),
+        'sample': dict({
+          'id': 'test',
+        }),
+        'subtractions': list([
+          dict({
+            'id': 'foo',
+            'name': 'Malus domestica',
+          }),
+        ]),
+        'updated_at': '2015-10-06T20:00:00Z',
+        'user': dict({
+          'administrator': False,
+          'handle': 'zclark',
+          'id': '7cf872dc',
+        }),
+        'workflow': 'pathoscope_bowtie',
+      }),
+    ]),
+    'found_count': 3,
+    'page': 1,
+    'page_count': 1,
+    'per_page': 25,
+    'total_count': 4,
+  })
+# ---
 # name: test_find_analyses[Baz-None]
   dict({
     'documents': list([

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -3,7 +3,7 @@ import pytest
 import virtool.subtractions.db
 from virtool.data.transforms import apply_transforms
 from virtool.subtractions.db import (
-    AttachSubtractionTransform,
+    AttachSubtractionsTransform,
     unlink_default_subtractions,
 )
 
@@ -24,7 +24,7 @@ async def test_attach_subtractions(documents, mongo, snapshot):
         [{"_id": "foo", "name": "Foo"}, {"_id": "bar", "name": "Bar"}], session=None
     )
 
-    result = await apply_transforms(documents, [AttachSubtractionTransform(mongo)])
+    result = await apply_transforms(documents, [AttachSubtractionsTransform(mongo)])
 
     assert result == snapshot
 

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -2,14 +2,19 @@
 Work with analyses in the database.
 
 """
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.analyses.models import SQLAnalysisFile
 from virtool.data.transforms import AbstractTransform
+from virtool.samples.utils import get_sample_rights
 from virtool.types import Document
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
+
 
 PROJECTION = (
     "_id",
@@ -54,3 +59,42 @@ class AttachAnalysisFileTransform(AbstractTransform):
             )
 
         return [result.to_dict() for result in results]
+
+
+async def filter_analyses_by_sample_rights(
+    client, mongo: "Mongo", analyses: list[dict]
+) -> list[dict]:
+    """
+    Filter a list of analyses based on the user's rights to the samples they are associated with.
+
+    :param mongo: the application database client
+    :param analyses: the analyses to filter
+    :return: the filtered analyses
+
+    """
+    sample_ids = {a["sample"]["id"] for a in analyses}
+
+    sample_rights = await mongo.samples.find(
+        {"_id": {"$in": list(sample_ids)}},
+        [
+            "_id",
+            "group",
+            "group_read",
+            "group_write",
+            "all_read",
+            "all_write",
+            "user",
+        ],
+    ).to_list(None)
+
+    sample_rights_lookup = {s["_id"]: s for s in sample_rights}
+
+    filtered = []
+
+    for analysis in analyses:
+        sample_id = analysis["sample"]["id"]
+
+        if get_sample_rights(sample_rights_lookup[sample_id], client):
+            filtered.append(analysis)
+
+    return filtered


### PR DESCRIPTION
Take some measures to try to speed up the analysis find enpdoints:
* Convert all lookups to transforms. Mongo lookups in aggregations have been difficult to optimize.
* Get rid of extra round of transforms.
* Make sample right checking more efficient. It now only checks for each sample referred to by the analyses once, instead of checking for every analysis document.