### PR TITLE
Simplify mongo

### DIFF
--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -13,6 +13,7 @@ import pytest
 from aiohttp.test_utils import make_mocked_coro
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from syrupy import SnapshotAssertion
 
 from tests.fixtures.client import ClientSpawner
 from virtool.config import get_config_from_app
@@ -34,8 +35,8 @@ class TestFind:
         self,
         fake2: DataFaker,
         mocker,
-        snapshot,
         mongo: Mongo,
+        snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         static_time,
     ):

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -1,8 +1,8 @@
 import pytest
+from aiohttp.test_utils import make_mocked_coro
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.indexes.db
-from aiohttp.test_utils import make_mocked_coro
 from virtool.indexes.db import (
     attach_files,
     get_current_id_and_version,
@@ -15,7 +15,12 @@ from virtool.indexes.models import SQLIndexFile
 
 @pytest.mark.parametrize("index_id", [None, "abc"])
 async def test_create(
-    index_id, mocker, snapshot, mongo, test_random_alphanumeric, static_time
+    index_id,
+    mocker,
+    snapshot,
+    mongo,
+    test_random_alphanumeric,
+    static_time,
 ):
     await mongo.references.insert_one({"_id": "foo"})
 
@@ -24,13 +29,17 @@ async def test_create(
             "_id": "abc",
             "index": {"id": "unbuilt", "version": "unbuilt"},
             "reference": {"id": "foo"},
-        }
+        },
     )
 
     mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
 
     document = await virtool.indexes.db.create(
-        mongo, "foo", "test", "bar", index_id=index_id
+        mongo,
+        "foo",
+        "test",
+        "bar",
+        index_id=index_id,
     )
 
     assert document == snapshot
@@ -72,29 +81,6 @@ async def test_get_next_version(empty, has_ref, test_indexes, mongo):
     assert await get_next_version(mongo, "hxn167" if has_ref else "foobar") == expected
 
 
-async def test_processor(snapshot, fake2, mongo):
-    user = await fake2.users.create()
-
-    await mongo.history.insert_many(
-        [
-            {"_id": "foo.0", "index": {"id": "baz"}, "otu": {"id": "foo"}},
-            {"_id": "foo.1", "index": {"id": "baz"}, "otu": {"id": "foo"}},
-            {"_id": "bar.0", "index": {"id": "baz"}, "otu": {"id": "bar"}},
-            {"_id": "bar.1", "index": {"id": "baz"}, "otu": {"id": "bar"}},
-            {"_id": "bar.2", "index": {"id": "baz"}, "otu": {"id": "bar"}},
-            {"_id": "far.0", "index": {"id": "boo"}, "otu": {"id": "foo"}},
-        ],
-        session=None,
-    )
-
-    assert (
-        await virtool.indexes.db.processor(
-            mongo, {"_id": "baz", "user": {"id": user.id}}
-        )
-        == snapshot
-    )
-
-
 async def test_get_patched_otus(mocker, mongo, config):
     m = mocker.patch(
         "virtool.history.db.patch_to_version",
@@ -112,7 +98,7 @@ async def test_get_patched_otus(mocker, mongo, config):
             mocker.call(config.data_path, mongo, "foo", 2),
             mocker.call(config.data_path, mongo, "bar", 10),
             mocker.call(config.data_path, mongo, "baz", 4),
-        ]
+        ],
     )
 
 
@@ -132,10 +118,18 @@ async def test_update_last_indexed_versions(mongo, test_otu, spawn_client):
 
 async def test_attach_files(snapshot, pg: AsyncEngine):
     index_1 = SQLIndexFile(
-        id=1, name="reference.1.bt2", index="foo", type="bowtie2", size=1234567
+        id=1,
+        name="reference.1.bt2",
+        index="foo",
+        type="bowtie2",
+        size=1234567,
     )
     index_2 = SQLIndexFile(
-        id=2, name="reference.2.bt2", index="foo", type="bowtie2", size=1234567
+        id=2,
+        name="reference.2.bt2",
+        index="foo",
+        type="bowtie2",
+        size=1234567,
     )
 
     async with AsyncSession(pg) as session:

--- a/tests/mongo/test_utils.py
+++ b/tests/mongo/test_utils.py
@@ -1,47 +1,4 @@
-import pytest
 import virtool.mongo.utils
-
-
-class TestApplyProjection:
-    @pytest.mark.parametrize(
-        "projection,expected",
-        [
-            (["_id", "name"], {"_id": "foo", "name": "bar"}),
-            (["name"], {"_id": "foo", "name": "bar"}),
-            ({"_id": True, "name": True}, {"_id": "foo", "name": "bar"}),
-            ({"name": True}, {"_id": "foo", "name": "bar"}),
-            ({"_id": False, "name": True}, {"name": "bar"}),
-            ({"_id": False}, {"name": "bar", "age": 25}),
-        ],
-    )
-    def test(self, projection, expected):
-        """
-        Test that projections are applied to documents in the same way they are in MongoDB.
-
-        """
-        document = {"_id": "foo", "name": "bar", "age": 25}
-
-        assert virtool.mongo.utils.apply_projection(document, projection) == expected
-
-    def test_type_error(self):
-        """
-        Test that a `TypeError` is raised when the projection parameter is not a `dict` or `list`.
-
-        """
-        with pytest.raises(TypeError) as excinfo:
-            virtool.mongo.utils.apply_projection({}, "_id")
-
-        assert "Invalid type for projection: <class 'str'>" in str(excinfo.value)
-
-
-async def test_delete_unready(mongo):
-    await mongo.analyses.insert_many(
-        [{"_id": 1, "ready": True}, {"_id": 2, "ready": False}], session=None
-    )
-
-    await virtool.mongo.utils.delete_unready(mongo.analyses)
-
-    assert await mongo.analyses.find().to_list(None) == [{"_id": 1, "ready": True}]
 
 
 async def test_check_missing_ids(mongo):
@@ -60,7 +17,8 @@ async def test_check_missing_ids(mongo):
     )
 
     non_existent_subtractions = await virtool.mongo.utils.check_missing_ids(
-        mongo.subtraction, ["foo", "bar", "baz"]
+        mongo.subtraction,
+        ["foo", "bar", "baz"],
     )
 
     assert non_existent_subtractions == {"baz"}

--- a/tests/otus/__snapshots__/test_api.ambr
+++ b/tests/otus/__snapshots__/test_api.ambr
@@ -3174,11 +3174,10 @@
       'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
       'host': 'sweet cherry',
       'id': 'abcd1234',
-      'reference': dict({
-        'id': 'ref',
-      }),
+      'remote': None,
       'segment': None,
       'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
+      'target': None,
     }),
   ])
 # ---

--- a/virtool/account/mongo.py
+++ b/virtool/account/mongo.py
@@ -1,29 +1,14 @@
-"""
-Work with the current user account and its API keys.
+"""Work with the current user account and its API keys."""
 
-"""
 from typing import Any
 
 import virtool.users.utils
 import virtool.utils
 from virtool.mongo.core import Mongo
 
-ACCOUNT_PROJECTION = (
-    "_id",
-    "email",
-    "force_reset",
-    "groups",
-    "handle",
-    "last_password_change",
-    "permissions",
-    "primary_group",
-    "settings",
-)
-
 
 def compose_password_update(password: str) -> dict[str, Any]:
-    """
-    Compose an update dict for self-changing a users account password.
+    """Compose an update dict for self-changing a users account password.
 
     This will disable forced reset and won't invalidate current sessions, unlike a
     password change by an administrator.
@@ -41,8 +26,7 @@ def compose_password_update(password: str) -> dict[str, Any]:
 
 
 async def get_alternate_id(mongo: Mongo, name: str) -> str:
-    """
-    Get an alternate id for an API key whose provided `name` is not unique. Appends an
+    """Get an alternate id for an API key whose provided `name` is not unique. Appends an
     integer suffix to the end of the `name`.
 
     :param mongo: the application mongodb client

--- a/virtool/account/mongo.py
+++ b/virtool/account/mongo.py
@@ -26,8 +26,8 @@ def compose_password_update(password: str) -> dict[str, Any]:
 
 
 async def get_alternate_id(mongo: Mongo, name: str) -> str:
-    """Get an alternate id for an API key whose provided `name` is not unique. Appends an
-    integer suffix to the end of the `name`.
+    """Get an alternate id for an API key whose provided `name` is not unique. Appends
+    an integer suffix to the end of the `name`.
 
     :param mongo: the application mongodb client
     :param name: the API key name

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -1,34 +1,15 @@
-"""
-Work with analyses in the database.
+"""Work with analyses in the database."""
 
-"""
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.analyses.models import SQLAnalysisFile
 from virtool.data.transforms import AbstractTransform
+from virtool.mongo.core import Mongo
 from virtool.samples.utils import get_sample_rights
 from virtool.types import Document
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
-
-PROJECTION = (
-    "_id",
-    "workflow",
-    "created_at",
-    "index",
-    "job",
-    "ready",
-    "reference",
-    "sample",
-    "subtractions",
-    "updated_at",
-    "user",
-)
 
 TARGET_FILES = (
     "hmm.tsv",
@@ -51,7 +32,7 @@ class AttachAnalysisFileTransform(AbstractTransform):
             results = (
                 (
                     await session.execute(
-                        select(SQLAnalysisFile).filter_by(analysis=document["id"])
+                        select(SQLAnalysisFile).filter_by(analysis=document["id"]),
                     )
                 )
                 .scalars()
@@ -62,10 +43,11 @@ class AttachAnalysisFileTransform(AbstractTransform):
 
 
 async def filter_analyses_by_sample_rights(
-    client, mongo: "Mongo", analyses: list[dict]
+    client,
+    mongo: "Mongo",
+    analyses: list[dict],
 ) -> list[dict]:
-    """
-    Filter a list of analyses based on the user's rights to the samples they are associated with.
+    """Filter a list of analyses based on the user's rights to the samples they are associated with.
 
     :param mongo: the application database client
     :param analyses: the analyses to filter

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -47,7 +47,8 @@ async def filter_analyses_by_sample_rights(
     mongo: Mongo,
     analyses: list[dict],
 ) -> list[dict]:
-    """Filter a list of analyses based on the user's rights to the samples they are associated with.
+    """Filter a list of analyses based on the user's rights to the samples they are
+    associated with.
 
     :param mongo: the application database client
     :param analyses: the analyses to filter

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -44,7 +44,7 @@ class AttachAnalysisFileTransform(AbstractTransform):
 
 async def filter_analyses_by_sample_rights(
     client,
-    mongo: "Mongo",
+    mongo: Mongo,
     analyses: list[dict],
 ) -> list[dict]:
     """Filter a list of analyses based on the user's rights to the samples they are associated with.

--- a/virtool/api/utils.py
+++ b/virtool/api/utils.py
@@ -41,8 +41,8 @@ def compose_exists_query(field: str) -> Dict[str, Dict[str, bool]]:
 
 
 def compose_regex_query(term, fields: List[str]) -> Dict[str, List[Dict[str, dict]]]:
-    """Compose a MongoDB query that checks if the values of the passed `fields` match the
-    passed search `term`.
+    """Compose a MongoDB query that checks if the values of the passed `fields` match
+    the passed search `term`.
 
     :param term: the term to search
     :param fields: the list of field to match against

--- a/virtool/api/utils.py
+++ b/virtool/api/utils.py
@@ -2,14 +2,13 @@ import asyncio
 import math
 import re
 from dataclasses import dataclass
-from typing import Union
-from typing import Dict, List, Optional, Tuple, Mapping, Any
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 from aiohttp.web import Request
 from aiohttp.web_response import Response
 from multidict import MultiDictProxy
 
-from virtool.types import Projection, Document
+from virtool.types import Document, Projection
 from virtool.utils import coerce_list, to_bool
 
 
@@ -32,8 +31,7 @@ class Paginated:
 
 
 def compose_exists_query(field: str) -> Dict[str, Dict[str, bool]]:
-    """
-    Compose a MongoDB query that checks if the passed `field` exists.
+    """Compose a MongoDB query that checks if the passed `field` exists.
 
     :param field: the field to check for existence
     :return: a query
@@ -43,8 +41,7 @@ def compose_exists_query(field: str) -> Dict[str, Dict[str, bool]]:
 
 
 def compose_regex_query(term, fields: List[str]) -> Dict[str, List[Dict[str, dict]]]:
-    """
-    Compose a MongoDB query that checks if the values of the passed `fields` match the
+    """Compose a MongoDB query that checks if the values of the passed `fields` match the
     passed search `term`.
 
     :param term: the term to search
@@ -63,21 +60,20 @@ def compose_regex_query(term, fields: List[str]) -> Dict[str, List[Dict[str, dic
         "$or": [
             {field: {"$regex": regex}}
             for field in [str(field) for field in coerce_list(fields)]
-        ]
+        ],
     }
 
 
 async def paginate(
     collection,
-    db_query: Union[Dict, MultiDictProxy[str]],
-    url_query: Union[Dict, MultiDictProxy[str]],
-    sort: Optional[Union[List[Tuple[str, int]], str]] = None,
-    projection: Optional[Projection] = None,
-    base_query: Optional[Dict] = None,
+    mongo_query: dict | MultiDictProxy[str],
+    url_query: dict | MultiDictProxy[str],
+    base_query: dict | None = None,
+    projection: Projection | None = None,
     reverse: bool = False,
+    sort: list[tuple[str, int]] | str | None = None,
 ):
-    """
-    A function for searching and paging collections.
+    """A function for searching and paging collections.
 
     Uses a number of different queries to return search results.
 
@@ -103,7 +99,7 @@ async def paginate(
     `page`: the page number to return (starts at one)
 
     :param collection: the database collection
-    :param db_query: a query derived from user supplied - affects found count
+    :param mongo_query: a query derived from user supplied - affects found count
     :param url_query: the raw URL query; used to get the `page` and `page_count` values
     :param sort: a field to sort by
     :param projection: the projection to apply to the returned documents
@@ -127,11 +123,11 @@ async def paginate(
     if isinstance(sort, str):
         sort = [(sort, -1 if reverse else 1)]
 
-    db_query = {"$and": [base_query, db_query]}
+    mongo_query = {"$and": [base_query, mongo_query]}
 
-    cursor = collection.find(db_query, projection, sort=sort)
+    cursor = collection.find(mongo_query, projection, sort=sort)
 
-    found_count = await collection.count_documents(db_query)
+    found_count = await collection.count_documents(mongo_query)
 
     page_count = int(math.ceil(found_count / per_page))
 
@@ -141,9 +137,7 @@ async def paginate(
         if page > 1:
             cursor.skip((page - 1) * per_page)
 
-        documents = [
-            await collection.apply_processor(d) for d in await cursor.to_list(per_page)
-        ]
+        documents = await cursor.to_list(per_page)
 
     total_count = await collection.count_documents(base_query)
 
@@ -168,8 +162,7 @@ async def paginate_aggregate(
     sort: Optional[Union[List[Tuple[str, int]], str]] = None,
     reverse: bool = False,
 ):
-    """
-    A function to return parameters used in aggregate.
+    """A function to return parameters used in aggregate.
 
     Uses a number of different queries to return search results.
 
@@ -204,7 +197,6 @@ async def paginate_aggregate(
     :param reverse: reverse the sort order
 
     """
-
     base_query = base_query or {}
 
     client_query = client_query or {}
@@ -242,16 +234,16 @@ async def paginate_aggregate(
                         {"$limit": per_page},
                         *lookup_steps,
                     ],
-                }
+                },
             },
             {
                 "$project": {
                     "data": projection,
                     "total_count": {"$arrayElemAt": ["$total_count.total_count", 0]},
                     "found_count": {"$arrayElemAt": ["$found_count.found_count", 0]},
-                }
+                },
             },
-        ]
+        ],
     ):
         data = paginate_dict["data"]
         total_count = paginate_dict.get("total_count", 0)
@@ -277,8 +269,7 @@ async def paginate2(
     reverse: bool = False,
     sort: Optional[Union[List[Tuple[str, int]], str]] = None,
 ) -> Paginated:
-    """
-    A function for searching and paging collections.
+    """A function for searching and paging collections.
 
     Uses a number of different queries to return search results.
 
@@ -323,7 +314,8 @@ async def paginate2(
     cursor = collection.find(search_query, projection, sort=sort)
 
     found_count, total_count = await asyncio.gather(
-        collection.count_documents(search_query), collection.count_documents(base_query)
+        collection.count_documents(search_query),
+        collection.count_documents(base_query),
     )
 
     if page > 1:
@@ -345,8 +337,7 @@ async def paginate2(
 
 
 def get_query_bool(query: Mapping, key: str, default: Optional[Any] = None) -> bool:
-    """
-    Return a `bool` calculated from a URL query given its `key`.
+    """Return a `bool` calculated from a URL query given its `key`.
 
     :param query: the URL query
     :param key: the URL query key
@@ -361,8 +352,7 @@ def get_query_bool(query: Mapping, key: str, default: Optional[Any] = None) -> b
 
 
 def get_req_bool(req: Request, key: str, default: Optional[Any] = None) -> bool:
-    """
-    Return a `bool` calculated from the request's query given its `key`.
+    """Return a `bool` calculated from the request's query given its `key`.
 
     :param req: the request
     :param key: the URL query key

--- a/virtool/blast/db.py
+++ b/virtool/blast/db.py
@@ -1,28 +1,32 @@
-from sqlalchemy import select, delete
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.blast.models import SQLNuVsBlast
 
 
 async def get_nuvs_blast(
-    session: AsyncSession, analysis_id: str, sequence_index: int
+    session: AsyncSession,
+    analysis_id: str,
+    sequence_index: int,
 ) -> SQLNuVsBlast:
     result = await session.scalar(
         select(SQLNuVsBlast)
         .where(SQLNuVsBlast.analysis_id == analysis_id)
-        .where(SQLNuVsBlast.sequence_index == sequence_index)
+        .where(SQLNuVsBlast.sequence_index == sequence_index),
     )
 
     return result
 
 
 async def delete_nuvs_blast(
-    session: AsyncSession, analysis_id: str, sequence_index: int
+    session: AsyncSession,
+    analysis_id: str,
+    sequence_index: int,
 ) -> int:
     result = await session.execute(
         delete(SQLNuVsBlast)
         .where(SQLNuVsBlast.analysis_id == analysis_id)
-        .where(SQLNuVsBlast.sequence_index == sequence_index)
+        .where(SQLNuVsBlast.sequence_index == sequence_index),
     )
 
     await session.commit()

--- a/virtool/caches/db.py
+++ b/virtool/caches/db.py
@@ -17,8 +17,6 @@ from virtool.utils import base_processor
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
 
-PROJECTION = ("_id", "created_at", "files", "key", "program", "ready", "sample")
-
 
 async def get(mongo: "Mongo", cache_id: str) -> dict[str, Any]:
     """Get the complete representation for the cache with the given `cache_id`.

--- a/virtool/groups/mongo.py
+++ b/virtool/groups/mongo.py
@@ -1,7 +1,4 @@
-"""
-Database utilities for groups.
-
-"""
+"""Database utilities for groups."""
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy import select
@@ -17,8 +14,7 @@ async def update_member_users_and_api_keys(
     pg_session: AsyncSession,
     group_id: int,
 ):
-    """
-    For the ``group_id``, update member users ``groups`` and ``primary_group`` fields
+    """For the ``group_id``, update member users ``groups`` and ``primary_group`` fields
     and update their API key permissions.
 
     This function should be called after a group is updated or deleted.

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -67,28 +67,15 @@ class DiffTransform(AbstractTransform):
         return document["diff"]
 
 
-async def processor(mongo, document: Document) -> Document:
-    """Process a history document before it is returned to the client.
-
-    :param mongo: the application object
-    :param document: the document to process
-    :return: the processed document
-    """
-    return await apply_transforms(
-        base_processor(document),
-        [AttachUserTransform(mongo, ignore_errors=True)],
-    )
-
-
 async def add(
     mongo: "Mongo",
     data_path: Path,
     method_name: HistoryMethod,
-    old: Optional[dict],
-    new: Optional[dict],
+    old: dict | None,
+    new: dict | None,
     description: str,
     user_id: str,
-    session: Optional[AsyncIOMotorClientSession] = None,
+    session: AsyncIOMotorClientSession | None = None,
 ) -> dict:
     """Add a change document to the history collection.
 
@@ -205,7 +192,7 @@ async def find(mongo, req_query, base_query: Optional[Document] = None):
     return {
         **data,
         "documents": await apply_transforms(
-            data["documents"],
+            [base_processor(d) for d in data["documents"]],
             [AttachReferenceTransform(mongo), AttachUserTransform(mongo)],
         ),
     }

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -3,7 +3,7 @@
 import asyncio
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 import bson
 import dictdiffer
@@ -23,6 +23,7 @@ from virtool.history.utils import (
     derive_otu_information,
     write_diff_file,
 )
+from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
@@ -30,19 +31,7 @@ from virtool.users.db import ATTACH_PROJECTION
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
 
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
-MOST_RECENT_PROJECTION = [
-    "_id",
-    "description",
-    "method_name",
-    "user",
-    "otu",
-    "created_at",
-]
-
-LIST_PROJECTION = [
+HISTORY_LIST_PROJECTION = [
     "_id",
     "description",
     "method_name",
@@ -52,8 +41,10 @@ LIST_PROJECTION = [
     "reference",
     "user",
 ]
+"""A MongoDB projection for history for listing purposes."""
 
-PROJECTION = LIST_PROJECTION + ["diff"]
+HISTORY_PROJECTION = HISTORY_LIST_PROJECTION + ["diff"]
+"""A MongoDB projection for history that includes the ``diff`` field."""
 
 
 class DiffTransform(AbstractTransform):
@@ -207,7 +198,7 @@ async def find(mongo, req_query, base_query: Optional[Document] = None):
         req_query,
         base_query=base_query,
         sort="otu.version",
-        projection=LIST_PROJECTION,
+        projection=HISTORY_LIST_PROJECTION,
         reverse=True,
     )
 
@@ -233,7 +224,7 @@ async def get(app, change_id: str) -> Optional[Document]:
     """
     mongo = get_mongo_from_app(app)
 
-    document = await mongo.history.find_one(change_id, PROJECTION)
+    document = await mongo.history.find_one(change_id, HISTORY_PROJECTION)
 
     if document:
         return await apply_transforms(
@@ -287,7 +278,14 @@ async def get_most_recent_change(
     """
     return await mongo.history.find_one(
         {"otu.id": otu_id},
-        MOST_RECENT_PROJECTION,
+        [
+            "_id",
+            "description",
+            "method_name",
+            "user",
+            "otu",
+            "created_at",
+        ],
         sort=[("otu.version", -1)],
         session=session,
     )

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -315,7 +315,7 @@ class IndexData:
         )
 
         data["documents"] = await apply_transforms(
-            data["documents"],
+            [base_processor(d) for d in data["documents"]],
             [AttachReferenceTransform(self._mongo), AttachUserTransform(self._mongo)],
         )
 

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -23,9 +23,9 @@ from virtool.data.errors import (
     ResourceError,
     ResourceNotFoundError,
 )
-from virtool.data.events import emits, Operation, emit
+from virtool.data.events import Operation, emit, emits
 from virtool.data.transforms import apply_transforms
-from virtool.history.db import LIST_PROJECTION
+from virtool.history.db import HISTORY_LIST_PROJECTION
 from virtool.indexes.checks import check_fasta_file_uploaded, check_index_files_uploaded
 from virtool.indexes.db import (
     INDEX_FILE_NAMES,
@@ -41,9 +41,9 @@ from virtool.mongo.utils import get_one_field
 from virtool.pg.utils import get_rows
 from virtool.references.db import lookup_nested_reference_by_id
 from virtool.references.transforms import AttachReferenceTransform
-from virtool.uploads.utils import naive_writer, multipart_file_chunker
+from virtool.uploads.utils import multipart_file_chunker, naive_writer
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import compress_json_with_gzip, wait_for_checks, base_processor
+from virtool.utils import base_processor, compress_json_with_gzip, wait_for_checks
 
 logger = get_logger("indexes")
 
@@ -57,10 +57,11 @@ class IndexData:
         self._pg = pg
 
     async def find(
-        self, ready: bool, query: MultiDictProxy
+        self,
+        ready: bool,
+        query: MultiDictProxy,
     ) -> Union[List[IndexMinimal], IndexSearchResult]:
-        """
-        List all indexes.
+        """List all indexes.
 
         :param ready: the request object
         :param query: the request query object
@@ -78,32 +79,31 @@ class IndexData:
                         "$match": {
                             "ready": True,
                             "reference.id": {
-                                "$in": await self._mongo.references.distinct("_id")
+                                "$in": await self._mongo.references.distinct("_id"),
                             },
-                        }
+                        },
                     },
                     *lookup_nested_reference_by_id(local_field="reference.id"),
                     *lookup_index_otu_counts(local_field="_id"),
                     {"$sort": {"created_at": 1}},
                     {"$project": {"counts": False}},
-                ]
+                ],
             )
         ]
 
         items = await apply_transforms(
-            items, [AttachJobTransform(self._mongo), AttachUserTransform(self._mongo)]
+            items,
+            [AttachJobTransform(self._mongo), AttachUserTransform(self._mongo)],
         )
 
         return [IndexMinimal(**item) for item in items]
 
     async def get(self, index_id: str) -> Index:
-        """
-        Get a single index by its ID.
+        """Get a single index by its ID.
 
         :param index_id: the index ID
         :return: the index
         """
-
         result = await self._mongo.indexes.aggregate(
             [
                 {"$match": {"_id": index_id}},
@@ -111,7 +111,7 @@ class IndexData:
                 *lookup_index_otu_counts(local_field="_id"),
                 {"$sort": {"created_at": 1}},
                 {"$project": {"counts": False}},
-            ]
+            ],
         ).to_list(length=1)
 
         if not result:
@@ -127,7 +127,9 @@ class IndexData:
         document.update({"contributors": contributors, "otus": otus})
 
         document = await virtool.indexes.db.attach_files(
-            self._pg, self._config.base_url, document
+            self._pg,
+            self._config.base_url,
+            document,
         )
 
         document = await apply_transforms(
@@ -141,19 +143,21 @@ class IndexData:
         return Index(**document)
 
     async def get_reference(self, index_id: str) -> ReferenceNested:
-        """
-        Get a reference associated with an index.
+        """Get a reference associated with an index.
 
         :param index_id: the index ID
         :return: the reference
         """
         reference_field = await get_one_field(
-            self._mongo.indexes, "reference", index_id
+            self._mongo.indexes,
+            "reference",
+            index_id,
         )
 
         if reference_field and (
             reference := await self._mongo.references.find_one(
-                {"_id": reference_field["id"]}, ["data_type", "name"]
+                {"_id": reference_field["id"]},
+                ["data_type", "name"],
             )
         ):
             return ReferenceNested(**reference)
@@ -161,8 +165,7 @@ class IndexData:
         raise ResourceNotFoundError
 
     async def get_json_path(self, index_id: str) -> Path:
-        """
-        Get the json path needed for a complete compressed JSON
+        """Get the json path needed for a complete compressed JSON
         representation of the index OTUs.
 
         :param index_id: the index ID
@@ -181,7 +184,9 @@ class IndexData:
 
         if not json_path.exists():
             patched_otus = await virtool.indexes.db.get_patched_otus(
-                self._mongo, self._config, index["manifest"]
+                self._mongo,
+                self._config,
+                index["manifest"],
             )
 
             json_string = dump_bytes(patched_otus)
@@ -191,10 +196,14 @@ class IndexData:
         return json_path
 
     async def upload_file(
-        self, reference_id: str, index_id: str, file_type: str, name: str, multipart
+        self,
+        reference_id: str,
+        index_id: str,
+        file_type: str,
+        name: str,
+        multipart,
     ) -> IndexFile:
-        """
-        Uploads a new index file.
+        """Uploads a new index file.
 
         :param reference_id: the reference ID
         :param index_id: the index ID
@@ -232,13 +241,13 @@ class IndexData:
             await session.commit()
 
         return IndexFile(
-            **index_file_dict, download_url=f"/indexes/{index_id}/files/{name}"
+            **index_file_dict,
+            download_url=f"/indexes/{index_id}/files/{name}",
         )
 
     @emits(Operation.UPDATE)
     async def finalize(self, index_id: str) -> Index:
-        """
-        Finalize an index document.
+        """Finalize an index document.
 
         :param index_id: the index ID
         :return: the finalized Index
@@ -271,16 +280,19 @@ class IndexData:
             await update_last_indexed_versions(self._mongo, ref_id, session)
 
             await self._mongo.indexes.update_one(
-                {"_id": index_id}, {"$set": {"ready": True}}, session=session
+                {"_id": index_id},
+                {"$set": {"ready": True}},
+                session=session,
             )
 
         return await self.get(index_id)
 
     async def find_changes(
-        self, index_id: str, req_query: MultiDictProxy[str]
+        self,
+        index_id: str,
+        req_query: MultiDictProxy[str],
     ) -> HistorySearchResult:
-        """
-        Find the virus changes that are included in a given index build.
+        """Find the virus changes that are included in a given index build.
         :param index_id: the index ID
         :param req_query: the request query object
         :return: the changes
@@ -298,7 +310,7 @@ class IndexData:
             db_query,
             req_query,
             sort=[("otu.name", 1), ("otu.version", -1)],
-            projection=LIST_PROJECTION,
+            projection=HISTORY_LIST_PROJECTION,
             reverse=True,
         )
 
@@ -310,8 +322,7 @@ class IndexData:
         return HistorySearchResult(**data)
 
     async def ensure_files(self):
-        """
-        Ensure all data files associated with indexes are tracked.
+        """Ensure all data files associated with indexes are tracked.
 
         If a JSON file does not exist for an index, create it. If creation fails, the
         error will be logged and the index will be skipped.
@@ -321,23 +332,28 @@ class IndexData:
             index_id = index["_id"]
 
             index_path = join_index_path(
-                self._config.data_path, index["reference"]["id"], index_id
+                self._config.data_path,
+                index["reference"]["id"],
+                index_id,
             )
 
             try:
                 await self._ensure_json(
-                    index_path, index["reference"]["id"], index["manifest"]
+                    index_path,
+                    index["reference"]["id"],
+                    index["manifest"],
                 )
             except IndexError:
                 logger.exception(
-                    "Could not create JSON file for index", index_id=index_id
+                    "Could not create JSON file for index",
+                    index_id=index_id,
                 )
                 continue
 
             async with AsyncSession(self._pg) as session:
                 first = (
                     await session.execute(
-                        select(SQLIndexFile).where(SQLIndexFile.index == index_id)
+                        select(SQLIndexFile).where(SQLIndexFile.index == index_id),
                     )
                 ).first()
 
@@ -354,14 +370,13 @@ class IndexData:
                         )
                         for path in sorted(index_path.iterdir())
                         if path.name in INDEX_FILE_NAMES
-                    ]
+                    ],
                 )
 
                 await session.commit()
 
     async def _ensure_json(self, path: Path, ref_id: str, manifest: Dict):
-        """
-        Ensure that a there is a compressed JSON representation of the index found at
+        """Ensure that a there is a compressed JSON representation of the index found at
         `path`` exists.
 
         :param path: the path to the index directory
@@ -374,7 +389,8 @@ class IndexData:
             return
 
         reference = await self._mongo.references.find_one(
-            ref_id, ["data_type", "organism", "targets"]
+            ref_id,
+            ["data_type", "organism", "targets"],
         )
 
         index_data = await export_index(self._config.data_path, self._mongo, manifest)
@@ -387,14 +403,13 @@ class IndexData:
                     "organism": reference["organism"],
                     "otus": index_data,
                     "targets": reference.get("targets"),
-                }
+                },
             ),
             json_path,
         )
 
     async def delete(self, index_id: str):
-        """
-        Delete an index given it's id.
+        """Delete an index given it's id.
 
         :param index_id: the ID of the index to delete
         """
@@ -405,14 +420,16 @@ class IndexData:
 
         async with self._mongo.create_session() as mongo_session:
             delete_result = await self._mongo.indexes.delete_one(
-                {"_id": index_id}, session=mongo_session
+                {"_id": index_id},
+                session=mongo_session,
             )
 
             if delete_result.deleted_count == 0:
                 raise ResourceNotFoundError
 
             index_change_ids = await self._mongo.history.distinct(
-                "_id", {"index.id": index_id}
+                "_id",
+                {"index.id": index_id},
             )
 
             await self._mongo.history.update_many(

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import asyncio.tasks
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 import pymongo
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -17,26 +17,10 @@ from virtool.config.cls import Config
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.indexes.models import SQLIndexFile
 from virtool.jobs.transforms import AttachJobTransform
+from virtool.mongo.core import Mongo
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
-INDEXES_PROJECTION = [
-    "_id",
-    "created_at",
-    "has_files",
-    "job",
-    "otu_count",
-    "modification_count",
-    "modified_count",
-    "user",
-    "ready",
-    "reference",
-    "version",
-]
 
 INDEX_FILE_NAMES = (
     "reference.fa.gz",
@@ -188,7 +172,19 @@ async def find(
         {},
         req_query,
         base_query=base_query,
-        projection=INDEXES_PROJECTION,
+        projection=[
+            "_id",
+            "created_at",
+            "has_files",
+            "job",
+            "otu_count",
+            "modification_count",
+            "modified_count",
+            "user",
+            "ready",
+            "reference",
+            "version",
+        ],
         reverse=True,
         sort="version",
     )

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -21,6 +21,7 @@ from virtool.mongo.core import Mongo
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
+from virtool.utils import base_processor
 
 INDEX_FILE_NAMES = (
     "reference.fa.gz",
@@ -136,19 +137,6 @@ async def create(
     return document
 
 
-async def processor(mongo: "Mongo", document: Document) -> dict:
-    """A processor for index documents. Adds computed data about the index.
-
-    :param mongo: the application database client
-    :param document: the document to be processed
-    :return: the processed document
-    """
-    return await apply_transforms(
-        virtool.utils.base_processor(document),
-        [AttachUserTransform(mongo), IndexCountsTransform(mongo)],
-    )
-
-
 async def find(
     mongo: "Mongo",
     req_query: Mapping,
@@ -195,7 +183,7 @@ async def find(
         **data,
         **unbuilt_stats,
         "documents": await apply_transforms(
-            data["documents"],
+            [base_processor(d) for d in data["documents"]],
             [
                 AttachJobTransform(mongo),
                 AttachReferenceTransform(mongo),

--- a/virtool/mongo/core.py
+++ b/virtool/mongo/core.py
@@ -12,7 +12,7 @@ from pymongo.errors import DuplicateKeyError
 
 import virtool.references.db
 from virtool.mongo.identifier import AbstractIdProvider
-from virtool.mongo.utils import apply_projection, id_exists
+from virtool.mongo.utils import id_exists
 from virtool.types import Document, Projection
 from virtool.utils import base_processor
 
@@ -79,18 +79,16 @@ class Collection:
         document = await self._collection.find_one_and_update(
             query,
             update,
+            projection=projection,
             return_document=ReturnDocument.AFTER,
             upsert=upsert,
             session=session,
         )
 
-        if document is None:
-            return None
+        if document:
+            return document
 
-        if projection:
-            return apply_projection(document, projection)
-
-        return document
+        return None
 
     async def insert_one(
         self,

--- a/virtool/mongo/identifier.py
+++ b/virtool/mongo/identifier.py
@@ -9,19 +9,37 @@ from virtool.utils import random_alphanumeric
 class AbstractIdProvider(ABC):
     @abstractmethod
     def get(self) -> str:
+        """Generate a new unique identifier for MongoDB.
+
+        :return: a new unique identifier
+        """
         ...
 
 
 class FakeIdProvider(AbstractIdProvider):
+    """A provider for generating predictable, fake, unique identifiers for MongoDB."""
+
     def __init__(self):
         self._faker = Faker()
         self._faker.seed_instance(9950)
         self._faker.add_provider(misc)
 
     def get(self) -> str:
+        """Generate a fake unique identifier for MongoDB.
+
+        IDs are generated using Faker with a static seed. The same IDs will be generated
+        in the same order for a given provider instance.
+
+        :return: a new unique identifier
+        """
         return self._faker.md5()[:8]
 
 
 class RandomIdProvider(AbstractIdProvider):
+    """A provider for generating random, unique identifiers for MongoDB.
+
+    This provider is used in production.
+    """
+
     def get(self) -> str:
         return random_alphanumeric(8, True)

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -613,7 +613,7 @@ async def list_history(req):
 
     return json_response(
         await apply_transforms(
-            documents,
+            [base_processor(d) for d in documents],
             [AttachUserTransform(mongo, ignore_errors=True)],
         ),
     )

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -751,7 +751,7 @@ class OTUData:
             )
         ):
             document = await apply_transforms(
-                document,
+                base_processor(document),
                 [AttachReferenceTransform(self._mongo)],
             )
             return Sequence(**document)

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -1,7 +1,7 @@
 import asyncio
 from copy import deepcopy
 from pathlib import Path
-from typing import Optional, Tuple, Mapping
+from typing import Mapping, Optional, Tuple
 
 from pymongo.results import DeleteResult
 from virtool_core.models.enums import HistoryMethod
@@ -11,6 +11,7 @@ import virtool.history.db
 import virtool.otus.db
 import virtool.utils
 from virtool.data.errors import ResourceNotFoundError
+from virtool.data.transforms import apply_transforms
 from virtool.downloads.utils import format_fasta_entry, format_fasta_filename
 from virtool.history.utils import (
     compose_create_description,
@@ -18,10 +19,13 @@ from virtool.history.utils import (
     compose_remove_description,
 )
 from virtool.mongo.core import Mongo
-from virtool.data.transforms import apply_transforms
 from virtool.mongo.utils import get_one_field
-from virtool.otus.db import increment_otu_version, update_otu_verification
-from virtool.otus.oas import UpdateSequenceRequest, CreateOTURequest, UpdateOTURequest
+from virtool.otus.db import (
+    SEQUENCE_PROJECTION,
+    increment_otu_version,
+    update_otu_verification,
+)
+from virtool.otus.oas import CreateOTURequest, UpdateOTURequest, UpdateSequenceRequest
 from virtool.otus.utils import find_isolate, format_isolate_name
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
@@ -40,8 +44,7 @@ class OTUData:
         return await virtool.otus.db.find(self._mongo, term, query, verified)
 
     async def get(self, otu_id: str) -> OTU:
-        """
-        Get a single OTU by ID.
+        """Get a single OTU by ID.
 
         :param otu_id: the ID of the OTU to get
         :return: the OTU
@@ -52,21 +55,22 @@ class OTUData:
             raise ResourceNotFoundError
 
         document = await apply_transforms(
-            document, [AttachReferenceTransform(self._mongo)]
+            document,
+            [AttachReferenceTransform(self._mongo)],
         )
 
         return OTU(
             **{
                 **document,
                 "most_recent_change": await apply_transforms(
-                    document["most_recent_change"], [AttachUserTransform(self._mongo)]
+                    document["most_recent_change"],
+                    [AttachUserTransform(self._mongo)],
                 ),
-            }
+            },
         )
 
     async def get_fasta(self, otu_id: str) -> Optional[Tuple[str, str]]:
-        """
-        Generate a FASTA filename and body for an OTU's sequences.
+        """Generate a FASTA filename and body for an OTU's sequences.
 
         :param otu_id: the ID of the OTU
         :return: a FASTA filename and body
@@ -85,21 +89,26 @@ class OTUData:
             fasta.extend(
                 [
                     format_fasta_entry(
-                        otu["name"], isolate_name, sequence["_id"], sequence["sequence"]
+                        otu["name"],
+                        isolate_name,
+                        sequence["_id"],
+                        sequence["sequence"],
                     )
                     async for sequence in self._mongo.sequences.find(
-                        {"otu_id": otu_id, "isolate_id": isolate["id"]}, ["sequence"]
+                        {"otu_id": otu_id, "isolate_id": isolate["id"]},
+                        ["sequence"],
                     )
-                ]
+                ],
             )
 
         return format_fasta_filename(otu["name"]), "\n".join(fasta)
 
     async def get_otu_and_isolate_names(
-        self, otu_id: str, isolate_id: str
+        self,
+        otu_id: str,
+        isolate_id: str,
     ) -> Tuple[str, str]:
-        """
-        Get the OTU name and isolate name for a OTU-isolate combination specified by `otu_id` and `isolate_id`.
+        """Get the OTU name and isolate name for a OTU-isolate combination specified by `otu_id` and `isolate_id`.
 
         :param otu_id: the OTU ID
         :param isolate_id: the isolate ID
@@ -107,7 +116,8 @@ class OTUData:
 
         """
         otu = await self._mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id}, ["name", "isolates"]
+            {"_id": otu_id, "isolates.id": isolate_id},
+            ["name", "isolates"],
         )
 
         if not otu:
@@ -121,8 +131,7 @@ class OTUData:
         return otu["name"], virtool.otus.utils.format_isolate_name(isolate)
 
     async def get_isolate_fasta(self, otu_id: str, isolate_id: str) -> Tuple[str, str]:
-        """
-        Generate a FASTA filename and body for the sequences associated with the isolate identified by the passed
+        """Generate a FASTA filename and body for the sequences associated with the isolate identified by the passed
         ``otu_id`` and ``isolate_id``.
 
         :param otu_id: the id of the isolates' parent otu
@@ -133,57 +142,68 @@ class OTUData:
         _, isolate_name = await self.get_otu_and_isolate_names(otu_id, isolate_id)
 
         otu = await self._mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id}, ["name", "isolates"]
+            {"_id": otu_id, "isolates.id": isolate_id},
+            ["name", "isolates"],
         )
 
         fasta = []
 
         async for sequence in self._mongo.sequences.find(
-            {"otu_id": otu_id, "isolate_id": isolate_id}, ["sequence"]
+            {"otu_id": otu_id, "isolate_id": isolate_id},
+            ["sequence"],
         ):
             fasta.append(
                 virtool.downloads.utils.format_fasta_entry(
-                    otu["name"], isolate_name, sequence["_id"], sequence["sequence"]
-                )
+                    otu["name"],
+                    isolate_name,
+                    sequence["_id"],
+                    sequence["sequence"],
+                ),
             )
 
         return virtool.downloads.utils.format_fasta_filename(
-            otu["name"], isolate_name
+            otu["name"],
+            isolate_name,
         ), "\n".join(fasta)
 
     async def get_sequence_fasta(self, sequence_id: str) -> Tuple[str, str]:
-        """
-        Generate a FASTA filename and body for the sequence associated with the passed ``sequence_id``.
+        """Generate a FASTA filename and body for the sequence associated with the passed ``sequence_id``.
 
         :param sequence_id: the id sequence of the sequence to FASTAfy
         :return: as FASTA filename and body
 
         """
         sequence = await self._mongo.sequences.find_one(
-            sequence_id, ["sequence", "otu_id", "isolate_id"]
+            sequence_id,
+            ["sequence", "otu_id", "isolate_id"],
         )
 
         if not sequence:
             raise ResourceNotFoundError("Sequence does not exist")
 
         otu_name, isolate_name = await self.get_otu_and_isolate_names(
-            sequence["otu_id"], sequence["isolate_id"]
+            sequence["otu_id"],
+            sequence["isolate_id"],
         )
 
         fasta = virtool.downloads.utils.format_fasta_entry(
-            otu_name, isolate_name, sequence_id, sequence["sequence"]
+            otu_name,
+            isolate_name,
+            sequence_id,
+            sequence["sequence"],
         )
 
         return (
             virtool.downloads.utils.format_fasta_filename(
-                otu_name, isolate_name, sequence["_id"]
+                otu_name,
+                isolate_name,
+                sequence["_id"],
             ),
             fasta,
         )
 
     async def create(self, ref_id: str, data: CreateOTURequest, user_id: str) -> OTU:
-        """
-        Create an OTU and it's first history record.
+        """Create an OTU and it's first history record.
 
         :param ref_id: the ID of the parent reference
         :param data: an OTU creation request
@@ -220,8 +240,7 @@ class OTUData:
         return await self.get(document["_id"])
 
     async def update(self, otu_id: str, data: UpdateOTURequest, user_id: str) -> OTU:
-        """
-        Update an OTU.
+        """Update an OTU.
 
         Modifiable fields are `name`, `abbreviation`, and `schema`. Method creates a
         corresponding history record.
@@ -259,11 +278,17 @@ class OTUData:
             )
 
             await virtool.otus.db.update_sequence_segments(
-                self._mongo, old, document, session=session
+                self._mongo,
+                old,
+                document,
+                session=session,
             )
 
             new = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             await update_otu_verification(self._mongo, new, session=session)
@@ -275,7 +300,10 @@ class OTUData:
                 old,
                 new,
                 compose_edit_description(
-                    new["name"], new["abbreviation"], old["abbreviation"], new["schema"]
+                    new["name"],
+                    new["abbreviation"],
+                    old["abbreviation"],
+                    new["schema"],
                 ),
                 user_id,
                 session=session,
@@ -284,8 +312,7 @@ class OTUData:
         return await self.get(otu_id)
 
     async def remove(self, otu_id: str, user_id: str) -> Optional[DeleteResult]:
-        """
-        Remove an OTU.
+        """Remove an OTU.
 
         Create a history document to record the change.
 
@@ -369,14 +396,18 @@ class OTUData:
 
             # Get the complete, joined entry before the update.
             old = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             existing_ids = [isolate["id"] for isolate in isolates]
 
             if isolate_id is None:
                 isolate_id = virtool.utils.random_alphanumeric(
-                    length=3, excluded=existing_ids
+                    length=3,
+                    excluded=existing_ids,
                 )
 
             if isolate_id in existing_ids:
@@ -458,11 +489,16 @@ class OTUData:
 
             # Get the joined entry now that it has been updated.
             new = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             await virtool.otus.db.update_otu_verification(
-                self._mongo, new, session=session
+                self._mongo,
+                new,
+                session=session,
             )
 
             # Use the old and new entry to add a new history document for the change.
@@ -478,16 +514,20 @@ class OTUData:
             )
 
         complete = await virtool.otus.db.join_and_format(
-            self._mongo, otu_id, joined=new
+            self._mongo,
+            otu_id,
+            joined=new,
         )
 
         return find_isolate(complete["isolates"], isolate_id)
 
     async def set_isolate_as_default(
-        self, otu_id: str, isolate_id: str, user_id: str
+        self,
+        otu_id: str,
+        isolate_id: str,
+        user_id: str,
     ) -> Document:
-        """
-        Set a new default isolate.
+        """Set a new default isolate.
 
         :param otu_id: the ID of the parent OTU
         :param isolate_id: the ID of the isolate set as default
@@ -501,7 +541,10 @@ class OTUData:
             isolate = find_isolate(document["isolates"], isolate_id)
 
             old = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             # If the default isolate will be unchanged, immediately return the existing
@@ -528,7 +571,10 @@ class OTUData:
 
             # Get the joined entry now that it has been updated.
             new = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             await virtool.otus.db.update_otu_verification(self._mongo, new)
@@ -569,7 +615,10 @@ class OTUData:
                 new_default["default"] = True
 
             old = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             document = await self._mongo.otus.find_one_and_update(
@@ -582,15 +631,21 @@ class OTUData:
             )
 
             new = await virtool.otus.db.join(
-                self._mongo, otu_id, document, session=session
+                self._mongo,
+                otu_id,
+                document,
+                session=session,
             )
 
             await asyncio.gather(
                 virtool.otus.db.update_otu_verification(
-                    self._mongo, new, session=session
+                    self._mongo,
+                    new,
+                    session=session,
                 ),
                 self._mongo.sequences.delete_many(
-                    {"otu_id": otu_id, "isolate_id": isolate_id}, session=session
+                    {"otu_id": otu_id, "isolate_id": isolate_id},
+                    session=session,
                 ),
             )
 
@@ -642,24 +697,29 @@ class OTUData:
                 to_insert["_id"] = sequence_id
 
             sequence_document = await self._mongo.sequences.insert_one(
-                to_insert, session=session
+                to_insert,
+                session=session,
             )
 
             new = await virtool.otus.db.join(
                 self._mongo,
                 otu_id,
                 document=await increment_otu_version(
-                    self._mongo, otu_id, session=session
+                    self._mongo,
+                    otu_id,
+                    session=session,
                 ),
                 session=session,
             )
 
             await virtool.otus.db.update_otu_verification(
-                self._mongo, new, session=session
+                self._mongo,
+                new,
+                session=session,
             )
 
             isolate_name = format_isolate_name(
-                find_isolate(old["isolates"], isolate_id)
+                find_isolate(old["isolates"], isolate_id),
             )
 
             await virtool.history.db.add(
@@ -676,18 +736,23 @@ class OTUData:
         return base_processor(sequence_document)
 
     async def get_sequence(
-        self, otu_id: str, isolate_id: str, sequence_id: str
+        self,
+        otu_id: str,
+        isolate_id: str,
+        sequence_id: str,
     ) -> Sequence:
         if await self._mongo.otus.count_documents(
-            {"_id": otu_id, "isolates.id": isolate_id}, limit=1
+            {"_id": otu_id, "isolates.id": isolate_id},
+            limit=1,
         ) and (
             document := await self._mongo.sequences.find_one(
                 {"_id": sequence_id, "otu_id": otu_id, "isolate_id": isolate_id},
-                virtool.otus.db.SEQUENCE_PROJECTION,
+                SEQUENCE_PROJECTION,
             )
         ):
             document = await apply_transforms(
-                document, [AttachReferenceTransform(self._mongo)]
+                document,
+                [AttachReferenceTransform(self._mongo)],
             )
             return Sequence(**document)
 
@@ -716,7 +781,9 @@ class OTUData:
 
         async with self._mongo.create_session() as session:
             sequence_document = await self._mongo.sequences.find_one_and_update(
-                {"_id": sequence_id}, {"$set": update}, session=session
+                {"_id": sequence_id},
+                {"$set": update},
+                session=session,
             )
 
             await increment_otu_version(self._mongo, otu_id, session=session)
@@ -726,7 +793,7 @@ class OTUData:
             await update_otu_verification(self._mongo, new, session=session)
 
             isolate_name = format_isolate_name(
-                find_isolate(old["isolates"], isolate_id)
+                find_isolate(old["isolates"], isolate_id),
             )
 
             await virtool.history.db.add(
@@ -743,10 +810,13 @@ class OTUData:
         return base_processor(sequence_document)
 
     async def remove_sequence(
-        self, otu_id: str, isolate_id: str, sequence_id: str, user_id: str
+        self,
+        otu_id: str,
+        isolate_id: str,
+        sequence_id: str,
+        user_id: str,
     ):
-        """
-        Remove a sequence.
+        """Remove a sequence.
 
         :param otu_id: the ID of the parent OTU:
         :param isolate_id: the ID of the parent isolate
@@ -758,14 +828,17 @@ class OTUData:
 
         async with self._mongo.create_session() as session:
             await self._mongo.sequences.delete_one(
-                {"_id": sequence_id}, session=session
+                {"_id": sequence_id},
+                session=session,
             )
 
             new = await virtool.otus.db.join(
                 self._mongo,
                 otu_id,
                 document=await increment_otu_version(
-                    self._mongo, otu_id, session=session
+                    self._mongo,
+                    otu_id,
+                    session=session,
                 ),
                 session=session,
             )
@@ -773,7 +846,7 @@ class OTUData:
             await update_otu_verification(self._mongo, new, session=session)
 
             isolate_name = format_isolate_name(
-                find_isolate(old["isolates"], isolate_id)
+                find_isolate(old["isolates"], isolate_id),
             )
 
             await virtool.history.db.add(

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -108,7 +108,8 @@ class OTUData:
         otu_id: str,
         isolate_id: str,
     ) -> Tuple[str, str]:
-        """Get the OTU name and isolate name for a OTU-isolate combination specified by `otu_id` and `isolate_id`.
+        """Get the OTU name and isolate name for a OTU-isolate combination specified by
+        `otu_id` and `isolate_id`.
 
         :param otu_id: the OTU ID
         :param isolate_id: the isolate ID
@@ -131,8 +132,8 @@ class OTUData:
         return otu["name"], virtool.otus.utils.format_isolate_name(isolate)
 
     async def get_isolate_fasta(self, otu_id: str, isolate_id: str) -> Tuple[str, str]:
-        """Generate a FASTA filename and body for the sequences associated with the isolate identified by the passed
-        ``otu_id`` and ``isolate_id``.
+        """Generate a FASTA filename and body for the sequences associated with the
+        isolate identified by the passed ``otu_id`` and ``isolate_id``.
 
         :param otu_id: the id of the isolates' parent otu
         :param isolate_id: the id of the isolate to FASTA
@@ -167,7 +168,8 @@ class OTUData:
         ), "\n".join(fasta)
 
     async def get_sequence_fasta(self, sequence_id: str) -> Tuple[str, str]:
-        """Generate a FASTA filename and body for the sequence associated with the passed ``sequence_id``.
+        """Generate a FASTA filename and body for the sequence associated with the
+        passed ``sequence_id``.
 
         :param sequence_id: the id sequence of the sequence to FASTAfy
         :return: as FASTA filename and body

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,6 +1,6 @@
 """Work with OTUs in the database."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
@@ -9,17 +9,13 @@ import virtool.otus.utils
 from virtool.api.utils import compose_regex_query, paginate
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
+from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
 from virtool.utils import to_bool
 
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
-PROJECTION = ["_id", "abbreviation", "name", "reference", "verified", "version"]
-
-SEQUENCE_PROJECTION = [
+SEQUENCE_PROJECTION = (
     "_id",
     "accession",
     "definition",
@@ -29,7 +25,7 @@ SEQUENCE_PROJECTION = [
     "reference",
     "sequence",
     "segment",
-]
+)
 
 
 async def check_name_and_abbreviation(
@@ -94,7 +90,7 @@ async def find(
         req_query,
         base_query=base_query,
         sort="name",
-        projection=PROJECTION,
+        projection=["_id", "abbreviation", "name", "reference", "verified", "version"],
     )
 
     data["documents"] = await apply_transforms(

--- a/virtool/references/bulk_models.py
+++ b/virtool/references/bulk_models.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass, astuple, field
-from typing import Optional, List, Union, Callable, Any, Coroutine
+from dataclasses import astuple, dataclass, field
+from typing import Any, Callable, Coroutine, List, Optional, Union
 
-from pymongo import UpdateOne, DeleteMany, DeleteOne
+from pymongo import DeleteMany, DeleteOne, UpdateOne
 from virtool_core.models.enums import HistoryMethod
 
 from virtool.types import Document
@@ -46,7 +46,11 @@ class OTUChange:
 class OTUUpdate(OTUChange):
     def __init__(self, otu_change, sequences, old, otu_id):
         super().__init__(
-            otu_change, sequences, HistoryMethod.update, old, otu_id=otu_id
+            otu_change,
+            sequences,
+            HistoryMethod.update,
+            old,
+            otu_id=otu_id,
         )
 
 
@@ -58,7 +62,11 @@ class OTUInsert(OTUChange):
 class OTUDelete(OTUChange):
     def __init__(self, otu_change, sequences, old, reference_update, otu_id):
         super().__init__(
-            otu_change, sequences, HistoryMethod.remove, old, otu_id=otu_id
+            otu_change,
+            sequences,
+            HistoryMethod.remove,
+            old,
+            otu_id=otu_id,
         )
         self.is_reference_updated = False
         self.reference_update = reference_update

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -58,6 +58,7 @@ from virtool.references.db import (
     get_unbuilt_count,
     insert_change,
     insert_joined_otu,
+    processor,
 )
 from virtool.references.oas import (
     CreateReferenceGroupRequest,
@@ -125,9 +126,13 @@ class ReferencesData(DataLayerDomain):
             base_query=base_query,
         )
 
+        documents = [
+            await processor(self._mongo, document) for document in data["documents"]
+        ]
+
         documents, remote_slug_count = await asyncio.gather(
             apply_transforms(
-                data["documents"],
+                documents,
                 [
                     AttachUserTransform(self._mongo),
                     AttachImportedFromTransform(self._mongo, self._pg),

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -123,7 +123,6 @@ class ReferencesData(DataLayerDomain):
             query,
             sort="name",
             base_query=base_query,
-            projection=virtool.references.db.PROJECTION,
         )
 
         documents, remote_slug_count = await asyncio.gather(

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -52,6 +52,7 @@ from virtool.types import Document
 from virtool.uploads.models import SQLUpload
 from virtool.users.mongo import extend_user
 from virtool.users.transforms import AttachUserTransform
+from virtool.utils import base_processor
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -68,10 +69,9 @@ async def processor(mongo: "Mongo", document: Document) -> Document:
     :return: the processed document
 
     """
-    try:
-        ref_id = document.pop("_id")
-    except KeyError:
-        ref_id = document["id"]
+    document = base_processor(document)
+
+    ref_id = document["id"]
 
     latest_build, otu_count, unbuilt_count = await asyncio.gather(
         get_latest_build(mongo, ref_id),
@@ -386,7 +386,7 @@ async def get_latest_build(mongo: "Mongo", ref_id: str) -> Document | None:
 
     if latest_build:
         return await apply_transforms(
-            virtool.utils.base_processor(latest_build),
+            base_processor(latest_build),
             [AttachUserTransform(mongo)],
         )
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -57,29 +57,6 @@ if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
 
 
-PROJECTION = [
-    "_id",
-    "cloned_from",
-    "created_at",
-    "data_type",
-    "groups",
-    "imported_from",
-    "installed",
-    "internal_control",
-    "latest_build",
-    "name",
-    "organism",
-    "release",
-    "remotes_from",
-    "task",
-    "unbuilt_count",
-    "updates",
-    "updating",
-    "user",
-    "users",
-]
-
-
 async def processor(mongo: "Mongo", document: Document) -> Document:
     """Process a reference document to a form that can be dispatched or returned in a
     list.
@@ -186,7 +163,8 @@ async def check_right(req: Request, ref_id: str, right: str) -> bool:
         return True
 
     reference = await get_mongo_from_req(req).references.find_one(
-        ref_id, ["groups", "users"]
+        ref_id,
+        ["groups", "users"],
     )
 
     if reference is None:

--- a/virtool/references/oas.py
+++ b/virtool/references/oas.py
@@ -18,10 +18,7 @@ ALLOWED_DATA_TYPE = ["barcode", "genome"]
 
 
 def check_data_type(data_type: str) -> str:
-    """
-    Checks that the data type is valid.
-    """
-
+    """Checks that the data type is valid."""
     if data_type not in ALLOWED_DATA_TYPE:
         raise ValueError("data type not allowed")
 
@@ -30,37 +27,41 @@ def check_data_type(data_type: str) -> str:
 
 class CreateReferenceRequest(BaseModel):
     name: constr(strip_whitespace=True) = Field(
-        default="", description="the virus name"
+        default="",
+        description="the virus name",
     )
     description: constr(strip_whitespace=True) = Field(
-        default="", description="a longer description for the reference"
+        default="",
+        description="a longer description for the reference",
     )
     data_type: str = Field(default="genome", description="the sequence data type")
     organism: str = Field(default="", description="the organism")
     release_id: Optional[str] = Field(
-        default=11447367, description="the id of the GitHub release to install"
+        default=11447367,
+        description="the id of the GitHub release to install",
     )
     clone_from: Optional[str] = Field(
-        description="a valid ref_id that the new reference should be cloned from"
+        description="a valid ref_id that the new reference should be cloned from",
     )
     import_from: Optional[str] = Field(
-        description="a valid file_id that the new reference should be imported from"
+        description="a valid file_id that the new reference should be imported from",
     )
     remote_from: Optional[str] = Field(
-        description="a valid GitHub slug to download and update the new reference from"
+        description="a valid GitHub slug to download and update the new reference from",
     )
 
     _prevent_none = prevent_none(
-        "release_id", "clone_from", "import_from", "remote_from"
+        "release_id",
+        "clone_from",
+        "import_from",
+        "remote_from",
     )
 
     @root_validator
     def check_values(cls, values: Union[str, constr]):
-        """
-        Checks that only one of clone_from, import_from or
+        """Checks that only one of clone_from, import_from or
         remote_from are inputted, if any.
         """
-
         clone_from, import_from, remote_from = (
             values.get("clone_from"),
             values.get("import_from"),
@@ -70,17 +71,17 @@ class CreateReferenceRequest(BaseModel):
         if clone_from:
             if import_from or remote_from:
                 raise ValueError(
-                    "Only one of clone_from, import_from and remote_from are allowed"
+                    "Only one of clone_from, import_from and remote_from are allowed",
                 )
         elif import_from:
             if clone_from or remote_from:
                 raise ValueError(
-                    "Only one of clone_from, import_from and remote_from are allowed"
+                    "Only one of clone_from, import_from and remote_from are allowed",
                 )
         elif remote_from:
             if clone_from or import_from:
                 raise ValueError(
-                    "Only one of clone_from, import_from and remote_from are allowed"
+                    "Only one of clone_from, import_from and remote_from are allowed",
                 )
 
             if remote_from not in ALLOWED_REMOTE:
@@ -96,7 +97,7 @@ class CreateReferenceRequest(BaseModel):
                 "name": "Plant Viruses",
                 "organism": "viruses",
                 "data_type": "genome",
-            }
+            },
         }
 
 
@@ -142,7 +143,7 @@ class CreateReferenceResponse(Reference):
                         "modify": False,
                         "modify_otu": False,
                         "remove": False,
-                    }
+                    },
                 ],
                 "id": "d19exr83",
                 "internal_control": None,
@@ -176,7 +177,7 @@ class CreateReferenceResponse(Reference):
                         "remove": True,
                     },
                 ],
-            }
+            },
         }
 
 
@@ -197,7 +198,7 @@ class FindReferencesResponse(ReferenceSearchResult):
                                 "modify": False,
                                 "modify_otu": False,
                                 "remove": False,
-                            }
+                            },
                         ],
                         "id": "d19exr83",
                         "internal_control": None,
@@ -235,7 +236,7 @@ class FindReferencesResponse(ReferenceSearchResult):
                 "page_count": 1,
                 "per_page": 25,
                 "total_count": 2,
-            }
+            },
         }
 
 
@@ -254,7 +255,7 @@ class ReferenceResponse(Reference):
                         "modify": False,
                         "modify_otu": False,
                         "remove": False,
-                    }
+                    },
                 ],
                 "id": "d19exr83",
                 "internal_control": None,
@@ -304,7 +305,7 @@ class ReferenceReleaseResponse(ReferenceRelease):
                 "content_type": "application/gzip",
                 "retrieved_at": "2018-06-14T19:52:17.465000Z",
                 "newer": True,
-            }
+            },
         }
 
 
@@ -319,25 +320,25 @@ class ReferenceTargetRequest(BaseModel):
 
 class UpdateReferenceRequest(BaseModel):
     name: constr(strip_whitespace=True, min_length=1) | None = Field(
-        description="the virus name"
+        description="the virus name",
     )
     description: constr(strip_whitespace=True) | None = Field(
-        description="a longer description for the reference"
+        description="a longer description for the reference",
     )
     internal_control: str | None = Field(
-        description="set the OTU identified by the passed id as the internal control for the reference"
+        description="set the OTU identified by the passed id as the internal control for the reference",
     )
     organism: Optional[constr(strip_whitespace=True)] = Field(
-        description="the organism"
+        description="the organism",
     )
     restrict_source_types: Optional[bool] = Field(
-        description="option to restrict source types"
+        description="option to restrict source types",
     )
     source_types: Optional[List[constr(strip_whitespace=True, min_length=1)]] = Field(
-        description="source types"
+        description="source types",
     )
     targets: Optional[List[ReferenceTargetRequest]] = Field(
-        description="list of target sequences"
+        description="list of target sequences",
     )
 
     _prevent_none = prevent_none(
@@ -356,14 +357,12 @@ class UpdateReferenceRequest(BaseModel):
                 "name": "Regulated Pests",
                 "organism": "phytoplasma",
                 "internal_control": "ah4m5jqz",
-            }
+            },
         }
 
     @validator("targets", check_fields=False)
     def check_targets_name(cls, targets):
-        """
-        Sets `name` to the provided `id` if it is `None`.
-        """
+        """Sets `name` to the provided `id` if it is `None`."""
         names = [t.name for t in targets]
 
         if len(names) != len(set(names)):
@@ -374,13 +373,13 @@ class UpdateReferenceRequest(BaseModel):
 
 class ReferenceRightsRequest(BaseModel):
     build: bool | None = Field(
-        description="allow members to build new indexes for the reference"
+        description="allow members to build new indexes for the reference",
     )
     modify: bool | None = Field(
-        description="allow members to modify the reference metadata and settings"
+        description="allow members to modify the reference metadata and settings",
     )
     modify_otu: bool | None = Field(
-        description="allow members to modify the reference’s member OTUs"
+        description="allow members to modify the reference’s member OTUs",
     )
     remove: bool | None = Field(description="allow members to remove the reference")
 
@@ -408,8 +407,8 @@ class CreateReferenceGroupResponse(ReferenceGroup):
                     "modify": False,
                     "modify_otu": True,
                     "remove": False,
-                }
-            ]
+                },
+            ],
         }
 
 
@@ -424,8 +423,8 @@ class ReferenceGroupsResponse(ReferenceGroup):
                     "modify": False,
                     "modify_otu": False,
                     "remove": False,
-                }
-            ]
+                },
+            ],
         }
 
 
@@ -439,7 +438,7 @@ class ReferenceGroupResponse(ReferenceGroup):
                 "modify": False,
                 "modify_otu": False,
                 "remove": False,
-            }
+            },
         }
 
 
@@ -460,7 +459,7 @@ class ReferenceUsersResponse(ReferenceUser):
                 "modify": False,
                 "modify_otu": True,
                 "remove": False,
-            }
+            },
         }
 
 
@@ -479,8 +478,8 @@ class GetReferenceUpdateResponse(ReferenceInstalled):
                     "created_at": "2018-06-14T18:37:54.242000Z",
                     "user": {"id": "igboyes"},
                     "ready": True,
-                }
-            ]
+                },
+            ],
         }
 
 
@@ -518,7 +517,7 @@ class CreateReferenceIndexesResponse(IndexMinimal):
                 "reference": {"id": "foo"},
                 "user": {"administrator": False, "handle": "bob", "id": "test"},
                 "version": 9,
-            }
+            },
         }
 
 
@@ -544,12 +543,12 @@ class ReferenceHistoryResponse(HistorySearchResult):
                             "handle": "igboyes",
                             "id": "igboyes",
                         },
-                    }
+                    },
                 ],
                 "total_count": 1419,
                 "found_count": 1419,
                 "page_count": 710,
                 "per_page": 1,
                 "page": 1,
-            }
+            },
         }

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -304,11 +304,10 @@ def get_sequence_schema(require_id: bool) -> dict:
 
 
 def load_reference_file(path: Path) -> dict:
-    """Load a list of merged otus documents from a file associated with a Virtool reference
-    file.
+    """Load a list of merged otus documents from a file associated with a Virtool
+    reference file.
 
     :param path: the path to the otus.json.gz file
-
     :return: the otus data to import
     """
     if not path.suffixes == [".json", ".gz"]:

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from operator import itemgetter
 from pathlib import Path
-from typing import List, Set, Optional, Dict
+from typing import Dict, List, Optional, Set
 
 from cerberus import Validator
 from pydantic import BaseModel
@@ -11,11 +11,7 @@ from virtool_core.models.reference import ReferenceDataType
 
 import virtool.otus.utils
 
-ISOLATE_KEYS = ["id", "source_type", "source_name", "default"]
-
 RIGHTS = ["build", "modify", "modify_otu", "remove"]
-
-SEQUENCE_KEYS = ["accession", "definition", "host", "sequence"]
 
 
 class ReferenceSourceData(BaseModel):
@@ -26,7 +22,9 @@ class ReferenceSourceData(BaseModel):
 
 
 def check_import_data(
-    data: Dict, strict: bool = True, verify: bool = True
+    data: Dict,
+    strict: bool = True,
+    verify: bool = True,
 ) -> List[dict]:
     errors = detect_duplicates(data["otus"])
 
@@ -73,7 +71,8 @@ def check_will_change(old: dict, imported: dict) -> bool:
 
     # Will change if the schema has changed.
     if json.dumps(old["schema"], sort_keys=True) != json.dumps(
-        imported["schema"], sort_keys=True
+        imported["schema"],
+        sort_keys=True,
     ):
         return True
 
@@ -83,7 +82,7 @@ def check_will_change(old: dict, imported: dict) -> bool:
     # Check isolate by isolate. Order is ignored.
     for new_isolate, old_isolate in zip(new_isolates, old_isolates):
         # Will change if a value property of the isolate has changed.
-        for key in ISOLATE_KEYS:
+        for key in ("id", "source_type", "source_name", "default"):
             if new_isolate[key] != old_isolate[key]:
                 return True
 
@@ -96,11 +95,12 @@ def check_will_change(old: dict, imported: dict) -> bool:
         # Check sequence-by-sequence. Order is ignored.
         new_sequences = sorted(new_isolate["sequences"], key=itemgetter("_id"))
         old_sequences = sorted(
-            old_isolate["sequences"], key=lambda d: d["remote"]["id"]
+            old_isolate["sequences"],
+            key=lambda d: d["remote"]["id"],
         )
 
         for new_sequence, old_sequence in zip(new_sequences, old_sequences):
-            for key in SEQUENCE_KEYS:
+            for key in ("accession", "definition", "host", "sequence"):
                 if new_sequence[key] != old_sequence[key]:
                     return True
 
@@ -141,13 +141,15 @@ def detect_duplicate_isolate_ids(joined: dict, duplicate_isolate_ids: dict):
 
 
 def detect_duplicate_sequence_ids(
-    joined: dict, duplicate_sequence_ids: Set[str], seen_sequence_ids: Set[str]
+    joined: dict,
+    duplicate_sequence_ids: Set[str],
+    seen_sequence_ids: Set[str],
 ):
     sequence_ids = virtool.otus.utils.extract_sequence_ids(joined)
 
     # Add sequence ids that are duplicated within an OTU to the duplicate set.
     duplicate_sequence_ids.update(
-        {i for i in sequence_ids if sequence_ids.count(i) > 1}
+        {i for i in sequence_ids if sequence_ids.count(i) > 1},
     )
 
     sequence_ids = set(sequence_ids)
@@ -182,7 +184,9 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
 
     for joined in otus:
         detect_duplicate_abbreviation(
-            joined, duplicate_abbreviations, seen_abbreviations
+            joined,
+            duplicate_abbreviations,
+            seen_abbreviations,
         )
 
         detect_duplicate_name(joined, duplicate_names, seen_names)
@@ -197,7 +201,9 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
             detect_duplicate_isolate_ids(joined, duplicate_isolate_ids)
 
             detect_duplicate_sequence_ids(
-                joined, duplicate_sequence_ids, seen_sequence_ids
+                joined,
+                duplicate_sequence_ids,
+                seen_sequence_ids,
             )
 
     errors = []
@@ -208,7 +214,7 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
                 "id": "duplicate_abbreviations",
                 "message": "Duplicate OTU abbreviations found",
                 "duplicates": list(duplicate_abbreviations),
-            }
+            },
         )
 
     if duplicate_ids:
@@ -217,7 +223,7 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
                 "id": "duplicate_ids",
                 "message": "Duplicate OTU ids found",
                 "duplicates": list(duplicate_ids),
-            }
+            },
         )
 
     if duplicate_isolate_ids:
@@ -226,7 +232,7 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
                 "id": "duplicate_isolate_ids",
                 "message": "Duplicate isolate ids found in some OTUs",
                 "duplicates": duplicate_isolate_ids,
-            }
+            },
         )
 
     if duplicate_names:
@@ -235,7 +241,7 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
                 "id": "duplicate_names",
                 "message": "Duplicate OTU names found",
                 "duplicates": list(duplicate_names),
-            }
+            },
         )
 
     if duplicate_sequence_ids:
@@ -244,7 +250,7 @@ def detect_duplicates(otus: List[dict], strict: bool = True) -> List[dict]:
                 "id": "duplicate_sequence_ids",
                 "message": "Duplicate sequence ids found",
                 "duplicates": duplicate_sequence_ids,
-            }
+            },
         )
 
     return errors
@@ -298,8 +304,7 @@ def get_sequence_schema(require_id: bool) -> dict:
 
 
 def load_reference_file(path: Path) -> dict:
-    """
-    Load a list of merged otus documents from a file associated with a Virtool reference
+    """Load a list of merged otus documents from a file associated with a Virtool reference
     file.
 
     :param path: the path to the otus.json.gz file

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -49,7 +49,7 @@ from virtool.groups.pg import SQLGroup
 from virtool.mongo.utils import get_mongo_from_req, get_one_field
 from virtool.pg.utils import delete_row, get_rows
 from virtool.samples.db import (
-    RIGHTS_PROJECTION,
+    SAMPLE_RIGHTS_PROJECTION,
     check_rights,
     get_sample_owner,
     recalculate_workflow_tags,
@@ -359,7 +359,7 @@ class RightsView(PydanticView):
         document = await mongo.samples.find_one_and_update(
             {"_id": sample_id},
             {"$set": data},
-            projection=RIGHTS_PROJECTION,
+            projection=SAMPLE_RIGHTS_PROJECTION,
         )
 
         return json_response(document)

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -1,4 +1,5 @@
 """The sample data layer domain."""
+
 import asyncio
 import math
 from asyncio import gather, to_thread
@@ -12,15 +13,15 @@ from virtool_core.models.roles import AdministratorRole
 from virtool_core.models.samples import Sample, SampleSearchResult
 
 import virtool.utils
+from virtool.api.client import UserClient
 from virtool.api.utils import compose_regex_query
 from virtool.config.cls import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
-from virtool.data.events import emits, Operation
+from virtool.data.events import Operation, emits
 from virtool.data.topg import compose_legacy_id_expression
 from virtool.data.transforms import apply_transforms
 from virtool.groups.pg import SQLGroup
-from virtool.api.client import UserClient
 from virtool.jobs.client import JobsClient
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.labels.transforms import AttachLabelsTransform
@@ -32,7 +33,6 @@ from virtool.samples.checks import (
     check_subtractions_do_not_exist,
 )
 from virtool.samples.db import (
-    LIST_PROJECTION,
     AttachArtifactsAndReadsTransform,
     NameGenerator,
     compose_sample_workflow_query,
@@ -58,7 +58,11 @@ class SamplesData(DataLayerDomain):
     name = "samples"
 
     def __init__(
-        self, config: Config, mongo: Mongo, pg: AsyncEngine, jobs_client: JobsClient
+        self,
+        config: Config,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        jobs_client: JobsClient,
     ):
         self._config = config
         self._mongo = mongo
@@ -74,9 +78,7 @@ class SamplesData(DataLayerDomain):
         workflows: list[str],
         client,
     ) -> SampleSearchResult:
-        """
-        Find and filter samples.
-        """
+        """Find and filter samples."""
         queries = []
 
         if term:
@@ -104,8 +106,8 @@ class SamplesData(DataLayerDomain):
             async with AsyncSession(self._pg) as session:
                 result = await session.execute(
                     select(SQLGroup).where(
-                        compose_legacy_id_expression(SQLGroup, client.groups)
-                    )
+                        compose_legacy_id_expression(SQLGroup, client.groups),
+                    ),
                 )
 
                 group_ids = []
@@ -145,20 +147,39 @@ class SamplesData(DataLayerDomain):
                             {"$skip": skip_count},
                             {"$limit": per_page},
                         ],
-                    }
+                    },
                 },
                 {
                     "$project": {
-                        "data": {item: True for item in LIST_PROJECTION},
+                        "data": {
+                            item: True
+                            for item in (
+                                "_id",
+                                "created_at",
+                                "host",
+                                "isolate",
+                                "job",
+                                "library_type",
+                                "pathoscope",
+                                "name",
+                                "nuvs",
+                                "ready",
+                                "user",
+                                "notes",
+                                "labels",
+                                "subtractions",
+                                "workflows",
+                            )
+                        },
                         "total_count": {
-                            "$arrayElemAt": ["$total_count.total_count", 0]
+                            "$arrayElemAt": ["$total_count.total_count", 0],
                         },
                         "found_count": {
-                            "$arrayElemAt": ["$found_count.found_count", 0]
+                            "$arrayElemAt": ["$found_count.found_count", 0],
                         },
-                    }
+                    },
                 },
-            ]
+            ],
         ):
             data = paginate_dict["data"]
             found_count = paginate_dict.get("found_count", 0)
@@ -174,7 +195,7 @@ class SamplesData(DataLayerDomain):
         )
 
         return SampleSearchResult(
-            **{"documents": documents},
+            documents=documents,
             found_count=found_count,
             total_count=total_count,
             page=page,
@@ -183,8 +204,7 @@ class SamplesData(DataLayerDomain):
         )
 
     async def get(self, sample_id: str) -> Sample:
-        """
-        Get a sample by its id.
+        """Get a sample by its id.
 
         TODO: Remove the ``caches`` field from document as it is deprecated.
         TODO: Return `None` for unset group instead of `"none"`.
@@ -219,9 +239,7 @@ class SamplesData(DataLayerDomain):
         space_id: int,
         _id: str | None = None,
     ) -> Sample:
-        """
-        Create a sample.
-        """
+        """Create a sample."""
         settings = await self.data.settings.get_all()
 
         await wait_for_checks(
@@ -262,7 +280,7 @@ class SamplesData(DataLayerDomain):
             if isinstance(group, str):
                 async with AsyncSession(self._pg) as session:
                     group = await session.execute(
-                        select(SQLGroup).where(SQLGroup.legacy_id == group)
+                        select(SQLGroup).where(SQLGroup.legacy_id == group),
                     )
 
                     group = group.scalar_one().id
@@ -334,8 +352,7 @@ class SamplesData(DataLayerDomain):
 
     @emits(Operation.DELETE)
     async def delete(self, sample_id: str) -> Sample:
-        """
-        Deletes the sample identified by ``sample_id`` and all its analyses.
+        """Deletes the sample identified by ``sample_id`` and all its analyses.
 
         :param sample_id: the id of the sample to delete
         :return: the mongodb deletion result
@@ -347,7 +364,8 @@ class SamplesData(DataLayerDomain):
             result, _ = await asyncio.gather(
                 self._mongo.samples.delete_many({"_id": sample_id}, session=session),
                 self._mongo.analyses.delete_many(
-                    {"sample.id": sample_id}, session=session
+                    {"sample.id": sample_id},
+                    session=session,
                 ),
             )
 
@@ -368,20 +386,19 @@ class SamplesData(DataLayerDomain):
         sample_id: str,
         quality: dict[str, Any],
     ) -> Sample:
-        """
-        Finalize a sample by setting a ``quality`` field and ``ready`` to ``True``
+        """Finalize a sample by setting a ``quality`` field and ``ready`` to ``True``
 
         :param sample_id: the id of the sample
         :param quality: a dict containing quality data
         :return: the sample after finalizing
 
         """
-
         if await get_one_field(self._mongo.samples, "ready", sample_id):
             raise ResourceConflictError("Sample already finalized")
 
         result: UpdateResult = await self._mongo.samples.update_one(
-            {"_id": sample_id}, {"$set": {"quality": quality, "ready": True}}
+            {"_id": sample_id},
+            {"$set": {"quality": quality, "ready": True}},
         )
 
         if not result.modified_count:
@@ -393,7 +410,7 @@ class SamplesData(DataLayerDomain):
                     await session.execute(
                         select(SQLUpload)
                         .where(SQLSampleReads.sample == sample_id)
-                        .join_from(SQLSampleReads, SQLUpload)
+                        .join_from(SQLSampleReads, SQLUpload),
                     )
                 )
                 .unique()
@@ -421,8 +438,7 @@ class SamplesData(DataLayerDomain):
 
     @emits(Operation.UPDATE)
     async def update(self, sample_id: str, data: UpdateSampleRequest) -> Sample:
-        """
-        Update the sample identified by ``sample_id``.
+        """Update the sample identified by ``sample_id``.
 
         :param sample_id: the id of the sample to update
         :param data: the update data
@@ -435,7 +451,7 @@ class SamplesData(DataLayerDomain):
 
         if "name" in data:
             aws.append(
-                check_name_is_in_use(self._mongo, data["name"], sample_id=sample_id)
+                check_name_is_in_use(self._mongo, data["name"], sample_id=sample_id),
             )
 
         if "labels" in data:
@@ -443,7 +459,7 @@ class SamplesData(DataLayerDomain):
 
         if "subtractions" in data:
             aws.append(
-                check_subtractions_do_not_exist(self._mongo, data["subtractions"])
+                check_subtractions_do_not_exist(self._mongo, data["subtractions"]),
             )
 
         await wait_for_checks(*aws)
@@ -453,10 +469,14 @@ class SamplesData(DataLayerDomain):
         return await self.get(sample_id)
 
     async def has_right(
-        self, sample_id: str, client: UserClient, right: SampleRight
+        self,
+        sample_id: str,
+        client: UserClient,
+        right: SampleRight,
     ) -> bool:
         document = await self._mongo.samples.find_one(
-            {"_id": sample_id}, ["all_read", "all_write", "group", "group_read", "user"]
+            {"_id": sample_id},
+            ["all_read", "all_write", "group", "group_read", "user"],
         )
 
         if document is None:
@@ -481,33 +501,31 @@ class SamplesData(DataLayerDomain):
         raise ValueError(f"Invalid sample right: {right}")
 
     async def has_resources_for_analysis_job(self, ref_id, subtractions):
-        """
-        Checks that resources for analysis job exist.
+        """Checks that resources for analysis job exist.
         :param ref_id: the reference id
         :param subtractions: list of subtractions
         """
-
         if not await self._mongo.references.count_documents({"_id": ref_id}):
             raise ResourceConflictError("Reference does not exist")
 
         if not await self._mongo.indexes.count_documents(
-            {"reference.id": ref_id, "ready": True}
+            {"reference.id": ref_id, "ready": True},
         ):
             raise ResourceConflictError("No ready index")
 
         if subtractions is not None:
             non_existent_subtractions = await virtool.mongo.utils.check_missing_ids(
-                self._mongo.subtraction, subtractions
+                self._mongo.subtraction,
+                subtractions,
             )
 
             if non_existent_subtractions:
                 raise ResourceConflictError(
-                    f"Subtractions do not exist: {','.join(non_existent_subtractions)}"
+                    f"Subtractions do not exist: {','.join(non_existent_subtractions)}",
                 )
 
     async def compress_samples(self, progress_handler: AbstractProgressHandler):
-        """
-        Compress all uncompressed legacy samples.
+        """Compress all uncompressed legacy samples.
 
         :param progress_handler: a progress handler object
         """
@@ -524,7 +542,9 @@ class SamplesData(DataLayerDomain):
                 break
 
             await virtool.samples.db.compress_sample_reads(
-                self._mongo, self._config, sample
+                self._mongo,
+                self._config,
+                sample,
             )
 
             await tracker.add(1)
@@ -546,13 +566,14 @@ class SamplesData(DataLayerDomain):
                 break
 
             await virtool.samples.db.move_sample_files_to_pg(
-                self._mongo, self._pg, sample
+                self._mongo,
+                self._pg,
+                sample,
             )
             await tracker.add(1)
 
     async def deduplicate_sample_names(self):
-        """
-        Find all samples with duplicate names in the same space and rename
+        """Find all samples with duplicate names in the same space and rename
         them with increasing integers by order of creation.
         """
         async with self._mongo.create_session() as session:
@@ -563,9 +584,9 @@ class SamplesData(DataLayerDomain):
                             "_id": {"name": "$name", "space_id": "$space_id"},
                             "count": {"$sum": 1},
                             "documents": {
-                                "$push": {"_id": "$_id", "created_at": "$created_at"}
+                                "$push": {"_id": "$_id", "created_at": "$created_at"},
                             },
-                        }
+                        },
                     },
                     {"$match": {"count": {"$gt": 1}}},
                     {"$unwind": "$documents"},
@@ -574,7 +595,7 @@ class SamplesData(DataLayerDomain):
                         "$group": {
                             "_id": "$_id",
                             "sample_ids": {"$push": "$documents._id"},
-                        }
+                        },
                     },
                     {
                         "$project": {
@@ -582,7 +603,7 @@ class SamplesData(DataLayerDomain):
                             "space_id": "$_id.space_id",
                             "_id": 0,
                             "sample_ids": 1,
-                        }
+                        },
                     },
                 ],
                 session=session,
@@ -608,5 +629,5 @@ class SamplesData(DataLayerDomain):
                 *[
                     recalculate_workflow_tags(self._mongo, sample_id)
                     for sample_id in chunk
-                ]
+                ],
             )

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -186,7 +186,7 @@ class SamplesData(DataLayerDomain):
             total_count = paginate_dict.get("total_count", 0)
 
         documents = await apply_transforms(
-            [base_processor(document) for document in data],
+            [base_processor(d) for d in data],
             [
                 AttachLabelsTransform(self._pg),
                 AttachUserTransform(self._mongo),

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -2,34 +2,18 @@
 
 import asyncio
 import glob
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from virtool.config.cls import Config
 from virtool.data.transforms import AbstractTransform
+from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.subtractions.utils import get_subtraction_files, join_subtraction_path
 from virtool.types import Document
 from virtool.utils import base_processor
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
-PROJECTION = [
-    "_id",
-    "count",
-    "created_at",
-    "file",
-    "ready",
-    "job",
-    "name",
-    "nickname",
-    "user",
-]
-
-ADD_SUBTRACTION_FILES_QUERY = {"deleted": False}
 
 
 def subtraction_processor(document: Document) -> Document:

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -10,13 +10,9 @@ from virtool.pg.utils import get_row_by_id
 from virtool.types import Document
 from virtool.uploads.models import SQLUpload
 
-PROJECTION = ["_id", "name", "size", "user", "uploaded_at", "type", "ready", "reserved"]
-
 
 class AttachUploadTransform(AbstractTransform):
-    """
-    Attaches an upload to a document that has an upload field.
-    """
+    """Attaches an upload to a document that has an upload field."""
 
     def __init__(self, pg: AsyncEngine):
         self._pg = pg
@@ -35,13 +31,11 @@ class AttachUploadTransform(AbstractTransform):
     async def prepare_many(self, documents: List[Document]) -> Dict[int, Dict]:
         async with AsyncSession(self._pg) as session:
             result = await session.execute(
-                (
-                    select(SQLUpload).where(
-                        SQLUpload.id.in_(
-                            list({document["upload"] for document in documents})
-                        )
-                    )
-                )
+                select(SQLUpload).where(
+                    SQLUpload.id.in_(
+                        list({document["upload"] for document in documents}),
+                    ),
+                ),
             )
 
             uploads = {upload.id: dict(upload) for upload in result.scalars()}
@@ -52,8 +46,7 @@ class AttachUploadTransform(AbstractTransform):
 
 
 async def finalize(pg, size: int, id_: int, model: Type[Base]) -> Optional[dict]:
-    """
-    Finalize row creation for tables that store uploaded files.
+    """Finalize row creation for tables that store uploaded files.
 
     Updates table with file information and sets `ready`    to `True`.
 

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -35,6 +35,7 @@ from virtool.users.oas import (
     UpdateUserRequest,
 )
 from virtool.users.transforms import AttachPermissionsTransform
+from virtool.utils import base_processor
 
 routes = Routes()
 
@@ -77,7 +78,7 @@ class UsersView(PydanticView):
         )
 
         data["documents"] = await apply_transforms(
-            data["documents"],
+            [base_processor(d) for d in data["documents"]],
             [AttachPermissionsTransform(pg)],
         )
 

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -5,7 +5,6 @@ from virtool_core.models.roles import AdministratorRole, SpaceRoleType
 from virtool_core.models.user import User
 
 import virtool.api.authentication
-import virtool.users.db
 from virtool.api.custom_json import json_response
 from virtool.api.errors import APIBadRequest, APIConflict, APINotFound
 from virtool.api.policy import (

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -66,7 +66,14 @@ class UsersView(PydanticView):
             mongo_query,
             self.request.query,
             sort="handle",
-            projection=virtool.users.db.PROJECTION,
+            projection=(
+                "_id",
+                "force_reset",
+                "handle",
+                "groups",
+                "last_password_change",
+                "primary_group",
+            ),
         )
 
         data["documents"] = await apply_transforms(

--- a/virtool/users/db.py
+++ b/virtool/users/db.py
@@ -14,15 +14,6 @@ from virtool.groups.pg import SQLGroup
 
 ATTACH_PROJECTION = ("_id", "handle")
 
-PROJECTION = (
-    "_id",
-    "force_reset",
-    "handle",
-    "groups",
-    "last_password_change",
-    "primary_group",
-)
-
 
 @dataclass
 class B2CUserAttributes:


### PR DESCRIPTION
## Changes
* Remove unused functionality from `Mongo` and `Collection`.
* Remove unused projections and their use in `virtool.mongo.core`.
* Remove unused mongo utilities.
* Call processors where they're used instead of in `paginate`.
* Change response of ...
  * Return `target` and `remote` fields for OTU sequences.
  * **Don't return `reference` for OTU sequences (breaking)**.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [ ] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
