### PR TITLE
chore: adopt storage abstraction in samples module

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -267,6 +267,7 @@ def spawn_client(
     data_layer: DataLayer,
     data_path: Path,
     fake: DataFaker,
+    memory_storage,
     mocker,
     mongo: Mongo,
     mongo_connection_string: str,
@@ -416,6 +417,10 @@ def spawn_client(
 
         mocker.patch("virtool.startup.connect_pg", return_value=pg)
         mocker.patch("virtool.startup.connect_mongo", return_value=mongo)
+        mocker.patch(
+            "virtool.startup.create_storage_backend",
+            return_value=memory_storage,
+        )
 
         app = create_app(config)
 
@@ -480,6 +485,7 @@ def spawn_client(
 def spawn_job_client(
     aiohttp_client,
     data_path: Path,
+    memory_storage,
     mongo: Mongo,
     mongo_connection_string,
     mongo_name: str,
@@ -512,6 +518,10 @@ def spawn_job_client(
             auth = None
 
         mocker.patch("virtool.startup.connect_pg", return_value=pg)
+        mocker.patch(
+            "virtool.startup.create_storage_backend",
+            return_value=memory_storage,
+        )
 
         app = await virtool.jobs.main.create_app(
             ServerConfig(

--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -13,6 +13,7 @@ from virtool.storage.memory import MemoryStorageProvider
 @pytest.fixture
 def data_layer(
     config,
+    memory_storage: MemoryStorageProvider,
     mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
@@ -32,5 +33,5 @@ def data_layer(
         pg,
         config,
         mocker.Mock(spec=ClientSession),
-        MemoryStorageProvider(),
+        memory_storage,
     )

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1,6 +1,5 @@
 import asyncio
 import gzip
-import os
 from http import HTTPStatus
 from pathlib import Path
 
@@ -881,7 +880,6 @@ class TestDelete:
     async def setup_unfinalized_sample_with_job(
         self,
         job_state: JobState,
-        data_path: Path,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -889,8 +887,6 @@ class TestDelete:
     ) -> VirtoolTestClient:
         """Helper to create an unfinalized sample with a job in a specific state."""
         client = await spawn_client(authenticated=True)
-
-        (data_path / "samples/test").mkdir(parents=True)
 
         user = await fake.users.create()
 
@@ -926,14 +922,11 @@ class TestDelete:
 
     async def test_finalized(
         self,
-        data_path: Path,
         fake: DataFaker,
         spawn_client: ClientSpawner,
     ):
         """Test that finalized samples can be deleted."""
         client = await spawn_client(authenticated=True)
-
-        (data_path / "samples/test").mkdir(parents=True)
 
         user = await fake.users.create()
 
@@ -945,7 +938,6 @@ class TestDelete:
 
     async def test_unfinalized_with_error_job(
         self,
-        data_path: Path,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -954,7 +946,6 @@ class TestDelete:
         """Test that unfinalized samples with errored jobs can be deleted."""
         client = await self.setup_unfinalized_sample_with_job(
             JobState.ERROR,
-            data_path,
             fake,
             mongo,
             spawn_client,
@@ -967,7 +958,6 @@ class TestDelete:
 
     async def test_unfinalized_with_timeout_job(
         self,
-        data_path: Path,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -976,7 +966,6 @@ class TestDelete:
         """Test that unfinalized samples with timed out jobs can be deleted."""
         client = await self.setup_unfinalized_sample_with_job(
             JobState.TIMEOUT,
-            data_path,
             fake,
             mongo,
             spawn_client,
@@ -989,7 +978,6 @@ class TestDelete:
 
     async def test_unfinalized_with_cancelled_job(
         self,
-        data_path: Path,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -998,7 +986,6 @@ class TestDelete:
         """Test that unfinalized samples with cancelled jobs can be deleted."""
         client = await self.setup_unfinalized_sample_with_job(
             JobState.CANCELLED,
-            data_path,
             fake,
             mongo,
             spawn_client,
@@ -1011,7 +998,6 @@ class TestDelete:
 
     async def test_unfinalized_with_terminated_job(
         self,
-        data_path: Path,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -1020,7 +1006,6 @@ class TestDelete:
         """Test that unfinalized samples with terminated jobs can be deleted."""
         client = await self.setup_unfinalized_sample_with_job(
             JobState.TERMINATED,
-            data_path,
             fake,
             mongo,
             spawn_client,
@@ -1033,7 +1018,6 @@ class TestDelete:
 
     async def test_unfinalized_with_running_job(
         self,
-        data_path: Path,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
@@ -1042,7 +1026,6 @@ class TestDelete:
         """Test that unfinalized samples with running jobs cannot be deleted."""
         client = await self.setup_unfinalized_sample_with_job(
             JobState.RUNNING,
-            data_path,
             fake,
             mongo,
             spawn_client,
@@ -1057,14 +1040,11 @@ class TestDelete:
     async def test_from_job(
         self,
         finalized: bool,
-        data_path: Path,
         fake: DataFaker,
         spawn_job_client,
     ):
         """Test that job client can delete a sample only when it is unfinalized."""
         client = await spawn_job_client(authenticated=True)
-
-        (data_path / "samples/test").mkdir(parents=True)
 
         user = await fake.users.create()
 
@@ -1275,8 +1255,8 @@ async def test_analyze(
 @pytest.mark.parametrize("error", [None, 400, 409])
 async def test_upload_artifact(
     error: int | None,
-    data_path: Path,
     example_path: Path,
+    memory_storage,
     mongo: Mongo,
     resp_is,
     snapshot: SnapshotAssertion,
@@ -1287,8 +1267,6 @@ async def test_upload_artifact(
     path = example_path / "sample" / "reads_1.fq.gz"
 
     client = await spawn_job_client(authenticated=True)
-
-    sample_file_path = data_path / "samples" / "test"
 
     await mongo.samples.insert_one(
         {
@@ -1320,7 +1298,9 @@ async def test_upload_artifact(
     if not error:
         assert resp.status == 201
         assert await resp.json() == snapshot
-        assert os.listdir(sample_file_path) == ["small.fq.gz"]
+
+        keys = {obj.key async for obj in memory_storage.list("samples/test/")}
+        assert keys == {"samples/test/small.fq.gz"}
     elif error == 400:
         await resp_is.bad_request(resp, "Unsupported sample artifact type")
 
@@ -1328,8 +1308,8 @@ async def test_upload_artifact(
 class TestUploadReads:
     async def test(
         self,
-        data_path: Path,
         example_path: Path,
+        memory_storage,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_job_client: JobClientSpawner,
@@ -1360,6 +1340,9 @@ class TestUploadReads:
 
         assert resp_2.status == 201
 
+        keys = {obj.key async for obj in memory_storage.list("samples/test/")}
+        assert keys == {"samples/test/reads_1.fq.gz", "samples/test/reads_2.fq.gz"}
+
         resp_3 = await client.put(
             "/samples/test/reads/reads_2.fq.gz",
             data={"file": open(example_path / "sample" / "reads_2.fq.gz", "rb")},
@@ -1367,11 +1350,6 @@ class TestUploadReads:
 
         assert resp_3.status == 409
         assert await resp_3.json() == snapshot(name="409")
-
-        assert set(os.listdir(data_path / "samples" / "test")) == {
-            "reads_1.fq.gz",
-            "reads_2.fq.gz",
-        }
 
     async def test_uncompressed(
         self,
@@ -1409,7 +1387,7 @@ class TestUploadReads:
 async def test_download_reads(
     suffix: str,
     error: str | None,
-    data_path: Path,
+    memory_storage,
     mongo: Mongo,
     pg: AsyncEngine,
     spawn_client: ClientSpawner,
@@ -1421,9 +1399,11 @@ async def test_download_reads(
     file_name = f"reads_{suffix}.fq.gz"
 
     if error != "404_file":
-        path = data_path / "samples" / "foo"
-        path.mkdir(parents=True)
-        path.joinpath(file_name).write_text("test")
+
+        async def _data():
+            yield b"test"
+
+        await memory_storage.write(f"samples/foo/{file_name}", _data())
 
     if error != "404_sample":
         await mongo.samples.insert_one(
@@ -1453,7 +1433,7 @@ async def test_download_reads(
     else:
         assert resp.status == job_resp.status == HTTPStatus.OK
         assert (
-            (data_path / "samples" / "foo" / file_name).read_bytes()
+            memory_storage.get_raw(f"samples/foo/{file_name}")
             == await resp.content.read()
             == await job_resp.content.read()
         )
@@ -1462,7 +1442,7 @@ async def test_download_reads(
 @pytest.mark.parametrize("error", [None, "404_sample", "404_artifact", "404_file"])
 async def test_download_artifact(
     error: str | None,
-    data_path: Path,
+    memory_storage,
     mongo: Mongo,
     pg: AsyncEngine,
     spawn_job_client: JobClientSpawner,
@@ -1470,9 +1450,11 @@ async def test_download_artifact(
     client = await spawn_job_client(authenticated=True)
 
     if error != "404_file":
-        path = data_path / "samples" / "foo"
-        path.mkdir(parents=True)
-        path.joinpath("fastqc.txt").write_text("test")
+
+        async def _data():
+            yield b"test"
+
+        await memory_storage.write("samples/foo/fastqc.txt", _data())
 
     if error != "404_sample":
         await mongo.samples.insert_one(
@@ -1503,9 +1485,7 @@ async def test_download_artifact(
         return
 
     assert resp.status == HTTPStatus.OK
-    assert (
-        data_path / "samples" / "foo" / "fastqc.txt"
-    ).read_bytes() == await resp.content.read()
+    assert memory_storage.get_raw("samples/foo/fastqc.txt") == await resp.content.read()
 
 
 class TestChangeSampleRights:

--- a/tests/samples/test_fake.py
+++ b/tests/samples/test_fake.py
@@ -1,10 +1,8 @@
-import os
 from pathlib import Path
 
 import pytest
 
 from tests.fixtures.client import ClientSpawner
-from virtool.config import get_config_from_app
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.samples.fake import copy_reads_file, create_fake_sample
@@ -42,11 +40,10 @@ async def test_create_fake_sample(
     assert sample == snapshot
 
 
-async def test_copy_reads_file(app, example_path: Path):
+async def test_copy_reads_file(memory_storage, example_path: Path):
     file_path = example_path / "sample" / "reads_1.fq.gz"
 
-    await copy_reads_file(app, file_path, "reads_1.fq.gz", "sample_1")
+    await copy_reads_file(memory_storage, file_path, "reads_1.fq.gz", "sample_1")
 
-    assert os.listdir(get_config_from_app(app).data_path / "samples" / "sample_1") == [
-        "reads_1.fq.gz",
-    ]
+    keys = {obj.key async for obj in memory_storage.list("samples/sample_1/")}
+    assert keys == {"samples/sample_1/reads_1.fq.gz"}

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -578,6 +578,7 @@ class TestDownloadSubtractionFile:
     async def test_not_found_path(
         self,
         fake: DataFaker,
+        memory_storage,
         spawn_job_client: JobClientSpawner,
     ):
         """Test that a 404 response is returned when attempting to download a file
@@ -591,6 +592,9 @@ class TestDownloadSubtractionFile:
             upload_type=UploadType.subtraction,
         )
         subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        async for obj in memory_storage.list(f"subtractions/{subtraction.id}/"):
+            await memory_storage.delete(obj.key)
 
         bowtie_resp = await client.get(
             f"/subtractions/{subtraction.id}/files/subtraction.1.bt2",

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -103,7 +103,7 @@ def create_data_layer(
         MLData(http_client, pg, storage),
         OTUData(config.data_path, mongo, pg),
         ReferencesData(mongo, pg, config, client, storage),
-        SamplesData(config, mongo, pg),
+        SamplesData(config, mongo, pg, storage),
         SubtractionsData(config.base_url, mongo, pg, storage),
         SessionData(pg),
         SettingsData(mongo),

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -608,7 +608,7 @@ async def download_reads(req: Request):
 
     if size > 0:
         try:
-            first_chunk = await stream.__anext__()
+            first_chunk = await anext(stream)
         except (StopAsyncIteration, StorageKeyNotFoundError):
             raise APINotFound()
 
@@ -650,7 +650,7 @@ async def download_artifact(req: Request):
 
     if size > 0:
         try:
-            first_chunk = await stream.__anext__()
+            first_chunk = await anext(stream)
         except (StopAsyncIteration, StorageKeyNotFoundError):
             raise APINotFound()
 

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -1,21 +1,17 @@
 import asyncio
-import os
-from asyncio import to_thread
 
 from aiohttp.web import (
-    FileResponse,
     Request,
     Response,
+    StreamResponse,
 )
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404
 from pydantic import Field, conint, constr
-from sqlalchemy import exc, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
-import virtool.uploads.db
-import virtool.uploads.utils
 from virtool.analyses.models import AnalysisMinimal
 from virtool.api.client import UserClient
 from virtool.api.custom_json import json_response
@@ -31,7 +27,6 @@ from virtool.api.policy import PermissionRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.api.schema import schema
 from virtool.authorization.permissions import LegacyPermission
-from virtool.config import get_config_from_req
 from virtool.data.errors import (
     ResourceConflictError,
     ResourceError,
@@ -43,17 +38,12 @@ from virtool.groups.pg import SQLGroup
 from virtool.jobs.models import JobState
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
-from virtool.pg.utils import delete_row, get_rows
+from virtool.pg.utils import get_rows
 from virtool.samples.db import (
     SAMPLE_RIGHTS_PROJECTION,
     check_rights,
     get_sample_owner,
     recalculate_workflow_tags,
-)
-from virtool.samples.files import (
-    create_artifact_file,
-    create_reads_file,
-    get_existing_reads,
 )
 from virtool.samples.models import Sample, SampleSearchResult
 from virtool.samples.oas import (
@@ -62,14 +52,14 @@ from virtool.samples.oas import (
     UpdateRightsRequest,
     UpdateSampleRequest,
 )
-from virtool.samples.sql import ArtifactType, SQLSampleArtifact, SQLSampleReads
-from virtool.samples.utils import SampleRight, join_sample_path
+from virtool.samples.sql import SQLSampleReads
+from virtool.samples.utils import SampleRight
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.uploads.utils import (
-    is_gzip_compressed,
     multipart_file_chunker,
     naive_validator,
 )
-from virtool.utils import file_stats, get_safely
+from virtool.utils import get_safely
 
 logger = get_logger("samples")
 
@@ -509,7 +499,6 @@ async def upload_artifact(req):
     Uploads artifact created during sample creation using the Jobs API.
     """
     mongo = get_mongo_from_req(req)
-    pg = req.app["pg"]
 
     sample_id = req.match_info["sample_id"]
     artifact_type = req.query.get("type")
@@ -522,43 +511,23 @@ async def upload_artifact(req):
 
     name = req.query.get("name")
 
-    sample_path = join_sample_path(get_config_from_req(req), sample_id)
-    await asyncio.to_thread(sample_path.mkdir, parents=True, exist_ok=True)
-
-    artifact_file_path = sample_path / name
-
-    if artifact_type and artifact_type not in ArtifactType.to_list():
-        raise APIBadRequest("Unsupported sample artifact type")
-
     try:
-        artifact = await create_artifact_file(pg, name, name, sample_id, artifact_type)
-    except exc.IntegrityError:
-        raise APIConflict("Artifact file has already been uploaded for this sample")
-
-    artifact_id = artifact["id"]
-
-    try:
-        size = await virtool.uploads.utils.naive_writer(
+        artifact = await get_data_from_req(req).samples.upload_artifact(
+            sample_id,
+            artifact_type,
+            name,
             multipart_file_chunker(await req.multipart()),
-            artifact_file_path,
         )
+    except ResourceConflictError as err:
+        if "Unsupported" in str(err):
+            raise APIBadRequest(str(err))
+        raise APIConflict(str(err))
     except asyncio.CancelledError:
         logger.info(
             "Sample artifact file upload aborted",
-            id=artifact_id,
             sample_id=sample_id,
         )
-        await delete_row(pg, artifact_id, SQLSampleArtifact)
-        await to_thread(os.remove, artifact_file_path)
-
         return Response(status=499)
-
-    artifact = await virtool.uploads.db.finalize(
-        pg,
-        size,
-        artifact_id,
-        SQLSampleArtifact,
-    )
 
     return json_response(
         artifact,
@@ -574,7 +543,6 @@ async def upload_reads(req):
     Uploads sample reads using the Jobs API.
     """
     mongo = get_mongo_from_req(req)
-    pg = req.app["pg"]
 
     name = req.match_info["filename"]
     sample_id = req.match_info["sample_id"]
@@ -587,36 +555,23 @@ async def upload_reads(req):
     if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         raise APIBadRequest("File name is not an accepted reads file")
 
-    sample_path = join_sample_path(get_config_from_req(req), sample_id)
-    await asyncio.to_thread(sample_path.mkdir, parents=True, exist_ok=True)
-
-    reads_path = sample_path / name
-
     if not await mongo.samples.find_one(sample_id):
         raise APINotFound()
 
     try:
-        size = await virtool.uploads.utils.naive_writer(
+        reads = await get_data_from_req(req).samples.upload_reads(
+            sample_id,
+            name,
             multipart_file_chunker(await req.multipart()),
-            reads_path,
-            is_gzip_compressed,
+            upload_id=upload,
         )
     except OSError:
         raise APIBadRequest("File is not compressed")
+    except ResourceConflictError as err:
+        raise APIConflict(str(err))
     except asyncio.CancelledError:
         logger.info("sample reads upload aborted", sample_id=sample_id)
         return Response(status=499)
-    try:
-        reads = await create_reads_file(
-            pg,
-            size,
-            name,
-            name,
-            sample_id,
-            upload_id=upload,
-        )
-    except exc.IntegrityError:
-        raise APIConflict("Reads file name is already uploaded for this sample")
 
     return json_response(
         reads,
@@ -632,32 +587,40 @@ async def download_reads(req: Request):
 
     Downloads the sample reads file.
     """
-    mongo = get_mongo_from_req(req)
-    pg = req.app["pg"]
-
     sample_id = req.match_info["sample_id"]
     suffix = req.match_info["suffix"]
-
     file_name = f"reads_{suffix}.fq.gz"
 
-    if not await mongo.samples.find_one(sample_id):
+    try:
+        stream, size, name = await get_data_from_req(req).samples.get_reads_file(
+            sample_id,
+            file_name,
+        )
+    except ResourceNotFoundError:
         raise APINotFound()
 
-    existing_reads = await get_existing_reads(pg, sample_id)
+    response = StreamResponse(
+        headers={
+            "Content-Length": str(size),
+            "Content-Type": "application/gzip",
+        },
+    )
 
-    if file_name not in existing_reads:
-        raise APINotFound()
+    if size > 0:
+        try:
+            first_chunk = await stream.__anext__()
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound()
 
-    file_path = get_config_from_req(req).data_path / "samples" / sample_id / file_name
+        await response.prepare(req)
+        await response.write(first_chunk)
 
-    if not os.path.isfile(file_path):
-        raise APINotFound()
+        async for chunk in stream:
+            await response.write(chunk)
+    else:
+        await response.prepare(req)
 
-    stats = await to_thread(file_stats, file_path)
-
-    headers = {"Content-Length": stats["size"], "Content-Type": "application/gzip"}
-
-    return FileResponse(file_path, chunk_size=1024 * 1024, headers=headers)
+    return response
 
 
 @routes.jobs_api.get("/samples/{sample_id}/artifacts/{filename}")
@@ -667,39 +630,36 @@ async def download_artifact(req: Request):
     Downloads the sample artifact.
 
     """
-    mongo = get_mongo_from_req(req)
-    pg = req.app["pg"]
-
     sample_id = req.match_info["sample_id"]
     filename = req.match_info["filename"]
 
-    if not await mongo.samples.find_one(sample_id):
+    try:
+        stream, size = await get_data_from_req(req).samples.get_artifact_file(
+            sample_id,
+            filename,
+        )
+    except ResourceNotFoundError:
         raise APINotFound()
 
-    async with AsyncSession(pg) as session:
-        result = (
-            await session.execute(
-                select(SQLSampleArtifact).filter_by(sample=sample_id, name=filename),
-            )
-        ).scalar()
-
-    if not result:
-        raise APINotFound()
-
-    artifact = result.to_dict()
-
-    file_path = (
-        get_config_from_req(req).data_path
-        / f"samples/{sample_id}/{artifact['name_on_disk']}"
+    response = StreamResponse(
+        headers={
+            "Content-Length": str(size),
+            "Content-Type": "application/gzip",
+        },
     )
 
-    if not os.path.isfile(file_path):
-        raise APINotFound()
+    if size > 0:
+        try:
+            first_chunk = await stream.__anext__()
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound()
 
-    stats = await to_thread(file_stats, file_path)
+        await response.prepare(req)
+        await response.write(first_chunk)
 
-    return FileResponse(
-        file_path,
-        chunk_size=1024 * 1024,
-        headers={"Content-Length": stats["size"], "Content-Type": "application/gzip"},
-    )
+        async for chunk in stream:
+            await response.write(chunk)
+    else:
+        await response.prepare(req)
+
+    return response

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -2,14 +2,16 @@
 
 import asyncio
 import math
-from asyncio import gather, to_thread
+from asyncio import CancelledError, gather, to_thread
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import suppress
 from typing import Any
 
 from pymongo.results import UpdateResult
-from sqlalchemy import select
+from sqlalchemy import exc, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+import virtool.uploads.db
 import virtool.utils
 from virtool.api.client import UserClient
 from virtool.api.utils import compose_regex_query
@@ -29,6 +31,7 @@ from virtool.labels.transforms import AttachLabelsTransform
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id, get_one_field
+from virtool.pg.utils import delete_row
 from virtool.samples.checks import (
     check_labels_do_not_exist,
     check_name_is_in_use,
@@ -41,14 +44,21 @@ from virtool.samples.db import (
     define_initial_workflows,
     recalculate_workflow_tags,
 )
+from virtool.samples.files import (
+    create_artifact_file,
+    create_reads_file,
+    get_existing_reads,
+)
 from virtool.samples.models import Sample, SampleSearchResult
 from virtool.samples.oas import CreateSampleRequest, UpdateSampleRequest
-from virtool.samples.sql import SQLSampleReads
-from virtool.samples.utils import SampleRight, join_sample_path
+from virtool.samples.sql import ArtifactType, SQLSampleArtifact, SQLSampleReads
+from virtool.samples.utils import SampleRight, sample_file_key, sample_prefix
+from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.db import (
     AttachSubtractionsTransform,
 )
 from virtool.uploads.sql import SQLUpload
+from virtool.uploads.utils import is_gzip_compressed
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor, chunk_list, wait_for_checks
 
@@ -61,10 +71,12 @@ class SamplesData(DataLayerDomain):
         config: Config,
         mongo: Mongo,
         pg: AsyncEngine,
+        storage: StorageBackend,
     ):
         self._config = config
         self._mongo = mongo
         self._pg = pg
+        self._storage = storage
 
     async def find(
         self,
@@ -393,12 +405,12 @@ class SamplesData(DataLayerDomain):
             )
 
         if result.deleted_count:
-            with suppress(FileNotFoundError):
-                await to_thread(
-                    virtool.utils.rm,
-                    join_sample_path(self._config, sample_id),
-                    recursive=True,
-                )
+            await asyncio.gather(
+                *[
+                    self._storage.delete(obj.key)
+                    async for obj in self._storage.list(sample_prefix(sample_id))
+                ],
+            )
 
             return sample
 
@@ -567,3 +579,127 @@ class SamplesData(DataLayerDomain):
                     for sample_id in chunk
                 ],
             )
+
+    async def upload_artifact(
+        self,
+        sample_id: str,
+        artifact_type: str | None,
+        filename: str,
+        chunker: AsyncGenerator[bytearray],
+    ) -> dict:
+        if artifact_type and artifact_type not in ArtifactType.to_list():
+            raise ResourceConflictError("Unsupported sample artifact type")
+
+        try:
+            artifact = await create_artifact_file(
+                self._pg,
+                filename,
+                filename,
+                sample_id,
+                artifact_type,
+            )
+        except exc.IntegrityError:
+            raise ResourceConflictError(
+                "Artifact file has already been uploaded for this sample",
+            )
+
+        key = sample_file_key(sample_id, filename)
+
+        try:
+            size = await self._storage.write(key, chunker)
+        except (CancelledError, Exception):
+            await delete_row(self._pg, artifact["id"], SQLSampleArtifact)
+            await self._storage.delete(key)
+            raise
+
+        return await virtool.uploads.db.finalize(
+            self._pg,
+            size,
+            artifact["id"],
+            SQLSampleArtifact,
+        )
+
+    async def upload_reads(
+        self,
+        sample_id: str,
+        filename: str,
+        chunker: AsyncGenerator[bytearray],
+        upload_id: int | None = None,
+    ) -> dict:
+        key = sample_file_key(sample_id, filename)
+
+        async def _validate_and_stream() -> AsyncIterator[bytearray]:
+            first = True
+            async for chunk in chunker:
+                if first:
+                    is_gzip_compressed(chunk)
+                    first = False
+                yield chunk
+
+        size = await self._storage.write(key, _validate_and_stream())
+
+        try:
+            return await create_reads_file(
+                self._pg,
+                size,
+                filename,
+                filename,
+                sample_id,
+                upload_id=upload_id,
+            )
+        except exc.IntegrityError:
+            await self._storage.delete(key)
+            raise ResourceConflictError(
+                "Reads file name is already uploaded for this sample",
+            )
+
+    async def get_reads_file(
+        self,
+        sample_id: str,
+        filename: str,
+    ) -> tuple[AsyncIterator[bytes], int, str]:
+        if not await self._mongo.samples.find_one(sample_id):
+            raise ResourceNotFoundError
+
+        existing_reads = await get_existing_reads(self._pg, sample_id)
+
+        if filename not in existing_reads:
+            raise ResourceNotFoundError
+
+        key = sample_file_key(sample_id, filename)
+
+        async for info in self._storage.list(key):
+            if info.key == key:
+                return self._storage.read(key), info.size, filename
+
+        raise ResourceNotFoundError
+
+    async def get_artifact_file(
+        self,
+        sample_id: str,
+        filename: str,
+    ) -> tuple[AsyncIterator[bytes], int]:
+        if not await self._mongo.samples.find_one(sample_id):
+            raise ResourceNotFoundError
+
+        async with AsyncSession(self._pg) as session:
+            result = (
+                await session.execute(
+                    select(SQLSampleArtifact).filter_by(
+                        sample=sample_id,
+                        name=filename,
+                    ),
+                )
+            ).scalar()
+
+        if not result:
+            raise ResourceNotFoundError
+
+        artifact = result.to_dict()
+        key = sample_file_key(sample_id, artifact["name_on_disk"])
+
+        async for info in self._storage.list(key):
+            if info.key == key:
+                return self._storage.read(key), info.size
+
+        raise ResourceNotFoundError

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -1,15 +1,14 @@
-import shutil
-from asyncio import to_thread
 from pathlib import Path
 
-from virtool.config import get_config_from_app
 from virtool.data.utils import get_data_from_app
 from virtool.example import example_path
 from virtool.fake.wrapper import FakerWrapper
 from virtool.mongo.utils import get_mongo_from_app
 from virtool.samples.db import create_sample
 from virtool.samples.files import create_reads_file
+from virtool.samples.utils import sample_file_key
 from virtool.settings.models import Settings
+from virtool.storage.protocol import STORAGE_CHUNK_SIZE, StorageBackend
 from virtool.types import App
 
 SAMPLE_ID_UNPAIRED = "sample_unpaired"
@@ -70,6 +69,7 @@ async def create_fake_sample(
 
     mongo = get_mongo_from_app(app)
     pg = app["pg"]
+    storage: StorageBackend = app["storage"]
 
     subtraction_ids = [doc["_id"] async for doc in mongo.subtraction.find()][:2]
 
@@ -78,7 +78,12 @@ async def create_fake_sample(
             for n in (1, 2):
                 file_path = example_path / "sample" / f"reads_{n}.fq.gz"
 
-                await copy_reads_file(app, file_path, f"reads_{n}.fq.gz", sample_id)
+                await copy_reads_file(
+                    storage,
+                    file_path,
+                    f"reads_{n}.fq.gz",
+                    sample_id,
+                )
 
                 await create_reads_file(
                     pg,
@@ -90,7 +95,7 @@ async def create_fake_sample(
         else:
             file_path = example_path / "sample" / "reads_1.fq.gz"
 
-            await copy_reads_file(app, file_path, "reads_1.fq.gz", sample_id)
+            await copy_reads_file(storage, file_path, "reads_1.fq.gz", sample_id)
 
             await create_reads_file(
                 pg,
@@ -129,18 +134,17 @@ async def create_fake_sample(
         )
 
 
+async def _stream_file(file_path: Path):
+    with file_path.open("rb") as f:
+        while chunk := f.read(STORAGE_CHUNK_SIZE):
+            yield chunk
+
+
 async def copy_reads_file(
-    app: App, file_path: Path, filename: str, sample_id: str
+    storage: StorageBackend,
+    file_path: Path,
+    filename: str,
+    sample_id: str,
 ) -> None:
-    """Copy the example reads file to the sample directory.
-
-    :param app: the application object
-    :param file_path: the path to the reads file
-    :param filename: the name of the file
-    :param sample_id: the id of the sample
-
-    """
-    reads_path = get_config_from_app(app).data_path / "samples" / sample_id
-    reads_path.mkdir(parents=True, exist_ok=True)
-
-    await to_thread(shutil.copy, file_path, reads_path / filename)
+    key = sample_file_key(sample_id, filename)
+    await storage.write(key, _stream_file(file_path))

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from pathlib import Path
 
 from aiohttp.web import Response
 from sqlalchemy import select
@@ -7,7 +6,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.api.client import AbstractClient
 from virtool.api.errors import APIBadRequest
-from virtool.config.cls import Config
 from virtool.labels.sql import SQLLabel
 
 PATHOSCOPE_TASK_NAMES = ["pathoscope_bowtie", "pathoscope_barracuda"]
@@ -94,17 +92,9 @@ def bad_labels_response(labels: list[int]) -> Response:
     )
 
 
-def join_legacy_read_path(sample_path: Path, suffix: int) -> Path:
-    """Create a path string for a sample read file using the old file naming
-    convention (eg. reads_1.fastq).
-
-    :param sample_path: the path to the sample directory
-    :param suffix: the read file suffix
-    :return: the read path
-
-    """
-    return sample_path / f"reads_{suffix}.fastq"
+def sample_file_key(sample_id: str, filename: str) -> str:
+    return f"samples/{sample_id}/{filename}"
 
 
-def join_sample_path(config: Config, sample_id) -> Path:
-    return config.data_path / "samples" / sample_id
+def sample_prefix(sample_id: str) -> str:
+    return f"samples/{sample_id}/"


### PR DESCRIPTION
## Summary

- Migrates `SamplesData` to use the `StorageBackend` abstraction for all file I/O (reads, artifacts, delete), replacing direct filesystem operations
- Moves upload/download/delete logic from the API layer into the data layer (`SamplesData.upload_artifact`, `upload_reads`, `get_reads_file`, `get_artifact_file`)
- Updates `copy_reads_file` in `fake.py` to stream via storage rather than `shutil.copy`, and replaces filesystem-based test assertions with `memory_storage` fixture checks

## Test plan

- [ ] Run `mise run test -- tests/samples` to verify samples API and fake tests pass
- [ ] Run `mise run test -- tests/subtractions/test_api.py` to verify the subtraction download test change passes
- [ ] Run full suite (`mise run test`) if touching shared fixtures causes concerns