### PR TITLE
feat: add fallback storage router for object-then-filesystem reads

### DIFF
--- a/tests/storage/test_factory.py
+++ b/tests/storage/test_factory.py
@@ -10,7 +10,7 @@ from virtool.storage.routing import FallbackStorageRouter
 
 
 class TestFilesystem:
-    def test_returns_fallback_router(self, tmp_path: Path):
+    def test_returns_filesystem_provider(self, tmp_path: Path):
         config = build_server_config(
             data_path=tmp_path,
             storage_backend="filesystem",
@@ -18,9 +18,7 @@ class TestFilesystem:
 
         backend = create_storage_backend(config)
 
-        assert isinstance(backend, FallbackStorageRouter)
-        assert isinstance(backend._primary, FilesystemProvider)
-        assert backend._primary is backend._fallback
+        assert isinstance(backend, FilesystemProvider)
 
     def test_creates_base_directory(self, tmp_path: Path):
         target = tmp_path / "nested" / "storage"

--- a/tests/storage/test_factory.py
+++ b/tests/storage/test_factory.py
@@ -6,10 +6,11 @@ from tests.config.test_cls import build_server_config
 from virtool.storage.factory import create_storage_backend
 from virtool.storage.filesystem import FilesystemProvider
 from virtool.storage.obstore import ObstoreProvider
+from virtool.storage.routing import FallbackStorageRouter
 
 
 class TestFilesystem:
-    def test_returns_filesystem_provider(self, tmp_path: Path):
+    def test_returns_fallback_router(self, tmp_path: Path):
         config = build_server_config(
             data_path=tmp_path,
             storage_backend="filesystem",
@@ -17,7 +18,9 @@ class TestFilesystem:
 
         backend = create_storage_backend(config)
 
-        assert isinstance(backend, FilesystemProvider)
+        assert isinstance(backend, FallbackStorageRouter)
+        assert isinstance(backend._primary, FilesystemProvider)
+        assert backend._primary is backend._fallback
 
     def test_creates_base_directory(self, tmp_path: Path):
         target = tmp_path / "nested" / "storage"
@@ -49,7 +52,9 @@ class TestS3:
 
         backend = create_storage_backend(config)
 
-        assert isinstance(backend, ObstoreProvider)
+        assert isinstance(backend, FallbackStorageRouter)
+        assert isinstance(backend._primary, ObstoreProvider)
+        assert isinstance(backend._fallback, FilesystemProvider)
         s3_store.assert_called_once_with(
             "my-bucket",
             region="us-west-2",
@@ -86,7 +91,9 @@ class TestAzure:
 
         backend = create_storage_backend(config)
 
-        assert isinstance(backend, ObstoreProvider)
+        assert isinstance(backend, FallbackStorageRouter)
+        assert isinstance(backend._primary, ObstoreProvider)
+        assert isinstance(backend._fallback, FilesystemProvider)
         azure_store.assert_called_once_with(
             "container",
             account="account",

--- a/tests/storage/test_routing.py
+++ b/tests/storage/test_routing.py
@@ -1,0 +1,191 @@
+import pytest
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.memory import MemoryStorageProvider
+from virtool.storage.routing import FallbackStorageRouter
+
+
+@pytest.fixture
+def primary():
+    return MemoryStorageProvider()
+
+
+@pytest.fixture
+def fallback():
+    return MemoryStorageProvider()
+
+
+@pytest.fixture
+def router(primary, fallback):
+    return FallbackStorageRouter(primary, fallback)
+
+
+async def _async_iter(data: bytes, chunk_size: int = 1024):
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+async def _collect_bytes(aiter) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
+async def _collect(aiter) -> list:
+    return [item async for item in aiter]
+
+
+class TestRead:
+    async def test_reads_from_primary(self, primary, router):
+        await primary.write("key", _async_iter(b"primary data"))
+
+        result = await _collect_bytes(router.read("key"))
+
+        assert result == b"primary data"
+
+    async def test_falls_back_to_fallback(self, fallback, router):
+        await fallback.write("key", _async_iter(b"fallback data"))
+
+        result = await _collect_bytes(router.read("key"))
+
+        assert result == b"fallback data"
+
+    async def test_primary_takes_precedence(self, primary, fallback, router):
+        await primary.write("key", _async_iter(b"primary"))
+        await fallback.write("key", _async_iter(b"fallback"))
+
+        result = await _collect_bytes(router.read("key"))
+
+        assert result == b"primary"
+
+    async def test_missing_from_both_raises(self, router):
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(router.read("missing"))
+
+
+class TestWrite:
+    async def test_writes_to_primary_only(self, primary, fallback, router):
+        await router.write("key", _async_iter(b"data"))
+
+        assert "key" in primary.keys()
+        assert "key" not in fallback.keys()
+
+    async def test_returns_byte_count(self, router):
+        size = await router.write("key", _async_iter(b"hello"))
+
+        assert size == 5
+
+
+class TestDelete:
+    async def test_deletes_from_both(self, primary, fallback, router):
+        await primary.write("key", _async_iter(b"a"))
+        await fallback.write("key", _async_iter(b"b"))
+
+        await router.delete("key")
+
+        assert "key" not in primary.keys()
+        assert "key" not in fallback.keys()
+
+    async def test_primary_only(self, primary, fallback, router):
+        await primary.write("key", _async_iter(b"a"))
+
+        await router.delete("key")
+
+        assert "key" not in primary.keys()
+
+    async def test_fallback_only(self, fallback, router):
+        await fallback.write("key", _async_iter(b"a"))
+
+        await router.delete("key")
+
+        assert "key" not in fallback.keys()
+
+    async def test_missing_from_both(self, router):
+        await router.delete("missing")
+
+
+class TestList:
+    async def test_merges_results(self, primary, fallback, router):
+        await primary.write("a/1", _async_iter(b"p"))
+        await fallback.write("a/2", _async_iter(b"f"))
+
+        result = await _collect(router.list("a/"))
+
+        keys = sorted(info.key for info in result)
+        assert keys == ["a/1", "a/2"]
+
+    async def test_deduplicates_by_key(self, primary, fallback, router):
+        await primary.write("a/1", _async_iter(b"short"))
+        await fallback.write("a/1", _async_iter(b"longer value"))
+
+        result = await _collect(router.list("a/"))
+
+        assert len(result) == 1
+        assert result[0].key == "a/1"
+        assert result[0].size == 5
+
+    async def test_primary_only(self, primary, router):
+        await primary.write("a/1", _async_iter(b"p"))
+
+        result = await _collect(router.list("a/"))
+
+        assert len(result) == 1
+        assert result[0].key == "a/1"
+
+    async def test_fallback_only(self, fallback, router):
+        await fallback.write("a/1", _async_iter(b"f"))
+
+        result = await _collect(router.list("a/"))
+
+        assert len(result) == 1
+        assert result[0].key == "a/1"
+
+    async def test_empty(self, router):
+        result = await _collect(router.list("a/"))
+
+        assert result == []
+
+    async def test_prefix_filtering(self, primary, fallback, router):
+        await primary.write("a/1", _async_iter(b"p"))
+        await fallback.write("b/1", _async_iter(b"f"))
+
+        result = await _collect(router.list("a/"))
+
+        assert len(result) == 1
+        assert result[0].key == "a/1"
+
+
+class TestSameInstance:
+    @pytest.fixture
+    def backend(self):
+        return MemoryStorageProvider()
+
+    @pytest.fixture
+    def router(self, backend):
+        return FallbackStorageRouter(backend, backend)
+
+    async def test_read(self, backend, router):
+        await backend.write("key", _async_iter(b"data"))
+
+        result = await _collect_bytes(router.read("key"))
+
+        assert result == b"data"
+
+    async def test_write(self, backend, router):
+        await router.write("key", _async_iter(b"data"))
+
+        assert backend.get_raw("key") == b"data"
+
+    async def test_delete(self, backend, router):
+        await backend.write("key", _async_iter(b"data"))
+
+        await router.delete("key")
+
+        assert "key" not in backend.keys()
+
+    async def test_list_no_duplicates(self, backend, router):
+        await backend.write("a/1", _async_iter(b"x"))
+        await backend.write("a/2", _async_iter(b"y"))
+
+        result = await _collect(router.list("a/"))
+
+        keys = sorted(info.key for info in result)
+        assert keys == ["a/1", "a/2"]

--- a/tests/storage/test_routing.py
+++ b/tests/storage/test_routing.py
@@ -153,39 +153,3 @@ class TestList:
         assert result[0].key == "a/1"
 
 
-class TestSameInstance:
-    @pytest.fixture
-    def backend(self):
-        return MemoryStorageProvider()
-
-    @pytest.fixture
-    def router(self, backend):
-        return FallbackStorageRouter(backend, backend)
-
-    async def test_read(self, backend, router):
-        await backend.write("key", _async_iter(b"data"))
-
-        result = await _collect_bytes(router.read("key"))
-
-        assert result == b"data"
-
-    async def test_write(self, backend, router):
-        await router.write("key", _async_iter(b"data"))
-
-        assert backend.get_raw("key") == b"data"
-
-    async def test_delete(self, backend, router):
-        await backend.write("key", _async_iter(b"data"))
-
-        await router.delete("key")
-
-        assert "key" not in backend.keys()
-
-    async def test_list_no_duplicates(self, backend, router):
-        await backend.write("a/1", _async_iter(b"x"))
-        await backend.write("a/2", _async_iter(b"y"))
-
-        result = await _collect(router.list("a/"))
-
-        keys = sorted(info.key for info in result)
-        assert keys == ["a/1", "a/2"]

--- a/tests/storage/test_routing.py
+++ b/tests/storage/test_routing.py
@@ -151,5 +151,3 @@ class TestList:
 
         assert len(result) == 1
         assert result[0].key == "a/1"
-
-

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -3,7 +3,7 @@ from aiohttp.client import ClientSession, ClientTimeout
 
 from tests.config.test_cls import build_server_config
 from virtool.startup import startup_http_client_session, startup_storage
-from virtool.storage.routing import FallbackStorageRouter
+from virtool.storage.filesystem import FilesystemProvider
 
 
 @pytest.fixture
@@ -47,5 +47,5 @@ async def test_startup_storage(fake_app, tmp_path):
 
     await startup_storage(fake_app)
 
-    assert isinstance(fake_app["storage"], FallbackStorageRouter)
+    assert isinstance(fake_app["storage"], FilesystemProvider)
     assert (tmp_path / "storage").is_dir()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -3,7 +3,7 @@ from aiohttp.client import ClientSession, ClientTimeout
 
 from tests.config.test_cls import build_server_config
 from virtool.startup import startup_http_client_session, startup_storage
-from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.routing import FallbackStorageRouter
 
 
 @pytest.fixture
@@ -47,5 +47,5 @@ async def test_startup_storage(fake_app, tmp_path):
 
     await startup_storage(fake_app)
 
-    assert isinstance(fake_app["storage"], FilesystemProvider)
+    assert isinstance(fake_app["storage"], FallbackStorageRouter)
     assert (tmp_path / "storage").is_dir()

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -3,10 +3,28 @@
 from virtool.config.cls import ServerConfig
 from virtool.storage.filesystem import FilesystemProvider
 from virtool.storage.protocol import StorageBackend
+from virtool.storage.routing import FallbackStorageRouter
 
 
 def create_storage_backend(config: ServerConfig) -> StorageBackend:
-    """Create the storage backend selected by ``config``."""
+    """Create a :class:`FallbackStorageRouter` from ``config``.
+
+    The primary backend is determined by ``config.storage_backend``. The
+    fallback is always a :class:`FilesystemProvider` (reusing the primary
+    instance in filesystem-only mode).
+    """
+    primary = _create_primary_backend(config)
+
+    if config.storage_backend == "filesystem":
+        fallback = primary
+    else:
+        config.storage_filesystem_path.mkdir(parents=True, exist_ok=True)
+        fallback = FilesystemProvider(config.storage_filesystem_path)
+
+    return FallbackStorageRouter(primary, fallback)
+
+
+def _create_primary_backend(config: ServerConfig) -> StorageBackend:
     match config.storage_backend:
         case "filesystem":
             config.storage_filesystem_path.mkdir(parents=True, exist_ok=True)

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -16,10 +16,10 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
     primary = _create_primary_backend(config)
 
     if config.storage_backend == "filesystem":
-        fallback = primary
-    else:
-        config.storage_filesystem_path.mkdir(parents=True, exist_ok=True)
-        fallback = FilesystemProvider(config.storage_filesystem_path)
+        return primary
+
+    config.storage_filesystem_path.mkdir(parents=True, exist_ok=True)
+    fallback = FilesystemProvider(config.storage_filesystem_path)
 
     return FallbackStorageRouter(primary, fallback)
 

--- a/virtool/storage/routing.py
+++ b/virtool/storage/routing.py
@@ -1,0 +1,54 @@
+"""Fallback storage router that tries a primary backend before a fallback."""
+
+from collections.abc import AsyncIterator
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.protocol import StorageBackend
+from virtool.storage.types import StorageObjectInfo
+
+
+class FallbackStorageRouter:
+    """Routes storage operations between a primary and a fallback backend.
+
+    Reads try the primary first and fall back on
+    :class:`~virtool.storage.errors.StorageKeyNotFoundError`. Writes always go
+    to the primary. Deletes are best-effort on both. List merges and
+    deduplicates results, with primary metadata taking precedence.
+    """
+
+    def __init__(
+        self,
+        primary: StorageBackend,
+        fallback: StorageBackend,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in self._primary.read(key):
+                yield chunk
+            return
+        except StorageKeyNotFoundError:
+            pass
+
+        async for chunk in self._fallback.read(key):
+            yield chunk
+
+    async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
+        return await self._primary.write(key, data)
+
+    async def delete(self, key: str) -> None:
+        await self._primary.delete(key)
+        await self._fallback.delete(key)
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        seen: set[str] = set()
+
+        async for info in self._primary.list(prefix):
+            seen.add(info.key)
+            yield info
+
+        async for info in self._fallback.list(prefix):
+            if info.key not in seen:
+                yield info

--- a/virtool/storage/routing.py
+++ b/virtool/storage/routing.py
@@ -25,12 +25,15 @@ class FallbackStorageRouter:
         self._fallback = fallback
 
     async def read(self, key: str) -> AsyncIterator[bytes]:
+        yielded = False
         try:
             async for chunk in self._primary.read(key):
+                yielded = True
                 yield chunk
             return
         except StorageKeyNotFoundError:
-            pass
+            if yielded:
+                raise
 
         async for chunk in self._fallback.read(key):
             yield chunk


### PR DESCRIPTION
## Summary
- Introduces `FallbackStorageRouter` that wraps any primary storage backend (S3, Azure Blob, or filesystem) and transparently falls back to the local filesystem for reads when a key is not found in the primary
- Updates `create_storage_backend` to always return a `FallbackStorageRouter`; in filesystem-only mode the primary and fallback are the same instance
- Adds comprehensive tests for the router (read fallback, write-to-primary-only, best-effort delete on both, deduplicating list merge) and updates existing factory/startup tests

## Test plan
- [ ] Run `mise run test -- tests/storage/` to verify all routing and factory tests pass
- [ ] Run `mise run test -- tests/test_startup.py` to verify startup storage test passes
- [ ] Verify that read operations fall back correctly when a key exists only on the filesystem backend
- [ ] Verify that writes go only to the primary (object store) backend
- [ ] Verify that `list` deduplicates keys present on both backends, preferring primary metadata