### PR TITLE
fix: exclude isolates with no hits in reported pathoscope results

### DIFF
--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -196,7 +196,9 @@ def format_pathoscope_isolates(
             format_pathoscope_sequences(isolate["sequences"], hits_by_sequence_ids),
         )
 
-        if any((key in sequence for sequence in sequences) for key in ("pi", "final")):
+        if any(
+            any(key in sequence for sequence in sequences) for key in ("pi", "final")
+        ):
             yield {**isolate, "sequences": sequences}
 
 


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes:

- Prevents bug where isolates with no mapped hits were reported to the client. This occurred as a result of the generator objects returned by the internal comprehension being evaluated  as truthy by the external any

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
