### PR TITLE
test: align `spawn_job_client` api with `spawn_client`

### DIFF
--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -13,7 +13,9 @@ from virtool.users.utils import Permission, hash_password
 
 
 async def test_get(
-    snapshot: SnapshotAssertion, spawn_client: ClientSpawner, static_time
+    snapshot: SnapshotAssertion,
+    spawn_client: ClientSpawner,
+    static_time,
 ):
     client = await spawn_client(authenticated=True)
 
@@ -500,7 +502,13 @@ async def test_is_valid_email(value, spawn_client, resp_is):
         "remember_is_none",
     ],
 )
-async def test_login(mongo: Mongo, spawn_client: ClientSpawner, body, status, snapshot):
+async def test_login(
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    body,
+    status,
+    snapshot,
+):
     client = await spawn_client()
 
     await mongo.users.insert_one(

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,6 +1,6 @@
 from aiohttp import BasicAuth
 
-from tests.fixtures.client import ClientSpawner
+from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.data.utils import get_data_from_app
 from virtool.mongo.core import Mongo
 from virtool.settings.oas import UpdateSettingsRequest
@@ -8,31 +8,28 @@ from virtool.utils import hash_key
 
 
 class TestJobAuthentication:
-    async def test_root_succeeds(self, spawn_job_client):
-        """
-        Check that a request against the job accessible root URL (GET /) succeeds.
-
-        """
-        client = await spawn_job_client(authorize=True)
+    async def test_root_succeeds(self, spawn_job_client: JobClientSpawner):
+        """Check that a request against the job accessible root URL (GET /) succeeds."""
+        client = await spawn_job_client(authenticated=True)
 
         resp = await client.get("/")
 
         assert resp.status == 200
 
-    async def test_unauthenticated_root_fails(self, spawn_job_client):
-        """
-        Check that a request against the root API URL
-
-        """
-        client = await spawn_job_client(authorize=False)
+    async def test_unauthenticated_root_fails(self, spawn_job_client: JobClientSpawner):
+        """Check that a request against the root API URL"""
+        client = await spawn_job_client(authenticated=False)
 
         resp = await client.get("/")
 
         assert resp.status == 401
 
-    async def test_protected_fails(self, mongo: Mongo, spawn_client: ClientSpawner):
-        """
-        Check that a request against GET /samples using job authentication fails.
+    async def test_protected_fails(
+        self,
+        mongo: Mongo,
+        spawn_client: ClientSpawner,
+    ):
+        """Check that a request against GET /samples using job authentication fails.
 
         This path is not accessible to jobs.
 
@@ -42,7 +39,7 @@ class TestJobAuthentication:
         client = await spawn_client(auth=BasicAuth("job-foo", key))
 
         await get_data_from_app(client.app).settings.update(
-            UpdateSettingsRequest(minimum_password_length=8)
+            UpdateSettingsRequest(minimum_password_length=8),
         )
 
         await mongo.jobs.insert_one({"_id": "foo", "key": hash_key(key)})

--- a/tests/api/test_policy.py
+++ b/tests/api/test_policy.py
@@ -1,5 +1,4 @@
-"""
-Tests for Virtool's route policies.
+"""Tests for Virtool's route policies.
 
 These are essential to security and are exhaustively tested and don't use snapshots.
 Do not use snapshots for these test.
@@ -16,19 +15,19 @@ from virtool_core.models.enums import Permission
 from virtool_core.models.roles import AdministratorRole
 
 from tests.fixtures.client import ClientSpawner
-from virtool.authorization.permissions import LegacyPermission
-from virtool.errors import PolicyError
 from virtool.api.policy import (
-    policy,
-    PublicRoutePolicy,
-    DefaultRoutePolicy,
     AdministratorRoutePolicy,
+    DefaultRoutePolicy,
     PermissionRoutePolicy,
+    PublicRoutePolicy,
+    policy,
 )
 from virtool.api.routes import Routes
+from virtool.authorization.permissions import LegacyPermission
+from virtool.errors import PolicyError
 
 
-@pytest.fixture
+@pytest.fixture()
 def privilege_routes():
     def func(route_policy):
         routes = Routes()
@@ -150,10 +149,7 @@ async def test_public(
     privilege_routes,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test that all clients can access public endpoints.
-
-    """
+    """Test that all clients can access public endpoints."""
     client = await spawn_client(
         addon_route_table=privilege_routes(PublicRoutePolicy),
         administrator=administrator,
@@ -178,10 +174,7 @@ async def test_default(
     privilege_routes,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test that a request to a non-public endpoint fails with a 401 status code.
-
-    """
+    """Test that a request to a non-public endpoint fails with a 401 status code."""
     client = await spawn_client(
         addon_route_table=privilege_routes(DefaultRoutePolicy),
         administrator=administrator,
@@ -215,10 +208,7 @@ async def test_no_policy(
     privilege_routes,
     spawn_client: ClientSpawner,
 ):
-    """
-    Test that routes fallback on the default if they have no policy explicitly defined.
-
-    """
+    """Test that routes fallback on the default if they have no policy explicitly defined."""
     client = await spawn_client(
         addon_route_table=privilege_routes(PublicRoutePolicy),
         administrator=administrator,
@@ -252,13 +242,10 @@ async def test_administrator(
     spawn_client: ClientSpawner,
     privilege_routes,
 ):
-    """
-    Test that only authenticated, administrator clients can access admin endpoints.
-
-    """
+    """Test that only authenticated, administrator clients can access admin endpoints."""
     client = await spawn_client(
         addon_route_table=privilege_routes(
-            AdministratorRoutePolicy(AdministratorRole.BASE)
+            AdministratorRoutePolicy(AdministratorRole.BASE),
         ),
         administrator=administrator,
         authenticated=authenticated,
@@ -304,7 +291,7 @@ async def test_permissions(
 ):
     client = await spawn_client(
         addon_route_table=privilege_routes(
-            PermissionRoutePolicy(LegacyPermission.CREATE_SAMPLE)
+            PermissionRoutePolicy(LegacyPermission.CREATE_SAMPLE),
         ),
         administrator=administrator,
         authenticated=authenticated,
@@ -345,8 +332,7 @@ async def test_permissions(
 
 
 async def test_more_than_one_function():
-    """
-    Test that attempting to load more than one policy on a function-based route leads to
+    """Test that attempting to load more than one policy on a function-based route leads to
     a ``PolicyError``.
 
     """
@@ -363,8 +349,7 @@ async def test_more_than_one_function():
 
 
 async def test_more_than_one_view(spawn_client):
-    """
-    Test that attempting to load more than one policy on a view-based route leads to
+    """Test that attempting to load more than one policy on a view-based route leads to
     a ``PolicyError``.
 
     """

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -9,7 +9,11 @@ from virtool.mongo.core import Mongo
 @pytest.mark.parametrize("dev", [True, False])
 @pytest.mark.parametrize("first_user", [True, False])
 async def test_get(
-    dev, first_user, mongo: Mongo, spawn_client: ClientSpawner, snapshot
+    dev,
+    first_user,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    snapshot,
 ):
     client = await spawn_client(authenticated=False)
     get_config_from_app(client.app).dev = dev

--- a/tests/dev/test_api.py
+++ b/tests/dev/test_api.py
@@ -1,14 +1,10 @@
-import pytest
+from tests.fixtures.client import ClientSpawner
 
 
-
-@pytest.mark.parametrize("dev", [True, False])
-async def test_dev_mode(dev, spawn_client):
-    """
-    Ensure that developer endpoint is not available when not in developer mode.
-    """
-    client = await spawn_client(authenticated=True, config_overrides={"dev": dev})
+async def test_dev_mode(spawn_client: ClientSpawner):
+    """Ensure that developer endpoint is not available when not in developer mode."""
+    client = await spawn_client(authenticated=True)
 
     resp = await client.post("/dev", {"command": "foo"})
 
-    assert resp.status == 204 if dev else 404
+    assert resp.status == 404

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -135,12 +135,35 @@ class VirtoolTestClient:
         return await self._test_client.delete(url)
 
 
+class JobClientSpawner(Protocol):
+    """A protocol the describes a function that can spawn a test job client.
+
+    The fixture :func:`spawn_job_client` returns a function that conforms to this
+    protocol.
+    """
+
+    async def __call__(
+        self,
+        add_route_table: RouteTableDef | None = None,
+        auth: BasicAuth | None = None,
+        authenticated: bool = False,
+        base_url: str = "",
+        dev: bool = False,
+    ) -> VirtoolTestClient:
+        """Spawn a test job client.
+
+        :param add_route_table: a route table that will be added to the app
+        :param authenticated: whether the client should be authenticated
+        :param dev: whether the client should be in development mode
+        :return: the test client
+        """
+        ...
+
+
 class ClientSpawner(Protocol):
-    """A protocol the describes a function that can spawn a test client.
+    """A protocol the describes a function that can spawn a user test client.
 
-    The fixtures :func:`spawn_client` and :func:`spawn_job_client` both return functions
-    that conform to this protocol.
-
+    The fixture :func:`spawn_client` returns a function that conforms to this protocol.
     """
 
     async def __call__(
@@ -150,7 +173,7 @@ class ClientSpawner(Protocol):
         auth: BasicAuth | None = None,
         authenticated: bool = False,
         base_url: str = "",
-        config_overrides: dict[str, Any] | None = None,
+        dev: bool = False,
         flags: list[FlagName] | None = None,
         permissions: list[Permission] | None = None,
     ) -> VirtoolTestClient:
@@ -166,7 +189,6 @@ class ClientSpawner(Protocol):
         :param permissions: a list of permissions to give the user
         :return: the test client
         """
-        ...
 
 
 @pytest.fixture()
@@ -183,15 +205,15 @@ def spawn_client(
     pg: AsyncEngine,
     redis: Redis,
     redis_connection_string: str,
-):
+) -> ClientSpawner:
     """A factory for spawning test clients
 
     The function conforms to the :class:`ClientSpawner` protocol, which describes which
     configuration arguments can be passed to the function.
 
-    When clients are created, a testing server instance is also created. All methods called
-    on the client (eg. ``await client.get("/samples")``) are directed to the server
-    instance.
+    When clients are created, a testing server instance is also created. All methods
+    called on the client (eg. ``await client.get("/samples")``) are directed to the
+    server instance.
 
     Basic Usage
     -----------
@@ -294,7 +316,7 @@ def spawn_client(
         auth: BasicAuth | None = None,
         authenticated: bool = False,
         base_url: str = "",
-        config_overrides: dict[str, Any] | None = None,
+        dev: bool = False,
         flags: list[FlagName] | None = None,
         permissions: list[Permission] | None = None,
     ):
@@ -303,7 +325,7 @@ def spawn_client(
         :param auth: a basic authentication object to use
         :param authenticated: whether the client should be authenticated
         :param base_url:
-        :param config_overrides:
+        :param dev:
         :param flags:
         :param permissions:
         :return:
@@ -315,7 +337,7 @@ def spawn_client(
             b2c_tenant="",
             b2c_user_flow="",
             data_path=Path("data"),
-            dev=False,
+            dev=dev,
             flags=[],
             host="localhost",
             mongodb_connection_string=f"{mongo_connection_string}/{mongo_name}?authSource=admin",
@@ -330,10 +352,6 @@ def spawn_client(
             sentry_dsn="",
             use_b2c=False,
         )
-
-        if config_overrides:
-            for key, value in config_overrides.items():
-                setattr(config, key, value)
 
         mocker.patch("virtool.startup.connect_pg", return_value=pg)
 
@@ -423,16 +441,19 @@ def spawn_job_client(
     pg_connection_string: str,
     redis_connection_string: str,
     mocker,
-):
-    """A factory method for creating an aiohttp client which can authenticate with the API as a Job."""
+) -> JobClientSpawner:
+    """A factory method for creating an aiohttp client which can authenticate with the
+    API as a Job.
+    """
 
     async def _spawn_job_client(
-        authorize: bool = False,
-        dev: bool = False,
         add_route_table: RouteTableDef = None,
+        authenticated: bool = False,
+        base_url: str = "",
+        dev: bool = False,
     ):
         # Create a test job to use for authentication.
-        if authorize:
+        if authenticated:
             job_id, key = "test_job", "test_key"
             await mongo.jobs.insert_one({"_id": job_id, "key": hash_key(key)})
 
@@ -445,7 +466,7 @@ def spawn_job_client(
 
         app = await virtool.jobs.main.create_app(
             ServerConfig(
-                base_url="",
+                base_url=base_url,
                 b2c_client_id="",
                 b2c_client_secret="",
                 b2c_tenant="",

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -1,11 +1,12 @@
 import json
 import shutil
+from pathlib import Path
 
 import aiofiles
 import pytest
 from virtool_core.utils import decompress_file
 
-from tests.fixtures.client import ClientSpawner
+from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.config import get_config_from_app
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
@@ -125,8 +126,8 @@ async def test_get(
     assert await resp.json() == snapshot(name="json")
 
 
-async def test_get_hmm_annotations(spawn_job_client, tmp_path):
-    client = await spawn_job_client(authorize=True)
+async def test_get_hmm_annotations(spawn_job_client: JobClientSpawner, tmp_path: Path):
+    client = await spawn_job_client(authenticated=True)
     get_config_from_app(client.app).data_path = tmp_path
     db = get_mongo_from_app(client.app)
 
@@ -153,14 +154,14 @@ async def test_get_hmm_annotations(spawn_job_client, tmp_path):
 @pytest.mark.parametrize("data_exists", [True, False])
 @pytest.mark.parametrize("file_exists", [True, False])
 async def test_get_hmm_profiles(
-    data_exists,
-    file_exists,
-    example_path,
-    spawn_job_client,
+    data_exists: bool,
+    file_exists: bool,
+    example_path: Path,
+    spawn_job_client: JobClientSpawner,
     tmp_path,
 ):
     """Test that HMM profiles can be properly downloaded once they are available."""
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     get_config_from_app(client.app).data_path = tmp_path
     hmms_path = tmp_path / "hmm"

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -6,7 +6,7 @@ from syrupy.matchers import path_type
 from virtool_core.models.enums import Permission
 from virtool_core.models.job import JobState
 
-from tests.fixtures.client import ClientSpawner
+from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
 
@@ -188,9 +188,14 @@ async def test_get(error, fake2: DataFaker, snapshot, spawn_client):
 
 
 class TestAcquire:
-    async def test_ok(self, fake2: DataFaker, snapshot, spawn_job_client):
+    async def test_ok(
+        self,
+        fake2: DataFaker,
+        snapshot,
+        spawn_job_client: JobClientSpawner,
+    ):
         """Test that a job can be acquired."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         job = await fake2.jobs.create(
             await fake2.users.create(),
@@ -206,7 +211,7 @@ class TestAcquire:
 
     async def test_already_acquired(self, fake2: DataFaker, spawn_job_client):
         """Test that a 400 is returned when the job is already acquired."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         user = await fake2.users.create()
         job = await fake2.jobs.create(user, state=JobState.WAITING)
@@ -224,7 +229,7 @@ class TestAcquire:
 
     async def test_not_found(self, spawn_job_client):
         """Test that a 404 is returned when the job doesn't exist."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         resp = await client.patch("/jobs/foo", json={"acquired": True})
 
@@ -236,7 +241,12 @@ class TestAcquire:
 
 
 class TestArchive:
-    async def test_ok(self, fake2: DataFaker, snapshot, spawn_client: ClientSpawner):
+    async def test_ok(
+        self,
+        fake2: DataFaker,
+        snapshot,
+        spawn_client: ClientSpawner,
+    ):
         """Test that a job can be archived."""
         client = await spawn_client(authenticated=True)
 
@@ -282,7 +292,7 @@ class TestArchive:
 class TestPing:
     async def test_ok(self, fake2: DataFaker, spawn_job_client):
         """Test that a job can be pinged."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         job = await fake2.jobs.create(
             await fake2.users.create(),
@@ -301,7 +311,7 @@ class TestPing:
 
     async def test_not_found(self, spawn_job_client):
         """Test that a 404 is returned when the job doesn't exist."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         resp = await client.put("/jobs/foo/ping", data={})
 

--- a/tests/jobs/test_auth.py
+++ b/tests/jobs/test_auth.py
@@ -16,7 +16,7 @@ def non_public_test_route(request: aiohttp.web.Request):
 
 
 async def test_public_routes_are_public(mongo: Mongo, spawn_job_client):
-    client = await spawn_job_client(authorize=False, add_route_table=test_routes)
+    client = await spawn_job_client(authenticated=False, add_route_table=test_routes)
 
     job_id = "test_job"
     insert_result = await mongo.jobs.insert_one({"_id": job_id})
@@ -29,7 +29,7 @@ async def test_public_routes_are_public(mongo: Mongo, spawn_job_client):
 
 
 async def test_unauthorized_when_header_missing(spawn_job_client):
-    client = await spawn_job_client(authorize=False, add_route_table=test_routes)
+    client = await spawn_job_client(authenticated=False, add_route_table=test_routes)
 
     response = await client.get("/not_public")
 
@@ -37,7 +37,7 @@ async def test_unauthorized_when_header_missing(spawn_job_client):
 
 
 async def test_unauthorized_when_header_invalid(spawn_job_client):
-    client = await spawn_job_client(authorize=False, add_route_table=test_routes)
+    client = await spawn_job_client(authenticated=False, add_route_table=test_routes)
 
     response = await client.get(
         "/not_public",
@@ -50,7 +50,7 @@ async def test_unauthorized_when_header_invalid(spawn_job_client):
 
 
 async def test_authorized_when_header_is_valid(spawn_job_client):
-    client = await spawn_job_client(authorize=True, add_route_table=test_routes)
+    client = await spawn_job_client(authenticated=True, add_route_table=test_routes)
 
     response = await client.get("/not_public")
 

--- a/tests/messages/test_api.py
+++ b/tests/messages/test_api.py
@@ -20,22 +20,21 @@ async def insert_test_message(fake2, pg, static_time):
                     created_at=static_time.datetime,
                     updated_at=static_time.datetime,
                     user=user.id,
-                )
+                ),
             )
             await session.commit()
 
     return insert
 
 
-
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
-    error: str | None, insert_test_message, snapshot, spawn_client: ClientSpawner
+    error: str | None,
+    insert_test_message,
+    snapshot,
+    spawn_client: ClientSpawner,
 ):
-    """
-    Test that a ``GET /instance_message`` return the active instance message.
-
-    """
+    """Test that a ``GET /instance_message`` return the active instance message."""
     client = await spawn_client(authenticated=True)
 
     if not error:
@@ -50,17 +49,16 @@ async def test_get(
         assert await resp.json() is None
 
 
-
 async def test_create(snapshot, spawn_client: ClientSpawner, static_time):
-    """
-    Test that a newly active instance message can be added
+    """Test that a newly active instance message can be added
     to the database at ``PUT /instance_message``.
 
     """
     client = await spawn_client(administrator=True, authenticated=True)
 
     resp = await client.put(
-        "/instance_message", {"color": "red", "message": "This is a new message"}
+        "/instance_message",
+        {"color": "red", "message": "This is a new message"},
     )
 
     assert resp.status == 200
@@ -68,10 +66,12 @@ async def test_create(snapshot, spawn_client: ClientSpawner, static_time):
     assert await resp.json() == snapshot
 
 
-
 class TestUpdate:
     async def test_active(
-        self, insert_test_message, snapshot, spawn_client: ClientSpawner
+        self,
+        insert_test_message,
+        snapshot,
+        spawn_client: ClientSpawner,
     ):
         client = await spawn_client(administrator=True, authenticated=True)
 
@@ -96,7 +96,10 @@ class TestUpdate:
         assert resp.status == 404
 
     async def test_inactive(
-        self, insert_test_message, resp_is, spawn_client: ClientSpawner
+        self,
+        insert_test_message,
+        resp_is,
+        spawn_client: ClientSpawner,
     ):
         client = await spawn_client(administrator=True, authenticated=True)
 
@@ -110,7 +113,10 @@ class TestUpdate:
         await resp_is.conflict(resp, "No active message set")
 
     async def test_deactivate(
-        self, insert_test_message, snapshot, spawn_client: ClientSpawner
+        self,
+        insert_test_message,
+        snapshot,
+        spawn_client: ClientSpawner,
     ):
         client = await spawn_client(administrator=True, authenticated=True)
 

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -849,7 +849,8 @@ async def test_finalize(
     get_sample_ready_false,
 ):
     """Test that sample can be finalized using the Jobs API."""
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
+
     json = {
         field: {
             "bases": [[1543]],
@@ -861,6 +862,7 @@ async def test_finalize(
             "sequences": [7091],
         },
     }
+
     resp = await client.patch("/samples/test", json=json)
 
     if field == "quality":
@@ -908,7 +910,7 @@ class TestDelete:
         spawn_job_client,
     ):
         """Test that job client can delete a sample only when it is unfinalized."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         (config.data_path / "samples/test").mkdir(parents=True)
 
@@ -929,7 +931,7 @@ class TestDelete:
         assert resp.status == 404
 
     async def test_not_found_from_job(self, spawn_job_client):
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
         resp = await client.delete("/samples/test")
         assert resp.status == 404
 
@@ -1132,7 +1134,7 @@ async def test_upload_artifact(
     """Test that new artifacts can be uploaded after sample creation using the Jobs API."""
     path = test_files_path / "nuvs" / "reads_1.fq"
 
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     get_config_from_app(client.app).data_path = tmp_path
     sample_file_path = tmp_path / "samples" / "test"
@@ -1183,7 +1185,7 @@ class TestUploadReads:
         """Test that paired sample reads can be uploaded using the Jobs API and that
         conflicts are properly handled.
         """
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
         get_config_from_app(client.app).data_path = tmp_path
 
         await client.db.samples.insert_one(
@@ -1231,7 +1233,7 @@ class TestUploadReads:
         tmp_path: Path,
     ):
         """Test that uncompressed sample reads are rejected."""
-        client = await spawn_job_client(authorize=True)
+        client = await spawn_job_client(authenticated=True)
 
         await client.db.samples.insert_one(
             {
@@ -1265,7 +1267,7 @@ async def test_download_reads(
     pg,
 ):
     client = await spawn_client(authenticated=True)
-    job_client = await spawn_job_client(authorize=True)
+    job_client = await spawn_job_client(authenticated=True)
 
     get_config_from_app(client.app).data_path = tmp_path
     get_config_from_app(job_client.app).data_path = tmp_path
@@ -1318,7 +1320,7 @@ async def test_download_reads(
 
 @pytest.mark.parametrize("error", [None, "404_sample", "404_artifact", "404_file"])
 async def test_download_artifact(error, tmp_path, mongo: Mongo, spawn_job_client, pg):
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     get_config_from_app(client.app).data_path = tmp_path
 

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -25,7 +25,11 @@ async def test_create_fake_sample(
     user = await fake2.users.create()
 
     await create_fake_sample(
-        client.app, "sample_1", user.id, finalized=finalized, paired=paired
+        client.app,
+        "sample_1",
+        user.id,
+        finalized=finalized,
+        paired=paired,
     )
 
     sample = await data_layer.samples.get("sample_1")
@@ -43,5 +47,5 @@ async def test_copy_reads_file(app):
     await copy_reads_file(app, file_path, "reads_1.fq.gz", "sample_1")
 
     assert os.listdir(get_config_from_app(app).data_path / "samples" / "sample_1") == [
-        "reads_1.fq.gz"
+        "reads_1.fq.gz",
     ]

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from virtool_core.models.enums import Permission
 
-from tests.fixtures.client import ClientSpawner
+from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.config import get_config_from_app
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
@@ -118,7 +118,7 @@ async def test_get(
 
 
 async def test_get_from_job(fake, spawn_job_client, snapshot):
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     subtraction = await fake.subtractions.insert()
 
@@ -242,7 +242,7 @@ async def test_upload(
     snapshot,
     tmp_path: Path,
 ):
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
     test_dir = tmp_path / "files"
     test_dir.mkdir()
     test_dir.joinpath("subtraction.1.bt2").write_text("Bowtie2 file")
@@ -295,7 +295,7 @@ async def test_finalize(
     static_time,
     test_subtraction_files,
 ):
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     user = await fake2.users.create()
     job = await fake2.jobs.create(user)
@@ -354,11 +354,11 @@ async def test_job_remove(
     resp_is,
     snapshot,
     mongo: Mongo,
-    spawn_job_client: ClientSpawner,
+    spawn_job_client: JobClientSpawner,
     static_time,
     tmp_path: Path,
 ):
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     get_config_from_app(client.app).data_path = tmp_path
 
@@ -409,7 +409,7 @@ async def test_download_subtraction_files(
     spawn_job_client,
     tmp_path,
 ):
-    client = await spawn_job_client(authorize=True)
+    client = await spawn_job_client(authenticated=True)
 
     get_config_from_app(client.app).data_path = tmp_path
 


### PR DESCRIPTION
## Changes
* Change `spawn_job_client` to take `authenticated` instead of `authorize`.
* Add a dedicate protocol for `spawn_job_client`. It did not comply with `ClientSpawner`.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
