### PR TITLE
test: remove `apitest` mark configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
     "Jake Alexander",
     "Josh Moreira",
     "Lilly Roberts",
+    "Matthew Curtis",
     "Naomi Schaufele",
     "Ryan Fang",
     "Sebastian Chen",
@@ -82,9 +83,7 @@ mypy = "^1.6.0"
 ruff = "^0.4.1"
 
 [tool.pytest.ini_options]
-addopts = "--capture tee-sys"
 asyncio_mode = "auto"
-markers = ["apitest", "serial"]
 python_files = ["test_*.py", "rev_*.py"]
 testpaths = ["tests", "assets/revisions"]
 


### PR DESCRIPTION
## Changes
* Remove configuration for `apitest` pytest mark from `pyproject.toml`.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
