### PR TITLE
test: remove apitest pytest mark

### DIFF
--- a/tests/account/test_data.py
+++ b/tests/account/test_data.py
@@ -18,7 +18,9 @@ from virtool.users.pg import SQLUser
 
 
 @pytest.mark.parametrize(
-    "has_permission", [True, False], ids=["has_permission", "does_not_have_permission"]
+    "has_permission",
+    [True, False],
+    ids=["has_permission", "does_not_have_permission"],
 )
 async def test_create_api_key(
     has_permission: bool,
@@ -29,8 +31,7 @@ async def test_create_api_key(
     snapshot: SnapshotAssertion,
     static_time,
 ):
-    """
-    Test that an API key is created correctly with varying key owner administrator status and
+    """Test that an API key is created correctly with varying key owner administrator status and
     permissions.
 
     """
@@ -43,8 +44,8 @@ async def test_create_api_key(
             **{
                 Permission.create_sample: True,
                 Permission.modify_subtraction: has_permission,
-            }
-        )
+            },
+        ),
     )
 
     user = await fake2.users.create(groups=[group_1, group_2])
@@ -70,7 +71,8 @@ class TestGetKey:
             CreateKeysRequest(
                 name="Foo",
                 permissions=PermissionsUpdate(
-                    create_sample=True, modify_subtraction=True
+                    create_sample=True,
+                    modify_subtraction=True,
                 ),
             ),
             user.id,
@@ -86,7 +88,8 @@ class TestGetKey:
             CreateKeysRequest(
                 name="Foo",
                 permissions=PermissionsUpdate(
-                    create_sample=True, modify_subtraction=True
+                    create_sample=True,
+                    modify_subtraction=True,
                 ),
             ),
             user.id,
@@ -105,7 +108,8 @@ class TestGetKeyBySecret:
             CreateKeysRequest(
                 name="Foo",
                 permissions=PermissionsUpdate(
-                    create_sample=True, modify_subtraction=True
+                    create_sample=True,
+                    modify_subtraction=True,
                 ),
             ),
             user.id,
@@ -114,16 +118,15 @@ class TestGetKeyBySecret:
         assert await data_layer.account.get_key_by_secret(user.id, secret) == api_key
 
     async def test_not_found(self, data_layer: DataLayer, fake2: DataFaker):
-        """
-        Test that ``ResourceNotFoundError`` is raised when the key secret is invalid.
-        """
+        """Test that ``ResourceNotFoundError`` is raised when the key secret is invalid."""
         user = await fake2.users.create()
 
         await data_layer.account.create_key(
             CreateKeysRequest(
                 name="Foo",
                 permissions=PermissionsUpdate(
-                    create_sample=True, modify_subtraction=True
+                    create_sample=True,
+                    modify_subtraction=True,
                 ),
             ),
             user.id,
@@ -162,7 +165,8 @@ async def test_update(
     )
 
     (row, document) = await asyncio.gather(
-        get_row_by_id(pg, SQLUser, 1), mongo.users.find_one({"_id": user.id})
+        get_row_by_id(pg, SQLUser, 1),
+        mongo.users.find_one({"_id": user.id}),
     )
 
     assert row == snapshot_recent(name="pg", exclude=props("password"))

--- a/tests/account/test_mongo.py
+++ b/tests/account/test_mongo.py
@@ -4,13 +4,13 @@ from virtool.account.mongo import compose_password_update, get_alternate_id
 
 
 def test_compose_password_update(mocker, static_time):
-    """
-    Test that compose password returns the expected update `dict`. Ensure the password is hashed
+    """Test that compose password returns the expected update `dict`. Ensure the password is hashed
     using :func:`hash_password`.
 
     """
     m_hash_password = mocker.patch(
-        "virtool.users.utils.hash_password", return_value="foobar"
+        "virtool.users.utils.hash_password",
+        return_value="foobar",
     )
 
     update = compose_password_update("baz")

--- a/tests/analyses/test_files.py
+++ b/tests/analyses/test_files.py
@@ -12,7 +12,10 @@ async def test_create_nuvs_analysis_files(snapshot, tmp_path, pg: AsyncEngine):
     test_dir.joinpath("hmm.tsv").write_text("HMM file")
 
     await virtool.analyses.files.create_nuvs_analysis_files(
-        pg, "foo", ["assembly.fa", "hmm.tsv"], test_dir
+        pg,
+        "foo",
+        ["assembly.fa", "hmm.tsv"],
+        test_dir,
     )
 
     async with AsyncSession(pg) as session:

--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -8,9 +8,8 @@ from virtool.mongo.core import Mongo
 
 
 @pytest.mark.parametrize("loadable", [True, False])
-async def test_load_results(loadable, mocker, tmp_path, config):
-    """
-    Test that results are loaded from a `results.json` as expected. Check that the file loading action is not pursued
+async def test_load_results(loadable, config, mocker, tmp_path):
+    """Test that results are loaded from a `results.json` as expected. Check that the file loading action is not pursued
     if the results are stored in the analysis document.
 
     """
@@ -26,7 +25,8 @@ async def test_load_results(loadable, mocker, tmp_path, config):
     results_file.write_text(json.dumps(results))
 
     m_join_analysis_json_path = mocker.patch(
-        "virtool.analyses.utils.join_analysis_json_path", return_value=str(results_file)
+        "virtool.analyses.utils.join_analysis_json_path",
+        return_value=str(results_file),
     )
 
     result = await load_results(config, document)
@@ -165,22 +165,17 @@ async def test_load_results(loadable, mocker, tmp_path, config):
     ],
 )
 def test_transform_coverage_to_coordinates(coverage, snapshot):
-    """
-    Test that two sample coverage data sets are correctly converted to coordinates.
-
-    """
+    """Test that two sample coverage data sets are correctly converted to coordinates."""
     assert transform_coverage_to_coordinates(coverage) == snapshot
 
 
 @pytest.mark.parametrize("workflow", [None, "foobar", "nuvs", "pathoscope"])
 async def test_format_analysis(workflow: str | None, config, mocker, mongo: Mongo):
-    """
-    Ensure that:
+    """Ensure that:
     * the correct formatting function is called based on the workflow field.
     * an exception is raised if the workflow field cannot be processed.
 
     """
-
     m_format_nuvs = mocker.patch(
         "virtool.analyses.format.format_nuvs",
         return_value={"is_nuvs": True, "is_pathoscope": False},

--- a/tests/analyses/test_utils.py
+++ b/tests/analyses/test_utils.py
@@ -2,16 +2,25 @@ import os
 from pathlib import Path
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+from syrupy import SnapshotAssertion
 
 import virtool.analyses.files
 import virtool.analyses.utils
 
 
 @pytest.mark.parametrize("exists", [True, False])
-async def test_attach_analysis_files(exists, snapshot, pg):
+async def test_attach_analysis_files(
+    exists: bool,
+    pg: AsyncEngine,
+    snapshot: SnapshotAssertion,
+):
     if exists:
         await virtool.analyses.files.create_analysis_file(
-            pg, "foobar", "fasta", "reference-fa"
+            pg,
+            "foobar",
+            "fasta",
+            "reference-fa",
         )
 
     document = {"_id": "foobar", "ready": True}
@@ -24,8 +33,7 @@ async def test_attach_analysis_files(exists, snapshot, pg):
 
 @pytest.mark.parametrize("name", ["nuvs", "pathoscope"])
 def test_get_json_path(name):
-    """
-    Test that the function can correctly extrapolate the path to a nuvs.json file given the `data_path`, `sample_id`,
+    """Test that the function can correctly extrapolate the path to a nuvs.json file given the `data_path`, `sample_id`,
     and `analysis_id` arguments.
 
     """

--- a/tests/dev/test_api.py
+++ b/tests/dev/test_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.apitest
+
 @pytest.mark.parametrize("dev", [True, False])
 async def test_dev_mode(dev, spawn_client):
     """

--- a/tests/downloads/test_api.py
+++ b/tests/downloads/test_api.py
@@ -4,7 +4,6 @@ from tests.fixtures.client import ClientSpawner
 from virtool.mongo.core import Mongo
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("get", ["isolate", "sequence"])
 @pytest.mark.parametrize("missing", [None, "otu", "isolate", "sequence"])
 async def test_all(
@@ -22,7 +21,7 @@ async def test_all(
 
     if missing != "otu":
         await mongo.otus.insert_one(
-            {"_id": "foobar", "name": "Foobar virus", "isolates": isolates}
+            {"_id": "foobar", "name": "Foobar virus", "isolates": isolates},
         )
 
     sequences = [
@@ -31,7 +30,7 @@ async def test_all(
             "otu_id": "foobar",
             "isolate_id": "baz",
             "sequence": "ATAGGGACATA",
-        }
+        },
     ]
 
     if missing != "sequence":
@@ -41,7 +40,7 @@ async def test_all(
                 "otu_id": "foobar",
                 "isolate_id": "foo",
                 "sequence": "ATAGGGACATA",
-            }
+            },
         )
 
     await mongo.sequences.insert_many(sequences, session=None)

--- a/tests/genbank/test_api.py
+++ b/tests/genbank/test_api.py
@@ -3,7 +3,6 @@ from aiohttp.client import ClientSession
 from aiohttp.test_utils import make_mocked_coro
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(error, mocker, resp_is, spawn_client):
     client = await spawn_client(authenticated=True)
@@ -11,7 +10,8 @@ async def test_get(error, mocker, resp_is, spawn_client):
     expected = {"accession": "baz"}
 
     m_fetch = mocker.patch(
-        "virtool.genbank.http.fetch", make_mocked_coro(None if error else expected)
+        "virtool.genbank.http.fetch",
+        make_mocked_coro(None if error else expected),
     )
 
     resp = await client.get("/genbank/NC_016574.1")

--- a/tests/groups/test_api.py
+++ b/tests/groups/test_api.py
@@ -8,10 +8,12 @@ from virtool.groups.oas import PermissionsUpdate
 
 class TestFind:
     async def test_list(
-        self, fake2: DataFaker, snapshot: SnapshotAssertion, spawn_client: ClientSpawner
+        self,
+        fake2: DataFaker,
+        snapshot: SnapshotAssertion,
+        spawn_client: ClientSpawner,
     ):
         """Test that a full list of groups is returned when pagination is not toggled."""
-
         for _ in range(10):
             await fake2.groups.create()
 
@@ -32,7 +34,8 @@ class TestFind:
         spawn_client: ClientSpawner,
     ):
         """Test that the correct page of groups and the correct search metadata values
-        are returned when `page` is `1` or `2`."""
+        are returned when `page` is `1` or `2`.
+        """
         for _ in range(4):
             await fake2.groups.create()
 
@@ -65,7 +68,10 @@ class TestCreate:
         assert await resp.json() == snapshot(name="json")
 
     async def test_duplicate(
-        self, fake2: DataFaker, snapshot, spawn_client: ClientSpawner
+        self,
+        fake2: DataFaker,
+        snapshot,
+        spawn_client: ClientSpawner,
     ):
         """Test that an error is returned when an existing group name is used."""
         client = await spawn_client(
@@ -81,7 +87,6 @@ class TestCreate:
         assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("status", [200, 404])
 async def test_get(
     status: int,
@@ -106,10 +111,12 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 class TestUpdate:
     async def test(
-        self, fake2: DataFaker, spawn_client: ClientSpawner, snapshot: SnapshotAssertion
+        self,
+        fake2: DataFaker,
+        spawn_client: ClientSpawner,
+        snapshot: SnapshotAssertion,
     ):
         client = await spawn_client(
             administrator=True,
@@ -147,17 +154,13 @@ class TestUpdate:
         assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("status", [204, 404])
 async def test_delete(status: int, fake2: DataFaker, spawn_client: ClientSpawner):
-    """
-    Test that an existing document can be removed at ``DELETE /groups/:group_id``.
-
-    """
+    """Test that an existing document can be removed at ``DELETE /groups/:group_id``."""
     client = await spawn_client(administrator=True, authenticated=True)
 
     group = await fake2.groups.create(
-        permissions=PermissionsUpdate(create_sample=True, remove_file=True)
+        permissions=PermissionsUpdate(create_sample=True, remove_file=True),
     )
 
     await fake2.users.create(groups=[group])

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -6,22 +6,23 @@ from tests.fixtures.client import ClientSpawner
 from virtool.mongo.core import Mongo
 
 
-@pytest.mark.apitest
 async def test_find(
-    snapshot, mongo: Mongo, spawn_client: ClientSpawner, test_changes, static_time
+    snapshot,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    test_changes,
+    static_time,
 ):
-    """
-    Test that a list of processed change documents are returned with a ``200`` status.
-
-    """
+    """Test that a list of processed change documents are returned with a ``200`` status."""
     client = await spawn_client(authenticated=True)
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"}
+            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"},
         ),
         mongo.history.insert_many(
-            [{**c, "user": {"id": client.user.id}} for c in test_changes], session=None
+            [{**c, "user": {"id": client.user.id}} for c in test_changes],
+            session=None,
         ),
     )
 
@@ -31,7 +32,6 @@ async def test_find(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error,
@@ -42,18 +42,16 @@ async def test_get(
     test_changes,
     static_time,
 ):
-    """
-    Test that a specific history change can be retrieved by its change_id.
-
-    """
+    """Test that a specific history change can be retrieved by its change_id."""
     client = await spawn_client(authenticated=True)
 
     await asyncio.gather(
         mongo.history.insert_many(
-            [{**c, "user": {"id": client.user.id}} for c in test_changes], session=None
+            [{**c, "user": {"id": client.user.id}} for c in test_changes],
+            session=None,
         ),
         mongo.references.insert_one(
-            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"}
+            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"},
         ),
     )
 
@@ -69,7 +67,6 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 @pytest.mark.parametrize("remove", [False, True])
 async def test_revert(
@@ -82,10 +79,7 @@ async def test_revert(
     check_ref_right,
     resp_is,
 ):
-    """
-    Test that a valid request results in a reversion and a ``204`` response.
-
-    """
+    """Test that a valid request results in a reversion and a ``204`` response."""
     client = await spawn_client(authenticated=True)
 
     await create_mock_history(remove)

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -10,7 +10,7 @@ from virtool.config import get_config_from_app
 from virtool.mongo.core import Mongo
 
 
-@pytest.fixture
+@pytest.fixture()
 async def fake_hmm_status(mongo, fake2, static_time):
     user = await fake2.users.create()
 
@@ -47,20 +47,20 @@ async def fake_hmm_status(mongo, fake2, static_time):
                 "size": 85904451,
             },
             "errors": [],
-        }
+        },
     )
 
     return user
 
 
-@pytest.mark.apitest
 async def test_find(
-    fake_hmm_status, snapshot, mongo: Mongo, spawn_client: ClientSpawner, hmm_document
+    fake_hmm_status,
+    snapshot,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    hmm_document,
 ):
-    """
-    Check that a request with no URL parameters returns a list of HMM annotation documents.
-
-    """
+    """Check that a request with no URL parameters returns a list of HMM annotation documents."""
     client = await spawn_client(authenticated=True)
 
     hmm_document["hidden"] = False
@@ -73,7 +73,6 @@ async def test_find(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 async def test_get_status(fake_hmm_status, snapshot, spawn_client, static_time):
     client = await spawn_client(authenticated=True)
     resp = await client.get("/hmms/status")
@@ -82,10 +81,8 @@ async def test_get_status(fake_hmm_status, snapshot, spawn_client, static_time):
     assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.apitest
 async def test_get_release(fake_hmm_status, spawn_client, snapshot):
-    """
-    Test that the endpoint returns the latest HMM release. Check that error responses are sent in all expected
+    """Test that the endpoint returns the latest HMM release. Check that error responses are sent in all expected
     situations.
 
     """
@@ -97,13 +94,16 @@ async def test_get_release(fake_hmm_status, spawn_client, snapshot):
     assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
-    error, snapshot, mongo: Mongo, spawn_client: ClientSpawner, hmm_document, resp_is
+    error,
+    snapshot,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    hmm_document,
+    resp_is,
 ):
-    """
-    Check that a ``GET`` request for a valid annotation document results in a response containing that complete
+    """Check that a ``GET`` request for a valid annotation document results in a response containing that complete
     document.
 
     Check that a `404` is returned if the HMM does not exist.
@@ -124,7 +124,6 @@ async def test_get(
     assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.apitest
 async def test_get_hmm_annotations(spawn_job_client, tmp_path):
     client = await spawn_job_client(authorize=True)
     get_config_from_app(client.app).data_path = tmp_path
@@ -150,7 +149,6 @@ async def test_get_hmm_annotations(spawn_job_client, tmp_path):
         assert hmms == [{"id": "foo"}, {"id": "bar"}]
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("data_exists", [True, False])
 @pytest.mark.parametrize("file_exists", [True, False])
 async def test_get_hmm_profiles(
@@ -160,10 +158,7 @@ async def test_get_hmm_profiles(
     spawn_job_client,
     tmp_path,
 ):
-    """
-    Test that HMM profiles can be properly downloaded once they are available.
-
-    """
+    """Test that HMM profiles can be properly downloaded once they are available."""
     client = await spawn_job_client(authorize=True)
 
     get_config_from_app(client.app).data_path = tmp_path

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -16,7 +16,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from tests.fixtures.client import ClientSpawner
 from virtool.config import get_config_from_app
-
 from virtool.data.utils import get_data_from_app
 from virtool.fake.next import DataFaker
 from virtool.indexes.db import INDEX_FILE_NAMES
@@ -29,7 +28,6 @@ from virtool.mongo.core import Mongo
 OTUS_JSON_PATH = Path.cwd() / "tests/test_files/index/otus.json.gz"
 
 
-@pytest.mark.apitest
 class TestFind:
     async def test(
         self,
@@ -100,7 +98,7 @@ class TestFind:
         mocker.patch(
             "virtool.indexes.db.get_unbuilt_stats",
             make_mocked_coro(
-                {"total_otu_count": 123, "change_count": 12, "modified_otu_count": 3}
+                {"total_otu_count": 123, "change_count": 12, "modified_otu_count": 3},
             ),
         )
 
@@ -165,7 +163,6 @@ class TestFind:
         assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error,
@@ -212,7 +209,7 @@ async def test_get(
                 "has_files": True,
                 "user": {"id": user.id},
                 "job": {"id": job.id},
-            }
+            },
         )
 
     m_get_contributors = mocker.patch(
@@ -221,7 +218,7 @@ async def test_get(
             [
                 {"id": "fred", "count": 1, "handle": "fred", "administrator": True},
                 {"id": "igboyes", "count": 3, "handle": "ian", "administrator": True},
-            ]
+            ],
         ),
     )
 
@@ -231,7 +228,7 @@ async def test_get(
             [
                 {"id": "kjs8sa99", "name": "Foo", "change_count": 1},
                 {"id": "zxbbvngc", "name": "Test", "change_count": 3},
-            ]
+            ],
         ),
     )
 
@@ -247,16 +244,20 @@ async def test_get(
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("file_exists", [True, False])
 async def test_download_otus_json(
-    file_exists: bool, mocker, mongo: Mongo, spawn_job_client, tmp_path: Path
+    file_exists: bool,
+    mocker,
+    mongo: Mongo,
+    spawn_job_client,
+    tmp_path: Path,
 ):
     with gzip.open(OTUS_JSON_PATH, "rt") as f:
         expected = json.load(f)
 
     m_get_patched_otus = mocker.patch(
-        "virtool.indexes.db.get_patched_otus", make_mocked_coro(expected)
+        "virtool.indexes.db.get_patched_otus",
+        make_mocked_coro(expected),
     )
 
     client = await spawn_job_client(authorize=True)
@@ -272,7 +273,7 @@ async def test_download_otus_json(
     manifest = {"foo": 2, "bar": 1, "bad": 5}
 
     await mongo.indexes.insert_one(
-        {"_id": "bar", "manifest": manifest, "reference": {"id": "foo"}}
+        {"_id": "bar", "manifest": manifest, "reference": {"id": "foo"}},
     )
 
     async with await client.get("/indexes/bar/files/otus.json.gz") as resp:
@@ -284,11 +285,12 @@ async def test_download_otus_json(
 
     if not file_exists:
         m_get_patched_otus.assert_called_with(
-            client.app["db"], get_config_from_app(client.app), manifest
+            client.app["db"],
+            get_config_from_app(client.app),
+            manifest,
         )
 
 
-@pytest.mark.apitest
 class TestCreate:
     async def test(
         self,
@@ -304,7 +306,8 @@ class TestCreate:
         mocker.patch("virtool.utils.generate_key", return_value=("foo", "bar"))
 
         client = await spawn_client(
-            authenticated=True, base_url="https://virtool.example.com"
+            authenticated=True,
+            base_url="https://virtool.example.com",
         )
 
         data = get_data_from_app(client.app)
@@ -314,7 +317,7 @@ class TestCreate:
 
         await asyncio.gather(
             mongo.references.insert_one(
-                {"_id": "foo", "name": "Foo", "data_type": "genome"}
+                {"_id": "foo", "name": "Foo", "data_type": "genome"},
             ),
             # Insert unbuilt changes to prevent initial check failure.
             mongo.history.insert_one(
@@ -323,7 +326,7 @@ class TestCreate:
                     "index": {"id": "unbuilt", "version": "unbuilt"},
                     "reference": {"id": "foo"},
                     "user": {"id": user.id},
-                }
+                },
             ),
         )
 
@@ -354,10 +357,16 @@ class TestCreate:
         m_create_manifest.assert_called_with(ANY, "foo")
 
     @pytest.mark.parametrize(
-        "error", [None, "400_unbuilt", "400_unverified", "409_running"]
+        "error",
+        [None, "400_unbuilt", "400_unverified", "409_running"],
     )
     async def test_checks(
-        self, error, resp_is, mongo: Mongo, spawn_client: ClientSpawner, check_ref_right
+        self,
+        error,
+        resp_is,
+        mongo: Mongo,
+        spawn_client: ClientSpawner,
+        check_ref_right,
     ):
         client = await spawn_client(authenticated=True)
 
@@ -388,7 +397,6 @@ class TestCreate:
             return
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_find_history(
     error,
@@ -471,7 +479,6 @@ async def test_find_history(
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, 404])
 async def test_delete_index(error, fake2, mongo: Mongo, spawn_job_client, static_time):
     index_id = "index1"
@@ -483,7 +490,7 @@ async def test_delete_index(error, fake2, mongo: Mongo, spawn_job_client, static
     if error != 404:
         await asyncio.gather(
             mongo.references.insert_one(
-                {"_id": "foo", "data_type": "genome", "name": "Foo"}
+                {"_id": "foo", "data_type": "genome", "name": "Foo"},
             ),
             mongo.indexes.insert_one(
                 {
@@ -495,7 +502,7 @@ async def test_delete_index(error, fake2, mongo: Mongo, spawn_job_client, static
                     "reference": {"id": "foo"},
                     "user": {"id": user.id},
                     "version": 4,
-                }
+                },
             ),
             mongo.history.insert_many(
                 [
@@ -518,12 +525,11 @@ async def test_delete_index(error, fake2, mongo: Mongo, spawn_job_client, static
     if error:
         assert error == response.status
     else:
-        assert 204 == response.status
+        assert response.status == 204
         async for doc in mongo.history.find({"index.id": index_id}):
             assert doc["index"]["id"] == doc["index"]["version"] == "unbuilt"
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "409", "404_index", "404_file"])
 async def test_upload(
     error,
@@ -561,7 +567,7 @@ async def test_upload(
             session.add(SQLIndexFile(name="reference.1.bt2", index="foo"))
             await session.commit()
 
-    if not error == "404_index":
+    if error != "404_index":
         await mongo.indexes.insert_one(index)
 
     url = "/indexes/foo/files"
@@ -597,7 +603,6 @@ async def test_upload(
         ).scalar() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "409_genome", "409_fasta", "404_reference"])
 async def test_finalize(
     error,
@@ -609,10 +614,7 @@ async def test_finalize(
     static_time,
     test_otu,
 ):
-    """
-    Test that an index can be finalized using the Jobs API.
-
-    """
+    """Test that an index can be finalized using the Jobs API."""
     client = await spawn_job_client(authorize=True)
 
     user = await fake2.users.create()
@@ -627,7 +629,7 @@ async def test_finalize(
 
     if error != "404_reference":
         await mongo.references.insert_one(
-            {"_id": "hxn167", "name": "Test A", "data_type": "genome"}
+            {"_id": "hxn167", "name": "Test A", "data_type": "genome"},
         )
 
     await asyncio.gather(
@@ -641,7 +643,7 @@ async def test_finalize(
                 "created_at": static_time.datetime,
                 "has_files": True,
                 "job": {"id": job.id},
-            }
+            },
         ),
         # change `version` that should be reflected in `last_indexed_version` after calling
         mongo.otus.insert_one({**test_otu, "version": 1}),
@@ -649,7 +651,11 @@ async def test_finalize(
 
     for file_name in files:
         await create_index_file(
-            pg, "test_index", check_index_file_type(file_name), file_name, 9000
+            pg,
+            "test_index",
+            check_index_file_type(file_name),
+            file_name,
+            9000,
         )
 
     resp = await client.patch("/indexes/test_index")
@@ -661,7 +667,6 @@ async def test_finalize(
         assert await mongo.otus.find_one("6116cba1") == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("status", [200, 404])
 async def test_download(status: int, mongo: Mongo, spawn_job_client, tmp_path):
     client = await spawn_job_client(authorize=True)
@@ -670,10 +675,10 @@ async def test_download(status: int, mongo: Mongo, spawn_job_client, tmp_path):
 
     await asyncio.gather(
         mongo.indexes.insert_one(
-            {"_id": "test_index", "reference": {"id": "test_reference"}}
+            {"_id": "test_index", "reference": {"id": "test_reference"}},
         ),
         mongo.references.insert_one(
-            {"_id": "test_reference", "name": "Test A", "data_type": "genome"}
+            {"_id": "test_reference", "name": "Test A", "data_type": "genome"},
         ),
     )
 

--- a/tests/labels/test_api.py
+++ b/tests/labels/test_api.py
@@ -5,15 +5,15 @@ from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
 
 
-@pytest.mark.apitest
 class TestFind:
     async def test_find(
-        self, fake2: DataFaker, snapshot, mongo: Mongo, spawn_client: ClientSpawner
+        self,
+        fake2: DataFaker,
+        snapshot,
+        mongo: Mongo,
+        spawn_client: ClientSpawner,
     ):
-        """
-        Test that a ``GET /labels`` return a complete list of labels.
-
-        """
+        """Test that a ``GET /labels`` return a complete list of labels."""
         client = await spawn_client(authenticated=True)
 
         label_1 = await fake2.labels.create()
@@ -40,12 +40,12 @@ class TestFind:
         assert await resp.json() == snapshot
 
     async def test_find_by_name(
-        self, fake2: DataFaker, snapshot, spawn_client: ClientSpawner
+        self,
+        fake2: DataFaker,
+        snapshot,
+        spawn_client: ClientSpawner,
     ):
-        """
-        Test that a ``GET /labels`` with a `find` query returns a particular label. Also test for partial matches.
-
-        """
+        """Test that a ``GET /labels`` with a `find` query returns a particular label. Also test for partial matches."""
         client = await spawn_client(authenticated=True)
 
         label = await fake2.labels.create()
@@ -63,15 +63,15 @@ class TestFind:
         assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("status", [200, 404])
 async def test_get(
-    status: int, fake2: DataFaker, snapshot, mongo: Mongo, spawn_client: ClientSpawner
+    status: int,
+    fake2: DataFaker,
+    snapshot,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
 ):
-    """
-    Test that a ``GET /labels/:label_id`` return the correct label document.
-
-    """
+    """Test that a ``GET /labels/:label_id`` return the correct label document."""
     client = await spawn_client(authenticated=True)
 
     label_1 = await fake2.labels.create()
@@ -92,7 +92,6 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "400_exists", "400_color"])
 async def test_create(
     error: str | None,
@@ -100,10 +99,7 @@ async def test_create(
     resp_is,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test that a label can be added to the database at ``POST /labels``.
-
-    """
+    """Test that a label can be added to the database at ``POST /labels``."""
     client = await spawn_client(authenticated=True)
 
     label = await fake2.labels.create()
@@ -134,7 +130,6 @@ async def test_create(
         assert resp.status == 400
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404", "400_name", "400_color", "400_null"])
 async def test_edit(
     error: str | None,
@@ -144,10 +139,7 @@ async def test_edit(
     mongo: Mongo,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test that a label can be updated at ``PATCH /labels/:label_id``.
-
-    """
+    """Test that a label can be updated at ``PATCH /labels/:label_id``."""
     client = await spawn_client(authenticated=True)
 
     label_1 = await fake2.labels.create()
@@ -178,7 +170,8 @@ async def test_edit(
         data["name"] = None
 
     resp = await client.patch(
-        f"/labels/{5 if error == '404' else label_1.id}", data=data
+        f"/labels/{5 if error == '404' else label_1.id}",
+        data=data,
     )
 
     match error:
@@ -195,7 +188,6 @@ async def test_edit(
             assert resp.status == 400
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("status", [204, 404])
 async def test_remove(
     status: int,
@@ -205,12 +197,10 @@ async def test_remove(
     mongo: Mongo,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test that a label can be deleted to the database at ``DELETE /labels/:label_id``.
+    """Test that a label can be deleted to the database at ``DELETE /labels/:label_id``.
 
     Test that samples are updated when a label is deleted.
     """
-
     client = await spawn_client(authenticated=True)
 
     label_1 = await fake2.labels.create()
@@ -218,7 +208,8 @@ async def test_remove(
     label_3 = await fake2.labels.create()
 
     await mongo.subtraction.insert_many(
-        [{"_id": "foo", "name": "Foo"}, {"_id": "bar", "name": "Bar"}], session=None
+        [{"_id": "foo", "name": "Foo"}, {"_id": "bar", "name": "Bar"}],
+        session=None,
     )
 
     mock_samples[0].update({"labels": [label_1.id, label_3.id]})
@@ -240,12 +231,9 @@ async def test_remove(
         assert label_3.id in label_ids_in_samples
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("value", ["valid_hex_color", "invalid_hex_color"])
 async def test_is_valid_hex_color(value: str, resp_is, spawn_client: ClientSpawner):
-    """
-    Tests that when an invalid hex color is used, validators.is_valid_hex_color raises a 422 error.
-    """
+    """Tests that when an invalid hex color is used, validators.is_valid_hex_color raises a 422 error."""
     client = await spawn_client(authenticated=True)
 
     resp = await client.patch(
@@ -267,5 +255,5 @@ async def test_is_valid_hex_color(value: str, resp_is, spawn_client: ClientSpawn
                 "msg": "The format of the color code is invalid",
                 "type": "value_error",
                 "in": "body",
-            }
+            },
         ]

--- a/tests/messages/test_api.py
+++ b/tests/messages/test_api.py
@@ -27,7 +27,7 @@ async def insert_test_message(fake2, pg, static_time):
     return insert
 
 
-@pytest.mark.apitest
+
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error: str | None, insert_test_message, snapshot, spawn_client: ClientSpawner
@@ -50,7 +50,7 @@ async def test_get(
         assert await resp.json() is None
 
 
-@pytest.mark.apitest
+
 async def test_create(snapshot, spawn_client: ClientSpawner, static_time):
     """
     Test that a newly active instance message can be added
@@ -68,7 +68,7 @@ async def test_create(snapshot, spawn_client: ClientSpawner, static_time):
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
+
 class TestUpdate:
     async def test_active(
         self, insert_test_message, snapshot, spawn_client: ClientSpawner

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -10,7 +10,6 @@ from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error: str | None,
@@ -24,10 +23,7 @@ async def test_get(
     test_ref,
     test_sequence,
 ):
-    """
-    Test that a valid request returns a complete otu document.
-
-    """
+    """Test that a valid request returns a complete otu document."""
     client = await spawn_client(authenticated=True)
 
     user = await fake2.users.create()
@@ -50,7 +46,6 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 class TestEdit:
     @pytest.mark.parametrize(
         "data, existing_abbreviation, description",
@@ -118,8 +113,7 @@ class TestEdit:
         test_otu,
         test_ref,
     ):
-        """
-        Test that changing the name and abbreviation results:
+        """Test that changing the name and abbreviation results:
 
         * Changes to the otu
         * A new change document in history.
@@ -164,12 +158,15 @@ class TestEdit:
         ],
     )
     async def test_field_exists(
-        self, data, message, mongo: Mongo, spawn_client, check_ref_right, resp_is
+        self,
+        data,
+        message,
+        mongo: Mongo,
+        spawn_client,
+        check_ref_right,
+        resp_is,
     ):
-        """
-        Test that the request fails with ``409 Conflict`` if the requested name or abbreviation already exists.
-
-        """
+        """Test that the request fails with ``409 Conflict`` if the requested name or abbreviation already exists."""
         client = await spawn_client(authenticated=True)
 
         await mongo.otus.insert_many(
@@ -257,9 +254,9 @@ class TestEdit:
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize(
-    "abbreviation,exists", [("", True), ("PVF", True), ("", False)]
+    "abbreviation,exists",
+    [("", True), ("PVF", True), ("", False)],
 )
 async def test_remove(
     abbreviation,
@@ -271,12 +268,10 @@ async def test_remove(
     resp_is,
     test_otu,
 ):
-    """
-    Test that an existing otu can be removed.
-
-    """
+    """Test that an existing otu can be removed."""
     client = await spawn_client(
-        authenticated=True, permissions=[ReferencePermission.modify_otu]
+        authenticated=True,
+        permissions=[ReferencePermission.modify_otu],
     )
 
     test_otu["abbreviation"] = abbreviation
@@ -302,15 +297,16 @@ async def test_remove(
     assert await mongo.history.find_one() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_list_isolates(
-    error, snapshot, mongo: Mongo, spawn_client, resp_is, test_otu
+    error,
+    snapshot,
+    mongo: Mongo,
+    spawn_client,
+    resp_is,
+    test_otu,
 ):
-    """
-    Test the isolates are properly listed and formatted for an existing otu.
-
-    """
+    """Test the isolates are properly listed and formatted for an existing otu."""
     client = await spawn_client(authenticated=True)
 
     if not error:
@@ -320,7 +316,7 @@ async def test_list_isolates(
                 "source_type": "isolate",
                 "source_name": "7865",
                 "id": "bcb9b352",
-            }
+            },
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -335,15 +331,17 @@ async def test_list_isolates(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404_otu", "404_isolate"])
 async def test_get_isolate(
-    error, snapshot, mongo: Mongo, spawn_client, resp_is, test_otu, test_sequence
+    error,
+    snapshot,
+    mongo: Mongo,
+    spawn_client,
+    resp_is,
+    test_otu,
+    test_sequence,
 ):
-    """
-    Test that an existing isolate is successfully returned.
-
-    """
+    """Test that an existing isolate is successfully returned."""
     client = await spawn_client(authenticated=True)
 
     if error == "404_isolate":
@@ -364,7 +362,6 @@ async def test_get_isolate(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 class TestAddIsolate:
     @pytest.mark.parametrize("default", [True, False])
     async def test_default(
@@ -379,8 +376,7 @@ class TestAddIsolate:
         test_otu,
         test_random_alphanumeric,
     ):
-        """
-        Test that a new default isolate can be added, setting ``default`` to ``False``
+        """Test that a new default isolate can be added, setting ``default`` to ``False``
         on all other isolates in the process.
 
         """
@@ -421,8 +417,7 @@ class TestAddIsolate:
         test_otu,
         test_random_alphanumeric,
     ):
-        """
-        Test that the first isolate for a otu is set as the ``default`` otu even if ``default`` is set to ``False``
+        """Test that the first isolate for a otu is set as the ``default`` otu even if ``default`` is set to ``False``
         in the POST input.
 
         """
@@ -464,10 +459,7 @@ class TestAddIsolate:
         test_otu,
         test_random_alphanumeric,
     ):
-        """
-        Test that the ``source_type`` value is forced to lower case.
-
-        """
+        """Test that the ``source_type`` value is forced to lower case."""
         client = await spawn_client(
             authenticated=True,
             base_url="https://virtool.example.com",
@@ -496,7 +488,8 @@ class TestAddIsolate:
 
     async def test_not_found(self, spawn_client, resp_is):
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         data = {"source_name": "Beta", "source_type": "Isolate", "default": False}
@@ -506,7 +499,6 @@ class TestAddIsolate:
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 class TestUpdateIsolate:
     @pytest.mark.parametrize(
         "data,description",
@@ -531,12 +523,10 @@ class TestUpdateIsolate:
         resp_is,
         test_otu,
     ):
-        """
-        Test that a change to the isolate name results in the correct changes, history, and response.
-
-        """
+        """Test that a change to the isolate name results in the correct changes, history, and response."""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         test_otu["isolates"].append(
@@ -545,7 +535,7 @@ class TestUpdateIsolate:
                 "source_name": "b",
                 "source_type": "isolate",
                 "default": False,
-            }
+            },
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -555,7 +545,7 @@ class TestUpdateIsolate:
                 "_id": "hxn167",
                 "restrict_source_types": False,
                 "source_types": ["isolate"],
-            }
+            },
         )
 
         resp = await client.patch("/otus/6116cba1/isolates/test", data)
@@ -571,14 +561,18 @@ class TestUpdateIsolate:
         assert await mongo.history.find_one() == snapshot
 
     async def test_force_case(
-        self, snapshot, mongo: Mongo, spawn_client, check_ref_right, resp_is, test_otu
+        self,
+        snapshot,
+        mongo: Mongo,
+        spawn_client,
+        check_ref_right,
+        resp_is,
+        test_otu,
     ):
-        """
-        Test that the ``source_type`` value is forced to lower case.
-
-        """
+        """Test that the ``source_type`` value is forced to lower case."""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         await asyncio.gather(
@@ -588,7 +582,7 @@ class TestUpdateIsolate:
                     "_id": "hxn167",
                     "restrict_source_types": False,
                     "source_types": ["isolate"],
-                }
+                },
             ),
         )
 
@@ -613,14 +607,18 @@ class TestUpdateIsolate:
         [("6116cba1", "test"), ("test", "cab8b360"), ("test", "test")],
     )
     async def test_not_found(
-        self, otu_id, isolate_id, mongo: Mongo, spawn_client, test_otu, resp_is
+        self,
+        otu_id,
+        isolate_id,
+        mongo: Mongo,
+        spawn_client,
+        test_otu,
+        resp_is,
     ):
-        """
-        Test that a request for a non-existent otu or isolate results in a ``404`` response.
-
-        """
+        """Test that a request for a non-existent otu or isolate results in a ``404`` response."""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -632,7 +630,6 @@ class TestUpdateIsolate:
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 class TestSetAsDefault:
     async def test(
         self,
@@ -645,12 +642,10 @@ class TestSetAsDefault:
         test_random_alphanumeric,
         static_time,
     ):
-        """
-        Test changing the default isolate results in the correct changes, history, and response.
-
-        """
+        """Test changing the default isolate results in the correct changes, history, and response."""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         test_otu["isolates"].append(
@@ -659,7 +654,7 @@ class TestSetAsDefault:
                 "source_name": "b",
                 "source_type": "isolate",
                 "default": False,
-            }
+            },
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -688,13 +683,13 @@ class TestSetAsDefault:
         test_change,
         test_random_alphanumeric,
     ):
-        """
-        Test that a call resulting in no change (calling endpoint on an already default isolate) results in no change.
+        """Test that a call resulting in no change (calling endpoint on an already default isolate) results in no change.
         Specifically no increment in version.
 
         """
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         test_otu["isolates"].append(
@@ -703,7 +698,7 @@ class TestSetAsDefault:
                 "source_name": "b",
                 "source_type": "isolate",
                 "default": False,
-            }
+            },
         )
 
         await asyncio.gather(
@@ -728,14 +723,18 @@ class TestSetAsDefault:
         [("6116cba1", "test"), ("test", "cab8b360"), ("test", "test")],
     )
     async def test_not_found(
-        self, otu_id, isolate_id, mongo: Mongo, spawn_client, test_otu, resp_is
+        self,
+        otu_id,
+        isolate_id,
+        mongo: Mongo,
+        spawn_client,
+        test_otu,
+        resp_is,
     ):
-        """
-        Test that ``404 Not found`` is returned if the otu or isolate does not exist
-
-        """
+        """Test that ``404 Not found`` is returned if the otu or isolate does not exist"""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -745,7 +744,6 @@ class TestSetAsDefault:
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 class TestRemoveIsolate:
     async def test(
         self,
@@ -757,13 +755,13 @@ class TestRemoveIsolate:
         test_otu,
         test_sequence,
     ):
-        """
-        Test that a valid request results in a ``204`` response and the isolate and
+        """Test that a valid request results in a ``204`` response and the isolate and
         sequence data is removed from MongoDB.
 
         """
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -793,12 +791,10 @@ class TestRemoveIsolate:
         test_otu,
         test_sequence,
     ):
-        """
-        Test that a valid request results in a ``204`` response and ``default`` status is reassigned correctly.
-
-        """
+        """Test that a valid request results in a ``204`` response and ``default`` status is reassigned correctly."""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         test_otu["isolates"].append(
@@ -807,7 +803,7 @@ class TestRemoveIsolate:
                 "source_type": "isolate",
                 "source_name": "7865",
                 "id": "bcb9b352",
-            }
+            },
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -827,15 +823,14 @@ class TestRemoveIsolate:
         assert await mongo.history.find_one() == snapshot
 
     @pytest.mark.parametrize(
-        "url", ["/otus/foobar/isolates/cab8b360", "/otus/test/isolates/foobar"]
+        "url",
+        ["/otus/foobar/isolates/cab8b360", "/otus/test/isolates/foobar"],
     )
     async def test_not_found(self, url, mongo: Mongo, spawn_client, test_otu, resp_is):
-        """
-        Test that removal fails with ``404`` if the otu does not exist.
-
-        """
+        """Test that removal fails with ``404`` if the otu does not exist."""
         client = await spawn_client(
-            authenticated=True, permissions=[ReferencePermission.modify_otu]
+            authenticated=True,
+            permissions=[ReferencePermission.modify_otu],
         )
 
         await mongo.otus.insert_one(test_otu)
@@ -845,10 +840,15 @@ class TestRemoveIsolate:
         await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404_otu", "404_isolate"])
 async def test_list_sequences(
-    error, snapshot, mongo: Mongo, spawn_client, resp_is, test_otu, test_sequence
+    error,
+    snapshot,
+    mongo: Mongo,
+    spawn_client,
+    resp_is,
+    test_otu,
+    test_sequence,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -870,7 +870,6 @@ async def test_list_sequences(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404_otu", "404_isolate", "404_sequence"])
 async def test_get_sequence(
     error,
@@ -896,7 +895,7 @@ async def test_get_sequence(
         await mongo.sequences.insert_one(test_sequence)
 
     resp = await client.get(
-        f"/otus/6116cba1/isolates/cab8b360/sequences/{test_sequence['_id']}"
+        f"/otus/6116cba1/isolates/cab8b360/sequences/{test_sequence['_id']}",
     )
 
     if error:
@@ -907,7 +906,6 @@ async def test_get_sequence(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize(
     "error,segment",
     [(None, "null"), (None, "test_segment"), ("404_otu", None), ("404_isolate", None)],
@@ -950,8 +948,8 @@ async def test_create_sequence(
             "/otus/6116cba1",
             {
                 "schema": [
-                    {"name": "test_segment", "molecule": "ssDNA", "required": False}
-                ]
+                    {"name": "test_segment", "molecule": "ssDNA", "required": False},
+                ],
             },
         )
 
@@ -974,17 +972,13 @@ async def test_create_sequence(
     assert resp.headers["Location"] == snapshot
     assert await resp.json() == snapshot
 
-    assert (
-        await asyncio.gather(
-            mongo.sequences.find_one(),
-            mongo.otus.find_one("6116cba1"),
-            mongo.history.find_one({"method_name": "create_sequence"}),
-        )
-        == snapshot(name="db")
-    )
+    assert await asyncio.gather(
+        mongo.sequences.find_one(),
+        mongo.otus.find_one("6116cba1"),
+        mongo.history.find_one({"method_name": "create_sequence"}),
+    ) == snapshot(name="db")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize(
     "error, segment",
     [
@@ -1007,7 +1001,8 @@ async def test_edit_sequence(
     segment,
 ):
     client = await spawn_client(
-        authenticated=True, permissions=[ReferencePermission.modify_otu]
+        authenticated=True,
+        permissions=[ReferencePermission.modify_otu],
     )
 
     if error == "404_isolate":
@@ -1033,13 +1028,14 @@ async def test_edit_sequence(
             "/otus/6116cba1",
             {
                 "schema": [
-                    {"name": "test_segment", "molecule": "ssDNA", "required": False}
-                ]
+                    {"name": "test_segment", "molecule": "ssDNA", "required": False},
+                ],
             },
         )
 
     resp = await client.patch(
-        f"/otus/6116cba1/isolates/cab8b360/sequences/{test_sequence['_id']}", data
+        f"/otus/6116cba1/isolates/cab8b360/sequences/{test_sequence['_id']}",
+        data,
     )
 
     if error:
@@ -1058,7 +1054,6 @@ async def test_edit_sequence(
     assert await mongo.history.find_one({"method_name": "edit_sequence"}) == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404_otu", "404_isolate", "404_sequence"])
 async def test_remove_sequence(
     error,
@@ -1082,7 +1077,7 @@ async def test_remove_sequence(
         await mongo.sequences.insert_one(test_sequence)
 
     resp = await client.delete(
-        f"/otus/6116cba1/isolates/cab8b360/sequences/{test_sequence['_id']}"
+        f"/otus/6116cba1/isolates/cab8b360/sequences/{test_sequence['_id']}",
     )
 
     if error:
@@ -1099,10 +1094,14 @@ async def test_remove_sequence(
     assert await mongo.history.find_one() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_download_otu(
-    error, mongo: Mongo, spawn_client, resp_is, test_sequence, test_otu
+    error,
+    mongo: Mongo,
+    spawn_client,
+    resp_is,
+    test_sequence,
+    test_otu,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -1120,10 +1119,15 @@ async def test_download_otu(
     assert resp.status == 200
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404_otu", "404_isolate"])
 async def test_download_isolate(
-    error, resp_is, mongo: Mongo, spawn_client, test_otu, test_isolate, test_sequence
+    error,
+    resp_is,
+    mongo: Mongo,
+    spawn_client,
+    test_otu,
+    test_isolate,
+    test_sequence,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -1149,7 +1153,6 @@ async def test_download_isolate(
     return
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("get", ["isolate", "sequence"])
 @pytest.mark.parametrize("missing", [None, "otu", "isolate", "sequence"])
 async def test_all(get, missing, mongo: Mongo, spawn_client):
@@ -1162,7 +1165,7 @@ async def test_all(get, missing, mongo: Mongo, spawn_client):
 
     if missing != "otu":
         await mongo.otus.insert_one(
-            {"_id": "foobar", "name": "Foobar virus", "isolates": isolates}
+            {"_id": "foobar", "name": "Foobar virus", "isolates": isolates},
         )
 
     sequences = [
@@ -1171,7 +1174,7 @@ async def test_all(get, missing, mongo: Mongo, spawn_client):
             "otu_id": "foobar",
             "isolate_id": "baz",
             "sequence": "ATAGGGACATA",
-        }
+        },
     ]
 
     if missing != "sequence":
@@ -1181,7 +1184,7 @@ async def test_all(get, missing, mongo: Mongo, spawn_client):
                 "otu_id": "foobar",
                 "isolate_id": "foo",
                 "sequence": "ATAGGGACATA",
-            }
+            },
         )
 
     await mongo.sequences.insert_many(sequences, session=None)

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1,10 +1,10 @@
 import asyncio
 from pathlib import Path
-from unittest.mock import call, ANY
+from unittest.mock import ANY, call
 
 import pytest
 from aiohttp.test_utils import make_mocked_coro
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 from virtool_core.models.enums import Permission
@@ -22,7 +22,6 @@ from virtool.tasks.models import SQLTask
 from virtool.users.oas import UpdateUserRequest
 
 
-@pytest.mark.apitest
 async def test_find(
     data_layer: DataLayer,
     fake2: DataFaker,
@@ -119,7 +118,7 @@ async def test_find(
                     step="download",
                     type="import_reference",
                 ),
-            ]
+            ],
         )
         await session.commit()
 
@@ -134,7 +133,6 @@ async def test_find(
     assert {d["id"] for d in body["documents"]} == {"foo", "bar", "goo"}
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [404, None])
 async def test_get(error, mongo: Mongo, spawn_client, pg, snapshot, fake2, static_time):
     client = await spawn_client(authenticated=True, administrator=True)
@@ -167,7 +165,7 @@ async def test_get(error, mongo: Mongo, spawn_client, pg, snapshot, fake2, stati
                         "remove": True,
                     },
                 ],
-            }
+            },
         )
 
     async with AsyncSession(pg) as session:
@@ -182,7 +180,7 @@ async def test_get(error, mongo: Mongo, spawn_client, pg, snapshot, fake2, stati
                 progress=100,
                 step="download",
                 type="clone_reference",
-            )
+            ),
         )
 
         await session.commit()
@@ -196,7 +194,6 @@ async def test_get(error, mongo: Mongo, spawn_client, pg, snapshot, fake2, stati
         assert resp.status == 404
 
 
-@pytest.mark.apitest
 class TestCreate:
     @pytest.mark.parametrize("data_type", ["genome", "barcode"])
     async def test_ok(
@@ -216,7 +213,7 @@ class TestCreate:
         default_source_type = ["strain", "isolate"]
 
         await data_layer.settings.update(
-            UpdateSettingsRequest(default_source_types=default_source_type)
+            UpdateSettingsRequest(default_source_types=default_source_type),
         )
 
         resp = await client.post(
@@ -278,7 +275,8 @@ class TestCreate:
         tmpdir,
     ):
         client = await spawn_client(
-            authenticated=True, permissions=[Permission.create_ref]
+            authenticated=True,
+            permissions=[Permission.create_ref],
         )
 
         user_1 = await fake2.users.create()
@@ -306,7 +304,7 @@ class TestCreate:
                         "remove": True,
                     },
                 ],
-            }
+            },
         )
 
         resp = await client.post(
@@ -324,10 +322,15 @@ class TestCreate:
         assert await resp.json() == snapshot(name="resp")
 
     async def test_remote(
-        self, snapshot, spawn_client: ClientSpawner, static_time, tmpdir
+        self,
+        snapshot,
+        spawn_client: ClientSpawner,
+        static_time,
+        tmpdir,
     ):
         client = await spawn_client(
-            authenticated=True, permissions=[Permission.create_ref]
+            authenticated=True,
+            permissions=[Permission.create_ref],
         )
 
         resp = await client.post(
@@ -343,14 +346,15 @@ class TestCreate:
         assert resp.status == 201
         assert resp.headers["Location"] == snapshot(name="location")
         assert await resp.json() == snapshot(
-            matcher=path_type({".*etag": (str,)}, regex=True), name="resp"
+            matcher=path_type({".*etag": (str,)}, regex=True),
+            name="resp",
         )
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("data_type", ["genome", "barcode"])
 @pytest.mark.parametrize(
-    "error", [None, "403", "404", "400_invalid_input", "400_duplicates"]
+    "error",
+    [None, "403", "404", "400_invalid_input", "400_duplicates"],
 )
 async def test_edit(
     data_type: str,
@@ -400,7 +404,7 @@ async def test_edit(
                         "remove": True,
                     },
                 ],
-            }
+            },
         )
 
     data = {
@@ -418,13 +422,14 @@ async def test_edit(
                 "name": "CPN60",
                 "description": "This has a duplicate name",
                 "required": False,
-            }
+            },
         )
 
     can_modify = error != "403"
 
     mocker.patch(
-        "virtool.references.api.check_right", make_mocked_coro(return_value=can_modify)
+        "virtool.references.api.check_right",
+        make_mocked_coro(return_value=can_modify),
     )
 
     resp = await client.patch("/refs/foo", data)
@@ -442,7 +447,7 @@ async def test_edit(
                     "msg": "field required",
                     "type": "value_error.missing",
                     "in": "body",
-                }
+                },
             ]
 
         case "400_duplicates":
@@ -455,9 +460,11 @@ async def test_edit(
             await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 async def test_delete(
-    fake2: DataFaker, mongo: Mongo, spawn_client: ClientSpawner, static_time
+    fake2: DataFaker,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    static_time,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -495,7 +502,7 @@ async def test_delete(
                     "remove": True,
                 },
             ],
-        }
+        },
     )
 
     resp = await client.delete("/refs/foo")
@@ -505,10 +512,14 @@ async def test_delete(
     assert resp.status == 204
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "400", "404"])
 async def test_get_release(
-    error, mocker, mongo: Mongo, spawn_client, resp_is, snapshot
+    error,
+    mocker,
+    mongo: Mongo,
+    spawn_client,
+    resp_is,
+    snapshot,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -553,7 +564,7 @@ async def test_get_release(
                 "content_type": "application/gzip",
                 "retrieved_at": "2018-06-14T19:52:17.465000Z",
                 "newer": True,
-            }
+            },
         ),
     )
 
@@ -570,18 +581,25 @@ async def test_get_release(
     assert resp.status == 200
 
     assert await resp.json() == snapshot(
-        matcher=path_type({".*etag": (str,)}, regex=True)
+        matcher=path_type({".*etag": (str,)}, regex=True),
     )
 
     m_fetch_and_update_release.assert_called_with(
-        client.app["db"], client.app["client"], "foo"
+        client.app["db"],
+        client.app["client"],
+        "foo",
     )
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("empty", [True, False])
 async def test_list_updates(
-    empty, mocker, mongo: Mongo, spawn_client, id_exists, resp_is, snapshot
+    empty,
+    mocker,
+    mongo: Mongo,
+    spawn_client,
+    id_exists,
+    resp_is,
+    snapshot,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -607,8 +625,8 @@ async def test_list_updates(
                     },
                     "ready": True,
                     "newer": True,
-                }
-            ]
+                },
+            ],
         ),
     )
 
@@ -626,7 +644,6 @@ async def test_list_updates(
     m_get_one_field.assert_called_with(ANY, "updates", "foo")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "400", "404"])
 async def test_update(
     error: str | None,
@@ -665,7 +682,8 @@ async def test_update(
         await mongo.references.insert_one(reference)
 
         m_enqueue = mocker.patch.object(
-            get_data_from_app(client.app).tasks._tasks_client, "enqueue"
+            get_data_from_app(client.app).tasks._tasks_client,
+            "enqueue",
         )
 
     resp = await client.post("/refs/foo/updates", {})
@@ -679,13 +697,13 @@ async def test_update(
     else:
         assert resp.status == 201
         assert await resp.json() == snapshot(
-            name="json", matcher=path_type({".*etag": (str,)}, regex=True)
+            name="json",
+            matcher=path_type({".*etag": (str,)}, regex=True),
         )
         assert m_enqueue.call_args == call("update_remote_reference", 1)
         assert await get_one_field(mongo.references, "task", "foo") == {"id": 1}
 
 
-@pytest.mark.apitest
 class TestCreateOTU:
     @pytest.mark.parametrize("abbreviation", [None, "TMV", ""])
     @pytest.mark.parametrize("error", [None, "403", "404"])
@@ -699,12 +717,12 @@ class TestCreateOTU:
         spawn_client,
         static_time,
     ):
-        """
-        Test that a valid request results in the creation of a otu document and a
+        """Test that a valid request results in the creation of a otu document and a
         ``201`` response.
         """
         client = await spawn_client(
-            authenticated=True, base_url="https://virtool.example.com"
+            authenticated=True,
+            base_url="https://virtool.example.com",
         )
 
         if error != "404":
@@ -723,9 +741,9 @@ class TestCreateOTU:
                             "modify": True,
                             "modify_otu": True,
                             "remove": True,
-                        }
+                        },
                     ],
-                }
+                },
             )
 
         data = {"name": "Tobacco mosaic virus"}
@@ -744,7 +762,8 @@ class TestCreateOTU:
                 )
                 assert await resp.json() == snapshot(name="json")
                 assert await asyncio.gather(
-                    mongo.otus.find_one(), mongo.history.find_one()
+                    mongo.otus.find_one(),
+                    mongo.history.find_one(),
                 ) == snapshot(name="db")
             case "403":
                 await resp_is.insufficient_rights(resp)
@@ -771,14 +790,13 @@ class TestCreateOTU:
         spawn_client: ClientSpawner,
         static_time,
     ):
-        """
-        Test that the request fails with ``409 Conflict`` if the requested otu name
+        """Test that the request fails with ``409 Conflict`` if the requested otu name
         already exists.
         """
-
         # Pass name and abbreviation check.
         m_check_name_and_abbreviation = mocker.patch(
-            "virtool.otus.db.check_name_and_abbreviation", make_mocked_coro(message)
+            "virtool.otus.db.check_name_and_abbreviation",
+            make_mocked_coro(message),
         )
 
         client = await spawn_client(authenticated=True)
@@ -798,20 +816,24 @@ class TestCreateOTU:
                             "modify": True,
                             "modify_otu": True,
                             "remove": True,
-                        }
+                        },
                     ],
-                }
+                },
             )
 
         resp = await client.post(
-            "/refs/foo/otus", {"name": "Tobacco mosaic virus", "abbreviation": "TMV"}
+            "/refs/foo/otus",
+            {"name": "Tobacco mosaic virus", "abbreviation": "TMV"},
         )
 
         if error is None:
             assert resp.status == 201
             # Abbreviation defaults to empty string for OTU creation.
             m_check_name_and_abbreviation.assert_called_with(
-                ANY, "foo", "Tobacco mosaic virus", "TMV"
+                ANY,
+                "foo",
+                "Tobacco mosaic virus",
+                "TMV",
             )
         elif error == "404":
             await resp_is.not_found(resp)
@@ -819,7 +841,6 @@ class TestCreateOTU:
             await resp_is.bad_request(resp, message)
 
 
-@pytest.mark.apitest
 async def test_create_index(
     check_ref_right,
     fake2: DataFaker,
@@ -830,19 +851,17 @@ async def test_create_index(
     spawn_client: ClientSpawner,
     static_time,
 ):
-    """
-    Test that a valid request results in the creation of a otu document and a ``201`` response.
-
-    """
+    """Test that a valid request results in the creation of a otu document and a ``201`` response."""
     client = await spawn_client(
-        authenticated=True, base_url="https://virtool.example.com"
+        authenticated=True,
+        base_url="https://virtool.example.com",
     )
 
     user = await fake2.users.create()
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "foo", "name": "Foo", "data_type": "genome"}
+            {"_id": "foo", "name": "Foo", "data_type": "genome"},
         ),
         # Insert unbuilt changes to prevent initial check failure.
         mongo.history.insert_one(
@@ -851,12 +870,13 @@ async def test_create_index(
                 "index": {"id": "unbuilt", "version": "unbuilt"},
                 "reference": {"id": "foo"},
                 "user": {"id": user.id},
-            }
+            },
         ),
     )
 
     m_create_manifest = mocker.patch(
-        "virtool.references.db.get_manifest", new=make_mocked_coro({"foo": 2, "bar": 5})
+        "virtool.references.db.get_manifest",
+        new=make_mocked_coro({"foo": 2, "bar": 5}),
     )
 
     # Pass ref exists check.
@@ -875,7 +895,6 @@ async def test_create_index(
     m_create_manifest.assert_called_with(ANY, "foo")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "400_dne", "400_exists", "404"])
 async def test_create_user(
     error: str | None,
@@ -886,8 +905,7 @@ async def test_create_user(
     spawn_client: ClientSpawner,
     static_time,
 ):
-    """
-    Test that the group or user is added to the reference when no error condition
+    """Test that the group or user is added to the reference when no error condition
     exists.
 
     Test for the following error conditions:
@@ -919,7 +937,7 @@ async def test_create_user(
                 "modify": True,
                 "modify_otu": True,
                 "remove": True,
-            }
+            },
         ],
     }
 
@@ -934,7 +952,7 @@ async def test_create_user(
                 "modify": True,
                 "modify_otu": True,
                 "remove": True,
-            }
+            },
         )
 
     # Don't insert the ref document if we want to trigger a 404.
@@ -959,7 +977,6 @@ async def test_create_user(
             await resp_is.bad_request(resp, "User already exists")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "400_dne", "400_exists", "404"])
 async def test_create_group(
     error: str | None,
@@ -970,8 +987,7 @@ async def test_create_group(
     spawn_client: ClientSpawner,
     static_time,
 ):
-    """
-    Test that a group is added to the reference when no error condition exists.
+    """Test that a group is added to the reference when no error condition exists.
 
     * 400_dne: user group does not exist
     * 400_exists: group already a member of ref
@@ -998,7 +1014,7 @@ async def test_create_group(
                         "modify": True,
                         "modify_otu": True,
                         "remove": True,
-                    }
+                    },
                 ],
                 "name": "Test",
                 "organism": "virus",
@@ -1006,7 +1022,7 @@ async def test_create_group(
                 "source_types": [],
                 "user": {"id": client.user.id},
                 "users": [],
-            }
+            },
         )
 
     resp = await client.post(
@@ -1072,7 +1088,7 @@ async def test_update_user(
                         "remove": False,
                     },
                 ],
-            }
+            },
         )
 
     resp = await client.patch(
@@ -1089,7 +1105,6 @@ async def test_update_user(
             await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize(
     "error",
     [None, "404_group", "404_ref"],
@@ -1139,7 +1154,7 @@ async def test_update_group(
                         "remove": True,
                     },
                 ],
-            }
+            },
         )
 
     resp = await client.patch(
@@ -1156,7 +1171,6 @@ async def test_update_group(
             await resp_is.not_found(resp)
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize(
     "error",
     [None, "404_ref", "404_user"],
@@ -1205,11 +1219,11 @@ async def test_delete_user(
                         "remove": False,
                     },
                 ],
-            }
+            },
         )
 
     resp = await client.delete(
-        f"/refs/foo/users/{21 if error == '404_user' else user.id}"
+        f"/refs/foo/users/{21 if error == '404_user' else user.id}",
     )
 
     if error:
@@ -1219,7 +1233,6 @@ async def test_delete_user(
         assert await mongo.references.find_one() == snapshot(name="mongo")
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404_group", "404_ref"])
 async def test_delete_group(
     error: str | None,
@@ -1249,7 +1262,7 @@ async def test_delete_group(
                         "modify": False,
                         "modify_otu": False,
                         "remove": False,
-                    }
+                    },
                 ],
                 "name": "Test",
                 "organism": "virus",
@@ -1264,13 +1277,13 @@ async def test_delete_group(
                         "modify": True,
                         "modify_otu": True,
                         "remove": True,
-                    }
+                    },
                 ],
-            }
+            },
         )
 
     resp = await client.delete(
-        f"/refs/foo/groups/{21 if error == '404_group' else group.id}"
+        f"/refs/foo/groups/{21 if error == '404_group' else group.id}",
     )
 
     if error:
@@ -1280,7 +1293,6 @@ async def test_delete_group(
         assert await mongo.references.find_one() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("find", [None, "Prunus", "virus", "PVF", "VF"])
 @pytest.mark.parametrize("verified", [None, True, False])
 async def test_find_otus(
@@ -1290,16 +1302,14 @@ async def test_find_otus(
     mongo: Mongo,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test to check that the api returns the correct OTUs based on how the results are
+    """Test to check that the api returns the correct OTUs based on how the results are
     filtered.
     """
-
     client = await spawn_client(authenticated=True)
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "foo", "name": "Foo", "data_type": "genome"}
+            {"_id": "foo", "name": "Foo", "data_type": "genome"},
         ),
         mongo.otus.insert_many(
             [

--- a/tests/settings/test_api.py
+++ b/tests/settings/test_api.py
@@ -1,10 +1,11 @@
-import pytest
+from syrupy import SnapshotAssertion
 
 from tests.fixtures.client import ClientSpawner
 
 
-@pytest.mark.apitest
-async def test_get(snapshot, spawn_client: ClientSpawner, test_settings):
+async def test_get(
+    snapshot: SnapshotAssertion, spawn_client: ClientSpawner, test_settings
+):
     client = await spawn_client(authenticated=True)
 
     resp = await client.get("/settings")
@@ -13,8 +14,11 @@ async def test_get(snapshot, spawn_client: ClientSpawner, test_settings):
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
-async def test_update(snapshot, spawn_client: ClientSpawner, test_settings):
+async def test_update(
+    snapshot: SnapshotAssertion,
+    spawn_client: ClientSpawner,
+    test_settings,
+):
     client = await spawn_client(administrator=True, authenticated=True)
 
     resp = await client.patch(

--- a/tests/spaces/test_api.py
+++ b/tests/spaces/test_api.py
@@ -1,10 +1,9 @@
-import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool_core.models.roles import (
+    SpaceLabelRole,
+    SpaceProjectRole,
     SpaceRole,
     SpaceSampleRole,
-    SpaceProjectRole,
-    SpaceLabelRole,
 )
 
 from tests.fixtures.client import ClientSpawner
@@ -15,7 +14,6 @@ from virtool.flags import FlagName
 from virtool.spaces.models import SQLSpace
 
 
-
 async def test_list(
     pg: AsyncEngine,
     spawn_client: ClientSpawner,
@@ -23,7 +21,9 @@ async def test_list(
     static_time,
 ):
     client = await spawn_client(
-        administrator=True, authenticated=True, flags=[FlagName.SPACES]
+        administrator=True,
+        authenticated=True,
+        flags=[FlagName.SPACES],
     )
 
     async with AsyncSession(pg) as session:
@@ -43,7 +43,7 @@ async def test_list(
                     created_at=static_time.datetime,
                     updated_at=static_time.datetime,
                 ),
-            ]
+            ],
         )
 
         await session.commit()
@@ -60,7 +60,6 @@ async def test_list(
     assert await resp.json() == snapshot
 
 
-
 async def test_get(
     fake2: DataFaker,
     pg: AsyncEngine,
@@ -69,7 +68,9 @@ async def test_get(
     static_time,
 ):
     client = await spawn_client(
-        administrator=True, authenticated=True, flags=[FlagName.SPACES]
+        administrator=True,
+        authenticated=True,
+        flags=[FlagName.SPACES],
     )
 
     user = await fake2.users.create()
@@ -82,7 +83,7 @@ async def test_get(
                 description="",
                 created_at=static_time.datetime,
                 updated_at=static_time.datetime,
-            )
+            ),
         )
 
         await session.commit()
@@ -100,12 +101,16 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-
 async def test_update(
-    pg: AsyncEngine, spawn_client: ClientSpawner, snapshot, static_time
+    pg: AsyncEngine,
+    spawn_client: ClientSpawner,
+    snapshot,
+    static_time,
 ):
     client = await spawn_client(
-        administrator=True, authenticated=True, flags=[FlagName.SPACES]
+        administrator=True,
+        authenticated=True,
+        flags=[FlagName.SPACES],
     )
 
     async with AsyncSession(pg) as session:
@@ -116,18 +121,18 @@ async def test_update(
                 description="",
                 created_at=static_time.datetime,
                 updated_at=static_time.datetime,
-            )
+            ),
         )
 
         await session.commit()
 
     resp = await client.patch(
-        "/spaces/0", {"name": "New Name", "description": "New description"}
+        "/spaces/0",
+        {"name": "New Name", "description": "New description"},
     )
 
     assert resp.status == 200
     assert await resp.json() == snapshot
-
 
 
 async def test_list_space_members(
@@ -138,7 +143,9 @@ async def test_list_space_members(
     static_time,
 ):
     client = await spawn_client(
-        administrator=True, authenticated=True, flags=[FlagName.SPACES]
+        administrator=True,
+        authenticated=True,
+        flags=[FlagName.SPACES],
     )
 
     user_1 = await fake2.users.create()
@@ -152,7 +159,7 @@ async def test_list_space_members(
                 description="",
                 created_at=static_time.datetime,
                 updated_at=static_time.datetime,
-            )
+            ),
         )
 
         await session.commit()
@@ -170,7 +177,6 @@ async def test_list_space_members(
     assert await resp.json() == snapshot
 
 
-
 async def test_update_member_roles(
     fake2: DataFaker,
     pg: AsyncEngine,
@@ -179,7 +185,9 @@ async def test_update_member_roles(
     static_time,
 ):
     client = await spawn_client(
-        administrator=True, authenticated=True, flags=[FlagName.SPACES]
+        administrator=True,
+        authenticated=True,
+        flags=[FlagName.SPACES],
     )
 
     user = await fake2.users.create()
@@ -192,7 +200,7 @@ async def test_update_member_roles(
                 description="",
                 created_at=static_time.datetime,
                 updated_at=static_time.datetime,
-            )
+            ),
         )
 
         await session.commit()
@@ -211,7 +219,6 @@ async def test_update_member_roles(
     assert await resp.json() == snapshot
 
 
-
 async def test_remove_member(
     fake2: DataFaker,
     pg: AsyncEngine,
@@ -219,7 +226,9 @@ async def test_remove_member(
     static_time,
 ):
     client = await spawn_client(
-        administrator=True, authenticated=True, flags=[FlagName.SPACES]
+        administrator=True,
+        authenticated=True,
+        flags=[FlagName.SPACES],
     )
 
     user_1 = await fake2.users.create()
@@ -232,7 +241,7 @@ async def test_remove_member(
                 description="",
                 created_at=static_time.datetime,
                 updated_at=static_time.datetime,
-            )
+            ),
         )
 
         await session.commit()
@@ -248,7 +257,8 @@ async def test_remove_member(
     assert resp.status == 204
     assert (
         await get_authorization_client_from_app(client.app).list_user_roles(
-            user_1.id, 0
+            user_1.id,
+            0,
         )
         == []
     )

--- a/tests/spaces/test_api.py
+++ b/tests/spaces/test_api.py
@@ -15,7 +15,7 @@ from virtool.flags import FlagName
 from virtool.spaces.models import SQLSpace
 
 
-@pytest.mark.apitest
+
 async def test_list(
     pg: AsyncEngine,
     spawn_client: ClientSpawner,
@@ -60,7 +60,7 @@ async def test_list(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
+
 async def test_get(
     fake2: DataFaker,
     pg: AsyncEngine,
@@ -100,7 +100,7 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
+
 async def test_update(
     pg: AsyncEngine, spawn_client: ClientSpawner, snapshot, static_time
 ):
@@ -129,7 +129,7 @@ async def test_update(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
+
 async def test_list_space_members(
     fake2: DataFaker,
     pg: AsyncEngine,
@@ -170,7 +170,7 @@ async def test_list_space_members(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
+
 async def test_update_member_roles(
     fake2: DataFaker,
     pg: AsyncEngine,
@@ -211,7 +211,7 @@ async def test_update_member_roles(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
+
 async def test_remove_member(
     fake2: DataFaker,
     pg: AsyncEngine,

--- a/tests/tasks/test_api.py
+++ b/tests/tasks/test_api.py
@@ -5,12 +5,8 @@ from tests.fixtures.client import ClientSpawner
 from virtool.tasks.models import SQLTask
 
 
-@pytest.mark.apitest
 async def test_find(spawn_client, pg: AsyncEngine, snapshot, static_time):
-    """
-    Test that a ``GET /tasks`` return a complete list of tasks.
-
-    """
+    """Test that a ``GET /tasks`` return a complete list of tasks."""
     client = await spawn_client(authenticated=True)
 
     async with AsyncSession(pg) as session:
@@ -38,7 +34,7 @@ async def test_find(spawn_client, pg: AsyncEngine, snapshot, static_time):
                     step="download",
                     type="import_reference",
                 ),
-            ]
+            ],
         )
         await session.commit()
 
@@ -48,7 +44,6 @@ async def test_find(spawn_client, pg: AsyncEngine, snapshot, static_time):
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error: str | None,
@@ -58,10 +53,7 @@ async def test_get(
     snapshot,
     static_time,
 ):
-    """
-    Test that a ``GET /tasks/:task_id`` return the correct task document.
-
-    """
+    """Test that a ``GET /tasks/:task_id`` return the correct task document."""
     client = await spawn_client(authenticated=True)
 
     if not error:
@@ -77,7 +69,7 @@ async def test_get(
                     progress=100,
                     step="download",
                     type="clone_reference",
-                )
+                ),
             )
             await session.commit()
 

--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -12,14 +12,13 @@ from virtool.fake.next import DataFaker
 from virtool.uploads.models import UploadType
 
 
-@pytest.fixture
+@pytest.fixture()
 def upload_request_form(example_path: Path):
     return {
         "file": open(example_path / "reads/single.fq.gz", "rb"),
     }
 
 
-@pytest.mark.apitest
 class TestUpload:
     async def test(
         self,
@@ -29,12 +28,10 @@ class TestUpload:
         spawn_client: ClientSpawner,
         static_time,
     ):
-        """
-        Test `POST /uploads` to assure a file can be uploaded.
-
-        """
+        """Test `POST /uploads` to assure a file can be uploaded."""
         client = await spawn_client(
-            authenticated=True, permissions=[Permission.upload_file]
+            authenticated=True,
+            permissions=[Permission.upload_file],
         )
 
         resp = await client.post_form(
@@ -46,11 +43,15 @@ class TestUpload:
         assert await resp.json() == snapshot(matcher=path_type({"created_at": (str,)}))
 
     async def test_no_upload_type(
-        self, upload_request_form, snapshot, spawn_client: ClientSpawner
+        self,
+        upload_request_form,
+        snapshot,
+        spawn_client: ClientSpawner,
     ):
         """Test that not supplying ``type`` in the query string leads to a ``400``."""
         client = await spawn_client(
-            authenticated=True, permissions=[Permission.upload_file]
+            authenticated=True,
+            permissions=[Permission.upload_file],
         )
 
         resp = await client.post_form(
@@ -62,25 +63,30 @@ class TestUpload:
         assert await resp.json() == snapshot
 
     async def test_bad_upload_type(
-        self, snapshot, spawn_client: ClientSpawner, upload_request_form
+        self,
+        snapshot,
+        spawn_client: ClientSpawner,
+        upload_request_form,
     ):
         """Test that supplying a bad ``type`` in the query string leads to a ``400``."""
         client = await spawn_client(
-            authenticated=True, permissions=[Permission.upload_file]
+            authenticated=True,
+            permissions=[Permission.upload_file],
         )
 
         resp = await client.post_form(
-            "/uploads?name=Test.fq.gz&type=bad", data=upload_request_form
+            "/uploads?name=Test.fq.gz&type=bad",
+            data=upload_request_form,
         )
 
         assert resp.status == 400
         assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 class TestFind:
     @pytest.mark.parametrize(
-        "upload_type", [UploadType.reads, UploadType.reference, None]
+        "upload_type",
+        [UploadType.reads, UploadType.reference, None],
     )
     async def test(
         self,
@@ -90,10 +96,7 @@ class TestFind:
         snapshot,
         static_time,
     ):
-        """
-        Test `GET /uploads` to assure that it returns the correct `upload` documents.
-
-        """
+        """Test `GET /uploads` to assure that it returns the correct `upload` documents."""
         client = await spawn_client(authenticated=True)
 
         user = await fake2.users.create()
@@ -158,17 +161,13 @@ class TestFind:
         assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 async def test_get(
     config: ServerConfig,
     example_path: Path,
     fake2: DataFaker,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test `GET /uploads/:id` to assure that it lets you download a file.
-
-    """
+    """Test `GET /uploads/:id` to assure that it lets you download a file."""
     client = await spawn_client(authenticated=True)
     get_config_from_app(client.app).data_path = config.data_path
 
@@ -180,10 +179,8 @@ async def test_get(
     assert await resp.read() == open(example_path / "reads/single.fq.gz", "rb").read()
 
 
-@pytest.mark.apitest
 async def test_delete(fake2: DataFaker, resp_is, spawn_client: ClientSpawner):
-    """
-    Test `DELETE /uploads/:id to assure that it properly deletes an existing
+    """Test `DELETE /uploads/:id to assure that it properly deletes an existing
     `uploads` row and file.
 
     """

--- a/tests/users/test_api.py
+++ b/tests/users/test_api.py
@@ -2,25 +2,27 @@ import pytest
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy import SnapshotAssertion
-from tests.fixtures.client import ClientSpawner
 from virtool_core.models.enums import Permission
-from virtool_core.models.roles import SpaceSampleRole, SpaceReferenceRole
+from virtool_core.models.roles import SpaceReferenceRole, SpaceSampleRole
 
+from tests.fixtures.client import ClientSpawner
 from virtool.authorization.relationships import UserRoleAssignment
-from virtool.data.topg import both_transactions
-from virtool.users.pg import SQLUser
 from virtool.data.layer import DataLayer
+from virtool.data.topg import both_transactions
 from virtool.data.utils import get_data_from_app
 from virtool.fake.next import DataFaker
-from virtool.groups.oas import UpdateGroupRequest, PermissionsUpdate
+from virtool.groups.oas import PermissionsUpdate, UpdateGroupRequest
 from virtool.mongo.core import Mongo
 from virtool.settings.oas import UpdateSettingsRequest
+from virtool.users.pg import SQLUser
 from virtool.users.utils import check_password
 
 
-@pytest.fixture
+@pytest.fixture()
 async def setup_update_user(
-    data_layer: DataLayer, fake2: DataFaker, spawn_client: ClientSpawner
+    data_layer: DataLayer,
+    fake2: DataFaker,
+    spawn_client: ClientSpawner,
 ):
     client = await spawn_client(administrator=True, authenticated=True)
 
@@ -35,14 +37,13 @@ async def setup_update_user(
     await data_layer.groups.update(
         group_2.id,
         UpdateGroupRequest(
-            permissions=PermissionsUpdate(create_sample=True, create_ref=True)
+            permissions=PermissionsUpdate(create_sample=True, create_ref=True),
         ),
     )
 
     return client, group_1, group_2, await fake2.users.create(groups=[group_1])
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("find", [None, "fred"])
 async def test_find(
     find: str | None,
@@ -53,7 +54,9 @@ async def test_find(
 ):
     """Test that a ``GET /users`` returns a list of users."""
     client = await spawn_client(
-        administrator=True, authenticated=True, permissions=[Permission.create_sample]
+        administrator=True,
+        authenticated=True,
+        permissions=[Permission.create_sample],
     )
 
     await fake2.users.create(handle=find)
@@ -70,7 +73,6 @@ async def test_find(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("status", [200, 404])
 async def test_get(
     status: int,
@@ -85,7 +87,8 @@ async def test_get(
     group = await fake2.groups.create()
 
     user = await fake2.users.create(
-        groups=[group, await fake2.groups.create()], primary_group=group
+        groups=[group, await fake2.groups.create()],
+        primary_group=group,
     )
 
     await fake2.users.create()
@@ -96,7 +99,6 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.apitest
 @pytest.mark.parametrize("error", [None, "400_exists", "400_password", "400_reserved"])
 async def test_create(
     error: str | None,
@@ -108,10 +110,7 @@ async def test_create(
     spawn_client: ClientSpawner,
     static_time,
 ):
-    """
-    Test that a valid request results in a user document being properly inserted.
-
-    """
+    """Test that a valid request results in a user document being properly inserted."""
     await mongo.users.create_index("handle", unique=True, sparse=True)
 
     client = await spawn_client(administrator=True, authenticated=True)
@@ -119,7 +118,7 @@ async def test_create(
     user = await fake2.users.create()
 
     await get_data_from_app(client.app).settings.update(
-        UpdateSettingsRequest(minimum_password_length=8)
+        UpdateSettingsRequest(minimum_password_length=8),
     )
 
     data = {"handle": "fred", "password": "hello_world", "force_reset": False}
@@ -141,7 +140,8 @@ async def test_create(
 
     if error == "400_password":
         await resp_is.bad_request(
-            resp, "Password does not meet minimum length requirement (8)"
+            resp,
+            "Password does not meet minimum length requirement (8)",
         )
         return
 
@@ -164,10 +164,12 @@ async def test_create(
     assert await data_layer.users.get(resp_json["id"]) == snapshot(name="data_layer")
 
 
-@pytest.mark.apitest
 class TestUpdate:
     async def test_ok(
-        self, setup_update_user, snapshot: SnapshotAssertion, static_time
+        self,
+        setup_update_user,
+        snapshot: SnapshotAssertion,
+        static_time,
     ):
         client, group_1, _, user = setup_update_user
 
@@ -184,7 +186,10 @@ class TestUpdate:
         assert await resp.json() == snapshot
 
     async def test_with_groups(
-        self, setup_update_user, snapshot: SnapshotAssertion, static_time
+        self,
+        setup_update_user,
+        snapshot: SnapshotAssertion,
+        static_time,
     ):
         client, group_1, group_2, user = setup_update_user
 
@@ -214,7 +219,9 @@ class TestUpdate:
         assert await resp.json() == snapshot
 
     async def test_non_existent_primary_group(
-        self, setup_update_user, snapshot: SnapshotAssertion
+        self,
+        setup_update_user,
+        snapshot: SnapshotAssertion,
     ):
         client, _, _, user = setup_update_user
 
@@ -229,7 +236,9 @@ class TestUpdate:
         assert await resp.json() == snapshot
 
     async def test_not_a_member_of_primary_group(
-        self, setup_update_user, snapshot: SnapshotAssertion
+        self,
+        setup_update_user,
+        snapshot: SnapshotAssertion,
     ):
         client, _, group_2, user = setup_update_user
 
@@ -338,9 +347,7 @@ async def test_create_first_user(
     spawn_client: ClientSpawner,
     static_time,
 ):
-    """
-    Checks response when first user exists and does not exist.
-    """
+    """Checks response when first user exists and does not exist."""
     client = await spawn_client()
 
     if not first_user_exists:
@@ -349,7 +356,8 @@ async def test_create_first_user(
             await mongo.users.delete_many({}, session=mongo_session)
 
     resp = await client.put(
-        "/users/first", {"handle": "fred", "password": "hello_world"}
+        "/users/first",
+        {"handle": "fred", "password": "hello_world"},
     )
 
     assert resp.status == status


### PR DESCRIPTION
## Changes
* Remove pytest mark `apitest` usages.
* Remove pytest mark `apitest` configuration in `pyproject.toml`.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
