### PR TITLE
feat(references): add archived field and backfill migration

### DIFF
--- a/assets/revisions/rev_g2cecswiq3r2_add_archived_to_references.py
+++ b/assets/revisions/rev_g2cecswiq3r2_add_archived_to_references.py
@@ -12,8 +12,8 @@ name = "add archived to references"
 created_at = arrow.get("2026-04-24 20:04:03.395399")
 revision_id = "g2cecswiq3r2"
 
-alembic_down_revision = "ie7r3vdaf5mu"
-virtool_down_revision = None
+alembic_down_revision = None
+virtool_down_revision = "ie7r3vdaf5mu"
 
 required_alembic_revision = None
 

--- a/assets/revisions/rev_g2cecswiq3r2_add_archived_to_references.py
+++ b/assets/revisions/rev_g2cecswiq3r2_add_archived_to_references.py
@@ -1,0 +1,26 @@
+"""Add archived to references.
+
+Revision ID: g2cecswiq3r2
+Date: 2026-04-24 20:04:03.395399
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+
+name = "add archived to references"
+created_at = arrow.get("2026-04-24 20:04:03.395399")
+revision_id = "g2cecswiq3r2"
+
+alembic_down_revision = "ie7r3vdaf5mu"
+virtool_down_revision = None
+
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill ``archived`` on reference documents that predate the field."""
+    await ctx.mongo.references.update_many(
+        {"archived": {"$exists": False}},
+        {"$set": {"archived": False}},
+    )

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -55,8 +55,8 @@ async def test_find(
     await asyncio.gather(
         mongo.references.insert_many(
             [
-                {"_id": "foo", "data_type": "genome", "name": "Foo"},
-                {"_id": "baz", "data_type": "genome", "name": "Baz"},
+                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
+                {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
             ],
             session=None,
         ),
@@ -166,7 +166,7 @@ async def test_get(
             session=None,
         ),
         mongo.references.insert_one(
-            {"_id": "baz", "data_type": "genome", "name": "Baz"},
+            {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
         ),
     )
 
@@ -237,7 +237,7 @@ async def test_get_304(
             session=None,
         ),
         mongo.references.insert_one(
-            {"_id": "baz", "data_type": "genome", "name": "Baz"},
+            {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
         ),
         mongo.samples.insert_one(
             {
@@ -297,7 +297,7 @@ async def test_remove(
             {"_id": "bar", "version": 3, "reference": {"id": "baz"}},
         ),
         mongo.references.insert_one(
-            {"_id": "baz", "data_type": "genome", "name": "Baz"},
+            {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
         ),
         mongo.subtraction.insert_many(
             [{"_id": "plum", "name": "Plum"}, {"_id": "apple", "name": "Apple"}],
@@ -605,7 +605,7 @@ class TestFinalize:
                 },
             ),
             mongo.references.insert_one(
-                {"_id": "baz", "name": "Baz", "data_type": "genome"},
+                {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
             ),
             mongo.samples.insert_one(
                 {

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -32,8 +32,9 @@ async def setup_sample(mongo: "Mongo", fake: DataFaker) -> str:
         mongo.references.insert_one(
             {
                 "_id": "test_ref",
-                "name": "Test Reference",
+                "archived": False,
                 "data_type": "genome",
+                "name": "Test Reference",
             },
         ),
         mongo.subtraction.insert_many(

--- a/tests/blast/test_tasks.py
+++ b/tests/blast/test_tasks.py
@@ -25,7 +25,12 @@ async def test_task(
     await asyncio.gather(
         mongo.samples.insert_one({"_id": "sample"}),
         mongo.references.insert_one(
-            {"_id": "reference", "name": "Reference", "data_type": "genome"},
+            {
+                "_id": "reference",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Reference",
+            },
         ),
     )
 

--- a/tests/fixtures/references.py
+++ b/tests/fixtures/references.py
@@ -22,6 +22,7 @@ def check_ref_right(mocker: MockerFixture, request):
 def test_ref():
     return {
         "_id": "hxn167",
+        "archived": False,
         "data_type": "genome",
         "groups": [],
         "name": "Reference A",
@@ -34,6 +35,7 @@ def test_ref():
 def reference(static_time):
     return {
         "_id": "3tt0w336",
+        "archived": False,
         "created_at": static_time.datetime,
         "data_type": "genome",
         "description": "",

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -19,7 +19,12 @@ async def test_find(
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"},
+            {
+                "_id": "hxn167",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Reference A",
+            },
         ),
         mongo.history.insert_many(
             [{**c, "user": {"id": client.user.id}} for c in test_changes],
@@ -52,7 +57,12 @@ async def test_get(
             session=None,
         ),
         mongo.references.insert_one(
-            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"},
+            {
+                "_id": "hxn167",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Reference A",
+            },
         ),
     )
 

--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -26,7 +26,12 @@ async def test_get(
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "hxn167", "data_type": "genome", "name": "Reference A"},
+            {
+                "_id": "hxn167",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Reference A",
+            },
         ),
         mongo.history.insert_one(
             {

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -88,8 +88,18 @@ class TestFind:
             ),
             mongo.references.insert_many(
                 [
-                    {"_id": "bar", "name": "Bar", "data_type": "genome"},
-                    {"_id": "foo", "name": "Foo", "data_type": "genome"},
+                    {
+                        "_id": "bar",
+                        "archived": False,
+                        "data_type": "genome",
+                        "name": "Bar",
+                    },
+                    {
+                        "_id": "foo",
+                        "archived": False,
+                        "data_type": "genome",
+                        "name": "Foo",
+                    },
                 ],
                 session=None,
             ),
@@ -150,8 +160,18 @@ class TestFind:
             ),
             mongo.references.insert_many(
                 [
-                    {"_id": "bar", "name": "Bar", "data_type": "genome"},
-                    {"_id": "foo", "name": "Foo", "data_type": "genome"},
+                    {
+                        "_id": "bar",
+                        "archived": False,
+                        "data_type": "genome",
+                        "name": "Bar",
+                    },
+                    {
+                        "_id": "foo",
+                        "archived": False,
+                        "data_type": "genome",
+                        "name": "Foo",
+                    },
                 ],
                 session=None,
             ),
@@ -181,7 +201,7 @@ async def test_get(
     await asyncio.gather(
         mongo.references.insert_many(
             [
-                {"_id": "bar", "name": "Bar", "data_type": "genome"},
+                {"_id": "bar", "archived": False, "data_type": "genome", "name": "Bar"},
             ],
             session=None,
         ),
@@ -320,7 +340,7 @@ class TestCreate:
 
         await asyncio.gather(
             mongo.references.insert_one(
-                {"_id": "foo", "name": "Foo", "data_type": "genome"},
+                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
             ),
             # Insert unbuilt changes to prevent initial check failure.
             mongo.history.insert_one(
@@ -461,8 +481,8 @@ async def test_find_history(
         ),
         mongo.references.insert_many(
             [
-                {"_id": "bar", "name": "Bar", "data_type": "genome"},
-                {"_id": "foo", "name": "Foo", "data_type": "genome"},
+                {"_id": "bar", "archived": False, "data_type": "genome", "name": "Bar"},
+                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
             ],
             session=None,
         ),
@@ -494,7 +514,7 @@ async def test_delete_index(
     if error != 404:
         await asyncio.gather(
             mongo.references.insert_one(
-                {"_id": "foo", "data_type": "genome", "name": "Foo"},
+                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
             ),
             mongo.indexes.insert_one(
                 {
@@ -557,8 +577,8 @@ async def test_upload(
         fake.users.create(),
         mongo.references.insert_many(
             [
-                {"_id": "bar", "name": "Bar", "data_type": "genome"},
-                {"_id": "foo", "name": "Foo", "data_type": "genome"},
+                {"_id": "bar", "archived": False, "data_type": "genome", "name": "Bar"},
+                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
             ],
             session=None,
         ),
@@ -646,7 +666,12 @@ async def test_finalize(
 
     if error != "404_reference":
         await mongo.references.insert_one(
-            {"_id": "hxn167", "name": "Test A", "data_type": "genome"},
+            {
+                "_id": "hxn167",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Test A",
+            },
         )
 
     await asyncio.gather(
@@ -699,7 +724,12 @@ async def test_download(
             {"_id": "test_index", "reference": {"id": "test_reference"}},
         ),
         mongo.references.insert_one(
-            {"_id": "test_reference", "name": "Test A", "data_type": "genome"},
+            {
+                "_id": "test_reference",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Test A",
+            },
         ),
     )
 

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -21,7 +21,7 @@ async def test_finalize(
 
     await asyncio.gather(
         mongo.references.insert_one(
-            {"_id": "bar", "name": "Bar", "data_type": "genome"},
+            {"_id": "bar", "archived": False, "data_type": "genome", "name": "Bar"},
         ),
         mongo.indexes.insert_one(
             {

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -176,5 +176,12 @@
       'name': 'backfill user ids to integers',
       'revision': 'ie7r3vdaf5mu',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 26,
+      'name': 'add archived to references',
+      'revision': 'g2cecswiq3r2',
+    }),
   ])
 # ---

--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -82,7 +82,12 @@ async def test_check_segment_or_target(
     await asyncio.gather(
         mongo.otus.insert_one({"_id": "foo", "schema": [{"name": "RNA1"}]}),
         mongo.references.insert_one(
-            {"_id": "bar", "data_type": data_type, "targets": [{"name": "CPN60"}]}
+            {
+                "_id": "bar",
+                "archived": False,
+                "data_type": data_type,
+                "targets": [{"name": "CPN60"}],
+            }
         ),
         mongo.sequences.insert_one(
             {

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -4,6 +4,7 @@
 # ---
 # name: TestCreate.test_clone[resp]
   dict({
+    'archived': False,
     'cloned_from': dict({
       'id': 'foo',
       'name': 'Foo',
@@ -61,6 +62,7 @@
 # ---
 # name: TestCreate.test_import
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -133,6 +135,7 @@
 # ---
 # name: TestCreate.test_ok[barcode][resp]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -183,6 +186,7 @@
 # ---
 # name: TestCreate.test_ok[genome][resp]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -232,6 +236,7 @@
 # ---
 # name: TestCreate.test_remote[resp]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -666,6 +671,7 @@
 # name: TestDeleteUser.test_ok
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -824,6 +830,7 @@
 # ---
 # name: TestGet.test_ok
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -891,6 +898,7 @@
 # name: TestUpdateUser.test_ok.1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -939,6 +947,7 @@
 # name: test_create_group[None].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -1045,6 +1054,7 @@
 # name: test_create_user[None][mongo]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -1092,6 +1102,7 @@
 # name: test_delete_group[None]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -1144,6 +1155,7 @@
 # name: test_edit[None-barcode][db]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'barcode',
     'description': 'This is a test reference.',
@@ -1189,6 +1201,7 @@
 # ---
 # name: test_edit[None-barcode][resp]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -1251,6 +1264,7 @@
 # name: test_edit[None-genome][db]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -1289,6 +1303,7 @@
 # ---
 # name: test_edit[None-genome][resp]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -1346,6 +1361,7 @@
   dict({
     'documents': list([
       dict({
+        'archived': False,
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'barcode',
@@ -1376,6 +1392,7 @@
         }),
       }),
       dict({
+        'archived': False,
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'barcode',
@@ -1406,6 +1423,7 @@
         }),
       }),
       dict({
+        'archived': False,
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
@@ -1855,6 +1873,7 @@
 # name: test_update_group[None][mongo]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',

--- a/tests/references/__snapshots__/test_data.ambr
+++ b/tests/references/__snapshots__/test_data.ambr
@@ -2,6 +2,7 @@
 # name: TestCreateGroup.test_ok_and_duplicate[mongo]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -43,6 +44,7 @@
 # ---
 # name: TestCreateUser.test_ok[reference]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -110,6 +112,7 @@
 # name: TestDeleteGroup.test_ok
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -131,6 +134,7 @@
 # name: TestDeleteUser.test_ok
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -152,6 +156,7 @@
 # name: TestPopulateRemoteReference.test_ok
   dict({
     '_id': 'ref_id',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'Remote reference description',
@@ -295,6 +300,7 @@
 # ---
 # name: TestUpdate.test_control[-False]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -340,6 +346,7 @@
 # name: TestUpdate.test_control[-False].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -367,6 +374,7 @@
 # ---
 # name: TestUpdate.test_control[-True]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -412,6 +420,7 @@
 # name: TestUpdate.test_control[-True].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -439,6 +448,7 @@
 # ---
 # name: TestUpdate.test_control[None-False]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -484,6 +494,7 @@
 # name: TestUpdate.test_control[None-False].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -511,6 +522,7 @@
 # ---
 # name: TestUpdate.test_control[None-True]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -556,6 +568,7 @@
 # name: TestUpdate.test_control[None-True].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -583,6 +596,7 @@
 # ---
 # name: TestUpdate.test_control[baz-False]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -628,6 +642,7 @@
 # name: TestUpdate.test_control[baz-False].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -655,6 +670,7 @@
 # ---
 # name: TestUpdate.test_control[baz-True]
   dict({
+    'archived': False,
     'cloned_from': None,
     'contributors': list([
     ]),
@@ -700,6 +716,7 @@
 # name: TestUpdate.test_control[baz-True].1
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -728,6 +745,7 @@
 # name: TestUpdateGroup.test_ok[mongo]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',
@@ -3562,6 +3580,7 @@
 # name: TestUpdateUser.test_ok[mongo]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'This is a test reference.',

--- a/tests/references/__snapshots__/test_tasks.ambr
+++ b/tests/references/__snapshots__/test_tasks.ambr
@@ -2,6 +2,7 @@
 # name: test_clean_references_task[clean]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2020, 1, 1, 21, 0),
     'data_type': 'genome',
     'description': '',
@@ -32,6 +33,7 @@
 # name: test_clean_references_task[no_updates]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2020, 1, 1, 21, 0),
     'data_type': 'genome',
     'description': '',
@@ -62,6 +64,7 @@
 # name: test_clean_references_task[ready]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2020, 1, 1, 21, 0),
     'data_type': 'genome',
     'description': '',
@@ -114,6 +117,7 @@
 # name: test_clean_references_task[too_new]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2020, 1, 1, 21, 0),
     'data_type': 'genome',
     'description': '',
@@ -167,6 +171,7 @@
 # name: test_clean_references_task[too_old]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2020, 1, 1, 21, 0),
     'data_type': 'genome',
     'description': '',
@@ -2443,6 +2448,7 @@
 # name: test_import_reference_task[ref]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'A test reference',
@@ -5101,6 +5107,7 @@
 # name: test_remote_reference_task[ref]
   dict({
     '_id': 'foo',
+    'archived': False,
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'data_type': 'genome',
     'description': 'A test reference',

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -48,6 +48,7 @@ async def test_find(
         [
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "groups": [],
@@ -60,6 +61,7 @@ async def test_find(
             },
             {
                 "_id": "baz",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "barcode",
                 "groups": [],
@@ -72,6 +74,7 @@ async def test_find(
             },
             {
                 "_id": "bar",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "barcode",
                 "groups": [],
@@ -85,6 +88,7 @@ async def test_find(
             },
             {
                 "_id": "goo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "barcode",
                 "groups": [{"id": group.id}],
@@ -269,6 +273,7 @@ class TestCreate:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": virtool.utils.timestamp(),
                 "data_type": "genome",
                 "name": "Foo",
@@ -383,6 +388,7 @@ async def test_edit(
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": virtool.utils.timestamp(),
                 "data_type": data_type,
                 "name": "Foo",
@@ -480,6 +486,7 @@ async def test_delete(
     await mongo.references.insert_one(
         {
             "_id": "foo",
+            "archived": False,
             "created_at": virtool.utils.timestamp(),
             "data_type": "genome",
             "description": "This is a test reference.",
@@ -927,6 +934,7 @@ async def test_create_user(
 
     document = {
         "_id": "foo",
+        "archived": False,
         "created_at": static_time.datetime,
         "data_type": "genome",
         "description": "This is a test reference.",
@@ -1010,6 +1018,7 @@ async def test_create_group(
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -1067,6 +1076,7 @@ class TestUpdateUser:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -1145,6 +1155,7 @@ async def test_update_group(
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -1206,6 +1217,7 @@ class TestDeleteUser:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -1270,6 +1282,7 @@ async def test_delete_group(
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -51,6 +51,7 @@ class TestUpdate:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -136,6 +137,7 @@ class TestCreateUser:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -187,6 +189,7 @@ class TestCreateUser:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -226,6 +229,7 @@ class TestUpdateUser:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -286,6 +290,7 @@ class TestUpdateUser:
             await mongo.references.insert_one(
                 {
                     "_id": "foo",
+                    "archived": False,
                     "created_at": static_time.datetime,
                     "data_type": "genome",
                     "description": "This is a test reference.",
@@ -326,6 +331,7 @@ class TestDeleteUser:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -377,6 +383,7 @@ class TestDeleteUser:
             await mongo.references.insert_one(
                 {
                     "_id": "foo",
+                    "archived": False,
                     "created_at": static_time.datetime,
                     "data_type": "genome",
                     "description": "This is a test reference.",
@@ -411,6 +418,7 @@ class TestCreateGroup:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -481,6 +489,7 @@ class TestCreateGroup:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -520,6 +529,7 @@ class TestUpdateGroup:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -573,6 +583,7 @@ class TestUpdateGroup:
             await mongo.references.insert_one(
                 {
                     "_id": "foo",
+                    "archived": False,
                     "created_at": static_time.datetime,
                     "data_type": "genome",
                     "description": "This is a test reference.",
@@ -613,6 +624,7 @@ class TestDeleteGroup:
         await mongo.references.insert_one(
             {
                 "_id": "foo",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "This is a test reference.",
@@ -664,6 +676,7 @@ class TestDeleteGroup:
             await mongo.references.insert_one(
                 {
                     "_id": "foo",
+                    "archived": False,
                     "created_at": static_time.datetime,
                     "data_type": "genome",
                     "description": "This is a test reference.",
@@ -863,6 +876,7 @@ class TestUpdateRemoteReference:
         await mongo.references.insert_one(
             {
                 "_id": ref_id,
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "Test remote reference",
@@ -1585,6 +1599,7 @@ class TestPopulateRemoteReference:
         await mongo.references.insert_one(
             {
                 "_id": "ref_id",
+                "archived": False,
                 "created_at": static_time.datetime,
                 "data_type": "genome",
                 "description": "Remote reference description",

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -65,6 +65,7 @@ async def test_check_right(
     await mongo.references.insert_one(
         {
             "_id": "baz",
+            "archived": False,
             "groups": [
                 {
                     "id": "foo" if membership == "group" else "none",
@@ -118,6 +119,7 @@ async def test_fetch_and_update_release(mongo: Mongo, fake_app, snapshot, static
     await mongo.references.insert_one(
         {
             "_id": "fake_ref_id",
+            "archived": False,
             "installed": {"name": "1.0.0-fake-install"},
             "release": {"name": "1.0.0-fake-release"},
             "remotes_from": {"slug": "virtool/ref-plant-viruses"},

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -102,6 +102,7 @@ async def test_clean_references_task(
     await mongo.references.insert_one(
         {
             "_id": "foo",
+            "archived": False,
             "created_at": datetime.datetime(2020, 1, 1, 21, 0, 0),
             "data_type": "genome",
             "description": "",
@@ -246,6 +247,7 @@ async def test_import_reference_task(
     await mongo.references.insert_one(
         {
             "_id": "foo",
+            "archived": False,
             "created_at": static_time.datetime,
             "data_type": "genome",
             "description": "A test reference",
@@ -331,6 +333,7 @@ async def test_remote_reference_task(
             mongo.references.insert_one(
                 {
                     "_id": "foo",
+                    "archived": False,
                     "created_at": static_time.datetime,
                     "data_type": "genome",
                     "description": "A test reference",
@@ -430,6 +433,7 @@ async def create_reference(
             mongo.references.insert_one(
                 {
                     "_id": "bar",
+                    "archived": False,
                     "created_at": static_time.datetime,
                     "data_type": "genome",
                     "description": "This is a test reference.",
@@ -468,6 +472,7 @@ async def test_clone_reference_task(
     await mongo.references.insert_one(
         {
             "_id": "foo",
+            "archived": False,
             "created_at": static_time.datetime,
             "data_type": "genome",
             "description": "A test reference",

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1063,8 +1063,8 @@ async def test_find_analyses(
         ),
         mongo.references.insert_many(
             [
-                {"_id": "foo", "data_type": "genome", "name": "Foo"},
-                {"_id": "baz", "data_type": "genome", "name": "Baz"},
+                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
+                {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
             ],
             session=None,
         ),
@@ -1155,8 +1155,9 @@ async def test_analyze(
         await mongo.references.insert_one(
             {
                 "_id": "test_ref",
-                "name": "Test Reference",
+                "archived": False,
                 "data_type": "genome",
+                "name": "Test Reference",
             },
         )
 

--- a/virtool/migration/required.py
+++ b/virtool/migration/required.py
@@ -1,6 +1,6 @@
 """Required migration constants."""
 
-REQUIRED_VIRTOOL_REVISION = "1c57bca78c4c"
+REQUIRED_VIRTOOL_REVISION = "g2cecswiq3r2"
 """The revision that Virtool requires to be applied before it can run.
 
 This constant can be updated automatically using `virtool migrate depend`.

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -561,6 +561,7 @@ async def create_document(
 
     document = {
         "_id": ref_id,
+        "archived": False,
         "created_at": created_at,
         "data_type": data_type,
         "description": description,

--- a/virtool/references/models.py
+++ b/virtool/references/models.py
@@ -140,6 +140,7 @@ class ReferenceNested(BaseModel):
 
 
 class ReferenceMinimal(ReferenceNested):
+    archived: bool
     cloned_from: ReferenceClonedFrom | None = None
     created_at: datetime
     imported_from: UploadMinimal | None = None
@@ -168,6 +169,7 @@ class Reference(ReferenceMinimal):
     class Config:
         schema_extra = {
             "example": {
+                "archived": False,
                 "cloned_from": {"id": "pat6xdn3", "name": "Plant Viruses"},
                 "contributors": [
                     {
@@ -253,6 +255,7 @@ class ReferenceSearchResult(SearchResult):
             "example": {
                 "documents": [
                     {
+                        "archived": False,
                         "cloned_from": {"id": "pat6xdn3", "name": "Plant Viruses"},
                         "created_at": "2022-01-28T23:42:48.321000Z",
                         "data_type": "genome",


### PR DESCRIPTION
## Summary

- Add non-optional `archived: bool` to `ReferenceMinimal`, propagating it through `Reference`, `ReferenceSearchResult`, and every `AttachReferenceTransform` consumer (analyses, OTUs, indexes, history).
- Default `archived: False` in `create_document` so clone, import, remote, and fresh creation paths all persist the field.
- Ship migration `g2cecswiq3r2` that backfills `archived: False` on legacy Mongo references and bump `REQUIRED_VIRTOOL_REVISION` so the server refuses to boot until the backfill has applied — the field is required, so reads of un-migrated docs would otherwise fail Pydantic validation.
- Update reference fixtures, inline test inserts under `tests/references/`, and regenerated snapshots.

Closes VIR-2295.