### PR TITLE
feat: define storage backend protocol and types

### DIFF
--- a/virtool/storage/__init__.py
+++ b/virtool/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage backend abstraction for Virtool."""

--- a/virtool/storage/errors.py
+++ b/virtool/storage/errors.py
@@ -1,0 +1,9 @@
+"""Errors raised by storage operations."""
+
+
+class StorageError(Exception):
+    """Base exception for storage operations."""
+
+
+class StorageKeyNotFoundError(StorageError):
+    """The requested key does not exist in storage."""

--- a/virtool/storage/protocol.py
+++ b/virtool/storage/protocol.py
@@ -1,0 +1,50 @@
+"""The storage backend protocol."""
+
+from collections.abc import AsyncIterator
+from typing import Protocol
+
+from virtool.storage.types import StorageObjectInfo
+
+STORAGE_CHUNK_SIZE: int = 4 * 1024 * 1024
+"""The default chunk size for storage operations in bytes (4 MiB)."""
+
+
+class StorageBackend(Protocol):
+    """A protocol for storage backends.
+
+    All methods are async. Read and list return async iterators for streaming.
+    Keys are ``/``-delimited strings with no leading slash (e.g.,
+    ``"samples/abc123/reads_1.fq.gz"``).
+    """
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        """Stream the contents of the object at ``key`` as chunks of bytes.
+
+        Raises :class:`~virtool.storage.errors.StorageKeyNotFoundError` if the
+        key does not exist.
+        """
+        ...
+
+    async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
+        """Write streamed data to the object at ``key``.
+
+        Accepts an async iterator of byte chunks. Creates or overwrites the
+        object. Returns the total number of bytes written.
+        """
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Delete the object at ``key``.
+
+        Raises :class:`~virtool.storage.errors.StorageKeyNotFoundError` if the
+        key does not exist.
+        """
+        ...
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        """List objects whose keys start with ``prefix``.
+
+        Yields :class:`~virtool.storage.types.StorageObjectInfo` for each
+        matching object.
+        """
+        ...

--- a/virtool/storage/types.py
+++ b/virtool/storage/types.py
@@ -1,0 +1,18 @@
+"""Types for the storage abstraction."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class StorageObjectInfo:
+    """Metadata for a stored object, yielded by ``StorageBackend.list()``."""
+
+    key: str
+    """The full key of the object (e.g., ``"samples/abc123/reads_1.fq.gz"``)."""
+
+    size: int
+    """The size of the object in bytes."""
+
+    last_modified: datetime
+    """When the object was last modified."""


### PR DESCRIPTION
## Summary

- Add `virtool/storage/` module with the `StorageBackend` typing protocol, `StorageObjectInfo` frozen dataclass, storage-specific errors, and a default chunk size constant.
- This is the root dependency for all storage backend implementations in the Object Storage project (VIR-2253).
- All new code uses stdlib only (no third-party dependencies) and targets Python 3.13+.