### PR TITLE
chore: adopt storage abstraction in HMMs module

### DIFF
--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -1,7 +1,5 @@
 import json
-import shutil
 from http import HTTPStatus
-from pathlib import Path
 
 import pytest
 
@@ -126,56 +124,47 @@ async def test_get(
     assert await resp.json() == snapshot(name="json")
 
 
-async def test_get_hmm_annotations(data_path: Path, spawn_job_client: JobClientSpawner):
+async def test_get_hmm_annotations(spawn_job_client: JobClientSpawner):
     client = await spawn_job_client(authenticated=True)
     mongo = get_mongo_from_app(client.app)
 
     await mongo.hmm.insert_one({"_id": "foo"})
     await mongo.hmm.insert_one({"_id": "bar"})
 
-    compressed_hmm_annotations = data_path / "annotations.json.gz"
-    decompressed_hmm_annotations = data_path / "annotations.json"
-
     async with client.get("/hmms/files/annotations.json.gz") as response:
         assert response.status == HTTPStatus.OK
 
-        with compressed_hmm_annotations.open("wb") as f:
-            f.write(await response.read())
+        compressed_bytes = await response.read()
 
-        decompress_file(compressed_hmm_annotations, decompressed_hmm_annotations)
+    import gzip
 
-        with decompressed_hmm_annotations.open("r") as f:
-            hmms = json.load(f)
+    decompressed = gzip.decompress(compressed_bytes)
+    hmms = json.loads(decompressed)
 
-        assert hmms == [{"id": "foo"}, {"id": "bar"}]
+    assert hmms == [{"id": "foo"}, {"id": "bar"}]
 
 
-@pytest.mark.parametrize("data_exists", [True, False])
 @pytest.mark.parametrize("file_exists", [True, False])
 async def test_get_hmm_profiles(
-    data_exists: bool,
     file_exists: bool,
-    data_path: Path,
-    example_path: Path,
+    example_path,
     spawn_job_client: JobClientSpawner,
 ):
     """Test that HMM profiles can be properly downloaded once they are available."""
     client = await spawn_job_client(authenticated=True)
 
-    hmms_path = data_path / "hmm"
-    profiles_path = hmms_path / "profiles.hmm"
+    if file_exists:
+        profile_bytes = (example_path / "hmms" / "profiles.hmm").read_bytes()
 
-    if data_exists:
-        hmms_path.mkdir()
+        async def _data():
+            yield profile_bytes
 
-        if file_exists:
-            shutil.copy(example_path / "hmms" / "profiles.hmm", hmms_path)
-            assert profiles_path.exists()
+        await client.app["storage"].write("hmm/profiles.hmm", _data())
 
     resp = await client.get("/hmms/files/profiles.hmm")
 
-    if data_exists and file_exists:
+    if file_exists:
         assert resp.status == HTTPStatus.OK
-        assert profiles_path.read_bytes() == await resp.content.read()
+        assert await resp.content.read() == profile_bytes
     else:
-        assert resp.status == 404
+        assert resp.status == HTTPStatus.NOT_FOUND

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -7,7 +7,6 @@ from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
-from virtool.utils import decompress_file
 
 
 @pytest.fixture

--- a/tests/hmm/test_db.py
+++ b/tests/hmm/test_db.py
@@ -6,7 +6,7 @@ from aiohttp.test_utils import make_mocked_coro
 from pytest_mock import MockerFixture
 
 from virtool.hmm.db import (
-    generate_annotations_json_file,
+    generate_annotations,
     get_hmms_referenced_in_db,
     get_hmms_referenced_in_files,
     get_referenced_hmm_ids,
@@ -91,15 +91,13 @@ async def test_get_referenced_hmm_ids(
     ]
 
 
-async def test_generate_annotations_json_file(data_path: Path, mongo: Mongo):
+async def test_generate_annotations(mongo: Mongo):
     await mongo.hmm.insert_one({"_id": "foo"})
     await mongo.hmm.insert_one({"_id": "bar"})
 
-    path = await generate_annotations_json_file(data_path, mongo)
+    result = await generate_annotations(mongo)
 
-    assert path.exists()
-
-    hmms = json.loads(path.read_text())
+    hmms = json.loads(result)
 
     ids = [document["id"] for document in hmms]
 

--- a/tests/hmm/test_tasks.py
+++ b/tests/hmm/test_tasks.py
@@ -44,8 +44,6 @@ async def test_hmm_install_task(
         )
         await session.commit()
 
-    (tmp_path / "hmm").mkdir(parents=True)
-
     temp_dir = get_temp_dir()
 
     compress_dir = tmp_path / "comp"
@@ -72,4 +70,7 @@ async def test_hmm_install_task(
 
     assert await mongo.hmm.find().to_list(1) == snapshot(name="mongo_hmms")
     assert await data_layer.tasks.get(1) == snapshot(name="data_layer_task")
-    assert {p.name for p in (tmp_path / "hmm").iterdir()} == {"profiles.hmm"}
+    assert "hmm/profiles.hmm" in data_layer.hmms._storage.keys()
+
+    raw = data_layer.hmms._storage.get_raw("hmm/profiles.hmm")
+    assert raw == b"test_profile"

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -95,7 +95,7 @@ def create_data_layer(
         BLASTData(client, mongo, pg),
         GroupsData(mongo, pg),
         HistoryData(config.data_path, mongo, pg),
-        HmmsData(client, config, mongo, pg),
+        HmmsData(client, mongo, pg, storage),
         IndexData(mongo, config, pg),
         JobsData(mongo, pg),
         LabelsData(mongo, pg),

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -1,9 +1,7 @@
 """API request handlers for managing and querying HMM data."""
 
-import asyncio
-
 from aiohttp.web import Response
-from aiohttp.web_fileresponse import FileResponse
+from aiohttp.web_response import StreamResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r400, r403, r404, r502
 
@@ -11,7 +9,6 @@ from virtool.api.custom_json import json_response
 from virtool.api.errors import APIBadGateway, APIConflict, APINotFound
 from virtool.api.policy import AdministratorRoutePolicy, policy
 from virtool.api.routes import Routes
-from virtool.config import get_config_from_req
 from virtool.data.errors import (
     ResourceConflictError,
     ResourceError,
@@ -22,6 +19,7 @@ from virtool.data.utils import get_data_from_req
 from virtool.hmm.models import HMM, HMMInstalled, HMMSearchResult
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req, get_one_field
+from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
 
@@ -178,18 +176,31 @@ async def get_hmm_annotations(req):
 
     Fetches a compressed json file containing the database documents for all HMMs.
     """
-    hmm_path = get_config_from_req(req).data_path / "hmm"
-    await asyncio.to_thread(hmm_path.mkdir, parents=True, exist_ok=True)
+    try:
+        stream, size = await get_data_from_req(req).hmms.download_annotations()
+    except ResourceNotFoundError:
+        raise APINotFound()
 
-    path = await get_data_from_req(req).hmms.get_annotations_path()
+    try:
+        first_chunk = await stream.__anext__()
+    except (StopAsyncIteration, StorageKeyNotFoundError):
+        raise APINotFound()
 
-    return FileResponse(
-        path,
+    response = StreamResponse(
         headers={
             "Content-Disposition": "attachment; filename=annotations.json.gz",
+            "Content-Length": str(size),
             "Content-Type": "application/octet-stream",
         },
     )
+
+    await response.prepare(req)
+    await response.write(first_chunk)
+
+    async for chunk in stream:
+        await response.write(chunk)
+
+    return response
 
 
 @routes.jobs_api.get("/hmms/files/profiles.hmm")
@@ -197,21 +208,29 @@ async def get_hmm_profiles(req):
     """Get HMM profiles.
 
     Downloads the HMM profiles file if HMM data is available.
-
     """
-    hmm_path = get_config_from_req(req).data_path / "hmm"
-    await asyncio.to_thread(hmm_path.mkdir, parents=True, exist_ok=True)
-
     try:
-        path = await get_data_from_req(req).hmms.get_profiles_path()
+        stream, size = await get_data_from_req(req).hmms.download_profiles()
     except ResourceNotFoundError:
         raise APINotFound()
 
-    return FileResponse(
-        path,
-        chunk_size=1024 * 1024,
+    try:
+        first_chunk = await stream.__anext__()
+    except (StopAsyncIteration, StorageKeyNotFoundError):
+        raise APINotFound()
+
+    response = StreamResponse(
         headers={
             "Content-Disposition": "attachment; filename=profiles.hmm",
+            "Content-Length": str(size),
             "Content-Type": "application/octet-stream",
         },
     )
+
+    await response.prepare(req)
+    await response.write(first_chunk)
+
+    async for chunk in stream:
+        await response.write(chunk)
+
+    return response

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -1,7 +1,6 @@
 import asyncio
 import gzip
 from collections.abc import AsyncIterator
-from pathlib import Path
 
 from aiohttp import ClientSession
 from multidict import MultiDictProxy
@@ -178,22 +177,26 @@ class HmmsData(DataLayerDomain):
                 raise
 
     async def download_profiles(self) -> tuple[AsyncIterator[bytes], int]:
-        size = 0
-        async for info in self._storage.list("hmm/profiles.hmm"):
-            size = info.size
+        info = None
+        async for item in self._storage.list("hmm/profiles.hmm"):
+            info = item
             break
 
-        if not size:
+        if info is None:
             raise ResourceNotFoundError("Profiles file could not be found")
 
-        return self._storage.read("hmm/profiles.hmm"), size
+        return self._storage.read("hmm/profiles.hmm"), info.size
 
     async def download_annotations(self) -> tuple[AsyncIterator[bytes], int]:
         async for info in self._storage.list("hmm/annotations.json.gz"):
             return self._storage.read("hmm/annotations.json.gz"), info.size
 
         annotations_bytes = await generate_annotations(self._mongo)
-        compressed = gzip.compress(annotations_bytes, compresslevel=6)
+        compressed = await asyncio.to_thread(
+            gzip.compress,
+            annotations_bytes,
+            compresslevel=6,
+        )
 
         async def _data():
             yield compressed

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -1,7 +1,6 @@
 import asyncio
-import shutil
-from asyncio import to_thread
-from functools import cached_property
+import gzip
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 from aiohttp import ClientSession
@@ -10,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 import virtool.hmm.db
 from virtool.api.utils import compose_regex_query, paginate
-from virtool.config.cls import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import (
     ResourceConflictError,
@@ -22,36 +20,35 @@ from virtool.github import create_update_subdocument
 from virtool.hmm.db import (
     HMMS_PROJECTION,
     fetch_and_update_release,
-    generate_annotations_json_file,
+    generate_annotations,
 )
 from virtool.hmm.models import HMM, HMMInstalled, HMMSearchResult, HMMStatus
 from virtool.hmm.tasks import HMMInstallTask
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
+from virtool.storage.protocol import StorageBackend
 from virtool.tasks.progress import (
     AbstractProgressHandler,
     AccumulatingProgressHandlerWrapper,
 )
 from virtool.tasks.transforms import AttachTaskTransform
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import compress_file_with_gzip
 
 
 class HmmsData(DataLayerDomain):
     name = "hmms"
 
     def __init__(
-        self, client: ClientSession, config: Config, mongo: Mongo, pg: AsyncEngine
+        self,
+        client: ClientSession,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        storage: StorageBackend,
     ):
         self._client = client
-        self._config = config
         self._mongo = mongo
         self._pg = pg
-
-    @cached_property
-    def profiles_path(self) -> Path:
-        """The path to the HMM profiles file in the application data."""
-        return self._config.data_path / "hmm" / "profiles.hmm"
+        self._storage = storage
 
     async def find(self, query: MultiDictProxy):
         db_query = {}
@@ -74,11 +71,6 @@ class HmmsData(DataLayerDomain):
         return HMMSearchResult(**data, status=status)
 
     async def get(self, hmm_id: str) -> HMM:
-        """Get an HMM resource.
-
-        :param hmm_id: the id of the hmm to get
-        :return: the hmm
-        """
         document = await self._mongo.hmm.find_one({"_id": hmm_id})
 
         if document:
@@ -151,12 +143,8 @@ class HmmsData(DataLayerDomain):
         release,
         user_id: str,
         progress_handler: AbstractProgressHandler,
-        hmm_temp_profile_path,
+        profile_data: AsyncIterator[bytes],
     ) -> None:
-        """Installs annotation and profiles given a list of annotation dictionaries and
-        path to profile file.
-
-        """
         tracker = AccumulatingProgressHandlerWrapper(progress_handler, len(annotations))
 
         try:
@@ -184,46 +172,37 @@ class HmmsData(DataLayerDomain):
             )
 
             try:
-                await to_thread(
-                    self.profiles_path.parent.mkdir,
-                    parents=True,
-                    exist_ok=True,
-                )
-                await to_thread(
-                    shutil.move,
-                    str(hmm_temp_profile_path),
-                    str(self.profiles_path),
-                )
+                await self._storage.write("hmm/profiles.hmm", profile_data)
             except Exception:
                 await session.abort_transaction()
                 raise
 
-    async def get_profiles_path(self) -> Path:
-        path = self._config.data_path / "hmm" / "profiles.hmm"
+    async def download_profiles(self) -> tuple[AsyncIterator[bytes], int]:
+        size = 0
+        async for info in self._storage.list("hmm/profiles.hmm"):
+            size = info.size
+            break
 
-        if await to_thread(path.is_file):
-            return path
+        if not size:
+            raise ResourceNotFoundError("Profiles file could not be found")
 
-        raise ResourceNotFoundError("Profiles file could not be found")
+        return self._storage.read("hmm/profiles.hmm"), size
 
-    async def get_annotations_path(self) -> Path:
-        path = self._config.data_path / "hmm" / "annotations.json.gz"
+    async def download_annotations(self) -> tuple[AsyncIterator[bytes], int]:
+        async for info in self._storage.list("hmm/annotations.json.gz"):
+            return self._storage.read("hmm/annotations.json.gz"), info.size
 
-        if not await to_thread(path.is_file):
-            json_path = await generate_annotations_json_file(
-                self._config.data_path,
-                self._mongo,
-            )
+        annotations_bytes = await generate_annotations(self._mongo)
+        compressed = gzip.compress(annotations_bytes, compresslevel=6)
 
-            await to_thread(compress_file_with_gzip, json_path, path)
+        async def _data():
+            yield compressed
 
-        return path
+        await self._storage.write("hmm/annotations.json.gz", _data())
+
+        return self._storage.read("hmm/annotations.json.gz"), len(compressed)
 
     async def clean_status(self) -> None:
-        """Reset the HMM status to its starting state.
-
-        This is called in the event that an HMM data installation fails.
-        """
         async with self._mongo.create_session() as session:
             await self._mongo.status.find_one_and_update(
                 {"_id": "hmm"},

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -14,7 +14,7 @@ from virtool.github import get_etag, get_release
 from virtool.hmm.utils import format_hmm_release
 from virtool.mongo.core import Mongo
 from virtool.types import Document
-from virtool.utils import base_processor, dump_json, load_json
+from virtool.utils import base_processor, load_json
 
 logger = get_logger("hmms")
 
@@ -178,20 +178,14 @@ async def fetch_and_update_release(
         return release
 
 
-async def generate_annotations_json_file(data_path: Path, mongo: Mongo) -> Path:
-    """Generate the HMMs annotation file at `config.data_path/hmm/annotations.json.gz
+async def generate_annotations(mongo: Mongo) -> bytes:
+    """Generate the HMM annotations as JSON bytes.
 
-    :param data_path: the app data path
     :param mongo: the app mongo client
-    :return: the path to the annotations json file
+    :return: the annotations as JSON bytes
     """
-    annotations_path = data_path / "hmm" / "annotations.json"
-    annotations_path.parent.mkdir(parents=True, exist_ok=True)
+    import json
 
-    await asyncio.to_thread(
-        dump_json,
-        annotations_path,
-        [base_processor(document) async for document in mongo.hmm.find({})],
-    )
+    annotations = [base_processor(document) async for document in mongo.hmm.find({})]
 
-    return annotations_path
+    return json.dumps(annotations).encode()

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -1,6 +1,7 @@
 """Work with HMM data in the database."""
 
 import asyncio
+import json
 from pathlib import Path
 
 import aiohttp.client_exceptions
@@ -184,8 +185,6 @@ async def generate_annotations(mongo: Mongo) -> bytes:
     :param mongo: the app mongo client
     :return: the annotations as JSON bytes
     """
-    import json
-
     annotations = [base_processor(document) async for document in mongo.hmm.find({})]
 
     return json.dumps(annotations).encode()

--- a/virtool/hmm/tasks.py
+++ b/virtool/hmm/tasks.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio import to_thread
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
@@ -21,8 +22,7 @@ class HMMInstallTask(BaseTask):
     """Runs a background Task that:
         - downloads the official profiles.hmm.gz file
         - decompresses the hmm.tar.gz file
-        - moves the file to the correct data path
-        - downloads the official annotations.json.gz file
+        - writes the profiles to storage
         - imports the annotations into the database
 
     Task reports the following stages to the hmm_install status document:
@@ -80,12 +80,18 @@ class HMMInstallTask(BaseTask):
             self.temp_path / "hmm" / "annotations.json",
         )
 
+        profile_path = self.temp_path / "hmm" / "profiles.hmm"
+
+        async def _read_profile():
+            data = await to_thread(profile_path.read_bytes)
+            yield data
+
         await self.data.hmms.install(
             annotations,
             self.context["release"],
             self.context["user_id"],
             self.create_progress_handler(),
-            self.temp_path / "hmm" / "profiles.hmm",
+            _read_profile(),
         )
 
     async def cleanup(self) -> None:

--- a/virtool/hmm/tasks.py
+++ b/virtool/hmm/tasks.py
@@ -1,6 +1,5 @@
 import asyncio
 from asyncio import to_thread
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
@@ -83,8 +82,12 @@ class HMMInstallTask(BaseTask):
         profile_path = self.temp_path / "hmm" / "profiles.hmm"
 
         async def _read_profile():
-            data = await to_thread(profile_path.read_bytes)
-            yield data
+            with profile_path.open("rb") as f:
+                while True:
+                    chunk = await to_thread(f.read, 1024 * 1024)
+                    if not chunk:
+                        break
+                    yield chunk
 
         await self.data.hmms.install(
             annotations,


### PR DESCRIPTION
## Summary
- Replaces direct filesystem access in the HMMs module with the storage abstraction layer (`StorageBackend`), consistent with the pattern adopted in the ML models module
- Refactors `generate_annotations_json_file` into `generate_annotations` which returns JSON bytes directly instead of writing to disk, and compresses/stores via the storage backend
- Updates `HmmsData` to accept a `StorageBackend` instead of `Config`, and replaces `FileResponse` with streaming `StreamResponse` for HMM profile and annotation downloads

## Test plan
- [ ] Run `mise run test -- tests/hmm` to verify HMM-specific tests pass
- [ ] Confirm annotation download endpoint returns correctly compressed JSON
- [ ] Confirm profiles download endpoint streams file content from storage backend
- [ ] Verify HMM install task correctly writes profiles to storage via the abstraction