### PR TITLE
Support user type flag

### DIFF
--- a/assets/alembic/versions/e52b2748f384_add_user_type_field.py
+++ b/assets/alembic/versions/e52b2748f384_add_user_type_field.py
@@ -1,0 +1,42 @@
+"""add user type field
+
+Revision ID: e52b2748f384
+Revises: b79c1e6cf56c
+Create Date: 2024-12-03 18:03:12.062643+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "e52b2748f384"
+down_revision = "b79c1e6cf56c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    user_type_enum = postgresql.ENUM("user", "bot", name="usertype")
+    user_type_enum.create(op.get_bind())
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "type",
+            postgresql.ENUM("user", "bot", name="usertype"),
+            nullable=True,
+        ),
+    )
+
+    op.execute("UPDATE users SET type = 'user'")
+
+    op.alter_column("users", "type", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "type")
+
+    user_type_enum = postgresql.ENUM("user", "bot", name="usertype")
+    user_type_enum.drop(op.get_bind())

--- a/assets/revisions/__snapshots__/rev_wlh6h0hb1tm0_add_user_type_field_to_mongo.ambr
+++ b/assets/revisions/__snapshots__/rev_wlh6h0hb1tm0_add_user_type_field_to_mongo.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_upgrade
+  list([
+    dict({
+      '_id': 'no type',
+      'type': 'user',
+    }),
+    dict({
+      '_id': 'user_type',
+      'type': 'user',
+    }),
+    dict({
+      '_id': 'bot_type',
+      'type': 'bot',
+    }),
+  ])
+# ---

--- a/assets/revisions/rev_wlh6h0hb1tm0_add_user_type_field_to_mongo.py
+++ b/assets/revisions/rev_wlh6h0hb1tm0_add_user_type_field_to_mongo.py
@@ -1,0 +1,41 @@
+"""add user type field to mongo
+
+Revision ID: wlh6h0hb1tm0
+Date: 2024-12-04 16:29:19.348922
+
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+
+# Revision identifiers.
+name = "add user type field to mongo"
+created_at = arrow.get("2024-12-04 16:29:19.348922")
+revision_id = "wlh6h0hb1tm0"
+
+alembic_down_revision = "e52b2748f384"
+virtool_down_revision = "None"
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext):
+    ctx.mongo.users.update_many(
+        {"type": {"$exists": False}}, {"$set": {"type": "user"}}
+    )
+
+
+async def test_upgrade(ctx: MigrationContext, snapshot):
+    await ctx.mongo.users.insert_many(
+        [
+            {"_id": "no type"},
+            {"_id": "user_type", "type": "user"},
+            {"_id": "bot_type", "type": "bot"},
+        ],
+    )
+
+    await upgrade(ctx)
+
+    assert await ctx.mongo.users.find({}).to_list() == snapshot()

--- a/assets/revisions/rev_wlh6h0hb1tm0_add_user_type_field_to_mongo.py
+++ b/assets/revisions/rev_wlh6h0hb1tm0_add_user_type_field_to_mongo.py
@@ -15,7 +15,7 @@ created_at = arrow.get("2024-12-04 16:29:19.348922")
 revision_id = "wlh6h0hb1tm0"
 
 alembic_down_revision = "e52b2748f384"
-virtool_down_revision = "None"
+virtool_down_revision = None
 
 # Change this if an Alembic revision is required to run this migration.
 required_alembic_revision = None
@@ -23,7 +23,8 @@ required_alembic_revision = None
 
 async def upgrade(ctx: MigrationContext):
     ctx.mongo.users.update_many(
-        {"type": {"$exists": False}}, {"$set": {"type": "user"}}
+        {"type": {"$exists": False}},
+        {"$set": {"type": "user"}},
     )
 
 

--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -822,6 +822,12 @@
     'reset': False,
   })
 # ---
+# name: test_login_system_user
+  dict({
+    'id': 'bad_request',
+    'message': 'Invalid username or password',
+  })
+# ---
 # name: test_remove_api_key[404]
   dict({
     'id': 'not_found',

--- a/tests/account/__snapshots__/test_data.ambr
+++ b/tests/account/__snapshots__/test_data.ambr
@@ -113,10 +113,11 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: test_update[email][pg]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', type='user', groups='[]', primary_group='[]')>
 # ---
 # name: test_update[password and email][mongo]
   dict({
@@ -136,10 +137,11 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: test_update[password and email][pg]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', type='user', groups='[]', primary_group='[]')>
 # ---
 # name: test_update[password][mongo]
   dict({
@@ -158,8 +160,9 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: test_update[password][pg]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', type='user', groups='[]', primary_group='[]')>
 # ---

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -128,7 +128,7 @@ async def test_update_settings(data, status, spawn_client, resp_is, snapshot):
 
 
 async def test_get_api_keys(
-        fake: DataFaker,
+    fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
     snapshot,
@@ -177,7 +177,7 @@ class TestCreateAPIKey:
         has_perm,
         req_perm,
         data_layer: DataLayer,
-            fake: DataFaker,
+        fake: DataFaker,
         mocker,
         snapshot,
         spawn_client: ClientSpawner,
@@ -248,7 +248,7 @@ class TestUpdateAPIKey:
         has_admin: bool,
         has_perm: bool,
         data_layer: DataLayer,
-            fake: DataFaker,
+        fake: DataFaker,
         mongo: Mongo,
         snapshot,
         spawn_client: ClientSpawner,
@@ -344,7 +344,7 @@ async def test_remove_api_key(
 
 
 async def test_remove_all_api_keys(
-        fake: DataFaker,
+    fake: DataFaker,
     mongo: Mongo,
     spawn_client: ClientSpawner,
 ):
@@ -516,12 +516,38 @@ async def test_login(
             "user_id": "abc123",
             "handle": "foobar",
             "password": hash_password("p@ssword123"),
+            "type": "user",
         },
     )
 
     resp = await client.post("/account/login", body)
 
     assert resp.status == status
+    assert await resp.json() == snapshot
+
+
+async def test_login_system_user(
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    snapshot,
+):
+    client = await spawn_client()
+
+    await mongo.users.insert_one(
+        {
+            "user_id": "abc123",
+            "handle": "foobar",
+            "password": hash_password("p@ssword123"),
+            "type": "bot",
+        },
+    )
+
+    resp = await client.post(
+        "/account/login",
+        {"username": "foobar", "password": "p@ssword123", "remember": False},
+    )
+
+    assert resp.status == 400
     assert await resp.json() == snapshot
 
 
@@ -536,7 +562,7 @@ async def test_login(
 async def test_login_reset(
     spawn_client,
     snapshot,
-        fake: DataFaker,
+    fake: DataFaker,
     request_path,
     correct_code,
     data_layer: DataLayer,

--- a/tests/administrators/__snapshots__/test_api.ambr
+++ b/tests/administrators/__snapshots__/test_api.ambr
@@ -416,6 +416,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: test_create[None][location]

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -295,5 +295,19 @@
       'name': 'update subtraction nicknames created_at and file names',
       'revision': 'oxu8ghlvuqmh',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 43,
+      'name': 'add user type field',
+      'revision': 'e52b2748f384',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 44,
+      'name': 'add user type field to mongo',
+      'revision': 'wlh6h0hb1tm0',
+    }),
   ])
 # ---

--- a/tests/users/__snapshots__/test_api.ambr
+++ b/tests/users/__snapshots__/test_api.ambr
@@ -282,6 +282,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: test_create[None][location]

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -43,6 +43,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_first[pg]
@@ -68,6 +69,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_force_reset[false][mongo]
@@ -87,6 +89,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_force_reset[false][obj]
@@ -139,6 +142,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_force_reset[not_specified][mongo]
@@ -158,6 +162,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_force_reset[not_specified][obj]
@@ -210,6 +215,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_force_reset[true][mongo]
@@ -229,6 +235,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestCreate.test_force_reset[true][obj]
@@ -281,6 +288,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestFind.test_active
@@ -566,6 +574,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_force_reset[mongo_2]
@@ -585,6 +594,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_force_reset[mongo_3]
@@ -604,6 +614,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_force_reset[pg_1]
@@ -629,6 +640,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_force_reset[pg_2]
@@ -654,6 +666,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_force_reset[pg_3]
@@ -679,6 +692,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_groups[mongo_1]
@@ -700,6 +714,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_groups[mongo_2]
@@ -721,6 +736,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_groups[mongo_3]
@@ -740,6 +756,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_groups[obj_1]
@@ -847,10 +864,10 @@
   })
 # ---
 # name: TestUpdate.test_groups[pg_1]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=meteorologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', type='user', groups='[<SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=meteorologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
 # ---
 # name: TestUpdate.test_groups[pg_2]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=2, legacy_id=None, name=geoscientists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', type='user', groups='[<SQLGroup(id=2, legacy_id=None, name=geoscientists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
 # ---
 # name: TestUpdate.test_groups[pg_3]
   dict({
@@ -875,6 +892,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_groups_unset_primary[mongo]
@@ -894,6 +912,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_groups_unset_primary[obj]
@@ -947,6 +966,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_password[db]
@@ -967,6 +987,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_password[obj]
@@ -1026,6 +1047,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_primary_group_when_member[mongo]
@@ -1046,6 +1068,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: TestUpdate.test_primary_group_when_member[obj]
@@ -1109,6 +1132,7 @@
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
     }),
+    'type': 'user',
   })
 # ---
 # name: test_find_or_create_b2c_user[False]

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -26,7 +26,7 @@ from virtool.groups.transforms import AttachGroupsTransform
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.users.mongo import validate_credentials
-from virtool.users.pg import SQLUser
+from virtool.users.pg import SQLUser, UserType
 from virtool.users.utils import limit_permissions
 from virtool.utils import base_processor, hash_key
 
@@ -387,10 +387,14 @@ class AccountData(DataLayerDomain):
         # the database and/or password are invalid.
         document = await self._mongo.users.find_one({"handle": data.username})
 
-        if not document or not await validate_credentials(
-            self._mongo,
-            document["_id"],
-            data.password,
+        if (
+            not document
+            or document["type"] == UserType.bot
+            or not await validate_credentials(
+                self._mongo,
+                document["_id"],
+                data.password,
+            )
         ):
             raise ResourceError()
 

--- a/virtool/api/authentication.py
+++ b/virtool/api/authentication.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 import jwt
 from aiohttp import BasicAuth, web
 from aiohttp.web import Request, Response
+from aiohttp.web_exceptions import HTTPForbidden
 from structlog import get_logger
 
 from virtool.api.client import UserClient
@@ -18,6 +19,7 @@ from virtool.data.utils import get_data_from_req
 from virtool.errors import AuthError
 from virtool.oidc.utils import validate_token
 from virtool.users.db import B2CUserAttributes
+from virtool.users.pg import UserType
 from virtool.users.utils import limit_permissions
 
 logger = get_logger("authn")
@@ -154,6 +156,9 @@ async def authenticate_with_session(req: Request, handler: Callable) -> Response
 
     if not user.active:
         raise APIUnauthorized("User is deactivated", error_id="deactivated_user")
+
+    if user == UserType.bot:
+        raise HTTPForbidden("Cannot authenticate system users", error_id="system_user")
 
     req["client"] = UserClient(
         administrator_role=user.administrator_role,

--- a/virtool/migration/pg.py
+++ b/virtool/migration/pg.py
@@ -9,7 +9,7 @@ from structlog import get_logger
 from virtool.migration.cls import AppliedRevision
 from virtool.pg.base import Base
 
-REQUIRED_VIRTOOL_REVISION = "b79c1e6cf56c"
+REQUIRED_VIRTOOL_REVISION = "wlh6h0hb1tm0"
 
 logger = get_logger("migration")
 

--- a/virtool/users/data.py
+++ b/virtool/users/data.py
@@ -294,6 +294,7 @@ class UsersData(DataLayerDomain):
                 handle,
                 None,
                 force_reset,
+                user_type=UserType.user,
                 b2c_user_attributes=b2c_user_attributes,
                 session=mongo_session,
             )

--- a/virtool/users/mongo.py
+++ b/virtool/users/mongo.py
@@ -16,6 +16,7 @@ from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.types import Document
 from virtool.users.db import ATTACH_PROJECTION, B2CUserAttributes
+from virtool.users.pg import UserType
 from virtool.users.settings import DEFAULT_USER_SETTINGS
 from virtool.users.utils import (
     check_legacy_password,
@@ -69,6 +70,7 @@ async def create_user(
     handle: str,
     password: str | None,
     force_reset: bool,
+    user_type: UserType,
     b2c_user_attributes: B2CUserAttributes | None = None,
     session: AsyncIOMotorClientSession | None = None,
 ) -> Document:
@@ -81,6 +83,7 @@ async def create_user(
         "last_password_change": virtool.utils.timestamp(),
         "primary_group": None,
         "settings": DEFAULT_USER_SETTINGS,
+        "type": user_type,
     }
 
     if password is None:

--- a/virtool/users/pg.py
+++ b/virtool/users/pg.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, Index
+from sqlalchemy import Enum, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from virtool.groups.pg import SQLGroup
 from virtool.pg.base import Base
+from virtool.pg.utils import SQLEnum
 
 
 class SQLUserGroup(Base):
@@ -36,6 +37,11 @@ class SQLUserGroup(Base):
     )
 
 
+class UserType(str, SQLEnum):
+    user = "user"
+    bot = "bot"
+
+
 class SQLUser(Base):
     __tablename__ = "users"
 
@@ -53,6 +59,9 @@ class SQLUser(Base):
     legacy_id: Mapped[str | None] = mapped_column(unique=True)
     password: Mapped[bytes | None]
     settings: Mapped[dict] = mapped_column(JSONB)
+    type: Mapped[UserType] = mapped_column(
+        Enum(UserType, name="usertype"), nullable=False
+    )
 
     user_group_associations: Mapped[list[SQLUserGroup]] = relationship(
         back_populates="user",


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes:
- Adds a `alembic` migration to add a `type` field to the `users` table in postgres
- Adds a `virtool` migration to add a `type` field to the `users` collection in mongodb
- Enforces usage of latest migration at startup
- updates users data layer to handle the new parameter
   - find only returns users of type `user`
   - create functions assume type of `user` but in some cases allow specification of the type
   - update function only allows updating of `user` type users
   - Fetching a single user ignores the flag
- Users of type `bot` are blocked from authenticating via session or logging on 

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
