### PR TITLE
feat: implement in-memory fake storage backend for testing

### DIFF
--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -17,6 +17,7 @@ import aiohttp
 import pytest
 from obstore.store import AzureStore, S3Store
 
+from virtool.storage.memory import MemoryStorageProvider
 from virtool.storage.obstore import ObstoreProvider
 
 
@@ -139,3 +140,8 @@ async def azure_storage(
     await _purge(provider, prefix)
     yield provider
     await _purge(provider, prefix)
+
+
+@pytest.fixture
+def memory_storage() -> MemoryStorageProvider:
+    return MemoryStorageProvider()

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -1,0 +1,133 @@
+import pytest
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.memory import MemoryStorageProvider
+from virtool.storage.protocol import STORAGE_CHUNK_SIZE
+from virtool.storage.types import StorageObjectInfo
+
+
+@pytest.fixture
+def provider():
+    return MemoryStorageProvider()
+
+
+async def _async_iter(data: bytes, chunk_size: int = 1024):
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+async def _collect_bytes(aiter) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
+async def _collect(aiter) -> list:
+    return [item async for item in aiter]
+
+
+class TestRead:
+    async def test_ok(self, provider):
+        await provider.write("samples/abc/reads.fq.gz", _async_iter(b"read data here"))
+
+        result = await _collect_bytes(provider.read("samples/abc/reads.fq.gz"))
+
+        assert result == b"read data here"
+
+    async def test_nonexistent_key(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(provider.read("does/not/exist"))
+
+    async def test_chunked_read(self, provider):
+        data = b"x" * (STORAGE_CHUNK_SIZE + 1000)
+
+        await provider.write("big/file.bin", _async_iter(data))
+
+        chunks = [chunk async for chunk in provider.read("big/file.bin")]
+
+        assert len(chunks) == 2
+        assert b"".join(chunks) == data
+
+
+class TestWrite:
+    async def test_returns_byte_count(self, provider):
+        data = b"x" * 5000
+
+        size = await provider.write("uploads/file.txt", _async_iter(data))
+
+        assert size == 5000
+
+    async def test_creates_object(self, provider):
+        data = b"hello"
+
+        await provider.write("uploads/file.txt", _async_iter(data))
+
+        assert provider.get_raw("uploads/file.txt") == data
+
+    async def test_overwrites_existing(self, provider):
+        await provider.write("key", _async_iter(b"first"))
+        await provider.write("key", _async_iter(b"second"))
+
+        assert provider.get_raw("key") == b"second"
+
+
+class TestDelete:
+    async def test_existing_key(self, provider):
+        await provider.write("to_delete", _async_iter(b"data"))
+
+        await provider.delete("to_delete")
+
+        assert "to_delete" not in provider.keys()
+
+    async def test_nonexistent_is_idempotent(self, provider):
+        await provider.delete("does/not/exist")
+
+
+class TestList:
+    async def test_with_prefix(self, provider):
+        await provider.write("samples/a/reads.fq.gz", _async_iter(b"a"))
+        await provider.write("samples/b/reads.fq.gz", _async_iter(b"b"))
+        await provider.write("uploads/file.txt", _async_iter(b"c"))
+
+        result = await _collect(provider.list("samples/"))
+
+        keys = sorted(item.key for item in result)
+        assert keys == ["samples/a/reads.fq.gz", "samples/b/reads.fq.gz"]
+
+    async def test_no_matches(self, provider):
+        await provider.write("samples/a/reads.fq.gz", _async_iter(b"a"))
+
+        result = await _collect(provider.list("uploads/"))
+
+        assert result == []
+
+    async def test_metadata(self, provider):
+        await provider.write("test/file.txt", _async_iter(b"hello"))
+
+        result = await _collect(provider.list("test/"))
+
+        assert len(result) == 1
+
+        info = result[0]
+        assert isinstance(info, StorageObjectInfo)
+        assert info.key == "test/file.txt"
+        assert info.size == 5
+        assert info.last_modified is not None
+
+
+class TestHelpers:
+    async def test_keys_empty(self, provider):
+        assert provider.keys() == set()
+
+    async def test_keys_after_writes(self, provider):
+        await provider.write("a", _async_iter(b"1"))
+        await provider.write("b/c", _async_iter(b"2"))
+
+        assert provider.keys() == {"a", "b/c"}
+
+    async def test_get_raw(self, provider):
+        await provider.write("key", _async_iter(b"value"))
+
+        assert provider.get_raw("key") == b"value"
+
+    async def test_get_raw_missing_raises_key_error(self, provider):
+        with pytest.raises(KeyError):
+            provider.get_raw("missing")

--- a/virtool/storage/memory.py
+++ b/virtool/storage/memory.py
@@ -1,0 +1,65 @@
+"""In-memory storage backend for testing."""
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.protocol import STORAGE_CHUNK_SIZE
+from virtool.storage.types import StorageObjectInfo
+
+
+@dataclass(frozen=True, slots=True)
+class _StoredObject:
+    data: bytes
+    last_modified: datetime
+
+
+class MemoryStorageProvider:
+    """``StorageBackend`` implementation backed by an in-memory dictionary.
+
+    Intended for use in tests. Each instance starts with an empty store.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, _StoredObject] = {}
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        try:
+            obj = self._store[key]
+        except KeyError as exc:
+            raise StorageKeyNotFoundError(key) from exc
+
+        data = obj.data
+        for i in range(0, len(data), STORAGE_CHUNK_SIZE):
+            yield data[i : i + STORAGE_CHUNK_SIZE]
+
+    async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
+        chunks = []
+        async for chunk in data:
+            chunks.append(chunk)
+
+        blob = b"".join(chunks)
+        self._store[key] = _StoredObject(data=blob, last_modified=datetime.now(tz=UTC))
+
+        return len(blob)
+
+    async def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        for key, obj in self._store.items():
+            if key.startswith(prefix):
+                yield StorageObjectInfo(
+                    key=key,
+                    size=len(obj.data),
+                    last_modified=obj.last_modified,
+                )
+
+    def keys(self) -> set[str]:
+        """Return the set of all stored keys."""
+        return set(self._store)
+
+    def get_raw(self, key: str) -> bytes:
+        """Return raw bytes for the given key. Raises ``KeyError`` if missing."""
+        return self._store[key].data

--- a/virtool/storage/memory.py
+++ b/virtool/storage/memory.py
@@ -48,7 +48,7 @@ class MemoryStorageProvider:
         self._store.pop(key, None)
 
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
-        for key, obj in self._store.items():
+        for key, obj in list(self._store.items()):
             if key.startswith(prefix):
                 yield StorageObjectInfo(
                     key=key,


### PR DESCRIPTION
## Summary

- Adds `MemoryStorageProvider`, an in-memory `StorageBackend` implementation backed by a plain dictionary, intended solely for use in tests
- Exposes a `memory_storage` pytest fixture in `tests/fixtures/storage.py` so tests can get a fresh, isolated store without any external dependencies
- Includes a full test suite covering `read`, `write`, `delete`, `list`, and the helper methods `keys` / `get_raw`

## Test plan

- [ ] Run `mise run test -- tests/storage/test_memory.py` to verify all new unit tests pass
- [ ] Confirm `memory_storage` fixture is importable and works in a sample test that uses it
- [ ] Run full test suite (`mise run test`) to confirm no regressions