### PR TITLE
feat(references): reject writes on archived references

### DIFF
--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1492,3 +1492,173 @@ class TestFindHistory:
         resp = await self.client.get("/references/v1/nonexistent/history")
 
         assert resp.status == HTTPStatus.NOT_FOUND
+
+
+class TestArchivedReferenceRejectsWrites:
+    """User-driven writes against archived references must return 409."""
+
+    @pytest.fixture
+    async def archived_ref(
+        self,
+        mongo: Mongo,
+        spawn_client: ClientSpawner,
+        static_time: StaticTime,
+    ) -> tuple[VirtoolTestClient, str]:
+        client = await spawn_client(authenticated=True)
+
+        await mongo.references.insert_one(
+            {
+                "_id": "foo",
+                "archived": True,
+                "created_at": static_time.datetime,
+                "data_type": "genome",
+                "groups": [],
+                "internal_control": None,
+                "name": "Foo",
+                "organism": "virus",
+                "release": {
+                    "id": 10742520,
+                    "name": "v0.3.0",
+                    "body": "Lorem ipsum",
+                    "etag": 'W/"ef123d746a33f88ee44203d3ca6bc2f7"',
+                    "filename": "reference.json.gz",
+                    "size": 3709091,
+                    "html_url": "https://example.com",
+                    "download_url": "https://example.com/reference.json.gz",
+                    "published_at": "2018-04-26T19:35:33Z",
+                    "content_type": "application/gzip",
+                    "newer": True,
+                    "retrieved_at": "2018-04-14T19:52:17.465000Z",
+                },
+                "restrict_source_types": False,
+                "source_types": ["isolate", "strain"],
+                "user": {"id": client.user.id},
+                "users": [
+                    {
+                        "id": client.user.id,
+                        "build": True,
+                        "created_at": static_time.datetime,
+                        "modify": True,
+                        "modify_otu": True,
+                        "remove": True,
+                    },
+                ],
+            },
+        )
+
+        return client, "foo"
+
+    async def test_patch(
+        self,
+        archived_ref: tuple[VirtoolTestClient, str],
+        mocker,
+        resp_is: RespIs,
+    ):
+        client, ref_id = archived_ref
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.patch(f"/references/v1/{ref_id}", {"name": "Bar"})
+
+        await resp_is.conflict(resp, "Reference is archived")
+
+    async def test_create_otu(
+        self,
+        archived_ref: tuple[VirtoolTestClient, str],
+        mocker,
+        resp_is: RespIs,
+    ):
+        client, ref_id = archived_ref
+
+        mocker.patch(
+            "virtool.references.db.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post(
+            f"/references/v1/{ref_id}/otus",
+            {"name": "Tobacco mosaic virus"},
+        )
+
+        await resp_is.conflict(resp, "Reference is archived")
+
+    async def test_create_index(
+        self,
+        archived_ref: tuple[VirtoolTestClient, str],
+        mocker,
+        resp_is: RespIs,
+    ):
+        client, ref_id = archived_ref
+
+        mocker.patch(
+            "virtool.references.db.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post(f"/references/v1/{ref_id}/indexes", {})
+
+        await resp_is.conflict(resp, "Reference is archived")
+
+    async def test_create_update(
+        self,
+        archived_ref: tuple[VirtoolTestClient, str],
+        mocker,
+        resp_is: RespIs,
+    ):
+        client, ref_id = archived_ref
+
+        mocker.patch(
+            "virtool.references.db.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post(f"/references/v1/{ref_id}/updates", {})
+
+        await resp_is.conflict(resp, "Reference is archived")
+
+
+async def test_archived_reference_allows_user_rights_update(
+    fake: DataFaker,
+    mongo: Mongo,
+    spawn_client: ClientSpawner,
+    static_time: StaticTime,
+):
+    """Rights-management routes are unaffected by the archived guard (D5)."""
+    client = await spawn_client(authenticated=True)
+    user = await fake.users.create()
+
+    await mongo.references.insert_one(
+        {
+            "_id": "foo",
+            "archived": True,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [],
+            "name": "Test",
+            "organism": "virus",
+            "restrict_source_types": False,
+            "source_types": [],
+            "user": {"id": client.user.id},
+            "users": [
+                {
+                    "id": client.user.id,
+                    "build": True,
+                    "created_at": static_time.datetime,
+                    "modify": True,
+                    "modify_otu": True,
+                    "remove": True,
+                },
+            ],
+        },
+    )
+
+    resp = await client.post(
+        "/references/v1/foo/users",
+        {"user_id": user.id, "modify": True},
+    )
+
+    assert resp.status == 201

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -174,7 +174,7 @@ class ReferenceView(PydanticView):
         except ResourceNotFoundError:
             raise APINotFound()
         except ResourceConflictError as err:
-            raise APIBadRequest(str(err))
+            raise APIConflict(str(err))
 
         return json_response(reference)
 
@@ -273,6 +273,8 @@ class ReferenceUpdatesView(PydanticView):
             )
         except ResourceNotFoundError:
             raise APINotFound()
+        except ResourceConflictError as err:
+            raise APIConflict(str(err))
         except ResourceError as err:
             raise APIBadRequest(str(err))
 
@@ -335,6 +337,8 @@ class ReferenceOTUsView(PydanticView):
             )
         except ResourceNotFoundError:
             raise APINotFound()
+        except ResourceConflictError as e:
+            raise APIConflict(str(e))
         except ResourceError as e:
             raise APIBadRequest(str(e))
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -110,6 +110,18 @@ class ReferencesData(DataLayerDomain):
         self._client = client
         self._storage = storage
 
+    async def _require_not_archived(self, ref_id: str) -> None:
+        document = await self._mongo.references.find_one(
+            {"_id": ref_id},
+            {"archived": 1},
+        )
+
+        if document is None:
+            raise ResourceNotFoundError()
+
+        if document.get("archived"):
+            raise ResourceConflictError("Reference is archived")
+
     async def _extend_user(self, user: Document) -> Document:
         """Extend a user document with additional data from PostgreSQL.
 
@@ -387,6 +399,8 @@ class ReferencesData(DataLayerDomain):
     @emits(Operation.UPDATE)
     async def update(self, ref_id: str, data: UpdateReferenceRequest) -> Reference:
         """Update a reference."""
+        await self._require_not_archived(ref_id)
+
         document = await self._mongo.references.find_one(ref_id)
 
         if document is None:
@@ -455,6 +469,8 @@ class ReferencesData(DataLayerDomain):
         ref_id: str,
         user_id: str,
     ) -> ReferenceRelease:
+        await self._require_not_archived(ref_id)
+
         document = await self._mongo.references.find_one(ref_id, ["release"])
 
         if document is None:
@@ -519,6 +535,8 @@ class ReferencesData(DataLayerDomain):
         data: CreateOTURequest,
         user_id: str,
     ) -> OTU:
+        await self._require_not_archived(ref_id)
+
         # Check if either the name or abbreviation are already in use. Send a ``400`` if
         # they are.
         if message := await virtool.otus.db.check_name_and_abbreviation(
@@ -570,6 +588,8 @@ class ReferencesData(DataLayerDomain):
     async def create_index(self, ref_id: str, req, user_id: str) -> IndexMinimal:
         if not await virtool.references.db.check_right(req, ref_id, "build"):
             raise APIInsufficientRights()
+
+        await self._require_not_archived(ref_id)
 
         if await self._mongo.indexes.count_documents(
             {"reference.id": ref_id, "ready": False},


### PR DESCRIPTION
## Summary

- Add a `_require_not_archived` data-layer guard wired into `ReferencesData.update`, `create_otu`, `create_index`, and `create_update`. User-driven writes against archived references now raise `ResourceConflictError("Reference is archived")` and surface as **409 Conflict** (RFC 9110 §15.5.10), matching the existing `create_index` precedent.
- Correct the PATCH outlier mapping (`ResourceConflictError → APIBadRequest` → `APIConflict`) — the only reference write route still mapping conflicts to 400.
- Insert explicit `ResourceConflictError → APIConflict` handlers ahead of `ResourceError → APIBadRequest` in `ReferenceUpdateView.post` and `ReferenceOTUsView.post` (top-down catch-order trap).
- Rights-management routes (`/groups`, `/users`) and in-flight long-running tasks (`CloneReferenceTask`, `ImportReferenceTask`, `RemoteReferenceTask`, `UpdateRemoteReferenceTask`) are intentionally **not** guarded, per project decisions D5 and D12.

Closes VIR-2298.