### PR TITLE
ci: use basic github actions token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,5 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
* Use the basic `GITHUB_TOKEN` instead of the bot account.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
