### PR TITLE
chore: adopt storage abstraction in indexes module

### DIFF
--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -602,8 +602,18 @@ async def test_upload(
     assert resp.status == 201
 
     expected_key = compose_index_file_key("foo", "reference.1.bt2")
-    assert expected_key in memory_storage.keys()
-    assert memory_storage.get_raw(expected_key) == path.read_bytes()
+
+    found = False
+    async for info in memory_storage.list(expected_key):
+        if info.key == expected_key:
+            found = True
+            break
+    assert found
+
+    chunks = []
+    async for chunk in memory_storage.read(expected_key):
+        chunks.append(chunk)
+    assert b"".join(chunks) == path.read_bytes()
 
     assert await resp.json() == snapshot
     assert await mongo.indexes.find_one("foo") == snapshot

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -1,9 +1,6 @@
 import asyncio
-import filecmp
 import gzip
 import json
-import os
-import shutil
 from datetime import timedelta
 from http import HTTPStatus
 from io import BytesIO
@@ -24,9 +21,10 @@ from virtool.fake.next import DataFaker
 from virtool.indexes.db import INDEX_FILE_NAMES
 from virtool.indexes.files import create_index_file
 from virtool.indexes.sql import SQLIndexFile
-from virtool.indexes.utils import check_index_file_type
+from virtool.indexes.utils import check_index_file_type, compose_index_file_key
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
+from virtool.storage.memory import MemoryStorageProvider
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
 
@@ -253,8 +251,8 @@ async def test_get(
 @pytest.mark.parametrize("file_exists", [True, False])
 async def test_download_otus_json(
     file_exists: bool,
-    data_path: Path,
     example_path: Path,
+    memory_storage: MemoryStorageProvider,
     mocker: MockerFixture,
     mongo: Mongo,
     spawn_job_client: JobClientSpawner,
@@ -271,11 +269,13 @@ async def test_download_otus_json(
 
     client = await spawn_job_client(authenticated=True)
 
-    index_dir = data_path / "references" / "foo" / "bar"
-    index_dir.mkdir(parents=True)
-
     if file_exists:
-        shutil.copy(otus_json_path, index_dir / "otus.json.gz")
+        key = compose_index_file_key("bar", "otus.json.gz")
+
+        async def _stream():
+            yield otus_json_path.read_bytes()
+
+        await memory_storage.write(key, _stream())
 
     manifest = {"foo": 2, "bar": 1, "bad": 5}
 
@@ -541,9 +541,9 @@ async def test_delete_index(
 @pytest.mark.parametrize("error", [None, "409", "404_index", "404_file"])
 async def test_upload(
     error: str | None,
-    data_path: Path,
     example_path: Path,
     fake: DataFaker,
+    memory_storage: MemoryStorageProvider,
     mongo: Mongo,
     pg: AsyncEngine,
     resp_is,
@@ -600,7 +600,10 @@ async def test_upload(
         return
 
     assert resp.status == 201
-    assert os.listdir(data_path / "references" / "bar" / "foo") == ["reference.1.bt2"]
+
+    expected_key = compose_index_file_key("foo", "reference.1.bt2")
+    assert expected_key in memory_storage.keys()
+    assert memory_storage.get_raw(expected_key) == path.read_bytes()
 
     assert await resp.json() == snapshot
     assert await mongo.indexes.find_one("foo") == snapshot
@@ -678,8 +681,8 @@ async def test_finalize(
 @pytest.mark.parametrize("status", [200, 404])
 async def test_download(
     status: int,
-    data_path: Path,
     example_path: Path,
+    memory_storage: MemoryStorageProvider,
     mongo: Mongo,
     spawn_job_client: JobClientSpawner,
 ):
@@ -695,12 +698,14 @@ async def test_download(
     )
 
     path = example_path / "indexes" / "reference.1.bt2"
-    target_path = data_path / "references" / "test_reference" / "test_index"
-    target_path.mkdir(parents=True)
-    shutil.copyfile(path, target_path / "reference.1.bt2")
+    expected_bytes = path.read_bytes()
 
-    download_path = target_path / "downloads" / "reference.1.bt2"
-    download_path.parent.mkdir()
+    key = compose_index_file_key("test_index", "reference.1.bt2")
+
+    async def _stream():
+        yield expected_bytes
+
+    await memory_storage.write(key, _stream())
 
     files_url = "/indexes/test_index/files/"
 
@@ -712,7 +717,4 @@ async def test_download(
     async with client.get(files_url) as response:
         assert response.status == status
         if response.status == HTTPStatus.OK:
-            with download_path.open("wb") as f:
-                f.write(await response.read())
-
-            assert filecmp.cmp(download_path, path)
+            assert await response.read() == expected_bytes

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -24,7 +24,7 @@ from virtool.indexes.sql import SQLIndexFile
 from virtool.indexes.utils import check_index_file_type, compose_index_file_key
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
-from virtool.storage.memory import MemoryStorageProvider
+from virtool.storage.protocol import StorageBackend
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
 
@@ -252,7 +252,7 @@ async def test_get(
 async def test_download_otus_json(
     file_exists: bool,
     example_path: Path,
-    memory_storage: MemoryStorageProvider,
+    memory_storage: StorageBackend,
     mocker: MockerFixture,
     mongo: Mongo,
     spawn_job_client: JobClientSpawner,
@@ -543,7 +543,7 @@ async def test_upload(
     error: str | None,
     example_path: Path,
     fake: DataFaker,
-    memory_storage: MemoryStorageProvider,
+    memory_storage: StorageBackend,
     mongo: Mongo,
     pg: AsyncEngine,
     resp_is,
@@ -692,7 +692,7 @@ async def test_finalize(
 async def test_download(
     status: int,
     example_path: Path,
-    memory_storage: MemoryStorageProvider,
+    memory_storage: StorageBackend,
     mongo: Mongo,
     spawn_job_client: JobClientSpawner,
 ):

--- a/tests/indexes/test_utils.py
+++ b/tests/indexes/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 import virtool.indexes.utils
+from virtool.indexes.utils import compose_index_file_key, compose_index_prefix
 
 
 @pytest.mark.parametrize("file_type", ["json", "fasta", "bowtie2"])
@@ -16,3 +17,14 @@ async def test_check_index_file_type(file_type):
     if file_type == "bowtie2":
         result = virtool.indexes.utils.check_index_file_type("reference.1.bt2")
         assert result == "bowtie2"
+
+
+def test_compose_index_file_key():
+    assert (
+        compose_index_file_key("abc123", "reference.1.bt2")
+        == "indexes/abc123/reference.1.bt2"
+    )
+
+
+def test_compose_index_prefix():
+    assert compose_index_prefix("abc123") == "indexes/abc123/"

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -1,6 +1,4 @@
-from asyncio import to_thread
-
-from aiohttp.web import FileResponse, Request
+from aiohttp.web import Request, StreamResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r404
 from pydantic import Field
@@ -13,7 +11,6 @@ from virtool.api.errors import (
     APINotFound,
 )
 from virtool.api.routes import Routes
-from virtool.config import get_config_from_req
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.history.models import HistorySearchResult
@@ -23,8 +20,9 @@ from virtool.indexes.oas import (
     ListIndexesResponse,
     ReadyIndexesResponse,
 )
-from virtool.indexes.utils import check_index_file_type, join_index_path
+from virtool.indexes.utils import check_index_file_type
 from virtool.references.db import check_right
+from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
 
@@ -84,19 +82,35 @@ async def download_otus_json(req):
 
     """
     try:
-        json_path = await get_data_from_req(req).index.get_json_path(
-            req.match_info["index_id"]
+        stream, size = await get_data_from_req(req).index.get_otus_json(
+            req.match_info["index_id"],
         )
     except ResourceNotFoundError:
         raise APINotFound()
 
-    return FileResponse(
-        json_path,
+    response = StreamResponse(
         headers={
             "Content-Disposition": "attachment; filename=otus.json.gz",
+            "Content-Length": str(size),
             "Content-Type": "application/octet-stream",
         },
     )
+
+    if size > 0:
+        try:
+            first_chunk = await anext(stream)
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound()
+
+        await response.prepare(req)
+        await response.write(first_chunk)
+
+        async for chunk in stream:
+            await response.write(chunk)
+    else:
+        await response.prepare(req)
+
+    return response
 
 
 @routes.view("/indexes/{index_id}/files/{filename}")
@@ -123,23 +137,36 @@ class IndexFileView(PydanticView):
         if not await check_right(self.request, reference.id, "read"):
             raise APIInsufficientRights()
 
-        path = (
-            join_index_path(
-                get_config_from_req(self.request).data_path, reference.id, index_id
-            )
-            / filename
+        try:
+            stream, size = await get_data_from_req(
+                self.request,
+            ).index.get_index_file(index_id, filename)
+        except ResourceNotFoundError:
+            raise APINotFound("File not found")
+
+        response = StreamResponse(
+            headers={
+                "Content-Disposition": f"attachment; filename={filename}",
+                "Content-Length": str(size),
+                "Content-Type": "application/octet-stream",
+            },
         )
 
-        if await to_thread(path.exists):
-            return FileResponse(
-                path,
-                headers={
-                    "Content-Disposition": f"attachment; filename={filename}",
-                    "Content-Type": "application/octet-stream",
-                },
-            )
+        if size > 0:
+            try:
+                first_chunk = await anext(stream)
+            except (StopAsyncIteration, StorageKeyNotFoundError):
+                raise APINotFound("File not found")
 
-        raise APINotFound("File not found")
+            await response.prepare(self.request)
+            await response.write(first_chunk)
+
+            async for chunk in stream:
+                await response.write(chunk)
+        else:
+            await response.prepare(self.request)
+
+        return response
 
 
 @routes.jobs_api.get("/indexes/{index_id}/files/{filename}")
@@ -152,23 +179,36 @@ async def download_index_file_for_jobs(req: Request):
     index_id = req.match_info["index_id"]
     filename = req.match_info["filename"]
 
-    if filename not in INDEX_FILE_NAMES:
-        raise APINotFound()
-
     try:
-        reference = await get_data_from_req(req).index.get_reference(index_id)
+        stream, size = await get_data_from_req(req).index.get_index_file(
+            index_id,
+            filename,
+        )
     except ResourceNotFoundError:
         raise APINotFound()
 
-    path = (
-        join_index_path(get_config_from_req(req).data_path, reference.id, index_id)
-        / filename
+    response = StreamResponse(
+        headers={
+            "Content-Length": str(size),
+            "Content-Type": "application/octet-stream",
+        },
     )
 
-    if await to_thread(path.exists):
-        return FileResponse(path)
+    if size > 0:
+        try:
+            first_chunk = await anext(stream)
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound()
 
-    raise APINotFound("File not found")
+        await response.prepare(req)
+        await response.write(first_chunk)
+
+        async for chunk in stream:
+            await response.write(chunk)
+    else:
+        await response.prepare(req)
+
+    return response
 
 
 @routes.jobs_api.put("/indexes/{index_id}/files/{filename}")
@@ -184,7 +224,7 @@ async def upload(req):
         raise APINotFound("Index file not found")
 
     try:
-        reference = await get_data_from_req(req).index.get_reference(index_id)
+        await get_data_from_req(req).index.get_reference(index_id)
     except ResourceNotFoundError:
         raise APINotFound()
 
@@ -192,7 +232,7 @@ async def upload(req):
 
     try:
         index_file = await get_data_from_req(req).index.upload_file(
-            reference.id, index_id, file_type, name, req.multipart
+            index_id, file_type, name, req.multipart
         )
     except ResourceConflictError:
         raise APIConflict("File name already exists")

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -1,3 +1,5 @@
+from collections.abc import AsyncIterator
+
 from aiohttp.web import Request, StreamResponse
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r404
@@ -25,6 +27,32 @@ from virtool.references.db import check_right
 from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
+
+
+async def stream_storage_response(
+    req: Request,
+    stream: AsyncIterator[bytes],
+    size: int,
+    headers: dict[str, str],
+    not_found_message: str = "",
+) -> StreamResponse:
+    response = StreamResponse(headers=headers)
+
+    if size > 0:
+        try:
+            first_chunk = await anext(stream)
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound(not_found_message or None)
+
+        await response.prepare(req)
+        await response.write(first_chunk)
+
+        async for chunk in stream:
+            await response.write(chunk)
+    else:
+        await response.prepare(req)
+
+    return response
 
 
 @routes.view("/indexes")
@@ -88,29 +116,16 @@ async def download_otus_json(req):
     except ResourceNotFoundError:
         raise APINotFound()
 
-    response = StreamResponse(
-        headers={
+    return await stream_storage_response(
+        req,
+        stream,
+        size,
+        {
             "Content-Disposition": "attachment; filename=otus.json.gz",
             "Content-Length": str(size),
             "Content-Type": "application/octet-stream",
         },
     )
-
-    if size > 0:
-        try:
-            first_chunk = await anext(stream)
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound()
-
-        await response.prepare(req)
-        await response.write(first_chunk)
-
-        async for chunk in stream:
-            await response.write(chunk)
-    else:
-        await response.prepare(req)
-
-    return response
 
 
 @routes.view("/indexes/{index_id}/files/{filename}")
@@ -144,29 +159,17 @@ class IndexFileView(PydanticView):
         except ResourceNotFoundError:
             raise APINotFound("File not found")
 
-        response = StreamResponse(
-            headers={
+        return await stream_storage_response(
+            self.request,
+            stream,
+            size,
+            {
                 "Content-Disposition": f"attachment; filename={filename}",
                 "Content-Length": str(size),
                 "Content-Type": "application/octet-stream",
             },
+            not_found_message="File not found",
         )
-
-        if size > 0:
-            try:
-                first_chunk = await anext(stream)
-            except (StopAsyncIteration, StorageKeyNotFoundError):
-                raise APINotFound("File not found")
-
-            await response.prepare(self.request)
-            await response.write(first_chunk)
-
-            async for chunk in stream:
-                await response.write(chunk)
-        else:
-            await response.prepare(self.request)
-
-        return response
 
 
 @routes.jobs_api.get("/indexes/{index_id}/files/{filename}")
@@ -187,28 +190,15 @@ async def download_index_file_for_jobs(req: Request):
     except ResourceNotFoundError:
         raise APINotFound()
 
-    response = StreamResponse(
-        headers={
+    return await stream_storage_response(
+        req,
+        stream,
+        size,
+        {
             "Content-Length": str(size),
             "Content-Type": "application/octet-stream",
         },
     )
-
-    if size > 0:
-        try:
-            first_chunk = await anext(stream)
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound()
-
-        await response.prepare(req)
-        await response.write(first_chunk)
-
-        async for chunk in stream:
-            await response.write(chunk)
-    else:
-        await response.prepare(req)
-
-    return response
 
 
 @routes.jobs_api.put("/indexes/{index_id}/files/{filename}")

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -197,7 +197,7 @@ class IndexData:
             index["manifest"],
         )
 
-        compressed = gzip.compress(dump_bytes(patched_otus))
+        compressed = await asyncio.to_thread(gzip.compress, dump_bytes(patched_otus))
 
         async def _stream():
             yield compressed

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -1,6 +1,6 @@
 import asyncio
-from asyncio import to_thread
-from pathlib import Path
+import gzip
+from collections.abc import AsyncIterator
 
 from multidict import MultiDictProxy
 from sqlalchemy.exc import IntegrityError
@@ -23,12 +23,13 @@ from virtool.history.db import HISTORY_LIST_PROJECTION
 from virtool.history.models import HistorySearchResult
 from virtool.indexes.checks import check_fasta_file_uploaded, check_index_files_uploaded
 from virtool.indexes.db import (
+    INDEX_FILE_NAMES,
     lookup_index_otu_counts,
     update_last_indexed_versions,
 )
 from virtool.indexes.models import Index, IndexFile, IndexMinimal, IndexSearchResult
 from virtool.indexes.sql import SQLIndexFile
-from virtool.indexes.utils import join_index_path
+from virtool.indexes.utils import compose_index_file_key, compose_index_prefix
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
@@ -37,9 +38,9 @@ from virtool.references.db import lookup_nested_reference_by_id
 from virtool.references.models import ReferenceNested
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.storage.protocol import StorageBackend
-from virtool.uploads.utils import multipart_file_chunker, naive_writer
+from virtool.uploads.utils import multipart_file_chunker
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import base_processor, compress_json_with_gzip, wait_for_checks
+from virtool.utils import base_processor, wait_for_checks
 
 logger = get_logger("indexes")
 
@@ -170,40 +171,43 @@ class IndexData:
 
         raise ResourceNotFoundError
 
-    async def get_json_path(self, index_id: str) -> Path:
-        """Get the json path needed for a complete compressed JSON
-        representation of the index OTUs.
+    async def get_otus_json(
+        self,
+        index_id: str,
+    ) -> tuple[AsyncIterator[bytes], int]:
+        """Get a complete compressed JSON representation of the index OTUs.
 
         :param index_id: the index ID
-        :return: the json path
+        :return: an async iterator of bytes and the size
         """
         index = await self._mongo.indexes.find_one(index_id)
 
         if index is None:
             raise ResourceNotFoundError()
 
-        ref_id = index["reference"]["id"]
+        key = compose_index_file_key(index_id, "otus.json.gz")
 
-        json_path = (
-            join_index_path(self._config.data_path, ref_id, index_id) / "otus.json.gz"
+        async for info in self._storage.list(key):
+            if info.key == key:
+                return self._storage.read(key), info.size
+
+        patched_otus = await virtool.indexes.db.get_patched_otus(
+            self._mongo,
+            self._storage,
+            index["manifest"],
         )
 
-        if not json_path.exists():
-            patched_otus = await virtool.indexes.db.get_patched_otus(
-                self._mongo,
-                self._storage,
-                index["manifest"],
-            )
+        compressed = gzip.compress(dump_bytes(patched_otus))
 
-            json_string = dump_bytes(patched_otus)
+        async def _stream():
+            yield compressed
 
-            await to_thread(compress_json_with_gzip, json_string, json_path)
+        size = await self._storage.write(key, _stream())
 
-        return json_path
+        return self._storage.read(key), size
 
     async def upload_file(
         self,
-        reference_id: str,
         index_id: str,
         file_type: str,
         name: str,
@@ -211,7 +215,6 @@ class IndexData:
     ) -> IndexFile:
         """Uploads a new index file.
 
-        :param reference_id: the reference ID
         :param index_id: the index ID
         :param file_type: the type of the file to upload
         :param name: the name of the new file
@@ -228,15 +231,12 @@ class IndexData:
             except IntegrityError:
                 raise ResourceConflictError()
 
-            index_path = self._config.data_path / "references" / index_id
+            key = compose_index_file_key(index_id, name)
 
-            await asyncio.to_thread(index_path.mkdir, parents=True, exist_ok=True)
-
-            path = (
-                join_index_path(self._config.data_path, reference_id, index_id) / name
+            size = await self._storage.write(
+                key,
+                multipart_file_chunker(await multipart()),
             )
-
-            size = await naive_writer(multipart_file_chunker(await multipart()), path)
 
             index_file.size = size
             index_file.uploaded_at = virtool.utils.timestamp()
@@ -250,6 +250,28 @@ class IndexData:
             **index_file_dict,
             download_url=f"/indexes/{index_id}/files/{name}",
         )
+
+    async def get_index_file(
+        self,
+        index_id: str,
+        filename: str,
+    ) -> tuple[AsyncIterator[bytes], int]:
+        """Get an index file as a stream.
+
+        :param index_id: the index ID
+        :param filename: the file name
+        :return: an async iterator of bytes and the size
+        """
+        if filename not in INDEX_FILE_NAMES:
+            raise ResourceNotFoundError
+
+        key = compose_index_file_key(index_id, filename)
+
+        async for info in self._storage.list(key):
+            if info.key == key:
+                return self._storage.read(key), info.size
+
+        raise ResourceNotFoundError
 
     @emits(Operation.UPDATE)
     async def finalize(self, index_id: str) -> Index:
@@ -357,5 +379,12 @@ class IndexData:
                 {"$set": {"index": {"id": "unbuilt", "version": "unbuilt"}}},
                 session=mongo_session,
             )
+
+        await asyncio.gather(
+            *[
+                self._storage.delete(obj.key)
+                async for obj in self._storage.list(compose_index_prefix(index_id))
+            ],
+        )
 
         emit(index, "indexes", "delete", Operation.DELETE)

--- a/virtool/indexes/utils.py
+++ b/virtool/indexes/utils.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-
 def check_index_file_type(file_name: str) -> str:
     """Get the index file type based on the extension of given `file_name`
 
@@ -17,12 +14,9 @@ def check_index_file_type(file_name: str) -> str:
     return "bowtie2"
 
 
-def join_index_path(data_path: Path, reference_id: str, index_id: str) -> Path:
-    """Return the path to an index.
+def compose_index_file_key(index_id: str, filename: str) -> str:
+    return f"indexes/{index_id}/{filename}"
 
-    :param data_path: the application data path
-    :param reference_id: the ID of the parent reference
-    :param index_id: the ID of the index
-    :return: the index path
-    """
-    return data_path / "references" / reference_id / index_id
+
+def compose_index_prefix(index_id: str) -> str:
+    return f"indexes/{index_id}/"


### PR DESCRIPTION
## Summary
- Replace direct filesystem access in the indexes module with the storage abstraction layer (`StorageBackend`)
- Rename `join_index_path` to `compose_index_file_key`/`compose_index_prefix` returning object-storage keys instead of filesystem paths
- Update file upload, download, and delete operations to stream through the storage backend; update API handlers to use `StreamResponse` instead of `FileResponse`

## Test plan
- [ ] Run `mise run test -- tests/indexes` to verify all index tests pass
- [ ] Verify index file upload stores the file under the correct key (`indexes/{index_id}/{filename}`)
- [ ] Verify downloading an index file (bowtie2/fasta/json) streams the correct bytes
- [ ] Verify `download_otus_json` falls back to generating and caching the gzipped JSON when not already in storage
- [ ] Verify deleting an index removes all associated storage objects