### PR TITLE
Prevent error when setting sample rights

### DIFF
--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -1,4 +1,289 @@
 # serializer version: 1
+# name: TestChangeSampleRights.test_set_none_group_id[mongo]
+  dict({
+    '_id': 'test',
+    'all_read': True,
+    'all_write': True,
+    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+    'files': list([
+      dict({
+        'download_url': '/download/samples/files/file_1.fq.gz',
+        'id': 'foo',
+        'name': 'Bar.fq.gz',
+      }),
+    ]),
+    'format': 'fastq',
+    'group': 'none',
+    'group_read': True,
+    'group_write': True,
+    'hold': False,
+    'host': '',
+    'is_legacy': False,
+    'isolate': '',
+    'labels': list([
+      1,
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'pathoscope': True,
+    'ready': True,
+    'subtractions': list([
+      'apple',
+      'pear',
+    ]),
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_set_none_group_id[resp]
+  dict({
+    'all_read': True,
+    'all_write': True,
+    'group': 'none',
+    'group_read': True,
+    'group_write': True,
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_all_rights[mongo]
+  dict({
+    '_id': 'test',
+    'all_read': False,
+    'all_write': False,
+    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+    'files': list([
+      dict({
+        'download_url': '/download/samples/files/file_1.fq.gz',
+        'id': 'foo',
+        'name': 'Bar.fq.gz',
+      }),
+    ]),
+    'format': 'fastq',
+    'group': 1,
+    'group_read': False,
+    'group_write': False,
+    'hold': False,
+    'host': '',
+    'is_legacy': False,
+    'isolate': '',
+    'labels': list([
+      1,
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'pathoscope': True,
+    'ready': True,
+    'subtractions': list([
+      'apple',
+      'pear',
+    ]),
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_all_rights[resp]
+  dict({
+    'all_read': False,
+    'all_write': False,
+    'group': 1,
+    'group_read': False,
+    'group_write': False,
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_all_user_rights[mongo]
+  dict({
+    '_id': 'test',
+    'all_read': False,
+    'all_write': False,
+    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+    'files': list([
+      dict({
+        'download_url': '/download/samples/files/file_1.fq.gz',
+        'id': 'foo',
+        'name': 'Bar.fq.gz',
+      }),
+    ]),
+    'format': 'fastq',
+    'group': 'none',
+    'group_read': True,
+    'group_write': True,
+    'hold': False,
+    'host': '',
+    'is_legacy': False,
+    'isolate': '',
+    'labels': list([
+      1,
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'pathoscope': True,
+    'ready': True,
+    'subtractions': list([
+      'apple',
+      'pear',
+    ]),
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_all_user_rights[resp]
+  dict({
+    'all_read': False,
+    'all_write': False,
+    'group': 'none',
+    'group_read': True,
+    'group_write': True,
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_group_id[mongo]
+  dict({
+    '_id': 'test',
+    'all_read': True,
+    'all_write': True,
+    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+    'files': list([
+      dict({
+        'download_url': '/download/samples/files/file_1.fq.gz',
+        'id': 'foo',
+        'name': 'Bar.fq.gz',
+      }),
+    ]),
+    'format': 'fastq',
+    'group': 1,
+    'group_read': True,
+    'group_write': True,
+    'hold': False,
+    'host': '',
+    'is_legacy': False,
+    'isolate': '',
+    'labels': list([
+      1,
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'pathoscope': True,
+    'ready': True,
+    'subtractions': list([
+      'apple',
+      'pear',
+    ]),
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_group_id[resp]
+  dict({
+    'all_read': True,
+    'all_write': True,
+    'group': 1,
+    'group_read': True,
+    'group_write': True,
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_group_rights[mongo]
+  dict({
+    '_id': 'test',
+    'all_read': True,
+    'all_write': True,
+    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+    'files': list([
+      dict({
+        'download_url': '/download/samples/files/file_1.fq.gz',
+        'id': 'foo',
+        'name': 'Bar.fq.gz',
+      }),
+    ]),
+    'format': 'fastq',
+    'group': 'none',
+    'group_read': False,
+    'group_write': False,
+    'hold': False,
+    'host': '',
+    'is_legacy': False,
+    'isolate': '',
+    'labels': list([
+      1,
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'pathoscope': True,
+    'ready': True,
+    'subtractions': list([
+      'apple',
+      'pear',
+    ]),
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
+    }),
+  })
+# ---
+# name: TestChangeSampleRights.test_update_group_rights[resp]
+  dict({
+    'all_read': True,
+    'all_write': True,
+    'group': 'none',
+    'group_read': False,
+    'group_write': False,
+    'user': dict({
+      'id': 'bf1b993c',
+    }),
+  })
+# ---
 # name: TestCreate.test_name_exists[/samples][json]
   dict({
     'id': 'bad_request',

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -325,7 +325,7 @@ class RightsView(PydanticView):
         ):
             raise APIInsufficientRights("Must be administrator or sample owner")
 
-        group = data["group"]
+        group = data.get("group")
 
         if group is not None and group != "none":
             async with AsyncSession(pg) as session:


### PR DESCRIPTION
Changes:
  -  No longer requires setting the group when changing sample rights to prevent a 500 error
  - Adds check that the sample rights API works as expected