### PR TITLE
fix: mock GitHub API in test_remote to prevent rate limit flakiness

### DIFF
--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -307,10 +307,31 @@ class TestCreate:
 
     async def test_remote(
         self,
+        mocker,
         spawn_client: ClientSpawner,
         snapshot: SnapshotAssertion,
         static_time,
     ):
+        mocker.patch(
+            "virtool.github.get_release",
+            make_mocked_coro({
+                "id": 11447367,
+                "name": "v0.1.1",
+                "body": "#### Fixed\n- fixed uploading to GitHub releases in `.travis.yml`",
+                "etag": 'W/"mock_etag"',
+                "html_url": "https://github.com/virtool/ref-plant-viruses/releases/tag/v0.1.1",
+                "published_at": "2018-06-12T19:20:57Z",
+                "assets": [
+                    {
+                        "name": "reference.json.gz",
+                        "size": 3695872,
+                        "browser_download_url": "https://github.com/virtool/ref-plant-viruses/releases/download/v0.1.1/reference.json.gz",
+                        "content_type": "application/gzip",
+                    },
+                ],
+            }),
+        )
+
         client = await spawn_client(
             authenticated=True,
             permissions=[Permission.create_ref],

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -314,22 +314,24 @@ class TestCreate:
     ):
         mocker.patch(
             "virtool.github.get_release",
-            make_mocked_coro({
-                "id": 11447367,
-                "name": "v0.1.1",
-                "body": "#### Fixed\n- fixed uploading to GitHub releases in `.travis.yml`",
-                "etag": 'W/"mock_etag"',
-                "html_url": "https://github.com/virtool/ref-plant-viruses/releases/tag/v0.1.1",
-                "published_at": "2018-06-12T19:20:57Z",
-                "assets": [
-                    {
-                        "name": "reference.json.gz",
-                        "size": 3695872,
-                        "browser_download_url": "https://github.com/virtool/ref-plant-viruses/releases/download/v0.1.1/reference.json.gz",
-                        "content_type": "application/gzip",
-                    },
-                ],
-            }),
+            make_mocked_coro(
+                {
+                    "id": 11447367,
+                    "name": "v0.1.1",
+                    "body": "#### Fixed\n- fixed uploading to GitHub releases in `.travis.yml`",
+                    "etag": 'W/"mock_etag"',
+                    "html_url": "https://github.com/virtool/ref-plant-viruses/releases/tag/v0.1.1",
+                    "published_at": "2018-06-12T19:20:57Z",
+                    "assets": [
+                        {
+                            "name": "reference.json.gz",
+                            "size": 3695872,
+                            "browser_download_url": "https://github.com/virtool/ref-plant-viruses/releases/download/v0.1.1/reference.json.gz",
+                            "content_type": "application/gzip",
+                        },
+                    ],
+                }
+            ),
         )
 
         client = await spawn_client(


### PR DESCRIPTION
## Summary
- The `test_remote` test in `tests/references/test_api.py` was hitting the real GitHub API, causing intermittent failures due to rate limiting
- Mocks `virtool.github.get_release` with a deterministic coro returning a fixed release payload, making the test fully offline and stable

## Test plan
- [ ] Run `mise run test -- tests/references/test_api.py` and confirm `test_remote` passes consistently
- [ ] Confirm no real HTTP calls are made during the test (mock is applied correctly)