### PR TITLE
refactor: rename fake2 fixture to fake

### DIFF
--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -128,7 +128,7 @@ async def test_update_settings(data, status, spawn_client, resp_is, snapshot):
 
 
 async def test_get_api_keys(
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
     snapshot,
@@ -136,7 +136,7 @@ async def test_get_api_keys(
 ):
     client = await spawn_client(authenticated=True)
 
-    group = await fake2.groups.create()
+    group = await fake.groups.create()
 
     await mongo.keys.insert_many(
         [
@@ -177,7 +177,7 @@ class TestCreateAPIKey:
         has_perm,
         req_perm,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mocker,
         snapshot,
         spawn_client: ClientSpawner,
@@ -189,7 +189,7 @@ class TestCreateAPIKey:
             return_value=("raw_key", "hashed_key"),
         )
 
-        group = await fake2.groups.create(
+        group = await fake.groups.create(
             PermissionsUpdate(**{Permission.create_sample: True}),
         )
 
@@ -248,7 +248,7 @@ class TestUpdateAPIKey:
         has_admin: bool,
         has_perm: bool,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         spawn_client: ClientSpawner,
@@ -256,7 +256,7 @@ class TestUpdateAPIKey:
     ):
         client = await spawn_client(authenticated=True)
 
-        group = await fake2.groups.create(
+        group = await fake.groups.create(
             permissions=PermissionsUpdate(
                 create_sample=True,
                 modify_subtraction=(has_perm if has_perm != "missing" else False),
@@ -344,13 +344,13 @@ async def test_remove_api_key(
 
 
 async def test_remove_all_api_keys(
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await mongo.keys.insert_many(
         [
@@ -536,7 +536,7 @@ async def test_login(
 async def test_login_reset(
     spawn_client,
     snapshot,
-    fake2,
+        fake: DataFaker,
     request_path,
     correct_code,
     data_layer: DataLayer,

--- a/tests/account/test_data.py
+++ b/tests/account/test_data.py
@@ -25,7 +25,7 @@ from virtool.users.pg import SQLUser
 async def test_create_api_key(
     has_permission: bool,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
@@ -38,8 +38,8 @@ async def test_create_api_key(
     mocker.patch("virtool.account.mongo.get_alternate_id", make_mocked_coro("foo_0"))
     mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
 
-    group_1 = await fake2.groups.create()
-    group_2 = await fake2.groups.create(
+    group_1 = await fake.groups.create()
+    group_2 = await fake.groups.create(
         PermissionsUpdate(
             **{
                 Permission.create_sample: True,
@@ -48,7 +48,7 @@ async def test_create_api_key(
         ),
     )
 
-    user = await fake2.users.create(groups=[group_1, group_2])
+    user = await fake.users.create(groups=[group_1, group_2])
 
     _, api_key = await data_layer.account.create_key(
         CreateKeysRequest(
@@ -63,9 +63,9 @@ async def test_create_api_key(
 
 
 class TestGetKey:
-    async def test_ok(self, data_layer: DataLayer, fake2: DataFaker):
+    async def test_ok(self, data_layer: DataLayer, fake: DataFaker):
         """Test that a created key can later be retrieved by its id."""
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         _, api_key = await data_layer.account.create_key(
             CreateKeysRequest(
@@ -80,9 +80,9 @@ class TestGetKey:
 
         assert await data_layer.account.get_key(user.id, api_key.id) == api_key
 
-    async def test_not_found(self, data_layer: DataLayer, fake2: DataFaker):
+    async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
         """Test that ``ResourceNotFoundError`` is raised when a key id is not found."""
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         _, api_key = await data_layer.account.create_key(
             CreateKeysRequest(
@@ -100,9 +100,9 @@ class TestGetKey:
 
 
 class TestGetKeyBySecret:
-    async def test_ok(self, data_layer: DataLayer, fake2: DataFaker):
+    async def test_ok(self, data_layer: DataLayer, fake: DataFaker):
         """Test that a created key can later be retrieved by its secret value."""
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         secret, api_key = await data_layer.account.create_key(
             CreateKeysRequest(
@@ -117,9 +117,9 @@ class TestGetKeyBySecret:
 
         assert await data_layer.account.get_key_by_secret(user.id, secret) == api_key
 
-    async def test_not_found(self, data_layer: DataLayer, fake2: DataFaker):
+    async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
         """Test that ``ResourceNotFoundError`` is raised when the key secret is invalid."""
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await data_layer.account.create_key(
             CreateKeysRequest(
@@ -154,10 +154,10 @@ async def test_update(
     data_layer: DataLayer,
     mongo: Mongo,
     pg: AsyncEngine,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot_recent: SnapshotAssertion,
 ):
-    user = await fake2.users.create(password="hello_world_1")
+    user = await fake.users.create(password="hello_world_1")
 
     await data_layer.account.update(
         user.id,

--- a/tests/administrators/test_api.py
+++ b/tests/administrators/test_api.py
@@ -41,7 +41,7 @@ async def test_get_roles(spawn_client: ClientSpawner, snapshot: SnapshotAssertio
 async def test_list_users(
     authorization_client: AuthorizationClient,
     spawn_client: ClientSpawner,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot: SnapshotAssertion,
 ):
     client = await spawn_client(
@@ -49,8 +49,8 @@ async def test_list_users(
         authenticated=True,
     )
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
     await authorization_client.add(
         AdministratorRoleAssignment(user_1.id, AdministratorRole.BASE),
@@ -67,7 +67,7 @@ async def test_list_users(
 
 async def test_get_user(
     authorization_client: AuthorizationClient,
-    fake2: DataFaker,
+        fake: DataFaker,
     spawn_client: ClientSpawner,
     snapshot: SnapshotAssertion,
     static_time,
@@ -77,7 +77,7 @@ async def test_get_user(
         authenticated=True,
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await authorization_client.add(
         AdministratorRoleAssignment(user.id, AdministratorRole.BASE),
@@ -93,7 +93,7 @@ async def test_get_user(
 async def test_create(
     error: str | None,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     resp_is,
     snapshot: SnapshotAssertion,
@@ -105,7 +105,7 @@ async def test_create(
 
     client = await spawn_client(administrator=True, authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await get_data_from_app(client.app).settings.update(
         UpdateSettingsRequest(minimum_password_length=8),
@@ -159,7 +159,7 @@ async def test_create(
     [None, AdministratorRole.USERS, AdministratorRole.FULL],
 )
 async def test_update_admin_role(
-    fake2: DataFaker,
+        fake: DataFaker,
     spawn_client: ClientSpawner,
     snapshot: SnapshotAssertion,
     role: AdministratorRole,
@@ -169,7 +169,7 @@ async def test_update_admin_role(
         authenticated=True,
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     resp = await client.put(f"/admin/users/{user.id}/role", {"role": role})
 
@@ -180,7 +180,7 @@ async def test_update_admin_role(
 class TestUpdateUser:
     async def test_force_reset(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
@@ -189,7 +189,7 @@ class TestUpdateUser:
             authenticated=True,
         )
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         resp = await client.patch(f"/admin/users/{user.id}", {"force_reset": True})
         body = await resp.json()
@@ -200,7 +200,7 @@ class TestUpdateUser:
 
     async def test_groups(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
@@ -210,10 +210,10 @@ class TestUpdateUser:
             authenticated=True,
         )
 
-        group_1 = await fake2.groups.create()
-        group_2 = await fake2.groups.create()
+        group_1 = await fake.groups.create()
+        group_2 = await fake.groups.create()
 
-        user = await fake2.users.create(groups=[group_1])
+        user = await fake.users.create(groups=[group_1])
 
         resp = await client.patch(
             f"/admin/users/{user.id}",
@@ -249,7 +249,7 @@ class TestUpdateUser:
     async def test_password(
         self,
         mongo: Mongo,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         password,
@@ -262,7 +262,7 @@ class TestUpdateUser:
             authenticated=True,
         )
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         resp = await client.patch(
             f"/admin/users/{user.id}",
@@ -291,7 +291,7 @@ class TestUpdateUser:
     async def test_primary_group(
         self,
         is_member: bool,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
@@ -304,8 +304,8 @@ class TestUpdateUser:
             authenticated=True,
         )
 
-        group = await fake2.groups.create()
-        user = await fake2.users.create(groups=([group] if is_member else []))
+        group = await fake.groups.create()
+        user = await fake.users.create(groups=([group] if is_member else []))
 
         resp = await client.patch(
             f"/admin/users/{user.id}",
@@ -325,7 +325,7 @@ class TestAdministratorRoles:
     async def test_ok(
         self,
         role: AdministratorRole,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
@@ -335,7 +335,7 @@ class TestAdministratorRoles:
             authenticated=True,
         )
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         resp = await client.put(f"/admin/users/{user.id}/role", {"role": role})
         body = await resp.json()
@@ -377,7 +377,7 @@ class TestAdministratorRoles:
         self,
         role: AdministratorRole,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         spawn_client: ClientSpawner,
     ):
         """Test that an administrator with a lower role or non-administrator can't change a
@@ -387,7 +387,7 @@ class TestAdministratorRoles:
 
         await data_layer.users.set_administrator_role(client.user.id, role)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         resp = await client.put(
             f"/admin/users/{user.id}/role",

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -32,7 +32,7 @@ def create_files(test_files_path, tmp_path):
 
 
 async def test_find(
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker: MockerFixture,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
@@ -43,10 +43,10 @@ async def test_find(
 
     client = await spawn_client(authenticated=True)
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
-    job = await fake2.jobs.create(user=user_2)
+    job = await fake.jobs.create(user=user_2)
 
     await asyncio.gather(
         mongo.references.insert_many(
@@ -141,7 +141,7 @@ async def test_get(
     ready: bool,
     exists: bool,
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
@@ -152,10 +152,10 @@ async def test_get(
 ):
     client = await spawn_client(authenticated=True)
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
-    job = await fake2.jobs.create(user=user_2, state=JobState.COMPLETE)
+    job = await fake.jobs.create(user=user_2, state=JobState.COMPLETE)
 
     await asyncio.gather(
         mongo.subtraction.insert_many(
@@ -258,14 +258,14 @@ async def test_get(
 async def test_get_304(
     ready: bool,
     mongo: Mongo,
-    fake2: DataFaker,
+        fake: DataFaker,
     pg,
     spawn_client: ClientSpawner,
     static_time,
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.subtraction.insert_many(
@@ -318,7 +318,7 @@ async def test_get_304(
 @pytest.mark.parametrize("error", [None, "403", "404_analysis", "404_sample", "409"])
 async def test_remove(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     resp_is,
     spawn_client: ClientSpawner,
@@ -329,7 +329,7 @@ async def test_remove(
 
     get_config_from_app(client.app).data_path = tmp_path
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.indexes.insert_one(
@@ -679,16 +679,16 @@ async def test_blast(
 @pytest.mark.parametrize("error", [None, 422, 404, 409])
 async def test_finalize(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
     spawn_job_client: JobClientSpawner,
     static_time,
 ):
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
-    job = await fake2.jobs.create(user=user_2)
+    job = await fake.jobs.create(user=user_2)
 
     patch_json = {"results": {"result": "TEST_RESULT", "hits": []}}
 
@@ -758,13 +758,13 @@ async def test_finalize(
 
 
 async def test_finalize_large(
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
     spawn_job_client: JobClientSpawner,
     static_time,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     faker = Faker(1)
 

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -16,8 +16,8 @@ from virtool.samples.oas import CreateAnalysisRequest
 
 
 @pytest.fixture()
-async def setup_sample(mongo: "Mongo", fake2: DataFaker) -> str:
-    user = await fake2.users.create()
+async def setup_sample(mongo: "Mongo", fake: DataFaker) -> str:
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.samples.insert_one({"_id": "test_sample", "name": "Test Sample"}),

--- a/tests/blast/test_tasks.py
+++ b/tests/blast/test_tasks.py
@@ -13,14 +13,14 @@ from virtool.utils import get_temp_dir
 
 async def test_task(
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     static_time,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.samples.insert_one({"_id": "sample"}),

--- a/tests/fake/test_next.py
+++ b/tests/fake/test_next.py
@@ -6,11 +6,11 @@ from virtool.fake.next import DataFaker
 from virtool.uploads.models import UploadType
 
 
-async def test_groups_and_users(fake2, snapshot):
-    group = await fake2.groups.create()
+async def test_groups_and_users(fake: DataFaker, snapshot):
+    group = await fake.groups.create()
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create(groups=[group])
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create(groups=[group])
 
     matcher = path_type(
         {
@@ -22,7 +22,7 @@ async def test_groups_and_users(fake2, snapshot):
     assert user_1 == snapshot(matcher=matcher)
     assert user_2 == snapshot(matcher=matcher)
 
-    job = await fake2.jobs.create(user_1)
+    job = await fake.jobs.create(user_1)
 
     assert job == snapshot(
         name="job",
@@ -36,10 +36,10 @@ async def test_groups_and_users(fake2, snapshot):
     )
 
 
-async def test_jobs(fake2: DataFaker, snapshot):
-    user = await fake2.users.create()
+async def test_jobs(fake: DataFaker, snapshot):
+    user = await fake.users.create()
 
-    assert await fake2.jobs.create(user) == snapshot(
+    assert await fake.jobs.create(user) == snapshot(
         name="job",
         matcher=path_type(
             {
@@ -51,7 +51,7 @@ async def test_jobs(fake2: DataFaker, snapshot):
     )
 
 
-async def test_uploads(fake2: DataFaker, snapshot):
+async def test_uploads(fake: DataFaker, snapshot):
     matcher = path_type(
         {
             "created_at": (datetime,),
@@ -61,25 +61,24 @@ async def test_uploads(fake2: DataFaker, snapshot):
         regex=True,
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
-    assert await fake2.uploads.create(user=user) == snapshot(
+    assert await fake.uploads.create(user=user) == snapshot(
         name="upload", matcher=matcher,
     )
 
-    assert await fake2.uploads.create(
+    assert await fake.uploads.create(
         user=user, upload_type=UploadType.subtraction,
     ) == snapshot(name="upload[subtraction]", matcher=matcher)
 
-    assert await fake2.uploads.create(user=user, reserved=True) == snapshot(
+    assert await fake.uploads.create(user=user, reserved=True) == snapshot(
         name="upload[reserved]", matcher=matcher,
     )
 
 
-async def test_subtractions(fake2: DataFaker, snapshot_recent):
-
-    user = await fake2.users.create()
-    upload = await fake2.uploads.create(user=user, upload_type="subtraction", name="foobar.fq.gz")
-    subtraction = await fake2.subtractions.create(user=user, upload=upload)
+async def test_subtractions(fake: DataFaker, snapshot_recent):
+    user = await fake.users.create()
+    upload = await fake.uploads.create(user=user, upload_type="subtraction", name="foobar.fq.gz")
+    subtraction = await fake.subtractions.create(user=user, upload=upload)
 
     assert subtraction == snapshot_recent

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -195,7 +195,7 @@ class ClientSpawner(Protocol):
 def spawn_client(
     aiohttp_client,
     data_path: Path,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker,
     mongo_connection_string: str,
     mongo_name: str,
@@ -365,7 +365,7 @@ def spawn_client(
 
         if permissions:
             groups = [
-                await fake2.groups.create(
+                await fake.groups.create(
                     permissions=PermissionsUpdate(
                         **{
                             permission: True
@@ -376,7 +376,7 @@ def spawn_client(
                 ),
             ]
 
-        test_client_user = await fake2.users.create(
+        test_client_user = await fake.users.create(
             administrator_role=AdministratorRole.FULL if administrator else None,
             groups=groups,
             handle="bob",
@@ -458,7 +458,7 @@ def spawn_job_client(
             job_id, key = "test_job", "test_key"
 
             await mongo.jobs.insert_one(
-                {"_id": "test_job", "key": hash_key("test_key")}
+                {"_id": "test_job", "key": hash_key("test_key")},
             )
 
             # Create Basic Authentication header.

--- a/tests/fixtures/fake.py
+++ b/tests/fixtures/fake.py
@@ -263,7 +263,7 @@ def app(mongo, pg, tmp_path, config, data_layer):
 
 
 @pytest.fixture()
-def fake2(
+def fake(
     data_layer: "DataLayer",
     example_path: Path,
     mocker,

--- a/tests/fixtures/samples.py
+++ b/tests/fixtures/samples.py
@@ -1,8 +1,10 @@
-import pytest
 import arrow
+import pytest
+
+from virtool.fake.next import DataFaker
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_sample(static_time):
     return {
         "_id": "test",
@@ -14,7 +16,7 @@ def mock_sample(static_time):
                 "id": "foo",
                 "name": "Bar.fq.gz",
                 "download_url": "/download/samples/files/file_1.fq.gz",
-            }
+            },
         ],
         "labels": [],
         "subtractions": ["foo", "bar"],
@@ -22,11 +24,11 @@ def mock_sample(static_time):
     }
 
 
-@pytest.fixture
-async def mock_samples(fake2, mock_sample, static_time):
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
-    user_3 = await fake2.users.create()
+@pytest.fixture()
+async def mock_samples(fake: DataFaker, mock_sample, static_time):
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
+    user_3 = await fake.users.create()
 
     return [
         {

--- a/tests/groups/test_api.py
+++ b/tests/groups/test_api.py
@@ -9,16 +9,16 @@ from virtool.groups.oas import PermissionsUpdate
 class TestFind:
     async def test_list(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
         """Test that a full list of groups is returned when pagination is not toggled."""
         for _ in range(10):
-            await fake2.groups.create()
+            await fake.groups.create()
 
         # Need a capitalized group name to make sure ordering is case-insensitive.
-        await fake2.groups.create(name="Caps")
+        await fake.groups.create(name="Caps")
 
         client = await spawn_client(authenticated=True)
 
@@ -29,7 +29,7 @@ class TestFind:
 
     async def test_paginate(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
@@ -37,12 +37,12 @@ class TestFind:
         are returned when `page` is `1` or `2`.
         """
         for _ in range(4):
-            await fake2.groups.create()
+            await fake.groups.create()
 
-        await fake2.groups.create(name="Caps")
+        await fake.groups.create(name="Caps")
 
         for _ in range(10):
-            await fake2.groups.create()
+            await fake.groups.create()
 
         client = await spawn_client(authenticated=True)
 
@@ -69,7 +69,7 @@ class TestCreate:
 
     async def test_duplicate(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
@@ -79,7 +79,7 @@ class TestCreate:
             authenticated=True,
         )
 
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
         resp = await client.post("/groups", data={"name": group.name})
 
@@ -90,7 +90,7 @@ class TestCreate:
 @pytest.mark.parametrize("status", [200, 404])
 async def test_get(
     status: int,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot,
     spawn_client: ClientSpawner,
 ):
@@ -100,10 +100,10 @@ async def test_get(
         authenticated=True,
     )
 
-    group = await fake2.groups.create()
-    await fake2.groups.create()
+    group = await fake.groups.create()
+    await fake.groups.create()
 
-    await fake2.users.create(groups=[group])
+    await fake.users.create(groups=[group])
 
     resp = await client.get(f"/groups/{group.id if status == 200 else 5}")
 
@@ -114,7 +114,7 @@ async def test_get(
 class TestUpdate:
     async def test(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         spawn_client: ClientSpawner,
         snapshot: SnapshotAssertion,
     ):
@@ -123,13 +123,13 @@ class TestUpdate:
             authenticated=True,
         )
 
-        group = await fake2.groups.create()
-        await fake2.groups.create()
+        group = await fake.groups.create()
+        await fake.groups.create()
 
-        await fake2.users.create()
-        await fake2.users.create(groups=[group])
-        await fake2.users.create(groups=[group])
-        await fake2.users.create(groups=[group])
+        await fake.users.create()
+        await fake.users.create(groups=[group])
+        await fake.users.create(groups=[group])
+        await fake.users.create(groups=[group])
 
         resp = await client.patch(
             f"/groups/{group.id}",
@@ -155,15 +155,15 @@ class TestUpdate:
 
 
 @pytest.mark.parametrize("status", [204, 404])
-async def test_delete(status: int, fake2: DataFaker, spawn_client: ClientSpawner):
+async def test_delete(status: int, fake: DataFaker, spawn_client: ClientSpawner):
     """Test that an existing document can be removed at ``DELETE /groups/:group_id``."""
     client = await spawn_client(administrator=True, authenticated=True)
 
-    group = await fake2.groups.create(
+    group = await fake.groups.create(
         permissions=PermissionsUpdate(create_sample=True, remove_file=True),
     )
 
-    await fake2.users.create(groups=[group])
+    await fake.users.create(groups=[group])
 
     resp = await client.delete(f"/groups/{5 if status == 404 else group.id}")
 

--- a/tests/groups/test_mongo.py
+++ b/tests/groups/test_mongo.py
@@ -1,5 +1,6 @@
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
 from virtool.fake.next import DataFaker
 from virtool.groups.mongo import update_member_users_and_api_keys
 from virtool.groups.pg import SQLGroup
@@ -8,12 +9,12 @@ from virtool.mongo.utils import get_one_field
 
 
 async def test_update_member_users_and_api_keys(
-    fake2: DataFaker, mongo: Mongo, pg: AsyncEngine
+        fake: DataFaker, mongo: Mongo, pg: AsyncEngine,
 ):
-    group_1 = await fake2.groups.create()
-    group_2 = await fake2.groups.create()
+    group_1 = await fake.groups.create()
+    group_2 = await fake.groups.create()
 
-    user = await fake2.users.create(groups=[group_1, group_2])
+    user = await fake.users.create(groups=[group_1, group_2])
 
     async with AsyncSession(pg) as session:
         await session.execute(delete(SQLGroup).where(SQLGroup.id == group_2.id))
@@ -21,7 +22,7 @@ async def test_update_member_users_and_api_keys(
 
     async with AsyncSession(pg) as pg_session, mongo.create_session() as mongo_session:
         await update_member_users_and_api_keys(
-            mongo, mongo_session, pg_session, group_2.id
+            mongo, mongo_session, pg_session, group_2.id,
         )
 
     assert await get_one_field(mongo.users, "groups", user.id) == [group_1.id]

--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -14,13 +14,13 @@ from virtool.mongo.core import Mongo
 async def test_get(
     data_path: Path,
     file,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
     static_time,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.references.insert_one(

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -7,13 +7,14 @@ import pytest
 from virtool_core.utils import decompress_file
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
+from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
 
 
 @pytest.fixture()
-async def fake_hmm_status(mongo, fake2, static_time):
-    user = await fake2.users.create()
+async def fake_hmm_status(mongo, fake: DataFaker, static_time):
+    user = await fake.users.create()
 
     await mongo.status.insert_one(
         {

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -1,9 +1,11 @@
-async def test_get_status(config, data_layer, fake2, mongo, snapshot, static_time):
-    """
-    Test that function works when the HMM data are being updated and when they are not.
+from virtool.fake.next import DataFaker
+
+
+async def test_get_status(config, data_layer, fake: DataFaker, mongo, snapshot, static_time):
+    """Test that function works when the HMM data are being updated and when they are not.
 
     """
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await mongo.status.insert_one(
         {
@@ -38,7 +40,7 @@ async def test_get_status(config, data_layer, fake2, mongo, snapshot, static_tim
                 "size": 85904451,
             },
             "errors": [],
-        }
+        },
     )
 
     assert await data_layer.hmms.get_status() == snapshot

--- a/tests/hmm/test_fake.py
+++ b/tests/hmm/test_fake.py
@@ -1,4 +1,7 @@
-async def test_create_fake_hmm(fake2, snapshot):
-    hmm = await fake2.hmm.create(fake2.mongo)
+from virtool.fake.next import DataFaker
+
+
+async def test_create_fake_hmm(fake: DataFaker, snapshot):
+    hmm = await fake.hmm.create(fake.mongo)
 
     assert hmm == snapshot

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -34,7 +34,7 @@ OTUS_JSON_PATH = Path.cwd() / "tests/test_files/index/otus.json.gz"
 class TestFind:
     async def test(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         mocker,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
@@ -43,10 +43,10 @@ class TestFind:
     ):
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
-        job_1 = await fake2.jobs.create(user=user, workflow="build_index")
-        job_2 = await fake2.jobs.create(user=user, workflow="build_index")
+        job_1 = await fake.jobs.create(user=user, workflow="build_index")
+        job_2 = await fake.jobs.create(user=user, workflow="build_index")
 
         await asyncio.gather(
             mongo.history.insert_many(
@@ -112,7 +112,7 @@ class TestFind:
 
     async def test_ready(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -120,8 +120,8 @@ class TestFind:
     ):
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
-        job = await fake2.jobs.create(user=user)
+        user = await fake.users.create()
+        job = await fake.jobs.create(user=user)
 
         await asyncio.gather(
             mongo.indexes.insert_many(
@@ -169,7 +169,7 @@ class TestFind:
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker,
     resp_is,
     snapshot,
@@ -179,7 +179,7 @@ async def test_get(
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.references.insert_many(
@@ -198,7 +198,7 @@ async def test_get(
         ),
     )
 
-    job = await fake2.jobs.create(user=user, workflow="build_index")
+    job = await fake.jobs.create(user=user, workflow="build_index")
 
     if not error:
         await mongo.indexes.insert_one(
@@ -296,7 +296,7 @@ class TestCreate:
     async def test(
         self,
         check_ref_right,
-        fake2: DataFaker,
+            fake: DataFaker,
         mocker,
         resp_is,
         snapshot: SnapshotAssertion,
@@ -314,7 +314,7 @@ class TestCreate:
         data = get_data_from_app(client.app)
         data.jobs._client = DummyJobsClient()
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await asyncio.gather(
             mongo.references.insert_one(
@@ -401,7 +401,7 @@ class TestCreate:
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_find_history(
     error,
-    fake2,
+        fake: DataFaker,
     static_time,
     snapshot,
     mongo: Mongo,
@@ -413,8 +413,8 @@ async def test_find_history(
     if not error:
         await mongo.indexes.insert_one({"_id": "foobar", "version": 0})
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
     await asyncio.gather(
         mongo.history.insert_many(
@@ -483,7 +483,7 @@ async def test_find_history(
 @pytest.mark.parametrize("error", [None, 404])
 async def test_delete_index(
     error,
-    fake2,
+        fake: DataFaker,
     mongo: Mongo,
     spawn_job_client: JobClientSpawner,
     static_time,
@@ -492,7 +492,7 @@ async def test_delete_index(
 
     client = await spawn_job_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     if error != 404:
         await asyncio.gather(
@@ -541,7 +541,7 @@ async def test_delete_index(
 async def test_upload(
     error: str | None,
     data_path: Path,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     pg: AsyncEngine,
     resp_is,
@@ -555,7 +555,7 @@ async def test_upload(
     files = {"file": open(path, "rb")}
 
     user, _ = await asyncio.gather(
-        fake2.users.create(),
+        fake.users.create(),
         mongo.references.insert_many(
             [
                 {"_id": "bar", "name": "Bar", "data_type": "genome"},
@@ -611,7 +611,7 @@ async def test_upload(
 @pytest.mark.parametrize("error", [None, "409_genome", "409_fasta", "404_reference"])
 async def test_finalize(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
@@ -622,8 +622,8 @@ async def test_finalize(
     """Test that an index can be finalized using the Jobs API."""
     client = await spawn_job_client(authenticated=True)
 
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user=user, workflow="build_index")
+    user = await fake.users.create()
+    job = await fake.jobs.create(user=user, workflow="build_index")
 
     if error == "409_genome":
         files = ["reference.fa.gz"]

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -10,18 +10,18 @@ from virtool.mongo.core import Mongo
 
 async def test_finalize(
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     pg: AsyncEngine,
     snapshot,
     static_time,
 ):
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user=user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user=user)
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "bar", "name": "Bar", "data_type": "genome"}
+            {"_id": "bar", "name": "Bar", "data_type": "genome"},
         ),
         mongo.indexes.insert_one(
             {
@@ -33,7 +33,7 @@ async def test_finalize(
                 "job": {"id": job.id},
                 "has_files": True,
                 "manifest": {},
-            }
+            },
         ),
     )
 
@@ -89,7 +89,7 @@ async def test_finalize(
                     type="fasta",
                     size=1234567,
                 ),
-            ]
+            ],
         )
         await session.commit()
 

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -19,20 +19,20 @@ _job_response_matcher = path_type(
 class TestFind:
     async def test_basic(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
         client = await spawn_client(authenticated=True)
 
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         for _ in range(4):
-            await fake2.jobs.create(user=user_1)
+            await fake.jobs.create(user=user_1)
 
         for _ in range(7):
-            await fake2.jobs.create(user=user_2)
+            await fake.jobs.create(user=user_2)
 
         resp = await client.get("/jobs?per_page=5")
 
@@ -43,20 +43,20 @@ class TestFind:
     async def test_archived(
         self,
         archived: bool,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
         """Test that jobs are filtered correctly when archived is ``true`` or ``false``."""
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
-        await fake2.jobs.create(user=user)
-        await fake2.jobs.create(user=user, archived=True)
-        await fake2.jobs.create(user=user)
-        await fake2.jobs.create(user=user, archived=True)
-        await fake2.jobs.create(user=user)
+        await fake.jobs.create(user=user)
+        await fake.jobs.create(user=user, archived=True)
+        await fake.jobs.create(user=user)
+        await fake.jobs.create(user=user, archived=True)
+        await fake.jobs.create(user=user)
 
         resp = await client.get(f"/jobs?archived={archived}")
         body = await resp.json()
@@ -65,20 +65,20 @@ class TestFind:
         assert body == snapshot(matcher=_job_response_matcher)
         assert all(job["archived"] == archived for job in body["documents"])
 
-    async def test_user(self, fake2: DataFaker, spawn_client: ClientSpawner):
+    async def test_user(self, fake: DataFaker, spawn_client: ClientSpawner):
         """Test that jobs are filtered correctly when user id(s) are provided."""
         client = await spawn_client(authenticated=True)
 
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
-        user_3 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
+        user_3 = await fake.users.create()
 
-        await fake2.jobs.create(user=user_1)
-        await fake2.jobs.create(user=user_2)
-        await fake2.jobs.create(user=user_1)
-        await fake2.jobs.create(user=user_2)
-        await fake2.jobs.create(user=user_1)
-        await fake2.jobs.create(user=user_3)
+        await fake.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_2)
+        await fake.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_2)
+        await fake.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_3)
 
         resp_1 = await client.get(f"/jobs?user={user_1.id}")
         body_1 = await resp_1.json()
@@ -116,29 +116,29 @@ class TestFind:
     async def test_state(
         self,
         state: str,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
         client = await spawn_client(authenticated=True)
 
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
-        await fake2.jobs.create(user=user_1)
-        await fake2.jobs.create(user=user_2, state=JobState.PREPARING)
-        await fake2.jobs.create(user=user_2, state=JobState.RUNNING)
-        await fake2.jobs.create(user=user_2)
-        await fake2.jobs.create(user=user_1, state=JobState.WAITING)
-        await fake2.jobs.create(user=user_1)
-        await fake2.jobs.create(user=user_2, state=JobState.ERROR)
-        await fake2.jobs.create(user=user_1, state=JobState.CANCELLED)
-        await fake2.jobs.create(user=user_1, state=JobState.COMPLETE)
-        await fake2.jobs.create(user=user_1)
-        await fake2.jobs.create(user=user_2)
-        await fake2.jobs.create(user=user_2, state=JobState.TERMINATED)
-        await fake2.jobs.create(user=user_1, state=JobState.TIMEOUT)
-        await fake2.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_2, state=JobState.PREPARING)
+        await fake.jobs.create(user=user_2, state=JobState.RUNNING)
+        await fake.jobs.create(user=user_2)
+        await fake.jobs.create(user=user_1, state=JobState.WAITING)
+        await fake.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_2, state=JobState.ERROR)
+        await fake.jobs.create(user=user_1, state=JobState.CANCELLED)
+        await fake.jobs.create(user=user_1, state=JobState.COMPLETE)
+        await fake.jobs.create(user=user_1)
+        await fake.jobs.create(user=user_2)
+        await fake.jobs.create(user=user_2, state=JobState.TERMINATED)
+        await fake.jobs.create(user=user_1, state=JobState.TIMEOUT)
+        await fake.jobs.create(user=user_1)
 
         resp = await client.get(f"/jobs?state={state}")
         body = await resp.json()
@@ -159,15 +159,15 @@ class TestFind:
 
 
 @pytest.mark.parametrize("error", [None, "404"])
-async def test_get(error, fake2: DataFaker, snapshot, spawn_client):
+async def test_get(error, fake: DataFaker, snapshot, spawn_client):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     job_id = "foo"
 
     if error is None:
-        job = await fake2.jobs.create(user=user)
+        job = await fake.jobs.create(user=user)
         job_id = job.id
 
     resp = await client.get(f"/jobs/{job_id}")
@@ -190,15 +190,15 @@ async def test_get(error, fake2: DataFaker, snapshot, spawn_client):
 class TestAcquire:
     async def test_ok(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_job_client: JobClientSpawner,
     ):
         """Test that a job can be acquired."""
         client = await spawn_job_client(authenticated=True)
 
-        job = await fake2.jobs.create(
-            await fake2.users.create(),
+        job = await fake.jobs.create(
+            await fake.users.create(),
             state=JobState.WAITING,
         )
 
@@ -209,12 +209,12 @@ class TestAcquire:
         assert body == snapshot(matcher=_job_response_matcher)
         assert "key" in body
 
-    async def test_already_acquired(self, fake2: DataFaker, spawn_job_client):
+    async def test_already_acquired(self, fake: DataFaker, spawn_job_client):
         """Test that a 400 is returned when the job is already acquired."""
         client = await spawn_job_client(authenticated=True)
 
-        user = await fake2.users.create()
-        job = await fake2.jobs.create(user, state=JobState.WAITING)
+        user = await fake.users.create()
+        job = await fake.jobs.create(user, state=JobState.WAITING)
 
         resp = await client.patch(f"/jobs/{job.id}", json={"acquired": True})
         assert resp.status == 200
@@ -243,14 +243,14 @@ class TestAcquire:
 class TestArchive:
     async def test_ok(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
         """Test that a job can be archived."""
         client = await spawn_client(authenticated=True)
 
-        job = await fake2.jobs.create(await fake2.users.create())
+        job = await fake.jobs.create(await fake.users.create())
 
         resp = await client.patch(f"/jobs/{job.id}/archive", data={"archived": True})
 
@@ -259,14 +259,14 @@ class TestArchive:
 
     async def test_already_archived(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         spawn_client: ClientSpawner,
     ):
         """Test that a 400 is returned when the job is already archived."""
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
-        job = await fake2.jobs.create(user, archived=True)
+        user = await fake.users.create()
+        job = await fake.jobs.create(user, archived=True)
 
         resp = await client.patch(f"/jobs/{job.id}/archive", data={"archived": True})
 
@@ -290,12 +290,12 @@ class TestArchive:
 
 
 class TestPing:
-    async def test_ok(self, fake2: DataFaker, spawn_job_client):
+    async def test_ok(self, fake: DataFaker, spawn_job_client):
         """Test that a job can be pinged."""
         client = await spawn_job_client(authenticated=True)
 
-        job = await fake2.jobs.create(
-            await fake2.users.create(),
+        job = await fake.jobs.create(
+            await fake.users.create(),
             state=JobState.RUNNING,
         )
 
@@ -322,10 +322,10 @@ class TestPing:
     "error",
     [None, 404, "409_complete", "409_errored", "409_cancelled"],
 )
-async def test_cancel(error, snapshot, mongo, fake2, resp_is, spawn_client, test_job):
+async def test_cancel(error, snapshot, mongo, fake: DataFaker, resp_is, spawn_client, test_job):
     client = await spawn_client(authenticated=True, permissions=[Permission.cancel_job])
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     test_job["user"] = {"id": user.id}
 
@@ -367,7 +367,7 @@ class TestPushStatus:
     async def test(
         self,
         error,
-        fake2,
+            fake: DataFaker,
         snapshot,
         resp_is,
         mongo: Mongo,
@@ -377,7 +377,7 @@ class TestPushStatus:
     ):
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
         test_job["user"] = {"id": user.id}
 
         if error != 409:
@@ -404,7 +404,7 @@ class TestPushStatus:
 
     async def test_name_and_description(
         self,
-        fake2,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client,
@@ -413,7 +413,7 @@ class TestPushStatus:
     ):
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
         test_job["user"] = {"id": user.id}
 
         del test_job["status"][-1]
@@ -434,7 +434,7 @@ class TestPushStatus:
 
     async def test_bad_state(
         self,
-        fake2,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client,
@@ -443,7 +443,7 @@ class TestPushStatus:
         """Check that an unallowed state is rejected with 422."""
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
         test_job["user"] = {"id": user.id}
 
         del test_job["status"][-1]
@@ -476,7 +476,7 @@ class TestPushStatus:
         error_type,
         traceback,
         details,
-        fake2,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client,
@@ -486,7 +486,7 @@ class TestPushStatus:
         """Ensure valid and invalid error inputs are handled correctly."""
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
         test_job["user"] = {"id": user.id}
 
         del test_job["status"][-1]

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -6,20 +6,20 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy.matchers import path_type
 from virtool_core.models.job import JobState
-from virtool.fake.next import DataFaker
 
+from virtool.fake.next import DataFaker
 from virtool.jobs.client import JobsClient
 from virtool.jobs.data import JobsData
 from virtool.jobs.utils import compose_status
 
 
-@pytest.fixture
+@pytest.fixture()
 async def jobs_data(mongo, mocker, pg: AsyncEngine) -> JobsData:
     return JobsData(mocker.Mock(spec=JobsClient), mongo, pg)
 
 
-async def test_cancel(mongo, fake2, jobs_data: JobsData, snapshot, static_time):
-    user = await fake2.users.create()
+async def test_cancel(mongo, fake: DataFaker, jobs_data: JobsData, snapshot, static_time):
+    user = await fake.users.create()
 
     await mongo.jobs.insert_one(
         {
@@ -32,14 +32,14 @@ async def test_cancel(mongo, fake2, jobs_data: JobsData, snapshot, static_time):
                     "error": None,
                     "progress": 0.33,
                     "timestamp": static_time.datetime,
-                }
+                },
             ],
             "rights": {},
             "archived": False,
             "workflow": "build_index",
             "args": {},
             "user": {"id": user.id},
-        }
+        },
     )
 
     assert await jobs_data.cancel("foo") == snapshot
@@ -55,11 +55,11 @@ async def test_create(
     mongo,
     test_random_alphanumeric,
     static_time,
-    fake2: DataFaker,
+        fake: DataFaker,
 ):
     mocker.patch("virtool.utils.generate_key", return_value=("key", "hashed"))
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     job = await jobs_data.create("create_sample", {"sample_id": "foo"}, user.id, 0, job_id=job_id)
 
@@ -69,9 +69,9 @@ async def test_create(
 
 
 async def test_acquire(
-    mongo, fake2, jobs_data: JobsData, mocker, pg, snapshot, static_time
+        mongo, fake: DataFaker, jobs_data: JobsData, mocker, pg, snapshot, static_time,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     mocker.patch("virtool.utils.generate_key", return_value=("key", "hashed"))
 
@@ -85,15 +85,15 @@ async def test_acquire(
             "workflow": "build_index",
             "args": {},
             "user": {"id": user.id},
-        }
+        },
     )
 
     assert await jobs_data.acquire("foo") == snapshot
     assert await mongo.jobs.find_one() == snapshot
 
 
-async def test_archive(mongo, fake2, jobs_data: JobsData, pg, snapshot, static_time):
-    user = await fake2.users.create()
+async def test_archive(mongo, fake: DataFaker, jobs_data: JobsData, pg, snapshot, static_time):
+    user = await fake.users.create()
 
     status = compose_status(JobState.WAITING, None)
 
@@ -108,7 +108,7 @@ async def test_archive(mongo, fake2, jobs_data: JobsData, pg, snapshot, static_t
             "rights": {},
             "workflow": "build_index",
             "args": {},
-        }
+        },
     )
 
     assert await jobs_data.archive("foo") == snapshot
@@ -121,14 +121,14 @@ async def test_force_delete_jobs(mongo, jobs_data: JobsData):
     await jobs_data.force_delete()
 
     jobs_data._client.cancel.assert_has_calls(
-        [call("foo"), call("bar")], any_order=True
+        [call("foo"), call("bar")], any_order=True,
     )
 
     assert await mongo.jobs.count_documents({}) == 0
 
 
-async def test_timeout(fake2, mongo, jobs_data: JobsData, snapshot):
-    user = await fake2.users.create()
+async def test_timeout(fake: DataFaker, mongo, jobs_data: JobsData, snapshot):
+    user = await fake.users.create()
 
     now = arrow.utcnow()
 

--- a/tests/jobs/test_tasks.py
+++ b/tests/jobs/test_tasks.py
@@ -1,6 +1,7 @@
 import pytest
 from virtool_core.models.job import JobState
 
+from virtool.fake.next import DataFaker
 from virtool.jobs.client import DummyJobsClient
 from virtool.jobs.data import JobsData
 
@@ -17,14 +18,12 @@ async def sleep_patch():
         (JobState.WAITING.value, True),
     ],
 )
-async def test_relist_jobs(fake2, pg, mongo, mocker, state, listed, snapshot):
-    """
-    Test that jobs are relisted in redis that are in the waiting state and are no longer in redis.
+async def test_relist_jobs(fake: DataFaker, pg, mongo, mocker, state, listed, snapshot):
+    """Test that jobs are relisted in redis that are in the waiting state and are no longer in redis.
 
     """
-
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user)
     dummy_client = DummyJobsClient()
 
     mocker.patch("virtool.jobs.data.asyncio.sleep", function=sleep_patch)

--- a/tests/labels/test_api.py
+++ b/tests/labels/test_api.py
@@ -8,7 +8,7 @@ from virtool.mongo.core import Mongo
 class TestFind:
     async def test_find(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -16,8 +16,8 @@ class TestFind:
         """Test that a ``GET /labels`` return a complete list of labels."""
         client = await spawn_client(authenticated=True)
 
-        label_1 = await fake2.labels.create()
-        label_2 = await fake2.labels.create()
+        label_1 = await fake.labels.create()
+        label_2 = await fake.labels.create()
 
         await mongo.samples.insert_many(
             [
@@ -41,14 +41,14 @@ class TestFind:
 
     async def test_find_by_name(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
     ):
         """Test that a ``GET /labels`` with a `find` query returns a particular label. Also test for partial matches."""
         client = await spawn_client(authenticated=True)
 
-        label = await fake2.labels.create()
+        label = await fake.labels.create()
 
         term = label.name[:2].lower()
 
@@ -66,7 +66,7 @@ class TestFind:
 @pytest.mark.parametrize("status", [200, 404])
 async def test_get(
     status: int,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot,
     mongo: Mongo,
     spawn_client: ClientSpawner,
@@ -74,8 +74,8 @@ async def test_get(
     """Test that a ``GET /labels/:label_id`` return the correct label document."""
     client = await spawn_client(authenticated=True)
 
-    label_1 = await fake2.labels.create()
-    label_2 = await fake2.labels.create()
+    label_1 = await fake.labels.create()
+    label_2 = await fake.labels.create()
 
     await mongo.samples.insert_many(
         [
@@ -95,14 +95,14 @@ async def test_get(
 @pytest.mark.parametrize("error", [None, "400_exists", "400_color"])
 async def test_create(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     spawn_client: ClientSpawner,
 ):
     """Test that a label can be added to the database at ``POST /labels``."""
     client = await spawn_client(authenticated=True)
 
-    label = await fake2.labels.create()
+    label = await fake.labels.create()
 
     data = {"name": "Bug", "color": "#a83432", "description": "This is a bug"}
 
@@ -133,7 +133,7 @@ async def test_create(
 @pytest.mark.parametrize("error", [None, "404", "400_name", "400_color", "400_null"])
 async def test_edit(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot,
     mongo: Mongo,
@@ -142,8 +142,8 @@ async def test_edit(
     """Test that a label can be updated at ``PATCH /labels/:label_id``."""
     client = await spawn_client(authenticated=True)
 
-    label_1 = await fake2.labels.create()
-    label_2 = await fake2.labels.create()
+    label_1 = await fake.labels.create()
+    label_2 = await fake.labels.create()
 
     await mongo.samples.insert_many(
         [
@@ -191,7 +191,7 @@ async def test_edit(
 @pytest.mark.parametrize("status", [204, 404])
 async def test_remove(
     status: int,
-    fake2: DataFaker,
+        fake: DataFaker,
     mock_samples: list[dict],
     snapshot,
     mongo: Mongo,
@@ -203,9 +203,9 @@ async def test_remove(
     """
     client = await spawn_client(authenticated=True)
 
-    label_1 = await fake2.labels.create()
-    label_2 = await fake2.labels.create()
-    label_3 = await fake2.labels.create()
+    label_1 = await fake.labels.create()
+    label_2 = await fake.labels.create()
+    label_3 = await fake.labels.create()
 
     await mongo.subtraction.insert_many(
         [{"_id": "foo", "name": "Foo"}, {"_id": "bar", "name": "Bar"}],

--- a/tests/messages/test_api.py
+++ b/tests/messages/test_api.py
@@ -2,13 +2,14 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.fixtures.client import ClientSpawner
+from virtool.fake.next import DataFaker
 from virtool.messages.models import SQLInstanceMessage
 
 
 @pytest.fixture()
-async def insert_test_message(fake2, pg, static_time):
+async def insert_test_message(fake: DataFaker, pg, static_time):
     async def insert(active=True):
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         async with AsyncSession(pg) as session:
             session.add(

--- a/tests/messages/test_data.py
+++ b/tests/messages/test_data.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.errors import ResourceConflictError
 from virtool.messages.data import MessagesData
@@ -8,14 +8,14 @@ from virtool.messages.oas import CreateMessageRequest, UpdateMessageRequest
 from virtool.mongo.core import Mongo
 
 
-@pytest.fixture
+@pytest.fixture()
 async def messages_data(pg: AsyncEngine, mongo: Mongo) -> MessagesData:
     return MessagesData(pg, mongo)
 
 
 class TestGet:
-    async def test_active(self, snapshot, static_time, messages_data, pg, fake2):
-        user = await fake2.users.create()
+    async def test_active(self, snapshot, static_time, messages_data, pg, fake):
+        user = await fake.users.create()
 
         async with AsyncSession(pg) as session:
             session.add_all(
@@ -36,7 +36,7 @@ class TestGet:
                         updated_at=static_time.datetime,
                         user=user.id,
                     ),
-                ]
+                ],
             )
             await session.commit()
 
@@ -53,7 +53,7 @@ class TestGet:
                     created_at=static_time.datetime,
                     updated_at=static_time.datetime,
                     user="test",
-                )
+                ),
             )
             await session.commit()
 
@@ -61,11 +61,11 @@ class TestGet:
             await messages_data.get()
 
 
-async def test_create(snapshot, static_time, messages_data, fake2):
-    user = await fake2.users.create()
+async def test_create(snapshot, static_time, messages_data, fake):
+    user = await fake.users.create()
 
     create_request = CreateMessageRequest(
-        color="blue", message="This is a test message"
+        color="blue", message="This is a test message",
     )
 
     await messages_data.create(create_request, user.id)
@@ -73,8 +73,8 @@ async def test_create(snapshot, static_time, messages_data, fake2):
     assert await messages_data.get() == snapshot
 
 
-async def test_update(snapshot, pg, static_time, messages_data, fake2):
-    user = await fake2.users.create()
+async def test_update(snapshot, pg, static_time, messages_data, fake):
+    user = await fake.users.create()
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -85,7 +85,7 @@ async def test_update(snapshot, pg, static_time, messages_data, fake2):
                 created_at=static_time.datetime,
                 updated_at=static_time.datetime,
                 user=user.id,
-            )
+            ),
         )
         await session.commit()
 

--- a/tests/ml/test_api.py
+++ b/tests/ml/test_api.py
@@ -7,11 +7,11 @@ from tests.fixtures.client import ClientSpawner
 from virtool.fake.next import DataFaker
 
 
-async def test_list(fake2, snapshot, spawn_client):
+async def test_list(fake: DataFaker, snapshot, spawn_client):
     """Test that a GET request to `/ml` returns a list of HMMs."""
     client = await spawn_client(authenticated=True)
 
-    await fake2.ml.populate()
+    await fake.ml.populate()
 
     resp = await client.get("/ml")
 
@@ -22,11 +22,11 @@ async def test_list(fake2, snapshot, spawn_client):
     )
 
 
-async def test_get(fake2, snapshot, spawn_client):
+async def test_get(fake: DataFaker, snapshot, spawn_client):
     """Test that a GET request to `/ml/:id` returns the details for a model."""
     client = await spawn_client(authenticated=True)
 
-    await fake2.ml.populate()
+    await fake.ml.populate()
 
     resp = await client.get("/ml/1")
 
@@ -37,13 +37,13 @@ async def test_get(fake2, snapshot, spawn_client):
     )
 
 
-async def test_download_release(fake2: DataFaker, spawn_client: ClientSpawner):
+async def test_download_release(fake: DataFaker, spawn_client: ClientSpawner):
     """Test that a GET request to `/ml/:id/releases/:id/model.tar.gz` returns a file
     download of the model archive for that release.
     """
     client = await spawn_client(authenticated=True)
 
-    await fake2.ml.populate()
+    await fake.ml.populate()
 
     resp: ClientResponse = await client.get("/ml/1/releases/1/model.tar.gz")
 

--- a/tests/ml/test_data.py
+++ b/tests/ml/test_data.py
@@ -19,7 +19,7 @@ from virtool.tasks.models import SQLTask
 async def test_list(
     has_last_checked_at: bool,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     static_time,
@@ -29,7 +29,7 @@ async def test_list(
     This test also indirectly tests that MLData.load() can be used by the data faker
     to populate the database with ML models and releases.
     """
-    await fake2.ml.populate()
+    await fake.ml.populate()
 
     if has_last_checked_at:
         async with AsyncSession(pg) as session:
@@ -51,11 +51,11 @@ async def test_list(
 
 async def test_get(
     data_layer: DataLayer,
-    fake2,
+        fake: DataFaker,
     snapshot,
 ):
     """Test that MLData.get() returns a complete representation of an ML model."""
-    await fake2.ml.populate()
+    await fake.ml.populate()
 
     assert await data_layer.ml.get(1) == snapshot(
         matcher=path_type({".*created_at": (datetime.datetime,)}, regex=True),
@@ -66,7 +66,7 @@ async def test_load(
     data_path: Path,
     data_layer: DataLayer,
     example_path,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker: MockerFixture,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
@@ -85,7 +85,7 @@ async def test_load(
 
     spy = mocker.spy(data_layer.ml._http, "download")
 
-    first = [fake2.ml.create_release_manifest_item() for _ in range(3)]
+    first = [fake.ml.create_release_manifest_item() for _ in range(3)]
 
     await data_layer.ml.load({"ml-plant-viruses": first})
 
@@ -98,9 +98,9 @@ async def test_load(
         {
             "ml-plant-viruses": [
                 *first,
-                *[fake2.ml.create_release_manifest_item() for _ in range(2)],
+                *[fake.ml.create_release_manifest_item() for _ in range(2)],
             ],
-            "ml-insect-viruses": [fake2.ml.create_release_manifest_item()],
+            "ml-insect-viruses": [fake.ml.create_release_manifest_item()],
         },
     )
 

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -13,7 +13,7 @@ from virtool.mongo.core import Mongo
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot,
     mongo: Mongo,
@@ -26,7 +26,7 @@ async def test_get(
     """Test that a valid request returns a complete otu document."""
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     if not error:
         await asyncio.gather(
@@ -211,7 +211,7 @@ class TestEdit:
         self,
         change_count,
         data,
-        fake2,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client,
@@ -224,7 +224,7 @@ class TestEdit:
     ):
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
         test_change.update({"user": {"id": user.id}, "_id": "6116cba1.0"})
 
         await asyncio.gather(

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -23,7 +23,7 @@ from virtool.utils import get_http_session_from_app
 
 async def test_find(
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot,
     mongo: Mongo,
@@ -32,8 +32,8 @@ async def test_find(
 ):
     client = await spawn_client(authenticated=True)
 
-    group = await fake2.groups.create()
-    user = await fake2.users.create()
+    group = await fake.groups.create()
+    user = await fake.users.create()
     await data_layer.users.update(client.user.id, UpdateUserRequest(groups=[group.id]))
 
     await mongo.references.insert_many(
@@ -133,11 +133,11 @@ async def test_find(
 
 
 @pytest.mark.parametrize("error", [404, None])
-async def test_get(error, mongo: Mongo, spawn_client, pg, snapshot, fake2, static_time):
+async def test_get(error, mongo: Mongo, spawn_client, pg, snapshot, fake: DataFaker, static_time):
     client = await spawn_client(authenticated=True, administrator=True)
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
     if error is None:
         await mongo.references.insert_one(
@@ -263,7 +263,7 @@ class TestCreate:
 
     async def test_clone(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
         snapshot: SnapshotAssertion,
@@ -274,8 +274,8 @@ class TestCreate:
             permissions=[Permission.create_ref],
         )
 
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -353,7 +353,7 @@ class TestCreate:
 async def test_edit(
     data_type: str,
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker,
     resp_is,
     snapshot,
@@ -363,9 +363,9 @@ async def test_edit(
 ):
     client = await spawn_client(authenticated=True)
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
-    user_3 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
+    user_3 = await fake.users.create()
 
     if error != "404":
         await mongo.references.insert_one(
@@ -455,15 +455,15 @@ async def test_edit(
 
 
 async def test_delete(
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
     static_time,
 ):
     client = await spawn_client(authenticated=True)
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
     await mongo.references.insert_one(
         {
@@ -837,7 +837,7 @@ class TestCreateOTU:
 
 async def test_create_index(
     check_ref_right,
-    fake2: DataFaker,
+        fake: DataFaker,
     mocker,
     resp_is,
     mongo: Mongo,
@@ -851,7 +851,7 @@ async def test_create_index(
         base_url="https://virtool.example.com",
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await asyncio.gather(
         mongo.references.insert_one(
@@ -892,7 +892,7 @@ async def test_create_index(
 @pytest.mark.parametrize("error", [None, "400_dne", "400_exists", "404"])
 async def test_create_user(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
@@ -910,7 +910,7 @@ async def test_create_user(
     """
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     document = {
         "_id": "foo",
@@ -974,7 +974,7 @@ async def test_create_user(
 @pytest.mark.parametrize("error", [None, "400_dne", "400_exists", "404"])
 async def test_create_group(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
@@ -990,8 +990,8 @@ async def test_create_group(
     """
     client = await spawn_client(authenticated=True)
 
-    group_1 = await fake2.groups.create()
-    group_2 = await fake2.groups.create()
+    group_1 = await fake.groups.create()
+    group_2 = await fake.groups.create()
 
     if error != "404":
         await mongo.references.insert_one(
@@ -1040,7 +1040,7 @@ async def test_create_group(
 @pytest.mark.parametrize("error", [None, "404_ref", "404_user"])
 async def test_update_user(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
@@ -1049,7 +1049,7 @@ async def test_update_user(
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     if error != "404_ref":
         await mongo.references.insert_one(
@@ -1105,7 +1105,7 @@ async def test_update_user(
 )
 async def test_update_group(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot,
     mongo: Mongo,
@@ -1114,7 +1114,7 @@ async def test_update_group(
 ):
     client = await spawn_client(authenticated=True)
 
-    group = await fake2.groups.create()
+    group = await fake.groups.create()
 
     if error != "404_ref":
         await mongo.references.insert_one(
@@ -1171,7 +1171,7 @@ async def test_update_group(
 )
 async def test_delete_user(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
@@ -1180,7 +1180,7 @@ async def test_delete_user(
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     if error != "404_ref":
         await mongo.references.insert_one(
@@ -1230,7 +1230,7 @@ async def test_delete_user(
 @pytest.mark.parametrize("error", [None, "404_group", "404_ref"])
 async def test_delete_group(
     error: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
@@ -1239,7 +1239,7 @@ async def test_delete_group(
 ):
     client = await spawn_client(authenticated=True)
 
-    group = await fake2.groups.create()
+    group = await fake.groups.create()
 
     if error != "404_ref":
         await mongo.references.insert_one(

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -6,10 +6,10 @@ from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
 from virtool.references.oas import (
-    UpdateReferenceRequest,
-    CreateReferenceUserRequest,
     CreateReferenceGroupRequest,
+    CreateReferenceUserRequest,
     ReferenceRightsRequest,
+    UpdateReferenceRequest,
 )
 
 
@@ -21,19 +21,18 @@ class TestUpdate:
         control_exists: bool,
         control_id: str | None,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mocker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
-        """
-        Test that the `internal_control` field is correctly set with various `internal_control` input value and the case
+        """Test that the `internal_control` field is correctly set with various `internal_control` input value and the case
         where the internal control ID refers to a non-existent OTU.
         The field should only be set when the input value is truthy and the control ID exists.
         """
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -55,13 +54,13 @@ class TestUpdate:
                         "modify": True,
                         "modify_otu": True,
                         "remove": True,
-                    }
+                    },
                 ],
-            }
+            },
         )
 
         update = UpdateReferenceRequest(
-            name="Tester", description="This is a test reference."
+            name="Tester", description="This is a test reference.",
         )
 
         if control_id is not None:
@@ -80,16 +79,15 @@ class TestCreateUser:
     async def test_ok(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
+        """Test that a user can be added to a reference.
         """
-        Test that a user can be added to a reference.
-        """
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -105,14 +103,14 @@ class TestCreateUser:
                 "source_types": [],
                 "user": {"id": user_1.id},
                 "users": [],
-            }
+            },
         )
 
         assert (
             await data_layer.references.create_user(
                 "foo",
                 CreateReferenceUserRequest(
-                    build=True, modify_otu=True, user_id=user_2.id
+                    build=True, modify_otu=True, user_id=user_2.id,
                 ),
             )
             == snapshot(name="obj")
@@ -120,13 +118,12 @@ class TestCreateUser:
         assert await mongo.references.find_one() == snapshot(name="mongo")
 
     async def test_duplicate(
-        self, data_layer: DataLayer, fake2: DataFaker, mongo: Mongo, static_time
+            self, data_layer: DataLayer, fake: DataFaker, mongo: Mongo, static_time,
     ):
+        """Test that a user cannot be added to a reference if they are already a member.
         """
-        Test that a user cannot be added to a reference if they are already a member.
-        """
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -142,22 +139,21 @@ class TestCreateUser:
                 "source_types": [],
                 "user": {"id": user_1.id},
                 "users": [{"id": user_2.id, "build": True, "modify_otu": True}],
-            }
+            },
         )
 
         with pytest.raises(ResourceConflictError) as err:
             await data_layer.references.create_user(
                 "foo",
                 CreateReferenceUserRequest(
-                    build=True, modify_otu=True, user_id=user_2.id
+                    build=True, modify_otu=True, user_id=user_2.id,
                 ),
             )
 
         assert "User already exists" in str(err)
 
     async def test_not_found(self, data_layer: DataLayer):
-        """
-        Test that a `NotFound` error is raised when the reference does not exist.
+        """Test that a `NotFound` error is raised when the reference does not exist.
         """
         with pytest.raises(ResourceNotFoundError):
             await data_layer.references.create_user(
@@ -166,10 +162,9 @@ class TestCreateUser:
             )
 
     async def test_user_does_not_exist(
-        self, data_layer: DataLayer, mongo: Mongo, static_time
+            self, data_layer: DataLayer, mongo: Mongo, static_time,
     ):
-        """
-        Test that a `NotFound` error is raised when the user does not exist.
+        """Test that a `NotFound` error is raised when the user does not exist.
         """
         await mongo.references.insert_one(
             {
@@ -185,14 +180,14 @@ class TestCreateUser:
                 "source_types": [],
                 "user": {"id": "bar"},
                 "users": [],
-            }
+            },
         )
 
         with pytest.raises(ResourceConflictError) as err:
             await data_layer.references.create_user(
                 "foo",
                 CreateReferenceUserRequest(
-                    build=True, modify_otu=True, user_id="not_exists"
+                    build=True, modify_otu=True, user_id="not_exists",
                 ),
             )
 
@@ -203,16 +198,15 @@ class TestUpdateUser:
     async def test_ok(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
+        """Test that the rights of a reference user can be updated.
         """
-        Test that the rights of a reference user can be updated.
-        """
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -235,9 +229,9 @@ class TestUpdateUser:
                         "modify": False,
                         "modify_otu": True,
                         "remove": False,
-                    }
+                    },
                 ],
-            }
+            },
         )
 
         assert (
@@ -270,15 +264,14 @@ class TestUpdateUser:
         self,
         reference_exists: bool,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         static_time,
     ):
-        """
-        Test that ``ResourceNotFound`` is raised when the reference or reference user
+        """Test that ``ResourceNotFound`` is raised when the reference or reference user
         do not exist.
         """
-        user_1 = await fake2.users.create()
+        user_1 = await fake.users.create()
 
         if reference_exists:
             await mongo.references.insert_one(
@@ -295,7 +288,7 @@ class TestUpdateUser:
                     "source_types": [],
                     "user": {"id": user_1.id},
                     "users": [],
-                }
+                },
             )
 
         with pytest.raises(ResourceNotFoundError):
@@ -312,16 +305,15 @@ class TestDeleteUser:
     async def test_ok(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
+        """Test that a user can be deleted from a reference.
         """
-        Test that a user can be deleted from a reference.
-        """
-        user_1 = await fake2.users.create()
-        user_2 = await fake2.users.create()
+        user_1 = await fake.users.create()
+        user_2 = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -344,9 +336,9 @@ class TestDeleteUser:
                         "modify": False,
                         "modify_otu": True,
                         "remove": False,
-                    }
+                    },
                 ],
-            }
+            },
         )
 
         assert await data_layer.references.delete_user("foo", user_2.id) is None
@@ -364,15 +356,14 @@ class TestDeleteUser:
         self,
         reference_exists: bool,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         static_time,
     ):
-        """
-        Test that ``ResourceNotFound`` is raised when the reference or reference user
+        """Test that ``ResourceNotFound`` is raised when the reference or reference user
         do not exist.
         """
-        user_1 = await fake2.users.create()
+        user_1 = await fake.users.create()
 
         if reference_exists:
             await mongo.references.insert_one(
@@ -389,7 +380,7 @@ class TestDeleteUser:
                     "source_types": [],
                     "user": {"id": user_1.id},
                     "users": [],
-                }
+                },
             )
 
         with pytest.raises(ResourceNotFoundError):
@@ -400,16 +391,15 @@ class TestCreateGroup:
     async def test_ok_and_duplicate(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
+        """Test that a group can be added to a reference.
         """
-        Test that a group can be added to a reference.
-        """
-        user = await fake2.users.create()
-        group = await fake2.groups.create()
+        user = await fake.users.create()
+        group = await fake.groups.create()
 
         await mongo.references.insert_one(
             {
@@ -425,14 +415,14 @@ class TestCreateGroup:
                 "source_types": [],
                 "user": {"id": user.id},
                 "users": [],
-            }
+            },
         )
 
         assert (
             await data_layer.references.create_group(
                 "foo",
                 CreateReferenceGroupRequest(
-                    build=True, modify_otu=True, group_id=group.id
+                    build=True, modify_otu=True, group_id=group.id,
                 ),
             )
             == snapshot(name="obj")
@@ -446,7 +436,7 @@ class TestCreateGroup:
             await data_layer.references.create_group(
                 "foo",
                 CreateReferenceGroupRequest(
-                    build=True, modify_otu=True, group_id=group.id
+                    build=True, modify_otu=True, group_id=group.id,
                 ),
             )
 
@@ -455,32 +445,30 @@ class TestCreateGroup:
     async def test_not_found(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
     ):
+        """Test that `ResourceNotFound` is raised when the reference does not exist.
         """
-        Test that `ResourceNotFound` is raised when the reference does not exist.
-        """
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
         with pytest.raises(ResourceNotFoundError):
             await data_layer.references.create_group(
                 "foo",
                 CreateReferenceGroupRequest(
-                    build=True, modify_otu=True, group_id=group.id
+                    build=True, modify_otu=True, group_id=group.id,
                 ),
             )
 
     async def test_group_does_not_exist(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         static_time,
     ):
+        """Test that `ResourceNotFound` is raised when the group does not exist.
         """
-        Test that `ResourceNotFound` is raised when the group does not exist.
-        """
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await mongo.references.insert_one(
             {
@@ -496,7 +484,7 @@ class TestCreateGroup:
                 "source_types": [],
                 "user": {"id": user.id},
                 "users": [],
-            }
+            },
         )
 
         with pytest.raises(ResourceConflictError) as err:
@@ -512,16 +500,15 @@ class TestUpdateGroup:
     async def test_ok(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
+        """Test that the rights of a reference group can be updated.
         """
-        Test that the rights of a reference group can be updated.
-        """
-        user = await fake2.users.create()
-        group = await fake2.groups.create()
+        user = await fake.users.create()
+        group = await fake.groups.create()
 
         await mongo.references.insert_one(
             {
@@ -537,7 +524,7 @@ class TestUpdateGroup:
                         "modify": False,
                         "modify_otu": True,
                         "remove": False,
-                    }
+                    },
                 ],
                 "internal_control": None,
                 "name": "Foo",
@@ -546,7 +533,7 @@ class TestUpdateGroup:
                 "source_types": [],
                 "user": {"id": user.id},
                 "users": [],
-            }
+            },
         )
 
         assert (
@@ -569,15 +556,14 @@ class TestUpdateGroup:
         self,
         reference_exists: bool,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         static_time,
     ):
-        """
-        Test that ``ResourceNotFound`` is raised when the reference or reference group
+        """Test that ``ResourceNotFound`` is raised when the reference or reference group
         do not exist.
         """
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         if reference_exists:
             await mongo.references.insert_one(
@@ -594,7 +580,7 @@ class TestUpdateGroup:
                     "source_types": [],
                     "user": {"id": user.id},
                     "users": [],
-                }
+                },
             )
 
         with pytest.raises(ResourceNotFoundError):
@@ -611,16 +597,15 @@ class TestDeleteGroup:
     async def test_ok(
         self,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot,
         static_time,
     ):
+        """Test that a group can be deleted from a reference.
         """
-        Test that a group can be deleted from a reference.
-        """
-        user = await fake2.users.create()
-        group = await fake2.groups.create()
+        user = await fake.users.create()
+        group = await fake.groups.create()
 
         await mongo.references.insert_one(
             {
@@ -636,7 +621,7 @@ class TestDeleteGroup:
                         "modify": False,
                         "modify_otu": True,
                         "remove": False,
-                    }
+                    },
                 ],
                 "internal_control": None,
                 "name": "Foo",
@@ -645,7 +630,7 @@ class TestDeleteGroup:
                 "source_types": [],
                 "user": {"id": user.id},
                 "users": [],
-            }
+            },
         )
 
         assert await data_layer.references.delete_group("foo", group.id) is None
@@ -663,15 +648,14 @@ class TestDeleteGroup:
         self,
         reference_exists: bool,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         static_time,
     ):
-        """
-        Test that ``ResourceNotFound`` is raised when the reference or reference group
+        """Test that ``ResourceNotFound`` is raised when the reference or reference group
         do not exist.
         """
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         if reference_exists:
             await mongo.references.insert_one(
@@ -688,7 +672,7 @@ class TestDeleteGroup:
                     "source_types": [],
                     "user": {"id": user.id},
                     "users": [],
-                }
+                },
             )
 
         with pytest.raises(ResourceNotFoundError):

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -123,13 +123,13 @@ async def test_fetch_and_update_release(mongo: Mongo, fake_app, snapshot, static
 
 
 async def test_get_reference_groups(
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
     """Test that reference groups are returned whether they have integer or string ids."""
-    group_1 = await fake2.groups.create()
-    group_2 = await fake2.groups.create(legacy_id="group_2")
+    group_1 = await fake.groups.create()
+    group_2 = await fake.groups.create(legacy_id="group_2")
 
     assert (
         await get_reference_groups(

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -48,7 +48,7 @@ TEST_FILES_PATH = Path(__file__).parent.parent / "test_files"
 async def test_clean_references_task(
     update,
     data_layer,
-    fake2,
+        fake: DataFaker,
     mocker,
     mongo,
     pg,
@@ -76,7 +76,7 @@ async def test_clean_references_task(
         created_at=static_time.datetime,
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     if update:
         updates = [
@@ -176,13 +176,13 @@ async def test_import_reference_task(
     assert_reference_created,
     data_layer: DataLayer,
     data_path: Path,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     pg: AsyncEngine,
     static_time,
     tmpdir,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     upload = await data_layer.uploads.create(
         fake_file_chunker(TEST_FILES_PATH / "reference.json.gz"),
@@ -285,14 +285,14 @@ async def test_remote_reference_task(
 
 @pytest.fixture()
 async def create_reference(
-    fake2: DataFaker,
+        fake: DataFaker,
     data_layer: DataLayer,
     mongo,
     pg,
     static_time,
     tmpdir,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     upload = await data_layer.uploads.create(
         fake_file_chunker(TEST_FILES_PATH / "reference.json.gz"),
@@ -351,7 +351,7 @@ async def test_clone_reference_task(
     assert_reference_created,
     create_reference: str,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo,
     pg: AsyncEngine,
     static_time,
@@ -359,7 +359,7 @@ async def test_clone_reference_task(
 ):
     manifest = await get_manifest(mongo, create_reference)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await mongo.references.insert_one(
         {

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -29,10 +29,10 @@ class MockJobInterface:
 
 
 @pytest.fixture()
-async def get_sample_ready_false(fake2: DataFaker, mongo: Mongo, static_time):
-    label = await fake2.labels.create()
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user, workflow="create_sample")
+async def get_sample_ready_false(fake: DataFaker, mongo: Mongo, static_time):
+    label = await fake.labels.create()
+    user = await fake.users.create()
+    job = await fake.jobs.create(user, workflow="create_sample")
 
     await mongo.subtraction.insert_many(
         [
@@ -87,13 +87,13 @@ async def get_sample_ready_false(fake2: DataFaker, mongo: Mongo, static_time):
 @pytest.fixture()
 async def get_sample_data(
     mongo: "Mongo",
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     static_time,
 ):
-    label = await fake2.labels.create()
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user, workflow="create_sample")
+    label = await fake.labels.create()
+    user = await fake.users.create()
+    job = await fake.jobs.create(user, workflow="create_sample")
 
     await asyncio.gather(
         mongo.subtraction.insert_many(
@@ -172,19 +172,19 @@ async def get_sample_data(
 
 @pytest.fixture()
 async def find_samples_client(
-    fake2,
+        fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
     static_time,
 ):
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
-    label_1 = await fake2.labels.create()
-    label_2 = await fake2.labels.create()
-    label_3 = await fake2.labels.create()
+    label_1 = await fake.labels.create()
+    label_2 = await fake.labels.create()
+    label_3 = await fake.labels.create()
 
-    job = await fake2.jobs.create(user_1, workflow="create_sample")
+    job = await fake.jobs.create(user_1, workflow="create_sample")
 
     client = await spawn_client(authenticated=True)
 
@@ -378,7 +378,7 @@ class TestGet:
 
     async def test_all_read(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         get_sample_data,
         snapshot: SnapshotAssertion,
         mongo: Mongo,
@@ -389,7 +389,7 @@ class TestGet:
         """
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await mongo.samples.update_one(
             {"_id": "test"},
@@ -412,7 +412,7 @@ class TestGet:
     async def test_group_read(
         self,
         is_member: bool,
-        fake2: DataFaker,
+            fake: DataFaker,
         get_sample_data,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
@@ -423,8 +423,8 @@ class TestGet:
         """
         client = await spawn_client(authenticated=True)
 
-        group = await fake2.groups.create()
-        user = await fake2.users.create()
+        group = await fake.groups.create()
+        user = await fake.users.create()
 
         if is_member:
             await get_data_from_app(client.app).users.update(
@@ -460,7 +460,7 @@ class TestCreate:
         self,
         group_setting: str,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot_recent,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -470,7 +470,7 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
         await data_layer.settings.update(
             UpdateSettingsRequest(
@@ -490,8 +490,8 @@ class TestCreate:
             UpdateUserRequest(primary_group=group.id),
         )
 
-        label = await fake2.labels.create()
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        label = await fake.labels.create()
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         await mongo.subtraction.insert_one({"_id": "apple", "name": "Apple"})
 
@@ -514,7 +514,7 @@ class TestCreate:
     async def test_name_exists(
         self,
         path: str,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -525,7 +525,7 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         await asyncio.gather(
             mongo.samples.insert_one(
@@ -554,7 +554,7 @@ class TestCreate:
     async def test_force_choice(
         self,
         error: str | None,
-        fake2: DataFaker,
+            fake: DataFaker,
         resp_is,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -569,9 +569,9 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         await asyncio.gather(
             get_data_from_app(client.app).settings.update(
@@ -596,7 +596,7 @@ class TestCreate:
 
     async def test_group_dne(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         resp_is,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -610,7 +610,7 @@ class TestCreate:
             UpdateSettingsRequest(sample_group="force_choice"),
         )
 
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         await asyncio.gather(
             get_data_from_app(client.app).settings.update(
@@ -635,7 +635,7 @@ class TestCreate:
 
     async def test_subtraction_dne(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         resp_is,
         spawn_client: ClientSpawner,
     ):
@@ -644,7 +644,7 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         resp = await client.post(
             "/samples",
@@ -657,7 +657,7 @@ class TestCreate:
     async def test_file_dne(
         self,
         one_exists: bool,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
         resp_is,
@@ -678,7 +678,7 @@ class TestCreate:
         )
 
         if one_exists:
-            upload = await fake2.uploads.create(user=await fake2.users.create())
+            upload = await fake.uploads.create(user=await fake.users.create())
             files = [upload.id, 21]
         else:
             files = [20, 21]
@@ -692,7 +692,7 @@ class TestCreate:
 
     async def test_label_dne(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         resp_is,
         spawn_client: ClientSpawner,
     ):
@@ -701,7 +701,7 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         resp = await client.post(
             "/samples",
@@ -803,7 +803,7 @@ class TestEdit:
 
     async def test_subtraction_exists(
         self,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -814,7 +814,7 @@ class TestEdit:
         """
         client = await spawn_client(administrator=True, authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await asyncio.gather(
             mongo.samples.insert_one(
@@ -883,7 +883,7 @@ class TestDelete:
         self,
         data_path: Path,
         finalized: bool,
-        fake2: DataFaker,
+            fake: DataFaker,
         spawn_client: ClientSpawner,
         tmp_path: Path,
     ):
@@ -891,7 +891,7 @@ class TestDelete:
 
         (data_path / "samples/test").mkdir(parents=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await create_fake_sample(client.app, "test", user.id, finalized=finalized)
 
@@ -904,7 +904,7 @@ class TestDelete:
         self,
         finalized: bool,
         data_path: Path,
-        fake2: DataFaker,
+            fake: DataFaker,
         spawn_job_client,
     ):
         """Test that job client can delete a sample only when it is unfinalized."""
@@ -912,7 +912,7 @@ class TestDelete:
 
         (data_path / "samples/test").mkdir(parents=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         await create_fake_sample(client.app, "test", user.id, finalized=finalized)
 
@@ -935,7 +935,7 @@ class TestDelete:
 
 
 async def test_find_analyses(
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
     spawn_client: ClientSpawner,
@@ -943,10 +943,10 @@ async def test_find_analyses(
 ):
     client = await spawn_client(authenticated=True)
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
-    job = await fake2.jobs.create(user=user_1)
+    job = await fake.jobs.create(user=user_1)
 
     await mongo.samples.insert_one(
         {
@@ -1222,7 +1222,7 @@ class TestUploadReads:
     async def test_uncompressed(
         self,
         example_path: Path,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_job_client: JobClientSpawner,
@@ -1237,7 +1237,7 @@ class TestUploadReads:
             },
         )
 
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         resp = await client.put(
             f"/samples/test/reads/reads_1.fq.gz?upload={upload.id}",
@@ -1357,13 +1357,13 @@ async def test_download_artifact(
 class TestChangeSampleRights:
     async def test_update_group_id(
         self,
-        fake2,
+            fake: DataFaker,
         get_sample_data,
         mongo,
         snapshot,
         spawn_client,
     ):
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
         client = await spawn_client(administrator=True, authenticated=True)
         resp = await client.patch("/samples/test/rights", data={"group": group.id})
@@ -1374,7 +1374,7 @@ class TestChangeSampleRights:
     async def test_set_none_group_id(
         self,
         get_sample_data,
-        fake2,
+            fake: DataFaker,
         mongo,
         snapshot,
         spawn_client,
@@ -1430,12 +1430,12 @@ class TestChangeSampleRights:
     async def test_update_all_rights(
         self,
         get_sample_data,
-        fake2: DataFaker,
+            fake: DataFaker,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
         client = await spawn_client(administrator=True, authenticated=True)
         resp = await client.patch(

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -20,10 +20,10 @@ from virtool.users.oas import UpdateUserRequest
 
 
 @pytest.fixture()
-async def get_sample_ready_false(fake2: DataFaker, mongo: Mongo, static_time):
-    label = await fake2.labels.create()
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user, workflow="create_sample")
+async def get_sample_ready_false(fake: DataFaker, mongo: Mongo, static_time):
+    label = await fake.labels.create()
+    user = await fake.users.create()
+    job = await fake.jobs.create(user, workflow="create_sample")
 
     await mongo.subtraction.insert_many(
         [
@@ -84,7 +84,7 @@ class TestCreate:
         self,
         group_setting: str,
         data_layer: DataLayer,
-        fake2: DataFaker,
+            fake: DataFaker,
         pg: AsyncEngine,
         mongo: Mongo,
         snapshot_recent,
@@ -96,7 +96,7 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        group = await fake2.groups.create()
+        group = await fake.groups.create()
 
         await data_layer.settings.update(
             UpdateSettingsRequest(
@@ -115,8 +115,8 @@ class TestCreate:
             UpdateUserRequest(primary_group=group.id),
         )
 
-        label = await fake2.labels.create()
-        upload = await fake2.uploads.create(user=await fake2.users.create())
+        label = await fake.labels.create()
+        upload = await fake.uploads.create(user=await fake.users.create())
 
         await asyncio.gather(
             mongo.subtraction.insert_one({"_id": "apple", "name": "Apple"}),

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -15,14 +15,14 @@ async def test_create_fake_sample(
     paired,
     finalized,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot,
     spawn_client: ClientSpawner,
     static_time,
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await create_fake_sample(
         client.app,

--- a/tests/samples/test_utils.py
+++ b/tests/samples/test_utils.py
@@ -1,11 +1,12 @@
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from virtool.fake.next import DataFaker
 from virtool.samples.utils import check_labels
 
 
-async def test_check_labels(fake2, spawn_client, pg: AsyncEngine):
-    label_1 = await fake2.labels.create()
-    label_2 = await fake2.labels.create()
+async def test_check_labels(fake: DataFaker, spawn_client, pg: AsyncEngine):
+    label_1 = await fake.labels.create()
+    label_2 = await fake.labels.create()
 
     assert await check_labels(pg, [label_1.id, label_2.id]) == []
     assert await check_labels(pg, [label_2.id, 14]) == [14]

--- a/tests/spaces/test_api.py
+++ b/tests/spaces/test_api.py
@@ -61,7 +61,7 @@ async def test_list(
 
 
 async def test_get(
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot,
     spawn_client: ClientSpawner,
@@ -73,7 +73,7 @@ async def test_get(
         flags=[FlagName.SPACES],
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -136,7 +136,7 @@ async def test_update(
 
 
 async def test_list_space_members(
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot,
     spawn_client: ClientSpawner,
@@ -148,8 +148,8 @@ async def test_list_space_members(
         flags=[FlagName.SPACES],
     )
 
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -178,7 +178,7 @@ async def test_list_space_members(
 
 
 async def test_update_member_roles(
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot,
     spawn_client: ClientSpawner,
@@ -190,7 +190,7 @@ async def test_update_member_roles(
         flags=[FlagName.SPACES],
     )
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -220,7 +220,7 @@ async def test_update_member_roles(
 
 
 async def test_remove_member(
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     spawn_client: ClientSpawner,
     static_time,
@@ -231,7 +231,7 @@ async def test_remove_member(
         flags=[FlagName.SPACES],
     )
 
-    user_1 = await fake2.users.create()
+    user_1 = await fake.users.create()
 
     async with AsyncSession(pg) as session:
         session.add(

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -32,7 +32,7 @@ async def test_find_empty_subtractions(
 async def test_find(
     page: int | None,
     per_page: int | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot,
     mongo: Mongo,
     spawn_client: ClientSpawner,
@@ -40,8 +40,8 @@ async def test_find(
 ):
     client = await spawn_client(authenticated=True)
 
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user)
 
     await mongo.subtraction.insert_many(
         [
@@ -82,14 +82,14 @@ async def test_find(
 
 
 async def test_get(
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
     snapshot,
     static_time,
 ):
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user)
 
     client = await spawn_client(authenticated=True)
 
@@ -117,14 +117,14 @@ async def test_get(
     assert await resp.json() == snapshot
 
 
-async def test_get_from_job(fake2: DataFaker, spawn_job_client, snapshot_recent):
+async def test_get_from_job(fake: DataFaker, spawn_job_client, snapshot_recent):
     client = await spawn_job_client(authenticated=True)
 
-    user = await fake2.users.create()
-    upload = await fake2.uploads.create(
+    user = await fake.users.create()
+    upload = await fake.uploads.create(
         user=user, upload_type=UploadType.subtraction, name="foobar.fq.gz",
     )
-    subtraction = await fake2.subtractions.create(user=user, upload=upload)
+    subtraction = await fake.subtractions.create(user=user, upload=upload)
 
     resp = await client.get(f"/subtractions/{subtraction.id}")
 
@@ -150,13 +150,13 @@ async def test_edit(
     data: dict,
     has_job: bool,
     has_user: bool,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
     spawn_client: ClientSpawner,
     static_time,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await mongo.samples.insert_many(
         [
@@ -185,7 +185,7 @@ async def test_edit(
         document["user"] = {"id": user.id}
 
     if has_job:
-        job = await fake2.jobs.create(user)
+        job = await fake.jobs.create(user)
         document["job"] = {"id": job.id}
 
     client = await spawn_client(
@@ -205,7 +205,7 @@ async def test_edit(
 @pytest.mark.parametrize("exists", [True, False])
 async def test_delete(
     exists: bool,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     mongo: Mongo,
     spawn_client: ClientSpawner,
@@ -219,8 +219,8 @@ async def test_delete(
     get_config_from_app(client.app).data_path = tmp_path
 
     if exists:
-        user = await fake2.users.create()
-        job = await fake2.jobs.create(user)
+        user = await fake.users.create()
+        job = await fake.jobs.create(user)
 
         await mongo.subtraction.insert_one(
             {
@@ -294,7 +294,7 @@ async def test_upload(
 @pytest.mark.parametrize("error", [None, "404", "409", "422"])
 async def test_finalize(
     error: str | None,
-    fake2,
+        fake: DataFaker,
     snapshot,
     mongo: Mongo,
     spawn_job_client,
@@ -304,8 +304,8 @@ async def test_finalize(
 ):
     client = await spawn_job_client(authenticated=True)
 
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user)
 
     document = {
         "_id": "foo",
@@ -357,7 +357,7 @@ async def test_finalize(
 async def test_job_remove(
     exists: bool,
     ready: bool,
-    fake2: DataFaker,
+        fake: DataFaker,
     resp_is,
     snapshot,
     mongo: Mongo,
@@ -369,8 +369,8 @@ async def test_job_remove(
 
     get_config_from_app(client.app).data_path = tmp_path
 
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user)
 
     if exists:
         await asyncio.gather(
@@ -466,7 +466,7 @@ async def test_download_subtraction_files(
 
 
 async def test_create(
-    fake2,
+        fake: DataFaker,
     pg,
     mongo: Mongo,
     spawn_client,
@@ -474,7 +474,7 @@ async def test_create(
     snapshot,
     static_time,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     async with AsyncSession(pg) as session:
         upload = SQLUpload(

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -8,13 +8,13 @@ from virtool.subtractions.oas import FinalizeSubtractionRequest
 
 async def test_finalize(
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     snapshot: SnapshotAssertion,
     static_time,
 ):
-    user = await fake2.users.create()
-    job = await fake2.jobs.create(user)
+    user = await fake.users.create()
+    job = await fake.jobs.create(user)
 
     await mongo.subtraction.insert_one(
         {
@@ -33,16 +33,13 @@ async def test_finalize(
             "ready": False,
             "user": {"id": user.id},
             "job": {"id": job.id},
-        }
+        },
     )
 
     subtraction = await data_layer.subtractions.finalize(
         "apple",
         FinalizeSubtractionRequest(
-            **{
-                "gc": {"a": 0.319, "t": 0.319, "g": 0.18, "c": 0.18, "n": 0.002},
-                "count": 100,
-            }
+            gc={"a": 0.319, "t": 0.319, "g": 0.18, "c": 0.18, "n": 0.002}, count=100,
         ),
     )
 

--- a/tests/tasks/test_transforms.py
+++ b/tests/tasks/test_transforms.py
@@ -5,14 +5,15 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy.matchers import path_type
 
 from virtool.data.transforms import apply_transforms
+from virtool.fake.next import DataFaker
 from virtool.tasks.transforms import AttachTaskTransform
 
 
-async def test_attach_task_transform(fake2, pg: AsyncEngine, snapshot):
-    await fake2.tasks.create()
-    await fake2.tasks.create()
-    task_2 = await fake2.tasks.create()
-    task_3 = await fake2.tasks.create()
+async def test_attach_task_transform(fake: DataFaker, pg: AsyncEngine, snapshot):
+    await fake.tasks.create()
+    await fake.tasks.create()
+    task_2 = await fake.tasks.create()
+    task_3 = await fake.tasks.create()
 
     documents = [
         {"id": 1, "task": {"id": task_2.id}},
@@ -26,18 +27,18 @@ async def test_attach_task_transform(fake2, pg: AsyncEngine, snapshot):
     transformed = await apply_transforms(documents, [AttachTaskTransform(pg)])
 
     assert transformed == snapshot(
-        matcher=path_type({".*created_at": (datetime,)}, regex=True)
+        matcher=path_type({".*created_at": (datetime,)}, regex=True),
     )
 
 
-async def test_attach_task_transform_single(fake2, pg: AsyncEngine, snapshot):
-    await fake2.tasks.create()
-    task = await fake2.tasks.create()
+async def test_attach_task_transform_single(fake: DataFaker, pg: AsyncEngine, snapshot):
+    await fake.tasks.create()
+    task = await fake.tasks.create()
 
     assert (
         await asyncio.gather(
             apply_transforms(
-                {"id": 1, "task": {"id": task.id}}, [AttachTaskTransform(pg)]
+                {"id": 1, "task": {"id": task.id}}, [AttachTaskTransform(pg)],
             ),
             apply_transforms({"id": 2, "task": None}, [AttachTaskTransform(pg)]),
         )

--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -101,7 +101,7 @@ class TestFind:
     async def test(
         self,
         upload_type: UploadType | None,
-        fake2: DataFaker,
+            fake: DataFaker,
         spawn_client: ClientSpawner,
         snapshot,
         static_time,
@@ -109,11 +109,11 @@ class TestFind:
         """Test `GET /uploads` to assure that it returns the correct `upload` documents."""
         client = await spawn_client(authenticated=True)
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
-        await fake2.uploads.create(user=user)
-        await fake2.uploads.create(user=user, upload_type=UploadType.reference)
-        await fake2.uploads.create(user=user, upload_type=UploadType.subtraction)
+        await fake.uploads.create(user=user)
+        await fake.uploads.create(user=user, upload_type=UploadType.reference)
+        await fake.uploads.create(user=user, upload_type=UploadType.subtraction)
 
         url = "/uploads"
 
@@ -140,7 +140,7 @@ class TestFind:
         self,
         page: int | None,
         per_page: int | None,
-        fake2: DataFaker,
+            fake: DataFaker,
         snapshot,
         spawn_client: ClientSpawner,
         static_time,
@@ -150,12 +150,12 @@ class TestFind:
             authenticated=True,
         )
 
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
-        await fake2.uploads.create(user=user)
-        await fake2.uploads.create(user=user, reserved=True)
-        await fake2.uploads.create(user=user, upload_type=UploadType.reference)
-        await fake2.uploads.create(user=user, upload_type=UploadType.subtraction)
+        await fake.uploads.create(user=user)
+        await fake.uploads.create(user=user, reserved=True)
+        await fake.uploads.create(user=user, upload_type=UploadType.reference)
+        await fake.uploads.create(user=user, upload_type=UploadType.subtraction)
 
         url = "/uploads?paginate=true"
 
@@ -173,13 +173,13 @@ class TestFind:
 
 async def test_get(
     example_path: Path,
-    fake2: DataFaker,
+        fake: DataFaker,
     spawn_client: ClientSpawner,
 ):
     """Test `GET /uploads/:id` to assure that it lets you download a file."""
     client = await spawn_client(authenticated=True)
 
-    upload = await fake2.uploads.create(user=await fake2.users.create())
+    upload = await fake.uploads.create(user=await fake.users.create())
 
     resp: ClientResponse = await client.get(f"/uploads/{upload.id}")
 
@@ -187,14 +187,14 @@ async def test_get(
     assert await resp.read() == open(example_path / "reads/single.fq.gz", "rb").read()
 
 
-async def test_delete(fake2: DataFaker, resp_is, spawn_client: ClientSpawner):
+async def test_delete(fake: DataFaker, resp_is, spawn_client: ClientSpawner):
     """Test `DELETE /uploads/:id to assure that it properly deletes an existing
     `uploads` row and file.
 
     """
     client = await spawn_client(authenticated=True, administrator=True)
 
-    upload = await fake2.uploads.create(user=await fake2.users.create())
+    upload = await fake.uploads.create(user=await fake.users.create())
 
     resp = await client.delete(f"/uploads/{upload.id}")
     await resp_is.no_content(resp)

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -18,11 +18,11 @@ async def test_create(
     data_path: Path,
     data_layer: DataLayer,
     example_path: Path,
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
     snapshot,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     fake_file_path = example_path / "reads/single.fq.gz"
 
@@ -56,10 +56,10 @@ async def test_create(
 async def test_delete(
     data_path: Path,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot_recent: SnapshotAssertion,
 ):
-    before = await fake2.uploads.create(user=await fake2.users.create())
+    before = await fake.uploads.create(user=await fake.users.create())
 
     path = data_path / "files" / before.name_on_disk
 
@@ -86,14 +86,14 @@ async def test_delete(
 async def test_release(
     multi: bool,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     pg: AsyncEngine,
 ):
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
-    upload_1 = await fake2.uploads.create(user=user, reserved=True)
-    upload_2 = await fake2.uploads.create(user=user, reserved=True)
-    upload_3 = await fake2.uploads.create(user=user, reserved=True)
+    upload_1 = await fake.uploads.create(user=user, reserved=True)
+    upload_2 = await fake.uploads.create(user=user, reserved=True)
+    upload_3 = await fake.uploads.create(user=user, reserved=True)
 
     assert all([upload_1.reserved, upload_2.reserved, upload_3.reserved])
 

--- a/tests/users/test_api.py
+++ b/tests/users/test_api.py
@@ -21,13 +21,13 @@ from virtool.users.utils import check_password
 @pytest.fixture()
 async def setup_update_user(
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     spawn_client: ClientSpawner,
 ):
     client = await spawn_client(administrator=True, authenticated=True)
 
-    group_1 = await fake2.groups.create()
-    group_2 = await fake2.groups.create()
+    group_1 = await fake.groups.create()
+    group_2 = await fake.groups.create()
 
     await data_layer.groups.update(
         group_1.id,
@@ -41,13 +41,13 @@ async def setup_update_user(
         ),
     )
 
-    return client, group_1, group_2, await fake2.users.create(groups=[group_1])
+    return client, group_1, group_2, await fake.users.create(groups=[group_1])
 
 
 @pytest.mark.parametrize("find", [None, "fred"])
 async def test_find(
     find: str | None,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot: SnapshotAssertion,
     spawn_client: ClientSpawner,
     static_time,
@@ -59,8 +59,8 @@ async def test_find(
         permissions=[Permission.create_sample],
     )
 
-    await fake2.users.create(handle=find)
-    await fake2.users.create()
+    await fake.users.create(handle=find)
+    await fake.users.create()
 
     url = "/users"
 
@@ -76,7 +76,7 @@ async def test_find(
 @pytest.mark.parametrize("status", [200, 404])
 async def test_get(
     status: int,
-    fake2: DataFaker,
+        fake: DataFaker,
     snapshot: SnapshotAssertion,
     spawn_client: ClientSpawner,
     static_time,
@@ -84,14 +84,14 @@ async def test_get(
     """Test that a ``GET /users`` returns a list of users."""
     client = await spawn_client(administrator=True, authenticated=True)
 
-    group = await fake2.groups.create()
+    group = await fake.groups.create()
 
-    user = await fake2.users.create(
-        groups=[group, await fake2.groups.create()],
+    user = await fake.users.create(
+        groups=[group, await fake.groups.create()],
         primary_group=group,
     )
 
-    await fake2.users.create()
+    await fake.users.create()
 
     resp = await client.get(f"/users/{'foo' if status == 404 else user.id}")
 
@@ -103,7 +103,7 @@ async def test_get(
 async def test_create(
     error: str | None,
     data_layer: DataLayer,
-    fake2: DataFaker,
+        fake: DataFaker,
     mongo: Mongo,
     resp_is,
     snapshot: SnapshotAssertion,
@@ -115,7 +115,7 @@ async def test_create(
 
     client = await spawn_client(administrator=True, authenticated=True)
 
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     await get_data_from_app(client.app).settings.update(
         UpdateSettingsRequest(minimum_password_length=8),

--- a/tests/users/test_sessions.py
+++ b/tests/users/test_sessions.py
@@ -7,6 +7,7 @@ from syrupy.matchers import path_type
 
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
+from virtool.fake.next import DataFaker
 
 
 async def test_remember_anonymous(data_layer, redis):
@@ -18,22 +19,21 @@ async def test_remember_anonymous(data_layer, redis):
 @pytest.mark.parametrize("remember", [False, True])
 async def test_remember_authenticated(
     data_layer,
-    fake2,
+        fake: DataFaker,
     redis,
     remember,
 ):
-    """
-    Test that the session object gets the correct TTL in Redis based on whether
+    """Test that the session object gets the correct TTL in Redis based on whether
     ``remember`` is set.
     """
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     session, _ = await data_layer.sessions.create_authenticated(
-        "1.1.1.1", user.id, remember=remember
+        "1.1.1.1", user.id, remember=remember,
     )
 
     assert isclose(
-        await redis.ttl(session.id), 2592000 if remember else 3600, abs_tol=10
+        await redis.ttl(session.id), 2592000 if remember else 3600, abs_tol=10,
     )
 
 
@@ -45,7 +45,7 @@ class TestAuthenticated:
     ):
         """Test that an authenticated session can be created and then retrieved."""
         session, token = await data_layer.sessions.create_authenticated(
-            "1.1.1.1", "user_id", False
+            "1.1.1.1", "user_id", False,
         )
 
         assert (
@@ -56,11 +56,10 @@ class TestAuthenticated:
         )
 
     async def test_invalid_token(self, data_layer: DataLayer, snapshot):
-        """
-        Test that a ``ResourceNotFound`` error is raised when the token is invalid.
+        """Test that a ``ResourceNotFound`` error is raised when the token is invalid.
         """
         session, _ = await data_layer.sessions.create_authenticated(
-            "1.1.1.1", "user_id", False
+            "1.1.1.1", "user_id", False,
         )
 
         with pytest.raises(ResourceNotFoundError) as err:
@@ -68,16 +67,14 @@ class TestAuthenticated:
             assert str(err) == "Invalid session token"
 
     async def test_invalid_session(self, data_layer):
-        """
-        Test that ``ResourceNotFound`` is raised when the session ID does not exist.
+        """Test that ``ResourceNotFound`` is raised when the session ID does not exist.
         """
         with pytest.raises(ResourceNotFoundError) as err:
             await data_layer.sessions.get_authenticated("invalid_session", "token")
             assert str(err) == "Session not found"
 
     async def test_anonymous_session(self, data_layer, snapshot):
-        """
-        Test that an anonymous session cannot be retrieved using get_authenticated.
+        """Test that an anonymous session cannot be retrieved using get_authenticated.
         """
         session = await data_layer.sessions.create_anonymous("1.1.1.1")
 
@@ -88,7 +85,7 @@ class TestAuthenticated:
     async def test_reset_session(self, data_layer, snapshot):
         """Test that a reset session cannot be retrieved using get_authenticated."""
         session, code = await data_layer.sessions.create_reset(
-            "1.1.1.1", "user_id", False
+            "1.1.1.1", "user_id", False,
         )
 
         with pytest.raises(ResourceNotFoundError) as err:
@@ -106,24 +103,22 @@ class TestAnonymous:
         session = await data_layer.sessions.create_anonymous("1.1.1.1")
 
         assert (await data_layer.sessions.get_anonymous(session.id)) == snapshot(
-            matcher=path_type({"id": (str,), "created_at": (datetime,)})
+            matcher=path_type({"id": (str,), "created_at": (datetime,)}),
         )
 
     async def test_no_session(self, data_layer):
-        """
-        Test that ``ResourceNotFound`` is raised when the session ID does not exist.
+        """Test that ``ResourceNotFound`` is raised when the session ID does not exist.
         """
         with pytest.raises(ResourceNotFoundError) as err:
             await data_layer.sessions.get_anonymous("invalid_session")
             assert str(err) == "Session not found"
 
     async def test_authenticated_session(self, data_layer, snapshot):
-        """
-        Test that an exception is raised when we attempt to get a session that is
+        """Test that an exception is raised when we attempt to get a session that is
         actually authenticated instead of anonymous.
         """
         session, _ = await data_layer.sessions.create_authenticated(
-            "1.1.1.1", "user_id"
+            "1.1.1.1", "user_id",
         )
 
         with pytest.raises(ResourceNotFoundError) as err:
@@ -131,8 +126,7 @@ class TestAnonymous:
             assert str(err) == "Session not found"
 
     async def test_reset_session(self, data_layer, snapshot):
-        """
-        Test that an exception is raised when and we attempt to get a session that is
+        """Test that an exception is raised when and we attempt to get a session that is
         actually a reset session instead of an anonymous one.
         """
         session, _ = await data_layer.sessions.create_reset("1.1.1.1", "user_id", False)
@@ -146,36 +140,34 @@ class TestReset:
     async def test_create_and_get(
         self,
         data_layer,
-        fake2,
+            fake: DataFaker,
         redis,
         snapshot,
     ):
-        """
-        Test that a reset session can be created and retrieved using its ID and reset
+        """Test that a reset session can be created and retrieved using its ID and reset
         code.
         """
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         created_session, reset_code = await data_layer.sessions.create_reset(
-            "1.1.1.1", user.id, remember=True
+            "1.1.1.1", user.id, remember=True,
         )
 
         session = await data_layer.sessions.get_reset(created_session.id, reset_code)
 
         assert session == snapshot(
-            matcher=path_type({"id": (str,), "created_at": (datetime,)})
+            matcher=path_type({"id": (str,), "created_at": (datetime,)}),
         )
 
         assert session.id == created_session.id
 
-    async def test_no_session(self, data_layer, fake2):
+    async def test_no_session(self, data_layer, fake):
+        """Test that ``ResourceNotFound`` is raised when the session doesn't exist.
         """
-        Test that ``ResourceNotFound`` is raised when the session doesn't exist.
-        """
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         session, reset_code = await data_layer.sessions.create_reset(
-            "1.1.1.1", user.id, remember=True
+            "1.1.1.1", user.id, remember=True,
         )
 
         await data_layer.sessions.delete(session.id)
@@ -184,15 +176,14 @@ class TestReset:
             await data_layer.sessions.get_reset(session.id, reset_code)
             assert str(err) == "Session not found"
 
-    async def test_invalid_reset_code(self, data_layer, fake2):
-        """
-        Test that ``ResourceNotFound`` is raised when the provided reset code is invalid
+    async def test_invalid_reset_code(self, data_layer, fake):
+        """Test that ``ResourceNotFound`` is raised when the provided reset code is invalid
         for the session.
         """
-        user = await fake2.users.create()
+        user = await fake.users.create()
 
         session, _ = await data_layer.sessions.create_reset(
-            "1.1.1.1", user.id, remember=True
+            "1.1.1.1", user.id, remember=True,
         )
 
         with pytest.raises(ResourceNotFoundError) as err:
@@ -202,18 +193,18 @@ class TestReset:
 
 async def test_delete(
     data_layer: DataLayer,
-    fake2,
+        fake: DataFaker,
     snapshot,
 ):
     """Test that all types of sessions can be deleted by their IDs."""
-    user = await fake2.users.create()
+    user = await fake.users.create()
 
     session_anonymous = await data_layer.sessions.create_anonymous("1.1.1.1")
     session_authenticated, token = await data_layer.sessions.create_authenticated(
-        "2.2.2.2", user.id, remember=True
+        "2.2.2.2", user.id, remember=True,
     )
     session_reset, reset_code = await data_layer.sessions.create_reset(
-        "3.3.3.3", user.id, remember=True
+        "3.3.3.3", user.id, remember=True,
     )
 
     # Make sure get method don't raise ``ResourceNotFound``.
@@ -222,7 +213,7 @@ async def test_delete(
             data_layer.sessions.get_anonymous(session_anonymous.id),
             data_layer.sessions.get_authenticated(session_authenticated.id, token),
             data_layer.sessions.get_reset(session_reset.id, reset_code),
-        )
+        ),
     )
 
     await asyncio.gather(

--- a/tests/users/test_transforms.py
+++ b/tests/users/test_transforms.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 from virtool.data.transforms import apply_transforms
@@ -10,10 +10,9 @@ from virtool.users.transforms import AttachPermissionsTransform, AttachUserTrans
 
 
 async def test_permission_transform(
-    no_permissions: dict[str, bool], pg: AsyncEngine, snapshot: SnapshotAssertion
+        no_permissions: dict[str, bool], pg: AsyncEngine, snapshot: SnapshotAssertion,
 ):
-    """
-    Test that the transform works with legacy and SQL ids, as well as a single document
+    """Test that the transform works with legacy and SQL ids, as well as a single document
     or a list of documents.
     """
     async with AsyncSession(pg) as session:
@@ -52,7 +51,7 @@ async def test_permission_transform(
                     legacy_id="group_5",
                     permissions={**no_permissions, "create_ref": True},
                 ),
-            ]
+            ],
         )
 
         await session.commit()
@@ -81,10 +80,10 @@ async def test_permission_transform(
 
 @pytest.mark.parametrize("multiple", [True, False])
 async def test_attach_user_transform(
-    multiple: bool, fake2: DataFaker, mongo: Mongo, snapshot: SnapshotAssertion
+        multiple: bool, fake: DataFaker, mongo: Mongo, snapshot: SnapshotAssertion,
 ):
-    user_1 = await fake2.users.create()
-    user_2 = await fake2.users.create()
+    user_1 = await fake.users.create()
+    user_2 = await fake.users.create()
 
     documents = {"id": "bar", "user": {"id": user_1.id}}
 


### PR DESCRIPTION
## Changes
<!--- Describe your changes in a bulleted list --->

- Rename fake2 fixture to fake 

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
