### PR TITLE
fix: publish missing events for task spawner

### DIFF
--- a/virtool/tasks/main.py
+++ b/virtool/tasks/main.py
@@ -92,6 +92,7 @@ def run_task_spawner(config: TaskSpawnerConfig):
             startup_sentry,
             startup_http_client_session,
             startup_databases_for_spawner,
+            startup_events,
             startup_datalayer_for_spawner,
             startup_executors,
             startup_task_spawner,

--- a/virtool/tasks/startup.py
+++ b/virtool/tasks/startup.py
@@ -30,8 +30,6 @@ async def startup_databases_for_spawner(app: Application):
 
     redis = Redis(config.redis_connection_string)
 
-    print("redis", redis)
-
     pg, _ = await asyncio.gather(
         connect_pg(config.postgres_connection_string),
         redis.connect(),


### PR DESCRIPTION
## Changes

Restore event publisher functionality for task spawner. It was being initialized.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
