### PR TITLE
fix: fix `AttributeError` related to `get_extra_info("peername")`

### DIFF
--- a/virtool/api/authentication.py
+++ b/virtool/api/authentication.py
@@ -24,13 +24,18 @@ logger = get_logger("authn")
 
 
 def get_ip(req: Request) -> str:
-    """A convenience function for getting the client IP address from a
-    :class:`~Request` object.
+    """Get the client IP address from a request.
+
+    Sometimes the transport is known, in which the returned IP address is
+    an empty string.
 
     :param req: the request
     :return: the client's IP address string
 
     """
+    if req.transport is None:
+        return ""
+
     return req.transport.get_extra_info("peername")[0]
 
 


### PR DESCRIPTION
The `req.transport` attribute is sometimes `None`. This change prevents the unhandled
exception by returning an empty string when `transport` is `None`.

<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

## Pre-Review Checklist
* [ ] I have considered backwards and forwards compatibility.
* [ ] All changes are tested.
* [ ] All touched code documentation is updated.
