### PR TITLE
ping on acquire

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ sphinx-autofixture = "^0.4.0"
 sphinx-toolbox = "^4.0.0"
 syrupy = "^4.5.0"
 
+[tool.pytest]
+norecursedirs = [".claude", ".git", ".github", "assets", "data", "docs"]
+testpaths = ["tests"]
+
 [tool.pytest.ini_options]
 addopts = [
     "-n", "auto",  # Automatically use the number of available CPUs

--- a/tests/fake/__snapshots__/test_next.ambr
+++ b/tests/fake/__snapshots__/test_next.ambr
@@ -83,7 +83,7 @@
     'created_at': datetime,
     'id': '7cf872dc',
     'ping': dict({
-      'pinged_at': datetime.datetime(2025, 6, 17, 23, 21, 15, 786000),
+      'pinged_at': datetime,
     }),
     'progress': 50,
     'retries': 0,
@@ -175,7 +175,7 @@
     'created_at': datetime,
     'id': 'fb085f7f',
     'ping': dict({
-      'pinged_at': datetime.datetime(2025, 6, 17, 23, 21, 15, 496000),
+      'pinged_at': datetime,
     }),
     'progress': 10,
     'retries': 0,

--- a/tests/fake/__snapshots__/test_next.ambr
+++ b/tests/fake/__snapshots__/test_next.ambr
@@ -82,7 +82,9 @@
     }),
     'created_at': datetime,
     'id': '7cf872dc',
-    'ping': None,
+    'ping': dict({
+      'pinged_at': datetime.datetime(2025, 6, 17, 23, 21, 15, 786000),
+    }),
     'progress': 50,
     'retries': 0,
     'stage': 'JURZHTCWaKMqqBTFitpK',
@@ -172,7 +174,9 @@
     }),
     'created_at': datetime,
     'id': 'fb085f7f',
-    'ping': None,
+    'ping': dict({
+      'pinged_at': datetime.datetime(2025, 6, 17, 23, 21, 15, 496000),
+    }),
     'progress': 10,
     'retries': 0,
     'stage': 'NzFJEUSgqMReEKilxKJT',

--- a/tests/fake/test_next.py
+++ b/tests/fake/test_next.py
@@ -29,6 +29,7 @@ async def test_groups_and_users(fake: DataFaker, snapshot):
         matcher=path_type(
             {
                 "created_at": (datetime,),
+                ".*pinged_at": (datetime,),
                 ".*timestamp": (datetime,),
             },
             regex=True,
@@ -44,6 +45,7 @@ async def test_jobs(fake: DataFaker, snapshot):
         matcher=path_type(
             {
                 "created_at": (datetime,),
+                ".*pinged_at": (datetime,),
                 ".*timestamp": (datetime,),
             },
             regex=True,

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -13,7 +13,9 @@
     'created_at': str,
     'id': 'fb085f7f',
     'key': str,
-    'ping': None,
+    'ping': dict({
+      'pinged_at': str,
+    }),
     'progress': 3,
     'retries': 0,
     'stage': None,
@@ -836,7 +838,9 @@
     }),
     'created_at': str,
     'id': '7cf872dc',
-    'ping': None,
+    'ping': dict({
+      'pinged_at': str,
+    }),
     'progress': 10,
     'retries': 0,
     'stage': 'NzFJEUSgqMReEKilxKJT',

--- a/tests/jobs/__snapshots__/test_data.ambr
+++ b/tests/jobs/__snapshots__/test_data.ambr
@@ -7,7 +7,9 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'id': 'foo',
     'key': 'key',
-    'ping': None,
+    'ping': dict({
+      'pinged_at': datetime.datetime(2015, 10, 6, 20, 0),
+    }),
     'progress': 3,
     'retries': 0,
     'stage': None,
@@ -38,6 +40,9 @@
     'args': dict({
     }),
     'key': 'hashed',
+    'ping': dict({
+      'pinged_at': datetime.datetime(2015, 10, 6, 20, 0),
+    }),
     'rights': dict({
     }),
     'state': 'preparing',

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -2,6 +2,7 @@ import datetime
 
 import arrow
 import pytest
+from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
@@ -11,7 +12,12 @@ from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 
 _job_response_matcher = path_type(
-    {".*created_at": (str,), ".*key": (str,), ".*timestamp": (str,)},
+    {
+        ".*created_at": (str,),
+        ".*key": (str,),
+        ".*pinged_at": (str,),
+        ".*timestamp": (str,),
+    },
     regex=True,
 )
 
@@ -20,7 +26,7 @@ class TestFind:
     async def test_basic(
         self,
         fake: DataFaker,
-        snapshot,
+        snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
         client = await spawn_client(authenticated=True)

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -162,15 +162,6 @@ class TestRetry:
         ):
             await data_layer.jobs.retry(job.id)
 
-    async def test_no_ping_field(self, data_layer: DataLayer, fake: DataFaker):
-        """Test a job cannot be retried if it has no ping field."""
-        job = await fake.jobs.create(self.user, state=JobState.RUNNING)
-
-        with pytest.raises(
-            ResourceConflictError, match="RUNNING job has no recorded ping field"
-        ):
-            await data_layer.jobs.retry(job.id)
-
     @pytest.mark.parametrize(
         "state",
         [JobState.COMPLETE, JobState.ERROR, JobState.TERMINATED, JobState.TIMEOUT],

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -540,29 +540,25 @@ class JobsData:
 
         # Handle PREPARING jobs without ping field - check if they've been preparing too
         # long.
-        if job.ping is None:
-            if job.state == JobState.PREPARING:
-                # Find the timestamp when the job entered PREPARING state
-                preparing_timestamp = None
-                for status in reversed(job.status):
-                    if status.state == JobState.PREPARING:
-                        preparing_timestamp = status.timestamp
-                        break
+        if job.ping is None and job.state == JobState.PREPARING:
+            # Find the timestamp when the job entered PREPARING state
+            preparing_timestamp = None
+            for status in reversed(job.status):
+                if status.state == JobState.PREPARING:
+                    preparing_timestamp = status.timestamp
+                    break
 
-                if preparing_timestamp is None:
-                    raise ResourceConflictError(
-                        "Cannot determine when job entered PREPARING state"
-                    )
+            if preparing_timestamp is None:
+                raise ResourceConflictError(
+                    "Cannot determine when job entered PREPARING state"
+                )
 
-                # If job has been PREPARING for more than 3 minutes without a ping,
-                # consider it stalled.
-                if preparing_timestamp > now.shift(minutes=-3).naive:
-                    raise ResourceConflictError(
-                        "Job has been PREPARING for less than 3 minutes"
-                    )
-            else:
-                # RUNNING jobs should always have a ping field
-                raise ResourceConflictError("RUNNING job has no recorded ping field")
+            # If job has been PREPARING for more than 3 minutes without a ping,
+            # consider it stalled.
+            if preparing_timestamp > now.shift(minutes=-3).naive:
+                raise ResourceConflictError(
+                    "Job has been PREPARING for less than 3 minutes"
+                )
 
         elif job.ping.pinged_at > now.shift(minutes=-5).naive:
             raise ResourceConflictError("Job has been pinged within the last 5 minutes")

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -271,6 +271,9 @@ class JobsData:
                 "$set": {
                     "acquired": True,
                     "key": hashed,
+                    "ping": {
+                        "pinged_at": virtool.utils.timestamp(),
+                    },
                     "state": JobState.PREPARING.value,
                 },
                 "$push": {


### PR DESCRIPTION
Ping jobs when they are acquired.

This tightens up state tracking for jobs. We can call a job stalled if it is not WAITING and its ping grace period has been exceeded.

<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

## Pre-Review Checklist
* [ ] I have considered backwards and forwards compatibility.
* [ ] All changes are tested.
* [ ] All touched code documentation is updated.
