### PR TITLE
feat: adopt storage abstraction in ML models module

### DIFF
--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from virtool.data.layer import DataLayer, create_data_layer
 from virtool.mongo.core import Mongo
+from virtool.storage.memory import MemoryStorageProvider
 
 
 @pytest.fixture
@@ -31,4 +32,5 @@ def data_layer(
         pg,
         config,
         mocker.Mock(spec=ClientSession),
+        MemoryStorageProvider(),
     )

--- a/tests/fixtures/fake.py
+++ b/tests/fixtures/fake.py
@@ -1,4 +1,3 @@
-import shutil
 from pathlib import Path
 
 import pytest
@@ -44,14 +43,11 @@ def fake(
 
             assert await data_layer.jobs.get(job.id) == job
     """
-    # Use a local example ML model instead of downloading from GitHub.
-    mocker.patch.object(
-        HTTPClient,
-        "download",
-        side_effect=lambda url, target: shutil.copy(
-            example_path / "ml/model.tar.gz",
-            target,
-        ),
-    )
+    model_bytes = (example_path / "ml/model.tar.gz").read_bytes()
+
+    async def fake_stream(url):
+        yield model_bytes
+
+    mocker.patch.object(HTTPClient, "stream", side_effect=fake_stream)
 
     return DataFaker(data_layer, mongo, pg)

--- a/tests/ml/test_api.py
+++ b/tests/ml/test_api.py
@@ -2,11 +2,14 @@ import hashlib
 from http import HTTPStatus
 
 from aiohttp import ClientResponse
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from tests.fixtures.client import ClientSpawner
 from virtool.fake.next import DataFaker
+from virtool.ml.pg import SQLMLModelRelease
 
 
 async def test_list(
@@ -43,13 +46,33 @@ async def test_get(
     )
 
 
-async def test_download_release(fake: DataFaker, spawn_client: ClientSpawner):
+async def test_download_release(
+    example_path,
+    fake: DataFaker,
+    pg: AsyncEngine,
+    spawn_client: ClientSpawner,
+):
     """Test that a GET request to `/ml/:id/releases/:id/model.tar.gz` returns a file
     download of the model archive for that release.
     """
     client = await spawn_client(authenticated=True)
 
     await fake.ml.populate()
+
+    model_bytes = (example_path / "ml/model.tar.gz").read_bytes()
+
+    async with AsyncSession(pg) as session:
+        await session.execute(
+            update(SQLMLModelRelease)
+            .where(SQLMLModelRelease.id == 1)
+            .values(size=len(model_bytes)),
+        )
+        await session.commit()
+
+    async def _data():
+        yield model_bytes
+
+    await client.app["storage"].write("ml/1/model.tar.gz", _data())
 
     resp: ClientResponse = await client.get("/ml/1/releases/1/model.tar.gz")
 

--- a/tests/ml/test_data.py
+++ b/tests/ml/test_data.py
@@ -1,5 +1,4 @@
 import datetime
-import shutil
 from pathlib import Path
 from unittest.mock import call
 
@@ -61,7 +60,6 @@ async def test_get(
 
 
 async def test_load(
-    data_path: Path,
     data_layer: DataLayer,
     example_path: Path,
     fake: DataFaker,
@@ -69,17 +67,13 @@ async def test_load(
     snapshot_recent: SnapshotAssertion,
 ):
     """Test that MLData.load() can load updated models into the database."""
+    model_bytes = (example_path / "ml/model.tar.gz").read_bytes()
 
-    async def download_func(url, target, _=None):
-        shutil.copy(example_path / "ml/model.tar.gz", target)
+    async def fake_stream(url):
+        yield model_bytes
 
-    mocker.patch.object(
-        data_layer.ml._http,
-        "download",
-        download_func,
-    )
-
-    spy = mocker.spy(data_layer.ml._http, "download")
+    mocker.patch.object(data_layer.ml._http, "stream", fake_stream)
+    spy = mocker.spy(data_layer.ml._http, "stream")
 
     first = [fake.ml.create_release_manifest_item() for _ in range(3)]
 
@@ -115,10 +109,13 @@ async def test_load(
 
     spy.assert_has_calls(
         [
-            call("https://www.snyder.com/", data_path / "ml/1/model.tar.gz"),
-            call("http://acosta.com/", data_path / "ml/2/model.tar.gz"),
-            call("http://www.love.net/", data_path / "ml/3/model.tar.gz"),
-            call("https://butler.com/", data_path / "ml/9/model.tar.gz"),
+            call("https://www.snyder.com/"),
+            call("http://acosta.com/"),
+            call("http://www.love.net/"),
+            call("https://butler.com/"),
         ],
         any_order=True,
     )
+
+    expected_keys = {f"ml/{i}/model.tar.gz" for i in [1, 2, 3, 9]}
+    assert data_layer.ml._storage.keys() >= expected_keys

--- a/virtool/data/http.py
+++ b/virtool/data/http.py
@@ -1,6 +1,6 @@
 """An HTTP client for the data layer."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 from aiohttp import ClientSession
@@ -21,6 +21,15 @@ class HTTPClient:
     def __init__(self, session: ClientSession) -> None:
         """:param session: the aiohttp client session"""
         self._session = session
+
+    async def stream(self, url: str) -> AsyncIterator[bytes]:
+        """Stream the contents of ``url`` as chunks of bytes."""
+        async with self._session.get(url) as resp:
+            if resp.status > 399:
+                raise HTTPClientError
+
+            async for chunk in resp.content.iter_chunked(DOWNLOAD_CHUNK_SIZE):
+                yield chunk
 
     async def download(
         self,

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -22,6 +22,7 @@ from virtool.references.data import ReferencesData
 from virtool.samples.data import SamplesData
 from virtool.sessions.data import SessionData
 from virtool.settings.data import SettingsData
+from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.data import SubtractionsData
 from virtool.tasks.data import TasksData
 from virtool.uploads.data import UploadsData
@@ -70,6 +71,7 @@ def create_data_layer(
     pg: AsyncEngine,
     config: Config,
     client: ClientSession,
+    storage: StorageBackend | None = None,
 ) -> DataLayer:
     """Create and return a data layer object.
 
@@ -77,9 +79,15 @@ def create_data_layer(
     :param pg: the Postgres client
     :param config: the application config object
     :param client: an async HTTP client session for the server
+    :param storage: the storage backend for file operations
     :return: the application data layer
     """
     http_client = HTTPClient(client)
+
+    if storage is None:
+        from virtool.storage.filesystem import FilesystemProvider
+
+        storage = FilesystemProvider(config.data_path / "storage")
 
     return DataLayer(
         AccountData(mongo, pg),
@@ -92,7 +100,7 @@ def create_data_layer(
         JobsData(mongo, pg),
         LabelsData(mongo, pg),
         MessagesData(pg),
-        MLData(config, http_client, pg),
+        MLData(http_client, pg, storage),
         OTUData(config.data_path, mongo, pg),
         ReferencesData(mongo, pg, config, client),
         SamplesData(config, mongo, pg),

--- a/virtool/ml/api.py
+++ b/virtool/ml/api.py
@@ -1,6 +1,6 @@
 """Request handlers for querying and downloading machine learning models."""
 
-from aiohttp.web_fileresponse import FileResponse
+from aiohttp.web_response import StreamResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r404
 
@@ -67,14 +67,24 @@ class MLModelFileView(PydanticView):
 
         Downloads the archived model release.
         """
-        file_descriptor = await get_data_from_req(self.request).ml.download_release(
-            release_id
-        )
+        try:
+            stream, size = await get_data_from_req(
+                self.request,
+            ).ml.download_release(release_id)
+        except ResourceNotFoundError:
+            raise APINotFound()
 
-        return FileResponse(
-            file_descriptor.path,
+        response = StreamResponse(
             headers={
                 "Content-Disposition": "attachment; filename=model.tar.gz",
+                "Content-Length": str(size),
                 "Content-Type": "application/octet-stream",
             },
         )
+
+        await response.prepare(self.request)
+
+        async for chunk in stream:
+            await response.write(chunk)
+
+        return response

--- a/virtool/ml/api.py
+++ b/virtool/ml/api.py
@@ -10,6 +10,7 @@ from virtool.api.routes import Routes
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.ml.models import MLModel, MLModelListResult, MLModelReleaseMinimal
+from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
 
@@ -74,6 +75,11 @@ class MLModelFileView(PydanticView):
         except ResourceNotFoundError:
             raise APINotFound()
 
+        try:
+            first_chunk = await stream.__anext__()
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound()
+
         response = StreamResponse(
             headers={
                 "Content-Disposition": "attachment; filename=model.tar.gz",
@@ -83,6 +89,7 @@ class MLModelFileView(PydanticView):
         )
 
         await response.prepare(self.request)
+        await response.write(first_chunk)
 
         async for chunk in stream:
             await response.write(chunk)

--- a/virtool/ml/data.py
+++ b/virtool/ml/data.py
@@ -247,16 +247,16 @@ class MLData(DataLayerDomain):
 
                 await session.flush()
 
-                for release in ml_model.releases:
-                    key = f"ml/{release.id}/model.tar.gz"
-
-                    if key not in existing_keys:
-                        await self._storage.write(
-                            key,
-                            self._http.stream(release.download_url),
-                        )
+                downloads = [
+                    (f"ml/{release.id}/model.tar.gz", release.download_url)
+                    for release in ml_model.releases
+                    if f"ml/{release.id}/model.tar.gz" not in existing_keys
+                ]
 
                 await session.commit()
+
+                for key, url in downloads:
+                    await self._storage.write(key, self._http.stream(url))
 
     async def sync(self):
         """Fetch the release manifests for ML models from www.virtool.ca and download any

--- a/virtool/ml/data.py
+++ b/virtool/ml/data.py
@@ -1,5 +1,5 @@
-import asyncio
 import builtins
+from collections.abc import AsyncIterator
 
 import arrow
 from sqlalchemy import asc, desc, select
@@ -8,10 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import joinedload
 from structlog import get_logger
 
-from virtool.config import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceNotFoundError
-from virtool.data.file import FileDescriptor
 from virtool.data.http import HTTPClient
 from virtool.ml.models import (
     MLModel,
@@ -27,6 +25,7 @@ from virtool.releases import (
     ReleaseType,
     fetch_release_manifest_from_virtool,
 )
+from virtool.storage.protocol import StorageBackend
 from virtool.tasks.sql import SQLTask
 from virtool.utils import timestamp
 
@@ -38,13 +37,13 @@ class MLData(DataLayerDomain):
 
     def __init__(
         self,
-        config: Config,
         http: HTTPClient,
         pg: AsyncEngine,
+        storage: StorageBackend,
     ):
-        self._config = config
         self._http = http
         self._pg = pg
+        self._storage = storage
 
     async def list(self) -> MLModelListResult:
         """Get a list of minimal representations of all ML models and the last time
@@ -151,11 +150,14 @@ class MLData(DataLayerDomain):
                 **{**release.to_dict(), "model": release.model.to_dict()},
             )
 
-    async def download_release(self, release_id: int) -> FileDescriptor:
-        """Download the latest release of an ML model.
+    async def download_release(
+        self,
+        release_id: int,
+    ) -> tuple[AsyncIterator[bytes], int]:
+        """Stream the contents of an ML model release archive.
 
         :param release_id: the ID of the release to download.
-        :return: a file descriptor for the downloaded file.
+        :return: a stream of bytes and the size of the archive.
 
         """
         async with AsyncSession(self._pg) as session:
@@ -168,8 +170,8 @@ class MLData(DataLayerDomain):
             if release is None:
                 raise ResourceNotFoundError
 
-            return FileDescriptor(
-                self._config.data_path / "ml" / str(release_id) / "model.tar.gz",
+            return (
+                self._storage.read(f"ml/{release_id}/model.tar.gz"),
                 release.size,
             )
 
@@ -184,7 +186,9 @@ class MLData(DataLayerDomain):
         :param releases: the release manifest for ML models from www.virtool.ca.
 
         """
-        ml_path = self._config.data_path / "ml"
+        existing_keys: set[str] = set()
+        async for info in self._storage.list("ml/"):
+            existing_keys.add(info.key)
 
         created_at = timestamp()
 
@@ -244,18 +248,13 @@ class MLData(DataLayerDomain):
                 await session.flush()
 
                 for release in ml_model.releases:
-                    release_path = ml_path / str(release.id)
+                    key = f"ml/{release.id}/model.tar.gz"
 
-                    await asyncio.to_thread(
-                        release_path.mkdir,
-                        parents=True,
-                        exist_ok=True,
-                    )
-
-                    release_path /= "model.tar.gz"
-
-                    if not await asyncio.to_thread(release_path.exists):
-                        await self._http.download(release.download_url, release_path)
+                    if key not in existing_keys:
+                        await self._storage.write(
+                            key,
+                            self._http.stream(release.download_url),
+                        )
 
                 await session.commit()
 

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -59,6 +59,7 @@ async def startup_data(app: App) -> None:
         app["pg"],
         get_config_from_app(app),
         get_http_session_from_app(app),
+        app.get("storage"),
     )
 
 


### PR DESCRIPTION
## Summary

- Replaces direct filesystem operations in the ML models module with the storage abstraction layer (`StorageBackend`), enabling pluggable backends (filesystem, S3, Azure, in-memory)
- Adds a `stream()` method to `HTTPClient` for streaming downloads directly into storage, and updates `MLData` to use it for downloading model archives
- Updates the download API endpoint to stream model files directly from storage using `StreamResponse` instead of serving them via `FileResponse`

## Test plan

- [ ] Run `mise run test -- tests/ml` to verify ML module tests pass
- [ ] Confirm `test_download_release` correctly writes to in-memory storage and streams back the file
- [ ] Confirm `test_load` validates that model archives are written to storage under the expected keys
- [ ] Run `mise run test` for the full suite to catch any regressions in shared fixtures