### PR TITLE
fix: store bulk reference history diffs in postgresql

### DIFF
--- a/tests/references/__snapshots__/test_data.ambr
+++ b/tests/references/__snapshots__/test_data.ambr
@@ -273,46 +273,7 @@
       '_id': 'otu_id_1.0',
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Cherry virus B',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': 'otu_id_1',
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_id_1',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'cherry virus b',
-              'name': 'Cherry virus B',
-              'reference': dict({
-                'id': 'ref_id',
-              }),
-              'remote': dict({
-                'id': 'otu_1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -811,52 +772,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -900,46 +816,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -983,46 +860,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1279,52 +1117,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1368,46 +1161,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1451,46 +1205,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1703,52 +1418,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1792,46 +1462,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1875,46 +1506,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2171,52 +1763,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2260,46 +1807,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2343,46 +1851,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2804,52 +2273,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2893,46 +2317,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2976,46 +2361,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3250,52 +2596,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3339,46 +2640,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3422,46 +2684,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3712,52 +2935,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3801,46 +2979,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3884,46 +3023,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -4142,52 +3242,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OO',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_1a',
-                  'source_name': 'S3',
-                  'source_type': 'strain',
-                }),
-                dict({
-                  'default': False,
-                  'id': 'iso_db_1b',
-                  'source_name': 'NSW',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu one',
-              'name': 'OTU One',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r1',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -4231,46 +3286,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OTH',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_3',
-                  'source_name': 'Type',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu three',
-              'name': 'OTU Three',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r3',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -4314,46 +3330,7 @@
       '_id': str,
       'created_at': datetime,
       'description': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'OT',
-              'created_at': datetime,
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': 'iso_db_2',
-                  'source_name': 'Standard',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'otu two',
-              'name': 'OTU Two',
-              'reference': dict({
-                'id': 'test_ref',
-              }),
-              'remote': dict({
-                'id': 'otu_r2',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',

--- a/tests/references/__snapshots__/test_tasks.ambr
+++ b/tests/references/__snapshots__/test_tasks.ambr
@@ -222,52 +222,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Habenaria mosaic virus (HaMV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HaMV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Ha-1',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'habenaria mosaic virus',
-              'name': 'Habenaria mosaic virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'a89b6529',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -289,52 +244,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hardenbergia virus A (HarVA)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HarVA',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'HarVA-57',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hardenbergia virus a',
-              'name': 'Hardenbergia virus A',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '0b9f16ba',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -356,52 +266,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Helenium virus S',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '',
-                  'source_type': 'unknown',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'helenium virus s',
-              'name': 'Helenium virus S',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '2oafytcq',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -423,52 +288,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Helicoverpa zea nudivirus 2 (HzNV-2)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HzNV-2',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'MS1',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'helicoverpa zea nudivirus 2',
-              'name': 'Helicoverpa zea nudivirus 2',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '6bb1fe0b',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'dsDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -490,52 +310,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Helleborus net necrosis virus (HeNNV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HeNNV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'G5',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'helleborus net necrosis virus',
-              'name': 'Helleborus net necrosis virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'c85dca33',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -557,52 +332,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hibbertia virus Y (HiVY)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HiVY',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Kioloa',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibbertia virus y',
-              'name': 'Hibbertia virus Y',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '579c7055',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -624,52 +354,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hibiscus chlorotic ringspot virus (HCRSV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HCRSV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'unknown',
-                  'source_type': 'unknown',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus chlorotic ringspot virus',
-              'name': 'Hibiscus chlorotic ringspot virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '0716c1e1',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -691,57 +376,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hibiscus golden mosaic virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'BR-IgM1-16',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus golden mosaic virus',
-              'name': 'Hibiscus golden mosaic virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'rpz4bwux',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'DNA A',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'DNA B',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -763,62 +398,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hibiscus green spot virus (HGSV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HGSV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'WAI 1-1',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus green spot virus',
-              'name': 'Hibiscus green spot virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '400ab879',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA 1',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA 2',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA 3',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -840,57 +420,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hibiscus-infecting cilevirus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'HiCV',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus-infecting cilevirus',
-              'name': 'Hibiscus-infecting cilevirus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'xxv54nax',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': '',
-                  'name': 'RNA1',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': '',
-                  'name': 'RNA2',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -912,52 +442,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hollyhock yellow vein mosaic Islamabad virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '3AK',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hollyhock yellow vein mosaic islamabad virus',
-              'name': 'Hollyhock yellow vein mosaic Islamabad virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'kqpzbw0s',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -979,52 +464,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hollyhock yellow vein virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'VIRO 881',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hollyhock yellow vein virus',
-              'name': 'Hollyhock yellow vein virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'qe8afugr',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1046,52 +486,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hollyhock yellow vein virus associated symptomless alphasatellite',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '[Pakistan:17-5:06] Lahore2',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hollyhock yellow vein virus associated symptomless alphasatellite',
-              'name': 'Hollyhock yellow vein virus associated symptomless alphasatellite',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '4ydohve6',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Satellite',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1113,52 +508,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Honeysuckle yellow vein Japan betasatellite (HYVJB)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HYVJB',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Myz',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'honeysuckle yellow vein japan betasatellite',
-              'name': 'Honeysuckle yellow vein Japan betasatellite',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '9457c8c7',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Satellite',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1180,46 +530,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Honeysuckle yellow vein beta-[Japan:Fukui:2001] (HYVB-Japan)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HYVB-Japan',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Fukui',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'honeysuckle yellow vein beta-[japan:fukui:2001]',
-              'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '51c5d911',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1241,64 +552,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hop latent virus (HpLV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HpLV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': False,
-                  'id': str,
-                  'source_name': 'Zatec 2008',
-                  'source_type': 'isolate',
-                }),
-                dict({
-                  'default': False,
-                  'id': str,
-                  'source_name': 'Taurus',
-                  'source_type': 'isolate',
-                }),
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '',
-                  'source_type': 'unknown',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hop latent virus',
-              'name': 'Hop latent virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'b67008d3',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1320,52 +574,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hosta virus X (HVX)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HVX',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'HVX-Kr',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hosta virus x',
-              'name': 'Hosta virus X',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '41915321',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1387,52 +596,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hot pepper endornavirus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'CS',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hot pepper endornavirus',
-              'name': 'Hot pepper endornavirus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '898l72tb',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'dsRNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1454,52 +618,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hoya chlorotic spot virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '12-415',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hoya chlorotic spot virus',
-              'name': 'Hoya chlorotic spot virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'q1gu14xk',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -1521,52 +640,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Imported Hypericum japonicum associated circular DNA',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'VNHJ1W',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hypericum japonicum associated circular dna',
-              'name': 'Hypericum japonicum associated circular DNA',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'lliyqfxq',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2796,52 +1870,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Habenaria mosaic virus (HaMV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HaMV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Ha-1',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'habenaria mosaic virus',
-              'name': 'Habenaria mosaic virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'a89b6529',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2863,52 +1892,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hardenbergia virus A (HarVA)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HarVA',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'HarVA-57',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hardenbergia virus a',
-              'name': 'Hardenbergia virus A',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '0b9f16ba',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2930,52 +1914,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Helenium virus S',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '',
-                  'source_type': 'unknown',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'helenium virus s',
-              'name': 'Helenium virus S',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '2oafytcq',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -2997,52 +1936,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Helicoverpa zea nudivirus 2 (HzNV-2)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HzNV-2',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'MS1',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'helicoverpa zea nudivirus 2',
-              'name': 'Helicoverpa zea nudivirus 2',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '6bb1fe0b',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'dsDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3064,52 +1958,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Helleborus net necrosis virus (HeNNV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HeNNV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'G5',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'helleborus net necrosis virus',
-              'name': 'Helleborus net necrosis virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'c85dca33',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3131,52 +1980,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hibbertia virus Y (HiVY)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HiVY',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Kioloa',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibbertia virus y',
-              'name': 'Hibbertia virus Y',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '579c7055',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3198,52 +2002,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hibiscus chlorotic ringspot virus (HCRSV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HCRSV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'unknown',
-                  'source_type': 'unknown',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus chlorotic ringspot virus',
-              'name': 'Hibiscus chlorotic ringspot virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '0716c1e1',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3265,57 +2024,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hibiscus golden mosaic virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'BR-IgM1-16',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus golden mosaic virus',
-              'name': 'Hibiscus golden mosaic virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'rpz4bwux',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'DNA A',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'DNA B',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3337,62 +2046,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hibiscus green spot virus (HGSV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HGSV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'WAI 1-1',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus green spot virus',
-              'name': 'Hibiscus green spot virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '400ab879',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA 1',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA 2',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'RNA 3',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3414,57 +2068,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hibiscus-infecting cilevirus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'HiCV',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hibiscus-infecting cilevirus',
-              'name': 'Hibiscus-infecting cilevirus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'xxv54nax',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': '',
-                  'name': 'RNA1',
-                  'required': True,
-                }),
-                dict({
-                  'molecule': '',
-                  'name': 'RNA2',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3486,52 +2090,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hollyhock yellow vein mosaic Islamabad virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '3AK',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hollyhock yellow vein mosaic islamabad virus',
-              'name': 'Hollyhock yellow vein mosaic Islamabad virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'kqpzbw0s',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3553,52 +2112,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hollyhock yellow vein virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'VIRO 881',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hollyhock yellow vein virus',
-              'name': 'Hollyhock yellow vein virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'qe8afugr',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3620,52 +2134,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hollyhock yellow vein virus associated symptomless alphasatellite',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '[Pakistan:17-5:06] Lahore2',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hollyhock yellow vein virus associated symptomless alphasatellite',
-              'name': 'Hollyhock yellow vein virus associated symptomless alphasatellite',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '4ydohve6',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Satellite',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3687,52 +2156,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Honeysuckle yellow vein Japan betasatellite (HYVJB)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HYVJB',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Myz',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'honeysuckle yellow vein japan betasatellite',
-              'name': 'Honeysuckle yellow vein Japan betasatellite',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '9457c8c7',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Satellite',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3754,46 +2178,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Honeysuckle yellow vein beta-[Japan:Fukui:2001] (HYVB-Japan)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HYVB-Japan',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Fukui',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'honeysuckle yellow vein beta-[japan:fukui:2001]',
-              'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '51c5d911',
-              }),
-              'schema': list([
-              ]),
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3815,64 +2200,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hop latent virus (HpLV)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HpLV',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': False,
-                  'id': str,
-                  'source_name': 'Zatec 2008',
-                  'source_type': 'isolate',
-                }),
-                dict({
-                  'default': False,
-                  'id': str,
-                  'source_name': 'Taurus',
-                  'source_type': 'isolate',
-                }),
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '',
-                  'source_type': 'unknown',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hop latent virus',
-              'name': 'Hop latent virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'b67008d3',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3894,52 +2222,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hosta virus X (HVX)',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HVX',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'HVX-Kr',
-                  'source_type': 'strain',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hosta virus x',
-              'name': 'Hosta virus X',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '41915321',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -3961,52 +2244,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hot pepper endornavirus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'CS',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hot pepper endornavirus',
-              'name': 'Hot pepper endornavirus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '898l72tb',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'dsRNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -4028,52 +2266,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hoya chlorotic spot virus',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': '12-415',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hoya chlorotic spot virus',
-              'name': 'Hoya chlorotic spot virus',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'q1gu14xk',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssRNA+',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -4095,52 +2288,7 @@
       '_id': str,
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Remoted Hypericum japonicum associated circular DNA',
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': '',
-              'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'VNHJ1W',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'hypericum japonicum associated circular dna',
-              'name': 'Hypericum japonicum associated circular DNA',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': 'lliyqfxq',
-              }),
-              'schema': list([
-                dict({
-                  'molecule': 'ssDNA',
-                  'name': 'Genome',
-                  'required': True,
-                }),
-              ]),
-              'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',

--- a/tests/references/__snapshots__/test_tasks.ambr
+++ b/tests/references/__snapshots__/test_tasks.ambr
@@ -660,6 +660,1016 @@
     }),
   ])
 # ---
+# name: test_import_reference_task[history_diffs]
+  list([
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HaMV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Ha-1',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'habenaria mosaic virus',
+              'name': 'Habenaria mosaic virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'a89b6529',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HarVA',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'HarVA-57',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hardenbergia virus a',
+              'name': 'Hardenbergia virus A',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '0b9f16ba',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '',
+                  'source_type': 'unknown',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'helenium virus s',
+              'name': 'Helenium virus S',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '2oafytcq',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HzNV-2',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'MS1',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'helicoverpa zea nudivirus 2',
+              'name': 'Helicoverpa zea nudivirus 2',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '6bb1fe0b',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'dsDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HeNNV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'G5',
+                  'source_type': 'strain',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'helleborus net necrosis virus',
+              'name': 'Helleborus net necrosis virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'c85dca33',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HiVY',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Kioloa',
+                  'source_type': 'strain',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibbertia virus y',
+              'name': 'Hibbertia virus Y',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '579c7055',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HCRSV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'unknown',
+                  'source_type': 'unknown',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus chlorotic ringspot virus',
+              'name': 'Hibiscus chlorotic ringspot virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '0716c1e1',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'BR-IgM1-16',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus golden mosaic virus',
+              'name': 'Hibiscus golden mosaic virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'rpz4bwux',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'DNA A',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'DNA B',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HGSV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'WAI 1-1',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus green spot virus',
+              'name': 'Hibiscus green spot virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '400ab879',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA 1',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA 2',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA 3',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'HiCV',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus-infecting cilevirus',
+              'name': 'Hibiscus-infecting cilevirus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'xxv54nax',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': '',
+                  'name': 'RNA1',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': '',
+                  'name': 'RNA2',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '3AK',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hollyhock yellow vein mosaic islamabad virus',
+              'name': 'Hollyhock yellow vein mosaic Islamabad virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'kqpzbw0s',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'VIRO 881',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hollyhock yellow vein virus',
+              'name': 'Hollyhock yellow vein virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'qe8afugr',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '[Pakistan:17-5:06] Lahore2',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hollyhock yellow vein virus associated symptomless alphasatellite',
+              'name': 'Hollyhock yellow vein virus associated symptomless alphasatellite',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '4ydohve6',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Satellite',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HYVJB',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Myz',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'honeysuckle yellow vein japan betasatellite',
+              'name': 'Honeysuckle yellow vein Japan betasatellite',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '9457c8c7',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Satellite',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HYVB-Japan',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Fukui',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'honeysuckle yellow vein beta-[japan:fukui:2001]',
+              'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '51c5d911',
+              }),
+              'schema': list([
+              ]),
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HpLV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': False,
+                  'id': str,
+                  'source_name': 'Zatec 2008',
+                  'source_type': 'isolate',
+                }),
+                dict({
+                  'default': False,
+                  'id': str,
+                  'source_name': 'Taurus',
+                  'source_type': 'isolate',
+                }),
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '',
+                  'source_type': 'unknown',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hop latent virus',
+              'name': 'Hop latent virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'b67008d3',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HVX',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'HVX-Kr',
+                  'source_type': 'strain',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hosta virus x',
+              'name': 'Hosta virus X',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '41915321',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'CS',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hot pepper endornavirus',
+              'name': 'Hot pepper endornavirus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '898l72tb',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'dsRNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '12-415',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hoya chlorotic spot virus',
+              'name': 'Hoya chlorotic spot virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'q1gu14xk',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'VNHJ1W',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hypericum japonicum associated circular dna',
+              'name': 'Hypericum japonicum associated circular DNA',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'lliyqfxq',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+  ])
+# ---
 # name: test_import_reference_task[otus]
   list([
     dict({
@@ -2305,6 +3315,1016 @@
       'user': dict({
         'id': 1,
       }),
+    }),
+  ])
+# ---
+# name: test_remote_reference_task[history_diffs]
+  list([
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HaMV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Ha-1',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'habenaria mosaic virus',
+              'name': 'Habenaria mosaic virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'a89b6529',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HarVA',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'HarVA-57',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hardenbergia virus a',
+              'name': 'Hardenbergia virus A',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '0b9f16ba',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '',
+                  'source_type': 'unknown',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'helenium virus s',
+              'name': 'Helenium virus S',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '2oafytcq',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HzNV-2',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'MS1',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'helicoverpa zea nudivirus 2',
+              'name': 'Helicoverpa zea nudivirus 2',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '6bb1fe0b',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'dsDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HeNNV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'G5',
+                  'source_type': 'strain',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'helleborus net necrosis virus',
+              'name': 'Helleborus net necrosis virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'c85dca33',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HiVY',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Kioloa',
+                  'source_type': 'strain',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibbertia virus y',
+              'name': 'Hibbertia virus Y',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '579c7055',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HCRSV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'unknown',
+                  'source_type': 'unknown',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus chlorotic ringspot virus',
+              'name': 'Hibiscus chlorotic ringspot virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '0716c1e1',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'BR-IgM1-16',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus golden mosaic virus',
+              'name': 'Hibiscus golden mosaic virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'rpz4bwux',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'DNA A',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'DNA B',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HGSV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'WAI 1-1',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus green spot virus',
+              'name': 'Hibiscus green spot virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '400ab879',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA 1',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA 2',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'RNA 3',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'HiCV',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hibiscus-infecting cilevirus',
+              'name': 'Hibiscus-infecting cilevirus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'xxv54nax',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': '',
+                  'name': 'RNA1',
+                  'required': True,
+                }),
+                dict({
+                  'molecule': '',
+                  'name': 'RNA2',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '3AK',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hollyhock yellow vein mosaic islamabad virus',
+              'name': 'Hollyhock yellow vein mosaic Islamabad virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'kqpzbw0s',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'VIRO 881',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hollyhock yellow vein virus',
+              'name': 'Hollyhock yellow vein virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'qe8afugr',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '[Pakistan:17-5:06] Lahore2',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hollyhock yellow vein virus associated symptomless alphasatellite',
+              'name': 'Hollyhock yellow vein virus associated symptomless alphasatellite',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '4ydohve6',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Satellite',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HYVJB',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Myz',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'honeysuckle yellow vein japan betasatellite',
+              'name': 'Honeysuckle yellow vein Japan betasatellite',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '9457c8c7',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Satellite',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HYVB-Japan',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Fukui',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'honeysuckle yellow vein beta-[japan:fukui:2001]',
+              'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '51c5d911',
+              }),
+              'schema': list([
+              ]),
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HpLV',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': False,
+                  'id': str,
+                  'source_name': 'Zatec 2008',
+                  'source_type': 'isolate',
+                }),
+                dict({
+                  'default': False,
+                  'id': str,
+                  'source_name': 'Taurus',
+                  'source_type': 'isolate',
+                }),
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '',
+                  'source_type': 'unknown',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hop latent virus',
+              'name': 'Hop latent virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'b67008d3',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': 'HVX',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'HVX-Kr',
+                  'source_type': 'strain',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hosta virus x',
+              'name': 'Hosta virus X',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '41915321',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'CS',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hot pepper endornavirus',
+              'name': 'Hot pepper endornavirus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '898l72tb',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'dsRNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': '12-415',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hoya chlorotic spot virus',
+              'name': 'Hoya chlorotic spot virus',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'q1gu14xk',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssRNA+',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
+              'abbreviation': '',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'VNHJ1W',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'hypericum japonicum associated circular dna',
+              'name': 'Hypericum japonicum associated circular DNA',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': 'lliyqfxq',
+              }),
+              'schema': list([
+                dict({
+                  'molecule': 'ssDNA',
+                  'name': 'Genome',
+                  'required': True,
+                }),
+              ]),
+              'taxid': None,
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
     }),
   ])
 # ---

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -1,9 +1,15 @@
+import asyncio
+
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine
+from pytest_mock import MockerFixture
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 from virtool.api.client import UserClient
 from virtool.fake.next import DataFaker
+from virtool.history.sql import SQLHistoryDiff
+from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.references.db import (
@@ -12,6 +18,7 @@ from virtool.references.db import (
     fetch_and_update_release,
     get_manifest,
     get_reference_groups,
+    populate_insert_only_reference,
 )
 from virtool.startup import startup_http_client_session
 
@@ -188,3 +195,99 @@ async def test_create_document_owner_user(
         "created_at": static_time.datetime,
         "remove": True,
     }
+
+
+async def test_populate_insert_only_reference_rollback(
+    fake: DataFaker,
+    mocker: MockerFixture,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    static_time,
+):
+    """When a Mongo write fails, rollback removes the ``history_diffs`` rows
+    written during the PostgreSQL phase and all Mongo state scoped to the
+    reference, leaving the database as it was before the call.
+    """
+    user = await fake.users.create()
+    ref_id = "ref_rollback_test"
+
+    await mongo.references.insert_one(
+        {
+            "_id": ref_id,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "name": "Rollback",
+            "user": {"id": user.id},
+        },
+    )
+
+    mocker.patch(
+        "virtool.references.alot.random_alphanumeric",
+        side_effect=[
+            "rbotu001",
+            "rbiso001",
+            "rbseq001",
+            "rbotu002",
+            "rbiso002",
+            "rbseq002",
+        ],
+    )
+
+    otus = [
+        {
+            "_id": f"remote_{i}",
+            "name": f"OTU {i}",
+            "abbreviation": f"O{i}",
+            "isolates": [
+                {
+                    "id": f"remote_iso_{i}",
+                    "default": True,
+                    "source_type": "isolate",
+                    "source_name": "a",
+                    "sequences": [
+                        {
+                            "_id": f"remote_seq_{i}",
+                            "accession": f"ACC{i}",
+                            "sequence": "ATCG",
+                            "definition": "test",
+                            "host": "h",
+                        },
+                    ],
+                },
+            ],
+        }
+        for i in (1, 2)
+    ]
+
+    async def fail_sequences_insert(documents, session):
+        # Yield to let the other gather tasks progress before raising, so the
+        # rollback has real Mongo state to clean up.
+        await asyncio.sleep(0.05)
+        raise RuntimeError("forced mongo failure")
+
+    mocker.patch.object(mongo.sequences, "insert_many", fail_sequences_insert)
+
+    with pytest.raises(RuntimeError, match="forced mongo failure"):
+        await populate_insert_only_reference(
+            static_time.datetime,
+            HistoryMethod.remote,
+            mongo,
+            pg,
+            otus,
+            ref_id,
+            user.id,
+        )
+
+    assert await mongo.otus.count_documents({"reference.id": ref_id}) == 0
+    assert await mongo.history.count_documents({"reference.id": ref_id}) == 0
+    assert await mongo.sequences.count_documents({"reference.id": ref_id}) == 0
+    assert await mongo.references.find_one({"_id": ref_id}) is None
+
+    async with AsyncSession(pg) as pg_session:
+        count = await pg_session.scalar(
+            select(func.count())
+            .select_from(SQLHistoryDiff)
+            .where(SQLHistoryDiff.change_id.in_(["rbotu001.0", "rbotu002.0"])),
+        )
+
+    assert count == 0

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -259,15 +259,39 @@ async def test_populate_insert_only_reference_rollback(
         for i in (1, 2)
     ]
 
-    async def fail_sequences_insert(documents, session):
-        # Yield to let the other gather tasks progress before raising, so the
-        # rollback has real Mongo state to clean up.
-        await asyncio.sleep(0.05)
+    history_done = asyncio.Event()
+    otus_done = asyncio.Event()
+
+    real_history_insert_many = mongo.history.insert_many
+    real_otus_insert_many = mongo.otus.insert_many
+
+    async def wrapped_history_insert_many(documents, session):
+        try:
+            return await real_history_insert_many(documents, session)
+        finally:
+            history_done.set()
+
+    async def wrapped_otus_insert_many(documents, session):
+        try:
+            return await real_otus_insert_many(documents, session)
+        finally:
+            otus_done.set()
+
+    async def fail_sequences_insert_many(documents, session):
+        # Wait for the sibling inserts to actually land so the rollback has
+        # real Mongo state to clean up — otherwise the test would pass
+        # trivially against empty collections.
+        await asyncio.wait_for(
+            asyncio.gather(history_done.wait(), otus_done.wait()),
+            timeout=5.0,
+        )
         raise RuntimeError("forced mongo failure")
 
-    mocker.patch.object(mongo.sequences, "insert_many", fail_sequences_insert)
+    mocker.patch.object(mongo.history, "insert_many", wrapped_history_insert_many)
+    mocker.patch.object(mongo.otus, "insert_many", wrapped_otus_insert_many)
+    mocker.patch.object(mongo.sequences, "insert_many", fail_sequences_insert_many)
 
-    with pytest.raises(RuntimeError, match="forced mongo failure"):
+    with pytest.raises(ExceptionGroup) as excinfo:
         await populate_insert_only_reference(
             static_time.datetime,
             HistoryMethod.remote,
@@ -277,6 +301,8 @@ async def test_populate_insert_only_reference_rollback(
             ref_id,
             user.id,
         )
+
+    assert excinfo.group_contains(RuntimeError, match="forced mongo failure")
 
     assert await mongo.otus.count_documents({"reference.id": ref_id}) == 0
     assert await mongo.history.count_documents({"reference.id": ref_id}) == 0

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -6,12 +6,14 @@ from pathlib import Path
 import arrow
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
+from virtool.history.sql import SQLHistoryDiff
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.db import get_manifest
@@ -136,6 +138,7 @@ async def test_clean_references_task(
 def assert_reference_created(
     data_layer: DataLayer,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
     async def func(
@@ -176,6 +179,37 @@ def assert_reference_created(
             name="history",
             matcher=path_type(
                 {".*_id": (str,), r".*\d\.id": (str,), ".*otu.id": (str,)}, regex=True
+            ),
+        )
+
+        change_ids = [doc["_id"] for doc in history]
+
+        async with AsyncSession(pg) as pg_session:
+            diff_rows = (
+                (
+                    await pg_session.execute(
+                        select(SQLHistoryDiff).where(
+                            SQLHistoryDiff.change_id.in_(change_ids),
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        diff_by_change_id = {row.change_id: row.diff for row in diff_rows}
+
+        assert [
+            {"change_id": cid, "diff": diff_by_change_id[cid]} for cid in change_ids
+        ] == snapshot(
+            name="history_diffs",
+            matcher=path_type(
+                {
+                    ".*change_id": (str,),
+                    ".*_id": (str,),
+                    r".*\d\.id": (str,),
+                },
+                regex=True,
             ),
         )
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import dictdiffer
 from motor.motor_asyncio import AsyncIOMotorClientSession
+from sqlalchemy import delete
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -44,6 +45,41 @@ HISTORY_LIST_PROJECTION = [
 
 HISTORY_PROJECTION = [*HISTORY_LIST_PROJECTION, "diff"]
 """A MongoDB projection for history that includes the ``diff`` field."""
+
+_HISTORY_DIFF_CHUNK_SIZE = 32767 // 2
+"""Max ``history_diffs`` rows per statement.
+
+asyncpg caps bind parameters per statement at 32767. Each row binds two
+(``change_id`` and ``diff``).
+"""
+
+
+async def bulk_insert_diffs(pg: AsyncEngine, rows: list[dict]) -> None:
+    """Insert ``rows`` into ``history_diffs`` in asyncpg-safe chunks."""
+    async with AsyncSession(pg) as session:
+        for start in range(0, len(rows), _HISTORY_DIFF_CHUNK_SIZE):
+            await session.execute(
+                insert(SQLHistoryDiff).values(
+                    rows[start : start + _HISTORY_DIFF_CHUNK_SIZE],
+                ),
+            )
+
+        await session.commit()
+
+
+async def bulk_delete_diffs(pg: AsyncEngine, change_ids: list[str]) -> None:
+    """Delete ``history_diffs`` rows for the given ``change_ids`` in chunks."""
+    async with AsyncSession(pg) as session:
+        for start in range(0, len(change_ids), _HISTORY_DIFF_CHUNK_SIZE):
+            await session.execute(
+                delete(SQLHistoryDiff).where(
+                    SQLHistoryDiff.change_id.in_(
+                        change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE],
+                    ),
+                ),
+            )
+
+        await session.commit()
 
 
 @dataclass

--- a/virtool/references/alot.py
+++ b/virtool/references/alot.py
@@ -15,10 +15,24 @@ from virtool.utils import random_alphanumeric
 
 
 @dataclass
+class PreparedInsertionHistory:
+    """A history record prepared for two-phase insertion.
+
+    The diff is stored in PostgreSQL's ``history_diffs`` table keyed by
+    ``id``, while ``document`` is inserted into Mongo's ``history`` collection
+    with a ``"postgres"`` sentinel in place of the diff.
+    """
+
+    diff: dict
+    document: Document
+    id: str
+
+
+@dataclass
 class OTUInsertion:
     """Represents the insertion of an OTU, sequences, and creation history record."""
 
-    history: dict
+    history: PreparedInsertionHistory
     id: str
     otu: dict
     sequences: list[dict]
@@ -29,14 +43,18 @@ def prepare_insertion_history(
     old: dict | None,
     new: dict | None,
     user_id: str,
-) -> Document:
-    """Add a change document to the history collection.
+) -> PreparedInsertionHistory:
+    """Prepare a history record for bulk OTU insertion.
+
+    The diff is returned separately from the Mongo document so the diff can be
+    written to PostgreSQL's ``history_diffs`` table while the Mongo document
+    stores the ``"postgres"`` sentinel.
 
     :param history_method: the name of the method that executed the change
     :param old: the otu document prior to the change
     :param new: the otu document after the change
     :param user_id: the id of the requesting user
-    :return: the change document
+    :return: the prepared history record
     """
     otu_id, otu_name, otu_version, ref_id = derive_otu_information(old, new)
 
@@ -59,17 +77,23 @@ def prepare_insertion_history(
         case _:
             diff = calculate_diff(old, new)
 
-    return {
-        "_id": ".".join([str(otu_id), str(otu_version)]),
-        "diff": diff,
-        "method_name": history_method.value,
-        "description": description,
-        "created_at": virtool.utils.timestamp(),
-        "otu": {"id": otu_id, "name": otu_name, "version": otu_version},
-        "reference": {"id": ref_id},
-        "index": {"id": "unbuilt", "version": "unbuilt"},
-        "user": {"id": user_id},
-    }
+    change_id = ".".join([str(otu_id), str(otu_version)])
+
+    return PreparedInsertionHistory(
+        diff=diff,
+        document={
+            "_id": change_id,
+            "diff": "postgres",
+            "method_name": history_method.value,
+            "description": description,
+            "created_at": virtool.utils.timestamp(),
+            "otu": {"id": otu_id, "name": otu_name, "version": otu_version},
+            "reference": {"id": ref_id},
+            "index": {"id": "unbuilt", "version": "unbuilt"},
+            "user": {"id": user_id},
+        },
+        id=change_id,
+    )
 
 
 def prepare_otu_insertion(

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -5,8 +5,7 @@ import arrow
 from aiohttp import ClientConnectionError, ClientConnectorError, ClientSession
 from multidict import MultiDictProxy
 from semver import VersionInfo
-from sqlalchemy import delete, select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
@@ -33,9 +32,8 @@ from virtool.data.transforms import apply_transforms
 from virtool.errors import GitHubError
 from virtool.github import create_update_subdocument, format_release
 from virtool.groups.pg import SQLGroup
-from virtool.history.db import patch_to_version
+from virtool.history.db import bulk_delete_diffs, bulk_insert_diffs, patch_to_version
 from virtool.history.models import HistorySearchResult
-from virtool.history.sql import SQLHistoryDiff
 from virtool.indexes.models import IndexMinimal, IndexSearchResult
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
@@ -46,7 +44,6 @@ from virtool.pg.utils import get_row_by_id
 from virtool.references.alot import prepare_otu_insertion
 from virtool.references.bulk import BulkOTUUpdater
 from virtool.references.db import (
-    HISTORY_DIFF_CHUNK_SIZE,
     compose_base_find_query,
     fetch_and_update_release,
     get_contributors,
@@ -1015,12 +1012,7 @@ class ReferencesData(DataLayerDomain):
             for insertion in insertions
         ]
 
-        async with AsyncSession(self._pg) as pg_session:
-            for start in range(0, len(diff_rows), HISTORY_DIFF_CHUNK_SIZE):
-                chunk = diff_rows[start : start + HISTORY_DIFF_CHUNK_SIZE]
-                await pg_session.execute(pg_insert(SQLHistoryDiff).values(chunk))
-
-            await pg_session.commit()
+        await bulk_insert_diffs(self._pg, diff_rows)
 
         await tracker.add(1)
 
@@ -1030,33 +1022,24 @@ class ReferencesData(DataLayerDomain):
             for insertion in insertions:
                 sequences.extend(insertion.sequences)
 
-            await asyncio.gather(
-                self._mongo.history.insert_many(
-                    [insertion.history.document for insertion in insertions],
-                    None,
-                ),
-                self._mongo.otus.insert_many(
-                    [insertion.otu for insertion in insertions],
-                    None,
-                ),
-                self._mongo.sequences.insert_many(
-                    sequences,
-                    None,
-                ),
-            )
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(
+                    self._mongo.history.insert_many(
+                        [insertion.history.document for insertion in insertions],
+                        None,
+                    ),
+                )
+                tg.create_task(
+                    self._mongo.otus.insert_many(
+                        [insertion.otu for insertion in insertions],
+                        None,
+                    ),
+                )
+                tg.create_task(
+                    self._mongo.sequences.insert_many(sequences, None),
+                )
         except Exception:
-            change_ids = [row["change_id"] for row in diff_rows]
-
-            async with AsyncSession(self._pg) as pg_session:
-                for start in range(0, len(change_ids), HISTORY_DIFF_CHUNK_SIZE):
-                    chunk = change_ids[start : start + HISTORY_DIFF_CHUNK_SIZE]
-                    await pg_session.execute(
-                        delete(SQLHistoryDiff).where(
-                            SQLHistoryDiff.change_id.in_(chunk),
-                        ),
-                    )
-
-                await pg_session.commit()
+            await bulk_delete_diffs(self._pg, [row["change_id"] for row in diff_rows])
 
             await asyncio.gather(
                 self._mongo.otus.delete_many({"reference.id": ref_id}),

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -1042,11 +1042,12 @@ class ReferencesData(DataLayerDomain):
             await bulk_delete_diffs(self._pg, [row["change_id"] for row in diff_rows])
 
             await asyncio.gather(
-                self._mongo.otus.delete_many({"reference.id": ref_id}),
                 self._mongo.history.delete_many({"reference.id": ref_id}),
-                self._mongo.references.delete_one({"_id": ref_id}),
                 self._mongo.sequences.delete_many({"reference.id": ref_id}),
+                self._mongo.otus.delete_many({"reference.id": ref_id}),
             )
+
+            await self._mongo.references.delete_one({"_id": ref_id})
             raise
 
         await tracker.add(1)

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -5,7 +5,8 @@ import arrow
 from aiohttp import ClientConnectionError, ClientConnectorError, ClientSession
 from multidict import MultiDictProxy
 from semver import VersionInfo
-from sqlalchemy import select
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
@@ -34,6 +35,7 @@ from virtool.github import create_update_subdocument, format_release
 from virtool.groups.pg import SQLGroup
 from virtool.history.db import patch_to_version
 from virtool.history.models import HistorySearchResult
+from virtool.history.sql import SQLHistoryDiff
 from virtool.indexes.models import IndexMinimal, IndexSearchResult
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
@@ -44,6 +46,7 @@ from virtool.pg.utils import get_row_by_id
 from virtool.references.alot import prepare_otu_insertion
 from virtool.references.bulk import BulkOTUUpdater
 from virtool.references.db import (
+    HISTORY_DIFF_CHUNK_SIZE,
     compose_base_find_query,
     fetch_and_update_release,
     get_contributors,
@@ -954,6 +957,7 @@ class ReferencesData(DataLayerDomain):
             created_at,
             HistoryMethod.clone,
             self._mongo,
+            self._pg,
             otus,
             ref_id,
             user_id,
@@ -1006,6 +1010,18 @@ class ReferencesData(DataLayerDomain):
             for otu in data.otus
         ]
 
+        diff_rows = [
+            {"change_id": insertion.history.id, "diff": insertion.history.diff}
+            for insertion in insertions
+        ]
+
+        async with AsyncSession(self._pg) as pg_session:
+            for start in range(0, len(diff_rows), HISTORY_DIFF_CHUNK_SIZE):
+                chunk = diff_rows[start : start + HISTORY_DIFF_CHUNK_SIZE]
+                await pg_session.execute(pg_insert(SQLHistoryDiff).values(chunk))
+
+            await pg_session.commit()
+
         await tracker.add(1)
 
         try:
@@ -1016,7 +1032,7 @@ class ReferencesData(DataLayerDomain):
 
             await asyncio.gather(
                 self._mongo.history.insert_many(
-                    [insertion.history for insertion in insertions],
+                    [insertion.history.document for insertion in insertions],
                     None,
                 ),
                 self._mongo.otus.insert_many(
@@ -1029,6 +1045,19 @@ class ReferencesData(DataLayerDomain):
                 ),
             )
         except Exception:
+            change_ids = [row["change_id"] for row in diff_rows]
+
+            async with AsyncSession(self._pg) as pg_session:
+                for start in range(0, len(change_ids), HISTORY_DIFF_CHUNK_SIZE):
+                    chunk = change_ids[start : start + HISTORY_DIFF_CHUNK_SIZE]
+                    await pg_session.execute(
+                        delete(SQLHistoryDiff).where(
+                            SQLHistoryDiff.change_id.in_(chunk),
+                        ),
+                    )
+
+                await pg_session.commit()
+
             await asyncio.gather(
                 self._mongo.otus.delete_many({"reference.id": ref_id}),
                 self._mongo.history.delete_many({"reference.id": ref_id}),
@@ -1081,6 +1110,7 @@ class ReferencesData(DataLayerDomain):
             created_at,
             HistoryMethod.remote,
             self._mongo,
+            self._pg,
             [otu.dict(by_alias=True) for otu in data.otus],
             ref_id,
             user_id,

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -10,8 +10,7 @@ from aiohttp.web import Request
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pymongo import DeleteMany, DeleteOne, UpdateOne
 from semver import VersionInfo
-from sqlalchemy import delete, select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
@@ -24,7 +23,7 @@ from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.db import bulk_delete_diffs, bulk_insert_diffs
 from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
@@ -788,14 +787,6 @@ async def insert_joined_otu(
     return document["_id"]
 
 
-HISTORY_DIFF_CHUNK_SIZE = 16000
-"""Chunk size for bulk inserts into ``history_diffs``.
-
-Each row binds two parameters (``change_id`` and ``diff``); asyncpg caps
-bind parameters per statement at 32767.
-"""
-
-
 async def populate_insert_only_reference(
     created_at: datetime,
     history_method: HistoryMethod,
@@ -821,12 +812,7 @@ async def populate_insert_only_reference(
         for insertion in insertions
     ]
 
-    async with AsyncSession(pg) as pg_session:
-        for start in range(0, len(diff_rows), HISTORY_DIFF_CHUNK_SIZE):
-            chunk = diff_rows[start : start + HISTORY_DIFF_CHUNK_SIZE]
-            await pg_session.execute(pg_insert(SQLHistoryDiff).values(chunk))
-
-        await pg_session.commit()
+    await bulk_insert_diffs(pg, diff_rows)
 
     try:
         sequences = []
@@ -834,28 +820,22 @@ async def populate_insert_only_reference(
         for insertion in insertions:
             sequences.extend(insertion.sequences)
 
-        await asyncio.gather(
-            mongo.history.insert_many(
-                [insertion.history.document for insertion in insertions],
-                None,
-            ),
-            mongo.otus.insert_many(
-                [insertion.otu for insertion in insertions],
-                None,
-            ),
-            mongo.sequences.insert_many(sequences, None),
-        )
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(
+                mongo.history.insert_many(
+                    [insertion.history.document for insertion in insertions],
+                    None,
+                ),
+            )
+            tg.create_task(
+                mongo.otus.insert_many(
+                    [insertion.otu for insertion in insertions],
+                    None,
+                ),
+            )
+            tg.create_task(mongo.sequences.insert_many(sequences, None))
     except Exception:
-        change_ids = [row["change_id"] for row in diff_rows]
-
-        async with AsyncSession(pg) as pg_session:
-            for start in range(0, len(change_ids), HISTORY_DIFF_CHUNK_SIZE):
-                chunk = change_ids[start : start + HISTORY_DIFF_CHUNK_SIZE]
-                await pg_session.execute(
-                    delete(SQLHistoryDiff).where(SQLHistoryDiff.change_id.in_(chunk)),
-                )
-
-            await pg_session.commit()
+        await bulk_delete_diffs(pg, [row["change_id"] for row in diff_rows])
 
         await asyncio.gather(
             mongo.otus.delete_many({"reference.id": reference_id}),

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -838,11 +838,12 @@ async def populate_insert_only_reference(
         await bulk_delete_diffs(pg, [row["change_id"] for row in diff_rows])
 
         await asyncio.gather(
-            mongo.otus.delete_many({"reference.id": reference_id}),
             mongo.history.delete_many({"reference.id": reference_id}),
-            mongo.references.delete_one({"_id": reference_id}),
             mongo.sequences.delete_many({"reference.id": reference_id}),
+            mongo.otus.delete_many({"reference.id": reference_id}),
         )
+
+        await mongo.references.delete_one({"_id": reference_id})
         raise
 
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -10,7 +10,8 @@ from aiohttp.web import Request
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pymongo import DeleteMany, DeleteOne, UpdateOne
 from semver import VersionInfo
-from sqlalchemy import select
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
@@ -23,6 +24,7 @@ from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
+from virtool.history.sql import SQLHistoryDiff
 from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
@@ -786,10 +788,19 @@ async def insert_joined_otu(
     return document["_id"]
 
 
+HISTORY_DIFF_CHUNK_SIZE = 16000
+"""Chunk size for bulk inserts into ``history_diffs``.
+
+Each row binds two parameters (``change_id`` and ``diff``); asyncpg caps
+bind parameters per statement at 32767.
+"""
+
+
 async def populate_insert_only_reference(
     created_at: datetime,
     history_method: HistoryMethod,
     mongo: "Mongo",
+    pg: AsyncEngine,
     otus: list[dict],
     reference_id: str,
     user_id: str,
@@ -805,6 +816,18 @@ async def populate_insert_only_reference(
         for otu in otus
     ]
 
+    diff_rows = [
+        {"change_id": insertion.history.id, "diff": insertion.history.diff}
+        for insertion in insertions
+    ]
+
+    async with AsyncSession(pg) as pg_session:
+        for start in range(0, len(diff_rows), HISTORY_DIFF_CHUNK_SIZE):
+            chunk = diff_rows[start : start + HISTORY_DIFF_CHUNK_SIZE]
+            await pg_session.execute(pg_insert(SQLHistoryDiff).values(chunk))
+
+        await pg_session.commit()
+
     try:
         sequences = []
 
@@ -813,7 +836,7 @@ async def populate_insert_only_reference(
 
         await asyncio.gather(
             mongo.history.insert_many(
-                [insertion.history for insertion in insertions],
+                [insertion.history.document for insertion in insertions],
                 None,
             ),
             mongo.otus.insert_many(
@@ -823,6 +846,17 @@ async def populate_insert_only_reference(
             mongo.sequences.insert_many(sequences, None),
         )
     except Exception:
+        change_ids = [row["change_id"] for row in diff_rows]
+
+        async with AsyncSession(pg) as pg_session:
+            for start in range(0, len(change_ids), HISTORY_DIFF_CHUNK_SIZE):
+                chunk = change_ids[start : start + HISTORY_DIFF_CHUNK_SIZE]
+                await pg_session.execute(
+                    delete(SQLHistoryDiff).where(SQLHistoryDiff.change_id.in_(chunk)),
+                )
+
+            await pg_session.commit()
+
         await asyncio.gather(
             mongo.otus.delete_many({"reference.id": reference_id}),
             mongo.history.delete_many({"reference.id": reference_id}),


### PR DESCRIPTION
## Summary
- Aligns the bulk reference write paths (`populate_insert_only_reference`, `populate_imported_reference`) with the two-phase history storage pattern already used by the single-record path.
- History diffs are bulk-inserted into `history_diffs` with asyncpg-safe chunking and committed before any Mongo writes; the Mongo history documents carry the `"postgres"` sentinel in place of the inline diff.
- Rollback cleans up `history_diffs` rows alongside the scoped Mongo cleanup so Mongo and PostgreSQL stay in sync when a bulk insert fails.

Closes VIR-2292.

## Test plan
- [x] `mise run test -- tests/references -n4`
- [x] `mise run test -- -n4` (full suite)
- [x] New `test_populate_insert_only_reference_rollback` in `tests/references/test_db.py` forces a Mongo failure after the PG commit and asserts both PostgreSQL `history_diffs` rows and all reference-scoped Mongo state are cleaned up.
- [x] Reference snapshot files updated to reflect the `"postgres"` sentinel in bulk-path history documents.