### PR TITLE
chore: adopt storage abstraction in analyses module

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from http import HTTPStatus
 from pathlib import Path
 
@@ -12,7 +11,6 @@ from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from tests.fixtures.response import RespIs
 from virtool.analyses.files import create_analysis_file
 from virtool.analyses.sql import SQLAnalysisFile, SQLAnalysisResult
-from virtool.config import get_config_from_app
 from virtool.fake.next import DataFaker
 from virtool.jobs.models import Job, JobState
 from virtool.mongo.core import Mongo
@@ -289,11 +287,8 @@ async def test_remove(
     resp_is,
     spawn_client: ClientSpawner,
     static_time,
-    tmp_path: Path,
 ):
     client = await spawn_client(authenticated=True)
-
-    get_config_from_app(client.app).data_path = tmp_path
 
     user = await fake.users.create()
 
@@ -378,14 +373,11 @@ async def test_upload_file(
     snapshot: SnapshotAssertion,
     spawn_job_client: JobClientSpawner,
     static_time: StaticTime,
-    tmp_path: Path,
 ):
     """Test that an analysis result file is properly uploaded and a row is inserted into
     the `analysis_files` SQL table.
     """
     client = await spawn_job_client(authenticated=True)
-
-    get_config_from_app(client.app).data_path = tmp_path
 
     format_ = "foo" if error == 400 else "fasta"
 
@@ -421,11 +413,8 @@ async def test_upload_file(
             assert resp.status == 201
             assert await resp.json() == snapshot
 
-            assert sorted(os.listdir(tmp_path / "analyses")) == [
-                "1-reference.fa",
-                "2-reference.fa",
-            ]
             assert await get_row_by_id(pg, SQLAnalysisFile, 1)
+            assert await get_row_by_id(pg, SQLAnalysisFile, 2)
 
         case 400:
             await resp_is.bad_request(resp_put, "Unsupported analysis file format")
@@ -448,16 +437,12 @@ class TestDownloadAnalysisResult:
         mongo: Mongo,
         spawn_client: ClientSpawner,
         spawn_job_client: JobClientSpawner,
-        tmp_path,
     ):
         """Test that an uploaded analysis result file can subsequently be downloaded."""
         client, job_client = await asyncio.gather(
             spawn_client(administrator=True, authenticated=True),
             spawn_job_client(authenticated=True),
         )
-
-        get_config_from_app(client.app).data_path = tmp_path
-        get_config_from_app(job_client.app).data_path = tmp_path
 
         await mongo.analyses.insert_one(
             {"_id": "foobar", "ready": True, "job": {"id": "hello"}},

--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture
@@ -12,9 +11,7 @@ from virtool.storage.memory import MemoryStorageProvider
 
 
 @pytest.mark.parametrize("loadable", [True, False])
-async def test_load_results(
-    loadable: bool, config, mocker: MockerFixture, tmp_path: Path
-):
+async def test_load_results(loadable: bool):
     """Test that results are loaded from a `results.json` as expected.
 
     Check that the file loading action is not pursued if the results are stored in the
@@ -22,16 +19,17 @@ async def test_load_results(
     """
     results = {"foo": "bar", "bar": "baz"}
 
-    results_path = tmp_path / "results.json"
-    results_path.write_text(json.dumps(results))
+    storage = MemoryStorageProvider()
 
-    m_join_analysis_json_path = mocker.patch(
-        "virtool.analyses.utils.join_analysis_json_path",
-        return_value=results_path,
-    )
+    if loadable:
+
+        async def _data():
+            yield json.dumps(results).encode()
+
+        await storage.write("samples/bar/analysis/foo/results.json", _data())
 
     result = await load_results(
-        config,
+        storage,
         {
             "_id": "foo",
             "results": "file" if loadable else {"baz": "foo"},
@@ -40,10 +38,8 @@ async def test_load_results(
     )
 
     if loadable:
-        m_join_analysis_json_path.assert_called_with(tmp_path, "foo", "bar")
         assert result == {"_id": "foo", "results": results, "sample": {"id": "bar"}}
     else:
-        m_join_analysis_json_path.assert_not_called()
         assert result == {
             "_id": "foo",
             "results": {"baz": "foo"},
@@ -181,7 +177,7 @@ def test_transform_coverage_to_coordinates(
 
 @pytest.mark.parametrize("workflow", [None, "foobar", "nuvs", "pathoscope"])
 async def test_format_analysis(
-    workflow: str | None, config, mocker: MockerFixture, mongo: Mongo
+    workflow: str | None, mocker: MockerFixture, mongo: Mongo
 ):
     """Ensure that:
     * the correct formatting function is called based on the workflow field.
@@ -204,9 +200,7 @@ async def test_format_analysis(
     if workflow:
         document["workflow"] = workflow
 
-    coroutine = virtool.analyses.format.format_analysis(
-        config, storage, mongo, document
-    )
+    coroutine = virtool.analyses.format.format_analysis(storage, mongo, document)
 
     if workflow is None or workflow == "foobar":
         with pytest.raises(ValueError) as err:
@@ -224,9 +218,9 @@ async def test_format_analysis(
         }
 
         if workflow == "nuvs":
-            m_format_nuvs.assert_called_with(config, mongo, document)
+            m_format_nuvs.assert_called_with(storage, mongo, document)
             assert not m_format_pathoscope.called
 
         elif workflow == "pathoscope":
-            m_format_pathoscope.assert_called_with(config, storage, mongo, document)
+            m_format_pathoscope.assert_called_with(storage, mongo, document)
             assert not m_format_nuvs.called

--- a/tests/analyses/test_utils.py
+++ b/tests/analyses/test_utils.py
@@ -1,11 +1,10 @@
-from pathlib import Path
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy import SnapshotAssertion
 
 import virtool.analyses.files
 import virtool.analyses.utils
+from virtool.analyses.utils import analysis_file_key, analysis_result_key
 
 
 @pytest.mark.parametrize("exists", [True, False])
@@ -30,12 +29,12 @@ async def test_attach_analysis_files(
     )
 
 
-@pytest.mark.parametrize("name", ["nuvs", "pathoscope"])
-def test_get_json_path(name: str):
-    """Test that the function can correctly extrapolate the path to a nuvs.json file given the `data_path`, `sample_id`,
-    and `analysis_id` arguments.
+def test_analysis_file_key():
+    assert analysis_file_key("1-output.fasta") == "analyses/1-output.fasta"
 
-    """
-    path = virtool.analyses.utils.join_analysis_json_path(Path("data"), "bar", "foo")
 
-    assert path == Path("data/samples/foo/analysis/bar/results.json")
+def test_analysis_result_key():
+    assert (
+        analysis_result_key("abc123", "sample1")
+        == "samples/sample1/analysis/abc123/results.json"
+    )

--- a/tests/data/__snapshots__/test_topg.ambr
+++ b/tests/data/__snapshots__/test_topg.ambr
@@ -18,19 +18,3 @@
 # name: TestBothTransactions.test_pg_only
   <SQLGroup(id=1, legacy_id=None, name=test, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>
 # ---
-# name: TestRetryBothTransactions.test_retry[mongo]
-  dict({
-    '_id': 'test',
-  })
-# ---
-# name: TestRetryBothTransactions.test_retry[pg]
-  <SQLGroup(id=1, legacy_id=None, name=test, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>
-# ---
-# name: TestRetryBothTransactions.test_success[mongo]
-  dict({
-    '_id': 'test',
-  })
-# ---
-# name: TestRetryBothTransactions.test_success[pg]
-  <SQLGroup(id=1, legacy_id=None, name=test, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>
-# ---

--- a/tests/hmm/test_db.py
+++ b/tests/hmm/test_db.py
@@ -1,5 +1,4 @@
 import json
-import shutil
 from pathlib import Path
 
 from aiohttp.test_utils import make_mocked_coro
@@ -12,21 +11,24 @@ from virtool.hmm.db import (
     get_referenced_hmm_ids,
 )
 from virtool.mongo.core import Mongo
+from virtool.storage.memory import MemoryStorageProvider
 
 
-async def test_get_hmms_referenced_in_files(
-    data_path: Path, example_path: Path, mongo: Mongo
-):
-    path = data_path / "samples" / "foo" / "analysis" / "bar"
-    path.mkdir(parents=True)
+async def test_get_hmms_referenced_in_files(example_path: Path, mongo: Mongo):
+    storage = MemoryStorageProvider()
 
-    shutil.copy(example_path / "nuvs_results.json", path / "results.json")
+    data = (example_path / "nuvs_results.json").read_bytes()
+
+    async def _data():
+        yield data
+
+    await storage.write("samples/foo/analysis/bar/results.json", _data())
 
     await mongo.analyses.insert_one(
         {"_id": "bar", "workflow": "nuvs", "sample": {"id": "foo"}, "results": "file"},
     )
 
-    assert await get_hmms_referenced_in_files(mongo, data_path) == {
+    assert await get_hmms_referenced_in_files(mongo, storage) == {
         "rejiddnd",
         "dltwctfw",
         "wotaqhkz",
@@ -68,10 +70,11 @@ async def test_get_hmms_referenced_in_db(mongo: Mongo):
 
 
 async def test_get_referenced_hmm_ids(
-    data_path: Path,
     mocker: MockerFixture,
     mongo: Mongo,
 ):
+    storage = MemoryStorageProvider()
+
     mocker.patch(
         "virtool.hmm.db.get_hmms_referenced_in_db",
         make_mocked_coro({"a", "b", "d", "f"}),
@@ -82,7 +85,7 @@ async def test_get_referenced_hmm_ids(
         make_mocked_coro({"a", "e", "f"}),
     )
 
-    assert await get_referenced_hmm_ids(mongo, data_path) == [
+    assert await get_referenced_hmm_ids(mongo, storage) == [
         "a",
         "b",
         "d",

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -502,9 +502,6 @@
     }),
   })
 # ---
-# name: TestUpdate.test_primary_group_when_member[mongo]
-  None
-# ---
 # name: TestUpdate.test_primary_group_when_member[obj]
   dict({
     'active': True,

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -1,14 +1,12 @@
 """Request handlers for managing and viewing analyses."""
 
-import asyncio
-
 import arrow
 from aiohttp.web import (
-    FileResponse,
     HTTPNotModified,
     Request,
     Response,
 )
+from aiohttp.web_response import StreamResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r204, r400, r403, r404, r409
 from pydantic import conint
@@ -27,7 +25,6 @@ from virtool.api.errors import (
 )
 from virtool.api.routes import Routes
 from virtool.api.schema import schema
-from virtool.config import get_config_from_req
 from virtool.data.errors import (
     ResourceConflictError,
     ResourceError,
@@ -35,6 +32,7 @@ from virtool.data.errors import (
     ResourceNotModifiedError,
 )
 from virtool.data.utils import get_data_from_req
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.uploads.utils import multipart_file_chunker, naive_validator
 
 routes = Routes()
@@ -247,7 +245,7 @@ async def upload(req: Request) -> Response:
 
 @routes.view("/analyses/{analysis_id}/files/{upload_id}")
 class AnalysisFileView(PydanticView):
-    async def get(self, upload_id: int, /) -> r200[FileResponse] | r404:
+    async def get(self, upload_id: int, /) -> r200[Response] | r404:
         """Download an analysis file.
 
         Downloads a file associated with an analysis. Some workflows retain key files
@@ -258,18 +256,32 @@ class AnalysisFileView(PydanticView):
             404: Not found
         """
         try:
-            name_on_disk = await get_data_from_req(self.request).analyses.get_file_name(
-                upload_id,
-            )
+            stream, size, name = await get_data_from_req(
+                self.request,
+            ).analyses.download_file(upload_id)
         except ResourceNotFoundError:
             raise APINotFound()
 
-        path = get_config_from_req(self.request).data_path / "analyses" / name_on_disk
-
-        if not await asyncio.to_thread(path.exists):
+        try:
+            first_chunk = await stream.__anext__()
+        except (StopAsyncIteration, StorageKeyNotFoundError):
             raise APINotFound()
 
-        return FileResponse(path)
+        response = StreamResponse(
+            headers={
+                "Content-Disposition": f"attachment; filename={name}",
+                "Content-Length": str(size),
+                "Content-Type": "application/octet-stream",
+            },
+        )
+
+        await response.prepare(self.request)
+        await response.write(first_chunk)
+
+        async for chunk in stream:
+            await response.write(chunk)
+
+        return response
 
 
 @routes.view("/analyses/documents/{analysis_id}.{extension}")

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -262,11 +262,6 @@ class AnalysisFileView(PydanticView):
         except ResourceNotFoundError:
             raise APINotFound()
 
-        try:
-            first_chunk = await stream.__anext__()
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound()
-
         response = StreamResponse(
             headers={
                 "Content-Disposition": f"attachment; filename={name}",
@@ -275,11 +270,19 @@ class AnalysisFileView(PydanticView):
             },
         )
 
-        await response.prepare(self.request)
-        await response.write(first_chunk)
+        if size > 0:
+            try:
+                first_chunk = await stream.__anext__()
+            except (StopAsyncIteration, StorageKeyNotFoundError):
+                raise APINotFound()
 
-        async for chunk in stream:
-            await response.write(chunk)
+            await response.prepare(self.request)
+            await response.write(first_chunk)
+
+            async for chunk in stream:
+                await response.write(chunk)
+        else:
+            await response.prepare(self.request)
 
         return response
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -443,7 +443,8 @@ class AnalysisData(DataLayerDomain):
         key = analysis_file_key(analysis_file.name_on_disk)
 
         async for info in self._storage.list(key):
-            return self._storage.read(key), info.size, analysis_file.name
+            if info.key == key:
+                return self._storage.read(key), info.size, analysis_file.name
 
         raise ResourceNotFoundError()
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -1,5 +1,6 @@
 import asyncio
 import math
+from collections.abc import AsyncIterator
 from datetime import datetime
 
 import sentry_sdk
@@ -20,6 +21,7 @@ from virtool.analyses.files import create_analysis_file
 from virtool.analyses.models import Analysis, AnalysisFile, AnalysisSearchResult
 from virtool.analyses.sql import SQLAnalysisFile, SQLAnalysisResult
 from virtool.analyses.utils import (
+    analysis_file_key,
     attach_analysis_files,
 )
 from virtool.blast.sql import SQLNuVsBlast
@@ -47,9 +49,8 @@ from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.db import (
     AttachSubtractionsTransform,
 )
-from virtool.uploads.utils import naive_writer
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import base_processor, rm, wait_for_checks
+from virtool.utils import base_processor, wait_for_checks
 
 logger = get_logger("analyses")
 
@@ -57,8 +58,7 @@ logger = get_logger("analyses")
 class AnalysisData(DataLayerDomain):
     name = "analyses"
 
-    def __init__(self, mongo: Mongo, config, pg: AsyncEngine, storage: StorageBackend):
-        self._config = config
+    def __init__(self, mongo: Mongo, pg: AsyncEngine, storage: StorageBackend):
         self._mongo = mongo
         self._pg = pg
         self._storage = storage
@@ -200,7 +200,6 @@ class AnalysisData(DataLayerDomain):
                     document["results"] = result.scalars().one()
 
             document = await virtool.analyses.format.format_analysis(
-                self._config,
                 self._storage,
                 self._mongo,
                 document,
@@ -364,18 +363,10 @@ class AnalysisData(DataLayerDomain):
                 ),
             )
 
-        try:
-            await asyncio.to_thread(
-                rm,
-                self._config.data_path
-                / "samples"
-                / analysis.sample.id
-                / "analysis"
-                / analysis_id,
-                True,
-            )
-        except FileNotFoundError:
-            pass
+        async for obj in self._storage.list(
+            f"samples/{analysis.sample.id}/analysis/{analysis_id}/",
+        ):
+            await self._storage.delete(obj.key)
 
         await recalculate_workflow_tags(self._mongo, analysis.sample.id)
 
@@ -417,9 +408,9 @@ class AnalysisData(DataLayerDomain):
         upload_id = analysis_file["id"]
 
         try:
-            size = await naive_writer(
+            size = await self._storage.write(
+                analysis_file_key(analysis_file["name_on_disk"]),
                 chunks,
-                self._config.data_path / "analyses" / analysis_file["name_on_disk"],
             )
         except asyncio.CancelledError:
             logger.info("analysis file upload aborted", upload_id=upload_id)
@@ -435,16 +426,24 @@ class AnalysisData(DataLayerDomain):
 
         return AnalysisFile(**analysis_file)
 
-    async def get_file_name(self, upload_id: int) -> str:
-        """Get a file generated during the analysis.
+    async def download_file(
+        self,
+        upload_id: int,
+    ) -> tuple[AsyncIterator[bytes], int, str]:
+        """Download a file generated during an analysis.
 
         :param upload_id: the upload ID
-        :return: the name on disk of the analysis file
+        :return: the file stream, size, and filename
         """
         analysis_file = await get_row_by_id(self._pg, SQLAnalysisFile, upload_id)
 
-        if analysis_file:
-            return analysis_file.name_on_disk
+        if not analysis_file:
+            raise ResourceNotFoundError()
+
+        key = analysis_file_key(analysis_file.name_on_disk)
+
+        async for info in self._storage.list(key):
+            return self._storage.read(key), info.size, analysis_file.name
 
         raise ResourceNotFoundError()
 
@@ -477,7 +476,6 @@ class AnalysisData(DataLayerDomain):
         if extension == "xlsx":
             return (
                 await virtool.analyses.format.format_analysis_to_excel(
-                    self._config,
                     self._storage,
                     self._mongo,
                     document,
@@ -487,7 +485,6 @@ class AnalysisData(DataLayerDomain):
 
         return (
             await virtool.analyses.format.format_analysis_to_csv(
-                self._config,
                 self._storage,
                 self._mongo,
                 document,

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -4,9 +4,9 @@ Formatted documents are destined for API responses or CSV/Excel formatted file
 downloads.
 """
 
-import asyncio
 import csv
 import io
+import json
 import statistics
 from asyncio import gather
 from collections import defaultdict
@@ -15,13 +15,11 @@ from typing import TYPE_CHECKING, Any
 import openpyxl.styles
 import visvalingamwyatt as vw
 
-import virtool.analyses.utils
-from virtool.config.cls import Config
+from virtool.analyses.utils import analysis_result_key
 from virtool.history.db import patch_to_version
 from virtool.models.enums import AnalysisWorkflow
 from virtool.otus.utils import format_isolate_name
 from virtool.storage.protocol import StorageBackend
-from virtool.utils import load_json
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -49,30 +47,26 @@ def calculate_median_depths(hits: list[dict]) -> dict[str, int]:
     return {hit["id"]: statistics.median(hit["align"]) for hit in hits}
 
 
-async def load_results(config: Config, document: dict[str, Any]) -> dict:
-    """Load the analysis results. Hide the alternative loading from a `results.json`
-    file.
+async def load_results(
+    storage: StorageBackend,
+    document: dict[str, Any],
+) -> dict:
+    """Load the analysis results from storage when they were too large for MongoDB.
 
-    These files are only generated if the analysis data had exceeded the MongoDB size
-    limit (16 MB.
+    The document is returned unmodified if loading from storage is not required.
 
-    The document is returned unmodified if loading from file is not required.
-
-    :param config: the application configuration
+    :param storage: the storage backend
     :param document: the document to load results for
     :return: a complete analysis document
-
     """
     if document["results"] == "file":
-        path = virtool.analyses.utils.join_analysis_json_path(
-            config.data_path,
-            document["_id"],
-            document["sample"]["id"],
-        )
+        key = analysis_result_key(document["_id"], document["sample"]["id"])
 
-        data = await asyncio.to_thread(load_json, path)
+        chunks = []
+        async for chunk in storage.read(key):
+            chunks.append(chunk)
 
-        return {**document, "results": data}
+        return {**document, "results": json.loads(b"".join(chunks))}
 
     return document
 
@@ -115,7 +109,6 @@ async def format_aodp(
 
 
 async def format_pathoscope(
-    config,
     storage: StorageBackend,
     mongo: "Mongo",
     document: dict[str, Any],
@@ -125,14 +118,13 @@ async def format_pathoscope(
 
     Calculate metrics for different organizational levels: OTU, isolate, and sequence.
 
-    :param config: the application config object
     :param storage: the storage backend
     :param mongo: the application Mongo object
     :param document: the document to format
     :return: the formatted document
 
     """
-    document = await load_results(config, document)
+    document = await load_results(storage, document)
 
     hits_by_otu = defaultdict(list)
 
@@ -239,20 +231,20 @@ def format_pathoscope_sequences(
 
 
 async def format_nuvs(
-    config: Config,
+    storage: StorageBackend,
     mongo: "Mongo",
     document: dict[str, Any],
 ) -> dict[str, Any]:
     """Format a NuVs analysis document by attaching the HMM annotation data to the
     results.
 
-    :param config: the config object
+    :param storage: the storage backend
     :param mongo: the database object
     :param document: the document to format
     :return: the formatted document
 
     """
-    document = await load_results(config, document)
+    document = await load_results(storage, document)
 
     hits = document["results"]["hits"]
 
@@ -271,14 +263,12 @@ async def format_nuvs(
 
 
 async def format_analysis_to_excel(
-    config: Config,
     storage: StorageBackend,
     mongo: "Mongo",
     document: dict[str, Any],
 ) -> bytes:
     """Convert a pathoscope analysis document to byte-encoded Excel format for download.
 
-    :param config: the config object
     :param storage: the storage backend
     :param mongo: the database object
     :param document: the document to format
@@ -287,7 +277,7 @@ async def format_analysis_to_excel(
     """
     depths = calculate_median_depths(document["results"]["hits"])
 
-    formatted = await format_analysis(config, storage, mongo, document)
+    formatted = await format_analysis(storage, mongo, document)
 
     output = io.BytesIO()
 
@@ -333,14 +323,12 @@ async def format_analysis_to_excel(
 
 
 async def format_analysis_to_csv(
-    config: Config,
     storage: StorageBackend,
     mongo: "Mongo",
     document: dict[str, Any],
 ) -> str:
     """Convert a pathoscope analysis document to CSV format for download.
 
-    :param config: the app config object
     :param storage: the storage backend
     :param mongo: the app mongo object
     :param document: the document to format
@@ -349,7 +337,7 @@ async def format_analysis_to_csv(
     """
     depths = calculate_median_depths(document["results"]["hits"])
 
-    formatted = await format_analysis(config, storage, mongo, document)
+    formatted = await format_analysis(storage, mongo, document)
 
     output = io.StringIO()
 
@@ -376,14 +364,12 @@ async def format_analysis_to_csv(
 
 
 async def format_analysis(
-    config: Config,
     storage: StorageBackend,
     mongo: "Mongo",
     document: dict[str, Any],
 ) -> dict[str, any]:
     """Format an analysis document to be returned by the API.
 
-    :param config: the config object
     :param storage: the storage backend
     :param mongo: the database object
     :param document: the analysis document to format
@@ -396,13 +382,13 @@ async def format_analysis(
         raise ValueError("Analysis has no workflow field")
 
     if workflow == AnalysisWorkflow.nuvs.value:
-        return await format_nuvs(config, mongo, document)
+        return await format_nuvs(storage, mongo, document)
 
     if workflow == AnalysisWorkflow.aodp.value:
         return await format_aodp(storage, mongo, document)
 
     if "pathoscope" in workflow:
-        return await format_pathoscope(config, storage, mongo, document)
+        return await format_pathoscope(storage, mongo, document)
 
     if workflow == AnalysisWorkflow.iimi.value:
         return document
@@ -427,7 +413,7 @@ async def gather_patched_otus(
     # Use set to only id-version combinations once.
     otu_specifiers = {(hit["otu"]["id"], hit["otu"]["version"]) for hit in results}
 
-    patched_otus = await asyncio.gather(
+    patched_otus = await gather(
         *[
             patch_to_version(storage, mongo, otu_id, version)
             for otu_id, version in otu_specifiers

--- a/virtool/analyses/utils.py
+++ b/virtool/analyses/utils.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -7,6 +6,16 @@ from sqlalchemy.future import select
 from virtool.analyses.sql import SQLAnalysisFile
 
 WORKFLOW_NAMES = ("aodp", "nuvs", "pathoscope_bowtie")
+
+
+def analysis_file_key(name_on_disk: str) -> str:
+    """Derive the storage key for an uploaded analysis file."""
+    return f"analyses/{name_on_disk}"
+
+
+def analysis_result_key(analysis_id: str, sample_id: str) -> str:
+    """Derive the storage key for an analysis results JSON file."""
+    return f"samples/{sample_id}/analysis/{analysis_id}/results.json"
 
 
 async def attach_analysis_files(
@@ -62,31 +71,3 @@ def find_nuvs_sequence_by_index(
         raise ValueError(f"More than one sequence with index {sequence_index}")
 
     return sequences[0]
-
-
-def join_analysis_path(data_path: Path, analysis_id: str, sample_id: str) -> Path:
-    """Returns the path to an analysis JSON output file.
-
-    :param data_path: the application data path
-    :param analysis_id: the id of the NuVs analysis
-    :param sample_id: the id of the parent sample
-    :return: an analysis JSON path
-
-    """
-    return data_path / "samples" / sample_id / "analysis" / analysis_id
-
-
-def join_analysis_json_path(data_path: Path, analysis_id: str, sample_id: str) -> Path:
-    """Join the path to an analysis JSON file for the given sample-analysis ID
-    combination.
-
-    Analysis JSON files are created when the analysis data is too large for a MongoDB
-    document.
-
-    :param data_path: the path to the application data
-    :param analysis_id: the ID of the analysis
-    :param sample_id: the ID of the sample
-    :return: a path
-
-    """
-    return join_analysis_path(data_path, analysis_id, sample_id) / "results.json"

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -91,7 +91,7 @@ def create_data_layer(
 
     return DataLayer(
         AccountData(mongo, pg),
-        AnalysisData(mongo, config, pg, storage),
+        AnalysisData(mongo, pg, storage),
         BLASTData(client, mongo, pg),
         GroupsData(mongo, pg),
         HistoryData(storage, mongo, pg),

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -2,20 +2,20 @@
 
 import asyncio
 import json
-from pathlib import Path
 
 import aiohttp.client_exceptions
 from aiohttp import ClientSession
 from structlog import get_logger
 
-import virtool.analyses.utils
 import virtool.utils
+from virtool.analyses.utils import analysis_result_key
 from virtool.errors import GitHubError
 from virtool.github import get_etag, get_release
 from virtool.hmm.utils import format_hmm_release
 from virtool.mongo.core import Mongo
+from virtool.storage.protocol import StorageBackend
 from virtool.types import Document
-from virtool.utils import base_processor, load_json
+from virtool.utils import base_processor
 
 logger = get_logger("hmms")
 
@@ -30,50 +30,53 @@ HMMS_PROJECTION = ["_id", "cluster", "names", "count", "families"]
 """A MongoDB projection for HMM document lists."""
 
 
-async def get_referenced_hmm_ids(mongo: Mongo, data_path: Path) -> list[str]:
+async def get_referenced_hmm_ids(mongo: Mongo, storage: StorageBackend) -> list[str]:
     """List the IDs of HMM documents that are used in analyses.
 
     :param mongo: the application database client
-    :param data_path: the application data path
+    :param storage: the storage backend
     :return: a list of unreferenced hmm ids
 
     """
     in_db, in_files = await asyncio.gather(
         get_hmms_referenced_in_db(mongo),
-        get_hmms_referenced_in_files(mongo, data_path),
+        get_hmms_referenced_in_files(mongo, storage),
     )
 
     return sorted(list(in_db | in_files))
 
 
-async def get_hmms_referenced_in_files(mongo: Mongo, data_path: Path) -> set[str]:
+async def get_hmms_referenced_in_files(
+    mongo: Mongo,
+    storage: StorageBackend,
+) -> set[str]:
     """Parse all NuVs JSON results files and return a set of found HMM profile ids.
 
     Used for removing unreferenced HMMs when purging the collection.
 
     :param mongo: the application database object
-    :param data_path: the application data path
+    :param storage: the storage backend
     :return: hmm ids referenced in nuvs result files
 
     """
-    paths = []
+    keys = []
 
     async for document in mongo.analyses.find(
         {"workflow": "nuvs", "results": "file"},
         ["_id", "sample"],
     ):
-        path = virtool.analyses.utils.join_analysis_json_path(
-            data_path,
-            document["_id"],
-            document["sample"]["id"],
+        keys.append(
+            analysis_result_key(document["_id"], document["sample"]["id"]),
         )
-
-        paths.append(path)
 
     hmm_ids = set()
 
-    for path in paths:
-        data = await asyncio.to_thread(load_json, path)
+    for key in keys:
+        chunks = []
+        async for chunk in storage.read(key):
+            chunks.append(chunk)
+
+        data = json.loads(b"".join(chunks))
 
         for sequence in data:
             for orf in sequence["orfs"]:


### PR DESCRIPTION
## Summary

- Replaces all direct filesystem access in the analyses module with the `StorageBackend` abstraction, removing `Config`/`data_path` dependencies from `AnalysisData`, `format_analysis`, `format_nuvs`, `format_pathoscope`, and related helpers
- Adds `analysis_file_key` and `analysis_result_key` utility functions and removes the old `join_analysis_path`/`join_analysis_json_path` path-based helpers
- Updates the file download endpoint to stream responses through storage rather than returning a `FileResponse`, and updates HMM reference file scanning (`get_hmms_referenced_in_files`) to use the storage backend

## Test plan

- [ ] Run analyses module tests: `mise run test -- tests/analyses`
- [ ] Run HMM tests: `mise run test -- tests/hmm`
- [ ] Verify analysis file upload, download, and delete work end-to-end in a dev environment
- [ ] Run the full test suite to check for regressions in shared data layer code