### PR TITLE
fix: send websocket message when an analysis is created

### DIFF
--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -215,6 +215,7 @@ class AnalysisData(DataLayerDomain):
             **{**analysis, "job": analysis["job"] if analysis["job"] else None},
         )
 
+    @emits(Operation.CREATE, "analyses")
     async def create(
         self,
         data: CreateAnalysisRequest,

--- a/virtool/data/events.py
+++ b/virtool/data/events.py
@@ -99,14 +99,26 @@ def emit(data: BaseModel, domain: str, name: str, operation: Operation):
 
 
 def emits(operation: Operation, domain: str | None = None, name: str | None = None):
-    """Emits the return value of decorated method as an event."""
+    """Emits the return value of the decorated method as an event.
+
+    By default, ``domain`` is the name of the ``DataLayerDomain`` object the decorated
+    method is bound to. It can be overridden by passing a value to the decorator.
+
+    By default, ``name`` is the name of the decorated method. It can be overridden by
+    passing a value to the decorator.
+
+    :param operation: The operation that was performed on the resource.
+    :param domain: The domain of the resource.
+    :param name: The name of the event.
+
+    """
 
     def decorator(func: Callable[..., Awaitable[BaseModel]]):
         emitted_name = name or func.__name__
 
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
-            # This is the DataLayerPiece instance the method is bound to.
+            # This is the DataLayerDomain object the method is bound to.
             obj = args[0]
 
             return_value = await func(*args, **kwargs)


### PR DESCRIPTION
## Changes
* Send a websocket message when analyses are created.
* Wrap the `create` method with `emits`.
* Add docs for `emits`.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
