### PR TITLE
refactor: derive upload from subtraction instead of job args

### DIFF
--- a/tests/subtractions/__snapshots__/test_api.ambr
+++ b/tests/subtractions/__snapshots__/test_api.ambr
@@ -84,12 +84,6 @@
     '_id': 'bf1b993c',
     'acquired': False,
     'args': dict({
-      'files': list([
-        dict({
-          'id': 1,
-          'name': 'test.fq.gz',
-        }),
-      ]),
       'subtraction_id': 'fb085f7f',
     }),
     'created_at': 'approximately_now_datetime',

--- a/tests/workflow/data/test_subtractions.py
+++ b/tests/workflow/data/test_subtractions.py
@@ -18,7 +18,6 @@ def _new_subtraction_job(workflow_data: WorkflowData):
     """A job for creating a new subtraction."""
     workflow_data.job.args = {
         "subtraction_id": workflow_data.new_subtraction.id,
-        "files": [{"id": 3, "name": "subtraction.fa.gz"}],
     }
     workflow_data.job.workflow = "create_subtraction"
 

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -214,7 +214,6 @@ class SubtractionsData(DataLayerDomain):
             "create_subtraction",
             {
                 "subtraction_id": subtraction.id,
-                "files": [{"id": upload.id, "name": upload.name}],
             },
             user_id,
             0,

--- a/virtool/workflow/data/subtractions.py
+++ b/virtool/workflow/data/subtractions.py
@@ -176,16 +176,12 @@ async def new_subtraction(
 
     subtraction_json = await _api.get_json(f"/subtractions/{id_}")
 
-    # TODO: Remove fallback to job.args["files"] once all subtractions have uploads stored.
-    # Older subtractions don't have uploads stored, so we fall back to job.args.
     subtraction_upload = subtraction_json.get("upload")
 
-    if subtraction_upload:
-        upload_id = subtraction_upload["id"]
-    elif "files" in job.args:
-        upload_id = job.args["files"][0]["id"]
-    else:
-        raise MissingJobArgumentError("files")
+    if subtraction_upload is None:
+        raise MissingJobArgumentError("upload")
+
+    upload_id = subtraction_upload["id"]
 
     subtraction_ = Subtraction(**subtraction_json)
 

--- a/virtool/workflow/data/subtractions.py
+++ b/virtool/workflow/data/subtractions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pyfixtures import fixture
 from structlog import get_logger
 
+from virtool.data.errors import ResourceNotFoundError
 from virtool.jobs.models import Job
 from virtool.subtractions.models import (
     NucleotideComposition,
@@ -179,7 +180,7 @@ async def new_subtraction(
     subtraction_upload = subtraction_json.get("upload")
 
     if subtraction_upload is None:
-        raise MissingJobArgumentError("upload")
+        raise ResourceNotFoundError("Subtraction has no upload")
 
     upload_id = subtraction_upload["id"]
 


### PR DESCRIPTION
## Summary
- Removes the `files` field from `create_subtraction` job arguments, so the upload is derived directly from the subtraction's stored upload data rather than being passed through job args
- Drops the fallback logic in the workflow data layer that previously supported older subtractions without stored uploads
- Updates tests and snapshots to reflect the simplified job args structure

## Test plan
- [ ] Run `mise run test -- tests/subtractions` to verify subtraction API tests pass
- [ ] Run `mise run test -- tests/workflow/data/test_subtractions.py` to verify workflow subtraction data tests pass
- [ ] Confirm that creating a new subtraction via the API correctly passes the upload through the subtraction record rather than job args