### PR TITLE
fix: use github event tag_name instead of string literal during checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: github.event.release.tag_name
+          ref: ${{ github.event.release.tag_name }}
       - name: Login to Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Changes
<!--- Describe your changes in a bulleted list --->
 - Fixes a mistake in the publish step where the string literal `github.event.release.tag_name` was getting used instead of the corresponding runner variable. 

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [ ] All changes are tested. - No virtool code was touched, changes to publish step 
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
