### PR TITLE
refactor: rename `db` to `mongo` in most places

### DIFF
--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -67,9 +67,9 @@ logger = get_logger("analyses")
 class AnalysisData(DataLayerDomain):
     name = "analyses"
 
-    def __init__(self, db: Mongo, config, pg: AsyncEngine):
+    def __init__(self, mongo: Mongo, config, pg: AsyncEngine):
         self._config = config
-        self._mongo = db
+        self._mongo = mongo
         self._pg = pg
 
     async def find(

--- a/virtool/caches/db.py
+++ b/virtool/caches/db.py
@@ -1,46 +1,46 @@
+"""Work with caches in the database. Caches are bundles of trimmed read and QC data
+generated during analyses.
 """
-Work with caches in the database. Caches are bundles of
-trimmed read and QC data generated during analyses.
 
-"""
 from asyncio import to_thread
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any
 
 import pymongo.errors
 from virtool_core.utils import rm
-from virtool.config import get_config_from_app
 
 import virtool.utils
+from virtool.config import get_config_from_app
 from virtool.types import App
 from virtool.utils import base_processor
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
 
 PROJECTION = ("_id", "created_at", "files", "key", "program", "ready", "sample")
 
 
-async def get(db, cache_id: str) -> Dict[str, Any]:
-    """
-    Get the complete representation for the cache with the given `cache_id`.
+async def get(mongo: "Mongo", cache_id: str) -> dict[str, Any]:
+    """Get the complete representation for the cache with the given `cache_id`.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param cache_id: the id of the cache to get
     :return: the cache document
 
     """
-    document = await db.caches.find_one(cache_id)
+    document = await mongo.caches.find_one(cache_id)
     return base_processor(document)
 
 
 async def create(
-    db,
+    mongo: "Mongo",
     sample_id: str,
     key: str,
     paired: bool,
-) -> Dict[str, Any]:
-    """
-    Create and insert a new cache database document.
+) -> dict[str, Any]:
+    """Create and insert a new cache database document.
     Return the generated cache document.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param sample_id: the id of the sample the cache is derived from
     :param key: Unique key for a cache
     :param paired: boolean indicating if the sample contains paired data
@@ -62,7 +62,7 @@ async def create(
             "sample": {"id": sample_id},
         }
 
-        await db.caches.insert_one(document)
+        await mongo.caches.insert_one(document)
 
         return base_processor(document)
 
@@ -70,25 +70,23 @@ async def create(
         # Check if key-sample.id uniqueness was enforced
         # Keep trying to add the cache with new ids if the generated id is not unique.
         if "_id" in e.details["keyPattern"]:
-            return await create(db, sample_id, key, paired)
+            return await create(mongo, sample_id, key, paired)
 
         raise
 
 
 async def remove(app: App, cache_id: str):
-    """
-    Remove the cache database document and files with the given `cache_id`.
+    """Remove the cache database document and files with the given `cache_id`.
 
     :param app: the application object
     :param cache_id: the id of the cache to remove
 
     """
-    db = app["db"]
-    config = get_config_from_app(app)
+    mongo: "Mongo" = app["db"]
 
-    await db.caches.delete_one({"_id": cache_id})
+    await mongo.caches.delete_one({"_id": cache_id})
 
-    path = config.data_path / "caches" / cache_id
+    path = get_config_from_app(app).data_path / "caches" / cache_id
 
     try:
         await to_thread(rm, path, True)

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 from aioredis import Redis
@@ -9,10 +7,9 @@ from virtool.account.data import AccountData
 from virtool.administrators.data import AdministratorsData
 from virtool.analyses.data import AnalysisData
 from virtool.authorization.client import AuthorizationClient
-from virtool.data.http import HTTPClient
-from virtool.ml.data import MLData
 from virtool.blast.data import BLASTData
 from virtool.config import Config
+from virtool.data.http import HTTPClient
 from virtool.groups.data import GroupsData
 from virtool.history.data import HistoryData
 from virtool.hmm.data import HmmsData
@@ -21,6 +18,7 @@ from virtool.jobs.client import JobsClient
 from virtool.jobs.data import JobsData
 from virtool.labels.data import LabelsData
 from virtool.messages.data import MessagesData
+from virtool.ml.data import MLData
 from virtool.mongo.core import Mongo
 from virtool.otus.data import OTUData
 from virtool.references.data import ReferencesData
@@ -37,9 +35,7 @@ from virtool.users.sessions import SessionData
 
 @dataclass
 class DataLayer:
-
-    """
-    Provides access to Virtool application data through an abstract interface over
+    """Provides access to Virtool application data through an abstract interface over
     database and storage.
 
     """
@@ -88,8 +84,7 @@ def create_data_layer(
     client,
     redis: Redis,
 ) -> DataLayer:
-    """
-    Create and return a data layer object.
+    """Create and return a data layer object.
 
     :param authorization_client: the authorization client
     :param mongo: the MongoDB client

--- a/virtool/data/transforms.py
+++ b/virtool/data/transforms.py
@@ -1,5 +1,4 @@
-"""
-Transforms are used to attach additional data to a dictionary before it is sent to the
+"""Transforms are used to attach additional data to a dictionary before it is sent to the
 client.
 
 For example, you have a ``dict`` like the following:
@@ -47,7 +46,6 @@ have the same user ID, you could override :meth:`prepare_many` to only query the
 collection once for each unique user ID.
 
 """
-from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
@@ -60,8 +58,7 @@ from virtool.types import Document
 
 
 class AbstractTransform(ABC):
-    """
-    A base class for writing transforms.
+    """A base class for writing transforms.
 
     Override the :meth:`prepare_one` and :meth:`attach_one` methods to implement attach
     data to a single document.
@@ -72,15 +69,12 @@ class AbstractTransform(ABC):
     """
 
     def preprocess(self, document: Document) -> Document:
-        """
-        Perform any necessary operations on documents before the transform is applied.
-        """
+        """Perform any necessary operations on documents before the transform is applied."""
         return document
 
     @abstractmethod
     async def attach_one(self, document: Document, prepared: Any) -> Document:
-        """
-        Attaches data to a single document.
+        """Attaches data to a single document.
 
         This method must be overriden to implement a transform.
 
@@ -91,7 +85,9 @@ class AbstractTransform(ABC):
         ...
 
     async def attach_many(
-        self, documents: list[Document], prepared: Document
+        self,
+        documents: list[Document],
+        prepared: Document,
     ) -> list[Document]:
         return [
             await self.attach_one(document, prepared[document["id"]])
@@ -99,8 +95,7 @@ class AbstractTransform(ABC):
         ]
 
     @abstractmethod
-    async def prepare_one(self, document: Document) -> Any:
-        ...
+    async def prepare_one(self, document: Document) -> Any: ...
 
     async def prepare_many(self, documents: list[Document]) -> Any:
         return {
@@ -109,10 +104,10 @@ class AbstractTransform(ABC):
 
 
 async def apply_transforms(
-    documents: Document | list[Document], pipeline: list[AbstractTransform]
+    documents: Document | list[Document],
+    pipeline: list[AbstractTransform],
 ) -> Document | list[Document]:
-    """
-    Apply a list of transforms to one or more documents.
+    """Apply a list of transforms to one or more documents.
 
     The function will concurrently prepare the data to be attached and then attach it to
     the documents. **Transforms are applied in the order they are listed**.
@@ -134,12 +129,13 @@ async def apply_transforms(
                 *[
                     transform.prepare_many([transform.preprocess(d) for d in documents])
                     for transform in pipeline
-                ]
+                ],
             )
 
             for prepared, transform in zip(all_prepared, pipeline):
                 documents = await transform.attach_many(
-                    [transform.preprocess(d) for d in documents], prepared
+                    [transform.preprocess(d) for d in documents],
+                    prepared,
                 )
 
             return documents
@@ -151,7 +147,7 @@ async def apply_transforms(
             *[
                 transform.prepare_one(transform.preprocess(document))
                 for transform in pipeline
-            ]
+            ],
         )
 
         for p, transform in zip(prepared, pipeline):

--- a/virtool/data/transforms.py
+++ b/virtool/data/transforms.py
@@ -1,5 +1,5 @@
-"""Transforms are used to attach additional data to a dictionary before it is sent to the
-client.
+"""Transforms are used to attach additional data to a dictionary before it is sent to
+the client.
 
 For example, you have a ``dict`` like the following:
 
@@ -69,14 +69,16 @@ class AbstractTransform(ABC):
     """
 
     def preprocess(self, document: Document) -> Document:
-        """Perform any necessary operations on documents before the transform is applied."""
+        """Perform any necessary operations on documents before the transform is
+        applied.
+        """
         return document
 
     @abstractmethod
     async def attach_one(self, document: Document, prepared: Any) -> Document:
         """Attaches data to a single document.
 
-        This method must be overriden to implement a transform.
+        This method must be overridden to implement a transform.
 
         :param document:
         :param prepared:

--- a/virtool/data/utils.py
+++ b/virtool/data/utils.py
@@ -1,18 +1,17 @@
-from __future__ import annotations
+"""Utility functions for the data layer."""
 
-import typing
+from typing import TYPE_CHECKING
 
 from aiohttp.web_request import Request
 
 from virtool.types import App
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from virtool.data.layer import DataLayer
 
 
-def get_data_from_app(app: App) -> DataLayer:
-    """
-    Get the application data layer object from the :class:``Application`` object.
+def get_data_from_app(app: App) -> "DataLayer":
+    """Get the application data layer object from the :class:``Application`` object.
 
     :param app: the application object
     :return: the application data layer
@@ -20,9 +19,8 @@ def get_data_from_app(app: App) -> DataLayer:
     return app["data"]
 
 
-def get_data_from_req(req: Request) -> DataLayer:
-    """
-    Get the application data layer object from a :class:``Request`` object.
+def get_data_from_req(req: Request) -> "DataLayer":
+    """Get the application data layer object from a :class:``Request`` object.
 
     :param req: an aiohttp request
     :return: the application data layer

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -1,11 +1,9 @@
-"""
-Work with OTU history in the database.
+"""Work with OTU history in the database."""
 
-"""
 import asyncio
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, List, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 import bson
 import dictdiffer
@@ -21,9 +19,9 @@ from virtool.config import get_config_from_app
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.history.utils import (
     calculate_diff,
+    compose_history_description,
     derive_otu_information,
     write_diff_file,
-    compose_history_description,
 )
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
@@ -69,15 +67,16 @@ class DiffTransform(AbstractTransform):
             otu_id, otu_version = document["id"].split(".")
 
             document["diff"] = await virtool.history.utils.read_diff_file(
-                self._data_path, otu_id, otu_version
+                self._data_path,
+                otu_id,
+                otu_version,
             )
 
         return document["diff"]
 
 
 async def processor(mongo, document: Document) -> Document:
-    """
-    Process a history document before it is returned to the client.
+    """Process a history document before it is returned to the client.
 
     :param mongo: the application object
     :param document: the document to process
@@ -90,7 +89,7 @@ async def processor(mongo, document: Document) -> Document:
 
 
 async def add(
-    db: "Mongo",
+    mongo: "Mongo",
     data_path: Path,
     method_name: HistoryMethod,
     old: Optional[dict],
@@ -99,11 +98,10 @@ async def add(
     user_id: str,
     session: Optional[AsyncIOMotorClientSession] = None,
 ) -> dict:
-    """
-    Add a change document to the history collection.
+    """Add a change document to the history collection.
 
     :param data_path: system path to the applications datafolder
-    :param db: the application database object
+    :param mongo: the application database object
     :param method_name: the name of the handler method that executed the change
     :param old: the otu document prior to the change
     :param new: the otu document after the change
@@ -112,7 +110,6 @@ async def add(
     :return: the change document
 
     """
-
     otu_id, otu_name, otu_version, ref_id = derive_otu_information(old, new)
 
     document = {
@@ -136,14 +133,14 @@ async def add(
         document["diff"] = calculate_diff(old, new)
 
     try:
-        await db.history.insert_one(document, session=session)
+        await mongo.history.insert_one(document, session=session)
     except pymongo.errors.DocumentTooLarge:
         history_path = data_path / "history"
         await asyncio.to_thread(history_path.mkdir, parents=True, exist_ok=True)
 
         await write_diff_file(data_path, otu_id, otu_version, document["diff"])
 
-        await db.history.insert_one(dict(document, diff="file"), session=session)
+        await mongo.history.insert_one(dict(document, diff="file"), session=session)
 
     return document
 
@@ -155,8 +152,7 @@ async def prepare_add(
     user_id: str,
     data_path: Path,
 ) -> Document:
-    """
-    Add a change document to the history collection.
+    """Add a change document to the history collection.
     :param history_method: the name of the method that executed the change
     :param old: the otu document prior to the change
     :param new: the otu document after the change
@@ -224,8 +220,7 @@ async def find(mongo, req_query, base_query: Optional[Document] = None):
 
 
 async def get(app, change_id: str) -> Optional[Document]:
-    """
-    Get a complete history document identified by the passed `changed_id`.
+    """Get a complete history document identified by the passed `changed_id`.
 
     Loads diff field from file if necessary. Returns `None` if the document does not
     exist.
@@ -235,15 +230,15 @@ async def get(app, change_id: str) -> Optional[Document]:
     :return: the change
 
     """
-    db = app["db"]
+    mongo: "Mongo" = app["db"]
 
-    document = await db.history.find_one(change_id, PROJECTION)
+    document = await mongo.history.find_one(change_id, PROJECTION)
 
     if document:
         return await apply_transforms(
             base_processor(document),
             [
-                AttachUserTransform(db),
+                AttachUserTransform(mongo),
                 DiffTransform(get_config_from_app(app).data_path),
             ],
         )
@@ -251,24 +246,24 @@ async def get(app, change_id: str) -> Optional[Document]:
     return None
 
 
-async def get_contributors(db, query: dict) -> List[dict]:
-    """
-    Return list of contributors and their contribution count for a specific set of
+async def get_contributors(mongo: "Mongo", query: dict) -> list[dict]:
+    """Return list of contributors and their contribution count for a specific set of
     history.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param query: a query to filter scanned history by
     :return: a list of contributors to the scanned history changes
 
     """
-    cursor = db.history.aggregate(
-        [{"$match": query}, {"$group": {"_id": "$user.id", "count": {"$sum": 1}}}]
+    cursor = mongo.history.aggregate(
+        [{"$match": query}, {"$group": {"_id": "$user.id", "count": {"$sum": 1}}}],
     )
 
     contributors = [{"id": c["_id"], "count": c["count"]} async for c in cursor]
 
-    users = await db.users.find(
-        {"_id": {"$in": [c["id"] for c in contributors]}}, projection=ATTACH_PROJECTION
+    users = await mongo.users.find(
+        {"_id": {"$in": [c["id"] for c in contributors]}},
+        projection=ATTACH_PROJECTION,
     ).to_list(None)
 
     users = {u.pop("_id"): u for u in users}
@@ -277,18 +272,19 @@ async def get_contributors(db, query: dict) -> List[dict]:
 
 
 async def get_most_recent_change(
-    db, otu_id: str, session: Optional[AsyncIOMotorClientSession] = None
+    mongo: "Mongo",
+    otu_id: str,
+    session: Optional[AsyncIOMotorClientSession] = None,
 ) -> Document:
-    """
-    Get the most recent change for the otu identified by the passed ``otu_id``.
+    """Get the most recent change for the otu identified by the passed ``otu_id``.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param otu_id: the target otu_id
     :param session: a Motor session to use for database operations
     :return: the most recent change document
 
     """
-    return await db.history.find_one(
+    return await mongo.history.find_one(
         {"otu.id": otu_id},
         MOST_RECENT_PROJECTION,
         sort=[("otu.version", -1)],
@@ -297,24 +293,25 @@ async def get_most_recent_change(
 
 
 async def patch_to_version(
-    data_path: Path, db, otu_id: str, version: Union[str, int]
+    data_path: Path,
+    mongo: "Mongo",
+    otu_id: str,
+    version: str | int,
 ) -> tuple:
-    """
-    Take a joined otu back in time to the passed ``version``.
+    """Take a joined otu back in time to the passed ``version``.
 
     Uses the diffs in the change documents associated with the otu.
 
     :param data_path: the data path
-    :param db: the database object
+    :param mongo: the database object
     :param otu_id: the id of the otu to patch
     :param version: the version to patch to
     :return: the current joined otu, patched otu, and the ids of reverted changes
 
     """
-
     reverted_history_ids = []
 
-    current = await virtool.otus.db.join(db, otu_id) or {}
+    current = await virtool.otus.db.join(mongo, otu_id) or {}
 
     if "version" in current and current["version"] == version:
         return current, deepcopy(current), reverted_history_ids
@@ -322,13 +319,18 @@ async def patch_to_version(
     patched = deepcopy(current)
 
     # Sort the changes by descending timestamp.
-    async for change in db.history.find({"otu.id": otu_id}, sort=[("otu.version", -1)]):
+    async for change in mongo.history.find(
+        {"otu.id": otu_id},
+        sort=[("otu.version", -1)],
+    ):
         if change["otu"]["version"] == "removed" or change["otu"]["version"] > version:
             reverted_history_ids.append(change["_id"])
 
             if change["diff"] == "file":
                 change["diff"] = await virtool.history.utils.read_diff_file(
-                    data_path, otu_id, change["otu"]["version"]
+                    data_path,
+                    otu_id,
+                    change["otu"]["version"],
                 )
 
             if change["method_name"] == "remove":

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -1,30 +1,31 @@
-"""
-API request handlers for managing and querying HMM data.
+"""API request handlers for managing and querying HMM data."""
 
-"""
 import asyncio
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from aiohttp.web import Response
 from aiohttp.web_fileresponse import FileResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r400, r403, r404, r502
-from virtool_core.models.hmm import HMM, HMMSearchResult, HMMInstalled
+from virtool_core.models.hmm import HMM, HMMInstalled, HMMSearchResult
 from virtool_core.models.roles import AdministratorRole
 
-from virtool.api.errors import APINotFound, APIBadGateway, APIConflict
 from virtool.api.custom_json import json_response
+from virtool.api.errors import APIBadGateway, APIConflict, APINotFound
+from virtool.api.policy import AdministratorRoutePolicy, policy
+from virtool.api.routes import Routes
 from virtool.config import get_config_from_req
 from virtool.data.errors import (
-    ResourceNotFoundError,
-    ResourceRemoteError,
     ResourceConflictError,
     ResourceError,
+    ResourceNotFoundError,
+    ResourceRemoteError,
 )
 from virtool.data.utils import get_data_from_req
-from virtool.api.policy import policy, AdministratorRoutePolicy
-from virtool.api.routes import Routes
 from virtool.mongo.utils import get_one_field
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
 
 routes = Routes()
 
@@ -32,8 +33,7 @@ routes = Routes()
 @routes.view("/hmms")
 class HmmsView(PydanticView):
     async def get(self) -> r200[HMMSearchResult]:
-        """
-        Find HMMs.
+        """Find HMMs.
 
         Lists profile hidden Markov model (HMM) annotations that are used in Virtool for
         novel virus prediction.
@@ -49,7 +49,7 @@ class HmmsView(PydanticView):
             200: Successful operation
         """
         search_results = await get_data_from_req(self.request).hmms.find(
-            self.request.query
+            self.request.query,
         )
 
         return json_response(search_results)
@@ -58,8 +58,7 @@ class HmmsView(PydanticView):
 @routes.view("/hmms/status")
 class StatusView(PydanticView):
     async def get(self) -> r200[Response]:
-        """
-        Get HMM status.
+        """Get HMM status.
 
         Lists the installation status of the HMM data. Contains the following
         fields:
@@ -84,8 +83,7 @@ class StatusView(PydanticView):
 @routes.view("/hmms/status/release")
 class ReleaseView(PydanticView):
     async def get(self) -> Union[r200[Response], r502]:
-        """
-        Get the latest HMM release.
+        """Get the latest HMM release.
 
         Fetches the latest release for the HMM data.
 
@@ -107,25 +105,23 @@ class ReleaseView(PydanticView):
 @routes.view("/hmms/status/updates")
 class UpdatesView(PydanticView):
     async def get(self) -> r200[Response]:
-        """
-        List updates.
+        """List updates.
 
         Lists all updates applied to the HMM collection.
 
         Status Codes:
             200: Successful operation
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        updates = await get_one_field(db.status, "updates", "hmm") or []
+        updates = await get_one_field(mongo.status, "updates", "hmm") or []
         updates.reverse()
 
         return json_response(updates)
 
     @policy(AdministratorRoutePolicy(AdministratorRole.BASE))
     async def post(self) -> Union[r201[HMMInstalled], r400, r403]:
-        """
-        Install HMMs.
+        """Install HMMs.
 
         Installs the latest official HMM database from GitHub.
 
@@ -136,7 +132,7 @@ class UpdatesView(PydanticView):
         """
         try:
             update = await get_data_from_req(self.request).hmms.install_update(
-                self.request["client"].user_id
+                self.request["client"].user_id,
             )
         except ResourceConflictError as err:
             raise APIConflict(str(err))
@@ -149,8 +145,7 @@ class UpdatesView(PydanticView):
 @routes.view("/hmms/{hmm_id}")
 class HMMView(PydanticView):
     async def get(self, hmm_id: str, /) -> Union[r200[HMM], r404]:
-        """
-        Get an HMM.
+        """Get an HMM.
 
         Fetches the details for an HMM annotation.
 
@@ -168,8 +163,7 @@ class HMMView(PydanticView):
 
 @routes.jobs_api.get("/hmms/{hmm_id}")
 async def get(req):
-    """
-    Get a HMM annotation document.
+    """Get a HMM annotation document.
 
     Fetches a complete individual HMM annotation document.
     """
@@ -184,12 +178,10 @@ async def get(req):
 @routes.jobs_api.get("/hmms/files/annotations.json.gz")
 @routes.get("/hmms/files/annotations.json.gz")
 async def get_hmm_annotations(req):
-    """
-    Get HMM annotations.
+    """Get HMM annotations.
 
     Fetches a compressed json file containing the database documents for all HMMs.
     """
-
     hmm_path = get_config_from_req(req).data_path / "hmm"
     await asyncio.to_thread(hmm_path.mkdir, parents=True, exist_ok=True)
 
@@ -206,8 +198,7 @@ async def get_hmm_annotations(req):
 
 @routes.jobs_api.get("/hmms/files/profiles.hmm")
 async def get_hmm_profiles(req):
-    """
-    Get HMM profiles.
+    """Get HMM profiles.
 
     Downloads the HMM profiles file if HMM data is available.
 

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -1,10 +1,8 @@
-"""
-Work with indexes in the database.
+"""Work with indexes in the database."""
 
-"""
 import asyncio
 import asyncio.tasks
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional
 
 import pymongo
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -16,12 +14,15 @@ import virtool.references.db
 import virtool.utils
 from virtool.api.utils import paginate
 from virtool.config.cls import Config
+from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.indexes.models import SQLIndexFile
 from virtool.jobs.transforms import AttachJobTransform
-from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
 
 INDEXES_PROJECTION = [
     "_id",
@@ -61,7 +62,10 @@ class IndexFilesTransform(AbstractTransform):
         index_id = document["id"]
 
         rows = await virtool.pg.utils.get_rows(
-            self._pg, SQLIndexFile, "index", index_id
+            self._pg,
+            SQLIndexFile,
+            "index",
+            index_id,
         )
 
         files = []
@@ -73,19 +77,17 @@ class IndexFilesTransform(AbstractTransform):
                 {
                     **index_file,
                     "download_url": str(self._base_url) + location,
-                }
+                },
             )
 
         return files
 
 
 class IndexCountsTransform(AbstractTransform):
-    """
-    Attaches modification counts to index documents based on OTU collection queries.
-    """
+    """Attaches modification counts to index documents based on OTU collection queries."""
 
-    def __init__(self, db):
-        self._db = db
+    def __init__(self, mongo: "Mongo"):
+        self._mongo = mongo
 
     async def attach_one(self, document: Document, prepared: Any) -> Document:
         return {**document, **prepared}
@@ -94,18 +96,21 @@ class IndexCountsTransform(AbstractTransform):
         query = {"index.id": document["id"]}
 
         change_count, otu_ids = await asyncio.gather(
-            self._db.history.count_documents(query),
-            self._db.history.distinct("otu.id", query),
+            self._mongo.history.count_documents(query),
+            self._mongo.history.distinct("otu.id", query),
         )
 
         return {"change_count": change_count, "modified_otu_count": len(otu_ids)}
 
 
 async def create(
-    mongo, ref_id: str, user_id: str, job_id: str, index_id: Optional[str] = None
+    mongo,
+    ref_id: str,
+    user_id: str,
+    job_id: str,
+    index_id: Optional[str] = None,
 ) -> dict:
-    """
-    Create a new index and update history to show the version and id of the new index.
+    """Create a new index and update history to show the version and id of the new index.
 
     :param mongo: the application database client
     :param ref_id: the ID of the reference to create index for
@@ -146,24 +151,25 @@ async def create(
     return document
 
 
-async def processor(db, document: dict) -> dict:
-    """
-    A processor for index documents. Adds computed data about the index.
+async def processor(mongo: "Mongo", document: Document) -> dict:
+    """A processor for index documents. Adds computed data about the index.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param document: the document to be processed
     :return: the processed document
-
     """
     return await apply_transforms(
         virtool.utils.base_processor(document),
-        [AttachUserTransform(db), IndexCountsTransform(db)],
+        [AttachUserTransform(mongo), IndexCountsTransform(mongo)],
     )
 
 
-async def find(mongo, req_query: Mapping, ref_id: Optional[str] = None) -> dict:
-    """
-    Find an index document matching the `req_query`
+async def find(
+    mongo: "Mongo",
+    req_query: Mapping,
+    ref_id: str | None = None,
+) -> dict:
+    """Find an index document matching the `req_query`
 
     :param mongo: the application database client
     :param req_query: the request object
@@ -203,17 +209,19 @@ async def find(mongo, req_query: Mapping, ref_id: Optional[str] = None) -> dict:
     }
 
 
-async def get_current_id_and_version(db, ref_id: str) -> Tuple[Optional[str], int]:
-    """
-    Return the current index id and version number.
+async def get_current_id_and_version(
+    mongo: "Mongo",
+    ref_id: str,
+) -> tuple[str | None, int]:
+    """Return the current index id and version number.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param ref_id: the id of the reference to get the current index for
 
     :return: the index and version of the current index
 
     """
-    document = await db.indexes.find_one(
+    document = await mongo.indexes.find_one(
         {"reference.id": ref_id, "ready": True},
         sort=[("version", pymongo.DESCENDING)],
         projection=["_id", "version"],
@@ -225,11 +233,10 @@ async def get_current_id_and_version(db, ref_id: str) -> Tuple[Optional[str], in
     return document["_id"], document["version"]
 
 
-async def get_otus(db, index_id: str) -> List[dict]:
-    """
-    Return a list of otus and number of changes for a specific index.
+async def get_otus(mongo: "Mongo", index_id: str) -> List[dict]:
+    """Return a list of otus and number of changes for a specific index.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param index_id: the id of the index to get otus for
 
     :return: a list of otus modified in the index
@@ -243,7 +250,7 @@ async def get_otus(db, index_id: str) -> List[dict]:
                 "_id": "$otu.id",
                 "name": {"$first": "$otu.name"},
                 "count": {"$sum": 1},
-            }
+            },
         },
         {"$match": {"name": {"$ne": None}}},
         {"$sort": {"name": 1}},
@@ -251,31 +258,29 @@ async def get_otus(db, index_id: str) -> List[dict]:
 
     return [
         {"id": otu["_id"], "name": otu["name"], "change_count": otu["count"]}
-        async for otu in db.history.aggregate(pipeline)
+        async for otu in mongo.history.aggregate(pipeline)
     ]
 
 
-async def get_next_version(db, ref_id: str) -> int:
-    """
-    Get the version number that should be used for the next index build.
+async def get_next_version(mongo: "Mongo", ref_id: str) -> int:
+    """Get the version number that should be used for the next index build.
 
-    :param db: the application database client
+    :param mongo: the application mongodb client
     :param ref_id: the id of the reference to get the next version for
 
     :return: the next version number
 
     """
-    return await db.indexes.count_documents({"reference.id": ref_id, "ready": True})
+    return await mongo.indexes.count_documents({"reference.id": ref_id, "ready": True})
 
 
-async def get_unbuilt_stats(db, ref_id: Optional[str] = None) -> dict:
-    """
-    Get the number of unbuilt changes and number of OTUs affected by those changes.
+async def get_unbuilt_stats(mongo: "Mongo", ref_id: Optional[str] = None) -> dict:
+    """Get the number of unbuilt changes and number of OTUs affected by those changes.
 
     Used to populate the metadata for an index find request.Can search against a
     specific reference or all references.
 
-    :param db: the application database client
+    :param mongo: the application mongodb client
     :param ref_id: the ref id to search unbuilt changes for
 
     :return: the change count and modified OTU count
@@ -289,41 +294,49 @@ async def get_unbuilt_stats(db, ref_id: Optional[str] = None) -> dict:
     history_query = {**ref_query, "index.id": "unbuilt"}
 
     return {
-        "total_otu_count": await db.otus.count_documents(ref_query),
-        "change_count": await db.history.count_documents(history_query),
-        "modified_otu_count": len(await db.history.distinct("otu.id", history_query)),
+        "total_otu_count": await mongo.otus.count_documents(ref_query),
+        "change_count": await mongo.history.count_documents(history_query),
+        "modified_otu_count": len(
+            await mongo.history.distinct("otu.id", history_query),
+        ),
     }
 
 
-async def get_patched_otus(db, config: Config, manifest: Dict[str, int]) -> List[dict]:
-    """
-    Get joined OTUs patched to a specific version based on a manifest of OTU ids and
+async def get_patched_otus(
+    mongo: "Mongo",
+    config: Config,
+    manifest: dict[str, int],
+) -> list[dict]:
+    """Get joined OTUs patched to a specific version based on a manifest of OTU ids and
     versions.
 
-    :param db: the job database client
+    :param mongo: the application mongodb client
     :param config: the application configuration
     :param manifest: the manifest
 
     """
-
     return [
         j[1]
         for j in await asyncio.tasks.gather(
             *[
                 virtool.history.db.patch_to_version(
-                    config.data_path, db, patch_id, patch_version
+                    config.data_path,
+                    mongo,
+                    patch_id,
+                    patch_version,
                 )
                 for patch_id, patch_version in manifest.items()
-            ]
+            ],
         )
     ]
 
 
 async def update_last_indexed_versions(
-    mongo, ref_id: str, session: AsyncIOMotorClientSession
+    mongo: "Mongo",
+    ref_id: str,
+    session: AsyncIOMotorClientSession,
 ):
-    """
-    Update the `last_indexed_version` field for OTUs associated with `ref_id`
+    """Update the `last_indexed_version` field for OTUs associated with `ref_id`
 
     :param mongo: the application mongo client
     :param session: the motor session to use
@@ -337,7 +350,7 @@ async def update_last_indexed_versions(
                 "version": True,
                 "last_indexed_version": True,
                 "comp": {"$cmp": ["$version", "$last_indexed_version"]},
-            }
+            },
         },
         {"$match": {"reference.id": ref_id, "comp": {"$ne": 0}}},
         {"$group": {"_id": "$version", "id_list": {"$addToSet": "$_id"}}},
@@ -355,13 +368,12 @@ async def update_last_indexed_versions(
                 session=session,
             )
             for version, id_list in id_version_key.items()
-        ]
+        ],
     )
 
 
 async def attach_files(pg: AsyncEngine, base_url: str, document: dict) -> dict:
-    """
-    Attach a list of index files under `files` field.
+    """Attach a list of index files under `files` field.
 
     :param pg: the application Postgres client
     :param base_url: the application base URL
@@ -383,15 +395,14 @@ async def attach_files(pg: AsyncEngine, base_url: str, document: dict) -> dict:
             {
                 **index_file,
                 "download_url": str(base_url) + location,
-            }
+            },
         )
 
     return {**document, "files": files}
 
 
 def lookup_index_otu_counts(local_field: str = "index.id") -> list[dict]:
-    """
-    Create a mongoDB aggregation pipeline step to look up index otu counts.
+    """Create a mongoDB aggregation pipeline step to look up index otu counts.
 
     :param local_field: index id field to look up
     :return: mongoDB aggregation steps for use in an aggregation pipeline
@@ -409,24 +420,24 @@ def lookup_index_otu_counts(local_field: str = "index.id") -> list[dict]:
                             "_id": None,
                             "change_count": {"$sum": 1},
                             "modified_otu_count": {"$addToSet": "$otu.id"},
-                        }
+                        },
                     },
                     {
                         "$project": {
                             "_id": False,
                             "change_count": True,
                             "modified_otu_count": {"$size": "$modified_otu_count"},
-                        }
+                        },
                     },
                 ],
                 "as": "counts",
-            }
+            },
         },
         {"$set": {"counts": {"$first": "$counts"}}},
         {"$set": {"change_count": {"$ifNull": ["$counts.change_count", 0]}}},
         {
             "$set": {
-                "modified_otu_count": {"$ifNull": ["$counts.modified_otu_count", 0]}
-            }
+                "modified_otu_count": {"$ifNull": ["$counts.modified_otu_count", 0]},
+            },
         },
     ]

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -110,7 +110,8 @@ async def create(
     job_id: str,
     index_id: Optional[str] = None,
 ) -> dict:
-    """Create a new index and update history to show the version and id of the new index.
+    """Create a new index and update history to show the version and id of the new
+    index.
 
     :param mongo: the application database client
     :param ref_id: the ID of the reference to create index for

--- a/virtool/jobs/auth.py
+++ b/virtool/jobs/auth.py
@@ -1,4 +1,5 @@
 import os
+from typing import TYPE_CHECKING
 
 from aiohttp import BasicAuth, web
 from aiohttp.web import Request
@@ -8,13 +9,15 @@ from virtool.api.errors import APIUnauthorized
 from virtool.types import RouteHandler
 from virtool.utils import hash_key
 
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
+
 PUBLIC_ROUTES = [("PATCH", "/jobs")]
 
 
 @web.middleware
 async def middleware(request: Request, handler: RouteHandler):
-    """
-    Ensure that the request was sent as part of an active job.
+    """Ensure that the request was sent as part of an active job.
 
     Uses HTTP basic access authentication, where the authorization header format is:
 
@@ -35,23 +38,26 @@ async def middleware(request: Request, handler: RouteHandler):
 
         job_prefix, job_id = holder_id.split("-")
         if job_prefix != "job":
-            raise ValueError()
+            raise ValueError
     except KeyError:
         raise APIUnauthorized(
-            "No authorization header", error_id="malformed_authorization_header"
+            "No authorization header",
+            error_id="malformed_authorization_header",
         )
     except ValueError:
         raise APIUnauthorized(
-            "Invalid authorization header", error_id="malformed_authorization_header"
+            "Invalid authorization header",
+            error_id="malformed_authorization_header",
         )
 
-    db = request.app["db"]
+    mongo: "Mongo" = request.app["db"]
 
-    job = await db.jobs.find_one({"_id": job_id, "key": hash_key(key)})
+    job = await mongo.jobs.find_one({"_id": job_id, "key": hash_key(key)})
 
     if not job:
         raise APIUnauthorized(
-            "Invalid authorization header", error_id="malformed_authorization_header"
+            "Invalid authorization header",
+            error_id="malformed_authorization_header",
         )
 
     request["client"] = JobClient(job_id)

--- a/virtool/jobs/tasks.py
+++ b/virtool/jobs/tasks.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from tempfile import TemporaryDirectory
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 from virtool.tasks.task import BaseTask
 
@@ -10,8 +8,7 @@ if TYPE_CHECKING:
 
 
 class TimeoutJobsTask(BaseTask):
-    """
-    Timeout dead jobs.
+    """Timeout dead jobs.
 
     Times out jobs that are in the running or preparing state and have either been
     running for more than 30 days or have a populated ping field and have not received a
@@ -37,8 +34,7 @@ class TimeoutJobsTask(BaseTask):
 
 
 class RelistJobsTask(BaseTask):
-    """
-    relist jobs in redis
+    """relist jobs in redis
 
     Relists jobs in redis that are in the waiting state and are no longer in redis
 

--- a/virtool/labels/data.py
+++ b/virtool/labels/data.py
@@ -2,29 +2,28 @@ from typing import List
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool_core.models.label import Label, LabelMinimal
 
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
-from virtool.data.events import emits, Operation, emit
-from virtool.labels.transforms import AttachSampleCountsTransform
+from virtool.data.events import Operation, emit, emits
+from virtool.data.transforms import apply_transforms
 from virtool.labels.models import SQLLabel
 from virtool.labels.oas import UpdateLabelRequest
+from virtool.labels.transforms import AttachSampleCountsTransform
 from virtool.mongo.core import Mongo
-from virtool.data.transforms import apply_transforms
 from virtool.pg.utils import get_generic
 
 
 class LabelsData:
     name = "labels"
 
-    def __init__(self, db: Mongo, pg: AsyncEngine):
-        self._db = db
+    def __init__(self, mongo: Mongo, pg: AsyncEngine):
+        self._mongo = mongo
         self._pg = pg
 
     async def find(self, term: str) -> List[LabelMinimal]:
-        """
-        List all sample labels.
+        """List all sample labels.
 
         :param term: the query term
         :return: a list of all sample labels.
@@ -38,15 +37,14 @@ class LabelsData:
 
         documents = await apply_transforms(
             [label.to_dict() for label in labels],
-            [AttachSampleCountsTransform(self._db)],
+            [AttachSampleCountsTransform(self._mongo)],
         )
 
         return [LabelMinimal(**label) for label in documents]
 
     @emits(Operation.CREATE)
     async def create(self, name: str, color: str, description: str) -> Label:
-        """
-        Create a new sample label given a label name, color and description.
+        """Create a new sample label given a label name, color and description.
 
         :param name: the label's name
         :param color: the label's color
@@ -65,18 +63,18 @@ class LabelsData:
             except IntegrityError:
                 raise ResourceConflictError()
 
-        document = await apply_transforms(row, [AttachSampleCountsTransform(self._db)])
+        document = await apply_transforms(
+            row, [AttachSampleCountsTransform(self._mongo)]
+        )
 
         return Label(**document)
 
     async def get(self, label_id: int) -> Label:
-        """
-        Get a single label by its ID.
+        """Get a single label by its ID.
 
         :param label_id: the label's ID
         :return: the label
         """
-
         async with AsyncSession(self._pg) as session:
             result = await session.execute(select(SQLLabel).filter_by(id=label_id))
             label = result.scalar()
@@ -85,15 +83,15 @@ class LabelsData:
             raise ResourceNotFoundError()
 
         document = await apply_transforms(
-            label.to_dict(), [AttachSampleCountsTransform(self._db)]
+            label.to_dict(),
+            [AttachSampleCountsTransform(self._mongo)],
         )
 
         return Label(**document)
 
     @emits(Operation.UPDATE)
     async def update(self, label_id: int, data: UpdateLabelRequest) -> Label:
-        """
-        Edit an existing label.
+        """Edit an existing label.
 
         :param label_id: the ID of the existing label to edit
         :param data: label fields for editing the existing label
@@ -124,27 +122,28 @@ class LabelsData:
             except IntegrityError:
                 raise ResourceConflictError()
 
-        document = await apply_transforms(row, [AttachSampleCountsTransform(self._db)])
+        document = await apply_transforms(
+            row, [AttachSampleCountsTransform(self._mongo)]
+        )
 
         return Label(**document)
 
     async def delete(self, label_id: int):
-        """
-        Delete an existing label.
+        """Delete an existing label.
 
         :param label_id: ID of the label to delete
         """
         label = await self.get(label_id)
 
         async with AsyncSession(self._pg) as session:
-            async with self._db.create_session() as mongo_session:
+            async with self._mongo.create_session() as mongo_session:
                 result = await session.execute(select(SQLLabel).filter_by(id=label_id))
                 label = result.scalar()
 
                 if label is None:
                     raise ResourceNotFoundError
 
-                await self._db.samples.update_many(
+                await self._mongo.samples.update_many(
                     {"labels": label_id},
                     {"$pull": {"labels": label_id}},
                     session=mongo_session,

--- a/virtool/mongo/migrate.py
+++ b/virtool/mongo/migrate.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from pymongo.errors import DuplicateKeyError
@@ -11,9 +9,8 @@ if TYPE_CHECKING:
 logger = get_logger("mongo")
 
 
-async def migrate_status(mongo: Mongo):
-    """
-    Automatically update the status collection.
+async def migrate_status(mongo: "Mongo"):
+    """Automatically update the status collection.
 
     :param mongo: the application MongoDB object
 
@@ -29,7 +26,7 @@ async def migrate_status(mongo: Mongo):
                 "task": None,
                 "updates": [],
                 "release": None,
-            }
+            },
         )
     except DuplicateKeyError:
         if await mongo.hmm.count_documents({}):

--- a/virtool/mongo/utils.py
+++ b/virtool/mongo/utils.py
@@ -1,17 +1,14 @@
-"""
-Utilities for working with MongoDB.
+"""Utilities for working with MongoDB."""
 
-"""
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession, AsyncIOMotorCollection
 
-from virtool.types import Projection, Document
+from virtool.types import Document, Projection
 
 
 def apply_projection(document: Document, projection: Projection):
-    """
-    Apply a Mongo-style projection to a document and return it.
+    """Apply a Mongo-style projection to a document and return it.
 
     :param document: the document to project
     :param projection: the projection to apply
@@ -45,8 +42,7 @@ async def check_missing_ids(
     query: dict | None = None,
     session: AsyncIOMotorClientSession | None = None,
 ) -> set[str]:
-    """
-    Check if all IDs in the ``id_list`` exist in the database.
+    """Check if all IDs in the ``id_list`` exist in the database.
 
     :param collection: the Mongo collection to check ``id_list`` against
     :param id_list: the IDs to check for
@@ -59,8 +55,7 @@ async def check_missing_ids(
 
 
 async def delete_unready(collection):
-    """
-    Delete documents in the `collection` where the `ready` field is set to `false`.
+    """Delete documents in the `collection` where the `ready` field is set to `false`.
 
     :param collection: the collection to modify
 
@@ -69,10 +64,10 @@ async def delete_unready(collection):
 
 
 async def get_new_id(
-    collection, session: AsyncIOMotorClientSession | None = None
+    collection,
+    session: AsyncIOMotorClientSession | None = None,
 ) -> str:
-    """
-    Returns a new, unique, id that can be used for inserting a new document. Will not
+    """Returns a new, unique, id that can be used for inserting a new document. Will not
     return any id that is included in ``excluded``.
 
     :param collection: the Mongo collection to get a new _id for
@@ -94,8 +89,7 @@ async def get_one_field(
     query: str | dict,
     session: AsyncIOMotorClientSession | None = None,
 ) -> Any:
-    """
-    Get the value for a single `field` from a single document matching the `query`.
+    """Get the value for a single `field` from a single document matching the `query`.
 
     :param collection: the database collection to search
     :param field: the field to return
@@ -111,8 +105,8 @@ async def get_one_field(
 
 
 async def get_non_existent_ids(collection, id_list: list[str]) -> set[str]:
-    """
-    Return the IDs that are in `id_list`, but don't exist in the specified `collection`.
+    """Return the IDs that are in `id_list`, but don't exist in the specified
+    `collection`.
 
     :param collection: the database collection to check
     :param id_list: a list of document IDs to check for existence
@@ -124,15 +118,16 @@ async def get_non_existent_ids(collection, id_list: list[str]) -> set[str]:
 
 
 async def id_exists(
-    collection, id_: str, session: AsyncIOMotorClientSession | None = None
+    collection,
+    id_: str,
+    session: AsyncIOMotorClientSession | None = None,
 ) -> bool:
-    """
-    Check if the document id exists in the collection.
+    """Check if the document id exists in the collection.
 
     :param collection: the Mongo collection to check the _id against
     :param id_: the _id to check for
     :return: does the id exist
     """
     return bool(
-        await collection.count_documents({"_id": id_}, limit=1, session=session)
+        await collection.count_documents({"_id": id_}, limit=1, session=session),
     )

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -1,19 +1,19 @@
-from typing import List, Union
+from typing import TYPE_CHECKING, List, Union
 
 from aiohttp import web
 from aiohttp_pydantic import PydanticView
-from aiohttp_pydantic.oas.typing import r200, r201, r404, r204, r401, r403, r400
+from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r401, r403, r404
 from virtool_core.models.otu import OTU, OTUIsolate, Sequence
 
 import virtool.otus.db
 import virtool.references.db
-from virtool.api.errors import (
-    APINotFound,
-    APIInsufficientRights,
-    APIBadRequest,
-    APINoContent,
-)
 from virtool.api.custom_json import json_response
+from virtool.api.errors import (
+    APIBadRequest,
+    APIInsufficientRights,
+    APINoContent,
+    APINotFound,
+)
 from virtool.api.routes import Routes
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.transforms import apply_transforms
@@ -21,15 +21,18 @@ from virtool.data.utils import get_data_from_req
 from virtool.history.db import LIST_PROJECTION
 from virtool.mongo.utils import get_one_field
 from virtool.otus.oas import (
-    UpdateOTURequest,
     CreateIsolateRequest,
-    UpdateIsolateRequest,
     CreateSequenceRequest,
+    UpdateIsolateRequest,
+    UpdateOTURequest,
     UpdateSequenceRequest,
 )
 from virtool.otus.utils import evaluate_changes, find_isolate
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
 
 routes = Routes()
 
@@ -37,8 +40,7 @@ routes = Routes()
 @routes.view("/otus/{otu_id}")
 class OTUView(PydanticView):
     async def get(self, otu_id: str, /) -> Union[r200[OTU], r403, r404]:
-        """
-        Get an OTU.
+        """Get an OTU.
 
         Fetches the details of an OTU.
 
@@ -51,7 +53,7 @@ class OTUView(PydanticView):
 
             try:
                 filename, fasta = await get_data_from_req(self.request).otus.get_fasta(
-                    otu_id
+                    otu_id,
                 )
             except ResourceNotFoundError:
                 raise APINotFound()
@@ -69,21 +71,24 @@ class OTUView(PydanticView):
         return json_response(otu)
 
     async def patch(
-        self, otu_id: str, /, data: UpdateOTURequest
+        self,
+        otu_id: str,
+        /,
+        data: UpdateOTURequest,
     ) -> Union[r200[OTU], r400, r403, r404]:
-        """
-        Update an OTU.
+        """Update an OTU.
 
         Checks to make sure the supplied OTU name and abbreviation don't already exist
         in the parent reference.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
         # Get existing complete otu record, at the same time ensuring it exists. Send a
         # ``404`` if not.
-        document = await db.otus.find_one(
-            otu_id, ["abbreviation", "name", "reference", "schema"]
+        document = await mongo.otus.find_one(
+            otu_id,
+            ["abbreviation", "name", "reference", "schema"],
         )
 
         if not document:
@@ -92,12 +97,15 @@ class OTUView(PydanticView):
         ref_id = document["reference"]["id"]
 
         if not await virtool.references.db.check_right(
-            self.request, ref_id, "modify_otu"
+            self.request,
+            ref_id,
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
         name, abbreviation, otu_schema = evaluate_changes(
-            data.dict(by_alias=True, exclude_unset=True), document
+            data.dict(by_alias=True, exclude_unset=True),
+            document,
         )
 
         # Send ``200`` with the existing otu record if no change will be made.
@@ -107,37 +115,44 @@ class OTUView(PydanticView):
 
         # Make sure new name or abbreviation are not already in use.
         if message := await virtool.otus.db.check_name_and_abbreviation(
-            db, ref_id, name, abbreviation
+            mongo,
+            ref_id,
+            name,
+            abbreviation,
         ):
             raise APIBadRequest(message)
 
         otu = await get_data_from_req(self.request).otus.update(
-            otu_id, data, self.request["client"].user_id
+            otu_id,
+            data,
+            self.request["client"].user_id,
         )
 
         return json_response(otu)
 
     async def delete(self, otu_id: str, /) -> Union[r204, r401, r403, r404]:
-        """
-        Delete an OTU.
+        """Delete an OTU.
 
         Deletes and OTU and its associated isolates and sequences.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        document = await db.otus.find_one(otu_id, ["reference"])
+        document = await mongo.otus.find_one(otu_id, ["reference"])
 
         if document is None:
             raise APINotFound()
 
         if not await virtool.references.db.check_right(
-            self.request, document["reference"]["id"], "modify_otu"
+            self.request,
+            document["reference"]["id"],
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
         await get_data_from_req(self.request).otus.remove(
-            otu_id, self.request["client"].user_id
+            otu_id,
+            self.request["client"].user_id,
         )
 
         return web.Response(status=204)
@@ -146,15 +161,14 @@ class OTUView(PydanticView):
 @routes.view("/otus/{otu_id}/isolates")
 class IsolatesView(PydanticView):
     async def get(self, otu_id: str, /):
-        """
-        List isolates.
+        """List isolates.
 
         Lists all the isolates and sequences for an OTU.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        document = await virtool.otus.db.join_and_format(db, otu_id)
+        document = await virtool.otus.db.join_and_format(mongo, otu_id)
 
         if not document:
             raise APINotFound()
@@ -162,23 +176,27 @@ class IsolatesView(PydanticView):
         return json_response(document["isolates"])
 
     async def post(
-        self, otu_id: str, /, data: CreateIsolateRequest
+        self,
+        otu_id: str,
+        /,
+        data: CreateIsolateRequest,
     ) -> Union[r201[OTUIsolate], r401, r404]:
-        """
-        Create an isolate.
+        """Create an isolate.
 
         Creates an isolate on the OTU specified by `otu_id`.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        reference = await get_one_field(db.otus, "reference", otu_id)
+        reference = await get_one_field(mongo.otus, "reference", otu_id)
 
         if not reference:
             raise APINotFound()
 
         if not await virtool.references.db.check_right(
-            self.request, reference["id"], "modify_otu"
+            self.request,
+            reference["id"],
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
@@ -186,7 +204,9 @@ class IsolatesView(PydanticView):
 
         # All source types are stored in lower case.
         if not await virtool.references.db.check_source_type(
-            db, reference["id"], source_type
+            mongo,
+            reference["id"],
+            source_type,
         ):
             raise APIBadRequest("Source type is not allowed")
 
@@ -208,24 +228,26 @@ class IsolatesView(PydanticView):
 @routes.view("/otus/{otu_id}/isolates/{isolate_id}")
 class IsolateView(PydanticView):
     async def get(
-        self, otu_id: str, isolate_id: str, /
+        self,
+        otu_id: str,
+        isolate_id: str,
+        /,
     ) -> Union[r200[OTUIsolate], r404]:
-        """
-        Get an isolate.
+        """Get an isolate.
 
         Fetches the details of an isolate.
 
         A FASTA file containing all sequences in the isolate can be downloaded by
         appending `.fa` to the path.
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
         isolate_id = isolate_id.rstrip(".fa")
 
         if self.request.path.endswith(".fa"):
             try:
                 filename, fasta = await get_data_from_req(
-                    self.request
+                    self.request,
                 ).otus.get_isolate_fasta(otu_id, isolate_id)
             except ResourceNotFoundError as err:
                 if "does not exist" in str(err):
@@ -238,8 +260,9 @@ class IsolateView(PydanticView):
                 headers={"Content-Disposition": f"attachment; filename={filename}"},
             )
 
-        document = await db.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id}, ["isolates"]
+        document = await mongo.otus.find_one(
+            {"_id": otu_id, "isolates.id": isolate_id},
+            ["isolates"],
         )
 
         if not document:
@@ -249,7 +272,7 @@ class IsolateView(PydanticView):
 
         isolate["sequences"] = [
             base_processor(sequence)
-            async for sequence in db.sequences.find(
+            async for sequence in mongo.sequences.find(
                 {"otu_id": otu_id, "isolate_id": isolate_id},
                 {"otu_id": False, "isolate_id": False},
             )
@@ -258,18 +281,23 @@ class IsolateView(PydanticView):
         return json_response(isolate)
 
     async def patch(
-        self, otu_id: str, isolate_id: str, /, data: UpdateIsolateRequest
+        self,
+        otu_id: str,
+        isolate_id: str,
+        /,
+        data: UpdateIsolateRequest,
     ) -> Union[r200[OTUIsolate], r401, r404]:
-        """
-        Update an isolate.
+        """Update an isolate.
 
         Updates an isolate using 'otu_id' and 'isolate_id'.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
         reference = await get_one_field(
-            db.otus, "reference", {"_id": otu_id, "isolates.id": isolate_id}
+            mongo.otus,
+            "reference",
+            {"_id": otu_id, "isolates.id": isolate_id},
         )
 
         if not reference:
@@ -278,7 +306,9 @@ class IsolateView(PydanticView):
         ref_id = reference["id"]
 
         if not await virtool.references.db.check_right(
-            self.request, ref_id, "modify_otu"
+            self.request,
+            ref_id,
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
@@ -291,7 +321,9 @@ class IsolateView(PydanticView):
             source_type = data["source_type"].lower()
 
             if not await virtool.references.db.check_source_type(
-                db, ref_id, source_type
+                mongo,
+                ref_id,
+                source_type,
             ):
                 raise APIBadRequest("Source type is not allowed")
 
@@ -306,28 +338,33 @@ class IsolateView(PydanticView):
         return json_response(isolate, status=200)
 
     async def delete(self, otu_id: str, isolate_id: str, /):
-        """
-        Delete an isolate.
+        """Delete an isolate.
 
         Deletes an isolate using its 'otu id' and 'isolate id'.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
         reference = await get_one_field(
-            db.otus, "reference", {"_id": otu_id, "isolates.id": isolate_id}
+            mongo.otus,
+            "reference",
+            {"_id": otu_id, "isolates.id": isolate_id},
         )
 
         if not reference:
             raise APINotFound()
 
         if not await virtool.references.db.check_right(
-            self.request, reference["id"], "modify_otu"
+            self.request,
+            reference["id"],
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
         await get_data_from_req(self.request).otus.remove_isolate(
-            otu_id, isolate_id, self.request["client"].user_id
+            otu_id,
+            isolate_id,
+            self.request["client"].user_id,
         )
 
         raise APINoContent()
@@ -336,18 +373,21 @@ class IsolateView(PydanticView):
 @routes.view("/otus/{otu_id}/isolates/{isolate_id}/sequences")
 class SequencesView(PydanticView):
     async def get(
-        self, otu_id: str, isolate_id: str, /
+        self,
+        otu_id: str,
+        isolate_id: str,
+        /,
     ) -> Union[r200[List[OTUIsolate]], r401, r403, r404]:
-        """
-        List sequences.
+        """List sequences.
 
         Lists the sequences for an isolate.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        if not await db.otus.count_documents(
-            {"_id": otu_id, "isolates.id": isolate_id}, limit=1
+        if not await mongo.otus.count_documents(
+            {"_id": otu_id, "isolates.id": isolate_id},
+            limit=1,
         ):
             raise APINotFound()
 
@@ -359,25 +399,30 @@ class SequencesView(PydanticView):
         return json_response(
             [
                 base_processor(d)
-                async for d in db.sequences.find(
-                    {"otu_id": otu_id, "isolate_id": isolate_id}, projection
+                async for d in mongo.sequences.find(
+                    {"otu_id": otu_id, "isolate_id": isolate_id},
+                    projection,
                 )
-            ]
+            ],
         )
 
     async def post(
-        self, otu_id: str, isolate_id: str, /, data: CreateSequenceRequest
+        self,
+        otu_id: str,
+        isolate_id: str,
+        /,
+        data: CreateSequenceRequest,
     ) -> Union[r201[Sequence], r400, r403, r404]:
-        """
-        Create a sequence.
+        """Create a sequence.
 
         Creates a new sequence for an isolate identified by `otu_id` and `isolate_id`.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        document = await db.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id}, ["reference", "schema"]
+        document = await mongo.otus.find_one(
+            {"_id": otu_id, "isolates.id": isolate_id},
+            ["reference", "schema"],
         )
 
         if not document:
@@ -386,12 +431,19 @@ class SequencesView(PydanticView):
         ref_id = document["reference"]["id"]
 
         if not await virtool.references.db.check_right(
-            self.request, ref_id, "modify_otu"
+            self.request,
+            ref_id,
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
         if message := await virtool.otus.db.check_sequence_segment_or_target(
-            db, otu_id, isolate_id, None, ref_id, data.dict()
+            mongo,
+            otu_id,
+            isolate_id,
+            None,
+            ref_id,
+            data.dict(),
         ):
             raise APIBadRequest(message)
 
@@ -411,7 +463,7 @@ class SequencesView(PydanticView):
             sequence_document,
             status=201,
             headers={
-                "Location": f"/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence_document['id']}"
+                "Location": f"/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence_document['id']}",
             },
         )
 
@@ -419,8 +471,7 @@ class SequencesView(PydanticView):
 @routes.view("/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence_id}")
 class SequenceView(PydanticView):
     async def get(self, otu_id: str, isolate_id: str, sequence_id: str, /):
-        """
-        Get a sequence.
+        """Get a sequence.
 
         Fetches the details for a sequence.
 
@@ -433,7 +484,7 @@ class SequenceView(PydanticView):
 
             try:
                 filename, fasta = await get_data_from_req(
-                    self.request
+                    self.request,
                 ).otus.get_sequence_fasta(sequence_id)
             except ResourceNotFoundError as err:
                 if "does not exist" in str(err):
@@ -451,7 +502,9 @@ class SequenceView(PydanticView):
 
         try:
             sequence = await get_data_from_req(self.request).otus.get_sequence(
-                otu_id, isolate_id, sequence_id
+                otu_id,
+                isolate_id,
+                sequence_id,
             )
         except ResourceNotFoundError:
             raise APINotFound()
@@ -466,30 +519,33 @@ class SequenceView(PydanticView):
         /,
         data: UpdateSequenceRequest,
     ) -> Union[r200[Sequence], r400, r401, r403, r404]:
-        """
-        Update a sequence.
+        """Update a sequence.
 
         Updates a sequence using its 'otu id', 'isolate id' and 'sequence id'.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        document = await db.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id}, ["reference", "segment"]
+        document = await mongo.otus.find_one(
+            {"_id": otu_id, "isolates.id": isolate_id},
+            ["reference", "segment"],
         )
 
-        if not document or not await db.sequences.count_documents(
-            {"_id": sequence_id}, limit=1
+        if not document or not await mongo.sequences.count_documents(
+            {"_id": sequence_id},
+            limit=1,
         ):
             raise APINotFound()
 
         if not await virtool.references.db.check_right(
-            self.request, document["reference"]["id"], "modify_otu"
+            self.request,
+            document["reference"]["id"],
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
         if message := await virtool.otus.db.check_sequence_segment_or_target(
-            db,
+            mongo,
             otu_id,
             isolate_id,
             sequence_id,
@@ -499,37 +555,46 @@ class SequenceView(PydanticView):
             raise APIBadRequest(message)
 
         sequence_document = await get_data_from_req(self.request).otus.update_sequence(
-            otu_id, isolate_id, sequence_id, self.request["client"].user_id, data
+            otu_id,
+            isolate_id,
+            sequence_id,
+            self.request["client"].user_id,
+            data,
         )
 
         return json_response(sequence_document)
 
     async def delete(self, otu_id: str, isolate_id: str, sequence_id: str, /):
-        """
-        Delete a sequence.
+        """Delete a sequence.
 
         Deletes the specified sequence.
 
         """
-        db = self.request.app["db"]
+        mongo: "Mongo" = self.request.app["db"]
 
-        if not await db.sequences.count_documents({"_id": sequence_id}, limit=1):
+        if not await mongo.sequences.count_documents({"_id": sequence_id}, limit=1):
             raise APINotFound()
 
-        document = await db.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id}, ["reference"]
+        document = await mongo.otus.find_one(
+            {"_id": otu_id, "isolates.id": isolate_id},
+            ["reference"],
         )
 
         if document is None:
             raise APINotFound()
 
         if not await virtool.references.db.check_right(
-            self.request, document["reference"]["id"], "modify_otu"
+            self.request,
+            document["reference"]["id"],
+            "modify_otu",
         ):
             raise APIInsufficientRights()
 
         await get_data_from_req(self.request).otus.remove_sequence(
-            otu_id, isolate_id, sequence_id, self.request["client"].user_id
+            otu_id,
+            isolate_id,
+            sequence_id,
+            self.request["client"].user_id,
         )
 
         raise APINoContent()
@@ -537,31 +602,33 @@ class SequenceView(PydanticView):
 
 @routes.get("/otus/{otu_id}/history")
 async def list_history(req):
-    """
-    List history.
+    """List history.
 
     Lists an OTU's history.
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
 
     otu_id = req.match_info["otu_id"]
 
-    if not await db.otus.count_documents({"_id": otu_id}, limit=1):
+    if not await mongo.otus.count_documents({"_id": otu_id}, limit=1):
         raise APINotFound()
 
-    documents = await db.history.find(
-        {"otu.id": otu_id}, projection=LIST_PROJECTION
+    documents = await mongo.history.find(
+        {"otu.id": otu_id},
+        projection=LIST_PROJECTION,
     ).to_list(None)
 
     return json_response(
-        await apply_transforms(documents, [AttachUserTransform(db, ignore_errors=True)])
+        await apply_transforms(
+            documents,
+            [AttachUserTransform(mongo, ignore_errors=True)],
+        ),
     )
 
 
 @routes.put("/otus/{otu_id}/isolates/{isolate_id}/default")
 async def set_as_default(req):
-    """
-    Set default isolate.
+    """Set default isolate.
 
     Sets an isolate as default.
 
@@ -570,19 +637,24 @@ async def set_as_default(req):
     isolate_id = req.match_info["isolate_id"]
 
     document = await req.app["db"].otus.find_one(
-        {"_id": otu_id, "isolates.id": isolate_id}, ["reference"]
+        {"_id": otu_id, "isolates.id": isolate_id},
+        ["reference"],
     )
 
     if not document:
         raise APINotFound()
 
     if not await virtool.references.db.check_right(
-        req, document["reference"]["id"], "modify_otu"
+        req,
+        document["reference"]["id"],
+        "modify_otu",
     ):
         raise APIInsufficientRights()
 
     isolate = await get_data_from_req(req).otus.set_isolate_as_default(
-        otu_id, isolate_id, req["client"].user_id
+        otu_id,
+        isolate_id,
+        req["client"].user_id,
     )
 
     return json_response(isolate)

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,17 +1,14 @@
-"""
-Work with OTUs in the database.
+"""Work with OTUs in the database."""
 
-"""
-
-from typing import Any, Dict, List, Optional, Union, Mapping, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
 import virtool.history.db
 import virtool.otus.utils
 from virtool.api.utils import compose_regex_query, paginate
-from virtool.errors import DatabaseError
 from virtool.data.transforms import apply_transforms
+from virtool.errors import DatabaseError
 from virtool.mongo.utils import get_one_field
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
@@ -36,25 +33,29 @@ SEQUENCE_PROJECTION = [
 
 
 async def check_name_and_abbreviation(
-    db, ref_id: str, name: Optional[str] = None, abbreviation: Optional[str] = None
+    mongo: "Mongo",
+    ref_id: str,
+    name: Optional[str] = None,
+    abbreviation: Optional[str] = None,
 ) -> Optional[str]:
-    """
-    Check of an OTU name and abbreviation are already in use.
+    """Check of an OTU name and abbreviation are already in use.
 
     Returns an error message if the ``name`` or ``abbreviation`` are already in use.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param ref_id: the id of the reference to check in
     :param name: an OTU name
     :param abbreviation: an OTU abbreviation
 
     """
-    name_exists = name and await db.otus.count_documents(
-        {"lower_name": name.lower(), "reference.id": ref_id}, limit=1
+    name_exists = name and await mongo.otus.count_documents(
+        {"lower_name": name.lower(), "reference.id": ref_id},
+        limit=1,
     )
 
-    abbreviation_exists = abbreviation and await db.otus.count_documents(
-        {"abbreviation": abbreviation, "reference.id": ref_id}, limit=1
+    abbreviation_exists = abbreviation and await mongo.otus.count_documents(
+        {"abbreviation": abbreviation, "reference.id": ref_id},
+        limit=1,
     )
 
     if name_exists and abbreviation_exists:
@@ -74,13 +75,13 @@ async def find(
     verified: Optional[bool],
     ref_id: Optional[str] = None,
 ) -> Union[Dict[str, Any], List[Optional[dict]]]:
-    db_query = {}
+    mongo_query = {}
 
     if term:
-        db_query.update(compose_regex_query(term, ["name", "abbreviation"]))
+        mongo_query.update(compose_regex_query(term, ["name", "abbreviation"]))
 
     if verified is not None:
-        db_query["verified"] = to_bool(verified)
+        mongo_query["verified"] = to_bool(verified)
 
     base_query = None
 
@@ -89,7 +90,7 @@ async def find(
 
     data = await paginate(
         mongo.otus,
-        db_query,
+        mongo_query,
         req_query,
         base_query=base_query,
         sort="name",
@@ -97,7 +98,8 @@ async def find(
     )
 
     data["documents"] = await apply_transforms(
-        data["documents"], [AttachReferenceTransform(mongo)]
+        data["documents"],
+        [AttachReferenceTransform(mongo)],
     )
 
     history_query = {"index.id": "unbuilt"}
@@ -106,36 +108,35 @@ async def find(
         history_query["reference.id"] = ref_id
 
     data["modified_count"] = len(
-        await mongo.history.distinct("otu.name", history_query)
+        await mongo.history.distinct("otu.name", history_query),
     )
 
     return data
 
 
 async def join(
-    db,
+    mongo: "Mongo",
     query: Union[dict, str],
     document: Optional[Dict[str, Any]] = None,
     session: Optional[AsyncIOMotorClientSession] = None,
 ) -> Optional[Dict[str, Any]]:
-    """
-    Join the otu associated with the supplied ``otu_id`` with its sequences.
+    """Join the otu associated with the supplied ``otu_id`` with its sequences.
 
     If an OTU is passed, the document will not be pulled from the database.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param query: the id of the otu to join or a Mongo query.
     :param document: use this otu document as a basis for the join
     :param session: a Motor session to use for database operations
     :return: the joined otu document
     """
     # Get the otu entry if a ``document`` parameter was not passed.
-    document = document or await db.otus.find_one(query, session=session)
+    document = document or await mongo.otus.find_one(query, session=session)
 
     if document is None:
         return None
 
-    cursor = db.sequences.find({"otu_id": document["_id"]}, session=session)
+    cursor = mongo.sequences.find({"otu_id": document["_id"]}, session=session)
 
     # Merge the sequence entries into the otu entry.
     return virtool.otus.utils.merge_otu(document, [d async for d in cursor])
@@ -146,8 +147,7 @@ async def bulk_join_query(
     query: dict,
     session: Optional[AsyncIOMotorClientSession] = None,
 ) -> List[Dict[str, Any]]:
-    """
-    Join the otu associated with the supplied ``otu_id`` with its sequences.
+    """Join the otu associated with the supplied ``otu_id`` with its sequences.
 
     If an OTU is passed, the document will not be pulled from the database.
 
@@ -157,7 +157,6 @@ async def bulk_join_query(
     :param session: a Motor session to use for database operations
     :return: the joined otu document
     """
-
     cursor = mongo.otus.find(query, session=session)
     documents = [document async for document in cursor]
 
@@ -169,8 +168,7 @@ async def bulk_join_ids(
     ids: List[str],
     session: Optional[AsyncIOMotorClientSession] = None,
 ) -> List[Dict[str, Any]]:
-    """
-    Join the otu associated with the supplied ``otu_id`` with its sequences.
+    """Join the otu associated with the supplied ``otu_id`` with its sequences.
 
     If an OTU is passed, the document will not be pulled from the database.
 
@@ -182,7 +180,9 @@ async def bulk_join_ids(
     cursor = mongo.otus.find({"_id": {"$in": ids}}, session=session)
 
     return await bulk_join_documents(
-        mongo, [document async for document in cursor], session
+        mongo,
+        [document async for document in cursor],
+        session,
     )
 
 
@@ -191,8 +191,7 @@ async def bulk_join_documents(
     otus: List[Document],
     session: Optional[AsyncIOMotorClientSession] = None,
 ) -> List[Dict[str, Any]]:
-    """
-    Join the otu associated with the supplied ``otu_id`` with its sequences.
+    """Join the otu associated with the supplied ``otu_id`` with its sequences.
 
     If an OTU is passed, the document will not be pulled from the database.
 
@@ -221,45 +220,43 @@ async def bulk_join_documents(
 
 
 async def join_and_format(
-    db,
+    mongo: "Mongo",
     otu_id: str,
-    joined: Optional[dict] = None,
-    issues: Union[dict, None, bool] = False,
-) -> Optional[dict]:
-    """
-    Join the otu identified by the passed ``otu_id``.
+    joined: dict | None = None,
+    issues: dict | bool | None = False,
+) -> dict | None:
+    """Join the otu identified by the passed ``otu_id``.
 
     Reuses the ``joined`` otu document if available to save a database query. Then,
     format the joined otu into a format that can be directly returned to API clients.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param otu_id: the id of the otu to join
     :param joined:
     :param issues: an object describing issues in the otu
     :return: a joined and formatted otu
 
     """
-    joined = joined or await join(db, otu_id)
+    joined = joined or await join(mongo, otu_id)
 
     if not joined:
         return None
 
-    most_recent_change = await virtool.history.db.get_most_recent_change(db, otu_id)
+    most_recent_change = await virtool.history.db.get_most_recent_change(mongo, otu_id)
 
     if issues is False:
-        issues = await verify(db, otu_id)
+        issues = await verify(mongo, otu_id)
 
     return virtool.otus.utils.format_otu(joined, issues, most_recent_change)
 
 
-async def verify(db, otu_id: str, joined: dict = None) -> Optional[dict]:
-    """
-    Verifies that the associated otu is ready to be included in an index rebuild.
+async def verify(mongo: "Mongo", otu_id: str, joined: dict = None) -> dict | None:
+    """Verifies that the associated otu is ready to be included in an index rebuild.
 
     Returns verification errors if necessary.
 
     """
-    joined = joined or await join(db, otu_id)
+    joined = joined or await join(mongo, otu_id)
 
     if not joined:
         raise DatabaseError(f"Could not find otu '{otu_id}'")
@@ -268,18 +265,19 @@ async def verify(db, otu_id: str, joined: dict = None) -> Optional[dict]:
 
 
 async def increment_otu_version(
-    db, otu_id: str, session: Optional[AsyncIOMotorClientSession] = None
+    mongo: "Mongo",
+    otu_id: str,
+    session: Optional[AsyncIOMotorClientSession] = None,
 ) -> Document:
-    """
-    Increment the `version` field by one for the OTU identified by `otu_id`.
+    """Increment the `version` field by one for the OTU identified by `otu_id`.
 
-    :param db: the application database client
+    :param mongo: the application database client
     :param otu_id: the ID of the OTU whose version should be increased
     :param session: a Motor session to use for database operations
     :return: the updated OTU document
 
     """
-    return await db.otus.find_one_and_update(
+    return await mongo.otus.find_one_and_update(
         {"_id": otu_id},
         {"$set": {"verified": False}, "$inc": {"version": 1}},
         session=session,
@@ -287,13 +285,17 @@ async def increment_otu_version(
 
 
 async def update_otu_verification(
-    db, joined: dict, session: Optional[AsyncIOMotorClientSession] = None
+    mongo: "Mongo",
+    joined: dict,
+    session: Optional[AsyncIOMotorClientSession] = None,
 ) -> Optional[dict]:
     issues = virtool.otus.utils.verify(joined)
 
     if issues is None:
-        await db.otus.update_one(
-            {"_id": joined["_id"]}, {"$set": {"verified": True}}, session=session
+        await mongo.otus.update_one(
+            {"_id": joined["_id"]},
+            {"$set": {"verified": True}},
+            session=session,
         )
         joined["verified"] = True
 
@@ -301,7 +303,10 @@ async def update_otu_verification(
 
 
 async def update_sequence_segments(
-    db, old: dict, new: dict, session: Optional[AsyncIOMotorClientSession] = None
+    mongo: "Mongo",
+    old: dict,
+    new: dict,
+    session: Optional[AsyncIOMotorClientSession] = None,
 ):
     if old is None or new is None or "schema" not in old:
         return
@@ -310,7 +315,7 @@ async def update_sequence_segments(
     new_names = {s["name"] for s in new["schema"]}
 
     if old_names != new_names:
-        await db.sequences.update_many(
+        await mongo.sequences.update_many(
             {"otu_id": old["_id"], "segment": {"$in": list(old_names - new_names)}},
             {"$unset": {"segment": ""}},
             session=session,
@@ -318,22 +323,21 @@ async def update_sequence_segments(
 
 
 async def check_sequence_segment_or_target(
-    db,
+    mongo: "Mongo",
     otu_id: str,
     isolate_id: str,
     sequence_id: Optional[str],
     ref_id: str,
     data: dict,
 ) -> Optional[str]:
-    """
-    Check that segment or target field is compatible with the reference.
+    """Check that segment or target field is compatible with the reference.
 
     Returns an error message string if the segment or target provided in `data` is not
     compatible with the parent reference (target) or OTU (segment).
 
     Returns `None` if the check passes.
 
-    :param db: the application database object
+    :param mongo: the application database object
     :param otu_id: the ID of the parent OTU
     :param isolate_id: the ID of the parent isolate
     :param sequence_id: the ID of the sequence if one is being edited
@@ -342,7 +346,7 @@ async def check_sequence_segment_or_target(
     :return: message or `None` if check passes
 
     """
-    reference = await db.references.find_one(ref_id, ["data_type", "targets"])
+    reference = await mongo.references.find_one(ref_id, ["data_type", "targets"])
 
     if reference["data_type"] == "barcode":
         target = data.get("target")
@@ -359,13 +363,13 @@ async def check_sequence_segment_or_target(
             if sequence_id:
                 used_targets_query["_id"] = {"$ne": sequence_id}
 
-            used_targets = await db.sequences.distinct("target", used_targets_query)
+            used_targets = await mongo.sequences.distinct("target", used_targets_query)
 
             if target in used_targets:
                 return f"Target {target} is already used in isolate {isolate_id}"
 
     if reference["data_type"] == "genome" and data.get("segment"):
-        schema = await get_one_field(db.otus, "schema", otu_id) or []
+        schema = await get_one_field(mongo.otus, "schema", otu_id) or []
 
         segment = data.get("segment")
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -80,7 +80,8 @@ PROJECTION = [
 
 
 async def processor(mongo: "Mongo", document: Document) -> Document:
-    """Process a reference document to a form that can be dispatched or returned in a list.
+    """Process a reference document to a form that can be dispatched or returned in a
+    list.
 
     Used `attach_computed` for complete representations of the reference.
 
@@ -206,8 +207,8 @@ async def check_right(req: Request, ref_id: str, right: str) -> bool:
 
 
 async def check_source_type(mongo: "Mongo", ref_id: str, source_type: str) -> bool:
-    """Check if the provided `source_type` is valid based on the current reference source
-    type configuration.
+    """Check if the provided `source_type` is valid based on the current reference
+    source type configuration.
 
     :param mongo: the application database client
     :param ref_id: the reference context
@@ -410,7 +411,8 @@ async def get_latest_build(mongo: "Mongo", ref_id: str) -> Document | None:
 
 
 async def get_official_installed(mongo: "Mongo") -> bool:
-    """Return a boolean indicating whether the official plant virus reference is installed.
+    """Return a boolean indicating whether the official plant virus reference is
+    installed.
 
     :param mongo: the application mongodb client
     :return: the install status for the official reference
@@ -649,7 +651,8 @@ async def insert_change(
     session: AsyncIOMotorClientSession,
     old: Document | None = None,
 ):
-    """Insert a history document for the OTU identified by `otu_id` and the passed `verb`.
+    """Insert a history document for the OTU identified by `otu_id` and the passed
+    `verb`.
 
     :param data_path: system path to the applications datafolder
     :param mongo: the application database object

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -3,8 +3,8 @@ import os
 from asyncio import to_thread
 
 from aiohttp.web import (
-    Request,
     FileResponse,
+    Request,
     Response,
 )
 from aiohttp_pydantic import PydanticView
@@ -12,7 +12,7 @@ from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404
 from pydantic import Field, conint, constr
 from pymongo.errors import DuplicateKeyError
 from sqlalchemy import exc, select
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 from virtool_core.models.roles import AdministratorRole
 from virtool_core.models.samples import SampleSearchResult
@@ -22,16 +22,16 @@ import virtool.caches.db
 import virtool.uploads.db
 import virtool.uploads.utils
 from virtool.api.client import UserClient
+from virtool.api.custom_json import json_response
 from virtool.api.errors import (
-    APINotFound,
-    APIInsufficientRights,
     APIBadRequest,
     APIConflict,
-    APINoContent,
+    APIInsufficientRights,
     APIInvalidQuery,
+    APINoContent,
+    APINotFound,
 )
 from virtool.api.policy import PermissionRoutePolicy, policy
-from virtool.api.custom_json import json_response
 from virtool.api.routes import Routes
 from virtool.api.schema import schema
 from virtool.authorization.permissions import LegacyPermission
@@ -40,8 +40,8 @@ from virtool.caches.utils import join_cache_path
 from virtool.config import get_config_from_req
 from virtool.data.errors import (
     ResourceConflictError,
-    ResourceNotFoundError,
     ResourceError,
+    ResourceNotFoundError,
 )
 from virtool.data.utils import get_data_from_req
 from virtool.errors import DatabaseError
@@ -92,13 +92,12 @@ class SamplesView(PydanticView):
     async def get(
         self,
         find: constr(strip_whitespace=True) = "",
-        label: list[int] = Field(default_factory=lambda: []),
+        label: list[int] = Field(default_factory=list),
         page: conint(gt=0) = 1,
         per_page: conint(ge=1, le=100) = 25,
-        workflows: list[str] = Field(default_factory=lambda: []),
+        workflows: list[str] = Field(default_factory=list),
     ) -> r200[SampleSearchResult] | r400:
-        """
-        Find samples.
+        """Find samples.
 
         Lists samples, filtering by data passed as URL parameters.
 
@@ -107,17 +106,22 @@ class SamplesView(PydanticView):
             400: Invalid query
         """
         search_result = await get_data_from_req(self.request).samples.find(
-            label, page, per_page, find, workflows, self.request["client"]
+            label,
+            page,
+            per_page,
+            find,
+            workflows,
+            self.request["client"],
         )
 
         return json_response(search_result)
 
     @policy(PermissionRoutePolicy(LegacyPermission.CREATE_SAMPLE))
     async def post(
-        self, data: CreateSampleRequest
+        self,
+        data: CreateSampleRequest,
     ) -> r201[CreateSampleResponse] | r400 | r403:
-        """
-        Create a sample.
+        """Create a sample.
 
         Creates a new sample with the given name, labels and subtractions.
 
@@ -133,7 +137,9 @@ class SamplesView(PydanticView):
         """
         try:
             sample = await get_data_from_req(self.request).samples.create(
-                data, self.request["client"].user_id, 0
+                data,
+                self.request["client"].user_id,
+                0,
             )
         except ResourceConflictError as err:
             raise APIBadRequest(str(err))
@@ -149,8 +155,7 @@ class SamplesView(PydanticView):
 @routes.view("/samples/{sample_id}")
 class SampleView(PydanticView):
     async def get(self, sample_id: str, /) -> r200[GetSampleResponse] | r403 | r404:
-        """
-        Get a sample.
+        """Get a sample.
 
         Fetches the details for a sample.
 
@@ -159,7 +164,9 @@ class SampleView(PydanticView):
             400: Invalid query
         """
         if not await get_data_from_req(self.request).samples.has_right(
-            sample_id, self.request["client"], SampleRight.read
+            sample_id,
+            self.request["client"],
+            SampleRight.read,
         ):
             raise APIInsufficientRights()
 
@@ -172,10 +179,12 @@ class SampleView(PydanticView):
         return json_response(sample)
 
     async def patch(
-        self, sample_id: str, /, data: UpdateSampleRequest
+        self,
+        sample_id: str,
+        /,
+        data: UpdateSampleRequest,
     ) -> r200[UpdateSampleResponse] | r400 | r403 | r404:
-        """
-        Update a sample.
+        """Update a sample.
 
         Updates a sample using its 'sample id'.
 
@@ -187,13 +196,16 @@ class SampleView(PydanticView):
             404: Not found
         """
         if not await get_data_from_req(self.request).samples.has_right(
-            sample_id, self.request["client"], SampleRight.write
+            sample_id,
+            self.request["client"],
+            SampleRight.write,
         ):
             raise APIInsufficientRights()
 
         try:
             sample = await get_data_from_req(self.request).samples.update(
-                sample_id, data
+                sample_id,
+                data,
             )
         except ResourceConflictError as err:
             raise APIBadRequest(str(err))
@@ -203,8 +215,7 @@ class SampleView(PydanticView):
         return json_response(sample)
 
     async def delete(self, sample_id: str, /) -> r204 | r403 | r404:
-        """
-        Delete a sample.
+        """Delete a sample.
 
         Removes a sample document and all associated analyses.
 
@@ -214,7 +225,9 @@ class SampleView(PydanticView):
             404: Not found
         """
         if not await get_data_from_req(self.request).samples.has_right(
-            sample_id, self.request["client"], SampleRight.write
+            sample_id,
+            self.request["client"],
+            SampleRight.write,
         ):
             raise APIInsufficientRights()
 
@@ -234,8 +247,7 @@ class SampleView(PydanticView):
 
 @routes.jobs_api.get("/samples/{sample_id}")
 async def get_sample(req):
-    """
-    Get a sample.
+    """Get a sample.
 
     Fetches a complete sample document from a job.
 
@@ -252,18 +264,17 @@ async def get_sample(req):
 
 @routes.jobs_api.get("/samples/{sample_id}/caches/{cache_key}")
 async def get_cache(req):
-    """
-    Get cache.
+    """Get cache.
 
     Fetches a cache document by key using the Jobs API.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
 
     sample_id = req.match_info["sample_id"]
     cache_key = req.match_info["cache_key"]
 
-    document = await db.caches.find_one({"key": cache_key, "sample.id": sample_id})
+    document = await mongo.caches.find_one({"key": cache_key, "sample.id": sample_id})
 
     if document is None:
         raise APINotFound()
@@ -274,8 +285,7 @@ async def get_cache(req):
 @routes.jobs_api.patch("/samples/{sample_id}")
 @schema({"quality": {"type": "dict", "required": True}})
 async def finalize(req):
-    """
-    Finalize a sample.
+    """Finalize a sample.
 
     Set the sample's quality field and the `ready` field to `True`.
 
@@ -295,10 +305,12 @@ async def finalize(req):
 @routes.view("/samples/{sample_id}/rights")
 class RightsView(PydanticView):
     async def patch(
-        self, sample_id: str, /, data: UpdateRightsRequest
+        self,
+        sample_id: str,
+        /,
+        data: UpdateRightsRequest,
     ) -> r200[UpdateRightsResponse] | r400 | r403 | r404:
-        """
-        Update rights settings.
+        """Update rights settings.
 
         Updates the rights settings for the specified sample document.
 
@@ -333,8 +345,8 @@ class RightsView(PydanticView):
                     select(SQLGroup.id).where(
                         (SQLGroup.id == group)
                         if isinstance(group, int)
-                        else (SQLGroup.legacy_id == group)
-                    )
+                        else (SQLGroup.legacy_id == group),
+                    ),
                 )
 
                 if not result.scalars().one_or_none():
@@ -352,8 +364,7 @@ class RightsView(PydanticView):
 
 @routes.jobs_api.delete("/samples/{sample_id}")
 async def job_remove(req):
-    """
-    Remove a job.
+    """Remove a job.
 
     Removes a sample document and all associated analyses.
 
@@ -388,10 +399,9 @@ class AnalysesView(PydanticView):
         sample_id: str,
         page: conint(ge=1) = 1,
         per_page: conint(ge=1, le=100) = 25,
-            /
+        /,
     ) -> r200[list[GetSampleAnalysesResponse]] | r403 | r404:
-        """
-        Get analyses.
+        """Get analyses.
 
         Lists the analyses associated with the given `sample_id`.
 
@@ -401,16 +411,21 @@ class AnalysesView(PydanticView):
             404: Not found
         """
         search_result = await get_data_from_req(self.request).analyses.find(
-            page, per_page, self.request["client"], sample_id
+            page,
+            per_page,
+            self.request["client"],
+            sample_id,
         )
 
         return json_response(search_result)
 
     async def post(
-        self, sample_id: str, /, data: CreateAnalysisRequest
+        self,
+        sample_id: str,
+        /,
+        data: CreateAnalysisRequest,
     ) -> r201[CreateAnalysisResponse] | r400 | r403 | r404:
-        """
-        Start analysis job.
+        """Start analysis job.
 
         Starts an analysis job for a given sample.
 
@@ -435,7 +450,7 @@ class AnalysesView(PydanticView):
 
         try:
             await get_data_from_req(
-                self.request
+                self.request,
             ).samples.has_resources_for_analysis_job(data.ref_id, data.subtractions)
         except ResourceError as err:
             raise APIBadRequest(str(err))
@@ -458,23 +473,22 @@ class AnalysesView(PydanticView):
 
 @routes.jobs_api.delete("/samples/{sample_id}/caches/{cache_key}")
 async def cache_job_remove(req: Request):
-    """
-    Remove cache document.
+    """Remove cache document.
 
     Removes a cache document. Only usable in the Jobs API and when caches are
     unfinalized.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
 
     cache_key = req.match_info["cache_key"]
 
-    document = await db.caches.find_one({"key": cache_key})
+    document = await mongo.caches.find_one({"key": cache_key})
 
     if document is None:
         raise APINotFound()
 
-    if "ready" in document and document["ready"]:
+    if document.get("ready"):
         raise APIConflict("Jobs cannot delete finalized caches")
 
     await virtool.caches.db.remove(req.app, document["_id"])
@@ -484,18 +498,17 @@ async def cache_job_remove(req: Request):
 
 @routes.jobs_api.post("/samples/{sample_id}/artifacts")
 async def upload_artifact(req):
-    """
-    Upload an artifact.
+    """Upload an artifact.
 
     Uploads artifact created during sample creation using the Jobs API.
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
     artifact_type = req.query.get("type")
 
-    if not await db.samples.find_one(sample_id):
+    if not await mongo.samples.find_one(sample_id):
         raise APINotFound()
 
     if errors := naive_validator(req):
@@ -520,11 +533,14 @@ async def upload_artifact(req):
 
     try:
         size = await virtool.uploads.utils.naive_writer(
-            multipart_file_chunker(await req.multipart()), artifact_file_path
+            multipart_file_chunker(await req.multipart()),
+            artifact_file_path,
         )
     except asyncio.CancelledError:
         logger.info(
-            "Sample artifact file upload aborted", id=artifact_id, sample_id=sample_id
+            "Sample artifact file upload aborted",
+            id=artifact_id,
+            sample_id=sample_id,
         )
         await delete_row(pg, artifact_id, SQLSampleArtifact)
         await to_thread(os.remove, artifact_file_path)
@@ -532,7 +548,10 @@ async def upload_artifact(req):
         return Response(status=499)
 
     artifact = await virtool.uploads.db.finalize(
-        pg, size, artifact_id, SQLSampleArtifact
+        pg,
+        size,
+        artifact_id,
+        SQLSampleArtifact,
     )
 
     return json_response(
@@ -544,12 +563,11 @@ async def upload_artifact(req):
 
 @routes.jobs_api.put("/samples/{sample_id}/reads/{filename}")
 async def upload_reads(req):
-    """
-    Upload reads.
+    """Upload reads.
 
     Uploads sample reads using the Jobs API.
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     name = req.match_info["filename"]
@@ -568,7 +586,7 @@ async def upload_reads(req):
 
     reads_path = sample_path / name
 
-    if not await db.samples.find_one(sample_id):
+    if not await mongo.samples.find_one(sample_id):
         raise APINotFound()
 
     try:
@@ -584,37 +602,48 @@ async def upload_reads(req):
         return Response(status=499)
     try:
         reads = await create_reads_file(
-            pg, size, name, name, sample_id, upload_id=upload
+            pg,
+            size,
+            name,
+            name,
+            sample_id,
+            upload_id=upload,
         )
     except exc.IntegrityError:
         raise APIConflict("Reads file name is already uploaded for this sample")
 
-    headers = {"Location": f"/samples/{sample_id}/reads/{reads['name_on_disk']}"}
-
-    return json_response(reads, status=201, headers=headers)
+    return json_response(
+        reads,
+        status=201,
+        headers={"Location": f"/samples/{sample_id}/reads/{reads['name_on_disk']}"},
+    )
 
 
 @routes.jobs_api.post("/samples/{sample_id}/caches")
 @schema({"key": {"type": "string", "required": True}})
 async def create_cache(req):
-    """
-    Create cache document.
+    """Create cache document.
 
     Creates a new cache document using the Jobs API.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     key = req["data"]["key"]
 
     sample_id = req.match_info["sample_id"]
 
-    sample = await db.samples.find_one({"_id": sample_id}, ["paired"])
+    sample = await mongo.samples.find_one({"_id": sample_id}, ["paired"])
 
     if not sample:
         raise APINotFound("Sample does not exist")
 
     try:
-        document = await virtool.caches.db.create(db, sample_id, key, sample["paired"])
+        document = await virtool.caches.db.create(
+            mongo,
+            sample_id,
+            key,
+            sample["paired"],
+        )
     except DuplicateKeyError:
         raise APIConflict(f"Cache with key {key} already exists for this sample")
 
@@ -625,13 +654,12 @@ async def create_cache(req):
 
 @routes.jobs_api.put("/samples/{sample_id}/caches/{key}/reads/{filename}")
 async def upload_cache_reads(req):
-    """
-    Upload reads files to cache.
+    """Upload reads files to cache.
 
     Upload reads files to cache using the Jobs API.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     name = req.match_info["filename"]
@@ -644,7 +672,7 @@ async def upload_cache_reads(req):
     cache_path = join_cache_path(get_config_from_req(req), key) / name
     await asyncio.to_thread(cache_path.mkdir, parents=True, exist_ok=True)
 
-    if not await db.caches.count_documents({"key": key, "sample.id": sample_id}):
+    if not await mongo.caches.count_documents({"key": key, "sample.id": sample_id}):
         raise APINotFound("Cache doesn't exist with given key")
 
     try:
@@ -662,7 +690,13 @@ async def upload_cache_reads(req):
         return Response(status=499)
 
     reads = await create_reads_file(
-        pg, size, name, name, sample_id, key=key, cache=True
+        pg,
+        size,
+        name,
+        name,
+        sample_id,
+        key=key,
+        cache=True,
     )
 
     headers = {"Location": f"/samples/{sample_id}/caches/{key}/reads/{reads['id']}"}
@@ -672,20 +706,19 @@ async def upload_cache_reads(req):
 
 @routes.jobs_api.post("/samples/{sample_id}/caches/{key}/artifacts")
 async def upload_cache_artifact(req):
-    """
-    Upload artifacts to cache.
+    """Upload artifacts to cache.
 
     Uploads sample artifacts to cache using the Jobs API.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
     key = req.match_info["key"]
     artifact_type = req.query.get("type")
 
-    if not await db.caches.count_documents({"key": key, "sample.id": sample_id}):
+    if not await mongo.caches.count_documents({"key": key, "sample.id": sample_id}):
         raise APINotFound()
 
     errors = virtool.uploads.utils.naive_validator(req)
@@ -705,18 +738,24 @@ async def upload_cache_artifact(req):
 
     try:
         artifact = await create_artifact_file(
-            pg, name, name, sample_id, artifact_type, key=key
+            pg,
+            name,
+            name,
+            sample_id,
+            artifact_type,
+            key=key,
         )
     except exc.IntegrityError:
         raise APIConflict(
-            "Artifact file has already been uploaded for this sample cache"
+            "Artifact file has already been uploaded for this sample cache",
         )
 
     artifact_id = artifact["id"]
 
     try:
         size = await virtool.uploads.utils.naive_writer(
-            multipart_file_chunker(await req.multipart()), cache_path
+            multipart_file_chunker(await req.multipart()),
+            cache_path,
         )
     except asyncio.CancelledError:
         logger.info(
@@ -731,7 +770,10 @@ async def upload_cache_artifact(req):
         return Response(status=499)
 
     artifact = await virtool.uploads.db.finalize(
-        pg, size, artifact_id, SQLSampleArtifactCache
+        pg,
+        size,
+        artifact_id,
+        SQLSampleArtifactCache,
     )
 
     return json_response(
@@ -744,17 +786,17 @@ async def upload_cache_artifact(req):
 @routes.jobs_api.patch("/samples/{sample_id}/caches/{key}")
 @schema({"quality": {"type": "dict", "required": True}})
 async def finalize_cache(req):
-    """
-    Finalize cache.
+    """Finalize cache.
 
     Finalizes cache documents.
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     data = req["data"]
     key = req.match_info["key"]
 
-    document = await db.caches.find_one_and_update(
-        {"key": key}, {"$set": {"quality": data["quality"], "ready": True}}
+    document = await mongo.caches.find_one_and_update(
+        {"key": key},
+        {"$set": {"quality": data["quality"], "ready": True}},
     )
 
     return json_response(base_processor(document))
@@ -763,12 +805,11 @@ async def finalize_cache(req):
 @routes.get("/samples/{sample_id}/reads/reads_{suffix}.fq.gz")
 @routes.jobs_api.get("/samples/{sample_id}/reads/reads_{suffix}.fq.gz")
 async def download_reads(req: Request):
-    """
-    Download reads.
+    """Download reads.
 
     Downloads the sample reads file.
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
@@ -776,7 +817,7 @@ async def download_reads(req: Request):
 
     file_name = f"reads_{suffix}.fq.gz"
 
-    if not await db.samples.find_one(sample_id):
+    if not await mongo.samples.find_one(sample_id):
         raise APINotFound()
 
     existing_reads = await get_existing_reads(pg, sample_id)
@@ -798,25 +839,24 @@ async def download_reads(req: Request):
 
 @routes.jobs_api.get("/samples/{sample_id}/artifacts/{filename}")
 async def download_artifact(req: Request):
-    """
-    Download artifact.
+    """Download artifact.
 
     Downloads the sample artifact.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
     filename = req.match_info["filename"]
 
-    if not await db.samples.find_one(sample_id):
+    if not await mongo.samples.find_one(sample_id):
         raise APINotFound()
 
     async with AsyncSession(pg) as session:
         result = (
             await session.execute(
-                select(SQLSampleArtifact).filter_by(sample=sample_id, name=filename)
+                select(SQLSampleArtifact).filter_by(sample=sample_id, name=filename),
             )
         ).scalar()
 
@@ -842,13 +882,12 @@ async def download_artifact(req: Request):
 
 @routes.jobs_api.get("/samples/{sample_id}/caches/{key}/reads/reads_{suffix}.fq.gz")
 async def download_cache_reads(req):
-    """
-    Download reads cache.
+    """Download reads cache.
 
     Downloads sample reads cache for a given key.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
@@ -857,9 +896,9 @@ async def download_cache_reads(req):
 
     file_name = f"reads_{suffix}.fq.gz"
 
-    if not await db.samples.count_documents(
-        {"_id": sample_id}
-    ) or not await db.caches.count_documents({"key": key}):
+    if not await mongo.samples.count_documents(
+        {"_id": sample_id},
+    ) or not await mongo.caches.count_documents({"key": key}):
         raise APINotFound()
 
     existing_reads = await get_existing_reads(pg, sample_id, key=key)
@@ -881,30 +920,31 @@ async def download_cache_reads(req):
 
 @routes.jobs_api.get("/samples/{sample_id}/caches/{key}/artifacts/{filename}")
 async def download_cache_artifact(req):
-    """
-    Download artifact cache.
+    """Download artifact cache.
 
     Downloads sample artifact cache for a given key.
 
     """
-    db = req.app["db"]
+    mongo: "Mongo" = req.app["db"]
     pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
     key = req.match_info["key"]
     filename = req.match_info["filename"]
 
-    if not await db.samples.count_documents(
-        {"_id": sample_id}
-    ) or not await db.caches.count_documents({"key": key}):
+    if not await mongo.samples.count_documents(
+        {"_id": sample_id},
+    ) or not await mongo.caches.count_documents({"key": key}):
         raise APINotFound()
 
     async with AsyncSession(pg) as session:
         result = (
             await session.execute(
                 select(SQLSampleArtifactCache).filter_by(
-                    name=filename, key=key, sample=sample_id
-                )
+                    name=filename,
+                    key=key,
+                    sample=sample_id,
+                ),
             )
         ).scalar()
 

--- a/virtool/settings/data.py
+++ b/virtool/settings/data.py
@@ -21,6 +21,9 @@ class SettingsData:
             projection={"_id": False},
         )
 
+        if settings is None:
+            return Settings()
+
         return Settings(**settings)
 
     async def update(self, data: UpdateSettingsRequest) -> Settings:
@@ -43,7 +46,7 @@ class SettingsData:
         """
         existing = await self.get_all()
 
-        settings = {**(Settings().dict()), **existing}
+        settings = {**(Settings().dict()), **existing.dict()}
 
         await self._mongo.settings.update_one(
             {"_id": "settings"},

--- a/virtool/settings/data.py
+++ b/virtool/settings/data.py
@@ -1,14 +1,7 @@
-from typing import TYPE_CHECKING
-
 from virtool_core.models.settings import Settings
 
 from virtool.mongo.core import Mongo
 from virtool.settings.oas import UpdateSettingsRequest
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
-PROJECTION = {"_id": False}
 
 
 class SettingsData:
@@ -25,7 +18,7 @@ class SettingsData:
         """
         settings = await self._mongo.settings.find_one(
             {"_id": "settings"},
-            projection=PROJECTION,
+            projection={"_id": False},
         )
 
         return Settings(**settings)
@@ -48,9 +41,7 @@ class SettingsData:
 
         :return: the application settings
         """
-        existing = (
-            await self._mongo.settings.find_one({"_id": "settings"}, PROJECTION) or {}
-        )
+        existing = await self.get_all()
 
         settings = {**(Settings().dict()), **existing}
 

--- a/virtool/settings/data.py
+++ b/virtool/settings/data.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 from virtool_core.models.settings import Settings
 
 from virtool.mongo.core import Mongo
 from virtool.settings.oas import UpdateSettingsRequest
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
 
 PROJECTION = {"_id": False}
 
@@ -9,52 +14,50 @@ PROJECTION = {"_id": False}
 class SettingsData:
     name = "settings"
 
-    def __init__(self, db):
-        self._db: Mongo = db
+    def __init__(self, mongo: "Mongo"):
+        self._mongo: Mongo = mongo
 
     async def get_all(self) -> Settings:
-        """
-        List all settings.
+        """List all settings.
 
         :return: the application settings
 
         """
-
-        settings = await self._db.settings.find_one(
-            {"_id": "settings"}, projection=PROJECTION
+        settings = await self._mongo.settings.find_one(
+            {"_id": "settings"},
+            projection=PROJECTION,
         )
 
         return Settings(**settings)
 
     async def update(self, data: UpdateSettingsRequest) -> Settings:
-        """
-        Update the settings.
+        """Update the settings.
 
         :param data: updates to the current settings
         :return: the application settings
         """
-
-        updated = await self._db.settings.find_one_and_update(
-            {"_id": "settings"}, {"$set": data.dict(exclude_unset=True)}
+        updated = await self._mongo.settings.find_one_and_update(
+            {"_id": "settings"},
+            {"$set": data.dict(exclude_unset=True)},
         )
 
         return Settings(**updated)
 
     async def ensure(self) -> Settings:
-        """
-        Ensure the settings document is updated and filled with default values.
+        """Ensure the settings document is updated and filled with default values.
 
         :return: the application settings
         """
-
         existing = (
-            await self._db.settings.find_one({"_id": "settings"}, PROJECTION) or {}
+            await self._mongo.settings.find_one({"_id": "settings"}, PROJECTION) or {}
         )
 
         settings = {**(Settings().dict()), **existing}
 
-        await self._db.settings.update_one(
-            {"_id": "settings"}, {"$set": settings}, upsert=True
+        await self._mongo.settings.update_one(
+            {"_id": "settings"},
+            {"$set": settings},
+            upsert=True,
         )
 
         return Settings(**settings)

--- a/virtool/spaces/data.py
+++ b/virtool/spaces/data.py
@@ -1,18 +1,18 @@
-from typing import Union, List
+from typing import List, Union
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool_core.models.roles import (
-    SpaceRole,
     SpaceLabelRole,
     SpaceProjectRole,
     SpaceReferenceRole,
+    SpaceRole,
     SpaceSampleRole,
     SpaceSubtractionRole,
     SpaceUploadRole,
 )
-from virtool_core.models.spaces import SpaceMinimal, Space, MemberSearchResult
+from virtool_core.models.spaces import MemberSearchResult, Space, SpaceMinimal
 from virtool_core.utils import document_enum
 
 import virtool.utils
@@ -22,20 +22,20 @@ from virtool.authorization.relationships import (
     UserRoleAssignment,
 )
 from virtool.data.errors import (
-    ResourceNotFoundError,
     ResourceConflictError,
+    ResourceNotFoundError,
 )
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import id_exists
 from virtool.spaces.models import SQLSpace
 from virtool.spaces.oas import (
-    UpdateSpaceRequest,
     UpdateMemberRequest,
+    UpdateSpaceRequest,
 )
 from virtool.spaces.utils import (
-    remove_user_roles,
     format_space_user,
     format_space_users,
+    remove_user_roles,
 )
 
 AVAILABLE_ROLES = [
@@ -55,15 +55,17 @@ AVAILABLE_ROLES = [
 
 class SpacesData:
     def __init__(
-        self, authorization_client: AuthorizationClient, db: "Mongo", pg: AsyncEngine
+        self,
+        authorization_client: AuthorizationClient,
+        mongo: "Mongo",
+        pg: AsyncEngine,
     ):
         self._authorization_client = authorization_client
-        self._db = db
+        self._mongo = mongo
         self._pg = pg
 
     async def find(self, user_id: str) -> List[SpaceMinimal]:
-        """
-        Find all spaces that the user is a member of.
+        """Find all spaces that the user is a member of.
 
         :param user_id: the user ID
         :return: a list of spaces.
@@ -73,7 +75,7 @@ class SpacesData:
 
         async with AsyncSession(self._pg) as session:
             result = await session.execute(
-                select(SQLSpace).where(SQLSpace.id.in_(space_ids))
+                select(SQLSpace).where(SQLSpace.id.in_(space_ids)),
             )
 
             spaces = result.scalars().all()
@@ -81,8 +83,7 @@ class SpacesData:
         return [SpaceMinimal(**space.to_dict()) for space in spaces]
 
     async def get(self, space_id: int) -> Space:
-        """
-        Get the complete representation of a space.
+        """Get the complete representation of a space.
 
         :param space_id: the space id.
         :return: the space
@@ -100,14 +101,15 @@ class SpacesData:
             **{
                 **space.to_dict(),
                 "members": await format_space_users(
-                    self._authorization_client, self._db, space_id
+                    self._authorization_client,
+                    self._mongo,
+                    space_id,
                 ),
-            }
+            },
         )
 
     async def update(self, space_id: int, data: UpdateSpaceRequest) -> Space:
-        """
-        Update a space.
+        """Update a space.
 
         :param space_id: the space id.
         :param data: updates to the space.
@@ -141,14 +143,15 @@ class SpacesData:
             **{
                 **row,
                 "members": await format_space_users(
-                    self._authorization_client, self._db, space_id
+                    self._authorization_client,
+                    self._mongo,
+                    space_id,
                 ),
-            }
+            },
         )
 
     async def find_members(self, space_id: int) -> MemberSearchResult:
-        """
-        Find members of a space.
+        """Find members of a space.
 
         :param space_id: the space id.
         :return: a list of space members.
@@ -162,98 +165,117 @@ class SpacesData:
                 raise ResourceNotFoundError
 
         return MemberSearchResult(
-            **{
-                "items": await format_space_users(
-                    self._authorization_client, self._db, space_id
-                ),
-                "available_roles": AVAILABLE_ROLES,
-            }
+            items=await format_space_users(
+                self._authorization_client,
+                self._mongo,
+                space_id,
+            ),
+            available_roles=AVAILABLE_ROLES,
         )
 
     async def update_member(
-        self, space_id: int, member_id: int | str, data: UpdateMemberRequest
+        self,
+        space_id: int,
+        member_id: int | str,
+        data: UpdateMemberRequest,
     ):
-        """
-        Change the roles of a member.
+        """Change the roles of a member.
 
         :param space_id: the space id.
         :param member_id: the id of the user to update.
         :param data: the updates to the member
         :return: the space
         """
-
         data = data.dict(exclude_unset=True)
 
         async with AsyncSession(self._pg) as session:
             result = await session.execute(select(SQLSpace).filter_by(id=space_id))
             space = result.scalar()
 
-            if space is None or not await id_exists(self._db.users, member_id):
+            if space is None or not await id_exists(self._mongo.users, member_id):
                 raise ResourceNotFoundError
 
-        if "role" in data and data["role"]:
+        if data.get("role"):
             await self._authorization_client.add(
-                SpaceMembership(member_id, space_id, SpaceRole(data["role"]))
+                SpaceMembership(member_id, space_id, SpaceRole(data["role"])),
             )
 
         if "label" in data:
             await remove_user_roles(
-                self._authorization_client, member_id, space_id, [SpaceLabelRole]
+                self._authorization_client,
+                member_id,
+                space_id,
+                [SpaceLabelRole],
             )
 
             if data["label"]:
                 await self._authorization_client.add(
-                    UserRoleAssignment(member_id, space_id, data["label"])
+                    UserRoleAssignment(member_id, space_id, data["label"]),
                 )
 
         if "project" in data:
             await remove_user_roles(
-                self._authorization_client, member_id, space_id, [SpaceProjectRole]
+                self._authorization_client,
+                member_id,
+                space_id,
+                [SpaceProjectRole],
             )
 
             if data["project"]:
                 await self._authorization_client.add(
-                    UserRoleAssignment(member_id, space_id, data["project"])
+                    UserRoleAssignment(member_id, space_id, data["project"]),
                 )
 
         if "reference" in data:
             await remove_user_roles(
-                self._authorization_client, member_id, space_id, [SpaceReferenceRole]
+                self._authorization_client,
+                member_id,
+                space_id,
+                [SpaceReferenceRole],
             )
 
             if data["reference"]:
                 await self._authorization_client.add(
-                    UserRoleAssignment(member_id, space_id, data["reference"])
+                    UserRoleAssignment(member_id, space_id, data["reference"]),
                 )
 
         if "sample" in data:
             await remove_user_roles(
-                self._authorization_client, member_id, space_id, [SpaceSampleRole]
+                self._authorization_client,
+                member_id,
+                space_id,
+                [SpaceSampleRole],
             )
 
             if data["sample"]:
                 await self._authorization_client.add(
-                    UserRoleAssignment(member_id, space_id, data["sample"])
+                    UserRoleAssignment(member_id, space_id, data["sample"]),
                 )
 
         if "subtraction" in data:
             await remove_user_roles(
-                self._authorization_client, member_id, space_id, [SpaceSubtractionRole]
+                self._authorization_client,
+                member_id,
+                space_id,
+                [SpaceSubtractionRole],
             )
 
             if data["subtraction"]:
                 await self._authorization_client.add(
-                    UserRoleAssignment(member_id, space_id, data["subtraction"])
+                    UserRoleAssignment(member_id, space_id, data["subtraction"]),
                 )
 
         if "upload" in data:
             await remove_user_roles(
-                self._authorization_client, member_id, space_id, [SpaceUploadRole]
+                self._authorization_client,
+                member_id,
+                space_id,
+                [SpaceUploadRole],
             )
 
             if data["upload"]:
                 await self._authorization_client.add(
-                    UserRoleAssignment(member_id, space_id, data["upload"])
+                    UserRoleAssignment(member_id, space_id, data["upload"]),
                 )
 
         members = await self._authorization_client.list_space_users(space_id)
@@ -261,27 +283,25 @@ class SpacesData:
         for member in members:
             if member[0] == member_id:
                 return format_space_user(
-                    await self._db.users.find_one(member_id), member[1]
+                    await self._mongo.users.find_one(member_id),
+                    member[1],
                 )
 
         raise ResourceNotFoundError
 
     async def remove_member(self, space_id: int, member_id: Union[str, int]):
-        """
-        Remove a member from the space.
-
+        """Remove a member from the space.
 
         :param space_id: the space id.
         :param member_id: the user id.
         :return: the space
 
         """
-
         async with AsyncSession(self._pg) as session:
             result = await session.execute(select(SQLSpace).filter_by(id=space_id))
             space = result.scalar()
 
-            if space is None or not await id_exists(self._db.users, member_id):
+            if space is None or not await id_exists(self._mongo.users, member_id):
                 raise ResourceNotFoundError
 
         await remove_user_roles(

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -8,7 +8,8 @@ from aiojobs.aiohttp import get_scheduler_from_app
 from msal import ClientApplication
 from pymongo.errors import CollectionInvalid
 from structlog import get_logger
-from virtool_core.redis import connect as connect_redis, periodically_ping_redis
+from virtool_core.redis import connect as connect_redis
+from virtool_core.redis import periodically_ping_redis
 
 from virtool.authorization.client import (
     AuthorizationClient,
@@ -47,8 +48,7 @@ class B2C:
 
 
 async def startup_b2c(app: App):
-    """
-    Initiate connection to Azure AD B2C tenant.
+    """Initiate connection to Azure AD B2C tenant.
 
     :param app: Application object
     """
@@ -63,10 +63,10 @@ async def startup_b2c(app: App):
             config.b2c_client_secret,
             config.b2c_tenant,
             config.b2c_user_flow,
-        ]
+        ],
     ):
         logger.critical(
-            "Required B2C client information not provided for --use-b2c option"
+            "Required B2C client information not provided for --use-b2c option",
         )
         sys.exit(1)
 
@@ -85,26 +85,24 @@ async def startup_check_db(app: App):
     if get_config_from_app(app).no_check_db:
         return logger.info("Skipping database checks")
 
-    db = app["db"]
+    mongo: "Mongo" = app["db"]
 
     logger.info("Checking database")
-    await migrate_status(db)
+    await migrate_status(mongo)
 
     # Make sure the indexes collection exists before later trying to set an compound
     # index on it.
     try:
-        await db.motor_client.create_collection("indexes")
+        await mongo.motor_client.create_collection("indexes")
     except CollectionInvalid:
         pass
 
 
 async def startup_data(app: App):
-    """
-    Create the application data layer object.
+    """Create the application data layer object.
 
     :param app: the application object
     """
-
     app["data"] = create_data_layer(
         get_authorization_client_from_app(app),
         app["db"],
@@ -116,8 +114,7 @@ async def startup_data(app: App):
 
 
 async def startup_databases(app: App):
-    """
-    Connects to MongoDB, Redis and Postgres concurrently
+    """Connects to MongoDB, Redis and Postgres concurrently
 
     :param app: the app object
 
@@ -129,7 +126,9 @@ async def startup_databases(app: App):
         connect_pg(config.postgres_connection_string),
         connect_redis(config.redis_connection_string),
         connect_openfga(
-            config.openfga_host, config.openfga_scheme, config.openfga_store_name
+            config.openfga_host,
+            config.openfga_scheme,
+            config.openfga_store_name,
         ),
     )
 
@@ -144,7 +143,7 @@ async def startup_databases(app: App):
             "db": Mongo(mongo, RandomIdProvider()),
             "pg": pg,
             "redis": redis,
-        }
+        },
     )
 
 
@@ -155,8 +154,7 @@ async def startup_events(app: App):
 
 
 async def startup_executors(app: App):
-    """
-    An application ``on_startup`` callback that initializes a
+    """An application ``on_startup`` callback that initializes a
     :class:`~ThreadPoolExecutor` and attaches it to the ``app`` object.
 
     :param app: the application object
@@ -174,8 +172,7 @@ async def startup_executors(app: App):
 
 
 async def startup_http_client_session(app: App):
-    """
-    Create an async HTTP client session for the server.
+    """Create an async HTTP client session for the server.
 
     The client session is used to make requests to GitHub, NCBI, and
     https://www.virtool.ca.
@@ -186,7 +183,7 @@ async def startup_http_client_session(app: App):
     logger.info("Starting HTTP client")
 
     app["client"] = ClientSession(
-        headers={"User-Agent": f"virtool/{get_version_from_app(app)}"}
+        headers={"User-Agent": f"virtool/{get_version_from_app(app)}"},
     )
 
 
@@ -195,8 +192,7 @@ async def startup_routes(app: App):
 
 
 async def startup_sentry(app: App):
-    """
-    Create a Sentry client and attach it to the application if a DSN was configured.
+    """Create a Sentry client and attach it to the application if a DSN was configured.
 
     :param app: the application object
     """
@@ -208,8 +204,7 @@ async def startup_sentry(app: App):
 
 
 async def startup_settings(app: App):
-    """
-    Draws settings from the settings database collection.
+    """Draws settings from the settings database collection.
 
     Performs migration of old settings style to `v3.3.0` if necessary.
 
@@ -220,8 +215,7 @@ async def startup_settings(app: App):
 
 
 async def startup_task_runner(app: App):
-    """
-    An application `on_startup` callback that initializes a Virtool
+    """An application `on_startup` callback that initializes a Virtool
     :class:`virtool.tasks.runner.TaskRunner` object and puts it in app state.
 
     :param app: the app object
@@ -232,8 +226,7 @@ async def startup_task_runner(app: App):
 
 
 async def startup_version(app: App):
-    """
-    Store and log the Virtool version.
+    """Store and log the Virtool version.
 
     :param app: the application object
 

--- a/virtool/subtractions/fake.py
+++ b/virtool/subtractions/fake.py
@@ -1,5 +1,5 @@
 from shutil import copytree
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +9,9 @@ from virtool.subtractions.files import create_subtraction_files
 from virtool.subtractions.utils import FILES
 from virtool.types import App
 from virtool.uploads.models import SQLUpload
+
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
 
 
 async def create_fake_fasta_upload(app: App, user_id: str) -> Tuple[int, str]:
@@ -27,12 +30,16 @@ async def create_fake_fasta_upload(app: App, user_id: str) -> Tuple[int, str]:
 
 
 async def create_fake_finalized_subtraction(
-    app: App, upload_id: int, upload_name: str, subtraction_id: str, user_id: str
+    app: App,
+    upload_id: int,
+    upload_name: str,
+    subtraction_id: str,
+    user_id: str,
 ):
-    db = app["db"]
+    mongo: "Mongo" = app["db"]
     pg = app["pg"]
 
-    document = await db.subtraction.insert_one(
+    document = await mongo.subtraction.insert_one(
         {
             "_id": subtraction_id,
             "name": "subtraction_1",
@@ -43,7 +50,7 @@ async def create_fake_finalized_subtraction(
             "gc": {"a": 0.25, "t": 0.25, "g": 0.25, "c": 0.25},
             "ready": True,
             "count": 100,
-        }
+        },
     )
 
     subtractions_path = (

--- a/virtool/types.py
+++ b/virtool/types.py
@@ -1,5 +1,4 @@
 """Custom types aliases for Virtool."""
-from __future__ import annotations
 
 from datetime import datetime
 from typing import (
@@ -20,7 +19,8 @@ In testing ``dict``-like objects are sometimes used in place of an application.
 """
 
 Document: TypeAlias = dict[
-    str, dict | list | bool | str | int | float | datetime | None
+    str,
+    dict | list | bool | str | int | float | datetime | None,
 ]
 """
 A MongoDB document or similar dictionary.

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -1,39 +1,44 @@
 import asyncio
 import math
 from asyncio import to_thread
-from typing import List
+from typing import TYPE_CHECKING, List
 
-from sqlalchemy import select, update, func
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
-from virtool_core.models.upload import Upload, UploadSearchResult, UploadMinimal
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from virtool_core.models.upload import Upload, UploadMinimal, UploadSearchResult
 from virtool_core.utils import rm
 
 import virtool.utils
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceNotFoundError
-from virtool.data.events import emits, Operation
+from virtool.data.events import Operation, emits
 from virtool.data.transforms import apply_transforms
 from virtool.mongo.core import Mongo
 from virtool.uploads.models import SQLUpload, UploadType
 from virtool.uploads.utils import naive_writer
 from virtool.users.transforms import AttachUserTransform
 
+if TYPE_CHECKING:
+    from virtool.mongo.core import Mongo
+
 
 class UploadsData(DataLayerDomain):
     name = "uploads"
 
-    def __init__(self, config, db, pg):
+    def __init__(self, config, mongo: "Mongo", pg):
         self._config = config
-        self._db: Mongo = db
+        self._mongo: Mongo = mongo
         self._pg: AsyncEngine = pg
 
     async def find(
-        self, user, page: int, per_page: int, upload_type, paginate
+        self,
+        user,
+        page: int,
+        per_page: int,
+        upload_type,
+        paginate,
     ) -> List[UploadMinimal] | UploadSearchResult:
-        """
-        Find and filter uploads.
-        """
-
+        """Find and filter uploads."""
         if paginate:
             return await self._find_beta(user, page, per_page, upload_type)
 
@@ -52,7 +57,7 @@ class UploadsData(DataLayerDomain):
                 filters.append(SQLUpload.type == upload_type)
 
             results = await session.execute(
-                select(SQLUpload).where(*filters).order_by(SQLUpload.created_at.desc())
+                select(SQLUpload).where(*filters).order_by(SQLUpload.created_at.desc()),
             )
 
             for result in results.unique().scalars().all():
@@ -61,12 +66,17 @@ class UploadsData(DataLayerDomain):
             return [
                 UploadMinimal(**upload)
                 for upload in await apply_transforms(
-                    uploads, [AttachUserTransform(self._db)]
+                    uploads,
+                    [AttachUserTransform(self._mongo)],
                 )
             ]
 
     async def _find_beta(
-        self, user, page: int, per_page: int, upload_type
+        self,
+        user,
+        page: int,
+        per_page: int,
+        upload_type,
     ) -> UploadSearchResult:
         base_filters = [
             SQLUpload.ready == True,  # skipcq: PTC-W0068,PYL-R1714
@@ -119,7 +129,7 @@ class UploadsData(DataLayerDomain):
 
             uploads = [row.to_dict() for row in results.unique().scalars()]
 
-        uploads = await apply_transforms(uploads, [AttachUserTransform(self._db)])
+        uploads = await apply_transforms(uploads, [AttachUserTransform(self._mongo)])
 
         return UploadSearchResult(
             items=uploads,
@@ -132,11 +142,13 @@ class UploadsData(DataLayerDomain):
 
     @emits(Operation.CREATE)
     async def create(
-        self, chunker, name: str, upload_type: UploadType, user: str | None = None
+        self,
+        chunker,
+        name: str,
+        upload_type: UploadType,
+        user: str | None = None,
     ) -> Upload:
-        """
-        Create an upload.
-        """
+        """Create an upload."""
         uploads_path = self._config.data_path / "files"
 
         await asyncio.to_thread(uploads_path.mkdir, parents=True, exist_ok=True)
@@ -167,12 +179,11 @@ class UploadsData(DataLayerDomain):
             await session.commit()
 
         return Upload(
-            **await apply_transforms(upload_dict, [AttachUserTransform(self._db)])
+            **await apply_transforms(upload_dict, [AttachUserTransform(self._mongo)]),
         )
 
     async def get(self, upload_id: int) -> Upload:
-        """
-        Get a single upload by its ID.
+        """Get a single upload by its ID.
 
         :param upload_id: the upload's ID
         :return: the upload
@@ -180,7 +191,7 @@ class UploadsData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             upload = (
                 await session.execute(
-                    select(SQLUpload).filter_by(id=upload_id, removed=False)
+                    select(SQLUpload).filter_by(id=upload_id, removed=False),
                 )
             ).scalar()
 
@@ -188,22 +199,22 @@ class UploadsData(DataLayerDomain):
                 raise ResourceNotFoundError
 
         return Upload(
-            **await apply_transforms(upload.to_dict(), [AttachUserTransform(self._db)])
+            **await apply_transforms(
+                upload.to_dict(), [AttachUserTransform(self._mongo)]
+            ),
         )
 
     @emits(Operation.DELETE)
     async def delete(self, upload_id: int) -> Upload:
-        """
-        Delete an upload by its id.
+        """Delete an upload by its id.
 
         :param upload_id: The upload id
         :return: the upload
         """
-
         async with AsyncSession(self._pg) as session:
             upload = (
                 await session.execute(
-                    select(SQLUpload).where(SQLUpload.id == upload_id)
+                    select(SQLUpload).where(SQLUpload.id == upload_id),
                 )
             ).scalar()
 
@@ -219,7 +230,7 @@ class UploadsData(DataLayerDomain):
             await session.commit()
 
         upload = Upload(
-            **await apply_transforms(upload, [AttachUserTransform(self._db)])
+            **await apply_transforms(upload, [AttachUserTransform(self._mongo)]),
         )
 
         try:
@@ -230,8 +241,7 @@ class UploadsData(DataLayerDomain):
         return upload
 
     async def release(self, upload_ids: int | List[int]):
-        """
-        Release the uploads in `upload_ids` by setting the `reserved` field to `False`.
+        """Release the uploads in `upload_ids` by setting the `reserved` field to `False`.
 
         :param upload_ids: List of upload ids
         """
@@ -245,14 +255,13 @@ class UploadsData(DataLayerDomain):
                 update(SQLUpload)
                 .where(query)
                 .values(reserved=False)
-                .execution_options(synchronize_session="fetch")
+                .execution_options(synchronize_session="fetch"),
             )
 
             await session.commit()
 
     async def reserve(self, upload_ids: int | List[int]):
-        """
-        Reserve the uploads in `upload_ids` by setting the `reserved` field to `True`.
+        """Reserve the uploads in `upload_ids` by setting the `reserved` field to `True`.
 
         :param upload_ids: List of upload ids
         """
@@ -266,21 +275,20 @@ class UploadsData(DataLayerDomain):
                 update(SQLUpload)
                 .where(query)
                 .values(reserved=True)
-                .execution_options(synchronize_session="fetch")
+                .execution_options(synchronize_session="fetch"),
             )
             await session.commit()
 
     async def migrate_to_postgres(self):
-        """
-        Transforms documents in the `files` collection into rows in the `uploads` SQL
+        """Transforms documents in the `files` collection into rows in the `uploads` SQL
         table.
 
         """
-        async for document in self._db.files.find():
+        async for document in self._mongo.files.find():
             async with AsyncSession(self._pg) as session:
                 exists = (
                     await session.execute(
-                        select(SQLUpload).filter_by(name_on_disk=document["_id"])
+                        select(SQLUpload).filter_by(name_on_disk=document["_id"]),
                     )
                 ).scalar()
 
@@ -300,4 +308,4 @@ class UploadsData(DataLayerDomain):
                     session.add(upload)
                     await session.commit()
 
-                    await self._db.files.delete_one({"_id": document["_id"]})
+                    await self._mongo.files.delete_one({"_id": document["_id"]})

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -1,7 +1,7 @@
 import asyncio
 import math
 from asyncio import to_thread
-from typing import TYPE_CHECKING, List
+from typing import List
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -17,9 +17,6 @@ from virtool.mongo.core import Mongo
 from virtool.uploads.models import SQLUpload, UploadType
 from virtool.uploads.utils import naive_writer
 from virtool.users.transforms import AttachUserTransform
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
 
 
 class UploadsData(DataLayerDomain):
@@ -200,7 +197,8 @@ class UploadsData(DataLayerDomain):
 
         return Upload(
             **await apply_transforms(
-                upload.to_dict(), [AttachUserTransform(self._mongo)]
+                upload.to_dict(),
+                [AttachUserTransform(self._mongo)],
             ),
         )
 
@@ -241,7 +239,8 @@ class UploadsData(DataLayerDomain):
         return upload
 
     async def release(self, upload_ids: int | List[int]):
-        """Release the uploads in `upload_ids` by setting the `reserved` field to `False`.
+        """Release the uploads in `upload_ids` by setting the `reserved` field to
+        `False`.
 
         :param upload_ids: List of upload ids
         """
@@ -261,7 +260,8 @@ class UploadsData(DataLayerDomain):
             await session.commit()
 
     async def reserve(self, upload_ids: int | List[int]):
-        """Reserve the uploads in `upload_ids` by setting the `reserved` field to `True`.
+        """Reserve the uploads in `upload_ids` by setting the `reserved` field to
+        `True`.
 
         :param upload_ids: List of upload ids
         """

--- a/virtool/users/db.py
+++ b/virtool/users/db.py
@@ -1,21 +1,15 @@
-"""
-Database utilities for managing users.
+"""Database utilities for managing users.
 
 TODO: Drop legacy group id support when we fully migrate to integer ids.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
-
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-
 from virtool.data.errors import ResourceConflictError
 from virtool.data.topg import compose_legacy_id_expression
-
 from virtool.groups.pg import SQLGroup
 
 ATTACH_PROJECTION = ("_id", "handle")
@@ -32,9 +26,7 @@ PROJECTION = (
 
 @dataclass
 class B2CUserAttributes:
-    """
-    Class to store ID token claims from Azure AD B2C
-    """
+    """Class to store ID token claims from Azure AD B2C"""
 
     display_name: str
     family_name: str
@@ -43,10 +35,11 @@ class B2CUserAttributes:
 
 
 async def compose_groups_update(
-    pg: AsyncEngine, group_ids: list[int | str], primary_group: int | str | None
+    pg: AsyncEngine,
+    group_ids: list[int | str],
+    primary_group: int | str | None,
 ) -> dict[str, list[int | str]]:
-    """
-    Compose an update dict for updating the list of groups a user is a member of.
+    """Compose an update dict for updating the list of groups a user is a member of.
 
     Any legacy string ids will be converted to modern integer ids. A
     ``ResourceConflictError`` will be raised if any of the ``group_ids`` do not exist.
@@ -62,7 +55,7 @@ async def compose_groups_update(
         expr = compose_legacy_id_expression(SQLGroup, group_ids)
 
         result = await session.execute(
-            select(SQLGroup.id, SQLGroup.legacy_id).where(expr)
+            select(SQLGroup.id, SQLGroup.legacy_id).where(expr),
         )
 
         existing_group_ids = [id_ for row in result.all() for id_ in row]


### PR DESCRIPTION
## Changes
* Rename `db` or `_db` to `mongo` or `_mongo` in most places.
* Module names and `app["db"]` are unchanged in this PR.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
