### PR TITLE
feat: implement filesystem storage backend

### DIFF
--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -1,0 +1,176 @@
+import pytest
+
+from virtool.storage.errors import StorageError, StorageKeyNotFoundError
+from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.protocol import STORAGE_CHUNK_SIZE
+from virtool.storage.types import StorageObjectInfo
+
+
+@pytest.fixture
+def provider(tmp_path):
+    return FilesystemProvider(tmp_path)
+
+
+async def _async_iter(data: bytes, chunk_size: int = 1024):
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+async def _collect_bytes(aiter) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
+async def _collect(aiter) -> list:
+    return [item async for item in aiter]
+
+
+class TestRead:
+    async def test_ok(self, provider, tmp_path):
+        path = tmp_path / "samples" / "abc" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"read data here")
+
+        result = await _collect_bytes(provider.read("samples/abc/reads.fq.gz"))
+
+        assert result == b"read data here"
+
+    async def test_nonexistent_key(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(provider.read("does/not/exist"))
+
+    async def test_chunked_read(self, provider, tmp_path):
+        data = b"x" * (STORAGE_CHUNK_SIZE + 1000)
+
+        path = tmp_path / "big" / "file.bin"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(data)
+
+        chunks = [chunk async for chunk in provider.read("big/file.bin")]
+
+        assert len(chunks) == 2
+        assert b"".join(chunks) == data
+
+
+class TestWrite:
+    async def test_returns_byte_count(self, provider):
+        data = b"x" * 5000
+
+        size = await provider.write("uploads/file.txt", _async_iter(data))
+
+        assert size == 5000
+
+    async def test_creates_object(self, provider, tmp_path):
+        data = b"hello"
+
+        await provider.write("uploads/file.txt", _async_iter(data))
+
+        assert (tmp_path / "uploads" / "file.txt").read_bytes() == data
+
+    async def test_overwrites_existing(self, provider, tmp_path):
+        await provider.write("key", _async_iter(b"first"))
+        await provider.write("key", _async_iter(b"second"))
+
+        assert (tmp_path / "key").read_bytes() == b"second"
+
+    async def test_creates_parent_directories(self, provider, tmp_path):
+        await provider.write("deep/nested/path/file.txt", _async_iter(b"data"))
+
+        assert (tmp_path / "deep" / "nested" / "path" / "file.txt").exists()
+
+    async def test_atomic_no_partial_on_error(self, provider, tmp_path):
+        async def _failing_iter():
+            yield b"partial"
+            raise RuntimeError("mid-stream failure")
+
+        with pytest.raises(RuntimeError, match="mid-stream failure"):
+            await provider.write("target.txt", _failing_iter())
+
+        assert not (tmp_path / "target.txt").exists()
+
+
+class TestDelete:
+    async def test_existing_key(self, provider, tmp_path):
+        path = tmp_path / "to_delete"
+        path.write_bytes(b"data")
+
+        await provider.delete("to_delete")
+
+        assert not path.exists()
+
+    async def test_nonexistent_is_idempotent(self, provider):
+        await provider.delete("does/not/exist")
+
+    async def test_cleans_empty_parents(self, provider, tmp_path):
+        path = tmp_path / "a" / "b" / "c" / "file.txt"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"data")
+
+        await provider.delete("a/b/c/file.txt")
+
+        assert not (tmp_path / "a").exists()
+
+    async def test_preserves_non_empty_parents(self, provider, tmp_path):
+        (tmp_path / "a" / "b").mkdir(parents=True)
+        (tmp_path / "a" / "b" / "keep.txt").write_bytes(b"keep")
+        (tmp_path / "a" / "b" / "remove.txt").write_bytes(b"remove")
+
+        await provider.delete("a/b/remove.txt")
+
+        assert (tmp_path / "a" / "b" / "keep.txt").exists()
+
+
+class TestList:
+    async def test_with_prefix(self, provider, tmp_path):
+        (tmp_path / "samples" / "a").mkdir(parents=True)
+        (tmp_path / "samples" / "b").mkdir(parents=True)
+        (tmp_path / "uploads").mkdir(parents=True)
+
+        (tmp_path / "samples" / "a" / "reads.fq.gz").write_bytes(b"a")
+        (tmp_path / "samples" / "b" / "reads.fq.gz").write_bytes(b"b")
+        (tmp_path / "uploads" / "file.txt").write_bytes(b"c")
+
+        result = await _collect(provider.list("samples/"))
+
+        keys = sorted(item.key for item in result)
+        assert keys == ["samples/a/reads.fq.gz", "samples/b/reads.fq.gz"]
+
+    async def test_no_matches(self, provider, tmp_path):
+        (tmp_path / "samples" / "a").mkdir(parents=True)
+        (tmp_path / "samples" / "a" / "reads.fq.gz").write_bytes(b"a")
+
+        result = await _collect(provider.list("uploads/"))
+
+        assert result == []
+
+    async def test_metadata(self, provider, tmp_path):
+        (tmp_path / "test").mkdir()
+        (tmp_path / "test" / "file.txt").write_bytes(b"hello")
+
+        result = await _collect(provider.list("test/"))
+
+        assert len(result) == 1
+
+        info = result[0]
+        assert isinstance(info, StorageObjectInfo)
+        assert info.key == "test/file.txt"
+        assert info.size == 5
+        assert info.last_modified is not None
+
+    async def test_empty_directory(self, provider):
+        result = await _collect(provider.list("nonexistent/"))
+
+        assert result == []
+
+
+class TestSecurity:
+    async def test_path_traversal_rejected(self, provider):
+        with pytest.raises(StorageError):
+            await _collect_bytes(provider.read("../../etc/passwd"))
+
+    async def test_path_traversal_rejected_on_write(self, provider):
+        with pytest.raises(StorageError):
+            await provider.write("../../etc/evil", _async_iter(b"bad"))
+
+    async def test_path_traversal_rejected_on_delete(self, provider):
+        with pytest.raises(StorageError):
+            await provider.delete("../../etc/passwd")

--- a/virtool/storage/filesystem.py
+++ b/virtool/storage/filesystem.py
@@ -22,9 +22,9 @@ class FilesystemProvider:
     def __init__(self, base_path: Path) -> None:
         self._base_path = base_path.resolve()
 
-    def _resolve(self, key: str) -> Path:
+    async def _resolve(self, key: str) -> Path:
         """Map a storage key to an absolute path under the base directory."""
-        path = (self._base_path / key).resolve()
+        path = await asyncio.to_thread(lambda: (self._base_path / key).resolve())
 
         if not path.is_relative_to(self._base_path):
             msg = f"Key {key!r} resolves outside the base path"
@@ -34,7 +34,7 @@ class FilesystemProvider:
 
     async def read(self, key: str) -> AsyncIterator[bytes]:
         """Stream the contents of the object at ``key`` as chunks of bytes."""
-        path = self._resolve(key)
+        path = await self._resolve(key)
 
         if not await asyncio.to_thread(path.is_file):
             raise StorageKeyNotFoundError(key)
@@ -54,7 +54,7 @@ class FilesystemProvider:
 
         Uses a temporary file and atomic rename to prevent partial writes.
         """
-        path = self._resolve(key)
+        path = await self._resolve(key)
         await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
 
         tmp_fd = await asyncio.to_thread(
@@ -80,7 +80,7 @@ class FilesystemProvider:
 
     async def delete(self, key: str) -> None:
         """Delete the object at ``key``. Idempotent."""
-        path = self._resolve(key)
+        path = await self._resolve(key)
         await asyncio.to_thread(path.unlink, True)
 
         parent = path.parent
@@ -106,24 +106,23 @@ class FilesystemProvider:
 
             results = []
 
-            for p in search_dir.rglob("*"):
-                if not p.is_file():
-                    continue
+            for dirpath, _, filenames in os.walk(search_dir):
+                for filename in filenames:
+                    filepath = Path(dirpath) / filename
+                    key = str(filepath.relative_to(self._base_path))
 
-                key = str(p.relative_to(self._base_path))
-
-                if key.startswith(prefix):
-                    stat = p.stat()
-                    results.append(
-                        StorageObjectInfo(
-                            key=key,
-                            size=stat.st_size,
-                            last_modified=datetime.fromtimestamp(
-                                stat.st_mtime,
-                                tz=UTC,
+                    if key.startswith(prefix):
+                        stat = filepath.stat()
+                        results.append(
+                            StorageObjectInfo(
+                                key=key,
+                                size=stat.st_size,
+                                last_modified=datetime.fromtimestamp(
+                                    stat.st_mtime,
+                                    tz=UTC,
+                                ),
                             ),
-                        ),
-                    )
+                        )
 
             return results
 

--- a/virtool/storage/filesystem.py
+++ b/virtool/storage/filesystem.py
@@ -1,0 +1,133 @@
+"""Storage backend implementation using the local filesystem."""
+
+import asyncio
+import os
+import tempfile
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from virtool.storage.errors import StorageError, StorageKeyNotFoundError
+from virtool.storage.protocol import STORAGE_CHUNK_SIZE
+from virtool.storage.types import StorageObjectInfo
+
+
+class FilesystemProvider:
+    """StorageBackend implementation backed by the local filesystem.
+
+    Translates storage keys to paths under a base directory. All blocking I/O
+    is offloaded via ``asyncio.to_thread``.
+    """
+
+    def __init__(self, base_path: Path) -> None:
+        self._base_path = base_path.resolve()
+
+    def _resolve(self, key: str) -> Path:
+        """Map a storage key to an absolute path under the base directory."""
+        path = (self._base_path / key).resolve()
+
+        if not path.is_relative_to(self._base_path):
+            msg = f"Key {key!r} resolves outside the base path"
+            raise StorageError(msg)
+
+        return path
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        """Stream the contents of the object at ``key`` as chunks of bytes."""
+        path = self._resolve(key)
+
+        if not await asyncio.to_thread(path.is_file):
+            raise StorageKeyNotFoundError(key)
+
+        f = await asyncio.to_thread(open, path, "rb")  # noqa: ASYNC230
+        try:
+            while True:
+                chunk = await asyncio.to_thread(f.read, STORAGE_CHUNK_SIZE)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            await asyncio.to_thread(f.close)
+
+    async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
+        """Write streamed data to the object at ``key``.
+
+        Uses a temporary file and atomic rename to prevent partial writes.
+        """
+        path = self._resolve(key)
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+
+        tmp_fd = await asyncio.to_thread(
+            tempfile.NamedTemporaryFile,
+            dir=path.parent,
+            delete=False,
+        )
+        tmp_path = Path(tmp_fd.name)
+        size = 0
+
+        try:
+            async for chunk in data:
+                await asyncio.to_thread(tmp_fd.write, chunk)
+                size += len(chunk)
+            await asyncio.to_thread(tmp_fd.close)
+            await asyncio.to_thread(os.replace, tmp_path, path)
+        except BaseException:
+            await asyncio.to_thread(tmp_fd.close)
+            await asyncio.to_thread(tmp_path.unlink, True)
+            raise
+
+        return size
+
+    async def delete(self, key: str) -> None:
+        """Delete the object at ``key``. Idempotent."""
+        path = self._resolve(key)
+        await asyncio.to_thread(path.unlink, True)
+
+        parent = path.parent
+        while parent != self._base_path:
+            try:
+                await asyncio.to_thread(parent.rmdir)
+            except OSError:
+                break
+            parent = parent.parent
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        """List objects whose keys start with ``prefix``."""
+
+        def _walk():
+            prefix_path = self._base_path / prefix
+
+            if prefix_path.is_dir():
+                search_dir = prefix_path
+            elif prefix_path.parent.is_dir():
+                search_dir = prefix_path.parent
+            else:
+                return []
+
+            results = []
+
+            for p in search_dir.rglob("*"):
+                if not p.is_file():
+                    continue
+
+                key = str(p.relative_to(self._base_path))
+
+                if key.startswith(prefix):
+                    stat = p.stat()
+                    results.append(
+                        StorageObjectInfo(
+                            key=key,
+                            size=stat.st_size,
+                            last_modified=datetime.fromtimestamp(
+                                stat.st_mtime,
+                                tz=UTC,
+                            ),
+                        ),
+                    )
+
+            return results
+
+        items = await asyncio.to_thread(_walk)
+
+        for item in items:
+            yield item


### PR DESCRIPTION
## Summary

- Add `FilesystemProvider` class in `virtool/storage/filesystem.py` that implements the `StorageBackend` protocol using the local filesystem
- All blocking I/O offloaded via `asyncio.to_thread`, atomic writes via temp-file-then-`os.replace`, idempotent deletes with empty parent directory cleanup, and path traversal protection
- 19 tests covering read, write, delete, list, and security scenarios

Closes VIR-2255