### PR TITLE
fix: handle sample group "none"

### DIFF
--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -13,7 +13,7 @@
       }),
     ]),
     'format': 'fastq',
-    'group': 'none',
+    'group': None,
     'group_read': True,
     'group_write': True,
     'hold': False,
@@ -51,7 +51,7 @@
   dict({
     'all_read': True,
     'all_write': True,
-    'group': 'none',
+    'group': None,
     'group_read': True,
     'group_write': True,
     'user': dict({

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -515,7 +515,7 @@ class SamplesData(DataLayerDomain):
         group = document["group"]
         if group == "none":
             group = None
-            
+
         is_group_member = bool(group and group in client.groups)
 
         if right == SampleRight.read:

--- a/virtool/samples/oas.py
+++ b/virtool/samples/oas.py
@@ -22,10 +22,10 @@ class CreateSampleRequest(BaseModel):
     @root_validator
     def validate_group(cls, values):
         group = values.get("group")
-        
+
         if group == "none":
             values["group"] = None
-            
+
         return values
 
 

--- a/virtool/samples/oas.py
+++ b/virtool/samples/oas.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import Field, conlist, constr
+from pydantic import Field, conlist, constr, root_validator
 
 from virtool.models import BaseModel
 from virtool.models.enums import AnalysisWorkflow, LibraryType
@@ -18,6 +18,15 @@ class CreateSampleRequest(BaseModel):
     files: conlist(item_type=Any, min_items=1, max_items=2)
     notes: str = ""
     labels: list = Field(default_factory=list)
+
+    @root_validator
+    def validate_group(cls, values):
+        group = values.get("group")
+        
+        if group == "none":
+            values["group"] = None
+            
+        return values
 
 
 class UpdateSampleRequest(BaseModel):
@@ -42,18 +51,27 @@ class UpdateSampleRequest(BaseModel):
 
 
 class UpdateRightsRequest(BaseModel):
-    group: int | str | None
     all_read: bool | None
     all_write: bool | None
+    group: int | str | None
     group_read: bool | None
     group_write: bool | None
 
-    _prevent_none = prevent_none("*")
+    @root_validator
+    def validate_group(cls, values):
+        group = values.get("group")
+
+        if group == "none":
+            values["group"] = None
+
+        return values
+
+    _prevent_none = prevent_none("all_read", "all_write", "group_read", "group_write")
 
     class Config:
         schema_extra = {
             "example": {
-                "group": "administrator",
+                "group": 4,
                 "group_read": True,
                 "group_write": True,
             },

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -70,7 +70,7 @@ def get_sample_rights(sample: dict, client: AbstractClient):
     group = sample["group"]
     if group == "none":
         group = None
-    
+
     is_group_member = group and client.is_group_member(group)
 
     read = sample["all_read"] or (is_group_member and sample["group_read"])

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -66,7 +66,12 @@ def get_sample_rights(sample: dict, client: AbstractClient):
     ):
         return True, True
 
-    is_group_member = sample["group"] and client.is_group_member(sample["group"])
+    # Handle both None and "none" during the transition period
+    group = sample["group"]
+    if group == "none":
+        group = None
+    
+    is_group_member = group and client.is_group_member(group)
 
     read = sample["all_read"] or (is_group_member and sample["group_read"])
 


### PR DESCRIPTION
When setting the `group` field of a sample, `'none'` and `None` will be accepted to mean _no group_.

The end goal is that `null` will be the sole indicator of _no group_.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
