### PR TITLE
feat: drop JOBS_IN_POSTGRES feature flag

### DIFF
--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -12,7 +12,6 @@ from syrupy.matchers import path_type
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from tests.fixtures.response import RespIs
 from virtool.fake.next import DataFaker
-from virtool.flags import FlagName
 from virtool.jobs.models import JobState
 from virtool.jobs.pg import SQLJob
 from virtool.models.enums import Permission
@@ -314,7 +313,6 @@ class TestClaim:
         """Test that a job can be claimed successfully."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -382,7 +380,6 @@ class TestClaim:
         """Test that 404 is returned when no pending job is available."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         resp = await client.post(
@@ -409,7 +406,6 @@ class TestClaim:
         """Test that the oldest pending job is claimed first."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -457,7 +453,6 @@ class TestClaim:
     ):
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -501,7 +496,6 @@ class TestClaim:
         """Test that already-claimed jobs are skipped."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -577,7 +571,6 @@ class TestStartStep:
         """Test that a step can be started successfully."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -621,7 +614,6 @@ class TestStartStep:
         """Test that 404 is returned when job doesn't exist."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         resp = await client.post("/jobs/99999/steps/step_1/start")
@@ -637,7 +629,6 @@ class TestStartStep:
         """Test that 404 is returned when step doesn't exist."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -671,7 +662,6 @@ class TestStartStep:
         """Test that 409 is returned when step is already started."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()
@@ -716,7 +706,6 @@ class TestStartStep:
         """Test that 409 is returned when job is in a terminal state."""
         client = await spawn_job_client(
             authenticated=False,
-            flags=[FlagName.JOBS_IN_POSTGRES],
         )
 
         user = await fake.users.create()

--- a/tests/jobs/test_auth.py
+++ b/tests/jobs/test_auth.py
@@ -8,7 +8,6 @@ from aiohttp.web_routedef import RouteTableDef
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.flags import FlagName
 from virtool.jobs.models import JobState
 from virtool.jobs.pg import SQLJob
 
@@ -47,7 +46,6 @@ async def test_public_routes_are_public(fake, spawn_job_client):
     """Test that the claim endpoint is public and doesn't require authentication."""
     client = await spawn_job_client(
         authenticated=False,
-        flags=[FlagName.JOBS_IN_POSTGRES],
     )
 
     user = await fake.users.create()
@@ -87,7 +85,6 @@ async def test_authorized_when_header_is_valid(fake, spawn_job_client):
     client = await spawn_job_client(
         authenticated=False,
         add_route_table=test_routes,
-        flags=[FlagName.JOBS_IN_POSTGRES],
     )
 
     key = await claim_job(client, job)
@@ -111,7 +108,6 @@ async def test_unauthorized_with_wrong_job_id(fake, spawn_job_client):
     client = await spawn_job_client(
         authenticated=False,
         add_route_table=test_routes,
-        flags=[FlagName.JOBS_IN_POSTGRES],
     )
 
     key_1 = await claim_job(client, job_1)
@@ -133,7 +129,6 @@ async def test_unauthorized_with_wrong_key(fake, spawn_job_client):
     client = await spawn_job_client(
         authenticated=False,
         add_route_table=test_routes,
-        flags=[FlagName.JOBS_IN_POSTGRES],
     )
     await claim_job(client, job)
 
@@ -180,7 +175,6 @@ async def test_unauthorized_when_job_in_terminal_state(
     client = await spawn_job_client(
         authenticated=False,
         add_route_table=test_routes,
-        flags=[FlagName.JOBS_IN_POSTGRES],
     )
 
     key = await claim_job(client, job)

--- a/virtool/flags.py
+++ b/virtool/flags.py
@@ -9,7 +9,6 @@ from virtool.api.errors import APINotFound
 
 class FlagName(Enum):
     ADMINISTRATOR_ROLES = "ADMINISTRATOR_ROLES"
-    JOBS_IN_POSTGRES = "JOBS_IN_POSTGRES"
     ML_MODELS = "ML_MODELS"
 
 
@@ -19,7 +18,6 @@ class FeatureFlags:
     def __init__(self, overrides: list[FlagName]):
         self._flags = {
             FlagName.ADMINISTRATOR_ROLES: True,
-            FlagName.JOBS_IN_POSTGRES: False,
             FlagName.ML_MODELS: False,
         }
 

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -14,7 +14,6 @@ from virtool.data.errors import (
     ResourceNotFoundError,
 )
 from virtool.data.utils import get_data_from_req
-from virtool.flags import FlagName, flag
 from virtool.jobs.models import (
     CreateJobClaimRequest,
     Job,
@@ -129,7 +128,6 @@ class JobsAPIJobView(PydanticView):
 
 
 @routes.jobs_api.view("/jobs/claim")
-@flag(FlagName.JOBS_IN_POSTGRES)
 class ClaimJobView(PydanticView):
     @policy(PublicRoutePolicy)
     async def post(
@@ -156,7 +154,6 @@ class ClaimJobView(PydanticView):
 
 
 @routes.jobs_api.view("/jobs/{job_id}/steps/{step_id}/start")
-@flag(FlagName.JOBS_IN_POSTGRES)
 class StartJobStepView(PydanticView):
     @policy(PublicRoutePolicy)
     async def post(


### PR DESCRIPTION
## Summary

- Removes the `JOBS_IN_POSTGRES` feature flag now that jobs are fully migrated to PostgreSQL
- Drops the `@flag(FlagName.JOBS_IN_POSTGRES)` decorator from the claim and start-step job API views, making them unconditionally active
- Cleans up all test usages that previously passed the flag to `spawn_job_client`

## Test plan

- [ ] Run the jobs test suite: `mise run test -- tests/jobs`
- [ ] Verify that `POST /jobs/claim` and `POST /jobs/{job_id}/steps/{step_id}/start` endpoints work without the flag being set
- [ ] Confirm no remaining references to `JOBS_IN_POSTGRES` in the codebase