### PR TITLE
chore(deps): bump sqlalchemy from 2.0.24 to 2.0.42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,14 @@ __pycache__
 .pytest_cache
 .venv
 .vscode
+
 /assets/prunus_persica
 /build
 /data
 /docs/_build
 /misc
 /watch
+
 CLAUDE.md
 config.json
 settings.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pyyaml<7.0.0,>=6.0.0",
     "semver>=2.13.0,<4.0.0",
     "sentry-sdk<3.0.0,>=2.30.0",
-    "sqlalchemy==2.0.24",
+    "sqlalchemy>=2.0.42",
     "structlog-sentry<3.0.0,>=2.1.0",
     "uvloop<1.0.0,>=0.21.0",
     "visvalingamwyatt<1.0.0,>=0.1.4",

--- a/tests/account/__snapshots__/test_data.ambr
+++ b/tests/account/__snapshots__/test_data.ambr
@@ -116,7 +116,7 @@
   })
 # ---
 # name: test_update[email][pg]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='None')>
 # ---
 # name: test_update[password and email][mongo]
   dict({
@@ -139,7 +139,7 @@
   })
 # ---
 # name: test_update[password and email][pg]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='hello@world.com', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='None')>
 # ---
 # name: test_update[password][mongo]
   dict({
@@ -161,5 +161,5 @@
   })
 # ---
 # name: test_update[password][pg]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='None')>
 # ---

--- a/tests/revisions/__snapshots__/test_rev_e83uz1iz5tw2_copy_users_to_postgres.ambr
+++ b/tests/revisions/__snapshots__/test_rev_e83uz1iz5tw2_copy_users_to_postgres.ambr
@@ -1,17 +1,17 @@
 # serializer version: 1
 # name: TestUpgrade.test_upgrade
   list([
-    <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='modern_user', invalidate_sessions='False', last_password_change='datetime', legacy_id='9SYJ3IWB', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='[]')>,
+    <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='modern_user', invalidate_sessions='False', last_password_change='datetime', legacy_id='9SYJ3IWB', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[]', primary_group='None')>,
   ])
 # ---
 # name: TestUpgrade.test_upgrade_existing_sql_user
   list([
-    <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='pre-existing sql user', invalidate_sessions='False', last_password_change='datetime', legacy_id='9SYJ3IWB', settings='{}', groups='[]', primary_group='[]')>,
+    <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='pre-existing sql user', invalidate_sessions='False', last_password_change='datetime', legacy_id='9SYJ3IWB', settings='{}', groups='[]', primary_group='None')>,
   ])
 # ---
 # name: TestUpgrade.test_upgrade_groups
   list([
-    <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='modern_user', invalidate_sessions='False', last_password_change='datetime', legacy_id='9SYJ3IWB', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=test_group, permissions={})>]', primary_group='[<SQLGroup(id=1, legacy_id=None, name=test_group, permissions={})>]')>,
+    <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='modern_user', invalidate_sessions='False', last_password_change='datetime', legacy_id='9SYJ3IWB', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=test_group, permissions={})>]', primary_group='<SQLGroup(id=1, legacy_id=None, name=test_group, permissions={})>')>,
   ])
 # ---
 # name: test_upgrade

--- a/tests/uploads/__snapshots__/test_api.ambr
+++ b/tests/uploads/__snapshots__/test_api.ambr
@@ -123,15 +123,15 @@
     'items': list([
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 3,
+        'id': 1,
         'name': 'test.fq.gz',
-        'name_on_disk': '3-test.fq.gz',
+        'name_on_disk': '1-test.fq.gz',
         'ready': True,
         'removed': False,
         'removed_at': None,
         'reserved': False,
         'size': 16700094,
-        'type': 'reference',
+        'type': 'reads',
         'uploaded_at': '2015-10-06T20:00:00Z',
         'user': dict({
           'handle': 'leeashley',
@@ -151,15 +151,15 @@
     'items': list([
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 1,
+        'id': 4,
         'name': 'test.fq.gz',
-        'name_on_disk': '1-test.fq.gz',
+        'name_on_disk': '4-test.fq.gz',
         'ready': True,
         'removed': False,
         'removed_at': None,
         'reserved': False,
         'size': 16700094,
-        'type': 'reads',
+        'type': 'subtraction',
         'uploaded_at': '2015-10-06T20:00:00Z',
         'user': dict({
           'handle': 'leeashley',
@@ -179,6 +179,23 @@
     'items': list([
       dict({
         'created_at': '2015-10-06T20:00:00Z',
+        'id': 4,
+        'name': 'test.fq.gz',
+        'name_on_disk': '4-test.fq.gz',
+        'ready': True,
+        'removed': False,
+        'removed_at': None,
+        'reserved': False,
+        'size': 16700094,
+        'type': 'subtraction',
+        'uploaded_at': '2015-10-06T20:00:00Z',
+        'user': dict({
+          'handle': 'leeashley',
+          'id': 'fb085f7f',
+        }),
+      }),
+      dict({
+        'created_at': '2015-10-06T20:00:00Z',
         'id': 1,
         'name': 'test.fq.gz',
         'name_on_disk': '1-test.fq.gz',
@@ -188,23 +205,6 @@
         'reserved': False,
         'size': 16700094,
         'type': 'reads',
-        'uploaded_at': '2015-10-06T20:00:00Z',
-        'user': dict({
-          'handle': 'leeashley',
-          'id': 'fb085f7f',
-        }),
-      }),
-      dict({
-        'created_at': '2015-10-06T20:00:00Z',
-        'id': 3,
-        'name': 'test.fq.gz',
-        'name_on_disk': '3-test.fq.gz',
-        'ready': True,
-        'removed': False,
-        'removed_at': None,
-        'reserved': False,
-        'size': 16700094,
-        'type': 'reference',
         'uploaded_at': '2015-10-06T20:00:00Z',
         'user': dict({
           'handle': 'leeashley',

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -56,7 +56,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -122,7 +122,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -188,7 +188,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -254,7 +254,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -567,7 +567,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -592,7 +592,7 @@
     'invalidate_sessions': True,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -617,7 +617,7 @@
     'invalidate_sessions': True,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -777,10 +777,10 @@
   })
 # ---
 # name: TestUpdate.test_groups[pg_1]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=meteorologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=meteorologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
 # ---
 # name: TestUpdate.test_groups[pg_2]
-  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=2, legacy_id=None, name=geoscientists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='[]')>
+  <SQLUser(id='1', active='True', b2c_display_name='', b2c_given_name='', b2c_family_name='', b2c_oid='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='bf1b993c', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=2, legacy_id=None, name=geoscientists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
 # ---
 # name: TestUpdate.test_groups[pg_3]
   dict({
@@ -798,7 +798,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -865,7 +865,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -939,7 +939,7 @@
     'invalidate_sessions': True,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [],
+    'primary_group': None,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,
@@ -1017,7 +1017,7 @@
     'invalidate_sessions': False,
     'last_password_change': 'approximately_now_datetime',
     'legacy_id': 'bf1b993c',
-    'primary_group': [<SQLGroup(id=1, legacy_id=None, name=musicians, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>],
+    'primary_group': <SQLGroup(id=1, legacy_id=None, name=musicians, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,
     'settings': dict({
       'quick_analyze_workflow': 'pathoscope_bowtie',
       'show_ids': True,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12.3, <3.13"
 
 [[package]]
@@ -1542,23 +1542,23 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.24"
+version = "2.0.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/72/dd7a1062a9eb723a0c767e151386be92f0cf825317b864e6d5a7c0e60628/SQLAlchemy-2.0.24.tar.gz", hash = "sha256:6db97656fd3fe3f7e5b077f12fa6adb5feb6e0b567a3e99f47ecf5f7ea0a09e3", size = 9490665, upload-time = "2023-12-28T16:22:55.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/03/a0af991e3a43174d6b83fca4fb399745abceddd1171bdabae48ce877ff47/sqlalchemy-2.0.42.tar.gz", hash = "sha256:160bedd8a5c28765bd5be4dec2d881e109e33b34922e50a3b881a7681773ac5f", size = 9749972, upload-time = "2025-07-29T12:48:09.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/0f/6b1ea1b92bc26f277ad258d46bb3940da51822018ca9b724d2a26b4453ec/SQLAlchemy-2.0.24-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9f992e0f916201731993eab8502912878f02287d9f765ef843677ff118d0e0b1", size = 2071199, upload-time = "2023-12-28T16:34:28.009Z" },
-    { url = "https://files.pythonhosted.org/packages/42/3c/fe2f17890918e2a5b22bed1b1e151646bf1300a3cb9b3d47a3926cc32779/SQLAlchemy-2.0.24-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2587e108463cc2e5b45a896b2e7cc8659a517038026922a758bde009271aed11", size = 2063861, upload-time = "2023-12-28T16:34:31.04Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/ec/c1573635e20c7e9e35814e8fe7ab9f090a907f03b3974d5f000765401cee/SQLAlchemy-2.0.24-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bb7cedcddffca98c40bb0becd3423e293d1fef442b869da40843d751785beb3", size = 3216706, upload-time = "2023-12-28T18:10:48.223Z" },
-    { url = "https://files.pythonhosted.org/packages/54/af/905ae4c56eb2b4bcec0ed17ee84001ad7d43c19fd2594f203bd237c956c3/SQLAlchemy-2.0.24-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83fa6df0e035689df89ff77a46bf8738696785d3156c2c61494acdcddc75c69d", size = 3227214, upload-time = "2023-12-28T16:37:52.296Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/68/4446663485b0e8ebdcc5183c279ce6f3cacfbc317e33e6768a73dbb1235c/SQLAlchemy-2.0.24-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:cc889fda484d54d0b31feec409406267616536d048a450fc46943e152700bb79", size = 3220677, upload-time = "2023-12-28T18:10:51.078Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/6d/b031b6645f979ffb86b049ba96ef7b6d5e32f427496e4722f2ddcd4d5ace/SQLAlchemy-2.0.24-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:57ef6f2cb8b09a042d0dbeaa46a30f2df5dd1e1eb889ba258b0d5d7d6011b81c", size = 3226688, upload-time = "2023-12-28T16:37:55.158Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/78/f14cfd126ad584cba979b0d1d37062fbfa5b1ea5f205e11e3c850f2672c7/SQLAlchemy-2.0.24-cp312-cp312-win32.whl", hash = "sha256:ea490564435b5b204d8154f0e18387b499ea3cedc1e6af3b3a2ab18291d85aa7", size = 2040645, upload-time = "2023-12-28T16:43:42.47Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4f/eae2ab4a49fe7bad5649ea35a4a502c2445d779d9e32a3ac390842189058/SQLAlchemy-2.0.24-cp312-cp312-win_amd64.whl", hash = "sha256:ccfd336f96d4c9bbab0309f2a565bf15c468c2d8b2d277a32f89c5940f71fcf9", size = 2066513, upload-time = "2023-12-28T16:43:45.017Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/2a/9fbefab932c670cdb12dfd3d7c7e3ba2574bb644bc63381f526701e338a6/SQLAlchemy-2.0.24-py3-none-any.whl", hash = "sha256:8f358f5cfce04417b6ff738748ca4806fe3d3ae8040fb4e6a0c9a6973ccf9b6e", size = 1863328, upload-time = "2023-12-28T16:44:52.463Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/ac31a9821fc70a7376321fb2c70fdd7eadbc06dadf66ee216a22a41d6058/sqlalchemy-2.0.42-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:09637a0872689d3eb71c41e249c6f422e3e18bbd05b4cd258193cfc7a9a50da2", size = 2132203, upload-time = "2025-07-29T13:29:19.291Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ba/fd943172e017f955d7a8b3a94695265b7114efe4854feaa01f057e8f5293/sqlalchemy-2.0.42-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3cb3ec67cc08bea54e06b569398ae21623534a7b1b23c258883a7c696ae10df", size = 2120373, upload-time = "2025-07-29T13:29:21.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a2/b5f7d233d063ffadf7e9fff3898b42657ba154a5bec95a96f44cba7f818b/sqlalchemy-2.0.42-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e87e6a5ef6f9d8daeb2ce5918bf5fddecc11cae6a7d7a671fcc4616c47635e01", size = 3317685, upload-time = "2025-07-29T13:26:40.837Z" },
+    { url = "https://files.pythonhosted.org/packages/86/00/fcd8daab13a9119d41f3e485a101c29f5d2085bda459154ba354c616bf4e/sqlalchemy-2.0.42-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b718011a9d66c0d2f78e1997755cd965f3414563b31867475e9bc6efdc2281d", size = 3326967, upload-time = "2025-07-29T13:22:31.009Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/85/e622a273d648d39d6771157961956991a6d760e323e273d15e9704c30ccc/sqlalchemy-2.0.42-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:16d9b544873fe6486dddbb859501a07d89f77c61d29060bb87d0faf7519b6a4d", size = 3255331, upload-time = "2025-07-29T13:26:42.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a0/2c2338b592c7b0a61feffd005378c084b4c01fabaf1ed5f655ab7bd446f0/sqlalchemy-2.0.42-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:21bfdf57abf72fa89b97dd74d3187caa3172a78c125f2144764a73970810c4ee", size = 3291791, upload-time = "2025-07-29T13:22:32.454Z" },
+    { url = "https://files.pythonhosted.org/packages/41/19/b8a2907972a78285fdce4c880ecaab3c5067eb726882ca6347f7a4bf64f6/sqlalchemy-2.0.42-cp312-cp312-win32.whl", hash = "sha256:78b46555b730a24901ceb4cb901c6b45c9407f8875209ed3c5d6bcd0390a6ed1", size = 2096180, upload-time = "2025-07-29T13:16:08.952Z" },
+    { url = "https://files.pythonhosted.org/packages/48/1f/67a78f3dfd08a2ed1c7be820fe7775944f5126080b5027cc859084f8e223/sqlalchemy-2.0.42-cp312-cp312-win_amd64.whl", hash = "sha256:4c94447a016f36c4da80072e6c6964713b0af3c8019e9c4daadf21f61b81ab53", size = 2123533, upload-time = "2025-07-29T13:16:11.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/ba2546ab09a6adebc521bf3974440dc1d8c06ed342cceb30ed62a8858835/sqlalchemy-2.0.42-py3-none-any.whl", hash = "sha256:defcdff7e661f0043daa381832af65d616e060ddb54d3fe4476f51df7eaa1835", size = 1922072, upload-time = "2025-07-29T13:09:17.061Z" },
 ]
 
 [[package]]
@@ -1792,7 +1792,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.2.0,<7.0.0" },
     { name = "semver", specifier = ">=2.13.0,<4.0.0" },
     { name = "sentry-sdk", specifier = ">=2.30.0,<3.0.0" },
-    { name = "sqlalchemy", specifier = "==2.0.24" },
+    { name = "sqlalchemy", specifier = ">=2.0.42" },
     { name = "structlog-sentry", specifier = ">=2.1.0,<3.0.0" },
     { name = "uvloop", specifier = ">=0.21.0,<1.0.0" },
     { name = "visvalingamwyatt", specifier = ">=0.1.4,<1.0.0" },

--- a/virtool/groups/mongo.py
+++ b/virtool/groups/mongo.py
@@ -58,7 +58,7 @@ async def update_member_users_and_api_keys(
             }
 
             if user["primary_group"] not in all_group_ids:
-                update["primary_group"] = ""
+                update["primary_group"] = None
 
             user = await mongo.users.find_one_and_update(
                 {"_id": user["_id"]},

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -441,7 +441,8 @@ class SamplesData(DataLayerDomain):
             )
 
             for row in rows:
-                row.reads.clear()
+                if row.reads is not None:
+                    row.reads.clear()
                 row.removed = True
                 row.removed_at = virtool.utils.timestamp()
 

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -183,7 +183,8 @@ class UploadsData(DataLayerDomain):
             if not upload or upload.removed:
                 raise ResourceNotFoundError
 
-            upload.reads.clear()
+            if upload.reads is not None:
+                upload.reads.clear()
             upload.removed = True
             upload.removed_at = virtool.utils.timestamp()
 


### PR DESCRIPTION
Bumps sqlalchemy from 2.0.24 to 2.0.42.

This update broke some SQLAlechmy functionality and I had to patch it and
update tests.

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
