### PR TITLE
Support legacy groups for migration to SQL

### DIFF
--- a/assets/revisions/__snapshots__/rev_r4txubh413sp_move_groups_to_sql.ambr
+++ b/assets/revisions/__snapshots__/rev_r4txubh413sp_move_groups_to_sql.ambr
@@ -5,5 +5,6 @@
     <SQLGroup(id=2, legacy_id=group_1, name=Group 1, permissions={'create_sample': True})>,
     <SQLGroup(id=3, legacy_id=group_2, name=Group 2, permissions={'create_sample': False})>,
     <SQLGroup(id=4, legacy_id=group_4, name=Group 4, permissions={'create_sample': False})>,
+    <SQLGroup(id=5, legacy_id=group 5 (legacy), name=group 5 (legacy), permissions={'create_sample': False})>,
   ])
 # ---


### PR DESCRIPTION
## Changes
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Updates move groups to SQL migration to support getting the groups name from the `_id` instead of the `name` field. Groups present in the legacy database do not have a name field

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
