### PR TITLE
Rework session handling

### DIFF
--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -284,7 +284,7 @@ class LoginView(PydanticView):
             400: Invalid input
         """
 
-        session_id = self.request.cookies.get("session_id")
+        session_id = self.request["client"].session_id
         ip = virtool.api.authentication.get_ip(self.request)
 
         try:
@@ -344,7 +344,7 @@ class LogoutView(PydanticView):
             204: Successful operation
         """
         session = await get_data_from_req(self.request).account.logout(
-            self.request.cookies.get("session_id"),
+            self.request["client"].session_id,
             virtool.api.authentication.get_ip(self.request),
         )
 
@@ -376,7 +376,7 @@ class ResetView(PydanticView):
 
         try:
             session, token = await get_data_from_req(self.request).account.reset(
-                self.request.cookies.get("session_id"),
+                self.request["client"].session_id,
                 data,
                 virtool.api.authentication.get_ip(self.request),
             )

--- a/virtool/api/authentication.py
+++ b/virtool/api/authentication.py
@@ -11,11 +11,7 @@ from virtool.api.policy import (
     get_handler_policy,
     PublicRoutePolicy,
 )
-from virtool.api.utils import set_session_id_cookie
 from virtool.config import get_config_from_req
-from virtool.data.errors import (
-    ResourceNotFoundError,
-)
 from virtool.data.utils import get_data_from_req
 from virtool.errors import AuthError
 from virtool.oidc.utils import validate_token
@@ -134,63 +130,27 @@ async def authenticate_with_b2c(req: Request, handler: Callable) -> Response:
 
 async def authenticate_with_session(req: Request, handler: Callable) -> Response:
     """Authenticate the given request with session information in the cookie."""
-    session_id = req.cookies.get("session_id")
-    session_token = req.cookies.get("session_token")
+    session = req["session"]
 
-    if session_id:
-        try:
-            session = await get_data_from_req(req).sessions.get_authenticated(
-                session_id, session_token
-            )
-        except ResourceNotFoundError:
-            try:
-                session = await get_data_from_req(req).sessions.get_anonymous(
-                    session_id
-                )
-            except ResourceNotFoundError:
-                session = await get_data_from_req(req).sessions.create_anonymous(
-                    get_ip(req)
-                )
+    if not session.authentication:
+        raise APIUnauthorized("Requires authorization")
 
-    else:
-        session = await get_data_from_req(req).sessions.create_anonymous(get_ip(req))
+    user = await get_data_from_req(req).users.get(session.authentication.user_id)
 
-    if session.authentication:
-        user = await get_data_from_req(req).users.get(session.authentication.user_id)
+    if not user.active:
+        raise APIUnauthorized("User is deactivated", error_id="deactivated_user")
 
-        if not user.active:
-            raise APIUnauthorized("User is deactivated", error_id="deactivated_user")
-
-        req["client"] = UserClient(
-            administrator_role=user.administrator_role,
-            authenticated=True,
-            force_reset=user.force_reset,
-            groups=[group.id for group in user.groups],
-            permissions=user.permissions.dict(),
-            user_id=user.id,
-            session_id=session_id,
-        )
-    else:
-        req["client"] = UserClient(
-            administrator_role=None,
-            authenticated=False,
-            force_reset=False,
-            groups=[],
-            permissions={},
-            user_id=None,
-            session_id=session_id,
-        )
+    req["client"] = UserClient(
+        administrator_role=user.administrator_role,
+        authenticated=True,
+        force_reset=user.force_reset,
+        groups=[group.id for group in user.groups],
+        permissions=user.permissions.dict(),
+        user_id=user.id,
+        session_id=session.id,
+    )
 
     resp = await handler(req)
-
-    if req.path != "/account/reset" and session.reset:
-        with suppress(ResourceNotFoundError):
-            await get_data_from_req(req).sessions.delete(session_id)
-            session = await get_data_from_req(req).sessions.create_anonymous(
-                get_ip(req)
-            )
-
-    set_session_id_cookie(resp, session.id)
 
     return resp
 
@@ -212,7 +172,7 @@ async def authentication_middleware(req: Request, handler) -> Response:
             groups=[],
             permissions={},
             user_id=None,
-            session_id=None,
+            session_id=req["session"].id,
         )
 
         return await handler(req)

--- a/virtool/api/sessions.py
+++ b/virtool/api/sessions.py
@@ -1,0 +1,50 @@
+from aiohttp import web
+from aiohttp.web import Request, Response
+from virtool_core.models.session import Session
+
+from virtool.api.authentication import get_ip
+from virtool.api.utils import set_session_id_cookie
+from virtool.data.errors import (
+    ResourceNotFoundError,
+)
+from virtool.data.utils import get_data_from_req
+from virtool.utils import get_safely
+
+
+@web.middleware
+async def session_middleware(req: Request, handler) -> Response:
+    req["session"] = await get_session(req)
+
+    resp = await handler(req)
+
+    if not resp.cookies.get("session_id"):
+        set_session_id_cookie(resp, req["session"].id)
+
+    if not req["session"].authentication and not resp.cookies.get("session_token"):
+        resp.del_cookie("session_token")
+
+    return resp
+
+
+async def get_session(req: Request) -> Session:
+    session_id = req.cookies.get("session_id")
+    session_token = req.cookies.get("session_token")
+    sessions_data = get_data_from_req(req).sessions
+
+    try:
+        if session_id:
+            if session_token:
+                return await sessions_data.get_authenticated(session_id, session_token)
+
+            if req.path == "/account/reset":
+                body = await req.json()
+
+                return await sessions_data.get_reset(
+                    session_id, get_safely(body, "reset_code")
+                )
+
+            return await sessions_data.get_anonymous(session_id)
+    except ResourceNotFoundError:
+        pass
+
+    return await get_data_from_req(req).sessions.create_anonymous(get_ip(req))

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -11,6 +11,7 @@ from virtool.api.errors import error_middleware
 from virtool.api.headers import headers_middleware, on_prepare_location
 from virtool.api.logging import logging_middleware
 from virtool.api.policy import route_policy_middleware
+from virtool.api.sessions import session_middleware
 from virtool.config.cls import Config
 from virtool.flags import FeatureFlags, feature_flag_middleware
 from virtool.routes import setup_routes
@@ -49,6 +50,7 @@ def create_app_without_startup():
         logging_middleware,
         headers_middleware,
         error_middleware,
+        session_middleware,
         authentication_middleware,
         accept_middleware,
         route_policy_middleware,
@@ -72,6 +74,7 @@ def create_app(config: Config):
         headers_middleware,
         accept_middleware,
         error_middleware,
+        session_middleware,
         authentication_middleware,
         route_policy_middleware,
         feature_flag_middleware,


### PR DESCRIPTION
Reworks how session authentication is done as well as session management

Changes: 
 - correctly handle cases where the user has no session id
 - replace client's reset session when request is made to non-reset routes
 - deletes the reset session if ever accessed without the reset_code
 - ensures the client always has a session
 - respects `session_id` and `session_token` changes to the response