### PR TITLE
fix: prevent crash when sample folder not found

### DIFF
--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -364,11 +364,14 @@ class SamplesData(DataLayerDomain):
             )
 
         if result.deleted_count:
-            await to_thread(
-                virtool_core.utils.rm,
-                join_sample_path(self._config, sample_id),
-                recursive=True,
-            )
+            try:
+                await to_thread(
+                    virtool_core.utils.rm,
+                    join_sample_path(self._config, sample_id),
+                    recursive=True,
+                )
+            except FileNotFoundError:
+                pass
 
             return sample
 


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes:

- Catches and ignores `FileNotFound` error when attempting to delete a sample

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
