### PR TITLE
feat: rename pathoscope_bowtie to pathoscope everywhere

### DIFF
--- a/assets/revisions/rev_3g8rzbqj6k69_rename_pathoscope_bowtie_to_pathoscope.py
+++ b/assets/revisions/rev_3g8rzbqj6k69_rename_pathoscope_bowtie_to_pathoscope.py
@@ -1,0 +1,65 @@
+"""Rename the legacy ``pathoscope_bowtie`` workflow to ``pathoscope``.
+
+Backfills three stores so that the ``pathoscope_bowtie`` shims can be removed
+from the codebase:
+
+- PostgreSQL ``jobs.workflow``
+- PostgreSQL ``users.settings->>'quick_analyze_workflow'`` (JSONB)
+- MongoDB ``analyses.workflow``
+
+Idempotent: only rows still holding ``pathoscope_bowtie`` are touched, so a
+second run is a no-op.
+
+Revision ID: 3g8rzbqj6k69
+Date: 2026-04-29 22:40:02.765740
+"""
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+name = "rename pathoscope bowtie to pathoscope"
+created_at = arrow.get("2026-04-29 22:40:02.765740")
+revision_id = "3g8rzbqj6k69"
+
+alembic_down_revision = None
+virtool_down_revision = "g2cecswiq3r2"
+
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as session:
+        jobs_result = await session.execute(
+            text(
+                "UPDATE jobs SET workflow = 'pathoscope' "
+                "WHERE workflow = 'pathoscope_bowtie'",
+            ),
+        )
+        users_result = await session.execute(
+            text(
+                "UPDATE users "
+                "SET settings = jsonb_set("
+                "settings, '{quick_analyze_workflow}', '\"pathoscope\"'::jsonb"
+                ") "
+                "WHERE settings->>'quick_analyze_workflow' = 'pathoscope_bowtie'",
+            ),
+        )
+        await session.commit()
+
+    analyses_result = await ctx.mongo.analyses.update_many(
+        {"workflow": "pathoscope_bowtie"},
+        {"$set": {"workflow": "pathoscope"}},
+    )
+
+    logger.info(
+        "renamed pathoscope_bowtie to pathoscope",
+        jobs=jobs_result.rowcount,
+        users=users_result.rowcount,
+        analyses=analyses_result.modified_count,
+    )

--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -22,7 +22,7 @@
     }),
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -52,7 +52,7 @@
     }),
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -82,7 +82,7 @@
     }),
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -188,7 +188,7 @@
     }),
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -509,7 +509,7 @@
 # ---
 # name: TestUpdateSettings.test_ok[response]
   dict({
-    'quick_analyze_workflow': 'pathoscope_bowtie',
+    'quick_analyze_workflow': 'pathoscope',
     'show_ids': False,
     'show_versions': True,
     'skip_quick_analyze_dialog': True,
@@ -538,7 +538,7 @@
     }),
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -275,7 +275,7 @@ async def test_get_settings(spawn_client: ClientSpawner) -> None:
         "skip_quick_analyze_dialog": True,
         "show_ids": True,
         "show_versions": True,
-        "quick_analyze_workflow": "pathoscope_bowtie",
+        "quick_analyze_workflow": "pathoscope",
     }
 
 
@@ -303,7 +303,7 @@ class TestUpdateSettings:
         # Verify other settings remain unchanged
         assert body["show_versions"] is True
         assert body["skip_quick_analyze_dialog"] is True
-        assert body["quick_analyze_workflow"] == "pathoscope_bowtie"
+        assert body["quick_analyze_workflow"] == "pathoscope"
 
     async def test_invalid_input(
         self,

--- a/tests/account/test_models.py
+++ b/tests/account/test_models.py
@@ -23,7 +23,7 @@ BASE_ACCOUNT_DATA = {
     },
     "primary_group": None,
     "settings": {
-        "quick_analyze_workflow": "pathoscope_bowtie",
+        "quick_analyze_workflow": "pathoscope",
         "show_ids": True,
         "show_versions": True,
         "skip_quick_analyze_dialog": True,

--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -128,7 +128,7 @@
           'handle': 'myersmitchell',
           'id': 2,
         }),
-        'workflow': 'pathoscope_bowtie',
+        'workflow': 'pathoscope',
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
@@ -169,7 +169,7 @@
           'handle': 'myersmitchell',
           'id': 2,
         }),
-        'workflow': 'pathoscope_bowtie',
+        'workflow': 'pathoscope',
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
@@ -196,7 +196,7 @@
           'handle': 'myersmitchell',
           'id': 2,
         }),
-        'workflow': 'pathoscope_bowtie',
+        'workflow': 'pathoscope',
       }),
     ]),
     'found_count': 3,
@@ -266,7 +266,7 @@
       'handle': 'myersmitchell',
       'id': 2,
     }),
-    'workflow': 'pathoscope_bowtie',
+    'workflow': 'pathoscope',
   })
 # ---
 # name: test_get[None-True-True]
@@ -329,7 +329,7 @@
       'handle': 'myersmitchell',
       'id': 2,
     }),
-    'workflow': 'pathoscope_bowtie',
+    'workflow': 'pathoscope',
   })
 # ---
 # name: test_upload_file[None]

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -80,7 +80,7 @@ async def test_find(
             [
                 {
                     "_id": "test_1",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": {"id": job.id},
@@ -94,7 +94,7 @@ async def test_find(
                 },
                 {
                     "_id": "test_2",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": {"id": job.id},
@@ -108,7 +108,7 @@ async def test_find(
                 },
                 {
                     "_id": "test_3",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": None,
@@ -199,7 +199,7 @@ async def test_get(
                     "sample": {"id": "baz"},
                     "subtractions": ["plum", "apple"],
                     "user": {"id": user_1.id},
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                 },
             ),
             create_analysis_file(pg, "foobar", "fasta", "reference.fa"),
@@ -259,7 +259,7 @@ async def test_get_304(
                 "ready": ready,
                 "job": {"id": "test"},
                 "index": {"version": 3, "id": "bar"},
-                "workflow": "pathoscope_bowtie",
+                "workflow": "pathoscope",
                 "results": {"hits": []},
                 "sample": {"id": "baz"},
                 "reference": {"id": "baz"},
@@ -342,7 +342,7 @@ async def test_remove(
                 "sample": {"id": "baz", "name": "Baz"},
                 "subtractions": ["plum"],
                 "user": {"id": user.id},
-                "workflow": "pathoscope_bowtie",
+                "workflow": "pathoscope",
                 "results": {"hits": []},
             },
         )
@@ -529,7 +529,7 @@ async def test_blast(
             analysis_document["results"]["hits"].pop(1)
 
         elif error == "409_workflow":
-            analysis_document["workflow"] = "pathoscope_bowtie"
+            analysis_document["workflow"] = "pathoscope"
 
         elif error == "409_ready":
             analysis_document["ready"] = False

--- a/tests/jobs/__snapshots__/test_api.ambr
+++ b/tests/jobs/__snapshots__/test_api.ambr
@@ -36,7 +36,7 @@
         'create_subtraction': 1,
         'iimi': 0,
         'nuvs': 1,
-        'pathoscope': 0,
+        'pathoscope': 1,
       }),
       'succeeded': dict({
         'aodp': 0,
@@ -45,7 +45,7 @@
         'create_subtraction': 1,
         'iimi': 0,
         'nuvs': 0,
-        'pathoscope': 0,
+        'pathoscope': 1,
       }),
     }),
     'found_count': 11,

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -445,48 +445,6 @@ class TestClaim:
         body = await resp.json()
         assert body["id"] == older_job_id
 
-    async def test_claims_pathoscope_bowtie_alias(
-        self,
-        fake: DataFaker,
-        pg: AsyncEngine,
-        spawn_job_client: JobClientSpawner,
-    ):
-        client = await spawn_job_client(
-            authenticated=False,
-        )
-
-        user = await fake.users.create()
-
-        async with AsyncSession(pg) as session:
-            job = SQLJob(
-                created_at=arrow.utcnow().naive,
-                state="pending",
-                user_id=user.id,
-                workflow="pathoscope_bowtie",
-            )
-            session.add(job)
-            await session.flush()
-            job_id = job.id
-            await session.commit()
-
-        resp = await client.post(
-            "/jobs/claim?workflow=pathoscope_bowtie",
-            json={
-                "runner_id": "runner-1",
-                "mem": 8.0,
-                "cpu": 4.0,
-                "image": "virtool/workflow:1.0.0",
-                "runtime_version": "1.0.0",
-                "workflow_version": "2.0.0",
-                "steps": [],
-            },
-        )
-
-        assert resp.status == HTTPStatus.OK
-        body = await resp.json()
-        assert body["id"] == job_id
-        assert body["workflow"] == "pathoscope"
-
     async def test_skips_already_claimed(
         self,
         fake: DataFaker,

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -183,5 +183,12 @@
       'name': 'add archived to references',
       'revision': 'g2cecswiq3r2',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 27,
+      'name': 'rename pathoscope bowtie to pathoscope',
+      'revision': '3g8rzbqj6k69',
+    }),
   ])
 # ---

--- a/tests/migration/test_rename_pathoscope_bowtie_to_pathoscope.py
+++ b/tests/migration/test_rename_pathoscope_bowtie_to_pathoscope.py
@@ -1,0 +1,159 @@
+"""Tests for the rename-pathoscope-bowtie-to-pathoscope migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_3g8rzbqj6k69_rename_pathoscope_bowtie_to_pathoscope import (
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def applied(ctx: MigrationContext, apply_alembic: Callable) -> None:
+    await asyncio.to_thread(apply_alembic, "head")
+
+
+async def _insert_user(
+    ctx: MigrationContext,
+    handle: str,
+    quick_analyze_workflow: str | None,
+) -> int:
+    settings = (
+        '{"quick_analyze_workflow": "' + quick_analyze_workflow + '"}'
+        if quick_analyze_workflow is not None
+        else "{}"
+    )
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text(
+                f"""
+                INSERT INTO users (
+                    handle, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES (
+                    :handle, true, '', false, false, :now, :pw, '{settings}'::jsonb
+                )
+                RETURNING id
+                """,
+            ),
+            {"handle": handle, "now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_id = result.scalar_one()
+        await session.commit()
+    return user_id
+
+
+async def _insert_job(ctx: MigrationContext, user_id: int, workflow: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text(
+                """
+                INSERT INTO jobs (
+                    acquired, created_at, state, user_id, workflow
+                )
+                VALUES (false, :now, 'pending', :user_id, :workflow)
+                RETURNING id
+                """,
+            ),
+            {
+                "now": arrow.utcnow().naive,
+                "user_id": user_id,
+                "workflow": workflow,
+            },
+        )
+        job_id = result.scalar_one()
+        await session.commit()
+    return job_id
+
+
+async def _get_job_workflow(ctx: MigrationContext, job_id: int) -> str:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("SELECT workflow FROM jobs WHERE id = :id"),
+            {"id": job_id},
+        )
+        return result.scalar_one()
+
+
+async def _get_user_setting(ctx: MigrationContext, user_id: int) -> str | None:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text(
+                "SELECT settings->>'quick_analyze_workflow' FROM users WHERE id = :id",
+            ),
+            {"id": user_id},
+        )
+        return result.scalar_one()
+
+
+@pytest.mark.usefixtures("applied")
+class TestUpgrade:
+    async def test_renames_jobs_workflow(self, ctx: MigrationContext):
+        user_id = await _insert_user(ctx, "alice", None)
+        legacy = await _insert_job(ctx, user_id, "pathoscope_bowtie")
+        canonical = await _insert_job(ctx, user_id, "pathoscope")
+        unrelated = await _insert_job(ctx, user_id, "nuvs")
+
+        await upgrade(ctx)
+
+        assert await _get_job_workflow(ctx, legacy) == "pathoscope"
+        assert await _get_job_workflow(ctx, canonical) == "pathoscope"
+        assert await _get_job_workflow(ctx, unrelated) == "nuvs"
+
+    async def test_renames_user_quick_analyze_workflow(
+        self,
+        ctx: MigrationContext,
+    ):
+        legacy = await _insert_user(ctx, "alice", "pathoscope_bowtie")
+        canonical = await _insert_user(ctx, "bob", "pathoscope")
+        unrelated = await _insert_user(ctx, "carol", "nuvs")
+        unset = await _insert_user(ctx, "dave", None)
+
+        await upgrade(ctx)
+
+        assert await _get_user_setting(ctx, legacy) == "pathoscope"
+        assert await _get_user_setting(ctx, canonical) == "pathoscope"
+        assert await _get_user_setting(ctx, unrelated) == "nuvs"
+        assert await _get_user_setting(ctx, unset) is None
+
+    async def test_renames_mongo_analyses_workflow(self, ctx: MigrationContext):
+        await ctx.mongo.analyses.insert_many(
+            [
+                {"_id": "a1", "workflow": "pathoscope_bowtie"},
+                {"_id": "a2", "workflow": "pathoscope"},
+                {"_id": "a3", "workflow": "nuvs"},
+            ],
+        )
+
+        await upgrade(ctx)
+
+        docs = {
+            doc["_id"]: doc["workflow"] async for doc in ctx.mongo.analyses.find({})
+        }
+        assert docs == {
+            "a1": "pathoscope",
+            "a2": "pathoscope",
+            "a3": "nuvs",
+        }
+
+    async def test_idempotent(self, ctx: MigrationContext):
+        user_id = await _insert_user(ctx, "alice", "pathoscope_bowtie")
+        job_id = await _insert_job(ctx, user_id, "pathoscope_bowtie")
+        await ctx.mongo.analyses.insert_one(
+            {"_id": "a1", "workflow": "pathoscope_bowtie"},
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        assert await _get_job_workflow(ctx, job_id) == "pathoscope"
+        assert await _get_user_setting(ctx, user_id) == "pathoscope"
+        doc = await ctx.mongo.analyses.find_one({"_id": "a1"})
+        assert doc["workflow"] == "pathoscope"

--- a/tests/migration/test_rename_pathoscope_bowtie_to_pathoscope.py
+++ b/tests/migration/test_rename_pathoscope_bowtie_to_pathoscope.py
@@ -1,6 +1,7 @@
 """Tests for the rename-pathoscope-bowtie-to-pathoscope migration."""
 
 import asyncio
+import json
 from collections.abc import Callable
 
 import arrow
@@ -25,25 +26,31 @@ async def _insert_user(
     quick_analyze_workflow: str | None,
 ) -> int:
     settings = (
-        '{"quick_analyze_workflow": "' + quick_analyze_workflow + '"}'
+        {"quick_analyze_workflow": quick_analyze_workflow}
         if quick_analyze_workflow is not None
-        else "{}"
+        else {}
     )
     async with AsyncSession(ctx.pg) as session:
         result = await session.execute(
             text(
-                f"""
+                """
                 INSERT INTO users (
                     handle, active, email, force_reset,
                     invalidate_sessions, last_password_change, password, settings
                 )
                 VALUES (
-                    :handle, true, '', false, false, :now, :pw, '{settings}'::jsonb
+                    :handle, true, '', false, false, :now, :pw,
+                    CAST(:settings AS jsonb)
                 )
                 RETURNING id
                 """,
             ),
-            {"handle": handle, "now": arrow.utcnow().naive, "pw": b"hashed"},
+            {
+                "handle": handle,
+                "now": arrow.utcnow().naive,
+                "pw": b"hashed",
+                "settings": json.dumps(settings),
+            },
         )
         user_id = result.scalar_one()
         await session.commit()

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -2180,7 +2180,7 @@
       'handle': 'leeashley',
       'id': 1,
     }),
-    'workflow': 'pathoscope_bowtie',
+    'workflow': 'pathoscope',
   })
 # ---
 # name: test_finalize[quality]
@@ -2309,7 +2309,7 @@
           'handle': 'myersmitchell',
           'id': 2,
         }),
-        'workflow': 'pathoscope_bowtie',
+        'workflow': 'pathoscope',
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
@@ -2340,7 +2340,7 @@
           'handle': 'myersmitchell',
           'id': 2,
         }),
-        'workflow': 'pathoscope_bowtie',
+        'workflow': 'pathoscope',
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
@@ -2371,7 +2371,7 @@
           'handle': 'modonnell',
           'id': 3,
         }),
-        'workflow': 'pathoscope_bowtie',
+        'workflow': 'pathoscope',
       }),
     ]),
     'found_count': 3,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1072,7 +1072,7 @@ async def test_find_analyses(
             [
                 {
                     "_id": "test_1",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": {"id": job.id},
@@ -1085,7 +1085,7 @@ async def test_find_analyses(
                 },
                 {
                     "_id": "test_2",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": {"id": "foo"},
@@ -1098,7 +1098,7 @@ async def test_find_analyses(
                 },
                 {
                     "_id": "test_3",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": None,
@@ -1111,7 +1111,7 @@ async def test_find_analyses(
                 },
                 {
                     "_id": "test_4",
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                     "created_at": static_time.datetime,
                     "ready": True,
                     "job": None,
@@ -1191,7 +1191,7 @@ async def test_analyze(
     resp = await client.post(
         "/samples/test/analyses",
         data={
-            "workflow": "pathoscope_bowtie",
+            "workflow": "pathoscope",
             "ref_id": "test_ref",
             "subtractions": [
                 "subtraction_1",

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -29,15 +29,6 @@ class TestCalculateWorkflowTags:
         ],
     )
     @pytest.mark.parametrize(
-        ("alg1", "alg2"),
-        [
-            ("bowtie", "bowtie"),
-            ("bowtie", "barracuda"),
-            ("barracuda", "bowtie"),
-            ("barracuda", "barracuda"),
-        ],
-    )
-    @pytest.mark.parametrize(
         ("nuvs_ready", "nuvs_tag"),
         [
             ([False, False], "ip"),
@@ -46,10 +37,9 @@ class TestCalculateWorkflowTags:
             ([True, True], True),
         ],
     )
-    def test(self, path_ready, alg1, alg2, path_tag, nuvs_ready, nuvs_tag):
-        """Test that the function returns the correct update dict for every combination of pathoscope
-        and nuvs ready states.
-
+    def test(self, path_ready, path_tag, nuvs_ready, nuvs_tag):
+        """Test that the function returns the correct update dict for every
+        combination of pathoscope and nuvs ready states.
         """
         index = 0
 
@@ -57,12 +47,8 @@ class TestCalculateWorkflowTags:
         nuvs_ready_1, nuvs_ready_2 = nuvs_ready
 
         documents = [
-            {
-                "_id": index,
-                "ready": path_ready_1,
-                "workflow": f"pathoscope_{alg1}",
-            },
-            {"_id": index, "ready": path_ready_2, "workflow": f"pathoscope_{alg2}"},
+            {"_id": index, "ready": path_ready_1, "workflow": "pathoscope"},
+            {"_id": index, "ready": path_ready_2, "workflow": "pathoscope"},
             {"_id": index, "ready": nuvs_ready_1, "workflow": "nuvs"},
             {"_id": index, "ready": nuvs_ready_2, "workflow": "nuvs"},
         ]
@@ -78,13 +64,13 @@ async def test_recalculate_workflow_tags(mocker: MockerFixture, mongo: Mongo):
     analysis_documents = [
         {
             "_id": "test_1",
-            "workflow": "pathoscope_bowtie",
+            "workflow": "pathoscope",
             "ready": "ip",
             "sample": {"id": "test"},
         },
         {
             "_id": "test_2",
-            "workflow": "pathoscope_bowtie",
+            "workflow": "pathoscope",
             "ready": True,
             "sample": {"id": "test"},
         },
@@ -102,7 +88,7 @@ async def test_recalculate_workflow_tags(mocker: MockerFixture, mongo: Mongo):
             {
                 "_id": "test_4",
                 "sample": {"id": "foobar"},
-                "workflow": "pathoscope_bowtie",
+                "workflow": "pathoscope",
                 "ready": True,
             },
         ],

--- a/tests/samples/test_tasks.py
+++ b/tests/samples/test_tasks.py
@@ -39,7 +39,7 @@ async def test_update_workflows_fields(
                 "_id": "test",
                 "sample": {"id": "test_id"},
                 "ready": ready,
-                "workflow": "pathoscope_bowtie",
+                "workflow": "pathoscope",
             },
             {
                 "_id": "test1",

--- a/tests/users/__snapshots__/test_data.ambr
+++ b/tests/users/__snapshots__/test_data.ambr
@@ -330,10 +330,10 @@
   })
 # ---
 # name: TestUpdate.test_groups[pg_1]
-  <SQLUser(id='1', active='True', administrator_role='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='None', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=meteorologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
+  <SQLUser(id='1', active='True', administrator_role='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='None', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=3, legacy_id=None, name=meteorologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
 # ---
 # name: TestUpdate.test_groups[pg_2]
-  <SQLUser(id='1', active='True', administrator_role='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='None', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope_bowtie', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=2, legacy_id=None, name=geoscientists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
+  <SQLUser(id='1', active='True', administrator_role='None', email='', force_reset='False', handle='leeashley', invalidate_sessions='False', last_password_change='datetime', legacy_id='None', settings='{'show_ids': True, 'show_versions': True, 'quick_analyze_workflow': 'pathoscope', 'skip_quick_analyze_dialog': True}', groups='[<SQLGroup(id=2, legacy_id=None, name=geoscientists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>, <SQLGroup(id=1, legacy_id=None, name=haematologists, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>]', primary_group='None')>
 # ---
 # name: TestUpdate.test_groups[pg_3]
   dict({
@@ -350,7 +350,7 @@
     'legacy_id': None,
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -395,7 +395,7 @@
     'legacy_id': None,
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -446,7 +446,7 @@
     'legacy_id': None,
     'primary_group': None,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,
@@ -538,7 +538,7 @@
     'legacy_id': None,
     'primary_group': <SQLGroup(id=1, legacy_id=None, name=musicians, permissions={'cancel_job': False, 'create_ref': False, 'modify_hmm': False, 'remove_job': False, 'remove_file': False, 'upload_file': False, 'create_sample': False, 'modify_subtraction': False})>,
     'settings': dict({
-      'quick_analyze_workflow': 'pathoscope_bowtie',
+      'quick_analyze_workflow': 'pathoscope',
       'show_ids': True,
       'show_versions': True,
       'skip_quick_analyze_dialog': True,

--- a/virtool/account/models.py
+++ b/virtool/account/models.py
@@ -35,7 +35,7 @@ class AccountSettings(BaseModel):
                 "skip_quick_analyze_dialog": True,
                 "show_ids": True,
                 "show_versions": True,
-                "quick_analyze_workflow": "pathoscope_bowtie",
+                "quick_analyze_workflow": "pathoscope",
             }
         }
 
@@ -84,7 +84,7 @@ class Account(User):
                     "name": "Technician",
                 },
                 "settings": {
-                    "quick_analyze_workflow": "pathoscope_bowtie",
+                    "quick_analyze_workflow": "pathoscope",
                     "show_ids": True,
                     "show_versions": True,
                     "skip_quick_analyze_dialog": True,

--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -56,7 +56,7 @@ class AnalysisMinimal(BaseModel):
                         "handle": "mrott",
                         "id": "ihvze2u9",
                     },
-                    "workflow": "pathoscope_bowtie",
+                    "workflow": "pathoscope",
                 },
             ],
         }
@@ -124,7 +124,7 @@ class Analysis(AnalysisMinimal):
                 "subtractions": [{"id": "1sk885at", "name": "Vitis vinifera"}],
                 "updated_at": "2022-08-15T17:42:35.979000Z",
                 "user": {"administrator": True, "handle": "mrott", "id": "ihvze2u9"},
-                "workflow": "pathoscope_bowtie",
+                "workflow": "pathoscope",
             }
         }
 

--- a/virtool/analyses/oas.py
+++ b/virtool/analyses/oas.py
@@ -21,7 +21,7 @@ class FindAnalysesResponse(AnalysisSearchResult):
                             "handle": "mrott",
                             "id": "ihvze2u9",
                         },
-                        "workflow": "pathoscope_bowtie",
+                        "workflow": "pathoscope",
                     }
                 ],
                 "found_count": 2621,

--- a/virtool/analyses/utils.py
+++ b/virtool/analyses/utils.py
@@ -5,7 +5,7 @@ from sqlalchemy.future import select
 
 from virtool.analyses.sql import SQLAnalysisFile
 
-WORKFLOW_NAMES = ("aodp", "nuvs", "pathoscope_bowtie")
+WORKFLOW_NAMES = ("aodp", "nuvs", "pathoscope")
 
 
 def analysis_file_key(name_on_disk: str) -> str:

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -223,8 +223,7 @@ class JobsData:
                     ),
                 )
             elif (
-                workflow in ("aodp", "nuvs", "pathoscope", "pathoscope_bowtie")
-                and "analysis_id" in job_args
+                workflow in ("aodp", "nuvs", "pathoscope") and "analysis_id" in job_args
             ):
                 session.add(
                     SQLJobAnalysis(
@@ -307,15 +306,10 @@ class JobsData:
         :raises ResourceNotFoundError: if no unclaimed job is available
         """
         async with AsyncSession(self._pg) as session:
-            workflows = [workflow.value]
-
-            if workflow is Workflow.PATHOSCOPE:
-                workflows.append("pathoscope_bowtie")
-
             result = await session.execute(
                 select(SQLJob)
                 .where(
-                    SQLJob.workflow.in_(workflows),
+                    SQLJob.workflow == workflow.value,
                     SQLJob.acquired == False,  # noqa: E712
                     SQLJob.state == "pending",
                 )

--- a/virtool/jobs/models.py
+++ b/virtool/jobs/models.py
@@ -35,12 +35,6 @@ class Workflow(Enum):
     PATHOSCOPE = "pathoscope"
     IIMI = "iimi"
 
-    @classmethod
-    def _missing_(cls, value):
-        if value == "pathoscope_bowtie":
-            return cls.PATHOSCOPE
-        return super()._missing_(value)
-
 
 class WorkflowCounts(BaseModel):
     """Counts per workflow."""

--- a/virtool/jobs/utils.py
+++ b/virtool/jobs/utils.py
@@ -4,7 +4,7 @@ WORKFLOW_NAMES = (
     "jobs_create_subtraction",
     "jobs_aodp",
     "jobs_nuvs",
-    "jobs_pathoscope_bowtie",
+    "jobs_pathoscope",
 )
 
 

--- a/virtool/models/enums.py
+++ b/virtool/models/enums.py
@@ -42,7 +42,7 @@ class AnalysisWorkflow(str, Enum):
     aodp = "aodp"
     iimi = "iimi"
     nuvs = "nuvs"
-    pathoscope_bowtie = "pathoscope_bowtie"
+    pathoscope = "pathoscope"
 
 
 QuickAnalyzeWorkflow = AnalysisWorkflow

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -21,7 +21,6 @@ from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.samples.models import WorkflowState
 from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
-from virtool.samples.utils import PATHOSCOPE_TASK_NAMES
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.uploads.sql import SQLUpload
@@ -346,7 +345,7 @@ def derive_workflow_state(analyses: list, library_type) -> dict:
     workflow_states = define_initial_workflows(library_type)
 
     for analysis in analyses:
-        workflow_name = get_workflow_name(analysis["workflow"])
+        workflow_name = analysis["workflow"]
 
         if workflow_states[workflow_name] in (
             WorkflowState.COMPLETE.value,
@@ -361,20 +360,6 @@ def derive_workflow_state(analyses: list, library_type) -> dict:
         )
 
     return {"workflows": workflow_states}
-
-
-def get_workflow_name(workflow_name: str) -> str:
-    """Returns the name of the workflow that is being used. If the workflow name is
-    "pathoscope_bowtie" or "pathoscope_bowtie2", then "pathoscope" is returned.
-
-    :param workflow_name: the name of the workflow
-    :return: the name of the workflow that is being used
-
-    """
-    if workflow_name in PATHOSCOPE_TASK_NAMES:
-        return "pathoscope"
-
-    return workflow_name
 
 
 async def recalculate_workflow_tags(

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -8,8 +8,6 @@ from virtool.api.client import AbstractClient
 from virtool.api.errors import APIBadRequest
 from virtool.labels.sql import SQLLabel
 
-PATHOSCOPE_TASK_NAMES = ["pathoscope_bowtie", "pathoscope_barracuda"]
-
 
 class SampleRight(Enum):
     read = "read"
@@ -28,7 +26,7 @@ def calculate_workflow_tags(analyses: list) -> dict:
     nuvs = False
 
     for analysis in analyses:
-        if pathoscope is not True and analysis["workflow"] in PATHOSCOPE_TASK_NAMES:
+        if pathoscope is not True and analysis["workflow"] == "pathoscope":
             pathoscope = analysis["ready"] or "ip" or pathoscope
 
         if nuvs is not True and analysis["workflow"] == "nuvs":

--- a/virtool/users/settings.py
+++ b/virtool/users/settings.py
@@ -4,5 +4,5 @@ DEFAULT_USER_SETTINGS = {
     "skip_quick_analyze_dialog": True,
     "show_ids": True,
     "show_versions": True,
-    "quick_analyze_workflow": "pathoscope_bowtie",
+    "quick_analyze_workflow": "pathoscope",
 }

--- a/virtool/workflow/pytest_plugin/data.py
+++ b/virtool/workflow/pytest_plugin/data.py
@@ -225,7 +225,7 @@ def workflow_data(
 
     analysis: Analysis = AnalysisFactory.build()
     analysis.sample = AnalysisSample.parse_obj(sample)
-    analysis.workflow = "pathoscope_bowtie"
+    analysis.workflow = "pathoscope"
     analysis.index = IndexNested.parse_obj(index)
     analysis.reference = ReferenceNested.parse_obj(reference)
     analysis.subtractions = [SubtractionNested.parse_obj(subtraction)]


### PR DESCRIPTION
## Summary

* Removes all `pathoscope_bowtie` shims and aliases now that the backfill migration has been written, leaving `pathoscope` as the single canonical workflow name across PostgreSQL jobs, user settings (JSONB), MongoDB analyses, enums, and API models
* Adds an idempotent Virtool migration (`rev_3g8rzbqj6k69`) that renames any remaining `pathoscope_bowtie` values in the three data stores so the shims can be safely dropped
* Cleans up the `Workflow._missing_` compatibility hook, the `PATHOSCOPE_TASK_NAMES` list, the `get_workflow_name` helper, the job-claim alias query, and the corresponding test coverage for those shims