### PR TITLE
fix(migration): ensure samples document has notes and labels fields

### DIFF
--- a/assets/revisions/__snapshots__/rev_wo0wk22ngsgn_ensure_notes_and_labels_fields_in_sample_documents.ambr
+++ b/assets/revisions/__snapshots__/rev_wo0wk22ngsgn_ensure_notes_and_labels_fields_in_sample_documents.ambr
@@ -1,0 +1,67 @@
+# serializer version: 1
+# name: test_upgrade[after]
+  list([
+    dict({
+      '_id': 'sample_1',
+      'labels': list([
+        1,
+        2,
+      ]),
+      'name': 'has_both',
+      'notes': 'existing notes',
+    }),
+    dict({
+      '_id': 'sample_2',
+      'labels': list([
+        3,
+        4,
+      ]),
+      'name': 'has_labels',
+      'notes': '',
+    }),
+    dict({
+      '_id': 'sample_3',
+      'labels': list([
+      ]),
+      'name': 'has_notes',
+      'notes': 'only has notes',
+    }),
+    dict({
+      '_id': 'sample_4',
+      'labels': list([
+      ]),
+      'name': 'has_neither',
+      'notes': '',
+    }),
+  ])
+# ---
+# name: test_upgrade[before]
+  list([
+    dict({
+      '_id': 'sample_1',
+      'labels': list([
+        1,
+        2,
+      ]),
+      'name': 'has_both',
+      'notes': 'existing notes',
+    }),
+    dict({
+      '_id': 'sample_2',
+      'labels': list([
+        3,
+        4,
+      ]),
+      'name': 'has_labels',
+    }),
+    dict({
+      '_id': 'sample_3',
+      'name': 'has_notes',
+      'notes': 'only has notes',
+    }),
+    dict({
+      '_id': 'sample_4',
+      'name': 'has_neither',
+    }),
+  ])
+# ---

--- a/assets/revisions/rev_wo0wk22ngsgn_ensure_notes_and_labels_fields_in_sample_documents.py
+++ b/assets/revisions/rev_wo0wk22ngsgn_ensure_notes_and_labels_fields_in_sample_documents.py
@@ -1,0 +1,67 @@
+"""
+ensure notes and labels fields in sample documents
+
+Revision ID: wo0wk22ngsgn
+Date: 2024-06-05 15:54:12.149912
+
+"""
+
+import arrow
+from virtool.migration import MigrationContext
+
+# Revision identifiers.
+name = "ensure notes and labels fields in sample documents"
+created_at = arrow.get("2024-06-05 15:54:12.149912")
+revision_id = "wo0wk22ngsgn"
+
+alembic_down_revision = None
+virtool_down_revision = "uejy8b1tlmvv"
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext):
+    await ctx.mongo.samples.update_many(
+        {"notes": {"$exists": False}},
+        {
+            "$set": {
+                "notes": "",
+            }
+        },
+    )
+
+    await ctx.mongo.samples.update_many(
+        {"labels": {"$exists": False}},
+        {
+            "$set": {
+                "labels": [],
+            }
+        },
+    )
+
+
+async def test_upgrade(ctx, snapshot):
+    await ctx.mongo.samples.insert_many(
+        [
+            {
+                "_id": "sample_1",
+                "labels": [1, 2],
+                "name": "has_both",
+                "notes": "existing notes",
+            },
+            {"_id": "sample_2", "labels": [3, 4], "name": "has_labels"},
+            {"_id": "sample_3", "name": "has_notes", "notes": "only has notes"},
+            {"_id": "sample_4", "name": "has_neither"},
+        ]
+    )
+
+    assert [sample async for sample in ctx.mongo.samples.find({})] == snapshot(
+        name="before"
+    )
+
+    await upgrade(ctx)
+
+    assert [sample async for sample in ctx.mongo.samples.find({})] == snapshot(
+        name="after"
+    )

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -253,5 +253,12 @@
       'name': 'rename process to task',
       'revision': 'uejy8b1tlmvv',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 37,
+      'name': 'ensure notes and labels fields in sample documents',
+      'revision': 'wo0wk22ngsgn',
+    }),
   ])
 # ---


### PR DESCRIPTION
## Changes
<!--- Describe your changes in a bulleted list --->
 - Sets default values for all samples documents where `notes` and `labels` fields do not exist
## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
