### PR TITLE
Upgrade subtraction `created_at`, `nickname` and `file.name` fields

### DIFF
--- a/assets/revisions/__snapshots__/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.ambr
+++ b/assets/revisions/__snapshots__/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: test_upgrade
+  list([
+    dict({
+      '_id': 'complete',
+      'created_at': datetime,
+      'file': dict({
+        'id': 'complete_file_id',
+        'name': 'complete_file_name',
+      }),
+      'nickname': 'complete_nickname',
+    }),
+    dict({
+      '_id': 'legacy',
+      'created_at': datetime,
+      'file': dict({
+        'id': 'legacy_file_id',
+        'name': 'legacy_file_id',
+      }),
+      'nickname': '',
+    }),
+  ])
+# ---

--- a/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -37,7 +37,7 @@ async def upgrade(ctx: MigrationContext):
             ctx.data_path
             / "subtractions"
             / subtraction["_id"].replace(" ", "_")
-            / "reference.1.bt2"
+            / "subtraction.1.bt2"
         ).stat()
 
         created_at = (
@@ -81,7 +81,7 @@ async def test_upgrade(ctx: MigrationContext, snapshot):
 
     subtraction_path = ctx.data_path / "subtractions" / "legacy"
     subtraction_path.mkdir(exist_ok=True, parents=True)
-    index_file = subtraction_path / "reference.1.bt2"
+    index_file = subtraction_path / "subtraction.1.bt2"
     index_file.write_text("subtraction_index")
 
     await upgrade(ctx)

--- a/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -34,7 +34,10 @@ async def upgrade(ctx: MigrationContext):
         {"created_at": {"$exists": False}},
     ):
         index_stats = (
-            ctx.data_path / "subtractions" / subtraction["_id"] / "reference.1.bt2"
+            ctx.data_path
+            / "subtractions"
+            / subtraction["_id"].replace(" ", "_")
+            / "reference.1.bt2"
         ).stat()
 
         created_at = (

--- a/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -25,12 +25,12 @@ required_alembic_revision = None
 
 
 async def upgrade(ctx: MigrationContext):
-    await ctx.mongo.subtractions.update_many(
+    await ctx.mongo.subtraction.update_many(
         {"nickname": {"$exists": False}},
         {"$set": {"nickname": ""}},
     )
 
-    async for subtraction in ctx.mongo.subtractions.find(
+    async for subtraction in ctx.mongo.subtraction.find(
         {"created_at": {"$exists": False}},
     ):
         index_stats = (
@@ -43,12 +43,12 @@ async def upgrade(ctx: MigrationContext):
             else index_stats.st_mtime
         )
 
-        await ctx.mongo.subtractions.update_one(
+        await ctx.mongo.subtraction.update_one(
             {"_id": subtraction["_id"]},
             {"$set": {"created_at": datetime.datetime.fromtimestamp(created_at)}},
         )
 
-    await ctx.mongo.subtractions.update_many(
+    await ctx.mongo.subtraction.update_many(
         filter={"file.name": {"$exists": False}},
         update=[
             {
@@ -61,7 +61,7 @@ async def upgrade(ctx: MigrationContext):
 
 
 async def test_upgrade(ctx: MigrationContext, snapshot):
-    await ctx.mongo.subtractions.insert_many(
+    await ctx.mongo.subtraction.insert_many(
         [
             {
                 "_id": "complete",
@@ -84,5 +84,5 @@ async def test_upgrade(ctx: MigrationContext, snapshot):
     await upgrade(ctx)
 
     assert [
-        subtraction async for subtraction in ctx.mongo.subtractions.find({})
+        subtraction async for subtraction in ctx.mongo.subtraction.find({})
     ] == snapshot(matcher=path_type({".*created_at": (datetime.datetime,)}, regex=True))

--- a/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -1,0 +1,88 @@
+"""update subtraction nicknames, created_at and file names
+
+Revision ID: oxu8ghlvuqmh
+Date: 2024-11-21 18:03:09.177151
+
+"""
+
+import datetime
+
+import arrow
+from syrupy.matchers import path_type
+
+from virtool.migration import MigrationContext
+
+# Revision identifiers.
+name = "update subtraction nicknames created_at and file names"
+created_at = arrow.get("2024-11-21 18:03:09.177151")
+revision_id = "oxu8ghlvuqmh"
+
+alembic_down_revision = "b79c1e6cf56c"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext):
+    await ctx.mongo.subtractions.update_many(
+        {"nickname": {"$exists": False}},
+        {"$set": {"nickname": ""}},
+    )
+
+    async for subtraction in ctx.mongo.subtractions.find(
+        {"created_at": {"$exists": False}},
+    ):
+        index_stats = (
+            ctx.data_path / "subtractions" / subtraction["_id"] / "reference.1.bt2"
+        ).stat()
+
+        created_at = (
+            index_stats.st_ctime
+            if index_stats.st_ctime < index_stats.st_mtime
+            else index_stats.st_mtime
+        )
+
+        await ctx.mongo.subtractions.update_one(
+            {"_id": subtraction["_id"]},
+            {"$set": {"created_at": datetime.datetime.fromtimestamp(created_at)}},
+        )
+
+    await ctx.mongo.subtractions.update_many(
+        filter={"file.name": {"$exists": False}},
+        update=[
+            {
+                "$set": {
+                    "file.name": "$file.id",
+                },
+            },
+        ],
+    )
+
+
+async def test_upgrade(ctx: MigrationContext, snapshot):
+    await ctx.mongo.subtractions.insert_many(
+        [
+            {
+                "_id": "complete",
+                "created_at": datetime.datetime.now(),
+                "nickname": "complete_nickname",
+                "file": {"name": "complete_file_name", "id": "complete_file_id"},
+            },
+            {
+                "_id": "legacy",
+                "file": {"id": "legacy_file_id"},
+            },
+        ],
+    )
+
+    subtraction_path = ctx.data_path / "subtractions" / "legacy"
+    subtraction_path.mkdir(exist_ok=True, parents=True)
+    index_file = subtraction_path / "reference.1.bt2"
+    index_file.write_text("subtraction_index")
+
+    await upgrade(ctx)
+
+    assert [
+        subtraction async for subtraction in ctx.mongo.subtractions.find({})
+    ] == snapshot(matcher=path_type({".*created_at": (datetime.datetime,)}, regex=True))

--- a/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -52,7 +52,7 @@ async def upgrade(ctx: MigrationContext):
         )
 
     await ctx.mongo.subtraction.update_many(
-        filter={"file.name": {"$exists": False}},
+        filter={"file.name": None},
         update=[
             {
                 "$set": {
@@ -74,7 +74,7 @@ async def test_upgrade(ctx: MigrationContext, snapshot):
             },
             {
                 "_id": "legacy",
-                "file": {"id": "legacy_file_id"},
+                "file": {"id": "legacy_file_id", "name": None},
             },
         ],
     )

--- a/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/assets/revisions/rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -25,48 +25,50 @@ required_alembic_revision = None
 
 
 async def upgrade(ctx: MigrationContext):
-    with await ctx.mongo.motor_database.client.start_session() as mongo_session:
-        async with mongo_session.start_transaction():
-            await ctx.mongo.subtraction.update_many(
-                {"nickname": {"$exists": False}},
-                {"$set": {"nickname": ""}},
+    async with (
+        await ctx.mongo.client.start_session() as mongo_session,
+        mongo_session.start_transaction(),
+    ):
+        await ctx.mongo.subtraction.update_many(
+            {"nickname": {"$exists": False}},
+            {"$set": {"nickname": ""}},
+            session=mongo_session,
+        )
+
+        async for subtraction in ctx.mongo.subtraction.find(
+            {"created_at": {"$exists": False}},
+            session=mongo_session,
+        ):
+            index_stats = (
+                ctx.data_path
+                / "subtractions"
+                / subtraction["_id"].replace(" ", "_")
+                / "subtraction.1.bt2"
+            ).stat()
+
+            created_at = (
+                index_stats.st_ctime
+                if index_stats.st_ctime < index_stats.st_mtime
+                else index_stats.st_mtime
+            )
+
+            await ctx.mongo.subtraction.update_one(
+                {"_id": subtraction["_id"]},
+                {"$set": {"created_at": arrow.get(created_at).naive}},
                 session=mongo_session,
             )
 
-            async for subtraction in ctx.mongo.subtraction.find(
-                {"created_at": {"$exists": False}},
-                session=mongo_session,
-            ):
-                index_stats = (
-                    ctx.data_path
-                    / "subtractions"
-                    / subtraction["_id"].replace(" ", "_")
-                    / "subtraction.1.bt2"
-                ).stat()
-
-                created_at = (
-                    index_stats.st_ctime
-                    if index_stats.st_ctime < index_stats.st_mtime
-                    else index_stats.st_mtime
-                )
-
-                await ctx.mongo.subtraction.update_one(
-                    {"_id": subtraction["_id"]},
-                    {"$set": {"created_at": arrow.get(created_at).naive}},
-                    session=mongo_session,
-                )
-
-            await ctx.mongo.subtraction.update_many(
-                {"file.name": None},
-                update=[
-                    {
-                        "$set": {
-                            "file.name": "$file.id",
-                        },
+        await ctx.mongo.subtraction.update_many(
+            {"file.name": None},
+            update=[
+                {
+                    "$set": {
+                        "file.name": "$file.id",
                     },
-                ],
-                session=mongo_session,
-            )
+                },
+            ],
+            session=mongo_session,
+        )
 
 
 async def test_upgrade(ctx: MigrationContext, snapshot):

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -288,5 +288,12 @@
       'name': 'Add analysis results table',
       'revision': 'b79c1e6cf56c',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 42,
+      'name': 'update subtraction nicknames created_at and file names',
+      'revision': 'oxu8ghlvuqmh',
+    }),
   ])
 # ---


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

In order to get the legacy subtraction up to date with modern virtool data models a few updates are required to some of the legacy subtractions.

Changes:

1. `created_at` was missing in all legacy subtractions. There is no reliable way to derive this information. Best attempt at restoring this value is by using whichever is oldest of the time the subtractions index was first added to the file system or the last date the index was modified. \
**NOTE:** It is possible that this method will result in highly inaccurate timestamps if the user has moved the copied or otherwise changed the birth time of the file.

3. `nickname` is missing from some legacy subtractions. Any subtractions without a nickname have the default value of `""` set
4. `file.name` is missing for subtractions where the provided name was used directy as a an id without modification. (no-prepending of a random string) In cases where file name is missing the `file.id` is copied into `file.name`


Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
