### PR TITLE
feat: mark jobs as succeeded on workflow completion

### DIFF
--- a/tests/fixtures/workflow_api/jobs.py
+++ b/tests/fixtures/workflow_api/jobs.py
@@ -90,6 +90,23 @@ def create_jobs_routes(data: WorkflowData):
                 dumps=custom_dumps,
             )
 
+    @routes.view("/jobs/{job_id}/finish")
+    class JobFinishView(View):
+        async def post(self):
+            job_id = int(self.request.match_info["job_id"])
+
+            if job_id != data.job.id:
+                return generate_not_found()
+
+            data.job.state = JobState.SUCCEEDED
+            data.finish_called = True
+
+            return json_response(
+                data.job.dict(),
+                status=200,
+                dumps=custom_dumps,
+            )
+
     @routes.view("/jobs/{job_id}/steps/{step_id}/start")
     class JobStepStartView(View):
         async def post(self):

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -559,6 +559,66 @@ class TestClaim:
         assert resp.status == HTTPStatus.NOT_FOUND
 
 
+class TestFinish:
+    """Tests for POST /jobs/{job_id}/finish endpoint."""
+
+    async def test_ok(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+    ):
+        """Test that a running job can be finished."""
+        client = await spawn_job_client(authenticated=False)
+
+        user = await fake.users.create()
+        job = await fake.jobs.create(user, state=JobState.RUNNING)
+
+        resp = await client.post(f"/jobs/{job.id}/finish")
+
+        assert resp.status == HTTPStatus.OK
+
+        body = await resp.json()
+        assert body["state"] == "succeeded"
+        assert "key" not in body
+
+        async with AsyncSession(pg) as session:
+            sql_job = (
+                await session.execute(select(SQLJob).where(SQLJob.id == job.id))
+            ).scalar()
+
+        assert sql_job.state == "succeeded"
+        assert sql_job.finished_at is not None
+
+    async def test_not_found(self, spawn_job_client: JobClientSpawner):
+        """Test that 404 is returned when the job doesn't exist."""
+        client = await spawn_job_client(authenticated=False)
+
+        resp = await client.post("/jobs/999999/finish")
+
+        assert resp.status == HTTPStatus.NOT_FOUND
+
+    @pytest.mark.parametrize(
+        "state",
+        [JobState.PENDING, JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELLED],
+    )
+    async def test_not_running(
+        self,
+        state: JobState,
+        fake: DataFaker,
+        spawn_job_client: JobClientSpawner,
+    ):
+        """Test that 409 is returned when the job isn't running."""
+        client = await spawn_job_client(authenticated=False)
+
+        user = await fake.users.create()
+        job = await fake.jobs.create(user, state=state)
+
+        resp = await client.post(f"/jobs/{job.id}/finish")
+
+        assert resp.status == HTTPStatus.CONFLICT
+
+
 class TestStartStep:
     """Tests for POST /jobs/{job_id}/steps/{step_id}/start endpoint."""
 

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -3,6 +3,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.jobs.data import JobsData
@@ -290,6 +291,52 @@ class TestStartStepPostgres:
             updated_job.steps[0].started_at.replace(tzinfo=None) == static_time.datetime
         )
         assert updated_job.steps[1].started_at is None
+
+
+class TestFinish:
+    """Test the finish() method of JobsData."""
+
+    async def test_ok(
+        self,
+        fake: DataFaker,
+        jobs_data: JobsData,
+        pg: AsyncEngine,
+        static_time: StaticTime,
+    ):
+        user = await fake.users.create()
+        job = await fake.jobs.create(user, state=JobState.RUNNING)
+
+        finished = await jobs_data.finish(job.id)
+
+        assert finished.state == JobState.SUCCEEDED
+
+        async with AsyncSession(pg) as session:
+            sql_job = (
+                await session.execute(select(SQLJob).where(SQLJob.id == job.id))
+            ).scalar()
+
+        assert sql_job.state == "succeeded"
+        assert sql_job.finished_at == static_time.datetime
+
+    async def test_not_found(self, jobs_data: JobsData):
+        with pytest.raises(ResourceNotFoundError):
+            await jobs_data.finish(999999)
+
+    @pytest.mark.parametrize(
+        "state",
+        [JobState.PENDING, JobState.SUCCEEDED, JobState.FAILED, JobState.CANCELLED],
+    )
+    async def test_not_running(
+        self,
+        state: JobState,
+        fake: DataFaker,
+        jobs_data: JobsData,
+    ):
+        user = await fake.users.create()
+        job = await fake.jobs.create(user, state=state)
+
+        with pytest.raises(ResourceConflictError):
+            await jobs_data.finish(job.id)
 
 
 class TestCancelPostgres:

--- a/tests/workflow/test_runtime_hooks.py
+++ b/tests/workflow/test_runtime_hooks.py
@@ -98,6 +98,7 @@ async def test_success(
     assert success_called
     assert not error_called
     assert finish_called
+    assert workflow_data.finish_called is True
 
 
 async def test_error(
@@ -150,3 +151,4 @@ async def test_error(
 
     assert failure_called
     assert finish_called
+    assert workflow_data.finish_called is False

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -204,6 +204,29 @@ class CancelJobView(PydanticView):
         return json_response(document)
 
 
+@routes.jobs_api.view("/jobs/{job_id}/finish")
+class FinishJobView(PydanticView):
+    @policy(PublicRoutePolicy)
+    async def post(self, job_id: int, /) -> r200[Job] | r404 | r409:
+        """Finish a job.
+
+        Marks a job as succeeded.
+
+        Status Codes:
+            200: Successful operation
+            404: Job not found
+            409: Job is not in a running state
+        """
+        try:
+            job = await get_data_from_req(self.request).jobs.finish(job_id)
+        except ResourceNotFoundError:
+            raise APINotFound()
+        except ResourceConflictError as e:
+            raise APIConflict(str(e))
+
+        return json_response(job)
+
+
 @routes.jobs_api.view("/jobs/{job_id}/ping")
 class JobPingView(PydanticView):
     async def put(self, job_id: int, /) -> r200[JobPing] | r404:

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -445,6 +445,34 @@ class JobsData:
         )
 
     @emits(Operation.UPDATE)
+    async def finish(self, job_id: int) -> Job:
+        """Finish a job.
+
+        Marks the job as succeeded.
+
+        :param job_id: the ID of the job to finish
+        :return: the updated job
+        """
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLJob).where(SQLJob.id == job_id),
+            )
+            sql_job = result.scalar()
+
+            if sql_job is None:
+                raise ResourceNotFoundError
+
+            if sql_job.state != "running":
+                raise ResourceConflictError("Job is not running")
+
+            sql_job.state = JobState.SUCCEEDED.value
+            sql_job.finished_at = virtool.utils.timestamp()
+
+            await session.commit()
+
+        return await self.get(job_id)
+
+    @emits(Operation.UPDATE)
     async def cancel(self, job_id: int) -> Job:
         """Cancel a job.
 

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -455,7 +455,7 @@ class JobsData:
         """
         async with AsyncSession(self._pg) as session:
             result = await session.execute(
-                select(SQLJob).where(SQLJob.id == job_id),
+                select(SQLJob).where(SQLJob.id == job_id).with_for_update(),
             )
             sql_job = result.scalar()
 

--- a/virtool/workflow/pytest_plugin/data.py
+++ b/virtool/workflow/pytest_plugin/data.py
@@ -54,6 +54,9 @@ class WorkflowData:
     step_start_updates: list[dict]
     """Step start updates pushed during the workflow, for test assertions."""
 
+    finish_called: bool
+    """Whether the workflow runtime called the finish endpoint."""
+
 
 @pytest.fixture
 def workflow_data(
@@ -240,4 +243,5 @@ def workflow_data(
         subtraction=subtraction,
         new_subtraction=new_subtraction,
         step_start_updates=[],
+        finish_called=False,
     )

--- a/virtool/workflow/runtime/run.py
+++ b/virtool/workflow/runtime/run.py
@@ -16,12 +16,13 @@ from virtool.jobs.models import (
     JobClaimed,
     JobState,
     JobStepDefinition,
+    JobWithKey,
 )
 from virtool.logs import configure_logging
 from virtool.sentry import configure_sentry
 from virtool.version import get_virtool_version
 from virtool.workflow.acquire import claim_job_by_polling
-from virtool.workflow.client import api_client
+from virtool.workflow.client import WorkflowAPIClient, api_client
 from virtool.workflow.hooks import (
     cleanup_builtin_status_hooks,
     on_cancelled,
@@ -56,6 +57,13 @@ def configure_status_hooks() -> None:
     @on_step_start
     async def handle_step_start(start_step) -> None:
         await start_step()
+
+    @on_success
+    async def handle_success(
+        _api: WorkflowAPIClient,
+        _job: JobWithKey | JobClaimed,
+    ) -> None:
+        await _api.post_json(f"/jobs/{_job.id}/finish", {})
 
 
 async def execute(


### PR DESCRIPTION
## Summary

- Adds a `POST /jobs/{job_id}/finish` endpoint on the jobs API that transitions a running job to the `succeeded` state
- Wires the workflow runtime's `on_success` hook to call this endpoint after a workflow completes successfully, so jobs no longer remain in the `running` state after success
- Adds a `finish_called` field to the `WorkflowData` test fixture to assert whether the finish endpoint was called during workflow execution

## Test plan

- [ ] Run `mise run test -- tests/jobs/test_api.py::TestFinish` to verify the new API endpoint behaves correctly (200 OK, 404 not found, 409 when not running)
- [ ] Run `mise run test -- tests/jobs/test_data.py::TestFinish` to verify the data layer `finish()` method raises correct errors and persists state
- [ ] Run `mise run test -- tests/workflow/test_runtime_hooks.py` to verify the `on_success` hook calls the finish endpoint and `on_error` does not