### PR TITLE
fix: determine image version at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: "true"
+          fetch-depth: 0
       - name: Build
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
       - name: Build
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: 23.4.1
           fetch-depth: 0
       - name: Build
         uses: docker/build-push-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: 23.4.1
           fetch-depth: 0
       - name: Build
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: "true"
+          fetch-depth: 0
       - name: Login to Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
       - name: Login to Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Version
-        run: echo ${{ github.event.release.tag_name }} > VERSION
       - name: Login to Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: github.event.release.tag_name
       - name: Login to Registry
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN poetry install --without dev --no-root && rm -rf "$POETRY_CACHE_DIR"
 
 FROM python:3.12-bookworm as version
 COPY .git .
-RUN git describe --tags --abbrev=0 #This line is for testing ONLY remove before merge
-RUN git describe --tags --abbrev=0 > VERSION
+RUN git describe --tags #This line is for testing ONLY remove before merge
+RUN git describe --tags  > VERSION
 
 FROM python:3.12-bookworm as runtime
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,18 @@ WORKDIR /app
 COPY poetry.lock pyproject.toml ./
 RUN poetry install --without dev --no-root && rm -rf "$POETRY_CACHE_DIR"
 
+FROM python:3.12-bookworm as version
+COPY .git .
+RUN git describe --tags --abbrev=0 > VERSION
+
 FROM python:3.12-bookworm as runtime
 WORKDIR /app
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 COPY --from=ghcr.io/virtool/workflow-tools:2.0.1 /usr/local/bin/bowtie* /usr/local/bin/
 COPY --from=build /app/.venv /app/.venv
-COPY alembic.ini run.py VERSION* ./
+COPY alembic.ini run.py ./
+COPY --from=version /VERSION .
 COPY assets ./assets
 COPY virtool ./virtool
 COPY assets/bowtie2-inspect /user/local/bin/bowtie2-inspect

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN poetry install --without dev --no-root && rm -rf "$POETRY_CACHE_DIR"
 
 FROM python:3.12-bookworm as version
 COPY .git .
+RUN git describe --tags --abbrev=0 #This line is for testing ONLY remove before merge
 RUN git describe --tags --abbrev=0 > VERSION
 
 FROM python:3.12-bookworm as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,17 @@ RUN poetry install --without dev --no-root && rm -rf "$POETRY_CACHE_DIR"
 
 FROM python:3.12-bookworm as version
 COPY .git .
-RUN git describe --tags #This line is for testing ONLY remove before merge
-RUN git describe --tags  > VERSION
+RUN <<EOF
+git describe --tags | awk -F - '
+  {
+    version = $1
+    if (length($3) > 0) {
+      version = version "-pre+g" $3
+    }
+    print version
+  }' > VERSION
+EOF
+
 
 FROM python:3.12-bookworm as runtime
 WORKDIR /app

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,5 @@
-import concurrent.futures
-import subprocess
-
 import pytest
+
 import virtool.version
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,14 +1,11 @@
 import pytest
-
-import virtool.version
+from virtool.version import determine_server_version
 
 
 @pytest.mark.parametrize("source", [None,  "file"])
 async def test_find_server_version(source, tmp_path):
     if source == "file":
         tmp_path.joinpath("VERSION").write_text("1.0.12")
-
-        assert await virtool.version.determine_server_version(tmp_path) == "1.0.12"
-
+        assert await determine_server_version(tmp_path) == "1.0.12"
     else:
-        assert await virtool.version.determine_server_version(tmp_path) == "Unknown"
+        assert await determine_server_version(tmp_path) == "Unknown"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,23 +5,9 @@ import pytest
 import virtool.version
 
 
-@pytest.mark.parametrize("source", [None, "git", "file"])
-async def test_find_server_version(source, loop, mocker, tmp_path):
-    if source == "git":
-        mocker.patch(
-            "subprocess.check_output", return_value=bytes("1.0.13", encoding="utf-8")
-        )
-    else:
-        mocker.patch(
-            "subprocess.check_output",
-            side_effect=subprocess.CalledProcessError(1, "none"),
-        )
-
-    loop.set_default_executor(concurrent.futures.ThreadPoolExecutor())
-
-    if source == "git":
-        assert await virtool.version.determine_server_version(tmp_path) == "1.0.13"
-    elif source == "file":
+@pytest.mark.parametrize("source", [None,  "file"])
+async def test_find_server_version(source, tmp_path):
+    if source == "file":
         tmp_path.joinpath("VERSION").write_text("1.0.12")
 
         assert await virtool.version.determine_server_version(tmp_path) == "1.0.12"

--- a/virtool/version.py
+++ b/virtool/version.py
@@ -10,37 +10,12 @@ logger = get_logger("app")
 
 
 async def determine_server_version(install_path: Optional[Path] = Path.cwd()):
-    version = await asyncio.get_event_loop().run_in_executor(
-        None, determine_server_version_from_git
-    )
-
-    if version:
-        return version
-
     try:
         async with aiofiles.open(install_path / "VERSION", "r") as version_file:
             return (await version_file.read()).rstrip()
     except FileNotFoundError:
         logger.warning("Could not determine software version.")
         return "Unknown"
-
-
-def determine_server_version_from_git():
-    try:
-        command = ["git", "describe", "--tags"]
-
-        output = subprocess.check_output(command, stderr=subprocess.STDOUT)
-
-        output = output.decode().rstrip()
-
-        if not output or "Not a git repository" in output:
-            return None
-
-        return output
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
-
-    return None
 
 
 def get_version_from_app(app) -> str:

--- a/virtool/version.py
+++ b/virtool/version.py
@@ -9,10 +9,10 @@ logger = get_logger("app")
 
 async def determine_server_version(install_path: Optional[Path] = Path.cwd()):
     """
-        Get from the server version from the installation directory
+    Get from the server version from the installation directory
 
-        :param install_path: the absolute path to the root virtool directory
-        :return: the application version
+    :param install_path: the absolute path to the root virtool directory
+    :return: the application version
     """
     try:
         async with aiofiles.open(install_path / "VERSION", "r") as version_file:

--- a/virtool/version.py
+++ b/virtool/version.py
@@ -10,6 +10,12 @@ logger = get_logger("app")
 
 
 async def determine_server_version(install_path: Optional[Path] = Path.cwd()):
+    """
+        Get from the server version from the installation directory
+
+        :param install_path: the absolute path to the root virtool directory
+        :return: the application version
+    """
     try:
         async with aiofiles.open(install_path / "VERSION", "r") as version_file:
             return (await version_file.read()).rstrip()

--- a/virtool/version.py
+++ b/virtool/version.py
@@ -1,5 +1,3 @@
-import asyncio
-import subprocess
 from pathlib import Path
 from typing import Optional
 


### PR DESCRIPTION
## Changes
<!--- Describe your changes in a bulleted list --->
- remove real time version determination from git
- Image version now determined during docker image build.
- remove CI for setting the version during publishing

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

 New version breaks compatibility with dev.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

Compatibility with the current version of `dev` is broken due to needing to access `.git` at build time. 
Production images will work as expected with no breaking changes.

PR fix: https://github.com/virtool/dev/pull/29

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
