### PR TITLE
feat: add storage configuration and backend initialization

### DIFF
--- a/tests/config/test_cls.py
+++ b/tests/config/test_cls.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+
+from virtool.config.cls import ServerConfig
+
+
+def build_server_config(**overrides) -> ServerConfig:
+    defaults = {
+        "base_url": "",
+        "data_path": Path("./data"),
+        "dev": False,
+        "flags": [],
+        "host": "localhost",
+        "mongodb_connection_string": "mongodb://localhost:27017/virtool",
+        "no_check_db": True,
+        "no_periodic_tasks": True,
+        "no_revision_check": True,
+        "port": 9950,
+        "postgres_connection_string": "postgresql://virtool:virtool@localhost/virtool",
+        "real_ip_header": "",
+        "sentry_dsn": "",
+    }
+    defaults.update(overrides)
+    return ServerConfig(**defaults)
+
+
+class TestFilesystemPath:
+    def test_defaults_to_data_path_storage(self, data_path: Path):
+        config = build_server_config(data_path=data_path)
+
+        assert config.storage_filesystem_path == data_path / "storage"
+
+    def test_explicit_path_preserved(self, tmp_path: Path):
+        explicit = tmp_path / "custom-storage"
+
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_filesystem_path=explicit,
+        )
+
+        assert config.storage_filesystem_path == explicit
+
+    def test_string_path_coerced(self, tmp_path: Path):
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_filesystem_path=str(tmp_path / "strpath"),
+        )
+
+        assert isinstance(config.storage_filesystem_path, Path)
+        assert config.storage_filesystem_path == tmp_path / "strpath"
+
+
+class TestS3Validation:
+    def test_missing_bucket_raises(self):
+        with pytest.raises(ValueError, match="storage-s3-bucket"):
+            build_server_config(storage_backend="s3")
+
+    def test_bucket_only_ok(self):
+        config = build_server_config(
+            storage_backend="s3",
+            storage_s3_bucket="my-bucket",
+        )
+
+        assert config.storage_backend == "s3"
+        assert config.storage_s3_bucket == "my-bucket"
+
+
+class TestAzureValidation:
+    def test_missing_account_raises(self):
+        with pytest.raises(ValueError, match="storage-azure-account"):
+            build_server_config(
+                storage_backend="azure",
+                storage_azure_container="some-container",
+            )
+
+    def test_missing_container_raises(self):
+        with pytest.raises(ValueError, match="storage-azure-container"):
+            build_server_config(
+                storage_backend="azure",
+                storage_azure_account="some-account",
+            )
+
+    def test_account_and_container_ok(self):
+        config = build_server_config(
+            storage_backend="azure",
+            storage_azure_account="some-account",
+            storage_azure_container="some-container",
+        )
+
+        assert config.storage_backend == "azure"
+        assert config.storage_azure_account == "some-account"
+        assert config.storage_azure_container == "some-container"
+
+
+class TestFilesystemDefault:
+    def test_filesystem_backend_needs_no_extra_config(self, data_path: Path):
+        config = build_server_config(data_path=data_path)
+
+        assert config.storage_backend == "filesystem"
+        assert config.storage_filesystem_path == data_path / "storage"

--- a/tests/storage/test_factory.py
+++ b/tests/storage/test_factory.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+import pytest
+
+from tests.config.test_cls import build_server_config
+from virtool.storage.factory import create_storage_backend
+from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.obstore import ObstoreProvider
+
+
+class TestFilesystem:
+    def test_returns_filesystem_provider(self, tmp_path: Path):
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_backend="filesystem",
+        )
+
+        backend = create_storage_backend(config)
+
+        assert isinstance(backend, FilesystemProvider)
+
+    def test_creates_base_directory(self, tmp_path: Path):
+        target = tmp_path / "nested" / "storage"
+
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_backend="filesystem",
+            storage_filesystem_path=target,
+        )
+
+        create_storage_backend(config)
+
+        assert target.is_dir()
+
+
+class TestS3:
+    def test_constructs_s3_store(self, tmp_path: Path, mocker):
+        s3_store = mocker.patch("obstore.store.S3Store")
+
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_backend="s3",
+            storage_s3_bucket="my-bucket",
+            storage_s3_region="us-west-2",
+            storage_s3_access_key_id="AKIA",
+            storage_s3_secret_access_key="SECRET",
+            storage_s3_endpoint="https://s3.example.com",
+        )
+
+        backend = create_storage_backend(config)
+
+        assert isinstance(backend, ObstoreProvider)
+        s3_store.assert_called_once_with(
+            "my-bucket",
+            region="us-west-2",
+            endpoint="https://s3.example.com",
+            access_key_id="AKIA",
+            secret_access_key="SECRET",
+        )
+
+    def test_omits_empty_optional_kwargs(self, tmp_path: Path, mocker):
+        s3_store = mocker.patch("obstore.store.S3Store")
+
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_backend="s3",
+            storage_s3_bucket="my-bucket",
+        )
+
+        create_storage_backend(config)
+
+        s3_store.assert_called_once_with("my-bucket")
+
+
+class TestAzure:
+    def test_constructs_azure_store(self, tmp_path: Path, mocker):
+        azure_store = mocker.patch("obstore.store.AzureStore")
+
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_backend="azure",
+            storage_azure_account="account",
+            storage_azure_container="container",
+            storage_azure_access_key="KEY",
+        )
+
+        backend = create_storage_backend(config)
+
+        assert isinstance(backend, ObstoreProvider)
+        azure_store.assert_called_once_with(
+            "container",
+            account="account",
+            access_key="KEY",
+        )
+
+    def test_omits_empty_access_key(self, tmp_path: Path, mocker):
+        azure_store = mocker.patch("obstore.store.AzureStore")
+
+        config = build_server_config(
+            data_path=tmp_path,
+            storage_backend="azure",
+            storage_azure_account="account",
+            storage_azure_container="container",
+        )
+
+        create_storage_backend(config)
+
+        azure_store.assert_called_once_with("container", account="account")
+
+
+def test_unknown_backend_raises(tmp_path: Path):
+    config = build_server_config(data_path=tmp_path)
+    config.storage_backend = "nonsense"
+
+    with pytest.raises(ValueError, match="Unknown storage_backend"):
+        create_storage_backend(config)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,7 +1,9 @@
 import pytest
 from aiohttp.client import ClientSession, ClientTimeout
 
-from virtool.startup import startup_http_client_session
+from tests.config.test_cls import build_server_config
+from virtool.startup import startup_http_client_session, startup_storage
+from virtool.storage.filesystem import FilesystemProvider
 
 
 @pytest.fixture
@@ -15,7 +17,7 @@ async def fake_app():
     # Close real session created in `test_startup_executors()`.
     try:
         await app["client"].close()
-    except TypeError:
+    except (KeyError, TypeError):
         pass
 
 
@@ -35,3 +37,15 @@ async def test_startup_http_client_headers(mocker, fake_app):
         headers={"User-Agent": "virtool/v1.2.3"},
         timeout=expected_timeout,
     )
+
+
+async def test_startup_storage(fake_app, tmp_path):
+    fake_app["config"] = build_server_config(
+        data_path=tmp_path,
+        storage_backend="filesystem",
+    )
+
+    await startup_storage(fake_app)
+
+    assert isinstance(fake_app["storage"], FilesystemProvider)
+    assert (tmp_path / "storage").is_dir()

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -30,6 +30,7 @@ from virtool.startup import (
     startup_routes,
     startup_sentry,
     startup_settings,
+    startup_storage,
     startup_version,
     startup_ws,
 )
@@ -89,6 +90,7 @@ def create_app(config: Config):
             startup_version,
             startup_http_client_session,
             startup_databases,
+            startup_storage,
             startup_events,
             startup_routes,
             startup_executors,

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -29,6 +29,7 @@ from virtool.config.options import (
     postgres_connection_string_option,
     real_ip_header_option,
     sentry_dsn_option,
+    storage_options,
 )
 from virtool.jobs.main import run_jobs_server
 from virtool.logs import configure_logging
@@ -78,6 +79,7 @@ def server() -> None:
 @postgres_connection_string_option
 @real_ip_header_option
 @sentry_dsn_option
+@storage_options
 def start_api_server(**kwargs) -> None:
     """Start a Virtool public API server."""
     configure_logging(bool(kwargs["sentry_dsn"]))
@@ -98,6 +100,7 @@ def start_api_server(**kwargs) -> None:
 @postgres_connection_string_option
 @real_ip_header_option
 @sentry_dsn_option
+@storage_options
 def start_jobs_api(**kwargs) -> None:
     """Start a Virtool jobs API server."""
     configure_logging(bool(kwargs["sentry_dsn"]))

--- a/virtool/config/cls.py
+++ b/virtool/config/cls.py
@@ -8,12 +8,15 @@ These will be available in the application context and should be accessed using
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel
 from pymongo.uri_parser import parse_uri
 
 from virtool.flags import FlagName
 from virtool.pg.utils import PgOptions
+
+StorageBackendName = Literal["filesystem", "s3", "azure"]
 
 
 @dataclass
@@ -56,6 +59,16 @@ class ServerConfig:
     postgres_connection_string: str
     real_ip_header: str
     sentry_dsn: str | None
+    storage_backend: StorageBackendName = "filesystem"
+    storage_filesystem_path: Path | None = None
+    storage_s3_bucket: str = ""
+    storage_s3_region: str = ""
+    storage_s3_endpoint: str = ""
+    storage_s3_access_key_id: str = ""
+    storage_s3_secret_access_key: str = ""
+    storage_azure_account: str = ""
+    storage_azure_container: str = ""
+    storage_azure_access_key: str = ""
 
     @property
     def mongodb_database(self) -> str:
@@ -67,6 +80,26 @@ class ServerConfig:
 
     def __post_init__(self):
         self.data_path = Path(self.data_path)
+
+        if self.storage_filesystem_path is None:
+            self.storage_filesystem_path = self.data_path / "storage"
+        else:
+            self.storage_filesystem_path = Path(self.storage_filesystem_path)
+
+        if self.storage_backend == "s3" and not self.storage_s3_bucket:
+            raise ValueError(
+                "storage_backend=s3 requires --storage-s3-bucket",
+            )
+
+        if self.storage_backend == "azure":
+            if not self.storage_azure_account:
+                raise ValueError(
+                    "storage_backend=azure requires --storage-azure-account",
+                )
+            if not self.storage_azure_container:
+                raise ValueError(
+                    "storage_backend=azure requires --storage-azure-container",
+                )
 
 
 @dataclass

--- a/virtool/config/options.py
+++ b/virtool/config/options.py
@@ -11,6 +11,7 @@ def my_command(host, port):
 """
 
 import os
+from pathlib import Path
 
 import click
 
@@ -124,3 +125,80 @@ sentry_dsn_option = click.option(
     help="A Sentry DSN to report errors to",
     type=str,
 )
+
+
+def storage_options(func):
+    for decorator in [
+        click.option(
+            "--storage-backend",
+            default=get_from_environment("storage_backend", "filesystem"),
+            help="The storage backend to use for object storage",
+            type=click.Choice(["filesystem", "s3", "azure"]),
+        ),
+        click.option(
+            "--storage-filesystem-path",
+            default=get_from_environment("storage_filesystem_path", None),
+            help=(
+                "Base directory for the filesystem backend "
+                "(defaults to <data-path>/storage)"
+            ),
+            type=click.Path(path_type=Path),
+        ),
+        click.option(
+            "--storage-s3-bucket",
+            default=get_from_environment("storage_s3_bucket", ""),
+            help="S3 bucket name (required when --storage-backend=s3)",
+            type=str,
+        ),
+        click.option(
+            "--storage-s3-region",
+            default=get_from_environment("storage_s3_region", ""),
+            help="S3 region",
+            type=str,
+        ),
+        click.option(
+            "--storage-s3-endpoint",
+            default=get_from_environment("storage_s3_endpoint", ""),
+            help="S3 endpoint URL override (for MinIO or S3-compatible services)",
+            type=str,
+        ),
+        click.option(
+            "--storage-s3-access-key-id",
+            default=get_from_environment("storage_s3_access_key_id", ""),
+            help="S3 access key ID",
+            type=str,
+        ),
+        click.option(
+            "--storage-s3-secret-access-key",
+            default=get_from_environment("storage_s3_secret_access_key", ""),
+            help="S3 secret access key",
+            type=str,
+        ),
+        click.option(
+            "--storage-azure-account",
+            default=get_from_environment("storage_azure_account", ""),
+            help=(
+                "Azure Blob Storage account name "
+                "(required when --storage-backend=azure)"
+            ),
+            type=str,
+        ),
+        click.option(
+            "--storage-azure-container",
+            default=get_from_environment("storage_azure_container", ""),
+            help=(
+                "Azure Blob Storage container name "
+                "(required when --storage-backend=azure)"
+            ),
+            type=str,
+        ),
+        click.option(
+            "--storage-azure-access-key",
+            default=get_from_environment("storage_azure_access_key", ""),
+            help="Azure Blob Storage access key",
+            type=str,
+        ),
+    ]:
+        func = decorator(func)
+
+    return func

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -16,6 +16,7 @@ from virtool.startup import (
     startup_http_client_session,
     startup_sentry,
     startup_settings,
+    startup_storage,
     startup_version,
 )
 
@@ -42,6 +43,7 @@ async def create_app(config: ServerConfig):
             startup_version,
             startup_http_client_session,
             startup_databases,
+            startup_storage,
             startup_executors,
             startup_data,
             startup_events,

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -21,6 +21,7 @@ from virtool.references.tasks import ReferenceReleasesRefreshTask, ReferencesCle
 from virtool.routes import setup_routes
 from virtool.samples.tasks import SampleWorkflowsUpdateTask
 from virtool.sentry import configure_sentry
+from virtool.storage.factory import create_storage_backend
 from virtool.tasks.periodic import PeriodicTaskSpawner
 from virtool.tasks.runner import TaskRunner
 from virtool.types import App
@@ -157,6 +158,16 @@ async def startup_settings(app: App) -> None:
 
     """
     await get_data_from_app(app).settings.ensure()
+
+
+async def startup_storage(app: App) -> None:
+    """Create the storage backend and attach it to the application.
+
+    :param app: the application object
+    """
+    config = get_config_from_app(app)
+    logger.info("starting storage backend", backend=config.storage_backend)
+    app["storage"] = create_storage_backend(config)
 
 
 async def startup_task_runner(app: App) -> None:

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -2,7 +2,6 @@
 
 from virtool.config.cls import ServerConfig
 from virtool.storage.filesystem import FilesystemProvider
-from virtool.storage.obstore import ObstoreProvider
 from virtool.storage.protocol import StorageBackend
 
 
@@ -15,6 +14,8 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
 
         case "s3":
             from obstore.store import S3Store
+
+            from virtool.storage.obstore import ObstoreProvider
 
             kwargs = {}
             if config.storage_s3_region:
@@ -30,6 +31,8 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
 
         case "azure":
             from obstore.store import AzureStore
+
+            from virtool.storage.obstore import ObstoreProvider
 
             kwargs = {"account": config.storage_azure_account}
             if config.storage_azure_access_key:

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -1,0 +1,45 @@
+"""Factory for constructing the configured storage backend."""
+
+from virtool.config.cls import ServerConfig
+from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.obstore import ObstoreProvider
+from virtool.storage.protocol import StorageBackend
+
+
+def create_storage_backend(config: ServerConfig) -> StorageBackend:
+    """Create the storage backend selected by ``config``."""
+    match config.storage_backend:
+        case "filesystem":
+            config.storage_filesystem_path.mkdir(parents=True, exist_ok=True)
+            return FilesystemProvider(config.storage_filesystem_path)
+
+        case "s3":
+            from obstore.store import S3Store
+
+            kwargs = {}
+            if config.storage_s3_region:
+                kwargs["region"] = config.storage_s3_region
+            if config.storage_s3_endpoint:
+                kwargs["endpoint"] = config.storage_s3_endpoint
+            if config.storage_s3_access_key_id:
+                kwargs["access_key_id"] = config.storage_s3_access_key_id
+            if config.storage_s3_secret_access_key:
+                kwargs["secret_access_key"] = config.storage_s3_secret_access_key
+
+            return ObstoreProvider(S3Store(config.storage_s3_bucket, **kwargs))
+
+        case "azure":
+            from obstore.store import AzureStore
+
+            kwargs = {"account": config.storage_azure_account}
+            if config.storage_azure_access_key:
+                kwargs["access_key"] = config.storage_azure_access_key
+
+            return ObstoreProvider(
+                AzureStore(config.storage_azure_container, **kwargs),
+            )
+
+        case _:
+            raise ValueError(
+                f"Unknown storage_backend: {config.storage_backend}",
+            )


### PR DESCRIPTION
## Summary

- Adds `storage_*` fields to `ServerConfig` (backend choice, filesystem path, S3 credentials/endpoint, Azure credentials) with `__post_init__` validation that derives the filesystem default from `data_path` and enforces required fields for the `s3` and `azure` backends.
- Adds a `storage_options` Click decorator (with matching `VT_STORAGE_*` env vars) and wires it into both `virtool server api` and `virtool server jobs`.
- Adds `virtool/storage/factory.py` to construct `FilesystemProvider` or an `ObstoreProvider` wrapping obstore's `S3Store` / `AzureStore`, and registers a new `startup_storage` hook between `startup_databases` and `startup_data` in both the API and jobs `create_app` functions.

Resolves VIR-2257.