### PR TITLE
fix: skip DNS deliverability check in account email validation

### DIFF
--- a/virtool/account/models.py
+++ b/virtool/account/models.py
@@ -18,11 +18,9 @@ def check_email(email: str | None) -> str:
         return email
 
     try:
-        validate_email(email, check_deliverability=False)
+        return validate_email(email, check_deliverability=False).normalized
     except EmailSyntaxError:
         raise ValueError("The format of the email is invalid")
-
-    return email
 
 
 class AccountSettings(BaseModel):

--- a/virtool/account/models.py
+++ b/virtool/account/models.py
@@ -18,7 +18,7 @@ def check_email(email: str | None) -> str:
         return email
 
     try:
-        validate_email(email)
+        validate_email(email, check_deliverability=False)
     except EmailSyntaxError:
         raise ValueError("The format of the email is invalid")
 


### PR DESCRIPTION
## Summary
- The `email-validator` library performs a DNS lookup by default to verify email deliverability, which can fail in environments with restricted DNS access or network issues
- Disables the DNS deliverability check in `validate_email()` so that email format validation succeeds even when DNS resolution is unavailable

## Test plan
- [ ] Update account email to a valid address and verify it is accepted
- [ ] Attempt to set an invalid email address and verify it is rejected with the expected error message
- [ ] Verify no DNS-related errors occur in environments where DNS resolution may be restricted