### PR TITLE
fix: allow any redis url format

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3226,13 +3226,13 @@ test = ["Cython (>=0.29.36,<0.30.0)", "aiohttp (==3.9.0b0)", "aiohttp (>=3.8.1)"
 
 [[package]]
 name = "virtool-core"
-version = "12.3.2"
+version = "14.0.2"
 description = "Core utilities for Virtool."
 optional = false
-python-versions = "<3.13,>3.9"
+python-versions = "<3.13,>=3.12"
 files = [
-    {file = "virtool_core-12.3.2-py3-none-any.whl", hash = "sha256:61c9cdf67102a4100031952b04e86f5e57a298dcc33a64b7319f48b49ae86914"},
-    {file = "virtool_core-12.3.2.tar.gz", hash = "sha256:e1ab31a51e17b6f5be3825a7fe63d4dfb9fdc37fdbd7cdbfd7f296dc5f72e78a"},
+    {file = "virtool_core-14.0.2-py3-none-any.whl", hash = "sha256:368444aefbc352451c741b1c5684c3a9f8f405f9bb762edcafdfb312cf026cfe"},
+    {file = "virtool_core-14.0.2.tar.gz", hash = "sha256:54e3ed4b57b1d2e83a18b92b895f9c5c894215a3bf2409378bcb2d4a3d9558b7"},
 ]
 
 [package.dependencies]
@@ -3426,4 +3426,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "6f4bdf1e3522690248a52a946c5fa7f2c488340514a622b5193c81f11cc5ce86"
+content-hash = "3beae058477904b07293b5cdc42a94509b03895eb2c56d443c5dd852687814ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ aiohttp-pydantic = "^1.12.1"
 orjson = "^3.8.0"
 openfga-sdk = "^0.1.1"
 alembic = {extras = ["tz"], version = "^1.10.3"}
-virtool-core = "^12.1.0"
+virtool-core = "^14.0.2"
 pytest = "^7.4.0"
 syrupy = "^4.5.0"
 setuptools = "^69.0.3"

--- a/tests/fake/__snapshots__/test_next.ambr
+++ b/tests/fake/__snapshots__/test_next.ambr
@@ -95,8 +95,6 @@
     'id': '7cf872dc',
     'ping': None,
     'progress': 50,
-    'rights': dict({
-    }),
     'stage': 'JURZHTCWaKMqqBTFitpK',
     'state': <JobState.TIMEOUT: 'timeout'>,
     'status': list([
@@ -178,8 +176,6 @@
     'id': 'fb085f7f',
     'ping': None,
     'progress': 10,
-    'rights': dict({
-    }),
     'stage': 'NzFJEUSgqMReEKilxKJT',
     'state': <JobState.PREPARING: 'preparing'>,
     'status': list([

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -16,8 +16,6 @@
     'key': str,
     'ping': None,
     'progress': 3,
-    'rights': dict({
-    }),
     'stage': None,
     'state': 'preparing',
     'status': list([
@@ -63,8 +61,6 @@
     'id': '7cf872dc',
     'ping': None,
     'progress': 10,
-    'rights': dict({
-    }),
     'stage': 'NzFJEUSgqMReEKilxKJT',
     'state': 'preparing',
     'status': list([
@@ -1019,8 +1015,6 @@
     'id': '4c530449',
     'ping': None,
     'progress': 0,
-    'rights': dict({
-    }),
     'stage': 'mk_analysis_dir',
     'state': 'running',
     'status': list([
@@ -1075,8 +1069,6 @@
     'id': '7cf872dc',
     'ping': None,
     'progress': 10,
-    'rights': dict({
-    }),
     'stage': 'NzFJEUSgqMReEKilxKJT',
     'state': 'preparing',
     'status': list([

--- a/tests/jobs/__snapshots__/test_data.ambr
+++ b/tests/jobs/__snapshots__/test_data.ambr
@@ -10,8 +10,6 @@
     'key': 'key',
     'ping': None,
     'progress': 3,
-    'rights': dict({
-    }),
     'stage': None,
     'state': <JobState.PREPARING: 'preparing'>,
     'status': list([
@@ -70,8 +68,6 @@
     'id': 'foo',
     'ping': None,
     'progress': 0,
-    'rights': dict({
-    }),
     'stage': None,
     'state': <JobState.WAITING: 'waiting'>,
     'status': list([
@@ -129,8 +125,6 @@
     'id': 'foo',
     'ping': None,
     'progress': 0,
-    'rights': dict({
-    }),
     'stage': 'foo',
     'state': <JobState.RUNNING: 'running'>,
     'status': list([
@@ -186,8 +180,6 @@
     'id': 'fb085f7f',
     'ping': None,
     'progress': 0,
-    'rights': dict({
-    }),
     'stage': None,
     'state': <JobState.WAITING: 'waiting'>,
     'status': list([
@@ -252,8 +244,6 @@
     'id': 'bar',
     'ping': None,
     'progress': 0,
-    'rights': dict({
-    }),
     'stage': None,
     'state': <JobState.WAITING: 'waiting'>,
     'status': list([


### PR DESCRIPTION
* Remove Redis URL formatting restriction. This is blocking connections to Azure Cache for Redis.

## Compatibility

We need to be very careful to identify breaking changes in.

Sources of breaking changes:

### API
* Removing a field from a response from an API endpoint.
* Changing the shape of a response from an API endpoint.
* Changing paths or search query parameters.
* Removing deprecated functionality.

- [x] Any changes I have made to the API are backwards compatible.

### Migration
* Making changes that require a certain migration to have been applied.

- [x] My changes do not require a newer migration than the currently required migration..

### Configuration
* Changing configuration options that could break configurations in 
  production and development environments.

- [x] My changes do not change configuration value names or types.

### Services

* Making changes that require a certain version of a service like Postgres, Redis, or
  OpenFGA.

- [x] My changes don't impose any new service requirements.

### Notes

_If you have introduced breaking changes, explain here._

## Pre-Review Checklist
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
