### PR TITLE
refactor: rewrite v2 job query methods as postgres queries

### DIFF
--- a/assets/alembic/versions/998195bd5a8b_add_job_query_indexes.py
+++ b/assets/alembic/versions/998195bd5a8b_add_job_query_indexes.py
@@ -1,0 +1,39 @@
+"""add job query indexes
+
+Revision ID: 998195bd5a8b
+Revises: fd093be5e5c3
+Create Date: 2026-04-17 00:00:00.000000+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "998195bd5a8b"
+down_revision = "fd093be5e5c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_jobs_workflow_state",
+        "jobs",
+        ["workflow", "state"],
+    )
+    op.create_index(
+        "ix_jobs_state_created_at",
+        "jobs",
+        ["state", "created_at"],
+    )
+    op.create_index(
+        "ix_jobs_user_id_state",
+        "jobs",
+        ["user_id", "state"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_user_id_state", table_name="jobs")
+    op.drop_index("ix_jobs_state_created_at", table_name="jobs")
+    op.drop_index("ix_jobs_workflow_state", table_name="jobs")

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -211,30 +211,6 @@
     }),
   ])
 # ---
-# name: TestGetV2.test_ok
-  dict({
-    'args': dict({
-      'buy': 'aJUTVHuIhJxeMChNzFJE',
-      'letter': 'TzqyQTQjZGeLZuJqlLaQ',
-      'picture': 4.11362983803781,
-      'reduce': 24963.910062293,
-      'will': 'EKilxKJTbTDOKidKxUVF',
-    }),
-    'claim': None,
-    'claimed_at': str,
-    'created_at': str,
-    'id': 'bf1b993c',
-    'pinged_at': str,
-    'progress': 10,
-    'state': 'running',
-    'steps': None,
-    'user': dict({
-      'handle': 'myersmitchell',
-      'id': 2,
-    }),
-    'workflow': 'nuvs',
-  })
-# ---
 # name: TestPushStatus.test[None]
   dict({
     'error': None,

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -1110,23 +1110,71 @@ class TestFindV2:
         assert body["found_count"] == 0
         assert body["items"] == []
 
+    async def test_pagination(self, fake: DataFaker, spawn_client: ClientSpawner):
+        client = await spawn_client(authenticated=True)
+
+        user = await fake.users.create()
+
+        for _ in range(5):
+            await fake.jobs.create(user=user, state=JobState.RUNNING, workflow="nuvs")
+
+        resp = await client.get("/jobs/v2?per_page=2&page=2")
+        body = await resp.json()
+
+        assert resp.status == HTTPStatus.OK
+        assert body["page"] == 2
+        assert body["per_page"] == 2
+        assert body["page_count"] == 3
+        assert body["found_count"] == 5
+        assert body["total_count"] == 5
+        assert len(body["items"]) == 2
+
+    async def test_unknown_user(self, fake: DataFaker, spawn_client: ClientSpawner):
+        """Filtering by a user handle that doesn't exist returns no items."""
+        client = await spawn_client(authenticated=True)
+
+        user = await fake.users.create()
+        await fake.jobs.create(user=user, state=JobState.RUNNING, workflow="nuvs")
+
+        resp = await client.get("/jobs/v2?user=nobody-at-all")
+        body = await resp.json()
+
+        assert resp.status == HTTPStatus.OK
+        assert body["found_count"] == 0
+        assert body["items"] == []
+
 
 class TestGetV2:
     async def test_ok(
         self,
         fake: DataFaker,
-        snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
         client = await spawn_client(authenticated=True)
 
         user = await fake.users.create()
-        job = await fake.jobs.create(user=user, state=JobState.RUNNING)
+        job = await fake.jobs.create(
+            user=user,
+            state=JobState.RUNNING,
+            workflow="nuvs",
+        )
 
         resp = await client.get(f"/jobs/v2/{job.id}")
 
         assert resp.status == HTTPStatus.OK
-        assert await resp.json() == snapshot(matcher=_job_response_matcher)
+
+        body = await resp.json()
+
+        assert body["id"] == job.id
+        assert body["args"] == {}
+        assert body["claim"] is None
+        assert body["claimed_at"] is None
+        assert body["progress"] == 0
+        assert body["state"] == "running"
+        assert body["steps"] is None
+        assert body["workflow"] == "nuvs"
+        assert body["user"] == {"id": user.id, "handle": user.handle}
+        assert body["pinged_at"] is not None
 
     async def test_not_found(self, spawn_client: ClientSpawner):
         client = await spawn_client(authenticated=True)

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -9,6 +9,7 @@ from syrupy.matchers import path_type
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from tests.fixtures.response import RespIs
+from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.flags import FlagName
 from virtool.jobs.models import JobState
@@ -1186,6 +1187,39 @@ class TestGetV2:
             "id": "not_found",
             "message": "Not found",
         }
+
+    @pytest.mark.parametrize(
+        ("workflow", "args_key", "args_value"),
+        [
+            ("nuvs", "analysis_id", "abc123"),
+            ("create_sample", "sample_id", "smp-xyz"),
+            ("build_index", "index_id", "idx-9"),
+            ("create_subtraction", "subtraction_id", "sub-1"),
+        ],
+    )
+    async def test_args_from_join_tables(
+        self,
+        workflow: str,
+        args_key: str,
+        args_value: str,
+        fake: DataFaker,
+        data_layer: DataLayer,
+        spawn_client: ClientSpawner,
+    ):
+        """Args comes from the workflow-specific join table on SQLJob."""
+        client = await spawn_client(authenticated=True)
+
+        user = await fake.users.create()
+        job = await data_layer.jobs.create(
+            workflow,
+            {args_key: args_value},
+            user.id,
+        )
+
+        resp = await client.get(f"/jobs/v2/{job.id}")
+
+        assert resp.status == HTTPStatus.OK
+        assert (await resp.json())["args"] == {args_key: args_value}
 
     @pytest.mark.parametrize(
         ("v1_state", "v2_state"),

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -155,5 +155,12 @@
       'name': 'copy jobs to postgres',
       'revision': 'xtwxolun286s',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 23,
+      'name': 'add job query indexes',
+      'revision': '998195bd5a8b',
+    }),
   ])
 # ---

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -101,18 +101,22 @@ class JobsData:
 
     async def get_counts_v2(self) -> JobCountsV2:
         """Get job counts grouped by v2 state and workflow from PostgreSQL."""
+        async with AsyncSession(self._pg) as session:
+            return await self._query_counts_v2(session)
+
+    async def _query_counts_v2(self, session: AsyncSession) -> JobCountsV2:
+        """Run the counts query against an existing session."""
         counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
 
-        async with AsyncSession(self._pg) as session:
-            result = await session.execute(
-                select(SQLJob.state, SQLJob.workflow, func.count()).group_by(
-                    SQLJob.state,
-                    SQLJob.workflow,
-                ),
-            )
+        result = await session.execute(
+            select(SQLJob.state, SQLJob.workflow, func.count()).group_by(
+                SQLJob.state,
+                SQLJob.workflow,
+            ),
+        )
 
-            for state, workflow, count in result.all():
-                counts[state][workflow] = count
+        for state, workflow, count in result.all():
+            counts[state][workflow] = count
 
         return JobCountsV2.parse_obj(counts)
 
@@ -129,49 +133,54 @@ class JobsData:
         if states:
             filters.append(SQLJob.state.in_([s.value for s in states]))
 
-        if users:
-            modern_ids: list[int] = []
-            handles_or_legacy: list[str] = []
+        async with AsyncSession(self._pg) as session:
+            if users:
+                modern_ids: list[int] = []
+                handles_or_legacy: list[str] = []
 
-            for user in users:
-                if isinstance(user, int):
-                    modern_ids.append(user)
-                elif user.isdigit():
-                    modern_ids.append(int(user))
-                else:
-                    handles_or_legacy.append(user)
+                for user in users:
+                    if isinstance(user, int):
+                        modern_ids.append(user)
+                    elif user.isdigit():
+                        modern_ids.append(int(user))
+                    else:
+                        handles_or_legacy.append(user)
 
-            user_clauses = []
+                user_clauses = []
 
-            if modern_ids:
-                user_clauses.append(SQLUser.id.in_(modern_ids))
+                if modern_ids:
+                    user_clauses.append(SQLUser.id.in_(modern_ids))
 
-            if handles_or_legacy:
-                user_clauses.append(SQLUser.legacy_id.in_(handles_or_legacy))
-                user_clauses.append(SQLUser.handle.in_(handles_or_legacy))
+                if handles_or_legacy:
+                    user_clauses.append(SQLUser.legacy_id.in_(handles_or_legacy))
+                    user_clauses.append(SQLUser.handle.in_(handles_or_legacy))
 
-            async with AsyncSession(self._pg) as session:
-                result = await session.execute(
+                resolved = await session.execute(
                     select(SQLUser.id).where(or_(*user_clauses)),
                 )
-                resolved_user_ids = [row[0] for row in result.all()]
+                resolved_user_ids = [row[0] for row in resolved.all()]
 
-            if not resolved_user_ids:
-                return JobSearchResultV2(
-                    counts=await self.get_counts_v2(),
-                    items=[],
-                    total_count=await self._count_jobs(),
-                    found_count=0,
-                    page_count=0,
-                    per_page=per_page,
-                    page=page,
-                )
+                if not resolved_user_ids:
+                    total_count = (
+                        await session.execute(
+                            select(func.count()).select_from(SQLJob),
+                        )
+                    ).scalar_one()
 
-            filters.append(SQLJob.user_id.in_(resolved_user_ids))
+                    return JobSearchResultV2(
+                        counts=await self._query_counts_v2(session),
+                        items=[],
+                        total_count=total_count,
+                        found_count=0,
+                        page_count=0,
+                        per_page=per_page,
+                        page=page,
+                    )
 
-        skip_count = (page - 1) * per_page if page > 1 else 0
+                filters.append(SQLJob.user_id.in_(resolved_user_ids))
 
-        async with AsyncSession(self._pg) as session:
+            skip_count = (page - 1) * per_page if page > 1 else 0
+
             total_count = (
                 await session.execute(select(func.count()).select_from(SQLJob))
             ).scalar_one()
@@ -193,6 +202,8 @@ class JobsData:
 
             rows = (await session.execute(data_query)).unique().all()
 
+            counts = await self._query_counts_v2(session)
+
         page_count = int(math.ceil(found_count / per_page)) if found_count else 0
 
         items = [
@@ -208,7 +219,7 @@ class JobsData:
         ]
 
         return JobSearchResultV2(
-            counts=await self.get_counts_v2(),
+            counts=counts,
             items=items,
             total_count=total_count,
             found_count=found_count,
@@ -216,12 +227,6 @@ class JobsData:
             per_page=per_page,
             page=page,
         )
-
-    async def _count_jobs(self) -> int:
-        """Return the total number of jobs in PostgreSQL."""
-        async with AsyncSession(self._pg) as session:
-            result = await session.execute(select(func.count()).select_from(SQLJob))
-            return result.scalar_one()
 
     async def find(
         self,
@@ -457,8 +462,19 @@ class JobsData:
         """
         async with AsyncSession(self._pg) as session:
             result = await session.execute(
-                select(SQLJob, SQLUser)
+                select(
+                    SQLJob,
+                    SQLUser,
+                    SQLJobSample.sample_id,
+                    SQLJobIndex.index_id,
+                    SQLJobSubtraction.subtraction_id,
+                    SQLJobAnalysis.analysis_id,
+                )
                 .join(SQLUser, SQLJob.user_id == SQLUser.id)
+                .outerjoin(SQLJobSample, SQLJob.id == SQLJobSample.job_id)
+                .outerjoin(SQLJobIndex, SQLJob.id == SQLJobIndex.job_id)
+                .outerjoin(SQLJobSubtraction, SQLJob.id == SQLJobSubtraction.job_id)
+                .outerjoin(SQLJobAnalysis, SQLJob.id == SQLJobAnalysis.job_id)
                 .where(compose_legacy_id_single_expression(SQLJob, job_id)),
             )
             row = result.unique().first()
@@ -466,11 +482,22 @@ class JobsData:
         if row is None:
             raise ResourceNotFoundError
 
-        sql_job, sql_user = row
+        sql_job, sql_user, sample_id, index_id, subtraction_id, analysis_id = row
+
+        args = {
+            field: value
+            for field, value in (
+                ("sample_id", sample_id),
+                ("index_id", index_id),
+                ("subtraction_id", subtraction_id),
+                ("analysis_id", analysis_id),
+            )
+            if value is not None
+        }
 
         return JobV2(
             id=sql_job.legacy_id or str(sql_job.id),
-            args={},
+            args=args,
             claim=JobClaim(**sql_job.claim) if sql_job.claim else None,
             claimed_at=sql_job.claimed_at,
             created_at=sql_job.created_at,
@@ -532,7 +559,12 @@ class JobsData:
             )
             sql_job = pg_result.scalar()
 
-            if sql_job:
+            if sql_job is None:
+                logger.warning(
+                    "acquired job has no postgres row",
+                    job_id=job_id,
+                )
+            else:
                 sql_job.acquired = True
                 sql_job.key = hashed
                 sql_job.pinged_at = now

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -10,7 +10,7 @@ from virtool.users.models_base import UserNested
 if TYPE_CHECKING:
     from pymongo.results import UpdateResult
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
@@ -27,7 +27,6 @@ from virtool.data.transforms import apply_transforms
 from virtool.jobs.models import (
     TERMINAL_JOB_STATES,
     V1_TO_V2_STATE,
-    V2_TO_V1_STATES,
     CreateJobClaimRequest,
     Job,
     JobAcquired,
@@ -58,11 +57,13 @@ from virtool.jobs.pg import (
 from virtool.jobs.utils import (
     check_job_is_running_or_waiting,
     compose_status,
+    compute_progress,
     get_latest_status,
 )
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.types import Document
+from virtool.users.pg import SQLUser
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
 
@@ -99,17 +100,19 @@ class JobsData:
         return JobCountsV1.parse_obj(counts)
 
     async def get_counts_v2(self) -> JobCountsV2:
-        """Get job counts, translating v1 states to v2 states."""
-        v1_counts = await self.get_counts()
+        """Get job counts grouped by v2 state and workflow from PostgreSQL."""
         counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
 
-        for v1_state in JobState:
-            v2_state = V1_TO_V2_STATE[v1_state].value
-            for workflow in WorkflowV2:
-                counts[v2_state][workflow.value] += getattr(
-                    getattr(v1_counts, v1_state.value),
-                    workflow.value,
-                )
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLJob.state, SQLJob.workflow, func.count()).group_by(
+                    SQLJob.state,
+                    SQLJob.workflow,
+                ),
+            )
+
+            for state, workflow, count in result.all():
+                counts[state][workflow] = count
 
         return JobCountsV2.parse_obj(counts)
 
@@ -120,121 +123,105 @@ class JobsData:
         states: list[JobStateV2],
         users: list[str],
     ) -> JobSearchResultV2:
-        """Find jobs using v2 state names.
+        """Find jobs using v2 state names via a PostgreSQL query."""
+        filters = []
 
-        Queries MongoDB jobs during the transition period, translating v2 state
-        names to v1 for querying and back to v2 for the response.
-        """
-        v1_states = []
-        for state in states:
-            v1_states.extend(V2_TO_V1_STATES[state])
-
-        skip_count = 0
-
-        if page > 1:
-            skip_count = (page - 1) * per_page
+        if states:
+            filters.append(SQLJob.state.in_([s.value for s in states]))
 
         if users:
-            user_id_variants = await get_user_id_multi_variants(self._pg, users)
-            match_query = {"user.id": {"$in": user_id_variants}}
-        else:
-            match_query = {}
+            modern_ids: list[int] = []
+            handles_or_legacy: list[str] = []
 
-        match_state = (
-            {"state": {"$in": [state.value for state in v1_states]}}
-            if v1_states
-            else {}
-        )
+            for user in users:
+                if isinstance(user, int):
+                    modern_ids.append(user)
+                elif user.isdigit():
+                    modern_ids.append(int(user))
+                else:
+                    handles_or_legacy.append(user)
 
-        data = {}
-        found_count = 0
-        total_count = 0
-        page_count = 0
+            user_clauses = []
 
-        async for paginate_dict in self._mongo.jobs.aggregate(
-            [
-                {
-                    "$facet": {
-                        "total_count": [{"$count": "total_count"}],
-                        "found_count": [
-                            {"$match": match_query},
-                            {"$set": {"last_status": {"$last": "$status"}}},
-                            {"$set": {"state": "$last_status.state"}},
-                            {"$match": match_state},
-                            {"$count": "found_count"},
-                        ],
-                        "data": [
-                            {"$match": match_query},
-                            {
-                                "$set": {
-                                    "last_status": {"$last": "$status"},
-                                    "first_status": {"$first": "$status"},
-                                },
-                            },
-                            {
-                                "$set": {
-                                    "created_at": "$first_status.timestamp",
-                                    "progress": "$last_status.progress",
-                                    "state": "$last_status.state",
-                                },
-                            },
-                            {"$match": match_state},
-                            {"$sort": {"created_at": -1}},
-                            {"$skip": skip_count},
-                            {"$limit": per_page},
-                        ],
-                    },
-                },
-                {
-                    "$project": {
-                        "data": {
-                            "_id": True,
-                            "created_at": True,
-                            "progress": True,
-                            "state": True,
-                            "user": True,
-                            "workflow": True,
-                        },
-                        "total_count": {
-                            "$arrayElemAt": ["$total_count.total_count", 0],
-                        },
-                        "found_count": {
-                            "$arrayElemAt": ["$found_count.found_count", 0],
-                        },
-                    },
-                },
-            ],
-        ):
-            data = paginate_dict["data"]
-            found_count = paginate_dict.get("found_count", 0)
-            total_count = paginate_dict.get("total_count", 0)
-            page_count = int(math.ceil(found_count / per_page)) if found_count else 0
+            if modern_ids:
+                user_clauses.append(SQLUser.id.in_(modern_ids))
 
-        documents = await apply_transforms(
-            [base_processor(d) for d in data],
-            [AttachUserTransform(self._pg)],
-            self._pg,
-        )
+            if handles_or_legacy:
+                user_clauses.append(SQLUser.legacy_id.in_(handles_or_legacy))
+                user_clauses.append(SQLUser.handle.in_(handles_or_legacy))
+
+            async with AsyncSession(self._pg) as session:
+                result = await session.execute(
+                    select(SQLUser.id).where(or_(*user_clauses)),
+                )
+                resolved_user_ids = [row[0] for row in result.all()]
+
+            if not resolved_user_ids:
+                return JobSearchResultV2(
+                    counts=await self.get_counts_v2(),
+                    items=[],
+                    total_count=await self._count_jobs(),
+                    found_count=0,
+                    page_count=0,
+                    per_page=per_page,
+                    page=page,
+                )
+
+            filters.append(SQLJob.user_id.in_(resolved_user_ids))
+
+        skip_count = (page - 1) * per_page if page > 1 else 0
+
+        async with AsyncSession(self._pg) as session:
+            total_count = (
+                await session.execute(select(func.count()).select_from(SQLJob))
+            ).scalar_one()
+
+            found_count_query = select(func.count()).select_from(SQLJob)
+            if filters:
+                found_count_query = found_count_query.where(*filters)
+            found_count = (await session.execute(found_count_query)).scalar_one()
+
+            data_query = (
+                select(SQLJob, SQLUser)
+                .join(SQLUser, SQLJob.user_id == SQLUser.id)
+                .order_by(SQLJob.created_at.desc())
+                .offset(skip_count)
+                .limit(per_page)
+            )
+            if filters:
+                data_query = data_query.where(*filters)
+
+            rows = (await session.execute(data_query)).unique().all()
+
+        page_count = int(math.ceil(found_count / per_page)) if found_count else 0
+
+        items = [
+            JobMinimalV2(
+                id=sql_job.legacy_id or str(sql_job.id),
+                created_at=sql_job.created_at,
+                progress=compute_progress(sql_job.state, sql_job.steps),
+                state=JobStateV2(sql_job.state),
+                user=UserNested(id=sql_user.id, handle=sql_user.handle),
+                workflow=WorkflowV2(sql_job.workflow),
+            )
+            for sql_job, sql_user in rows
+        ]
 
         return JobSearchResultV2(
             counts=await self.get_counts_v2(),
-            items=[
-                JobMinimalV2(
-                    id=d["id"],
-                    created_at=d["created_at"],
-                    progress=d["progress"],
-                    state=V1_TO_V2_STATE[JobState(d["state"])],
-                    user=UserNested(**d["user"]),
-                    workflow=WorkflowV2(d["workflow"]),
-                )
-                for d in documents
-            ],
+            items=items,
             total_count=total_count,
             found_count=found_count,
             page_count=page_count,
             per_page=per_page,
             page=page,
         )
+
+    async def _count_jobs(self) -> int:
+        """Return the total number of jobs in PostgreSQL."""
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(select(func.count()).select_from(SQLJob))
+            return result.scalar_one()
 
     async def find(
         self,
@@ -463,45 +450,36 @@ class JobsData:
         return Job(**document)
 
     async def get_v2(self, job_id: str) -> JobV2:
-        """Get a job using v2 response format.
+        """Get a job using v2 response format from PostgreSQL.
 
-        Queries MongoDB and maps v1 fields to v2 format.
-
-        :param job_id: the ID of the job to get.
+        :param job_id: the ID of the job to get (modern integer or legacy string).
         :return: the job in v2 format
         """
-        document = await self._mongo.jobs.find_one(job_id)
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLJob, SQLUser)
+                .join(SQLUser, SQLJob.user_id == SQLUser.id)
+                .where(compose_legacy_id_single_expression(SQLJob, job_id)),
+            )
+            row = result.unique().first()
 
-        if document is None:
+        if row is None:
             raise ResourceNotFoundError
 
-        last_update = get_latest_status(document)
-
-        document = await apply_transforms(
-            {
-                **document,
-                "id": document["_id"],
-            },
-            [AttachUserTransform(self._pg)],
-            self._pg,
-        )
-
-        claimed_at = None
-        if len(document["status"]) > 1:
-            claimed_at = document["status"][1]["timestamp"]
+        sql_job, sql_user = row
 
         return JobV2(
-            id=document["id"],
-            args=document.get("args", {}),
-            claim=None,
-            claimed_at=claimed_at,
-            created_at=document["created_at"],
-            pinged_at=document["ping"]["pinged_at"] if document.get("ping") else None,
-            progress=last_update.progress,
-            state=V1_TO_V2_STATE[last_update.state],
-            steps=None,
-            user=UserNested(**document["user"]),
-            workflow=WorkflowV2(document["workflow"]),
+            id=sql_job.legacy_id or str(sql_job.id),
+            args={},
+            claim=JobClaim(**sql_job.claim) if sql_job.claim else None,
+            claimed_at=sql_job.claimed_at,
+            created_at=sql_job.created_at,
+            pinged_at=sql_job.pinged_at,
+            progress=compute_progress(sql_job.state, sql_job.steps),
+            state=JobStateV2(sql_job.state),
+            steps=[JobStep(**s) for s in sql_job.steps] if sql_job.steps else None,
+            user=UserNested(id=sql_user.id, handle=sql_user.handle),
+            workflow=WorkflowV2(sql_job.workflow),
         )
 
     @emits(Operation.UPDATE)
@@ -517,7 +495,6 @@ class JobsData:
         if job_doc is None:
             raise ResourceNotFoundError("Job not found")
 
-        # Check if job is in a terminal state (more specific than already acquired)
         latest_status = get_latest_status(job_doc)
         if latest_status and latest_status.state in TERMINAL_JOB_STATES:
             raise ResourceConflictError("Cannot acquire job in terminal state")
@@ -526,23 +503,40 @@ class JobsData:
             raise ResourceConflictError("Job already acquired")
 
         key, hashed = virtool.utils.generate_key()
+        now = virtool.utils.timestamp()
 
-        await self._mongo.jobs.update_one(
-            {"_id": job_id},
-            {
-                "$set": {
-                    "acquired": True,
-                    "key": hashed,
-                    "ping": {
-                        "pinged_at": virtool.utils.timestamp(),
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.jobs.update_one(
+                {"_id": job_id},
+                {
+                    "$set": {
+                        "acquired": True,
+                        "key": hashed,
+                        "ping": {"pinged_at": now},
+                        "state": JobState.PREPARING.value,
                     },
-                    "state": JobState.PREPARING.value,
+                    "$push": {
+                        "status": compose_status(JobState.PREPARING, None, progress=3),
+                    },
                 },
-                "$push": {
-                    "status": compose_status(JobState.PREPARING, None, progress=3),
-                },
-            },
-        )
+                session=mongo_session,
+            )
+
+            pg_result = await pg_session.execute(
+                select(SQLJob).where(
+                    compose_legacy_id_single_expression(SQLJob, job_id),
+                ),
+            )
+            sql_job = pg_result.scalar()
+
+            if sql_job:
+                sql_job.acquired = True
+                sql_job.key = hashed
+                sql_job.pinged_at = now
+                sql_job.state = JobStateV2.RUNNING.value
 
         job = await self.get(job_id)
 

--- a/virtool/jobs/utils.py
+++ b/virtool/jobs/utils.py
@@ -55,3 +55,16 @@ def get_latest_status(document: Document) -> JobStatus | None:
 def check_job_is_running_or_waiting(document: Document) -> bool:
     """Return a boolean indicating whether the passed job is running or waiting."""
     return document["status"][-1]["state"] in ("waiting", "running")
+
+
+def compute_progress(state: str, steps: list[dict] | None) -> int:
+    """Compute a v2 job's progress percentage from its state and steps."""
+    if state in ("succeeded", "failed", "cancelled"):
+        return 100
+
+    if state != "running" or not steps:
+        return 0
+
+    started = sum(1 for s in steps if s.get("started_at") is not None)
+
+    return int(started / len(steps) * 100)


### PR DESCRIPTION
## Summary
- Rewrites `find_v2`, `get_v2`, and `get_counts_v2` in `virtool/jobs/data.py` as real SQLAlchemy queries against `SQLJob` (+ `SQLUser` for user info), dropping the MongoDB `$facet` / aggregation path and the v1↔v2 state translation.
- Fixes a dual-write gap: `acquire()` now syncs `acquired`, `key`, `pinged_at`, and v2 `state` onto the `SQLJob` row inside `both_transactions`, so v2 reads don't return stale `pending` for jobs that have been acquired.
- Adds a `compute_progress(state, steps)` helper (`virtool/jobs/utils.py`) used by the v2 read methods — pending→0, terminal→100, running→fraction of steps with `started_at`. Computing at read time keeps the formula tunable without a migration.
- New Alembic revision adds supporting indexes: `ix_jobs_workflow_state`, `ix_jobs_state_created_at`, `ix_jobs_user_id_state`.
- Test updates: `TestGetV2.test_ok` swapped from a stale snapshot to explicit assertions; adds `TestFindV2.test_pagination` and `test_unknown_user`. Migration snapshot refreshed for the new revision row.

Closes VIR-2247. Unblocks VIR-2250 (remove dual-write from job operations). The `v1↔v2` mappings (`V1_TO_V2_STATE`, `V2_TO_V1_STATES`) and the v1 `find` / `get` / `get_counts` methods are intentionally left in place — still needed by v1 endpoints and other dual-write paths.