### PR TITLE
test: use bitnami mongo image

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,24 +4,30 @@ services:
   mongo:
     image: bitnami/mongodb:6.0.6
     environment:
-      MONGODB_REPLICA_SET_MODE: primary
-      MONGODB_REPLICA_SET_KEY: virtool
-      MONGODB_ROOT_PASSWORD: virtool
       MONGODB_ADVERTISED_HOSTNAME: localhost
       MONGODB_ADVERTISED_PORT: 9001
       MONGODB_PORT_NUMBER: 9001
+      MONGODB_REPLICA_SET_KEY: virtool
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_ROOT_PASSWORD: virtool
     ports:
       - 9001:9001
 
   postgres:
-    command: -c fsync=off -c shared_buffers=2000MB
     environment:
-      POSTGRES_PASSWORD: virtool
-      POSTGRES_USER: virtool
-      POSTGRES_DB: virtool
-    image: postgres:14.9
+      POSTGRESQL_FSYNC: off
+      POSTGRESQL_PASSWORD: virtool
+      POSTGRESQL_POSTGRES_PASSWORD: virtool
+      POSTGRESQL_USERNAME: virtool
+    image: bitnami/postgresql:14
     ports:
       - 9002:5432
+    volumes:
+      - ./setup_postgres.sh:/docker-entrypoint-initdb.d/setup_postgres.sh
+    healthcheck:
+      test: pg_isready -U postgres -d virtool
+      interval: 2s
+      retries: 5
 
   redis:
     image: redis:6.0
@@ -29,38 +35,24 @@ services:
     ports:
       - 9003:6379
 
-  postgres-openfga:
-    image: postgres:14.5
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: openfga
-    healthcheck:
-      test: pg_isready -U virtool -d virtool
-      interval: 10s
-      timeout: 3s
-      retries: 3
-
   migrate:
     image: openfga/openfga:v0.2.5
     depends_on:
-      postgres-openfga:
+      postgres:
         condition: service_healthy
-    command: |
-      migrate
+    command: migrate
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres
-      OPENFGA_DATASTORE_URI: postgres://postgres:password@postgres-openfga:5432/openfga
+      OPENFGA_DATASTORE_URI: postgres://openfga:openfga@postgres:5432/openfga
 
   openfga:
     image: openfga/openfga:v0.2.5
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres
-      OPENFGA_DATASTORE_URI: postgres://postgres:password@postgres-openfga:5432/openfga
+      OPENFGA_DATASTORE_URI: postgres://openfga:openfga@postgres:5432/openfga
       OPENFGA_LOG_FORMAT: json
     command: run
     depends_on:
-      - postgres-openfga
       - migrate
     ports:
       - "9004:8080"

--- a/tests/setup_postgres.sh
+++ b/tests/setup_postgres.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+export PGPASSWORD=virtool
+psql -v ON_ERROR_STOP=1 --username "postgres" --host "localhost" <<-EOSQL
+  CREATE USER openfga WITH PASSWORD 'openfga';
+	CREATE DATABASE openfga;
+	GRANT ALL PRIVILEGES ON DATABASE openfga TO "virtool";
+	CREATE DATABASE virtool;
+	GRANT ALL PRIVILEGES ON DATABASE virtool TO "openfga";
+EOSQL


### PR DESCRIPTION
## Changes
* Use `bitnami/postgresql` in local testing services.
* Get rid of extra `postgres-openfga` instance.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
