### PR TITLE
fix: prevent errors when logging github rate limit warning

### DIFF
--- a/virtool/github.py
+++ b/virtool/github.py
@@ -99,7 +99,10 @@ async def get_release(
         rate_limit_remaining = resp.headers.get("X-RateLimit-Remaining", "00")
         rate_limit = resp.headers.get("X-RateLimit-Limit", "00")
 
-        if int(rate_limit) / int(rate_limit_remaining) > 2.0:
+        if (
+            rate_limit_remaining == 0
+            or int(rate_limit) / int(rate_limit_remaining) > 2.0
+        ):
             logger.warning(
                 "less than half of github rate limit remaining",
                 remaining=rate_limit_remaining,

--- a/virtool/logs.py
+++ b/virtool/logs.py
@@ -12,7 +12,16 @@ logging.basicConfig(
 )
 
 
-def _exception_level_to_error(event_dict):
+def _exception_level_to_error(event_dict: dict) -> dict:
+    """Convert the log level of an exception event to error.
+
+    The `structlog_sentry` processor does not like the `exception` level which is used
+    by `structlog`.
+
+    :param event_dict: the event dictionary
+    :return: the event dictionary with the level changed to error
+
+    """
     if event_dict.get("level") == "exception":
         event_dict["level"] = "error"
 

--- a/virtool/tasks/task.py
+++ b/virtool/tasks/task.py
@@ -2,9 +2,10 @@
 
 import asyncio
 from asyncio import to_thread
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Type
+from typing import TYPE_CHECKING
 
 from structlog import get_logger
 
@@ -54,7 +55,7 @@ class BaseTask:
         self.errored: bool = False
         """Set ``True`` when the task has encountered an error."""
 
-        self.step: Optional[Callable] = None
+        self.step: Callable | None = None
         """
         The name of the step the task is current executing.
 
@@ -131,7 +132,7 @@ class BaseTask:
             try:
                 await func()
             except Exception as err:
-                log.exception("Encountered error in task")
+                log.exception("encountered error in task")
                 await self._set_error(f"{type(err)}: {err!s}")
 
         if self.errored:
@@ -160,7 +161,7 @@ class BaseTask:
         self.errored = True
 
 
-def get_task_from_name(task_name: str) -> Type[BaseTask]:
+def get_task_from_name(task_name: str) -> type[BaseTask]:
     """Get a task subclass by its ``name``.
 
     For example, ``get_task_from_name("add_subtraction_files")`` will return the


### PR DESCRIPTION
* Prevent zero-division when calculating rate limit ratio.
* Prevent errors related to `EXCEPTION` and `sentry-structlog`.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
