### PR TITLE
refactor: remove session legacy ID compatibility shims

### DIFF
--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -1444,7 +1444,7 @@ class TestLoginReset:
 
         # Create another session for the same user
         old_session, old_token = await data_layer.sessions.create_authenticated(
-            "127.0.0.1", str(self.user.id), False
+            "127.0.0.1", self.user.id, False
         )
 
         # Reset password

--- a/tests/users/test_data.py
+++ b/tests/users/test_data.py
@@ -1,5 +1,4 @@
 import pytest
-from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
@@ -393,37 +392,3 @@ class TestSetAdministratorRole:
         """Test that set_administrator_role raises error for non-existent user."""
         with pytest.raises(ResourceNotFoundError):
             await data_layer.users.set_administrator_role(99999, AdministratorRole.BASE)
-
-
-class TestResolveLegacyId:
-    """Tests for the resolve_legacy_id method."""
-
-    async def test_int_user_id(self, data_layer: DataLayer, fake: DataFaker):
-        """Test that integer user IDs are returned as-is."""
-        user = await fake.users.create()
-        resolved_id = await data_layer.users.resolve_legacy_id(user.id)
-        assert resolved_id == user.id
-
-    async def test_legacy_string_id(
-        self, data_layer: DataLayer, fake: DataFaker, pg: AsyncEngine
-    ):
-        """Test that legacy string IDs are resolved to current integer IDs."""
-        # Create a user with a legacy ID
-        user = await fake.users.create()
-        legacy_id = "legacy_test_user_123"
-
-        # Manually set the legacy_id in the database
-        async with AsyncSession(pg) as session:
-            await session.execute(
-                update(SQLUser).where(SQLUser.id == user.id).values(legacy_id=legacy_id)
-            )
-            await session.commit()
-
-        # Test that resolve_legacy_id returns the current integer ID
-        resolved_id = await data_layer.users.resolve_legacy_id(legacy_id)
-        assert resolved_id == user.id
-
-    async def test_nonexistent_legacy_id(self, data_layer: DataLayer):
-        """Test that resolve_legacy_id raises ResourceNotFoundError for nonexistent legacy ID."""
-        with pytest.raises(ResourceNotFoundError):
-            await data_layer.users.resolve_legacy_id("nonexistent_legacy_id")

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -472,24 +472,21 @@ class AccountData(DataLayerDomain):
         """
         session = await self.data.sessions.get_reset(session_id, data.reset_code)
 
-        # TODO: Remove this compatibility layer after sessions are migrated to PostgreSQL
-        resolved_user_id = await self.data.users.resolve_legacy_id(
-            session.reset.user_id
-        )
-
-        if await self.data.users.validate_password(resolved_user_id, data.password):
+        if await self.data.users.validate_password(
+            session.reset.user_id, data.password
+        ):
             raise ResourceError("Cannot reuse current password")
 
-        await self.data.sessions.delete_by_user(resolved_user_id)
+        await self.data.sessions.delete_by_user(session.reset.user_id)
 
         await self.data.users.update(
-            resolved_user_id,
+            session.reset.user_id,
             UpdateUserRequest(force_reset=False, password=data.password),
         )
 
         return await self.data.sessions.create_authenticated(
             ip,
-            resolved_user_id,
+            session.reset.user_id,
             remember=session.reset.remember,
         )
 

--- a/virtool/api/authentication.py
+++ b/virtool/api/authentication.py
@@ -77,11 +77,7 @@ async def authenticate_with_session(req: Request, handler: Callable) -> Response
     if not session.authentication:
         raise APIUnauthorized("Requires authorization")
 
-    # TODO: Remove this compatibility layer after sessions are migrated to PostgreSQL
-    resolved_user_id = await get_data_from_req(req).users.resolve_legacy_id(
-        session.authentication.user_id
-    )
-    user = await get_data_from_req(req).users.get(resolved_user_id)
+    user = await get_data_from_req(req).users.get(session.authentication.user_id)
 
     if not user.active:
         raise APIUnauthorized("User is deactivated", error_id="deactivated_user")

--- a/virtool/models/sessions.py
+++ b/virtool/models/sessions.py
@@ -4,12 +4,12 @@ from virtool.models import BaseModel
 
 
 class SessionAuthentication(BaseModel):
-    user_id: int | str
+    user_id: int
 
 
 class SessionPasswordReset(BaseModel):
     remember: bool
-    user_id: int | str
+    user_id: int
 
 
 class Session(BaseModel):

--- a/virtool/sessions/data.py
+++ b/virtool/sessions/data.py
@@ -53,7 +53,7 @@ class SessionData(DataLayerDomain):
     async def create_authenticated(
         self,
         ip: str,
-        user_id: str,
+        user_id: int,
         remember: bool,
     ) -> tuple[Session, str]:
         """Create a new authenticated session.
@@ -75,7 +75,7 @@ class SessionData(DataLayerDomain):
 
         sql_session = SQLSession(
             session_id=session_id,
-            user_id=int(user_id),
+            user_id=user_id,
             ip=ip,
             created_at=created_at,
             expires_at=expires_at,
@@ -94,7 +94,7 @@ class SessionData(DataLayerDomain):
     async def create_reset(
         self,
         ip: str,
-        user_id: str,
+        user_id: int,
         remember: bool,
     ) -> tuple[Session, str]:
         """Create a new reset session.
@@ -111,7 +111,7 @@ class SessionData(DataLayerDomain):
 
         sql_session = SQLSession(
             session_id=session_id,
-            user_id=int(user_id),
+            user_id=user_id,
             ip=ip,
             created_at=created_at,
             expires_at=expires_at,

--- a/virtool/sessions/models.py
+++ b/virtool/sessions/models.py
@@ -65,14 +65,14 @@ class SQLSession(Base):
             and self.token_hash
         ):
             session_dict["authentication"] = {
-                "user_id": str(self.user_id),
+                "user_id": self.user_id,
                 "token": self.token_hash,
             }
         elif (
             self.session_type == SessionType.reset and self.user_id and self.reset_code
         ):
             session_dict["reset"] = {
-                "user_id": str(self.user_id),
+                "user_id": self.user_id,
                 "code": self.reset_code,
                 "remember": self.reset_remember or False,
             }

--- a/virtool/users/data.py
+++ b/virtool/users/data.py
@@ -154,32 +154,6 @@ class UsersData(DataLayerDomain):
             }
         )
 
-    async def resolve_legacy_id(self, user_id: int | str) -> int:
-        """Convert a legacy string user ID to the current integer user ID.
-
-        This method provides compatibility for sessions that may contain string legacy IDs
-        from before the migration to PostgreSQL.
-
-        TODO: Remove this method after sessions are migrated to PostgreSQL.
-
-        :param user_id: the user's ID (int) or legacy ID (string)
-        :return: the current integer user ID
-        """
-        if isinstance(user_id, int):
-            return user_id
-
-        # Look up the current ID from the legacy ID
-        async with AsyncSession(self._pg) as session:
-            result = await session.execute(
-                select(SQLUser.id).where(SQLUser.legacy_id == user_id)
-            )
-            current_id = result.scalar_one_or_none()
-
-            if current_id is None:
-                raise ResourceNotFoundError
-
-            return current_id
-
     async def get_by_handle(self, handle: str) -> User:
         """Get a user by their ``handle``.
 


### PR DESCRIPTION
## Summary
- Removes the `resolve_legacy_id` compatibility shim from `UsersData` that translated legacy string user IDs to integer IDs — no longer needed now that sessions are fully stored in PostgreSQL
- Tightens `SessionAuthentication` and `SessionPasswordReset` models to use `int` instead of `int | str` for `user_id`, and removes the `str()` cast in `SQLSession.to_dict()`
- Removes the now-dead test class `TestResolveLegacyId` and updates a test that was passing a stringified user ID

## Test plan
- [ ] Run `mise run test -- tests/account` to verify account/session flows pass
- [ ] Run `mise run test -- tests/users` to confirm removed tests don't break anything
- [ ] Run `mise run test -- tests/sessions` to verify session creation and authentication still work