### PR TITLE
fix: insert placeholder date for deleted subtractions without create_at

### DIFF
--- a/tests/revisions/__snapshots__/test_rev_lcq797n5ryxk_migrate_sample_files.ambr
+++ b/tests/revisions/__snapshots__/test_rev_lcq797n5ryxk_migrate_sample_files.ambr
@@ -44,8 +44,8 @@
 # ---
 # name: TestUpgrade.test_paired_unknown_legacy[paired_unknown_legacyfiles after]
   list([
-    'reads_2.fq.gz',
     'reads_1.fq.gz',
+    'reads_2.fq.gz',
   ])
 # ---
 # name: TestUpgrade.test_unpaired_legacy[SQLSampleReads after]

--- a/tests/revisions/__snapshots__/test_rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.ambr
+++ b/tests/revisions/__snapshots__/test_rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.ambr
@@ -19,5 +19,15 @@
       }),
       'nickname': '',
     }),
+    dict({
+      '_id': 'deleted_legacy',
+      'created_at': datetime,
+      'deleted': True,
+      'file': dict({
+        'id': 'legacy_file_id',
+        'name': 'legacy_file_id',
+      }),
+      'nickname': '',
+    }),
   ])
 # ---

--- a/tests/revisions/test_rev_lcq797n5ryxk_migrate_sample_files.py
+++ b/tests/revisions/test_rev_lcq797n5ryxk_migrate_sample_files.py
@@ -39,7 +39,11 @@ class TestUpgrade:
                     await session.execute(select(SQLSampleReads))
                 ).scalars().all() == snapshot(name="SQLSampleReads after")
 
-            assert os.listdir(ctx.data_path / "samples" / sample["_id"]) == snapshot(
+            assert sorted(
+                os.listdir(
+                    ctx.data_path / "samples" / sample["_id"],
+                ),
+            ) == snapshot(
                 name=f"{sample["_id"]}files after",
             )
 

--- a/tests/revisions/test_rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
+++ b/tests/revisions/test_rev_oxu8ghlvuqmh_update_subtraction_nicknames_created_at_and_file_names.py
@@ -21,6 +21,11 @@ async def test_upgrade(ctx: MigrationContext, snapshot):
                 "_id": "legacy",
                 "file": {"id": "legacy_file_id", "name": None},
             },
+            {
+                "_id": "deleted_legacy",
+                "file": {"id": "legacy_file_id", "name": None},
+                "deleted": True,
+            },
         ],
     )
 


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes:
 - Modify migration that sets `created_at` for subtractions to use a placeholder date when the subtraction both does not have a `created_at` field and the `subtraction` 's `deleted` field is `True`

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
