### PR TITLE
refactor: remove unused job args from build_index and analysis jobs

### DIFF
--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -28,13 +28,6 @@
     'acquired': False,
     'args': dict({
       'index_id': 'fb085f7f',
-      'index_version': 0,
-      'manifest': dict({
-        'bar': 2,
-        'foo': 1,
-      }),
-      'ref_id': 'foo',
-      'user_id': 1,
     }),
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'key': None,

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -250,12 +250,9 @@ class AnalysisData(DataLayerDomain):
         """
         created_at = virtool.utils.timestamp()
 
-        (
-            (index_id, index_version),
-            sample_name,
-        ) = await asyncio.gather(
-            get_current_id_and_version(self._mongo, data.ref_id),
-            get_one_field(self._mongo.samples, "name", sample_id),
+        index_id, index_version = await get_current_id_and_version(
+            self._mongo,
+            data.ref_id,
         )
 
         analysis_id = await get_new_id(self._mongo.analyses)

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -289,11 +289,6 @@ class AnalysisData(DataLayerDomain):
             data.workflow.value,
             {
                 "analysis_id": analysis_id,
-                "ref_id": data.ref_id,
-                "sample_id": sample_id,
-                "sample_name": sample_name,
-                "index_id": index_id,
-                "subtractions": data.subtractions,
             },
             user_id,
             space_id,

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -595,11 +595,7 @@ class ReferencesData(DataLayerDomain):
         await self.data.jobs.create(
             "build_index",
             {
-                "ref_id": ref_id,
-                "user_id": user_id,
                 "index_id": document["_id"],
-                "index_version": document["version"],
-                "manifest": document["manifest"],
             },
             user_id,
             0,


### PR DESCRIPTION
## Summary
- Removes redundant fields (`ref_id`, `sample_id`, `sample_name`, `index_id`, `subtractions`) from the analysis job args dict, as they are not needed by the job
- Removes redundant fields (`ref_id`, `user_id`, `index_version`, `manifest`) from the `build_index` job args dict, keeping only the required `index_id`

## Test plan
- [ ] Verify analysis job creation still works end-to-end
- [ ] Verify `build_index` job creation still works end-to-end
- [ ] Run targeted tests: `mise run test -- tests/analyses tests/references`