### PR TITLE
fix: resolve workflow sample from analysis jobs

### DIFF
--- a/tests/workflow/data/test_samples.py
+++ b/tests/workflow/data/test_samples.py
@@ -6,7 +6,11 @@ from pyfixtures import FixtureScope
 
 from virtool.samples.models import Quality
 from virtool.workflow.data.samples import WFNewSample, WFSample
-from virtool.workflow.errors import JobsAPIConflictError, JobsAPINotFoundError
+from virtool.workflow.errors import (
+    JobsAPIConflictError,
+    JobsAPINotFoundError,
+    MissingJobArgumentError,
+)
 from virtool.workflow.pytest_plugin.data import WorkflowData
 
 QUALITY = {
@@ -81,6 +85,29 @@ class TestSample:
 
             assert path.exists()
 
+    async def test_ok_from_analysis_id(
+        self,
+        scope: FixtureScope,
+        workflow_data: WorkflowData,
+    ):
+        workflow_data.job.args = {"analysis_id": workflow_data.analysis.id}
+
+        sample: WFSample = await scope.instantiate_by_key("sample")
+
+        assert sample.id == workflow_data.sample.id
+
+    async def test_missing_sample_id(
+        self,
+        scope: FixtureScope,
+        workflow_data: WorkflowData,
+    ):
+        workflow_data.job.args = {}
+
+        with pytest.raises(MissingJobArgumentError) as err:
+            await scope.instantiate_by_key("sample")
+
+        assert "Missing job args key 'sample_id'" in str(err)
+
     async def test_not_found(self, scope: FixtureScope, workflow_data: WorkflowData):
         workflow_data.job.args["sample_id"] = "not_found"
 
@@ -126,6 +153,18 @@ class TestNewSample:
                 ) as f2,
             ):
                 assert f1.read() == f2.read()
+
+    async def test_missing_sample_id(
+        self,
+        scope: FixtureScope,
+        workflow_data: WorkflowData,
+    ):
+        workflow_data.job.args = {}
+
+        with pytest.raises(MissingJobArgumentError) as err:
+            await scope.instantiate_by_key("new_sample")
+
+        assert "Missing job args key 'sample_id'" in str(err)
 
     async def test_finalize(self, scope: FixtureScope, workflow_data: WorkflowData):
         """Test that the finalize method updates the sample with the given quality."""

--- a/virtool/workflow/data/samples.py
+++ b/virtool/workflow/data/samples.py
@@ -13,7 +13,7 @@ from virtool.samples.models import Quality, Sample
 from virtool.workflow.analysis import ReadPaths
 from virtool.workflow.client import WorkflowAPIClient
 from virtool.workflow.data.uploads import WFUploads
-from virtool.workflow.errors import JobsAPINotFoundError
+from virtool.workflow.errors import JobsAPINotFoundError, MissingJobArgumentError
 
 logger = get_logger("api")
 
@@ -81,6 +81,27 @@ class WFNewSample:
     upload: Callable[[Path], Coroutine[None, None, None]]
 
 
+async def get_sample_id(_api: WorkflowAPIClient, job: Job) -> str:
+    try:
+        return job.args["sample_id"]
+    except KeyError:
+        pass
+
+    try:
+        analysis_id = job.args["analysis_id"]
+    except KeyError:
+        raise MissingJobArgumentError("Missing job args key 'sample_id'") from None
+
+    analysis = await _api.get_json(f"/analyses/{analysis_id}")
+
+    try:
+        return analysis["sample"]["id"]
+    except KeyError:
+        raise MissingJobArgumentError(
+            f"Analysis {analysis_id!r} does not include sample id",
+        ) from None
+
+
 @fixture
 async def sample(
     _api: WorkflowAPIClient,
@@ -89,7 +110,7 @@ async def sample(
     work_path: Path,
 ) -> WFSample:
     """The sample associated with the current job."""
-    id_ = job.args["sample_id"]
+    id_ = await get_sample_id(_api, job)
 
     base_url_path = f"/samples/{id_}"
 
@@ -138,7 +159,10 @@ async def new_sample(
     work_path: Path,
 ) -> WFNewSample:
     """The sample associated with the current job."""
-    id_ = job.args["sample_id"]
+    try:
+        id_ = job.args["sample_id"]
+    except KeyError:
+        raise MissingJobArgumentError("Missing job args key 'sample_id'") from None
 
     log = logger.bind(resource="sample", id=id_)
     log.info("loading sample for sample creation")


### PR DESCRIPTION
## Summary
- Fixes a `KeyError` crash when workflow jobs carry an `analysis_id` but no `sample_id` in their args (e.g. analysis-type jobs)
- Adds `get_sample_id()` helper that falls back to fetching the sample ID via the analysis endpoint when `sample_id` is absent
- Raises a descriptive `MissingJobArgumentError` instead of a bare `KeyError` when neither arg is present

## Test plan
- [ ] Verify `TestSample.test_ok_from_analysis_id` passes — sample resolves correctly from an analysis job
- [ ] Verify `TestSample.test_missing_sample_id` passes — raises `MissingJobArgumentError` with expected message
- [ ] Verify `TestNewSample.test_missing_sample_id` passes — same error raised for new-sample fixture
- [ ] Run full workflow data test suite: `mise run test -- tests/workflow/data`