### PR TITLE
feat: make job counts endpoints public for KEDA

### DIFF
--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -81,6 +81,7 @@ class JobsView(PydanticView):
 
 @routes.view("/jobs/counts")
 class JobsCountsView(PydanticView):
+    @policy(PublicRoutePolicy)
     async def get(self) -> r200[dict[str, dict[str, int]]]:
         """Get job counts.
 
@@ -94,6 +95,7 @@ class JobsCountsView(PydanticView):
 
 @routes.view("/jobs/v2/counts")
 class JobsCountsV2View(PydanticView):
+    @policy(PublicRoutePolicy)
     async def get(self) -> r200[JobCountsV2]:
         """Get v2 job counts.
 


### PR DESCRIPTION
## Summary
- Apply `PublicRoutePolicy` to both `/jobs/counts` and `/jobs/v2/counts` endpoints so they can be accessed without authentication
- This enables KEDA (Kubernetes Event-driven Autoscaling) to poll job counts for autoscaling decisions without requiring API credentials

## Test plan
- [ ] Verify `/jobs/counts` returns 200 without authentication headers
- [ ] Verify `/jobs/v2/counts` returns 200 without authentication headers
- [ ] Confirm other job endpoints (e.g. `/jobs`, `/jobs/v2`) still require authentication