### PR TITLE
chore: adopt storage abstraction in uploads module

### DIFF
--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -21,9 +21,9 @@ from virtool.references.tasks import (
     ReferencesCleanTask,
     RemoteReferenceTask,
 )
-from virtool.references.utils import upload_file_key
 from virtool.tasks.sql import SQLTask
 from virtool.uploads.sql import SQLUpload, UploadType
+from virtool.uploads.utils import upload_file_key
 from virtool.utils import get_temp_dir
 from virtool.workflow.pytest_plugin.utils import StaticTime
 

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -43,11 +43,10 @@ async def test_create(
     assert row.name_on_disk.endswith("-sample_1.fq.gz")
 
     key = upload_file_key(row.name_on_disk)
-    chunks = []
-    async for chunk in memory_storage.read(key):
-        chunks.append(chunk)
 
-    assert b"".join(chunks) == open(fake_file_path, "rb").read()
+    assert b"".join(
+        [chunk async for chunk in memory_storage.read(key)]
+    ) == fake_file_path.read_bytes()
 
 
 async def test_delete(

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -44,9 +44,10 @@ async def test_create(
 
     key = upload_file_key(row.name_on_disk)
 
-    assert b"".join(
-        [chunk async for chunk in memory_storage.read(key)]
-    ) == fake_file_path.read_bytes()
+    assert (
+        b"".join([chunk async for chunk in memory_storage.read(key)])
+        == fake_file_path.read_bytes()
+    )
 
 
 async def test_delete(

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -8,14 +8,16 @@ from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.pg.utils import get_row_by_id
+from virtool.storage.protocol import StorageBackend
 from virtool.uploads.sql import SQLUpload, UploadType
+from virtool.uploads.utils import upload_file_key
 
 
 async def test_create(
-    data_path: Path,
     data_layer: DataLayer,
     example_path: Path,
     fake: DataFaker,
+    memory_storage: StorageBackend,
     pg: AsyncEngine,
 ):
     user = await fake.users.create()
@@ -40,24 +42,30 @@ async def test_create(
     assert row.name == "sample_1.fq.gz"
     assert row.name_on_disk.endswith("-sample_1.fq.gz")
 
-    assert (
-        open(data_path / "files" / row.name_on_disk, "rb").read()
-        == open(fake_file_path, "rb").read()
-    )
+    key = upload_file_key(row.name_on_disk)
+    chunks = []
+    async for chunk in memory_storage.read(key):
+        chunks.append(chunk)
+
+    assert b"".join(chunks) == open(fake_file_path, "rb").read()
 
 
 async def test_delete(
-    data_path: Path,
     data_layer: DataLayer,
     fake: DataFaker,
+    memory_storage: StorageBackend,
     pg: AsyncEngine,
 ):
     before = await fake.uploads.create(user=await fake.users.create())
 
     row = await get_row_by_id(pg, SQLUpload, before.id)
-    path = data_path / "files" / row.name_on_disk
+    key = upload_file_key(row.name_on_disk)
 
-    assert path.is_file()
+    found = False
+    async for info in memory_storage.list(key):
+        if info.key == key:
+            found = True
+    assert found
     assert before.removed_at is None
 
     after = await data_layer.uploads.delete(before.id)
@@ -66,7 +74,12 @@ async def test_delete(
     assert after.name == before.name
     assert after.removed is True
     assert after.removed_at is not None
-    assert not path.is_file()
+
+    found = False
+    async for info in memory_storage.list(key):
+        if info.key == key:
+            found = True
+    assert not found
 
     with pytest.raises(ResourceNotFoundError):
         await data_layer.uploads.get(before.id)

--- a/virtool/api/streaming.py
+++ b/virtool/api/streaming.py
@@ -1,0 +1,32 @@
+from collections.abc import AsyncIterator
+
+from aiohttp.web import Request, StreamResponse
+
+from virtool.api.errors import APINotFound
+from virtool.storage.errors import StorageKeyNotFoundError
+
+
+async def stream_storage_response(
+    req: Request,
+    stream: AsyncIterator[bytes],
+    size: int,
+    headers: dict[str, str],
+    not_found_message: str = "",
+) -> StreamResponse:
+    response = StreamResponse(headers=headers)
+
+    if size > 0:
+        try:
+            first_chunk = await anext(stream)
+        except (StopAsyncIteration, StorageKeyNotFoundError):
+            raise APINotFound(not_found_message or None)
+
+        await response.prepare(req)
+        await response.write(first_chunk)
+
+        async for chunk in stream:
+            await response.write(chunk)
+    else:
+        await response.prepare(req)
+
+    return response

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -108,6 +108,6 @@ def create_data_layer(
         SessionData(pg),
         SettingsData(mongo),
         TasksData(pg),
-        UploadsData(config, mongo, pg),
+        UploadsData(config, mongo, pg, storage),
         UsersData(pg),
     )

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -1,6 +1,4 @@
-from collections.abc import AsyncIterator
-
-from aiohttp.web import Request, StreamResponse
+from aiohttp.web import Request
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r404
 from pydantic import Field
@@ -13,6 +11,7 @@ from virtool.api.errors import (
     APINotFound,
 )
 from virtool.api.routes import Routes
+from virtool.api.streaming import stream_storage_response
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.history.models import HistorySearchResult
@@ -24,35 +23,8 @@ from virtool.indexes.oas import (
 )
 from virtool.indexes.utils import check_index_file_type
 from virtool.references.db import check_right
-from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
-
-
-async def stream_storage_response(
-    req: Request,
-    stream: AsyncIterator[bytes],
-    size: int,
-    headers: dict[str, str],
-    not_found_message: str = "",
-) -> StreamResponse:
-    response = StreamResponse(headers=headers)
-
-    if size > 0:
-        try:
-            first_chunk = await anext(stream)
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound(not_found_message or None)
-
-        await response.prepare(req)
-        await response.write(first_chunk)
-
-        async for chunk in stream:
-            await response.write(chunk)
-    else:
-        await response.prepare(req)
-
-    return response
 
 
 @routes.view("/indexes")

--- a/virtool/references/tasks.py
+++ b/virtool/references/tasks.py
@@ -10,11 +10,11 @@ from virtool.references.utils import (
     ReferenceSourceData,
     load_reference_file,
     load_reference_from_storage,
-    upload_file_key,
 )
 from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.tasks.progress import AccumulatingProgressHandlerWrapper
 from virtool.tasks.task import BaseTask
+from virtool.uploads.utils import upload_file_key
 
 if TYPE_CHECKING:
     from virtool.data.layer import DataLayer

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -208,11 +208,6 @@ def check_will_change(old: dict, imported: dict) -> bool:
     return False
 
 
-def upload_file_key(name_on_disk: str) -> str:
-    """Derive the storage key for an uploaded file."""
-    return f"files/{name_on_disk}"
-
-
 def load_reference_file(path: Path) -> dict:
     """Load a list of merged otus documents from a file associated with a Virtool
     reference file.

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -1,4 +1,3 @@
-from aiohttp.web_fileresponse import FileResponse
 from aiohttp.web_response import Response
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r401, r403, r404
@@ -8,6 +7,7 @@ from virtool.api.custom_json import json_response
 from virtool.api.errors import APINotFound
 from virtool.api.policy import PermissionRoutePolicy, policy
 from virtool.api.routes import Routes
+from virtool.api.streaming import stream_storage_response
 from virtool.authorization.permissions import LegacyPermission
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
@@ -76,7 +76,7 @@ class UploadsView(PydanticView):
 
 @routes.view("/uploads/{upload_id}")
 class UploadView(PydanticView):
-    async def get(self, upload_id: int, /) -> r200[FileResponse] | r404:
+    async def get(self, upload_id: int, /) -> r200 | r404:
         """Download an upload.
 
         Downloads a previously uploaded file.
@@ -90,17 +90,20 @@ class UploadView(PydanticView):
             404: Not found
         """
         try:
-            upload_path, name = await get_data_from_req(
+            stream, size, name = await get_data_from_req(
                 self.request
             ).uploads.get_upload_file_info(upload_id)
         except ResourceNotFoundError:
             raise APINotFound()
 
-        return FileResponse(
-            upload_path,
-            headers={
+        return await stream_storage_response(
+            self.request,
+            stream,
+            size,
+            {
                 "Content-Disposition": f"attachment; filename={name}",
                 "Content-Type": "application/octet-stream",
+                "Content-Length": str(size),
             },
         )
 
@@ -133,16 +136,19 @@ async def download(req):
     upload_id = int(req.match_info["id"])
 
     try:
-        upload_path, name = await get_data_from_req(req).uploads.get_upload_file_info(
+        stream, size, name = await get_data_from_req(req).uploads.get_upload_file_info(
             upload_id
         )
     except ResourceNotFoundError:
         raise APINotFound()
 
-    return FileResponse(
-        upload_path,
-        headers={
+    return await stream_storage_response(
+        req,
+        stream,
+        size,
+        {
             "Content-Disposition": f"attachment; filename={name}",
             "Content-Type": "application/octet-stream",
+            "Content-Length": str(size),
         },
     )

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -183,9 +183,9 @@ class UploadsData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             upload = (
                 await session.execute(
-                    select(SQLUpload.name_on_disk, SQLUpload.name).filter_by(
-                        id=upload_id, removed=False
-                    ),
+                    select(
+                        SQLUpload.name_on_disk, SQLUpload.name, SQLUpload.size
+                    ).filter_by(id=upload_id, removed=False),
                 )
             ).first()
 
@@ -194,11 +194,7 @@ class UploadsData(DataLayerDomain):
 
         key = upload_file_key(upload.name_on_disk)
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), info.size, upload.name
-
-        raise ResourceNotFoundError
+        return self._storage.read(key), upload.size, upload.name
 
     @emits(Operation.DELETE)
     async def delete(self, upload_id: int) -> Upload:

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -1,9 +1,6 @@
-import asyncio
 import math
 import uuid
-from asyncio import to_thread
-from contextlib import suppress
-from pathlib import Path
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select, update
@@ -14,11 +11,11 @@ from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.events import Operation, emits
 from virtool.data.transforms import apply_transforms
+from virtool.storage.protocol import StorageBackend
 from virtool.uploads.models import Upload, UploadSearchResult
 from virtool.uploads.sql import SQLUpload, UploadType
-from virtool.uploads.utils import get_upload_path, naive_writer
+from virtool.uploads.utils import upload_file_key
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import rm
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -27,10 +24,13 @@ if TYPE_CHECKING:
 class UploadsData(DataLayerDomain):
     name = "uploads"
 
-    def __init__(self, config, mongo: "Mongo", pg: AsyncEngine):
+    def __init__(
+        self, config, mongo: "Mongo", pg: AsyncEngine, storage: StorageBackend
+    ):
         self._config = config
         self._mongo: Mongo = mongo
         self._pg: AsyncEngine = pg
+        self._storage = storage
 
     async def find(
         self,
@@ -114,14 +114,13 @@ class UploadsData(DataLayerDomain):
         user: int | None = None,
     ) -> Upload:
         """Create an upload."""
-        uploads_path = self._config.data_path / "files"
-
-        await asyncio.to_thread(uploads_path.mkdir, parents=True, exist_ok=True)
-
         created_at = virtool.utils.timestamp()
         name_on_disk = f"{uuid.uuid4()}-{name}"
 
-        size = await naive_writer(chunker, uploads_path / name_on_disk)
+        size = await self._storage.write(
+            upload_file_key(name_on_disk),
+            chunker,
+        )
 
         async with AsyncSession(self._pg) as session:
             upload = SQLUpload(
@@ -173,11 +172,13 @@ class UploadsData(DataLayerDomain):
             ),
         )
 
-    async def get_upload_file_info(self, upload_id: int) -> tuple[Path, str]:
-        """Get the file path and original name for downloading an upload.
+    async def get_upload_file_info(
+        self, upload_id: int
+    ) -> tuple[AsyncIterator[bytes], int, str]:
+        """Get a stream, size, and original name for downloading an upload.
 
         :param upload_id: the upload's ID
-        :return: a tuple of the file path and original filename
+        :return: a tuple of the file stream, size, and original filename
         """
         async with AsyncSession(self._pg) as session:
             upload = (
@@ -191,10 +192,13 @@ class UploadsData(DataLayerDomain):
             if not upload:
                 raise ResourceNotFoundError
 
-        return (
-            await get_upload_path(self._config, upload.name_on_disk),
-            upload.name,
-        )
+        key = upload_file_key(upload.name_on_disk)
+
+        async for info in self._storage.list(key):
+            if info.key == key:
+                return self._storage.read(key), info.size, upload.name
+
+        raise ResourceNotFoundError
 
     @emits(Operation.DELETE)
     async def delete(self, upload_id: int) -> Upload:
@@ -227,8 +231,7 @@ class UploadsData(DataLayerDomain):
             **await apply_transforms(upload, [AttachUserTransform(self._pg)], self._pg),
         )
 
-        with suppress(FileNotFoundError):
-            await to_thread(rm, self._config.data_path / "files" / name_on_disk)
+        await self._storage.delete(upload_file_key(name_on_disk))
 
         return upload
 

--- a/virtool/uploads/utils.py
+++ b/virtool/uploads/utils.py
@@ -1,17 +1,7 @@
-from asyncio import to_thread
-from collections.abc import AsyncGenerator, Callable
-from pathlib import Path
-from typing import Any
+from collections.abc import AsyncGenerator
 
 from aiohttp import MultipartReader
 from cerberus import Validator
-from structlog import get_logger
-
-from virtool.config.cls import Config
-from virtool.data.errors import ResourceNotFoundError
-from virtool.data.file import ChunkWriter
-
-logger = get_logger("uploads")
 
 CHUNK_SIZE = 1024 * 1000 * 50
 
@@ -53,48 +43,6 @@ async def multipart_file_chunker(
         yield chunk
 
 
-async def naive_writer(
-    chunker,
-    path: Path,
-    on_first_chunk: Callable[[bytes], Any] | None = None,
-) -> int:
-    """Write a new file from an HTTP multipart request.
-
-    :param chunker: yields chunks of a file acquired from a multipart request
-    :param path: the file path to write the data to
-    :param on_first_chunk: a function to call with the first chunk of the file stream
-    :return: size of the new file in bytes
-    """
-    size = 0
-
-    await to_thread(path.parent.mkdir, exist_ok=True, parents=True)
-
-    async with ChunkWriter(path) as writer:
-        async for chunk in chunker:
-            if type(chunk) is str:
-                logger.warning(
-                    "got string chunk while writing file",
-                    path=path,
-                    chunk=chunk,
-                )
-                break
-
-            if size == 0 and on_first_chunk:
-                on_first_chunk(chunk)
-
-            await writer.write(chunk)
-            size += len(chunk)
-
-    logger.info("wrote file", path=path, size=size)
-
-    return size
-
-
-async def get_upload_path(config: Config, name_on_disk: str) -> Path:
-    """Get the local upload path and return it."""
-    upload_path = config.data_path / "files" / name_on_disk
-
-    if not await to_thread(upload_path.exists):
-        raise ResourceNotFoundError("Uploaded file not found at expected location")
-
-    return upload_path
+def upload_file_key(name_on_disk: str) -> str:
+    """Derive the storage key for an uploaded file."""
+    return f"files/{name_on_disk}"


### PR DESCRIPTION
## Summary

- Replace direct filesystem operations in `UploadsData` with `StorageBackend` protocol calls for upload creation, download, and deletion
- Move `upload_file_key` helper from `virtool/references/utils.py` to `virtool/uploads/utils.py` (canonical location) and remove now-unused filesystem helpers (`naive_writer`, `get_upload_path`)
- Extract `stream_storage_response` into `virtool/api/streaming.py` to share it between the indexes and uploads API handlers

## Test plan

- [ ] Run `mise run test -- tests/uploads -n4` and verify all upload tests pass
- [ ] Run `mise run test -- tests/references -n4` to confirm the moved `upload_file_key` import doesn't break reference task tests
- [ ] Run `mise run test -- tests/indexes -n4` to confirm the shared `stream_storage_response` import is working correctly