### PR TITLE
Correctly timeout stale jobs in the preparing phase

### DIFF
--- a/tests/jobs/__snapshots__/test_data.ambr
+++ b/tests/jobs/__snapshots__/test_data.ambr
@@ -42,6 +42,7 @@
     'key': 'hashed',
     'rights': dict({
     }),
+    'state': 'preparing',
     'status': list([
       dict({
         'error': None,


### PR DESCRIPTION
Changes: 
 - Task for timing out jobs now checks the last item `status` rather than state
 - `acquire` datalayer method now updates the job `state` to `preparing` so that it matches with status