### PR TITLE
chore(ci): drop OAS generation from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,31 +53,6 @@ jobs:
       - name: Check formatting
         run: mise run format:check
 
-  # Generate the OpenAPI specification and upload it as an artifact.
-  oas:
-    name: Generate OAS
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Install mise
-        uses: jdx/mise-action@v3
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
-      - name: Set up Python
-        run: uv python install
-      - name: Install dependencies
-        run: uv sync
-      - name: Generate OAS
-        run: mise run oas
-      - name: Upload OAS
-        uses: actions/upload-artifact@v7
-        with:
-          name: openapi.json
-          path: virtool/spec/openapi.json
-
   # Run our test suite.
   test:
     name: Test
@@ -99,7 +74,7 @@ jobs:
     name: "Publish / Release"
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'Virtool' && github.event_name == 'push'
-    needs: [build, oas, test, ruff-format]
+    needs: [build, test, ruff-format]
     outputs:
       git-tag: ${{ steps.semantic.outputs.git-tag }}
     permissions:
@@ -107,11 +82,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Download OAS
-        uses: actions/download-artifact@v8
-        with:
-          name: openapi.json
-          path: virtool/spec/openapi.json
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- Remove the OAS generation and artifact upload job from CI
- Remove the OAS artifact download step from the release job