### PR TITLE
feat: implement obstore storage backend for S3 and Azure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,8 @@ Releases are automated with semantic-release.
 - Keep titles concise, lowercase
 - Include a body only when useful; keep it brief
 - Only push or create PRs when asked
+- Do not use `git -C` — it breaks allowed tools settings. Run git commands
+  from the working directory instead.
 
 ## Linear
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "sqlalchemy>=2.0.42",
   "structlog-sentry<3.0.0,>=2.1.0",
   "visvalingamwyatt<1.0.0,>=0.1.4",
+  "obstore>=0.5.0",
   "redis<7.0.0,>=6.2.0",
   "enum-tools<1.0.0,>=0.13.0",
   "aiofiles>=24.1.0",

--- a/tests/storage/test_obstore.py
+++ b/tests/storage/test_obstore.py
@@ -1,0 +1,106 @@
+import pytest
+from obstore.store import MemoryStore
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.obstore import ObstoreProvider
+from virtool.storage.types import StorageObjectInfo
+
+
+@pytest.fixture
+def provider():
+    return ObstoreProvider(MemoryStore())
+
+
+async def _async_iter(data: bytes, chunk_size: int = 1024):
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+async def _collect_bytes(aiter) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
+async def _collect(aiter) -> list:
+    return [item async for item in aiter]
+
+
+class TestRead:
+    async def test_ok(self, provider):
+        await provider._store.put_async("samples/abc/reads.fq.gz", b"read data here")
+
+        result = await _collect_bytes(provider.read("samples/abc/reads.fq.gz"))
+
+        assert result == b"read data here"
+
+    async def test_nonexistent_key(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(provider.read("does/not/exist"))
+
+
+class TestWrite:
+    async def test_returns_byte_count(self, provider):
+        data = b"x" * 5000
+
+        size = await provider.write("uploads/file.txt", _async_iter(data))
+
+        assert size == 5000
+
+    async def test_creates_object(self, provider):
+        data = b"hello"
+
+        await provider.write("uploads/file.txt", _async_iter(data))
+
+        result = await provider._store.get_async("uploads/file.txt")
+        assert await result.bytes_async() == data
+
+    async def test_overwrites_existing(self, provider):
+        await provider.write("key", _async_iter(b"first"))
+        await provider.write("key", _async_iter(b"second"))
+
+        result = await provider._store.get_async("key")
+        assert await result.bytes_async() == b"second"
+
+
+class TestDelete:
+    async def test_existing_key(self, provider):
+        await provider._store.put_async("to_delete", b"data")
+
+        await provider.delete("to_delete")
+
+        with pytest.raises(FileNotFoundError):
+            await provider._store.get_async("to_delete")
+
+    async def test_nonexistent_is_idempotent(self, provider):
+        await provider.delete("does/not/exist")
+
+
+class TestList:
+    async def test_with_prefix(self, provider):
+        await provider._store.put_async("samples/a/reads.fq.gz", b"a")
+        await provider._store.put_async("samples/b/reads.fq.gz", b"b")
+        await provider._store.put_async("uploads/file.txt", b"c")
+
+        result = await _collect(provider.list("samples/"))
+
+        keys = sorted(item.key for item in result)
+        assert keys == ["samples/a/reads.fq.gz", "samples/b/reads.fq.gz"]
+
+    async def test_no_matches(self, provider):
+        await provider._store.put_async("samples/a/reads.fq.gz", b"a")
+
+        result = await _collect(provider.list("uploads/"))
+
+        assert result == []
+
+    async def test_metadata(self, provider):
+        await provider._store.put_async("test/file.txt", b"hello")
+
+        result = await _collect(provider.list("test/"))
+
+        assert len(result) == 1
+
+        info = result[0]
+        assert isinstance(info, StorageObjectInfo)
+        assert info.key == "test/file.txt"
+        assert info.size == 5
+        assert info.last_modified is not None

--- a/uv.lock
+++ b/uv.lock
@@ -662,6 +662,40 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/96/b4e0d466715daec9e221cccb8ac57dc91ba08830a68d7ed5a2729ab21a32/obstore-0.9.3.tar.gz", hash = "sha256:0f56e7efd53c22e7eaf14ccce931c678b01a016ceb2226cd4bb01c741a58f5a2", size = 124143, upload-time = "2026-04-15T18:16:56.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/c0/202a30127786169e74516ae700de8f153c430d349985bf6d09b33ab7f481/obstore-0.9.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e56bd948c87e0b16211ea0363913529c1cda67d9ada809c28e70a9b22c385433", size = 4112171, upload-time = "2026-04-15T18:15:09.478Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8e/fc4995a82b53cdd8e61f5ebfe5007deeeda4f0746b0e46e1dbbd293d9d3d/obstore-0.9.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b65c3d17ff6fa7a239b99df05e6f2badb1852a1cc56ebcd24f9347d88b5cc629", size = 3880522, upload-time = "2026-04-15T18:15:11.744Z" },
+    { url = "https://files.pythonhosted.org/packages/86/82/5f6c3ff5b25e6bd0b97c6d5459b91edcbc4ab71e66a2df1b9a6884a8a4bc/obstore-0.9.3-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7178850a492a3bd534bf6d178d20aee4a171e6b4a4fead46f9879a630db06353", size = 4042745, upload-time = "2026-04-15T18:15:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b1/5df6a6b2f1a8039b3dc06e9a0d990fe26471f153529a8e92dad4167f505a/obstore-0.9.3-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5fdc75d11d4f17dd79fe47bb7576dd404675d52f99e0d998319f4bf032541171", size = 4145646, upload-time = "2026-04-15T18:15:15.829Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/a238ad9e1c4f3aba8a7acff04eba7d7e143aa07f7a26435acf5655372953/obstore-0.9.3-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1943511b022ce49010059b4b274f1608daf041827e9a8e0ae2311c70fcea921b", size = 4427486, upload-time = "2026-04-15T18:15:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/be/adffdbec3edb4cf2bea2f856ebf14efc0e398843a477823040c95a39c754/obstore-0.9.3-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c4ed947b1cb5da6d8a8af8d2378b038dab34deb86e679c940a8a09f2ad72a4", size = 4340837, upload-time = "2026-04-15T18:15:19.711Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/cf/92593c3981e38e9f682d858aff251f6731517d682a9b389cb1e2c94ed6a4/obstore-0.9.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab427bec57b8b5084eccd78d7592cf28860a1cf631bd0e0b8c0e0b793efdc033", size = 4231679, upload-time = "2026-04-15T18:15:21.473Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8b/920f726117180e57c51bf6bc503f286782a3bbb6fb8f70ed9bff4f674796/obstore-0.9.3-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:48f58c44c9a5c7b82346fe5e3469bae3109c8b168c1c096c41b80a9f0bc8d5a6", size = 4105350, upload-time = "2026-04-15T18:15:23.566Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5c/6abd29ae02f64f677a67cab6ee5492d14f004b483bafbf397c3ddef4f4bf/obstore-0.9.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:591db6375f90a7528f902d3cff8738d93219d6162d517e4d464bd333133daa1d", size = 4296104, upload-time = "2026-04-15T18:15:25.388Z" },
+    { url = "https://files.pythonhosted.org/packages/21/92/a1eacdf5bf0ca2d2d7fc6d6430e1f305782abaa0409fe120fcfc3083dea4/obstore-0.9.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e42c3caf9f77a2a5aaddfd6a2356c3ad317884f188cfec5b000c48c21362af79", size = 4278210, upload-time = "2026-04-15T18:15:27.43Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c6/8e62cab73552f5491f01bffbb279b7d25ec148fb89ca4ad4192ac00c6d95/obstore-0.9.3-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:bb509ea1fec9dcee996151f2c5d6664b1516da12675d2c27583ef9fff81c43ec", size = 4266039, upload-time = "2026-04-15T18:15:29.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/36b1823574277d3a494b7280883a0d78ed46e71d3e8e4de2b8135b15792a/obstore-0.9.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6eec5a7a917ec6a5148d4dd6a0e53ce87949c520de96b1822bbbc4aa79b65610", size = 4451602, upload-time = "2026-04-15T18:15:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/8f4650d2e29472998bbcbfb1f0a67e865fea419108faa43f5d180bdb166a/obstore-0.9.3-cp311-abi3-win_amd64.whl", hash = "sha256:87a1d5db9804df06f0ed5cd25b209c527fc2ec54a91c56ae6ff62d27db680b92", size = 4190181, upload-time = "2026-04-15T18:15:33.235Z" },
+    { url = "https://files.pythonhosted.org/packages/22/9f/8df3b10646a3b90c318f85f8e89feca337c6cf56cb50f003e03124186dd2/obstore-0.9.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d738d976a15cca90fb6a900c4f546544644b38a559bb99f6372030bb80e058d5", size = 4084824, upload-time = "2026-04-15T18:15:35.038Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ce/e5729f8504e48ab88586138a0311ae7800a2f61a3fc989444ee29a1dbdb6/obstore-0.9.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:663ed5b534d3896e703725d2b4f11959fbbb3e499b39e7f2fb9044aad658c568", size = 3867311, upload-time = "2026-04-15T18:15:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/30/c96619b6faf1337edd0ba82bf06cbf6d20124152d9848a20bbe4ec8da046/obstore-0.9.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c3d84f21424dbb9d7acd0111d3f281e61ca0f8a21f7b7f2e5599d515fff5b02", size = 4036006, upload-time = "2026-04-15T18:15:39.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ab/48e5caf2bac13deba9d4e87dda28850f68b39b69a0431e5254200bfed786/obstore-0.9.3-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d535037d5c4240a849716b69e98aa7e7e5cea1b116558ede08a9962f501c23b3", size = 4135380, upload-time = "2026-04-15T18:15:41.783Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d4/11f6a74df6d0b891be9538129c61cee50518835face031d0138a2505e371/obstore-0.9.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71cdbebbcb78f63ffe4042e86e1ad41e723245bad42cf79b4c750592cb01aa57", size = 4414425, upload-time = "2026-04-15T18:15:43.586Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c3/d299c174875490bbe9110d68887acbf4e197dd13becda75f1b8e13033f46/obstore-0.9.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d196a009870151d8c1bf8a550e3ce0c15c6a48af9bb36bb8954e70e52136863d", size = 4338358, upload-time = "2026-04-15T18:15:45.898Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ab/29b55e1536ea0891062d0f2109f5c81804cb36976590418700bf8ec287b9/obstore-0.9.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da32f949a21dfa15739ce6286572a67ce167b827e0a28cbcbb956c25d29162fa", size = 4220536, upload-time = "2026-04-15T18:15:47.822Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/08/3ee0302ccb106c82600e9e0c1985c426f9906116ef68ecb0a0547ad0e728/obstore-0.9.3-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:a97b7ba1211c39ec58821c52a8719fde710e17ee17c40067e360f45c1e444a0b", size = 4102754, upload-time = "2026-04-15T18:15:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/17/04/fa33f40d8f96ecce24bcd1c92989a95885c78509e587748960b0299df696/obstore-0.9.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f5051b250080f739b53ff0c09a16b369206aa0aa904449cd8eadae8f51b03d0f", size = 4290696, upload-time = "2026-04-15T18:15:52.003Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/43/30e1d06f1c037a2e032d016ba381950ba8589432f012b88c3866af00f6ea/obstore-0.9.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:9a7251b2ffbb945cf19daf05c074850a79661ee667ba1e95cb53891cb706b9aa", size = 4272490, upload-time = "2026-04-15T18:15:53.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/2b4fe6979a4f2b0c53b0caea2fa7ceaf1494a0662cd8fa1d127fdc3d659d/obstore-0.9.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b8db25033f71e17e996ca05043118e64cf2067190081912dee85cb4c0ab192e5", size = 4254455, upload-time = "2026-04-15T18:15:56.313Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/6974c786022f5339243d44a10f53708a8a17c8b7f7b5ad7cf7d9236c9e36/obstore-0.9.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e5f07ca479133dd1768b763cddcd1f3990a22ca4f2f071f5fd77d2bdf7d2baec", size = 4440612, upload-time = "2026-04-15T18:15:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/72/9efbd4331a7c58b520a15bf11086ef483c2f86859fa08788741442bb0b76/obstore-0.9.3-cp313-cp313t-win_amd64.whl", hash = "sha256:48e4debe9e0f2efc89208b95cc72dbc666debafd453fe6e9e71e6a24260fb4f6", size = 4177664, upload-time = "2026-04-15T18:16:00.642Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1242,6 +1276,7 @@ dependencies = [
     { name = "enum-tools" },
     { name = "faker" },
     { name = "motor" },
+    { name = "obstore" },
     { name = "openpyxl" },
     { name = "orjson" },
     { name = "pydantic" },
@@ -1291,6 +1326,7 @@ requires-dist = [
     { name = "enum-tools", specifier = ">=0.13.0,<1.0.0" },
     { name = "faker", specifier = ">=38.2.0" },
     { name = "motor", specifier = ">=3.7.1,<4.0.0" },
+    { name = "obstore", specifier = ">=0.5.0" },
     { name = "openpyxl", specifier = ">=3.1.5,<4.0.0" },
     { name = "orjson", specifier = ">=3.10.18,<4.0.0" },
     { name = "pydantic", specifier = ">=1.10.16,<2" },

--- a/virtool/storage/obstore.py
+++ b/virtool/storage/obstore.py
@@ -1,6 +1,9 @@
 """Storage backend implementation using the obstore library."""
 
 from collections.abc import AsyncIterator
+from typing import Any
+
+import obstore as obs
 
 from virtool.storage.errors import StorageError, StorageKeyNotFoundError
 from virtool.storage.protocol import STORAGE_CHUNK_SIZE
@@ -14,13 +17,13 @@ class ObstoreProvider:
     object. The caller is responsible for configuring the store.
     """
 
-    def __init__(self, store) -> None:
+    def __init__(self, store: Any) -> None:
         self._store = store
 
     async def read(self, key: str) -> AsyncIterator[bytes]:
         """Stream the contents of the object at ``key`` as chunks of bytes."""
         try:
-            result = await self._store.get_async(key)
+            result = await obs.get_async(self._store, key)
         except FileNotFoundError as exc:
             raise StorageKeyNotFoundError(key) from exc
 
@@ -38,7 +41,8 @@ class ObstoreProvider:
                 yield chunk
 
         try:
-            await self._store.put_async(
+            await obs.put_async(
+                self._store,
                 key,
                 _counting_iter(),
                 chunk_size=STORAGE_CHUNK_SIZE,
@@ -53,7 +57,7 @@ class ObstoreProvider:
     async def delete(self, key: str) -> None:
         """Delete the object at ``key``. Idempotent."""
         try:
-            await self._store.delete_async(key)
+            await obs.delete_async(self._store, key)
         except FileNotFoundError:
             pass
         except Exception as exc:
@@ -61,10 +65,8 @@ class ObstoreProvider:
 
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
         """List objects whose keys start with ``prefix``."""
-        stream = self._store.list(prefix=prefix)
-
-        async for chunk in stream:
-            for meta in chunk:
+        async for batch in obs.list(self._store, prefix=prefix):
+            for meta in batch:
                 yield StorageObjectInfo(
                     key=meta["path"],
                     size=meta["size"],

--- a/virtool/storage/obstore.py
+++ b/virtool/storage/obstore.py
@@ -1,0 +1,72 @@
+"""Storage backend implementation using the obstore library."""
+
+from collections.abc import AsyncIterator
+
+from virtool.storage.errors import StorageError, StorageKeyNotFoundError
+from virtool.storage.protocol import STORAGE_CHUNK_SIZE
+from virtool.storage.types import StorageObjectInfo
+
+
+class ObstoreProvider:
+    """StorageBackend implementation backed by any obstore ObjectStore.
+
+    Accepts an S3Store, AzureStore, MemoryStore, or any other obstore store
+    object. The caller is responsible for configuring the store.
+    """
+
+    def __init__(self, store) -> None:
+        self._store = store
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        """Stream the contents of the object at ``key`` as chunks of bytes."""
+        try:
+            result = await self._store.get_async(key)
+        except FileNotFoundError as exc:
+            raise StorageKeyNotFoundError(key) from exc
+
+        async for chunk in result.stream(min_chunk_size=STORAGE_CHUNK_SIZE):
+            yield chunk
+
+    async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
+        """Write streamed data to the object at ``key``."""
+        size = 0
+
+        async def _counting_iter():
+            nonlocal size
+            async for chunk in data:
+                size += len(chunk)
+                yield chunk
+
+        try:
+            await self._store.put_async(
+                key,
+                _counting_iter(),
+                chunk_size=STORAGE_CHUNK_SIZE,
+            )
+        except FileNotFoundError as exc:
+            raise StorageKeyNotFoundError(key) from exc
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+        return size
+
+    async def delete(self, key: str) -> None:
+        """Delete the object at ``key``. Idempotent."""
+        try:
+            await self._store.delete_async(key)
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        """List objects whose keys start with ``prefix``."""
+        stream = self._store.list(prefix=prefix)
+
+        async for chunk in stream:
+            for meta in chunk:
+                yield StorageObjectInfo(
+                    key=meta["path"],
+                    size=meta["size"],
+                    last_modified=meta["last_modified"],
+                )

--- a/virtool/storage/protocol.py
+++ b/virtool/storage/protocol.py
@@ -36,8 +36,7 @@ class StorageBackend(Protocol):
     async def delete(self, key: str) -> None:
         """Delete the object at ``key``.
 
-        Raises :class:`~virtool.storage.errors.StorageKeyNotFoundError` if the
-        key does not exist.
+        Idempotent: succeeds silently if the key does not exist.
         """
         ...
 


### PR DESCRIPTION
## Summary

- Add `ObstoreProvider` class in `virtool/storage/obstore.py` that wraps the `obstore` library to provide S3 and Azure Blob Storage support
- Implements the `StorageBackend` protocol: streaming read/write, idempotent delete, and prefix-filtered list
- Update `delete()` protocol docstring to reflect idempotent semantics
- Add `obstore>=0.5.0` dependency
- Add 10 tests using `obstore.store.MemoryStore`

Closes VIR-2254