### PR TITLE
feat(references): add archive and unarchive routes

### DIFF
--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -1,4 +1,80 @@
 # serializer version: 1
+# name: TestArchive.test_ok[False][resp]
+  dict({
+    'archived': True,
+    'cloned_from': None,
+    'contributors': list([
+    ]),
+    'created_at': 'approximately_now_isoformat',
+    'data_type': 'genome',
+    'description': '',
+    'groups': list([
+    ]),
+    'id': 'foo',
+    'imported_from': None,
+    'installed': None,
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Foo',
+    'organism': 'virus',
+    'otu_count': 0,
+    'release': None,
+    'remotes_from': None,
+    'restrict_source_types': False,
+    'source_types': list([
+      'isolate',
+      'strain',
+    ]),
+    'targets': None,
+    'task': None,
+    'unbuilt_change_count': 0,
+    'updating': None,
+    'user': dict({
+      'handle': 'myersmitchell',
+      'id': 2,
+    }),
+    'users': list([
+    ]),
+  })
+# ---
+# name: TestArchive.test_ok[True][resp]
+  dict({
+    'archived': True,
+    'cloned_from': None,
+    'contributors': list([
+    ]),
+    'created_at': 'approximately_now_isoformat',
+    'data_type': 'genome',
+    'description': '',
+    'groups': list([
+    ]),
+    'id': 'foo',
+    'imported_from': None,
+    'installed': None,
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Foo',
+    'organism': 'virus',
+    'otu_count': 0,
+    'release': None,
+    'remotes_from': None,
+    'restrict_source_types': False,
+    'source_types': list([
+      'isolate',
+      'strain',
+    ]),
+    'targets': None,
+    'task': None,
+    'unbuilt_change_count': 0,
+    'updating': None,
+    'user': dict({
+      'handle': 'myersmitchell',
+      'id': 2,
+    }),
+    'users': list([
+    ]),
+  })
+# ---
 # name: TestCreate.test_clone[location]
   '/references/v1/bf1b993c'
 # ---
@@ -881,6 +957,82 @@
         'modify_otu': False,
         'remove': False,
       }),
+    ]),
+  })
+# ---
+# name: TestUnarchive.test_ok[False][resp]
+  dict({
+    'archived': False,
+    'cloned_from': None,
+    'contributors': list([
+    ]),
+    'created_at': 'approximately_now_isoformat',
+    'data_type': 'genome',
+    'description': '',
+    'groups': list([
+    ]),
+    'id': 'foo',
+    'imported_from': None,
+    'installed': None,
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Foo',
+    'organism': 'virus',
+    'otu_count': 0,
+    'release': None,
+    'remotes_from': None,
+    'restrict_source_types': False,
+    'source_types': list([
+      'isolate',
+      'strain',
+    ]),
+    'targets': None,
+    'task': None,
+    'unbuilt_change_count': 0,
+    'updating': None,
+    'user': dict({
+      'handle': 'myersmitchell',
+      'id': 2,
+    }),
+    'users': list([
+    ]),
+  })
+# ---
+# name: TestUnarchive.test_ok[True][resp]
+  dict({
+    'archived': False,
+    'cloned_from': None,
+    'contributors': list([
+    ]),
+    'created_at': 'approximately_now_isoformat',
+    'data_type': 'genome',
+    'description': '',
+    'groups': list([
+    ]),
+    'id': 'foo',
+    'imported_from': None,
+    'installed': None,
+    'internal_control': None,
+    'latest_build': None,
+    'name': 'Foo',
+    'organism': 'virus',
+    'otu_count': 0,
+    'release': None,
+    'remotes_from': None,
+    'restrict_source_types': False,
+    'source_types': list([
+      'isolate',
+      'strain',
+    ]),
+    'targets': None,
+    'task': None,
+    'unbuilt_change_count': 0,
+    'updating': None,
+    'user': dict({
+      'handle': 'myersmitchell',
+      'id': 2,
+    }),
+    'users': list([
     ]),
   })
 # ---

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -711,6 +711,205 @@ async def test_update(
         assert await get_one_field(mongo.references, "task", "foo") == {"id": 1}
 
 
+def _archive_reference_doc(user_id: int, *, archived: bool, official: bool = False):
+    document = {
+        "_id": "foo",
+        "archived": archived,
+        "created_at": virtool.utils.timestamp(),
+        "data_type": "genome",
+        "description": "",
+        "groups": [],
+        "internal_control": None,
+        "name": "Foo",
+        "organism": "virus",
+        "restrict_source_types": False,
+        "source_types": ["isolate", "strain"],
+        "user": {"id": user_id},
+        "users": [],
+    }
+
+    if official:
+        document["remotes_from"] = {"slug": "virtool/ref-plant-viruses", "errors": []}
+
+    return document
+
+
+class TestArchive:
+    @pytest.mark.parametrize("already_archived", [False, True])
+    async def test_ok(
+        self,
+        already_archived: bool,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        snapshot_recent: SnapshotAssertion,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        user = await fake.users.create()
+
+        await mongo.references.insert_one(
+            _archive_reference_doc(user.id, archived=already_archived),
+        )
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post("/references/v1/foo/archive", {})
+
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["archived"] is True
+        assert body == snapshot_recent(name="resp")
+        assert await get_one_field(mongo.references, "archived", "foo") is True
+
+    async def test_official_conflict(
+        self,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        user = await fake.users.create()
+
+        await mongo.references.insert_one(
+            _archive_reference_doc(user.id, archived=False, official=True),
+        )
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post("/references/v1/foo/archive", {})
+
+        await resp_is.conflict(
+            resp,
+            "Cannot archive the official plant viruses reference",
+        )
+        assert await get_one_field(mongo.references, "archived", "foo") is False
+
+    async def test_insufficient_rights(
+        self,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        user = await fake.users.create()
+
+        await mongo.references.insert_one(
+            _archive_reference_doc(user.id, archived=False),
+        )
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=False),
+        )
+
+        resp = await client.post("/references/v1/foo/archive", {})
+
+        await resp_is.insufficient_rights(resp)
+        assert await get_one_field(mongo.references, "archived", "foo") is False
+
+    async def test_not_found(
+        self,
+        mocker,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post("/references/v1/foo/archive", {})
+
+        await resp_is.not_found(resp)
+
+
+class TestUnarchive:
+    @pytest.mark.parametrize("already_archived", [True, False])
+    async def test_ok(
+        self,
+        already_archived: bool,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        snapshot_recent: SnapshotAssertion,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        user = await fake.users.create()
+
+        await mongo.references.insert_one(
+            _archive_reference_doc(user.id, archived=already_archived),
+        )
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post("/references/v1/foo/unarchive", {})
+
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["archived"] is False
+        assert body == snapshot_recent(name="resp")
+        assert await get_one_field(mongo.references, "archived", "foo") is False
+
+    async def test_insufficient_rights(
+        self,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        user = await fake.users.create()
+
+        await mongo.references.insert_one(
+            _archive_reference_doc(user.id, archived=True),
+        )
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=False),
+        )
+
+        resp = await client.post("/references/v1/foo/unarchive", {})
+
+        await resp_is.insufficient_rights(resp)
+        assert await get_one_field(mongo.references, "archived", "foo") is True
+
+    async def test_not_found(
+        self,
+        mocker,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+
+        mocker.patch(
+            "virtool.references.api.check_right",
+            make_mocked_coro(return_value=True),
+        )
+
+        resp = await client.post("/references/v1/foo/unarchive", {})
+
+        await resp_is.not_found(resp)
+
+
 class TestCreateOTU:
     @pytest.mark.parametrize("abbreviation", [None, "TMV", ""])
     @pytest.mark.parametrize("error", [None, "403", "404"])

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -5,7 +5,17 @@ TODO: Drop support for string group ids when we fully migrate to SQL.
 
 from aiohttp.web_response import Response
 from aiohttp_pydantic import PydanticView
-from aiohttp_pydantic.oas.typing import r200, r201, r202, r204, r400, r403, r404, r502
+from aiohttp_pydantic.oas.typing import (
+    r200,
+    r201,
+    r202,
+    r204,
+    r400,
+    r403,
+    r404,
+    r409,
+    r502,
+)
 from pydantic import Field
 
 import virtool.references.db
@@ -277,6 +287,66 @@ class ReferenceUpdatesView(PydanticView):
             raise APIBadRequest(str(err))
 
         return json_response(update, status=201)
+
+
+@routes.view("/references/v1/{ref_id}/archive")
+class ReferenceArchiveView(PydanticView):
+    async def post(self, ref_id: str, /) -> r200[Reference] | r403 | r404 | r409:
+        """Archive a reference.
+
+        Marks a reference as archived. Archiving the official plant viruses
+        reference is not allowed.
+
+        Status Codes:
+            200: Successful operation
+            403: Insufficient rights
+            404: Not found
+            409: Cannot archive the official plant viruses reference
+        """
+        try:
+            if not await check_right(self.request, ref_id, "modify"):
+                raise APIInsufficientRights()
+        except ResourceNotFoundError:
+            raise APINotFound
+
+        try:
+            reference = await get_data_from_req(self.request).references.archive(
+                ref_id,
+            )
+        except ResourceNotFoundError:
+            raise APINotFound()
+        except ResourceConflictError as err:
+            raise APIConflict(str(err))
+
+        return json_response(reference)
+
+
+@routes.view("/references/v1/{ref_id}/unarchive")
+class ReferenceUnarchiveView(PydanticView):
+    async def post(self, ref_id: str, /) -> r200[Reference] | r403 | r404:
+        """Unarchive a reference.
+
+        Marks a reference as not archived.
+
+        Status Codes:
+            200: Successful operation
+            403: Insufficient rights
+            404: Not found
+        """
+        try:
+            if not await check_right(self.request, ref_id, "modify"):
+                raise APIInsufficientRights()
+        except ResourceNotFoundError:
+            raise APINotFound
+
+        try:
+            reference = await get_data_from_req(self.request).references.unarchive(
+                ref_id,
+            )
+        except ResourceNotFoundError:
+            raise APINotFound()
+
+        return json_response(reference)
 
 
 @routes.view("/references/v1/{ref_id}/otus")

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -79,7 +79,7 @@ from virtool.references.tasks import (
     UpdateRemoteReferenceTask,
 )
 from virtool.references.transforms import AttachImportedFromTransform
-from virtool.references.utils import RIGHTS, ReferenceSourceData
+from virtool.references.utils import OFFICIAL_REMOTE_SLUG, RIGHTS, ReferenceSourceData
 from virtool.storage.protocol import StorageBackend
 from virtool.tasks.progress import (
     AccumulatingProgressHandlerWrapper,
@@ -176,7 +176,7 @@ class ReferencesData(DataLayerDomain):
                 self._pg,
             ),
             self._mongo.references.count_documents(
-                {"remotes_from.slug": "virtool/ref-plant-viruses"},
+                {"remotes_from.slug": OFFICIAL_REMOTE_SLUG},
             ),
         )
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -402,6 +402,43 @@ class ReferencesData(DataLayerDomain):
 
         return await self.get(ref_id)
 
+    @emits(Operation.UPDATE)
+    async def archive(self, ref_id: str) -> Reference:
+        """Archive a reference."""
+        document = await self._mongo.references.find_one(ref_id)
+
+        if document is None:
+            raise ResourceNotFoundError()
+
+        if get_safely(document, "remotes_from", "slug") == OFFICIAL_REMOTE_SLUG:
+            raise ResourceConflictError(
+                "Cannot archive the official plant viruses reference",
+            )
+
+        if not document.get("archived", False):
+            await self._mongo.references.update_one(
+                {"_id": ref_id},
+                {"$set": {"archived": True}},
+            )
+
+        return await self.get(ref_id)
+
+    @emits(Operation.UPDATE)
+    async def unarchive(self, ref_id: str) -> Reference:
+        """Unarchive a reference."""
+        document = await self._mongo.references.find_one(ref_id)
+
+        if document is None:
+            raise ResourceNotFoundError()
+
+        if document.get("archived", False):
+            await self._mongo.references.update_one(
+                {"_id": ref_id},
+                {"$set": {"archived": False}},
+            )
+
+        return await self.get(ref_id)
+
     async def remove(self, ref_id: str, req) -> None:
         if not await virtool.references.db.check_right(req, ref_id, "remove"):
             raise APIInsufficientRights()

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -39,6 +39,7 @@ from virtool.references.bulk_models import (
     SequenceChanges,
 )
 from virtool.references.utils import (
+    OFFICIAL_REMOTE_SLUG,
     check_will_change,
 )
 from virtool.releases import (
@@ -447,7 +448,7 @@ async def get_official_installed(mongo: "Mongo") -> bool:
     """
     return (
         await mongo.references.count_documents(
-            {"remotes_from.slug": "virtool/ref-plant-viruses"},
+            {"remotes_from.slug": OFFICIAL_REMOTE_SLUG},
         )
         > 0
     )

--- a/virtool/references/oas.py
+++ b/virtool/references/oas.py
@@ -2,8 +2,9 @@ from pydantic import Field, constr, root_validator, validator
 
 from virtool.models import BaseModel
 from virtool.models.validators import prevent_none
+from virtool.references.utils import OFFICIAL_REMOTE_SLUG
 
-ALLOWED_REMOTE = ["virtool/ref-plant-viruses"]
+ALLOWED_REMOTE = [OFFICIAL_REMOTE_SLUG]
 ALLOWED_DATA_TYPE = ["barcode", "genome"]
 
 

--- a/virtool/references/utils.py
+++ b/virtool/references/utils.py
@@ -12,6 +12,8 @@ from virtool.storage.protocol import StorageBackend
 
 RIGHTS = ["build", "modify", "modify_otu", "remove"]
 
+OFFICIAL_REMOTE_SLUG = "virtool/ref-plant-viruses"
+
 
 class ReferenceSourceDataError(Exception):
     """An exception raised when source data used to create a reference is invalid."""


### PR DESCRIPTION
## Summary
- Add `POST /references/v1/{ref_id}/archive` and `POST /references/v1/{ref_id}/unarchive` routes that flip the `archived` flag.
- Both routes are gated on the `modify` right, are idempotent, and return the updated reference.
- `archive` refuses the official plant-viruses reference with `409 Conflict`.
- Hoist the plant-viruses slug to `OFFICIAL_REMOTE_SLUG` so the new archive guard, the existing official-installed count, and the `ALLOWED_REMOTE` list share one source of truth.

Closes VIR-2297.