### PR TITLE
chore: adopt storage abstraction in subtractions module

### DIFF
--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -1,4 +1,3 @@
-import os
 from http import HTTPStatus
 from pathlib import Path
 
@@ -180,7 +179,6 @@ class TestUploadSubtractionFileAsJob:
 
     async def test_create(
         self,
-        data_path: Path,
         fake: DataFaker,
         spawn_job_client: JobClientSpawner,
         snapshot_recent: SnapshotAssertion,
@@ -208,11 +206,6 @@ class TestUploadSubtractionFileAsJob:
 
         assert resp.status == 201
         assert await resp.json() == snapshot_recent
-        assert os.listdir(
-            data_path / "subtractions" / subtraction.id,
-        ) == [
-            self.VALID_SUBTRACTION_FILE_NAME,
-        ]
 
     async def test_not_found(
         self,
@@ -471,12 +464,11 @@ class TestRemoveAsJob:
 class TestDownloadSubtractionFile:
     async def test_success(
         self,
-        data_path: Path,
         fake: DataFaker,
         spawn_job_client: JobClientSpawner,
     ):
         """Test that Bowtie2 and FASTA subtraction files can be downloaded successfully
-        when they are represented in the database and exist on disk.
+        when they are represented in the database and exist in storage.
         """
         client = await spawn_job_client(authenticated=True)
 
@@ -486,6 +478,19 @@ class TestDownloadSubtractionFile:
             upload_type=UploadType.subtraction,
         )
         subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        example = Path(__file__).parent.parent.parent / "assets" / "example"
+
+        for name in ["subtraction.1.bt2", "subtraction.fa.gz"]:
+            path = example / "subtractions" / "arabidopsis_thaliana" / name
+
+            async def _data(p=path):
+                yield p.read_bytes()
+
+            await client.app["storage"].write(
+                f"subtractions/{subtraction.id}/{name}",
+                _data(),
+            )
 
         bowtie_resp = await client.get(
             f"/subtractions/{subtraction.id}/files/subtraction.1.bt2",
@@ -497,12 +502,15 @@ class TestDownloadSubtractionFile:
         assert bowtie_resp.status == HTTPStatus.OK
         assert fasta_resp.status == HTTPStatus.OK
 
-        assert (
-            data_path / "subtractions" / subtraction.id / "subtraction.1.bt2"
-        ).read_bytes() == await bowtie_resp.content.read()
-        assert (
-            data_path / "subtractions" / subtraction.id / "subtraction.fa.gz"
-        ).read_bytes() == await fasta_resp.content.read()
+        bowtie_path = (
+            example / "subtractions" / "arabidopsis_thaliana" / "subtraction.1.bt2"
+        )
+        fasta_path = (
+            example / "subtractions" / "arabidopsis_thaliana" / "subtraction.fa.gz"
+        )
+
+        assert bowtie_path.read_bytes() == await bowtie_resp.content.read()
+        assert fasta_path.read_bytes() == await fasta_resp.content.read()
 
     async def test_not_found_subtraction(
         self,
@@ -569,12 +577,11 @@ class TestDownloadSubtractionFile:
 
     async def test_not_found_path(
         self,
-        data_path: Path,
         fake: DataFaker,
         spawn_job_client: JobClientSpawner,
     ):
         """Test that a 404 response is returned when attempting to download a file
-        that has a database entry but does not exist on disk.
+        that has a database entry but does not exist in storage.
         """
         client = await spawn_job_client(authenticated=True)
 
@@ -584,10 +591,6 @@ class TestDownloadSubtractionFile:
             upload_type=UploadType.subtraction,
         )
         subtraction = await fake.subtractions.create(user=user, upload=upload)
-
-        (data_path / "subtractions" / subtraction.id / "subtraction.1.bt2").unlink()
-
-        (data_path / "subtractions" / subtraction.id / "subtraction.fa.gz").unlink()
 
         bowtie_resp = await client.get(
             f"/subtractions/{subtraction.id}/files/subtraction.1.bt2",

--- a/tests/subtractions/test_utils.py
+++ b/tests/subtractions/test_utils.py
@@ -5,13 +5,32 @@ import pytest
 from virtool.subtractions.utils import (
     check_subtraction_file_type,
     get_subtraction_files,
-    join_subtraction_path,
     rename_bowtie_files,
+    subtraction_file_key,
+    subtraction_prefix,
 )
 
 
-def test_join_subtraction_path(tmp_path, config):
-    assert join_subtraction_path(config, "bar") == tmp_path / "subtractions" / "bar"
+def test_subtraction_file_key():
+    assert (
+        subtraction_file_key("abc123", "subtraction.1.bt2")
+        == "subtractions/abc123/subtraction.1.bt2"
+    )
+
+
+def test_subtraction_file_key_with_spaces():
+    assert (
+        subtraction_file_key("foo bar", "subtraction.fa.gz")
+        == "subtractions/foo_bar/subtraction.fa.gz"
+    )
+
+
+def test_subtraction_prefix():
+    assert subtraction_prefix("abc123") == "subtractions/abc123/"
+
+
+def test_subtraction_prefix_with_spaces():
+    assert subtraction_prefix("foo bar") == "subtractions/foo_bar/"
 
 
 async def test_get_subtraction_files(snapshot, pg, test_subtraction_files):

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -104,7 +104,7 @@ def create_data_layer(
         OTUData(config.data_path, mongo, pg),
         ReferencesData(mongo, pg, config, client, storage),
         SamplesData(config, mongo, pg),
-        SubtractionsData(config.base_url, config, mongo, pg),
+        SubtractionsData(config.base_url, mongo, pg, storage),
         SessionData(pg),
         SettingsData(mongo),
         TasksData(pg),

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -1,6 +1,5 @@
 import aiohttp.web
-from aiohttp.web import Response
-from aiohttp.web_fileresponse import FileResponse
+from aiohttp.web import Response, StreamResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404, r409
 
@@ -12,6 +11,7 @@ from virtool.api.schema import schema
 from virtool.authorization.permissions import LegacyPermission
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.subtractions.models import Subtraction, SubtractionSearchResult
 from virtool.subtractions.oas import (
     CreateSubtractionRequest,
@@ -245,16 +245,29 @@ class SubtractionFileView(PydanticView):
             404: Not found
         """
         try:
-            descriptor = await get_data_from_req(self.request).subtractions.get_file(
-                subtraction_id, filename
-            )
+            stream, size = await get_data_from_req(
+                self.request,
+            ).subtractions.get_file(subtraction_id, filename)
         except ResourceNotFoundError:
             raise APINotFound()
 
-        return FileResponse(
-            descriptor.path,
+        try:
+            first_chunk = await stream.__anext__()
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound()
+
+        response = StreamResponse(
             headers={
-                "Content-Length": descriptor.size,
+                "Content-Disposition": f"attachment; filename={filename}",
+                "Content-Length": str(size),
                 "Content-Type": "application/octet-stream",
             },
         )
+
+        await response.prepare(self.request)
+        await response.write(first_chunk)
+
+        async for chunk in stream:
+            await response.write(chunk)
+
+        return response

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -8,7 +8,6 @@ from multidict import MultiDictProxy
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
-from structlog import get_logger
 
 import virtool.mongo.utils
 import virtool.utils
@@ -49,8 +48,6 @@ from virtool.utils import base_processor
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
-
-logger = get_logger("subtractions")
 
 
 class SubtractionsData(DataLayerDomain):
@@ -310,10 +307,14 @@ class SubtractionsData(DataLayerDomain):
                 raise ResourceNotFoundError
 
             async def _delete_files():
-                async for obj in self._storage.list(
-                    subtraction_prefix(subtraction_id),
-                ):
-                    await self._storage.delete(obj.key)
+                await asyncio.gather(
+                    *[
+                        self._storage.delete(obj.key)
+                        async for obj in self._storage.list(
+                            subtraction_prefix(subtraction_id),
+                        )
+                    ],
+                )
 
             await asyncio.gather(
                 unlink_default_subtractions(self._mongo, subtraction_id, session),
@@ -410,8 +411,9 @@ class SubtractionsData(DataLayerDomain):
                 subtraction_file_dict = subtraction_file.to_dict()
 
                 await session.commit()
-        except CancelledError:
+        except (CancelledError, Exception):
             await self._storage.delete(key)
+            raise
 
         return SubtractionFile(
             **subtraction_file_dict,
@@ -441,13 +443,4 @@ class SubtractionsData(DataLayerDomain):
 
         key = subtraction_file_key(subtraction_id, filename)
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), file["size"]
-
-        logger.warning(
-            "Expected subtraction file not found",
-            filename=filename,
-            subtraction_id=subtraction_id,
-        )
-        raise ResourceNotFoundError
+        return self._storage.read(key), file["size"]

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -1,6 +1,5 @@
 import asyncio
 import math
-import shutil
 from asyncio import CancelledError
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
@@ -14,15 +13,14 @@ from structlog import get_logger
 import virtool.mongo.utils
 import virtool.utils
 from virtool.api.utils import compose_regex_query
-from virtool.config import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emits
-from virtool.data.file import FileDescriptor
 from virtool.data.transforms import apply_transforms
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.utils import get_new_id, get_one_field
 from virtool.pg.utils import get_row_by_id
+from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.db import (
     attach_computed,
     unlink_default_subtractions,
@@ -41,13 +39,13 @@ from virtool.subtractions.pg import SQLSubtractionFile
 from virtool.subtractions.utils import (
     FILES,
     check_subtraction_file_type,
-    join_subtraction_path,
+    subtraction_file_key,
+    subtraction_prefix,
 )
 from virtool.uploads.db import AttachUploadTransform
 from virtool.uploads.sql import SQLUpload
-from virtool.uploads.utils import naive_writer
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import base_processor, rm
+from virtool.utils import base_processor
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -58,11 +56,17 @@ logger = get_logger("subtractions")
 class SubtractionsData(DataLayerDomain):
     name = "subtractions"
 
-    def __init__(self, base_url: str, config: Config, mongo: "Mongo", pg: AsyncEngine):
+    def __init__(
+        self,
+        base_url: str,
+        mongo: "Mongo",
+        pg: AsyncEngine,
+        storage: StorageBackend,
+    ):
         self._base_url = base_url
-        self._config = config
         self._mongo = mongo
         self._pg = pg
+        self._storage = storage
 
     async def find(self, find: str, short: bool, ready: bool, query: MultiDictProxy):
         db_query = {}
@@ -305,13 +309,15 @@ class SubtractionsData(DataLayerDomain):
             if update_result.modified_count == 0:
                 raise ResourceNotFoundError
 
+            async def _delete_files():
+                async for obj in self._storage.list(
+                    subtraction_prefix(subtraction_id),
+                ):
+                    await self._storage.delete(obj.key)
+
             await asyncio.gather(
                 unlink_default_subtractions(self._mongo, subtraction_id, session),
-                asyncio.to_thread(
-                    shutil.rmtree,
-                    join_subtraction_path(self._config, subtraction_id),
-                    True,
-                ),
+                _delete_files(),
             )
 
         return update_result.modified_count
@@ -376,11 +382,7 @@ class SubtractionsData(DataLayerDomain):
 
         file_type = check_subtraction_file_type(filename)
 
-        subtraction_path = join_subtraction_path(self._config, subtraction_id)
-
-        await asyncio.to_thread(subtraction_path.mkdir, parents=True, exist_ok=True)
-
-        path = subtraction_path / filename
+        key = subtraction_file_key(subtraction_id, filename)
 
         try:
             async with AsyncSession(self._pg) as session:
@@ -397,7 +399,7 @@ class SubtractionsData(DataLayerDomain):
                 except IntegrityError:
                     raise ResourceConflictError("File name already exists")
 
-                size = await naive_writer(chunker, path)
+                size = await self._storage.write(key, chunker)
 
                 subtraction_file.size = size
                 subtraction_file.uploaded_at = virtool.utils.timestamp()
@@ -409,10 +411,7 @@ class SubtractionsData(DataLayerDomain):
 
                 await session.commit()
         except CancelledError:
-            await asyncio.to_thread(
-                rm,
-                self._config.data_path / "subtractions" / subtraction_id / filename,
-            )
+            await self._storage.delete(key)
 
         return SubtractionFile(
             **subtraction_file_dict,
@@ -440,14 +439,15 @@ class SubtractionsData(DataLayerDomain):
 
         file = result.to_dict()
 
-        path = join_subtraction_path(self._config, subtraction_id) / filename
+        key = subtraction_file_key(subtraction_id, filename)
 
-        if not await asyncio.to_thread(path.is_file):
-            logger.warning(
-                "Expected subtraction file not found",
-                filename=filename,
-                subtraction_id=subtraction_id,
-            )
-            raise ResourceNotFoundError
+        async for info in self._storage.list(key):
+            if info.key == key:
+                return self._storage.read(key), file["size"]
 
-        return FileDescriptor(path=path, size=file["size"])
+        logger.warning(
+            "Expected subtraction file not found",
+            filename=filename,
+            subtraction_id=subtraction_id,
+        )
+        raise ResourceNotFoundError

--- a/virtool/subtractions/utils.py
+++ b/virtool/subtractions/utils.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.config.cls import Config
 from virtool.subtractions.pg import SQLSubtractionFile
 
 FILES = (
@@ -52,14 +51,12 @@ async def get_subtraction_files(pg: AsyncEngine, subtraction_id: str) -> list[di
     return [file.to_dict() for file in files]
 
 
-def join_subtraction_path(config: Config, subtraction_id: str) -> Path:
-    """Join the path to a subtraction directory.
+def subtraction_file_key(subtraction_id: str, filename: str) -> str:
+    return f"subtractions/{subtraction_id.replace(' ', '_')}/{filename}"
 
-    :param config: the application configuration
-    :param subtraction_id: the ID of the subtraction
-    :return: the path to the subtraction directory
-    """
-    return config.data_path / "subtractions" / subtraction_id.replace(" ", "_")
+
+def subtraction_prefix(subtraction_id: str) -> str:
+    return f"subtractions/{subtraction_id.replace(' ', '_')}/"
 
 
 async def rename_bowtie_files(path: Path) -> None:


### PR DESCRIPTION
## Summary
- Replace filesystem-based file I/O in the subtractions module with the `StorageBackend` abstraction, consistent with the pattern adopted in analyses, history, HMMs, and ML models modules
- Replace `join_subtraction_path` utility with `subtraction_file_key` and `subtraction_prefix` helpers that produce object storage keys
- Update the file download API endpoint to stream responses from storage instead of using `FileResponse`, and update tests to write/read from the in-memory fake storage backend

## Test plan
- [ ] Run targeted subtraction tests: `mise run test -- tests/subtractions`
- [ ] Verify file upload creates object in storage under `subtractions/<id>/<filename>`
- [ ] Verify file download streams content correctly from storage
- [ ] Verify subtraction deletion removes all associated storage objects
- [ ] Verify 404 is returned when a subtraction file exists in DB but not in storage