### PR TITLE
Attempt build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Commitlint
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: docker build .
   test-api:
@@ -49,7 +49,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Start OpenFGA
         run: |
           bash .github/workflows/scripts/setup_postgres.sh          
@@ -120,7 +120,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Start OpenFGA
         run: |
           bash .github/workflows/scripts/setup_postgres.sh          
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -207,7 +207,7 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
@@ -236,7 +236,7 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download OAS
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build
-        run: docker build .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
   test-api:
     runs-on: ubuntu-22.04
     services:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,13 @@ jobs:
     if: github.repository_owner == 'Virtool'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Write VERSION
         run: echo ${{ github.event.release.tag_name }} > VERSION
       - name: Update pyproject.toml version
         run: sed -i 's/0\.0\.0/${{ github.event.release.tag_name }}/' pyproject.toml
       - name: Login to Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GH_USERNAME }}
@@ -39,7 +39,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/virtool/virtool
       - name: Build and Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true


### PR DESCRIPTION
Try some changes to fix failing image builds.

```
No matching distribution found for virtool-core<124.0.0,>=123.0.1
```

* Fix `poetry.lock` / `pyproject.toml` inconsistency.
* Update action versions.
* Use `build-push-action` to test image build instead of `docker build .`.