### PR TITLE
feat(samples): block analyses on archived references and return 409

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -218,6 +218,63 @@ async def test_get(
         await resp_is.not_found(resp)
 
 
+async def test_get_archived_reference(
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    spawn_client: ClientSpawner,
+    static_time: StaticTime,
+):
+    """An existing analysis whose reference is archived still resolves
+    reference metadata on GET via ``AttachReferenceTransform``.
+    """
+    client = await spawn_client(authenticated=True)
+
+    user = await fake.users.create()
+    job = await fake.jobs.create(user=user, state=JobState.SUCCEEDED)
+
+    await asyncio.gather(
+        mongo.references.insert_one(
+            {"_id": "baz", "archived": True, "data_type": "genome", "name": "Baz"},
+        ),
+        mongo.samples.insert_one(
+            {
+                "_id": "baz",
+                "all_read": True,
+                "all_write": False,
+                "group": "tech",
+                "group_read": True,
+                "group_write": True,
+                "labels": [],
+                "subtractions": [],
+                "user": {"id": user.id},
+            },
+        ),
+        mongo.analyses.insert_one(
+            {
+                "_id": "foobar",
+                "created_at": static_time.datetime,
+                "index": {"version": 3, "id": "bar"},
+                "job": {"id": job.id},
+                "ready": True,
+                "reference": {"id": "baz"},
+                "results": {"hits": []},
+                "sample": {"id": "baz"},
+                "subtractions": [],
+                "user": {"id": user.id},
+                "workflow": "pathoscope_bowtie",
+            },
+        ),
+        create_analysis_file(pg, "foobar", "fasta", "reference.fa"),
+    )
+
+    resp = await client.get("/analyses/foobar")
+
+    assert resp.status == HTTPStatus.OK
+    body = await resp.json()
+    assert body["reference"] == {"id": "baz", "data_type": "genome", "name": "Baz"}
+
+
 @pytest.mark.parametrize("ready", [True, False])
 async def test_get_304(
     ready: bool,

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -2137,7 +2137,7 @@
     'message': 'File is not compressed',
   })
 # ---
-# name: test_analyze[None]
+# name: TestAnalyze.test_ok
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'files': list([

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -1,4 +1,50 @@
 # serializer version: 1
+# name: TestAnalyze.test_ok
+  dict({
+    'created_at': '2015-10-06T20:00:00Z',
+    'files': list([
+    ]),
+    'id': 'bf1b993c',
+    'index': dict({
+      'id': 'test',
+      'version': 4,
+    }),
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
+      'id': 1,
+      'progress': 0,
+      'state': 'pending',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'pathoscope',
+    }),
+    'ml': None,
+    'ready': False,
+    'reference': dict({
+      'data_type': 'genome',
+      'id': 'test_ref',
+      'name': 'Test Reference',
+    }),
+    'results': None,
+    'sample': dict({
+      'id': 'test',
+    }),
+    'subtractions': list([
+      dict({
+        'id': 'subtraction_1',
+        'name': 'Subtraction 1',
+      }),
+    ]),
+    'updated_at': '2015-10-06T20:00:00Z',
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflow': 'pathoscope',
+  })
+# ---
 # name: TestChangeSampleRights.test_set_none_group_id[mongo]
   dict({
     '_id': 'test',
@@ -642,6 +688,94 @@
   dict({
     'id': 'bad_request',
     'message': 'Subtractions do not exist: bar',
+  })
+# ---
+# name: TestFinalize.test_quality
+  dict({
+    'all_read': True,
+    'all_write': True,
+    'artifacts': list([
+    ]),
+    'created_at': '2015-10-06T20:00:00Z',
+    'format': 'fastq',
+    'group': None,
+    'group_read': True,
+    'group_write': True,
+    'hold': False,
+    'host': '',
+    'id': 'test',
+    'is_legacy': False,
+    'isolate': '',
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
+      'id': 1,
+      'progress': 100,
+      'state': 'failed',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'create_sample',
+    }),
+    'labels': list([
+      dict({
+        'color': '#629f70',
+        'description': 'American whole magazine truth stop whose.',
+        'id': 1,
+        'name': 'Three',
+      }),
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': True,
+    'quality': dict({
+      'bases': list([
+        list([
+          1543,
+        ]),
+      ]),
+      'composition': list([
+        list([
+          6372,
+        ]),
+      ]),
+      'count': 7069,
+      'encoding': 'OuBQPPuwYimrxkNpPWUx',
+      'gc': 34222440,
+      'length': list([
+        3237,
+      ]),
+      'sequences': list([
+        7091,
+      ]),
+    }),
+    'reads': list([
+    ]),
+    'ready': True,
+    'subtractions': list([
+      dict({
+        'id': 'apple',
+        'name': 'Apple',
+      }),
+      dict({
+        'id': 'pear',
+        'name': 'Pear',
+      }),
+    ]),
+    'uploads': None,
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
+    }),
   })
 # ---
 # name: TestFind.test_labels[None]
@@ -2125,6 +2259,17 @@
     }),
   })
 # ---
+# name: TestUploadArtifact.test_ok
+  dict({
+    'id': 1,
+    'name': 'small.fq.gz',
+    'name_on_disk': 'small.fq.gz',
+    'sample': 'test',
+    'size': 723988,
+    'type': 'fastq',
+    'uploaded_at': '2015-10-06T20:00:00Z',
+  })
+# ---
 # name: TestUploadReads.test[409]
   dict({
     'id': 'conflict',
@@ -2135,140 +2280,6 @@
   dict({
     'id': 'bad_request',
     'message': 'File is not compressed',
-  })
-# ---
-# name: TestAnalyze.test_ok
-  dict({
-    'created_at': '2015-10-06T20:00:00Z',
-    'files': list([
-    ]),
-    'id': 'bf1b993c',
-    'index': dict({
-      'id': 'test',
-      'version': 4,
-    }),
-    'job': dict({
-      'created_at': '2015-10-06T20:00:00Z',
-      'id': 1,
-      'progress': 0,
-      'state': 'pending',
-      'user': dict({
-        'handle': 'leeashley',
-        'id': 1,
-      }),
-      'workflow': 'pathoscope',
-    }),
-    'ml': None,
-    'ready': False,
-    'reference': dict({
-      'data_type': 'genome',
-      'id': 'test_ref',
-      'name': 'Test Reference',
-    }),
-    'results': None,
-    'sample': dict({
-      'id': 'test',
-    }),
-    'subtractions': list([
-      dict({
-        'id': 'subtraction_1',
-        'name': 'Subtraction 1',
-      }),
-    ]),
-    'updated_at': '2015-10-06T20:00:00Z',
-    'user': dict({
-      'handle': 'leeashley',
-      'id': 1,
-    }),
-    'workflow': 'pathoscope',
-  })
-# ---
-# name: test_finalize[quality]
-  dict({
-    'all_read': True,
-    'all_write': True,
-    'artifacts': list([
-    ]),
-    'created_at': '2015-10-06T20:00:00Z',
-    'format': 'fastq',
-    'group': None,
-    'group_read': True,
-    'group_write': True,
-    'hold': False,
-    'host': '',
-    'id': 'test',
-    'is_legacy': False,
-    'isolate': '',
-    'job': dict({
-      'created_at': '2015-10-06T20:00:00Z',
-      'id': 1,
-      'progress': 100,
-      'state': 'failed',
-      'user': dict({
-        'handle': 'leeashley',
-        'id': 1,
-      }),
-      'workflow': 'create_sample',
-    }),
-    'labels': list([
-      dict({
-        'color': '#629f70',
-        'description': 'American whole magazine truth stop whose.',
-        'id': 1,
-        'name': 'Three',
-      }),
-    ]),
-    'library_type': 'normal',
-    'locale': '',
-    'name': 'Test',
-    'notes': '',
-    'nuvs': False,
-    'paired': False,
-    'pathoscope': True,
-    'quality': dict({
-      'bases': list([
-        list([
-          1543,
-        ]),
-      ]),
-      'composition': list([
-        list([
-          6372,
-        ]),
-      ]),
-      'count': 7069,
-      'encoding': 'OuBQPPuwYimrxkNpPWUx',
-      'gc': 34222440,
-      'length': list([
-        3237,
-      ]),
-      'sequences': list([
-        7091,
-      ]),
-    }),
-    'reads': list([
-    ]),
-    'ready': True,
-    'subtractions': list([
-      dict({
-        'id': 'apple',
-        'name': 'Apple',
-      }),
-      dict({
-        'id': 'pear',
-        'name': 'Pear',
-      }),
-    ]),
-    'uploads': None,
-    'user': dict({
-      'handle': 'leeashley',
-      'id': 1,
-    }),
-    'workflows': dict({
-      'aodp': 'incompatible',
-      'nuvs': 'pending',
-      'pathoscope': 'complete',
-    }),
   })
 # ---
 # name: test_find_analyses
@@ -2379,16 +2390,5 @@
     'page_count': 1,
     'per_page': 25,
     'total_count': 3,
-  })
-# ---
-# name: test_upload_artifact[None]
-  dict({
-    'id': 1,
-    'name': 'small.fq.gz',
-    'name_on_disk': 'small.fq.gz',
-    'sample': 'test',
-    'size': 723988,
-    'type': 'fastq',
-    'uploaded_at': '2015-10-06T20:00:00Z',
   })
 # ---

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1151,7 +1151,7 @@ class TestAnalyze:
         return client
 
     @staticmethod
-    async def _seed(
+    async def _insert_analysis_resources(
         mongo: Mongo,
         static_time,
         *,
@@ -1217,7 +1217,7 @@ class TestAnalyze:
         snapshot: SnapshotAssertion,
         static_time,
     ):
-        await self._seed(mongo, static_time)
+        await self._insert_analysis_resources(mongo, static_time)
 
         resp = await self._post(analyze_client)
 
@@ -1232,7 +1232,7 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._seed(mongo, static_time, reference=False)
+        await self._insert_analysis_resources(mongo, static_time, reference=False)
 
         resp = await self._post(analyze_client)
 
@@ -1245,7 +1245,7 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._seed(mongo, static_time, archived=True)
+        await self._insert_analysis_resources(mongo, static_time, archived=True)
 
         resp = await self._post(analyze_client)
 
@@ -1258,7 +1258,7 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._seed(mongo, static_time, index=False)
+        await self._insert_analysis_resources(mongo, static_time, index=False)
 
         resp = await self._post(analyze_client)
 
@@ -1271,7 +1271,7 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._seed(mongo, static_time, index_ready=False)
+        await self._insert_analysis_resources(mongo, static_time, index_ready=False)
 
         resp = await self._post(analyze_client)
 
@@ -1284,7 +1284,7 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._seed(mongo, static_time, subtraction=False)
+        await self._insert_analysis_resources(mongo, static_time, subtraction=False)
 
         resp = await self._post(analyze_client)
 
@@ -1297,7 +1297,7 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._seed(mongo, static_time, sample=False)
+        await self._insert_analysis_resources(mongo, static_time, sample=False)
 
         resp = await self._post(analyze_client)
 

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -839,10 +839,17 @@ class TestEdit:
 class TestFinalize:
     """Test that sample can be finalized using the Jobs API."""
 
-    @staticmethod
-    def _quality_payload(field: str) -> dict:
-        return {
-            field: {
+    async def test_quality(
+        self,
+        resp_is,
+        snapshot,
+        spawn_job_client,
+        get_sample_ready_false,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        json = {
+            "quality": {
                 "bases": [[1543]],
                 "composition": [[6372]],
                 "count": 7069,
@@ -853,17 +860,6 @@ class TestFinalize:
             },
         }
 
-    async def test_quality(
-        self,
-        snapshot,
-        spawn_job_client,
-        tmp_path,
-        get_sample_ready_false,
-    ):
-        client = await spawn_job_client(authenticated=True)
-
-        json = self._quality_payload("quality")
-
         resp = await client.patch("/samples/test", json=json)
 
         assert resp.status == HTTPStatus.OK
@@ -873,21 +869,16 @@ class TestFinalize:
             await get_data_from_app(client.app).uploads.get(1)
 
         resp = await client.patch("/samples/test", json=json)
-        assert resp.status == 500
+        await resp_is.conflict(resp, "Sample already finalized")
 
     async def test_not_quality(
         self,
         resp_is,
         spawn_job_client,
-        tmp_path,
-        get_sample_ready_false,
     ):
         client = await spawn_job_client(authenticated=True)
 
-        resp = await client.patch(
-            "/samples/test",
-            json=self._quality_payload("not_quality"),
-        )
+        resp = await client.patch("/samples/test", json={})
 
         assert resp.status == 422
         await resp_is.invalid_input(resp, {"quality": ["required field"]})
@@ -1238,7 +1229,6 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._insert_index(mongo)
         await self._insert_subtraction(mongo)
         await self._insert_sample(analyze_client, fake)
 

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -836,33 +836,36 @@ class TestEdit:
         assert await resp.json() == snapshot(name="json")
 
 
-@pytest.mark.parametrize("field", ["quality", "not_quality"])
-async def test_finalize(
-    field: str,
-    snapshot,
-    resp_is,
-    spawn_job_client,
-    tmp_path,
-    get_sample_ready_false,
-):
+class TestFinalize:
     """Test that sample can be finalized using the Jobs API."""
-    client = await spawn_job_client(authenticated=True)
 
-    json = {
-        field: {
-            "bases": [[1543]],
-            "composition": [[6372]],
-            "count": 7069,
-            "encoding": "OuBQPPuwYimrxkNpPWUx",
-            "gc": 34222440,
-            "length": [3237],
-            "sequences": [7091],
-        },
-    }
+    @staticmethod
+    def _quality_payload(field: str) -> dict:
+        return {
+            field: {
+                "bases": [[1543]],
+                "composition": [[6372]],
+                "count": 7069,
+                "encoding": "OuBQPPuwYimrxkNpPWUx",
+                "gc": 34222440,
+                "length": [3237],
+                "sequences": [7091],
+            },
+        }
 
-    resp = await client.patch("/samples/test", json=json)
+    async def test_quality(
+        self,
+        snapshot,
+        spawn_job_client,
+        tmp_path,
+        get_sample_ready_false,
+    ):
+        client = await spawn_job_client(authenticated=True)
 
-    if field == "quality":
+        json = self._quality_payload("quality")
+
+        resp = await client.patch("/samples/test", json=json)
+
         assert resp.status == HTTPStatus.OK
         assert await resp.json() == snapshot
 
@@ -871,7 +874,21 @@ async def test_finalize(
 
         resp = await client.patch("/samples/test", json=json)
         assert resp.status == 500
-    else:
+
+    async def test_not_quality(
+        self,
+        resp_is,
+        spawn_job_client,
+        tmp_path,
+        get_sample_ready_false,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        resp = await client.patch(
+            "/samples/test",
+            json=self._quality_payload("not_quality"),
+        )
+
         assert resp.status == 422
         await resp_is.invalid_input(resp, {"quality": ["required field"]})
 
@@ -1151,53 +1168,37 @@ class TestAnalyze:
         return client
 
     @staticmethod
-    async def _insert_analysis_resources(
-        mongo: Mongo,
-        static_time,
-        *,
-        reference: bool = True,
-        archived: bool = False,
-        index: bool = True,
-        index_ready: bool = True,
-        subtraction: bool = True,
-        sample: bool = True,
-    ) -> None:
-        if reference:
-            await mongo.references.insert_one(
-                {
-                    "_id": "test_ref",
-                    "archived": archived,
-                    "data_type": "genome",
-                    "name": "Test Reference",
-                },
-            )
+    async def _insert_reference(mongo: Mongo, *, archived: bool = False) -> None:
+        await mongo.references.insert_one(
+            {
+                "_id": "test_ref",
+                "archived": archived,
+                "data_type": "genome",
+                "name": "Test Reference",
+            },
+        )
 
-        if index:
-            await mongo.indexes.insert_one(
-                {
-                    "_id": "test",
-                    "reference": {"id": "test_ref"},
-                    "ready": index_ready,
-                    "version": 4,
-                },
-            )
+    @staticmethod
+    async def _insert_index(mongo: Mongo, *, ready: bool = True) -> None:
+        await mongo.indexes.insert_one(
+            {
+                "_id": "test",
+                "reference": {"id": "test_ref"},
+                "ready": ready,
+                "version": 4,
+            },
+        )
 
-        if subtraction:
-            await mongo.subtraction.insert_one(
-                {"_id": "subtraction_1", "name": "Subtraction 1"},
-            )
+    @staticmethod
+    async def _insert_subtraction(mongo: Mongo) -> None:
+        await mongo.subtraction.insert_one(
+            {"_id": "subtraction_1", "name": "Subtraction 1"},
+        )
 
-        if sample:
-            await mongo.samples.insert_one(
-                {
-                    "_id": "test",
-                    "name": "Test",
-                    "created_at": static_time.datetime,
-                    "all_read": True,
-                    "all_write": True,
-                    "ready": True,
-                },
-            )
+    @staticmethod
+    async def _insert_sample(client: VirtoolTestClient, fake: DataFaker) -> None:
+        user = await fake.users.create()
+        await create_fake_sample(client.app, "test", user.id, finalized=True)
 
     @staticmethod
     async def _post(client: VirtoolTestClient):
@@ -1213,11 +1214,15 @@ class TestAnalyze:
     async def test_ok(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time)
+        await self._insert_reference(mongo)
+        await self._insert_index(mongo)
+        await self._insert_subtraction(mongo)
+        await self._insert_sample(analyze_client, fake)
 
         resp = await self._post(analyze_client)
 
@@ -1228,11 +1233,14 @@ class TestAnalyze:
     async def test_missing_reference(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         resp_is,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time, reference=False)
+        await self._insert_index(mongo)
+        await self._insert_subtraction(mongo)
+        await self._insert_sample(analyze_client, fake)
 
         resp = await self._post(analyze_client)
 
@@ -1241,11 +1249,15 @@ class TestAnalyze:
     async def test_archived_reference(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         resp_is,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time, archived=True)
+        await self._insert_reference(mongo, archived=True)
+        await self._insert_index(mongo)
+        await self._insert_subtraction(mongo)
+        await self._insert_sample(analyze_client, fake)
 
         resp = await self._post(analyze_client)
 
@@ -1254,11 +1266,14 @@ class TestAnalyze:
     async def test_no_index(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         resp_is,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time, index=False)
+        await self._insert_reference(mongo)
+        await self._insert_subtraction(mongo)
+        await self._insert_sample(analyze_client, fake)
 
         resp = await self._post(analyze_client)
 
@@ -1267,11 +1282,15 @@ class TestAnalyze:
     async def test_unbuilt_index(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         resp_is,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time, index_ready=False)
+        await self._insert_reference(mongo)
+        await self._insert_index(mongo, ready=False)
+        await self._insert_subtraction(mongo)
+        await self._insert_sample(analyze_client, fake)
 
         resp = await self._post(analyze_client)
 
@@ -1280,11 +1299,14 @@ class TestAnalyze:
     async def test_missing_subtraction(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         resp_is,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time, subtraction=False)
+        await self._insert_reference(mongo)
+        await self._insert_index(mongo)
+        await self._insert_sample(analyze_client, fake)
 
         resp = await self._post(analyze_client)
 
@@ -1297,64 +1319,94 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._insert_analysis_resources(mongo, static_time, sample=False)
+        await self._insert_reference(mongo)
+        await self._insert_index(mongo)
+        await self._insert_subtraction(mongo)
 
         resp = await self._post(analyze_client)
 
         await resp_is.not_found(resp)
 
 
-@pytest.mark.parametrize("error", [None, 400, 409])
-async def test_upload_artifact(
-    error: int | None,
-    example_path: Path,
-    memory_storage,
-    mongo: Mongo,
-    resp_is,
-    snapshot: SnapshotAssertion,
-    spawn_job_client: JobClientSpawner,
-    static_time,
-):
+class TestUploadArtifact:
     """Test that new artifacts can be uploaded after sample creation using the Jobs API."""
-    path = example_path / "sample" / "reads_1.fq.gz"
 
-    client = await spawn_job_client(authenticated=True)
+    @staticmethod
+    async def _insert_sample(mongo: Mongo) -> None:
+        await mongo.samples.insert_one({"_id": "test", "ready": True})
 
-    await mongo.samples.insert_one(
-        {
-            "_id": "test",
-            "ready": True,
-        },
-    )
-
-    artifact_type = "fastq" if error != 400 else "foo"
-
-    data = {"file": open(path, "rb")}
-
-    resp = await client.post(
-        f"/samples/test/artifacts?name=small.fq.gz&type={artifact_type}",
-        data=data,
-    )
-
-    if error == 409:
-        resp_2 = await client.post(
+    @staticmethod
+    async def _post(
+        client: VirtoolTestClient,
+        path: Path,
+        artifact_type: str,
+    ):
+        return await client.post(
             f"/samples/test/artifacts?name=small.fq.gz&type={artifact_type}",
-            data={**data, "file": open(path, "rb")},
+            data={"file": open(path, "rb")},
         )
 
-        await resp_is.conflict(
-            resp_2,
-            "Artifact file has already been uploaded for this sample",
+    async def test_ok(
+        self,
+        example_path: Path,
+        memory_storage,
+        mongo: Mongo,
+        snapshot: SnapshotAssertion,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        client = await spawn_job_client(authenticated=True)
+        await self._insert_sample(mongo)
+
+        resp = await self._post(
+            client, example_path / "sample" / "reads_1.fq.gz", "fastq"
         )
 
-    if not error:
         assert resp.status == 201
         assert await resp.json() == snapshot
 
         keys = {obj.key async for obj in memory_storage.list("samples/test/")}
         assert keys == {"samples/test/small.fq.gz"}
-    elif error == 400:
+
+    async def test_unsupported_type(
+        self,
+        example_path: Path,
+        mongo: Mongo,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        client = await spawn_job_client(authenticated=True)
+        await self._insert_sample(mongo)
+
+        resp = await self._post(
+            client, example_path / "sample" / "reads_1.fq.gz", "foo"
+        )
+
         await resp_is.bad_request(resp, "Unsupported sample artifact type")
+
+    async def test_duplicate_upload(
+        self,
+        example_path: Path,
+        mongo: Mongo,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        client = await spawn_job_client(authenticated=True)
+        await self._insert_sample(mongo)
+
+        path = example_path / "sample" / "reads_1.fq.gz"
+
+        resp_1 = await self._post(client, path, "fastq")
+        assert resp_1.status == 201
+
+        resp_2 = await self._post(client, path, "fastq")
+
+        await resp_is.conflict(
+            resp_2,
+            "Artifact file has already been uploaded for this sample",
+        )
 
 
 class TestUploadReads:
@@ -1434,38 +1486,20 @@ class TestUploadReads:
         assert await resp.json() == snapshot
 
 
-@pytest.mark.parametrize("suffix", ["1", "2"])
-@pytest.mark.parametrize("error", [None, "404_sample", "404_reads", "404_file"])
-async def test_download_reads(
-    suffix: str,
-    error: str | None,
-    memory_storage,
-    mongo: Mongo,
-    pg: AsyncEngine,
-    spawn_client: ClientSpawner,
-    spawn_job_client: JobClientSpawner,
-):
-    client = await spawn_client(authenticated=True)
-    job_client = await spawn_job_client(authenticated=True)
-
-    file_name = f"reads_{suffix}.fq.gz"
-
-    if error != "404_file":
-
+class TestDownloadReads:
+    @staticmethod
+    async def _write_file(memory_storage, file_name: str) -> None:
         async def _data():
             yield b"test"
 
         await memory_storage.write(f"samples/foo/{file_name}", _data())
 
-    if error != "404_sample":
-        await mongo.samples.insert_one(
-            {
-                "_id": "foo",
-                "ready": True,
-            },
-        )
+    @staticmethod
+    async def _insert_sample(mongo: Mongo) -> None:
+        await mongo.samples.insert_one({"_id": "foo", "ready": True})
 
-    if error != "404_reads":
+    @staticmethod
+    async def _insert_reads_row(pg: AsyncEngine, file_name: str) -> None:
         async with AsyncSession(pg) as session:
             session.add(
                 SQLSampleReads(
@@ -1477,43 +1511,107 @@ async def test_download_reads(
             )
             await session.commit()
 
-    resp = await client.get(f"/samples/foo/reads/{file_name}")
-    job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
+    @pytest.mark.parametrize("suffix", ["1", "2"])
+    async def test_ok(
+        self,
+        suffix: str,
+        memory_storage,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        job_client = await spawn_job_client(authenticated=True)
 
-    if error:
-        assert resp.status == job_resp.status == 404
-    else:
+        file_name = f"reads_{suffix}.fq.gz"
+
+        await self._write_file(memory_storage, file_name)
+        await self._insert_sample(mongo)
+        await self._insert_reads_row(pg, file_name)
+
+        resp = await client.get(f"/samples/foo/reads/{file_name}")
+        job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
+
         assert resp.status == job_resp.status == HTTPStatus.OK
         assert await resp.content.read() == b"test"
         assert await job_resp.content.read() == b"test"
 
+    async def test_404_sample(
+        self,
+        memory_storage,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        job_client = await spawn_job_client(authenticated=True)
 
-@pytest.mark.parametrize("error", [None, "404_sample", "404_artifact", "404_file"])
-async def test_download_artifact(
-    error: str | None,
-    memory_storage,
-    mongo: Mongo,
-    pg: AsyncEngine,
-    spawn_job_client: JobClientSpawner,
-):
-    client = await spawn_job_client(authenticated=True)
+        file_name = "reads_1.fq.gz"
 
-    if error != "404_file":
+        await self._write_file(memory_storage, file_name)
+        await self._insert_reads_row(pg, file_name)
 
+        resp = await client.get(f"/samples/foo/reads/{file_name}")
+        job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
+
+        assert resp.status == job_resp.status == 404
+
+    async def test_404_reads(
+        self,
+        memory_storage,
+        mongo: Mongo,
+        spawn_client: ClientSpawner,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        job_client = await spawn_job_client(authenticated=True)
+
+        file_name = "reads_1.fq.gz"
+
+        await self._write_file(memory_storage, file_name)
+        await self._insert_sample(mongo)
+
+        resp = await client.get(f"/samples/foo/reads/{file_name}")
+        job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
+
+        assert resp.status == job_resp.status == 404
+
+    async def test_404_file(
+        self,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        job_client = await spawn_job_client(authenticated=True)
+
+        file_name = "reads_1.fq.gz"
+
+        await self._insert_sample(mongo)
+        await self._insert_reads_row(pg, file_name)
+
+        resp = await client.get(f"/samples/foo/reads/{file_name}")
+        job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
+
+        assert resp.status == job_resp.status == 404
+
+
+class TestDownloadArtifact:
+    @staticmethod
+    async def _write_file(memory_storage) -> None:
         async def _data():
             yield b"test"
 
         await memory_storage.write("samples/foo/fastqc.txt", _data())
 
-    if error != "404_sample":
-        await mongo.samples.insert_one(
-            {
-                "_id": "foo",
-                "ready": True,
-            },
-        )
+    @staticmethod
+    async def _insert_sample(mongo: Mongo) -> None:
+        await mongo.samples.insert_one({"_id": "foo", "ready": True})
 
-    if error != "404_artifact":
+    @staticmethod
+    async def _insert_artifact_row(pg: AsyncEngine) -> None:
         async with AsyncSession(pg) as session:
             session.add(
                 SQLSampleArtifact(
@@ -1524,17 +1622,70 @@ async def test_download_artifact(
                     type="fastq",
                 ),
             )
-
             await session.commit()
 
-    resp = await client.get("/samples/foo/artifacts/fastqc.txt")
+    async def test_ok(
+        self,
+        memory_storage,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
 
-    if error:
+        await self._write_file(memory_storage)
+        await self._insert_sample(mongo)
+        await self._insert_artifact_row(pg)
+
+        resp = await client.get("/samples/foo/artifacts/fastqc.txt")
+
+        assert resp.status == HTTPStatus.OK
+        assert await resp.content.read() == b"test"
+
+    async def test_404_sample(
+        self,
+        memory_storage,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        await self._write_file(memory_storage)
+        await self._insert_artifact_row(pg)
+
+        resp = await client.get("/samples/foo/artifacts/fastqc.txt")
+
         assert resp.status == 404
-        return
 
-    assert resp.status == HTTPStatus.OK
-    assert await resp.content.read() == b"test"
+    async def test_404_artifact(
+        self,
+        memory_storage,
+        mongo: Mongo,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        await self._write_file(memory_storage)
+        await self._insert_sample(mongo)
+
+        resp = await client.get("/samples/foo/artifacts/fastqc.txt")
+
+        assert resp.status == 404
+
+    async def test_404_file(
+        self,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        await self._insert_sample(mongo)
+        await self._insert_artifact_row(pg)
+
+        resp = await client.get("/samples/foo/artifacts/fastqc.txt")
+
+        assert resp.status == 404
 
 
 class TestChangeSampleRights:

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1133,95 +1133,175 @@ async def test_find_analyses(
     assert await resp.json() == snapshot
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        None,
-        "409_reference",
-        "409_archived",
-        "409_index",
-        "409_ready_index",
-        "409_subtraction",
-        "404",
-    ],
-)
-async def test_analyze(
-    error: str | None,
-    mocker,
-    mongo: Mongo,
-    resp_is,
-    snapshot: SnapshotAssertion,
-    spawn_client: ClientSpawner,
-    static_time,
-):
-    mocker.patch("virtool.samples.utils.get_sample_rights", return_value=(True, True))
+class TestAnalyze:
+    @pytest.fixture
+    async def analyze_client(
+        self,
+        mocker,
+        spawn_client: ClientSpawner,
+    ) -> VirtoolTestClient:
+        mocker.patch(
+            "virtool.samples.utils.get_sample_rights",
+            return_value=(True, True),
+        )
 
-    client = await spawn_client(authenticated=True)
-    client.app["jobs"] = MockJobInterface()
+        client = await spawn_client(authenticated=True)
+        client.app["jobs"] = MockJobInterface()
 
-    if error != "409_reference":
-        await mongo.references.insert_one(
-            {
-                "_id": "test_ref",
-                "archived": error == "409_archived",
-                "data_type": "genome",
-                "name": "Test Reference",
+        return client
+
+    @staticmethod
+    async def _seed(
+        mongo: Mongo,
+        static_time,
+        *,
+        reference: bool = True,
+        archived: bool = False,
+        index: bool = True,
+        index_ready: bool = True,
+        subtraction: bool = True,
+        sample: bool = True,
+    ) -> None:
+        if reference:
+            await mongo.references.insert_one(
+                {
+                    "_id": "test_ref",
+                    "archived": archived,
+                    "data_type": "genome",
+                    "name": "Test Reference",
+                },
+            )
+
+        if index:
+            await mongo.indexes.insert_one(
+                {
+                    "_id": "test",
+                    "reference": {"id": "test_ref"},
+                    "ready": index_ready,
+                    "version": 4,
+                },
+            )
+
+        if subtraction:
+            await mongo.subtraction.insert_one(
+                {"_id": "subtraction_1", "name": "Subtraction 1"},
+            )
+
+        if sample:
+            await mongo.samples.insert_one(
+                {
+                    "_id": "test",
+                    "name": "Test",
+                    "created_at": static_time.datetime,
+                    "all_read": True,
+                    "all_write": True,
+                    "ready": True,
+                },
+            )
+
+    @staticmethod
+    async def _post(client: VirtoolTestClient):
+        return await client.post(
+            "/samples/test/analyses",
+            data={
+                "workflow": "pathoscope_bowtie",
+                "ref_id": "test_ref",
+                "subtractions": ["subtraction_1"],
             },
         )
 
-    if error != "409_index":
-        await mongo.indexes.insert_one(
-            {
-                "_id": "test",
-                "reference": {"id": "test_ref"},
-                "ready": error != "409_ready_index",
-                "version": 4,
-            },
-        )
+    async def test_ok(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        snapshot: SnapshotAssertion,
+        static_time,
+    ):
+        await self._seed(mongo, static_time)
 
-    if error != "409_subtraction":
-        await mongo.subtraction.insert_one(
-            {"_id": "subtraction_1", "name": "Subtraction 1"},
-        )
+        resp = await self._post(analyze_client)
 
-    if error != "404":
-        await mongo.samples.insert_one(
-            {
-                "_id": "test",
-                "name": "Test",
-                "created_at": static_time.datetime,
-                "all_read": True,
-                "all_write": True,
-                "ready": True,
-            },
-        )
+        assert resp.status == 201
+        assert resp.headers["Location"] == "/analyses/bf1b993c"
+        assert await resp.json() == snapshot
 
-    resp = await client.post(
-        "/samples/test/analyses",
-        data={
-            "workflow": "pathoscope_bowtie",
-            "ref_id": "test_ref",
-            "subtractions": [
-                "subtraction_1",
-            ],
-        },
-    )
+    async def test_missing_reference(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        resp_is,
+        static_time,
+    ):
+        await self._seed(mongo, static_time, reference=False)
 
-    match error:
-        case None:
-            assert resp.status == 201
-            assert resp.headers["Location"] == "/analyses/bf1b993c"
-            assert await resp.json() == snapshot
-        case "409_reference":
-            await resp_is.conflict(resp, "Reference does not exist")
-        case "409_archived":
-            await resp_is.conflict(resp, "Reference is archived")
-        case ("409_index", "409_ready_index"):
-            await resp_is.conflict(resp, "No ready index")
-        case "409_subtraction":
-            await resp_is.conflict(resp, "Subtractions do not exist: subtraction_1")
-        case "404":
-            await resp_is.not_found(resp)
+        resp = await self._post(analyze_client)
+
+        await resp_is.conflict(resp, "Reference does not exist")
+
+    async def test_archived_reference(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        resp_is,
+        static_time,
+    ):
+        await self._seed(mongo, static_time, archived=True)
+
+        resp = await self._post(analyze_client)
+
+        await resp_is.conflict(resp, "Reference is archived")
+
+    async def test_no_index(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        resp_is,
+        static_time,
+    ):
+        await self._seed(mongo, static_time, index=False)
+
+        resp = await self._post(analyze_client)
+
+        await resp_is.conflict(resp, "No ready index")
+
+    async def test_unbuilt_index(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        resp_is,
+        static_time,
+    ):
+        await self._seed(mongo, static_time, index_ready=False)
+
+        resp = await self._post(analyze_client)
+
+        await resp_is.conflict(resp, "No ready index")
+
+    async def test_missing_subtraction(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        resp_is,
+        static_time,
+    ):
+        await self._seed(mongo, static_time, subtraction=False)
+
+        resp = await self._post(analyze_client)
+
+        await resp_is.conflict(resp, "Subtractions do not exist: subtraction_1")
+
+    async def test_missing_sample(
+        self,
+        analyze_client: VirtoolTestClient,
+        mongo: Mongo,
+        resp_is,
+        static_time,
+    ):
+        await self._seed(mongo, static_time, sample=False)
+
+        resp = await self._post(analyze_client)
+
+        await resp_is.not_found(resp)
 
 
 @pytest.mark.parametrize("error", [None, 400, 409])

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1135,7 +1135,15 @@ async def test_find_analyses(
 
 @pytest.mark.parametrize(
     "error",
-    [None, "400_reference", "400_index", "400_ready_index", "400_subtraction", "404"],
+    [
+        None,
+        "409_reference",
+        "409_archived",
+        "409_index",
+        "409_ready_index",
+        "409_subtraction",
+        "404",
+    ],
 )
 async def test_analyze(
     error: str | None,
@@ -1151,27 +1159,27 @@ async def test_analyze(
     client = await spawn_client(authenticated=True)
     client.app["jobs"] = MockJobInterface()
 
-    if error != "400_reference":
+    if error != "409_reference":
         await mongo.references.insert_one(
             {
                 "_id": "test_ref",
-                "archived": False,
+                "archived": error == "409_archived",
                 "data_type": "genome",
                 "name": "Test Reference",
             },
         )
 
-    if error != "400_index":
+    if error != "409_index":
         await mongo.indexes.insert_one(
             {
                 "_id": "test",
                 "reference": {"id": "test_ref"},
-                "ready": error != "400_ready_index",
+                "ready": error != "409_ready_index",
                 "version": 4,
             },
         )
 
-    if error != "400_subtraction":
+    if error != "409_subtraction":
         await mongo.subtraction.insert_one(
             {"_id": "subtraction_1", "name": "Subtraction 1"},
         )
@@ -1204,12 +1212,14 @@ async def test_analyze(
             assert resp.status == 201
             assert resp.headers["Location"] == "/analyses/bf1b993c"
             assert await resp.json() == snapshot
-        case "400_reference":
-            await resp_is.bad_request(resp, "Reference does not exist")
-        case ("400_index", "400_ready_index"):
-            await resp_is.bad_request(resp, "No ready index")
-        case "400_subtraction":
-            await resp_is.bad_request(resp, "Subtractions do not exist: subtraction_1")
+        case "409_reference":
+            await resp_is.conflict(resp, "Reference does not exist")
+        case "409_archived":
+            await resp_is.conflict(resp, "Reference is archived")
+        case ("409_index", "409_ready_index"):
+            await resp_is.conflict(resp, "No ready index")
+        case "409_subtraction":
+            await resp_is.conflict(resp, "Subtractions do not exist: subtraction_1")
         case "404":
             await resp_is.not_found(resp)
 

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -17,7 +17,7 @@ from virtool.samples.models import WorkflowState
 from virtool.samples.oas import CreateSampleRequest
 from virtool.samples.utils import SampleRight
 from virtool.settings.oas import UpdateSettingsRequest
-from virtool.uploads.sql import SQLUpload
+from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.users.oas import UpdateUserRequest
 
 
@@ -390,34 +390,47 @@ class TestHasRight:
 
 class TestHasResourcesForAnalysisJob:
     @staticmethod
-    async def _seed(mongo: Mongo, *, archived: bool = False) -> None:
-        await mongo.references.insert_one(
-            {
-                "_id": "test_ref",
-                "archived": archived,
-                "data_type": "genome",
-                "name": "Test Reference",
-            },
-        )
-        await mongo.indexes.insert_one(
-            {
-                "_id": "test_index",
-                "reference": {"id": "test_ref"},
-                "ready": True,
-                "version": 1,
-            },
-        )
-        await mongo.subtraction.insert_one(
-            {"_id": "subtraction_1", "name": "Subtraction 1"},
+    async def _seed(
+        fake: DataFaker,
+        mongo: Mongo,
+        *,
+        archived: bool = False,
+    ) -> str:
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
         )
 
-    async def test_ok(self, data_layer: DataLayer, mongo: Mongo):
-        await self._seed(mongo)
+        _, _, subtraction = await asyncio.gather(
+            mongo.references.insert_one(
+                {
+                    "_id": "test_ref",
+                    "archived": archived,
+                    "data_type": "genome",
+                    "name": "Test Reference",
+                },
+            ),
+            mongo.indexes.insert_one(
+                {
+                    "_id": "test_index",
+                    "reference": {"id": "test_ref"},
+                    "ready": True,
+                    "version": 1,
+                },
+            ),
+            fake.subtractions.create(user=user, upload=upload),
+        )
+
+        return subtraction.id
+
+    async def test_ok(self, data_layer: DataLayer, fake: DataFaker, mongo: Mongo):
+        subtraction_id = await self._seed(fake, mongo)
 
         assert (
             await data_layer.samples.has_resources_for_analysis_job(
                 "test_ref",
-                ["subtraction_1"],
+                [subtraction_id],
             )
             is None
         )
@@ -429,23 +442,33 @@ class TestHasResourcesForAnalysisJob:
                 ["subtraction_1"],
             )
 
-    async def test_archived_reference(self, data_layer: DataLayer, mongo: Mongo):
-        await self._seed(mongo, archived=True)
+    async def test_archived_reference(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+    ):
+        subtraction_id = await self._seed(fake, mongo, archived=True)
 
         with pytest.raises(ResourceConflictError, match=r"Reference is archived"):
             await data_layer.samples.has_resources_for_analysis_job(
                 "test_ref",
-                ["subtraction_1"],
+                [subtraction_id],
             )
 
-    async def test_missing_subtraction(self, data_layer: DataLayer, mongo: Mongo):
-        await self._seed(mongo)
+    async def test_missing_subtraction(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+    ):
+        subtraction_id = await self._seed(fake, mongo)
 
         with pytest.raises(
             ResourceConflictError,
-            match=r"Subtractions do not exist: missing",
+            match=r"^Subtractions do not exist: missing$",
         ):
             await data_layer.samples.has_resources_for_analysis_job(
                 "test_ref",
-                ["missing"],
+                [subtraction_id, "missing"],
             )

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -386,3 +386,66 @@ class TestHasRight:
             client,
             SampleRight.write,
         )
+
+
+class TestHasResourcesForAnalysisJob:
+    @staticmethod
+    async def _seed(mongo: Mongo, *, archived: bool = False) -> None:
+        await mongo.references.insert_one(
+            {
+                "_id": "test_ref",
+                "archived": archived,
+                "data_type": "genome",
+                "name": "Test Reference",
+            },
+        )
+        await mongo.indexes.insert_one(
+            {
+                "_id": "test_index",
+                "reference": {"id": "test_ref"},
+                "ready": True,
+                "version": 1,
+            },
+        )
+        await mongo.subtraction.insert_one(
+            {"_id": "subtraction_1", "name": "Subtraction 1"},
+        )
+
+    async def test_ok(self, data_layer: DataLayer, mongo: Mongo):
+        await self._seed(mongo)
+
+        assert (
+            await data_layer.samples.has_resources_for_analysis_job(
+                "test_ref",
+                ["subtraction_1"],
+            )
+            is None
+        )
+
+    async def test_missing_reference(self, data_layer: DataLayer, mongo: Mongo):
+        with pytest.raises(ResourceConflictError, match=r"Reference does not exist"):
+            await data_layer.samples.has_resources_for_analysis_job(
+                "test_ref",
+                ["subtraction_1"],
+            )
+
+    async def test_archived_reference(self, data_layer: DataLayer, mongo: Mongo):
+        await self._seed(mongo, archived=True)
+
+        with pytest.raises(ResourceConflictError, match=r"Reference is archived"):
+            await data_layer.samples.has_resources_for_analysis_job(
+                "test_ref",
+                ["subtraction_1"],
+            )
+
+    async def test_missing_subtraction(self, data_layer: DataLayer, mongo: Mongo):
+        await self._seed(mongo)
+
+        with pytest.raises(
+            ResourceConflictError,
+            match=r"Subtractions do not exist: missing",
+        ):
+            await data_layer.samples.has_resources_for_analysis_job(
+                "test_ref",
+                ["missing"],
+            )

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -463,7 +463,7 @@ class AnalysesView(PydanticView):
                 self.request,
             ).samples.has_resources_for_analysis_job(data.ref_id, data.subtractions)
         except ResourceError as err:
-            raise APIBadRequest(str(err))
+            raise APIConflict(str(err))
 
         analysis = await get_data_from_req(self.request).analyses.create(
             data,

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -282,10 +282,15 @@ async def finalize(req):
 
     sample_id = req.match_info["sample_id"]
 
-    sample = await get_data_from_req(req).samples.finalize(
-        sample_id,
-        data["quality"],
-    )
+    try:
+        sample = await get_data_from_req(req).samples.finalize(
+            sample_id,
+            data["quality"],
+        )
+    except ResourceConflictError as err:
+        raise APIConflict(str(err))
+    except ResourceNotFoundError:
+        raise APINotFound()
 
     return json_response(sample)
 

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -6,7 +6,7 @@ from aiohttp.web import (
     StreamResponse,
 )
 from aiohttp_pydantic import PydanticView
-from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404
+from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404, r409
 from pydantic import Field, conint, constr
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -434,18 +434,20 @@ class AnalysesView(PydanticView):
         sample_id: str,
         /,
         data: CreateAnalysisRequest,
-    ) -> r201[AnalysisMinimal] | r400 | r403 | r404:
+    ) -> r201[AnalysisMinimal] | r400 | r403 | r404 | r409:
         """Start analysis job.
 
         Starts an analysis job for a given sample.
 
         Status Codes:
             201: Successful operation
-            400: Reference does not exist
-            400: No index is ready for the reference
             400: Invalid input
             403: Insufficient rights
             404: Not found
+            409: Reference does not exist
+            409: Reference is archived
+            409: No index is ready for the reference
+            409: Subtractions do not exist
         """
         mongo = get_mongo_from_req(self.request)
 

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -546,8 +546,16 @@ class SamplesData(DataLayerDomain):
         :param ref_id: the reference id
         :param subtractions: list of subtractions
         """
-        if not await self._mongo.references.count_documents({"_id": ref_id}):
+        reference = await self._mongo.references.find_one(
+            {"_id": ref_id},
+            ["archived"],
+        )
+
+        if reference is None:
             raise ResourceConflictError("Reference does not exist")
+
+        if reference.get("archived"):
+            raise ResourceConflictError("Reference is archived")
 
         if not await self._mongo.indexes.count_documents(
             {"reference.id": ref_id, "ready": True},


### PR DESCRIPTION
## Summary

- Reject new analyses targeting an archived reference with `ResourceConflictError("Reference is archived")`, raised from `SamplesData.has_resources_for_analysis_job` after the existence check.
- Map the analyze handler's `ResourceError` to `APIConflict` (409) instead of `APIBadRequest` (400), aligning the endpoint with the codebase-wide convention for conflict-style failures.

## Behaviour change — 400 → 409

This intentionally flips the response status for **all** existing `ResourceConflictError` reasons surfaced by `POST /samples/{id}/analyses`, not just the new archived case:

- `Reference does not exist`
- `No ready index`
- `Subtractions do not exist: ...`
- `Reference is archived` *(new)*

Any client checking specifically for 400 on these reasons will need to be updated to expect 409.

## Tests

- `tests/samples/test_data.py::TestHasResourcesForAnalysisJob` — direct unit coverage of the guard (ok / missing / archived / missing-subtraction).
- `tests/samples/test_api.py::test_analyze` — parametrize ids renamed `400_*` → `409_*`, new `409_archived` case, assertions switched to `resp_is.conflict(...)`.
- `tests/analyses/test_api.py::test_get_archived_reference` — read-side smoke test confirming `AttachReferenceTransform` still resolves reference metadata for an analysis whose reference is archived.

Closes VIR-2299.