### PR TITLE
Support legacy indexes in file migration

### DIFF
--- a/assets/revisions/__snapshots__/rev_0p3nhjg1fcfj_ensure_index_files.ambr
+++ b/assets/revisions/__snapshots__/rev_0p3nhjg1fcfj_ensure_index_files.ambr
@@ -1,41 +1,29 @@
 # serializer version: 1
-# name: test_upgrade[DNE-True]
+# name: TestUpgrade.test_upgrade[False]
   list([
     <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
     <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
     <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
 # ---
-# name: test_upgrade[DNE-True][json]
+# name: TestUpgrade.test_upgrade[False][json]
   '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
 # ---
-# name: test_upgrade[empty-True]
+# name: TestUpgrade.test_upgrade[True]
   list([
-    <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
-    <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
-    <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
+    <SQLIndexFile(id=1, name=previously upgraded reference.1.bt2, index=index_1, type=bowtie2, size=5)>,
+    <SQLIndexFile(id=2, name=previously upgraded reference.fa.gz, index=index_1, type=fasta, size=5)>,
+    <SQLIndexFile(id=3, name=previously upgraded reference.json.gz, index=index_1, type=json, size=5)>,
   ])
 # ---
-# name: test_upgrade[empty-True][json]
-  '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
+# name: TestUpgrade.test_upgrade[True][json]
+  'Complete index json'
 # ---
-# name: test_upgrade[full-True]
+# name: TestUpgrade.test_upgrade_no_files
   list([
-    <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
-    <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
-    <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
 # ---
-# name: test_upgrade[full-True][json]
-  '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
-# ---
-# name: test_upgrade[not_ready-True]
+# name: TestUpgrade.test_upgrade_not_ready
   list([
-    <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
-    <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
-    <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
-# ---
-# name: test_upgrade[not_ready-True][json]
-  '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
 # ---

--- a/assets/revisions/__snapshots__/rev_0p3nhjg1fcfj_ensure_index_files.ambr
+++ b/assets/revisions/__snapshots__/rev_0p3nhjg1fcfj_ensure_index_files.ambr
@@ -1,41 +1,41 @@
 # serializer version: 1
-# name: test_upgrade[DNE]
+# name: test_upgrade[DNE-True]
   list([
     <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
     <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
     <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
 # ---
-# name: test_upgrade[DNE][json]
+# name: test_upgrade[DNE-True][json]
   '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
 # ---
-# name: test_upgrade[empty]
+# name: test_upgrade[empty-True]
   list([
     <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
     <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
     <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
 # ---
-# name: test_upgrade[empty][json]
+# name: test_upgrade[empty-True][json]
   '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
 # ---
-# name: test_upgrade[full]
+# name: test_upgrade[full-True]
   list([
     <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
     <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
     <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
 # ---
-# name: test_upgrade[full][json]
+# name: test_upgrade[full-True][json]
   '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
 # ---
-# name: test_upgrade[not_ready]
+# name: test_upgrade[not_ready-True]
   list([
     <SQLIndexFile(id=1, name=reference.1.bt2, index=index_1, type=bowtie2, size=12)>,
     <SQLIndexFile(id=2, name=reference.fa.gz, index=index_1, type=fasta, size=10)>,
     <SQLIndexFile(id=3, name=reference.json.gz, index=index_1, type=json, size=322)>,
   ])
 # ---
-# name: test_upgrade[not_ready][json]
+# name: test_upgrade[not_ready-True][json]
   '{"data_type":"genome","organism":"virus","otus":[{"_id":"6116cba1","name":"Prunus virus F","abbreviation":"PVF","isolates":[{"id":"cab8b360","default":true,"source_name":"8816-v2","source_type":"isolate","sequences":[{"_id":"abcd1234","accession":"KX269872","definition":"Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.","host":"sweet cherry","sequence":"TGTTTAAGAGATTAAACAACCGCTTTC","segment":null}]}],"schema":[]}],"targets":null}'
 # ---

--- a/assets/revisions/rev_0p3nhjg1fcfj_ensure_index_files.py
+++ b/assets/revisions/rev_0p3nhjg1fcfj_ensure_index_files.py
@@ -57,7 +57,7 @@ async def upgrade(ctx: MigrationContext):
                 index_path,
                 ctx.data_path,
                 index["reference"]["id"],
-                index.get("manifest"),
+                index["manifest"],
             )
         except IndexError:
             continue
@@ -240,6 +240,7 @@ class TestUpgrade:
     Also, ensures that an index JSON file is generated if missing.
     """
 
+    @staticmethod
     @pytest.mark.parametrize(
         "previously_upgraded",
         [
@@ -248,7 +249,6 @@ class TestUpgrade:
         ],
     )
     async def test_upgrade(
-        self,
         ctx: MigrationContext,
         snapshot,
         previously_upgraded,
@@ -295,8 +295,8 @@ class TestUpgrade:
         with gzip.open(Path(test_dir) / "reference.json.gz", "rt") as f:
             assert f.read() == snapshot(name="json")
 
+    @staticmethod
     async def test_upgrade_no_files(
-        self,
         ctx: MigrationContext,
         snapshot,
         create_task_index,
@@ -330,8 +330,8 @@ class TestUpgrade:
         ):
             f.read()
 
+    @staticmethod
     async def test_upgrade_not_ready(
-        self,
         ctx: MigrationContext,
         snapshot,
         create_task_index,

--- a/assets/revisions/rev_0p3nhjg1fcfj_ensure_index_files.py
+++ b/assets/revisions/rev_0p3nhjg1fcfj_ensure_index_files.py
@@ -182,7 +182,7 @@ def format_otu_for_export(otu: Document) -> Document:
         "name": otu["name"],
         "abbreviation": otu["abbreviation"],
         "isolates": isolates,
-        "schema": otu["schema"],
+        "schema": otu.get("schema", []),
     }
 
 


### PR DESCRIPTION
## Changes
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes:
 - Skip creating index SQL files and json if the index file does not exist on drive
 - remove testing for cases where `index["files"]` are different values since they are not reference by the migration
 - add testing to ensure that non-ready, or indexes without files do not cause the migration to fail out

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
