### PR TITLE
refactor: assert against StorageBackend protocol, not provider internals

### DIFF
--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -7,13 +7,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from virtool.data.layer import DataLayer, create_data_layer
 from virtool.mongo.core import Mongo
-from virtool.storage.memory import MemoryStorageProvider
+from virtool.storage.protocol import StorageBackend
 
 
 @pytest.fixture
 def data_layer(
     config,
-    memory_storage: MemoryStorageProvider,
+    memory_storage: StorageBackend,
     mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -19,6 +19,7 @@ from obstore.store import AzureStore, S3Store
 
 from virtool.storage.memory import MemoryStorageProvider
 from virtool.storage.obstore import ObstoreProvider
+from virtool.storage.protocol import StorageBackend
 
 
 async def _ensure_azurite_container(
@@ -143,5 +144,5 @@ async def azure_storage(
 
 
 @pytest.fixture
-def memory_storage() -> MemoryStorageProvider:
+def memory_storage() -> StorageBackend:
     return MemoryStorageProvider()

--- a/tests/hmm/test_tasks.py
+++ b/tests/hmm/test_tasks.py
@@ -8,7 +8,6 @@ from virtool.hmm.tasks import HMMInstallTask
 from virtool.tasks.sql import SQLTask
 from virtool.utils import get_temp_dir
 
-
 annotations = [
     {
         "families": {"None": 2, "Geminiviridae": 235},
@@ -71,5 +70,7 @@ async def test_hmm_install_task(
 
     assert await mongo.hmm.find().to_list(1) == snapshot(name="mongo_hmms")
     assert await data_layer.tasks.get(1) == snapshot(name="data_layer_task")
-    raw = b"".join([chunk async for chunk in data_layer.hmms._storage.read("hmm/profiles.hmm")])
+    raw = b"".join(
+        [chunk async for chunk in data_layer.hmms._storage.read("hmm/profiles.hmm")]
+    )
     assert raw == b"test_profile"

--- a/tests/hmm/test_tasks.py
+++ b/tests/hmm/test_tasks.py
@@ -9,10 +9,6 @@ from virtool.tasks.sql import SQLTask
 from virtool.utils import get_temp_dir
 
 
-async def _collect_bytes(aiter) -> bytes:
-    return b"".join([chunk async for chunk in aiter])
-
-
 annotations = [
     {
         "families": {"None": 2, "Geminiviridae": 235},
@@ -75,5 +71,5 @@ async def test_hmm_install_task(
 
     assert await mongo.hmm.find().to_list(1) == snapshot(name="mongo_hmms")
     assert await data_layer.tasks.get(1) == snapshot(name="data_layer_task")
-    raw = await _collect_bytes(data_layer.hmms._storage.read("hmm/profiles.hmm"))
+    raw = b"".join([chunk async for chunk in data_layer.hmms._storage.read("hmm/profiles.hmm")])
     assert raw == b"test_profile"

--- a/tests/hmm/test_tasks.py
+++ b/tests/hmm/test_tasks.py
@@ -8,6 +8,11 @@ from virtool.hmm.tasks import HMMInstallTask
 from virtool.tasks.sql import SQLTask
 from virtool.utils import get_temp_dir
 
+
+async def _collect_bytes(aiter) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
 annotations = [
     {
         "families": {"None": 2, "Geminiviridae": 235},
@@ -70,7 +75,5 @@ async def test_hmm_install_task(
 
     assert await mongo.hmm.find().to_list(1) == snapshot(name="mongo_hmms")
     assert await data_layer.tasks.get(1) == snapshot(name="data_layer_task")
-    assert "hmm/profiles.hmm" in data_layer.hmms._storage.keys()
-
-    raw = data_layer.hmms._storage.get_raw("hmm/profiles.hmm")
+    raw = await _collect_bytes(data_layer.hmms._storage.read("hmm/profiles.hmm"))
     assert raw == b"test_profile"

--- a/tests/ml/test_data.py
+++ b/tests/ml/test_data.py
@@ -118,4 +118,5 @@ async def test_load(
     )
 
     expected_keys = {f"ml/{i}/model.tar.gz" for i in [1, 2, 3, 9]}
-    assert data_layer.ml._storage.keys() >= expected_keys
+    actual_keys = {info.key async for info in data_layer.ml._storage.list("ml/")}
+    assert actual_keys >= expected_keys

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1432,11 +1432,8 @@ async def test_download_reads(
         assert resp.status == job_resp.status == 404
     else:
         assert resp.status == job_resp.status == HTTPStatus.OK
-        assert (
-            memory_storage.get_raw(f"samples/foo/{file_name}")
-            == await resp.content.read()
-            == await job_resp.content.read()
-        )
+        assert await resp.content.read() == b"test"
+        assert await job_resp.content.read() == b"test"
 
 
 @pytest.mark.parametrize("error", [None, "404_sample", "404_artifact", "404_file"])
@@ -1485,7 +1482,7 @@ async def test_download_artifact(
         return
 
     assert resp.status == HTTPStatus.OK
-    assert memory_storage.get_raw("samples/foo/fastqc.txt") == await resp.content.read()
+    assert await resp.content.read() == b"test"
 
 
 class TestChangeSampleRights:

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -60,13 +60,13 @@ class TestWrite:
 
         await provider.write("uploads/file.txt", _async_iter(data))
 
-        assert provider.get_raw("uploads/file.txt") == data
+        assert await _collect_bytes(provider.read("uploads/file.txt")) == data
 
     async def test_overwrites_existing(self, provider):
         await provider.write("key", _async_iter(b"first"))
         await provider.write("key", _async_iter(b"second"))
 
-        assert provider.get_raw("key") == b"second"
+        assert await _collect_bytes(provider.read("key")) == b"second"
 
 
 class TestDelete:
@@ -75,7 +75,8 @@ class TestDelete:
 
         await provider.delete("to_delete")
 
-        assert "to_delete" not in provider.keys()
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(provider.read("to_delete"))
 
     async def test_nonexistent_is_idempotent(self, provider):
         await provider.delete("does/not/exist")
@@ -111,23 +112,3 @@ class TestList:
         assert info.key == "test/file.txt"
         assert info.size == 5
         assert info.last_modified is not None
-
-
-class TestHelpers:
-    async def test_keys_empty(self, provider):
-        assert provider.keys() == set()
-
-    async def test_keys_after_writes(self, provider):
-        await provider.write("a", _async_iter(b"1"))
-        await provider.write("b/c", _async_iter(b"2"))
-
-        assert provider.keys() == {"a", "b/c"}
-
-    async def test_get_raw(self, provider):
-        await provider.write("key", _async_iter(b"value"))
-
-        assert provider.get_raw("key") == b"value"
-
-    async def test_get_raw_missing_raises_key_error(self, provider):
-        with pytest.raises(KeyError):
-            provider.get_raw("missing")

--- a/tests/storage/test_routing.py
+++ b/tests/storage/test_routing.py
@@ -65,8 +65,10 @@ class TestWrite:
     async def test_writes_to_primary_only(self, primary, fallback, router):
         await router.write("key", _async_iter(b"data"))
 
-        assert "key" in primary.keys()
-        assert "key" not in fallback.keys()
+        assert await _collect_bytes(primary.read("key")) == b"data"
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(fallback.read("key"))
 
     async def test_returns_byte_count(self, router):
         size = await router.write("key", _async_iter(b"hello"))
@@ -81,22 +83,27 @@ class TestDelete:
 
         await router.delete("key")
 
-        assert "key" not in primary.keys()
-        assert "key" not in fallback.keys()
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(primary.read("key"))
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(fallback.read("key"))
 
     async def test_primary_only(self, primary, fallback, router):
         await primary.write("key", _async_iter(b"a"))
 
         await router.delete("key")
 
-        assert "key" not in primary.keys()
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(primary.read("key"))
 
     async def test_fallback_only(self, fallback, router):
         await fallback.write("key", _async_iter(b"a"))
 
         await router.delete("key")
 
-        assert "key" not in fallback.keys()
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(fallback.read("key"))
 
     async def test_missing_from_both(self, router):
         await router.delete("missing")

--- a/virtool/storage/memory.py
+++ b/virtool/storage/memory.py
@@ -55,11 +55,3 @@ class MemoryStorageProvider:
                     size=len(obj.data),
                     last_modified=obj.last_modified,
                 )
-
-    def keys(self) -> set[str]:
-        """Return the set of all stored keys."""
-        return set(self._store)
-
-    def get_raw(self, key: str) -> bytes:
-        """Return raw bytes for the given key. Raises ``KeyError`` if missing."""
-        return self._store[key].data


### PR DESCRIPTION
## Summary
- Replaces test assertions that accessed internal `MemoryStorageProvider` helpers (`keys()`, `get_raw()`) with assertions against the public `StorageBackend` protocol interface (`read()`, `list()`)
- Updates `memory_storage` fixture type annotation to `StorageBackend` instead of `MemoryStorageProvider`, enforcing use of the protocol surface in tests
- Removes the `keys()` and `get_raw()` helper methods from `MemoryStorageProvider` since they are no longer needed by tests and are not part of the protocol

## Test plan
- [ ] Run `mise run test -- tests/storage` to verify storage tests pass
- [ ] Run `mise run test -- tests/hmm` to verify HMM install task test passes
- [ ] Run `mise run test -- tests/ml` to verify ML data tests pass
- [ ] Run `mise run test -- tests/samples/test_api.py` to verify sample download tests pass