### PR TITLE
ci: use `GITHUB_TOKEN` to publish images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.GH_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Use `GITHUB_TOKEN` to publish images.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] Deepsource issues have been reviewed and addressed.
* [x] Comments and `print` statements have been removed.
