### PR TITLE
Remove usage of mongo session from subtractions field migration

### DIFF
--- a/assets/revisions/__snapshots__/rev_1keyha5n6l0j_add_subtractions_field.ambr
+++ b/assets/revisions/__snapshots__/rev_1keyha5n6l0j_add_subtractions_field.ambr
@@ -14,6 +14,12 @@
       ]),
     }),
     dict({
+      '_id': 'already_migrated',
+      'subtractions': list([
+        'malus',
+      ]),
+    }),
+    dict({
       '_id': 'baz',
       'subtractions': list([
       ]),
@@ -30,6 +36,12 @@
     }),
     dict({
       '_id': 'bar',
+      'subtractions': list([
+        'malus',
+      ]),
+    }),
+    dict({
+      '_id': 'already_migrated',
       'subtractions': list([
         'malus',
       ]),

--- a/assets/revisions/rev_1keyha5n6l0j_add_subtractions_field.py
+++ b/assets/revisions/rev_1keyha5n6l0j_add_subtractions_field.py
@@ -1,10 +1,10 @@
-"""
-Add subtractions field
+"""Add subtractions field
 
 Revision ID: 1keyha5n6l0j
 Date: 2022-06-09 22:04:28.890559
 
 """
+
 from asyncio import gather
 
 import arrow
@@ -37,9 +37,7 @@ async def upgrade(ctx: MigrationContext):
 
             updates.append(update)
 
-        if updates:
-            async with await ctx.mongo.client.start_session() as session, session.start_transaction():
-                await collection.bulk_write(updates, session=session)
+        await collection.bulk_write(updates)
 
 
 async def test_upgrade(ctx: MigrationContext, snapshot):
@@ -48,15 +46,17 @@ async def test_upgrade(ctx: MigrationContext, snapshot):
             [
                 {"_id": "foo", "subtraction": {"id": "prunus"}},
                 {"_id": "bar", "subtraction": {"id": "malus"}},
+                {"_id": "already_migrated", "subtractions": ["malus"]},
                 {"_id": "baz", "subtraction": None},
-            ]
+            ],
         ),
         ctx.mongo.analyses.insert_many(
             [
                 {"_id": "foo", "subtraction": {"id": "prunus"}},
                 {"_id": "bar", "subtraction": {"id": "malus"}},
+                {"_id": "already_migrated", "subtractions": ["malus"]},
                 {"_id": "baz", "subtraction": None},
-            ]
+            ],
         ),
     )
 

--- a/assets/revisions/rev_1keyha5n6l0j_add_subtractions_field.py
+++ b/assets/revisions/rev_1keyha5n6l0j_add_subtractions_field.py
@@ -37,7 +37,8 @@ async def upgrade(ctx: MigrationContext):
 
             updates.append(update)
 
-        await collection.bulk_write(updates)
+        if updates:
+            await collection.bulk_write(updates)
 
 
 async def test_upgrade(ctx: MigrationContext, snapshot):


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

The current version of the migration that makes use of mongo sessions fails when running on prod due to the transaction size. This PR strips the usage of mongo sessions, making the migration no longer atomic. Test cases were added to simulate the migration having already been previously run with only some `subtraction` fields having been replaced with `subtractions`.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
