### PR TITLE
feat: derive uploads from sample instead of job args

### DIFF
--- a/tests/workflow/data/test_samples.py
+++ b/tests/workflow/data/test_samples.py
@@ -98,24 +98,6 @@ class TestNewSample:
         work_path: Path,
         workflow_data: WorkflowData,
     ):
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
-
         workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         new_sample: WFNewSample = await scope.instantiate_by_key("new_sample")
@@ -147,23 +129,7 @@ class TestNewSample:
 
     async def test_finalize(self, scope: FixtureScope, workflow_data: WorkflowData):
         """Test that the finalize method updates the sample with the given quality."""
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
+        workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         new_sample = await scope.instantiate_by_key("new_sample")
 
@@ -188,23 +154,7 @@ class TestNewSample:
             __model__ = Quality
             __random_seed__ = 1
 
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
+        workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         workflow_data.new_sample.ready = True
         workflow_data.quality = QualityFactory.build()
@@ -216,23 +166,7 @@ class TestNewSample:
 
     async def test_delete(self, scope: FixtureScope, workflow_data: WorkflowData):
         """Test that the delete method deletes the sample."""
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
+        workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         new_sample: WFNewSample = await scope.instantiate_by_key("new_sample")
 
@@ -244,23 +178,7 @@ class TestNewSample:
         self, workflow_data: WorkflowData, scope: FixtureScope
     ):
         """Test that the delete method raises an error if the sample does not exist."""
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
+        workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         new_sample: WFNewSample = await scope.instantiate_by_key("new_sample")
 
@@ -273,23 +191,7 @@ class TestNewSample:
         self, workflow_data: WorkflowData, scope: FixtureScope
     ):
         """Test that the delete method raises an error if the sample is finalized."""
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
+        workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         new_sample: WFNewSample = await scope.instantiate_by_key("new_sample")
 
@@ -307,23 +209,7 @@ class TestNewSample:
         workflow_data: WorkflowData,
     ):
         """Test that reads can be uploaded to unfinalized samples."""
-        workflow_data.job.args.update(
-            {
-                "files": [
-                    {
-                        "id": 1,
-                        "name": "reads_1.fq.gz",
-                        "size": 100,
-                    },
-                    {
-                        "id": 2,
-                        "name": "reads_2.fq.gz",
-                        "size": 100,
-                    },
-                ],
-                "sample_id": workflow_data.new_sample.id,
-            },
-        )
+        workflow_data.job.args["sample_id"] = workflow_data.new_sample.id
 
         new_sample: WFNewSample = await scope.instantiate_by_key("new_sample")
 

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -366,17 +366,7 @@ class SamplesData(DataLayerDomain):
 
             await self.data.jobs.create(
                 "create_sample",
-                {
-                    "sample_id": sample_id,
-                    "files": [
-                        {
-                            "id": upload["id"],
-                            "name": upload["name"],
-                            "size": upload["size"],
-                        }
-                        for upload in uploads
-                    ],
-                },
+                {"sample_id": sample_id},
                 user_id,
                 job_id=job_id,
             )

--- a/virtool/workflow/data/samples.py
+++ b/virtool/workflow/data/samples.py
@@ -155,9 +155,7 @@ async def new_sample(
 
     log.info("created uploads directory")
 
-    # TODO: Remove fallback to job.args["files"] once all samples have uploads stored.
-    # Older samples don't have uploads in sample_dict, so we fall back to job.args.
-    sample_uploads = sample_dict.get("uploads") or job.args.get("files") or []
+    sample_uploads = sample_dict.get("uploads") or []
 
     files = tuple(
         WFNewSampleUpload(

--- a/virtool/workflow/data/samples.py
+++ b/virtool/workflow/data/samples.py
@@ -155,16 +155,14 @@ async def new_sample(
 
     log.info("created uploads directory")
 
-    sample_uploads = sample_dict.get("uploads") or []
-
     files = tuple(
         WFNewSampleUpload(
-            id=u["id"],
-            name=u["name"],
-            path=Path(uploads_path / u["name"]),
-            size=u["size"],
+            id=u.id,
+            name=u.name,
+            path=Path(uploads_path / u.name),
+            size=u.size,
         )
-        for u in sample_uploads
+        for u in sample.uploads or []
     )
 
     await asyncio.gather(*[uploads.download(f.id, f.path) for f in files])

--- a/virtool/workflow/pytest_plugin/data.py
+++ b/virtool/workflow/pytest_plugin/data.py
@@ -11,6 +11,7 @@ from virtool.ml.models import MLModelRelease
 from virtool.references.models import Reference, ReferenceNested
 from virtool.samples.models import Sample
 from virtool.subtractions.models import Subtraction, SubtractionFile, SubtractionNested
+from virtool.uploads.models import UploadMinimal
 from virtool.workflow.pytest_plugin.utils import SUBTRACTION_FILENAMES, StaticTime
 
 
@@ -120,22 +121,38 @@ def workflow_data(
     new_sample = SampleFactory.build()
 
     new_sample_job = JobFactory.build()
-    new_sample_job.args["files"] = [
-        {
-            "id": 1,
-            "name": "reads_1.fq.gz",
-            "size": 100,
-        },
-        {
-            "id": 2,
-            "name": "reads_2.fq.gz",
-            "size": 100,
-        },
-    ]
     new_sample_job.args["sample_id"] = new_sample.id
 
     new_sample.artifacts = []
     new_sample.job = JobMinimal.parse_obj(new_sample_job)
+    new_sample.uploads = [
+        UploadMinimal(
+            id=1,
+            created_at=static_time.datetime,
+            name="reads_1.fq.gz",
+            ready=True,
+            removed=False,
+            removed_at=None,
+            reserved=True,
+            size=100,
+            type="reads",
+            uploaded_at=static_time.datetime,
+            user=new_sample.user,
+        ),
+        UploadMinimal(
+            id=2,
+            created_at=static_time.datetime,
+            name="reads_2.fq.gz",
+            ready=True,
+            removed=False,
+            removed_at=None,
+            reserved=True,
+            size=100,
+            type="reads",
+            uploaded_at=static_time.datetime,
+            user=new_sample.user,
+        ),
+    ]
     new_sample.quality = None
     new_sample.reads = []
     new_sample.ready = False


### PR DESCRIPTION
## Summary
- Removes the `files` field from `create_sample` job arguments; the workflow now derives upload metadata directly from the sample's `uploads` field instead
- Cleans up the fallback path in `virtool/workflow/data/samples.py` that previously fell back to `job.args["files"]` for older samples
- Updates the workflow pytest plugin fixture and tests to set uploads on the sample model rather than in job args

## Test plan
- [ ] Run `mise run test -- tests/workflow/data/test_samples.py` to verify all `TestNewSample` tests pass
- [ ] Run `mise run test -- tests/samples/` to verify sample creation tests pass
- [ ] Verify that the `create_sample` job no longer receives a `files` argument in the job args