### PR TITLE
refactor: remove Redis PubSub cancellation signaling

### DIFF
--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -868,7 +868,7 @@
     'progress': 0,
     'retries': 0,
     'stage': 'mk_analysis_dir',
-    'state': 'running',
+    'state': 'cancelled',
     'status': list([
       dict({
         'error': None,
@@ -893,6 +893,15 @@
         'progress': 0,
         'stage': 'mk_analysis_dir',
         'state': 'running',
+        'step_description': None,
+        'step_name': None,
+        'timestamp': '2015-10-06T20:00:00Z',
+      }),
+      dict({
+        'error': None,
+        'progress': 0,
+        'stage': 'mk_analysis_dir',
+        'state': 'cancelled',
         'step_description': None,
         'step_name': None,
         'timestamp': '2015-10-06T20:00:00Z',

--- a/tests/jobs/__snapshots__/test_data.ambr
+++ b/tests/jobs/__snapshots__/test_data.ambr
@@ -76,13 +76,22 @@
     'progress': 0,
     'retries': 0,
     'stage': 'foo',
-    'state': <JobState.RUNNING: 'running'>,
+    'state': <JobState.CANCELLED: 'cancelled'>,
     'status': list([
       dict({
         'error': None,
         'progress': 0,
         'stage': 'foo',
         'state': <JobState.RUNNING: 'running'>,
+        'step_description': None,
+        'step_name': None,
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      }),
+      dict({
+        'error': None,
+        'progress': 0,
+        'stage': 'foo',
+        'state': <JobState.CANCELLED: 'cancelled'>,
         'step_description': None,
         'step_name': None,
         'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
@@ -104,13 +113,22 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'rights': dict({
     }),
-    'state': 'waiting',
+    'state': 'cancelled',
     'status': list([
       dict({
         'error': None,
         'progress': 0.33,
         'stage': 'foo',
         'state': 'running',
+        'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
+      }),
+      dict({
+        'error': None,
+        'progress': 0.33,
+        'stage': 'foo',
+        'state': 'cancelled',
+        'step_description': None,
+        'step_name': None,
         'timestamp': datetime.datetime(2015, 10, 6, 20, 0),
       }),
     ]),

--- a/tests/jobs/test_client.py
+++ b/tests/jobs/test_client.py
@@ -1,13 +1,7 @@
-import asyncio
-
 import pytest
 
-from virtool.jobs.client import (
-    JobCancellationResult,
-    JobsClient,
-)
+from virtool.jobs.client import JobsClient
 from virtool.redis import Redis
-from virtool.workflow.runtime.redis import get_cancellation_channel
 
 
 @pytest.fixture
@@ -28,7 +22,7 @@ async def test_enqueue(workflow: str, jobs_client: JobsClient, redis: Redis):
 
 @pytest.mark.parametrize("workflow", ["nuvs", "create_sample"])
 async def test_cancel_waiting(workflow: str, jobs_client: JobsClient, redis: Redis):
-    """Test that a job ID is cancelled by removal when still in a Redis list."""
+    """Test that a job ID is removed from Redis lists when cancelled."""
     await redis.rpush(f"jobs_{workflow}", "foo")
 
     keys = ("jobs_nuvs", "jobs_create_sample")
@@ -36,27 +30,7 @@ async def test_cancel_waiting(workflow: str, jobs_client: JobsClient, redis: Red
     for key in keys:
         await redis.rpush(key, "bar", "foo", "baz", "boo")
 
-    assert await jobs_client.cancel("foo") == JobCancellationResult.REMOVED_FROM_QUEUE
+    await jobs_client.cancel("foo")
 
     for key in keys:
         assert await redis.lrange(key, 0, 5) == ["bar", "baz", "boo"]
-
-
-async def test_cancel_running(jobs_client: JobsClient, redis: Redis):
-    """Test that cancellation is published to 'channel:cancel' if the job ID is not in a
-    list already.
-
-    """
-
-    async def cancel():
-        await asyncio.sleep(0.3)
-        await jobs_client.cancel("foo")
-
-    cancel_task = asyncio.create_task(cancel())
-
-    # Check that job ID was published to cancellation channel.
-    async for message in redis.subscribe(get_cancellation_channel(redis)):
-        assert message == "foo"
-        break
-
-    await cancel_task

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -9,7 +9,7 @@ from syrupy import SnapshotAssertion
 
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
-from virtool.jobs.client import JobCancellationResult, JobsClient
+from virtool.jobs.client import JobsClient
 from virtool.jobs.data import JobsData
 from virtool.jobs.models import JobState
 from virtool.jobs.pg import (
@@ -375,8 +375,6 @@ class TestCancelPostgres:
             0,
             job_id="foo",
         )
-
-        jobs_data._client.cancel.return_value = JobCancellationResult.REMOVED_FROM_QUEUE
 
         await jobs_data.cancel(job.id)
 

--- a/tests/workflow/test_exit.py
+++ b/tests/workflow/test_exit.py
@@ -11,7 +11,6 @@ from virtool.redis import Redis
 from virtool.workflow import Workflow
 from virtool.workflow.pytest_plugin.data import WorkflowData
 from virtool.workflow.pytest_plugin.utils import StaticTime
-from virtool.workflow.runtime.redis import get_cancellation_channel
 from virtool.workflow.runtime.run import start_runtime
 
 
@@ -114,7 +113,7 @@ async def test_cancellation(
 
     await asyncio.sleep(5)
 
-    await redis.publish(get_cancellation_channel(redis), workflow_data.job.id)
+    workflow_data.job.ping.cancelled = True
 
     await runtime_task
 
@@ -127,7 +126,7 @@ async def test_cancellation(
     assert state_and_progress[2] == (JobState.RUNNING, 0)
     assert state_and_progress[-1] == (JobState.CANCELLED, state_and_progress[-2][1])
 
-    assert log.has("received cancellation signal from redis", level="info")
+    assert log.has("received cancellation signal from ping response", level="info")
 
 
 async def test_timeout(

--- a/tests/workflow/test_subprocess.py
+++ b/tests/workflow/test_subprocess.py
@@ -11,7 +11,6 @@ from virtool.workflow import RunSubprocess, Workflow
 from virtool.workflow.errors import SubprocessFailedError
 from virtool.workflow.pytest_plugin.data import WorkflowData
 from virtool.workflow.pytest_plugin.utils import StaticTime
-from virtool.workflow.runtime.redis import get_cancellation_channel
 from virtool.workflow.runtime.run import start_runtime
 
 
@@ -155,7 +154,7 @@ async def test_terminated_by_cancellation(
     await asyncio.sleep(4)
 
     if cancel:
-        await redis.publish(get_cancellation_channel(redis), workflow_data.job.id)
+        workflow_data.job.ping.cancelled = True
 
     await runtime_task
 
@@ -166,6 +165,6 @@ async def test_terminated_by_cancellation(
 
     if cancel:
         assert last_status.state == JobState.CANCELLED
-        assert log.has("received cancellation signal from redis", level="info")
+        assert log.has("received cancellation signal from ping response", level="info")
     else:
         assert last_status.state == JobState.COMPLETE

--- a/virtool/jobs/client.py
+++ b/virtool/jobs/client.py
@@ -1,24 +1,12 @@
 from asyncio import gather
-from enum import Enum
 
 from structlog import get_logger
 
 from virtool.jobs.models import QueuedJobID
 from virtool.jobs.utils import WORKFLOW_NAMES
 from virtool.redis import Redis
-from virtool.workflow.runtime.redis import get_cancellation_channel
 
 logger = get_logger("jobs")
-
-
-class JobCancellationResult(Enum):
-    """The result of a job cancellation request."""
-
-    CANCELLATION_DISPATCHED = 1
-    """Whether the job cancellation was dispatched to job runners."""
-
-    REMOVED_FROM_QUEUE = 0
-    """Whether the job was removed from the queue."""
 
 
 class JobsClient:
@@ -26,9 +14,8 @@ class JobsClient:
 
     Pushes new job IDs to Redis lists to distribute them to job runner processes.
 
-    Cancels jobs by either:
-    * Removing a waiting job ID from a Redis list.
-    * Putting a message in Redis PubSub the job runners will see and cancel themselves.
+    Cancels jobs by removing waiting job IDs from Redis lists. Running jobs are
+    cancelled via ping-based cancellation signaling.
 
     """
 
@@ -53,40 +40,14 @@ class JobsClient:
 
         return QueuedJobID(job_id, workflow)
 
-    async def cancel(self, job_id: str) -> JobCancellationResult:
+    async def cancel(self, job_id: str) -> None:
         """Cancel the job with the given `job_id`.
 
-        If the job is still waiting, its ID will be in a Redis list. Remove the ID from
-        the list and append a cancelled status records the job document's status field.
-
-        If the job is running, set its state to `cancelling` and publish its ID to the
-        cancellation Redis PubSub channel. Listening runners will see the ID and cancel
-        their jobs if their current job ID matches.
+        Removes the job ID from any Redis queue lists. If the job is already running,
+        cancellation is handled by ping-based signaling in the workflow runner.
 
         :param job_id: the ID of the job to cancel
-        :return: the updated job document
 
-        """
-        counts = await gather(
-            *[
-                self._redis.lrem(workflow_name, 0, job_id)
-                for workflow_name in WORKFLOW_NAMES
-            ],
-        )
-
-        if any(counts):
-            logger.info("removed job from redis job list", id=job_id)
-            return JobCancellationResult.REMOVED_FROM_QUEUE
-
-        await self._redis.publish(get_cancellation_channel(self._redis), job_id)
-        logger.info("requested job cancellation via redis", id=job_id)
-
-        return JobCancellationResult.CANCELLATION_DISPATCHED
-
-    async def remove(self, job_id: str) -> None:
-        """Remove a job from Redis queues without cancellation logic.
-
-        :param job_id: the ID of the job to remove
         """
         await gather(
             *[

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -724,9 +724,9 @@ class JobsData:
         if document is None:
             raise ResourceNotFoundError
 
-        latest_status = get_latest_status(document)
+        latest_state = document["status"][-1]["state"]
 
-        if latest_status and latest_status.state in TERMINAL_JOB_STATES:
+        if latest_state not in ("waiting", "preparing", "running"):
             raise ResourceConflictError("Not cancellable")
 
         await self._client.cancel(job_id)

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -724,7 +724,9 @@ class JobsData:
         if document is None:
             raise ResourceNotFoundError
 
-        if not check_job_is_running_or_waiting(document):
+        latest_status = get_latest_status(document)
+
+        if latest_status and latest_status.state in TERMINAL_JOB_STATES:
             raise ResourceConflictError("Not cancellable")
 
         await self._client.cancel(job_id)

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -25,7 +25,7 @@ from virtool.data.topg import (
     retry_both_transactions,
 )
 from virtool.data.transforms import apply_transforms
-from virtool.jobs.client import JobCancellationResult, JobsClient
+from virtool.jobs.client import JobsClient
 from virtool.jobs.models import (
     TERMINAL_JOB_STATES,
     V1_TO_V2_STATE,
@@ -727,45 +727,44 @@ class JobsData:
         if not check_job_is_running_or_waiting(document):
             raise ResourceConflictError("Not cancellable")
 
-        result = await self._client.cancel(job_id)
+        await self._client.cancel(job_id)
 
-        if result == JobCancellationResult.REMOVED_FROM_QUEUE:
-            latest = document["status"][-1]
+        latest = document["status"][-1]
 
-            async with both_transactions(self._mongo, self._pg) as (
-                mongo_session,
-                pg_session,
-            ):
-                update_result: UpdateResult = await self._mongo.jobs.update_one(
-                    {"_id": job_id},
-                    {
-                        "$push": {
-                            "status": compose_status(
-                                JobState.CANCELLED,
-                                latest["stage"],
-                                progress=latest["progress"],
-                            ),
-                        },
-                        "$set": {
-                            "state": JobState.CANCELLED.value,
-                        },
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            update_result: UpdateResult = await self._mongo.jobs.update_one(
+                {"_id": job_id},
+                {
+                    "$push": {
+                        "status": compose_status(
+                            JobState.CANCELLED,
+                            latest["stage"],
+                            progress=latest["progress"],
+                        ),
                     },
-                    session=mongo_session,
-                )
+                    "$set": {
+                        "state": JobState.CANCELLED.value,
+                    },
+                },
+                session=mongo_session,
+            )
 
-                if update_result.modified_count == 0:
-                    raise ResourceNotFoundError
+            if update_result.modified_count == 0:
+                raise ResourceNotFoundError
 
-                pg_result = await pg_session.execute(
-                    select(SQLJob).where(
-                        compose_legacy_id_single_expression(SQLJob, job_id),
-                    ),
-                )
-                sql_job = pg_result.scalar()
+            pg_result = await pg_session.execute(
+                select(SQLJob).where(
+                    compose_legacy_id_single_expression(SQLJob, job_id),
+                ),
+            )
+            sql_job = pg_result.scalar()
 
-                if sql_job:
-                    sql_job.state = JobStateV2.CANCELLED.value
-                    sql_job.finished_at = virtool.utils.timestamp()
+            if sql_job:
+                sql_job.state = JobStateV2.CANCELLED.value
+                sql_job.finished_at = virtool.utils.timestamp()
 
         return await self.get(job_id)
 

--- a/virtool/workflow/runtime/redis.py
+++ b/virtool/workflow/runtime/redis.py
@@ -1,21 +1,8 @@
-from asyncio import CancelledError
-from collections.abc import Callable
-from contextlib import suppress
-
 from structlog import get_logger
 
 from virtool.redis import Redis
 
 logger = get_logger("redis")
-
-
-def get_cancellation_channel(redis_client: Redis) -> str:
-    """Get the database-specific cancellation channel name.
-
-    :param redis_client: Redis client instance
-    :return: the channel name
-    """
-    return f"channel:cancel:{redis_client.database_id}"
 
 
 async def get_next_job_id(list_name: str, redis: Redis) -> str:
@@ -31,17 +18,3 @@ async def get_next_job_id(list_name: str, redis: Redis) -> str:
         return job_id
 
     raise ValueError("Unexpected None from job id list")
-
-
-async def wait_for_cancellation(redis: Redis, job_id: str, func: Callable) -> None:
-    """Call a function ``func`` when a job matching ``job_id`` is cancelled.
-
-    :param redis: the Redis client
-    :param job_id: the job ID to watch for
-    :param func: the function to call when the job is cancelled
-
-    """
-    with suppress(CancelledError):
-        async for cancelled_job_id in redis.subscribe(get_cancellation_channel(redis)):
-            if cancelled_job_id == job_id:
-                func()

--- a/virtool/workflow/runtime/run.py
+++ b/virtool/workflow/runtime/run.py
@@ -37,10 +37,7 @@ from virtool.workflow.runtime.discover import (
 from virtool.workflow.runtime.events import Events
 from virtool.workflow.runtime.path import create_work_path
 from virtool.workflow.runtime.ping import ping_periodically
-from virtool.workflow.runtime.redis import (
-    get_next_job_id,
-    wait_for_cancellation,
-)
+from virtool.workflow.runtime.redis import get_next_job_id
 from virtool.workflow.utils import get_workflow_version
 from virtool.workflow.workflow import Workflow
 
@@ -260,20 +257,7 @@ async def start_runtime(
 
     signal.signal(signal.SIGTERM, terminate_workflow)
 
-    def cancel_workflow(*_):
-        logger.info("received cancellation signal from redis")
-        events.cancelled.set()
-        run_workflow_task.cancel()
-
-    async with Redis(config.redis_connection_string) as redis:
-        cancellation_task = asyncio.create_task(
-            wait_for_cancellation(redis, job_id, cancel_workflow),
-        )
-
-        await run_workflow_task
-
-        cancellation_task.cancel()
-        await cancellation_task
+    await run_workflow_task
 
     if events.terminated.is_set():
         sys.exit(124)


### PR DESCRIPTION
## Summary

- Remove Redis PubSub-based job cancellation (`wait_for_cancellation`, `get_cancellation_channel`, `JobCancellationResult`) now that ping-based cancellation is in place
- Simplify `JobsClient.cancel()` to only remove job IDs from Redis queues; delete unused `remove()` method
- Make `JobsData.cancel()` always write cancellation state to both MongoDB and PostgreSQL, instead of only when the job was removed from a queue
- Update workflow integration tests to trigger cancellation via `workflow_data.job.ping.cancelled = True` instead of Redis PubSub

Resolves VIR-2249