### PR TITLE
fix: prevent migration failure when pathoscope analysis lack `subtracted_count`

### DIFF
--- a/assets/revisions/__snapshots__/rev_7emq1brv0zz6_nest_analysis_results_field.ambr
+++ b/assets/revisions/__snapshots__/rev_7emq1brv0zz6_nest_analysis_results_field.ambr
@@ -47,6 +47,20 @@
       'workflow': 'pathoscope_bowtie',
     }),
     dict({
+      '_id': 'no_subtracted_count',
+      'results': dict({
+        'hits': list([
+          1,
+          2,
+          3,
+          4,
+          5,
+        ]),
+        'read_count': 1209,
+      }),
+      'workflow': 'pathoscope_bowtie',
+    }),
+    dict({
       '_id': 'baz',
       'results': dict({
         'hits': list([

--- a/assets/revisions/rev_7emq1brv0zz6_nest_analysis_results_field.py
+++ b/assets/revisions/rev_7emq1brv0zz6_nest_analysis_results_field.py
@@ -44,9 +44,11 @@ async def upgrade(ctx: MigrationContext):
                     "results": {
                         **results,
                         "read_count": document["read_count"],
-                        # TODO: add a migration that detects cases where subtraction_count DNE and set a flag
-                        # As is this prevents the crash during migration, but does not correct the underlying
-                        # data structure problem
+                        # TODO: add a migration that detects cases where
+                        # subtraction_count DNE and set a flag.
+                        # This prevents the crash during migration, but
+                        # does not correct the underlying data structure
+                        # problem
                         **(
                             {
                                 "subtracted_count": document["subtracted_count"],

--- a/assets/revisions/rev_7emq1brv0zz6_nest_analysis_results_field.py
+++ b/assets/revisions/rev_7emq1brv0zz6_nest_analysis_results_field.py
@@ -133,6 +133,12 @@ async def test_upgrade(ctx: MigrationContext, snapshot):
                     "subtracted_count": 112,
                     "workflow": "pathoscope_bowtie",
                 },
+                {
+                    "_id": "no_subtracted_count",
+                    "read_count": 1209,
+                    "results": [1, 2, 3, 4, 5],
+                    "workflow": "pathoscope_bowtie",
+                },
                 {"_id": "baz", "results": [9, 8, 7, 6, 5], "workflow": "nuvs"},
                 {
                     "_id": "bad",


### PR DESCRIPTION

<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes the existing migration to handle the case where `subtracted_count` DNE. When no `subtracted_count` exists then it is fully excluded from the newly nested version of results as well

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
