### PR TITLE
fix: ensure workflow_data fixture finalized sample has quality set

### DIFF
--- a/tests/fixtures/workflow_api/samples.py
+++ b/tests/fixtures/workflow_api/samples.py
@@ -7,7 +7,7 @@ from tests.fixtures.workflow_api.utils import (
     custom_dumps,
     generate_not_found,
 )
-from virtool.samples.models import Quality
+from virtool.quality.models import Quality
 from virtool.workflow.pytest_plugin import WorkflowData
 
 

--- a/tests/workflow/data/test_samples.py
+++ b/tests/workflow/data/test_samples.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic_factories import ModelFactory
 from pyfixtures import FixtureScope
 
-from virtool.samples.models import Quality
+from virtool.quality.models import Quality
 from virtool.workflow.data.samples import WFNewSample, WFSample
 from virtool.workflow.errors import JobsAPIConflictError, JobsAPINotFoundError
 from virtool.workflow.pytest_plugin.data import WorkflowData

--- a/virtool/quality/models.py
+++ b/virtool/quality/models.py
@@ -1,5 +1,4 @@
 from virtool.models import BaseModel
-from virtool.samples.models import Quality
 
 
 class NucleotidePoint(BaseModel):

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -6,6 +6,7 @@ from virtool.jobs.models import JobMinimal
 from virtool.labels.models import LabelNested
 from virtool.models import BaseModel, SearchResult
 from virtool.models.enums import LibraryType
+from virtool.quality.models import Quality
 from virtool.samples.models_base import SampleNested
 from virtool.subtractions.models import SubtractionNested
 from virtool.uploads.models import UploadMinimal
@@ -85,16 +86,6 @@ class SampleMinimal(SampleNested):
                 },
             ],
         }
-
-
-class Quality(BaseModel):
-    bases: list[list[int | float]]
-    composition: list[list[int | float]]
-    count: int
-    encoding: str
-    gc: int | float
-    length: list[int]
-    sequences: list[int]
 
 
 class Read(BaseModel):

--- a/virtool/workflow/data/samples.py
+++ b/virtool/workflow/data/samples.py
@@ -9,7 +9,8 @@ from structlog import get_logger
 
 from virtool.jobs.models import Job
 from virtool.models.enums import LibraryType
-from virtool.samples.models import Quality, Sample
+from virtool.quality.models import Quality
+from virtool.samples.models import Sample
 from virtool.workflow.analysis import ReadPaths
 from virtool.workflow.client import WorkflowAPIClient
 from virtool.workflow.data.uploads import WFUploads

--- a/virtool/workflow/pytest_plugin/data.py
+++ b/virtool/workflow/pytest_plugin/data.py
@@ -8,6 +8,7 @@ from virtool.analyses.models import Analysis, AnalysisSample
 from virtool.indexes.models import Index, IndexNested
 from virtool.jobs.models import JobMinimal, JobStep, JobWithKey
 from virtool.ml.models import MLModelRelease
+from virtool.quality.models import Quality
 from virtool.references.models import Reference, ReferenceNested
 from virtool.samples.models import Sample
 from virtool.subtractions.models import Subtraction, SubtractionFile, SubtractionNested
@@ -132,6 +133,16 @@ def workflow_data(
     sample = SampleFactory.build()
     sample.job = JobMinimal.parse_obj(job)
     sample.artifacts = []
+    sample.quality = Quality(
+        bases=[],
+        composition=[],
+        count=0,
+        encoding="",
+        gc=0,
+        length=[0, 0],
+        sequences=[],
+    )
+    sample.ready = True
 
     # A new sample with the fake job configured as the creation job for the sample.
     new_sample = SampleFactory.build()


### PR DESCRIPTION
## Summary
- Moves the `Quality` model from `virtool/samples/models.py` to `virtool/quality/models.py`, where it logically belongs alongside other quality-related models
- Fixes the `workflow_data` pytest fixture so the finalized `sample` always has an explicit `Quality` object and `ready=True`, rather than relying on random factory generation that can produce `None`
- Updates all import sites to reference `Quality` from its new location

## Test plan
- [ ] Run `mise run test -- tests/workflow/data/test_samples.py` to verify the fixture and workflow sample tests pass
- [ ] Run `mise run test -- tests/fixtures` to confirm no fixture regressions
- [ ] Verify no import errors by running a broader test pass: `mise run test`