### PR TITLE
feat: backfill mongodb user id fields to integers

### DIFF
--- a/assets/revisions/rev_ie7r3vdaf5mu_backfill_user_ids_to_integers.py
+++ b/assets/revisions/rev_ie7r3vdaf5mu_backfill_user_ids_to_integers.py
@@ -16,13 +16,11 @@ Date: 2026-04-28 18:00:54.759190
 from typing import TYPE_CHECKING
 
 import arrow
-from sqlalchemy import select
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from virtool.groups.pg import SQLGroup
 from virtool.migration import MigrationContext
-from virtool.users.pg import SQLUser
 
 if TYPE_CHECKING:
     from motor.motor_asyncio import AsyncIOMotorDatabase
@@ -55,14 +53,12 @@ SIMPLE_USER_COLLECTIONS = (
 async def upgrade(ctx: MigrationContext) -> None:
     async with AsyncSession(ctx.pg) as pg_session:
         user_result = await pg_session.execute(
-            select(SQLUser.id, SQLUser.legacy_id).where(SQLUser.legacy_id.isnot(None)),
+            text("SELECT id, legacy_id FROM users WHERE legacy_id IS NOT NULL"),
         )
         user_map: dict[str, int] = {row.legacy_id: row.id for row in user_result}
 
         group_result = await pg_session.execute(
-            select(SQLGroup.id, SQLGroup.legacy_id).where(
-                SQLGroup.legacy_id.isnot(None),
-            ),
+            text("SELECT id, legacy_id FROM groups WHERE legacy_id IS NOT NULL"),
         )
         group_map: dict[str, int] = {row.legacy_id: row.id for row in group_result}
 

--- a/assets/revisions/rev_ie7r3vdaf5mu_backfill_user_ids_to_integers.py
+++ b/assets/revisions/rev_ie7r3vdaf5mu_backfill_user_ids_to_integers.py
@@ -79,32 +79,26 @@ async def upgrade(ctx: MigrationContext) -> None:
     await _backfill_users_groups(ctx.mongo, group_map)
 
 
-def _coerce_user_id(value: int | str, user_map: dict[str, int]) -> int:
+def _coerce_id(value: int | str, id_map: dict[str, int], resource_name: str) -> int:
     if isinstance(value, int):
         return value
 
     if isinstance(value, str) and value.isdigit():
         return int(value)
 
-    if value not in user_map:
-        msg = f"User legacy id {value!r} not found in postgres"
+    if value not in id_map:
+        msg = f"{resource_name} legacy id {value!r} not found in postgres"
         raise ValueError(msg)
 
-    return user_map[value]
+    return id_map[value]
+
+
+def _coerce_user_id(value: int | str, user_map: dict[str, int]) -> int:
+    return _coerce_id(value, user_map, "User")
 
 
 def _coerce_group_id(value: int | str, group_map: dict[str, int]) -> int:
-    if isinstance(value, int):
-        return value
-
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-
-    if value not in group_map:
-        msg = f"Group legacy id {value!r} not found in postgres"
-        raise ValueError(msg)
-
-    return group_map[value]
+    return _coerce_id(value, group_map, "Group")
 
 
 async def _backfill_user_field(
@@ -160,15 +154,19 @@ async def _backfill_references(
         update: dict = {}
 
         user = doc.get("user")
+        users_list = doc.get("users")
+
+        if not (user and "id" in user) and users_list is None:
+            skipped += 1
+            continue
+
         if user and "id" in user:
             current = user["id"]
             new = _coerce_user_id(current, user_map)
             if not (isinstance(current, int) and new == current):
                 update["user.id"] = new
-        else:
-            skipped += 1
 
-        users = doc.get("users") or []
+        users = users_list or []
         new_users = []
         users_changed = False
 

--- a/assets/revisions/rev_ie7r3vdaf5mu_backfill_user_ids_to_integers.py
+++ b/assets/revisions/rev_ie7r3vdaf5mu_backfill_user_ids_to_integers.py
@@ -1,0 +1,237 @@
+"""Backfill MongoDB user.id fields to integers.
+
+Rewrites legacy string user IDs (stored when users lived in MongoDB) to the
+matching ``SQLUser.id`` integer in every Mongo collection that still carries a
+denormalized ``user.id``. Also rewrites the legacy group id strings in the
+``groups`` array of the Mongo ``users`` collection to ``SQLGroup.id``
+integers.
+
+Idempotent: integer ids are passed through unchanged, so a second run is a
+no-op.
+
+Revision ID: ie7r3vdaf5mu
+Date: 2026-04-28 18:00:54.759190
+"""
+
+from typing import TYPE_CHECKING
+
+import arrow
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.groups.pg import SQLGroup
+from virtool.migration import MigrationContext
+from virtool.users.pg import SQLUser
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill user ids to integers"
+created_at = arrow.get("2026-04-28 18:00:54.759190")
+revision_id = "ie7r3vdaf5mu"
+
+alembic_down_revision = "bd1ffbecfce5"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+SIMPLE_USER_COLLECTIONS = (
+    "keys",
+    "samples",
+    "subtractions",
+    "analyses",
+    "otus",
+    "history",
+    "indexes",
+)
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        user_result = await pg_session.execute(
+            select(SQLUser.id, SQLUser.legacy_id).where(SQLUser.legacy_id.isnot(None)),
+        )
+        user_map: dict[str, int] = {row.legacy_id: row.id for row in user_result}
+
+        group_result = await pg_session.execute(
+            select(SQLGroup.id, SQLGroup.legacy_id).where(
+                SQLGroup.legacy_id.isnot(None),
+            ),
+        )
+        group_map: dict[str, int] = {row.legacy_id: row.id for row in group_result}
+
+    logger.info(
+        "built id maps",
+        users=len(user_map),
+        groups=len(group_map),
+    )
+
+    for collection_name in SIMPLE_USER_COLLECTIONS:
+        await _backfill_user_field(ctx.mongo, collection_name, user_map)
+
+    await _backfill_references(ctx.mongo, user_map)
+    await _backfill_users_groups(ctx.mongo, group_map)
+
+
+def _coerce_user_id(value: int | str, user_map: dict[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+
+    if value not in user_map:
+        msg = f"User legacy id {value!r} not found in postgres"
+        raise ValueError(msg)
+
+    return user_map[value]
+
+
+def _coerce_group_id(value: int | str, group_map: dict[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+
+    if value not in group_map:
+        msg = f"Group legacy id {value!r} not found in postgres"
+        raise ValueError(msg)
+
+    return group_map[value]
+
+
+async def _backfill_user_field(
+    mongo: "AsyncIOMotorDatabase",
+    collection_name: str,
+    user_map: dict[str, int],
+) -> None:
+    collection = mongo[collection_name]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find({}, projection={"user": 1}):
+        user = doc.get("user")
+        if not user or "id" not in user:
+            skipped += 1
+            continue
+
+        current = user["id"]
+        new = _coerce_user_id(current, user_map)
+
+        if new == current and isinstance(current, int):
+            unchanged += 1
+            continue
+
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"user.id": new}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled user.id",
+        collection=collection_name,
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )
+
+
+async def _backfill_references(
+    mongo: "AsyncIOMotorDatabase",
+    user_map: dict[str, int],
+) -> None:
+    collection = mongo["references"]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find({}, projection={"user": 1, "users": 1}):
+        update: dict = {}
+
+        user = doc.get("user")
+        if user and "id" in user:
+            current = user["id"]
+            new = _coerce_user_id(current, user_map)
+            if not (isinstance(current, int) and new == current):
+                update["user.id"] = new
+        else:
+            skipped += 1
+
+        users = doc.get("users") or []
+        new_users = []
+        users_changed = False
+
+        for entry in users:
+            if "id" not in entry:
+                new_users.append(entry)
+                continue
+            current = entry["id"]
+            new = _coerce_user_id(current, user_map)
+            if not (isinstance(current, int) and new == current):
+                users_changed = True
+            new_entry = {**entry, "id": new}
+            new_users.append(new_entry)
+
+        if users_changed:
+            update["users"] = new_users
+
+        if not update:
+            unchanged += 1
+            continue
+
+        await collection.update_one({"_id": doc["_id"]}, {"$set": update})
+        migrated += 1
+
+    logger.info(
+        "backfilled references",
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )
+
+
+async def _backfill_users_groups(
+    mongo: "AsyncIOMotorDatabase",
+    group_map: dict[str, int],
+) -> None:
+    collection = mongo["users"]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find({}, projection={"groups": 1}):
+        groups = doc.get("groups")
+        if groups is None:
+            skipped += 1
+            continue
+
+        new_groups = [_coerce_group_id(g, group_map) for g in groups]
+
+        if new_groups == groups and all(isinstance(g, int) for g in groups):
+            unchanged += 1
+            continue
+
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"groups": new_groups}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled users.groups",
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -169,5 +169,12 @@
       'name': 'drop b2c columns from users',
       'revision': 'bd1ffbecfce5',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 25,
+      'name': 'backfill user ids to integers',
+      'revision': 'ie7r3vdaf5mu',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_user_ids_to_integers.py
+++ b/tests/migration/test_backfill_user_ids_to_integers.py
@@ -1,0 +1,275 @@
+"""Tests for the backfill-user-ids-to-integers migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_ie7r3vdaf5mu_backfill_user_ids_to_integers import upgrade
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_users_and_groups(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed two users + two groups with legacy ids.
+
+    Returns a mapping of legacy id -> Postgres id covering both users and
+    groups (the keys do not collide in the test data).
+    """
+    await asyncio.to_thread(apply_alembic, "head")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES
+                    ('alice', 'alice_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb),
+                    ('bob', 'bob_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_ids = {row.legacy_id: row.id for row in result}
+
+        result = await session.execute(
+            text("""
+                INSERT INTO groups (legacy_id, name, permissions)
+                VALUES
+                    ('admins_legacy', 'admins', '{}'::jsonb),
+                    ('readers_legacy', 'readers', '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+        )
+        group_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return {**user_ids, **group_ids}
+
+
+class TestSimpleCollections:
+    """``user.id`` rewrites for the flat-shaped collections."""
+
+    @pytest.mark.parametrize(
+        "collection_name",
+        ["keys", "samples", "subtractions", "analyses", "otus", "history", "indexes"],
+    )
+    async def test_legacy_string_converts(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+        collection_name: str,
+    ):
+        await ctx.mongo[collection_name].insert_one(
+            {"_id": "doc1", "user": {"id": "alice_legacy"}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo[collection_name].find_one({"_id": "doc1"})
+        assert doc["user"]["id"] == setup_users_and_groups["alice_legacy"]
+        assert isinstance(doc["user"]["id"], int)
+
+    async def test_already_int_passthrough(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        pg_id = setup_users_and_groups["bob_legacy"]
+        await ctx.mongo.samples.insert_one(
+            {"_id": "s1", "user": {"id": pg_id}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "s1"})
+        assert doc["user"]["id"] == pg_id
+
+    async def test_digit_string_coerces(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        pg_id = setup_users_and_groups["alice_legacy"]
+        await ctx.mongo.samples.insert_one(
+            {"_id": "s2", "user": {"id": str(pg_id)}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "s2"})
+        assert doc["user"]["id"] == pg_id
+
+    @pytest.mark.usefixtures("setup_users_and_groups")
+    async def test_missing_user_field_is_skipped(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.samples.insert_one({"_id": "no_user"})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "no_user"})
+        assert "user" not in doc
+
+    @pytest.mark.usefixtures("setup_users_and_groups")
+    async def test_unmapped_legacy_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.samples.insert_one(
+            {"_id": "orphan", "user": {"id": "ghost_user"}},
+        )
+
+        with pytest.raises(ValueError, match="ghost_user"):
+            await upgrade(ctx)
+
+
+class TestReferences:
+    """The ``references`` collection has both ``user.id`` and ``users[].id``."""
+
+    async def test_both_user_and_users_array_convert(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        alice = setup_users_and_groups["alice_legacy"]
+        bob = setup_users_and_groups["bob_legacy"]
+
+        await ctx.mongo.references.insert_one(
+            {
+                "_id": "ref1",
+                "user": {"id": "alice_legacy"},
+                "users": [
+                    {"id": "alice_legacy", "build": True},
+                    {"id": "bob_legacy", "build": False},
+                ],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.references.find_one({"_id": "ref1"})
+        assert doc["user"]["id"] == alice
+        assert [u["id"] for u in doc["users"]] == [alice, bob]
+        assert doc["users"][0]["build"] is True
+        assert doc["users"][1]["build"] is False
+
+    async def test_already_int_unchanged(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        alice = setup_users_and_groups["alice_legacy"]
+
+        await ctx.mongo.references.insert_one(
+            {
+                "_id": "ref2",
+                "user": {"id": alice},
+                "users": [{"id": alice, "build": True}],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.references.find_one({"_id": "ref2"})
+        assert doc["user"]["id"] == alice
+        assert doc["users"][0]["id"] == alice
+
+
+class TestUsersGroups:
+    """The Mongo ``users`` collection has a ``groups[]`` list of group ids."""
+
+    async def test_legacy_string_groups_convert(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        admins = setup_users_and_groups["admins_legacy"]
+        readers = setup_users_and_groups["readers_legacy"]
+
+        await ctx.mongo.users.insert_one(
+            {
+                "_id": "alice_legacy",
+                "groups": ["admins_legacy", "readers_legacy"],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.users.find_one({"_id": "alice_legacy"})
+        assert doc["groups"] == [admins, readers]
+
+    async def test_unmapped_group_raises(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        await ctx.mongo.users.insert_one(
+            {
+                "_id": "orphan_user",
+                "groups": ["admins_legacy", "ghost_group"],
+            },
+        )
+
+        with pytest.raises(ValueError, match="ghost_group"):
+            await upgrade(ctx)
+
+    async def test_missing_groups_field_skipped(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        await ctx.mongo.users.insert_one({"_id": "no_groups"})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.users.find_one({"_id": "no_groups"})
+        assert "groups" not in doc
+
+
+class TestIdempotent:
+    async def test_second_run_is_noop(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        alice = setup_users_and_groups["alice_legacy"]
+        admins = setup_users_and_groups["admins_legacy"]
+
+        await ctx.mongo.samples.insert_one(
+            {"_id": "s1", "user": {"id": "alice_legacy"}},
+        )
+        await ctx.mongo.references.insert_one(
+            {
+                "_id": "ref1",
+                "user": {"id": "alice_legacy"},
+                "users": [{"id": "alice_legacy"}],
+            },
+        )
+        await ctx.mongo.users.insert_one(
+            {"_id": "alice_legacy", "groups": ["admins_legacy"]},
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        sample = await ctx.mongo.samples.find_one({"_id": "s1"})
+        ref = await ctx.mongo.references.find_one({"_id": "ref1"})
+        user_doc = await ctx.mongo.users.find_one({"_id": "alice_legacy"})
+
+        assert sample["user"]["id"] == alice
+        assert ref["user"]["id"] == alice
+        assert ref["users"][0]["id"] == alice
+        assert user_doc["groups"] == [admins]


### PR DESCRIPTION
## Summary

- Adds a new migration (`rev_ie7r3vdaf5mu`) that rewrites legacy string user IDs stored in MongoDB to the matching PostgreSQL integer IDs across all collections that carry a denormalized `user.id` field (`keys`, `samples`, `subtractions`, `analyses`, `otus`, `history`, `indexes`, `references`)
- Also rewrites the legacy group ID strings in the `groups` array of the MongoDB `users` collection to `SQLGroup.id` integers
- Migration is idempotent — documents already using integer IDs are passed through unchanged, so a second run is a no-op

## Test plan

- [ ] Run migration tests: `mise run test -- tests/migration/test_backfill_user_ids_to_integers.py`
- [ ] Verify legacy string IDs are correctly mapped to Postgres integer IDs for each collection
- [ ] Verify already-integer IDs are unchanged after migration
- [ ] Verify digit-string IDs (e.g. `"42"`) are coerced to integers
- [ ] Verify unmapped legacy IDs raise `ValueError`
- [ ] Verify idempotency by running migration twice and checking results are identical
- [ ] Run full migration test suite: `mise run test -- tests/migration`