### PR TITLE
chore: adopt storage abstraction in references module

### DIFF
--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -21,6 +21,7 @@ from virtool.references.tasks import (
     ReferencesCleanTask,
     RemoteReferenceTask,
 )
+from virtool.references.utils import upload_file_key
 from virtool.tasks.sql import SQLTask
 from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.utils import get_temp_dir
@@ -186,7 +187,6 @@ def assert_reference_created(
 async def test_import_reference_task(
     assert_reference_created,
     data_layer: DataLayer,
-    data_path: Path,
     example_path: Path,
     fake: DataFaker,
     mongo: Mongo,
@@ -203,6 +203,11 @@ async def test_import_reference_task(
     )
 
     upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
+
+    await data_layer.references._storage.write(
+        upload_file_key(upload_row.name_on_disk),
+        fake_file_chunker(example_path / "indexes/reference.json.gz"),
+    )
 
     await mongo.references.insert_one(
         {
@@ -223,7 +228,7 @@ async def test_import_reference_task(
                 id=1,
                 complete=False,
                 context={
-                    "path": str(data_path / "files" / upload_row.name_on_disk),
+                    "name_on_disk": upload_row.name_on_disk,
                     "ref_id": "foo",
                     "user_id": user.id,
                 },
@@ -351,7 +356,6 @@ async def create_reference(
     mongo: Mongo,
     pg: AsyncEngine,
     static_time: StaticTime,
-    tmp_path: Path,
 ):
     user = await fake.users.create()
 
@@ -364,7 +368,10 @@ async def create_reference(
 
     upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
 
-    path = tmp_path / "files" / upload_row.name_on_disk
+    await data_layer.references._storage.write(
+        upload_file_key(upload_row.name_on_disk),
+        fake_file_chunker(example_path / "indexes/reference.json.gz"),
+    )
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -372,7 +379,7 @@ async def create_reference(
                 id=2,
                 complete=False,
                 context={
-                    "path": str(path),
+                    "name_on_disk": upload_row.name_on_disk,
                     "ref_id": "bar",
                     "user_id": "test",
                 },

--- a/virtool/references/bulk.py
+++ b/virtool/references/bulk.py
@@ -2,7 +2,6 @@ import asyncio
 from asyncio import FIRST_COMPLETED, CancelledError, Queue
 from collections.abc import Callable
 from datetime import datetime
-from pathlib import Path
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy.dialects.postgresql import insert
@@ -390,7 +389,6 @@ class OTUUpdateBuffer(BaseDataBuffer):
         bulk_db_updater: OTUDataBulkUpdater,
         mongo: "Mongo",
         user_id: str,
-        data_path: Path,
     ):
         async def func(
             data: list[OTUUpdateBufferData],
@@ -429,7 +427,6 @@ class BulkOTUUpdater:
         ref_id: str,
         user_id: str,
         created_at: datetime,
-        data_path: Path,
         progress_tracker: AccumulatingProgressHandlerWrapper,
         session: AsyncIOMotorClientSession,
     ):
@@ -464,7 +461,6 @@ class BulkOTUUpdater:
                 self.update_db,
                 mongo,
                 user_id,
-                data_path,
             )
         )
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -226,8 +226,6 @@ class ReferencesData(DataLayerDomain):
             if not upload:
                 raise ResourceNotFoundError("File not found")
 
-            path = self._config.data_path / "files" / upload.name_on_disk
-
             document = await virtool.references.db.create_import(
                 self._mongo,
                 self._pg,
@@ -242,7 +240,7 @@ class ReferencesData(DataLayerDomain):
 
             context = {
                 "created_at": document["created_at"],
-                "path": str(path),
+                "name_on_disk": upload.name_on_disk,
                 "ref_id": document["_id"],
                 "user_id": user_id,
             }
@@ -1161,7 +1159,6 @@ class ReferencesData(DataLayerDomain):
                 ref_id,
                 user_id,
                 created_at,
-                self._config.data_path,
                 tracker,
                 mongo_session,
             )

--- a/virtool/references/tasks.py
+++ b/virtool/references/tasks.py
@@ -66,8 +66,8 @@ class ImportReferenceTask(BaseTask):
         except StorageKeyNotFoundError:
             return await self._set_error("Could not find reference file in storage")
         except json.decoder.JSONDecodeError as err:
-            return await self._set_error(str(err).split("JSONDecodeError: ")[1])
-        except OSError as err:
+            return await self._set_error(str(err))
+        except (OSError, EOFError) as err:
             if "Not a gzipped file" in str(err):
                 await self._set_error("Not a gzipped file")
             else:

--- a/virtool/references/tasks.py
+++ b/virtool/references/tasks.py
@@ -1,6 +1,5 @@
 import json
 from asyncio import to_thread
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
@@ -10,7 +9,10 @@ from virtool.data.http import download_file
 from virtool.references.utils import (
     ReferenceSourceData,
     load_reference_file,
+    load_reference_from_storage,
+    upload_file_key,
 )
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.tasks.progress import AccumulatingProgressHandlerWrapper
 from virtool.tasks.task import BaseTask
 
@@ -54,11 +56,15 @@ class ImportReferenceTask(BaseTask):
         self.import_data: ReferenceSourceData | None = None
 
     async def load_file(self) -> None:
+        key = upload_file_key(self.context["name_on_disk"])
+
         try:
-            import_data = await to_thread(
-                load_reference_file,
-                Path(self.context["path"]),
+            import_data = await load_reference_from_storage(
+                self.data.references._storage,
+                key,
             )
+        except StorageKeyNotFoundError:
+            return await self._set_error("Could not find reference file in storage")
         except json.decoder.JSONDecodeError as err:
             return await self._set_error(str(err).split("JSONDecodeError: ")[1])
         except OSError as err:

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import gzip
+import io
 import json
 from operator import itemgetter
 from pathlib import Path
@@ -234,4 +235,8 @@ async def load_reference_from_storage(storage: StorageBackend, key: str) -> dict
 
     raw = b"".join(chunks)
 
-    return await asyncio.to_thread(lambda: json.loads(gzip.decompress(raw)))
+    def _load():
+        with gzip.GzipFile(fileobj=io.BytesIO(raw)) as f:
+            return json.load(f)
+
+    return await asyncio.to_thread(_load)

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import gzip
 import json
 from operator import itemgetter
@@ -6,6 +7,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field, validator
 
 from virtool.references.models import ReferenceDataType
+from virtool.storage.protocol import StorageBackend
 
 RIGHTS = ["build", "modify", "modify_otu", "remove"]
 
@@ -205,6 +207,11 @@ def check_will_change(old: dict, imported: dict) -> bool:
     return False
 
 
+def upload_file_key(name_on_disk: str) -> str:
+    """Derive the storage key for an uploaded file."""
+    return f"files/{name_on_disk}"
+
+
 def load_reference_file(path: Path) -> dict:
     """Load a list of merged otus documents from a file associated with a Virtool
     reference file.
@@ -217,3 +224,14 @@ def load_reference_file(path: Path) -> dict:
 
     with open(path, "rb") as handle, gzip.open(handle, "rt") as gzip_file:
         return json.load(gzip_file)
+
+
+async def load_reference_from_storage(storage: StorageBackend, key: str) -> dict:
+    """Load a gzip-compressed JSON reference file from storage."""
+    chunks = []
+    async for chunk in storage.read(key):
+        chunks.append(chunk)
+
+    raw = b"".join(chunks)
+
+    return await asyncio.to_thread(lambda: json.loads(gzip.decompress(raw)))


### PR DESCRIPTION
## Summary

- Replaces filesystem path-based file access in the references module with the storage abstraction layer (`StorageBackend`)
- Task context now passes `name_on_disk` instead of an absolute file path, and `ImportReferenceTask` reads the upload directly from storage using a derived key
- Adds `upload_file_key()` helper and `load_reference_from_storage()` utility in `references/utils.py`; removes unused `data_path` parameters from `BulkOTUUpdater` and related classes

## Test plan

- [ ] Run references tests: `mise run test -- tests/references -n4`
- [ ] Verify `ImportReferenceTask` correctly loads a reference file from the storage backend
- [ ] Verify the remote reference update flow still works end-to-end