### PR TITLE
chore: remove unused mongo files collection binding and drop collection

### DIFF
--- a/assets/revisions/rev_wsopnh02rvet_drop_unused_mongo_files_collection.py
+++ b/assets/revisions/rev_wsopnh02rvet_drop_unused_mongo_files_collection.py
@@ -1,0 +1,33 @@
+"""Drop the unused MongoDB ``files`` collection.
+
+Uploads have been managed in PostgreSQL via ``SQLUpload`` for some time, and
+the matching ``Mongo.files`` binding has been removed. This migration drops the
+collection so old deployments don't keep an empty ``files`` collection around.
+
+Idempotent: ``drop_collection`` is a no-op if the collection doesn't exist.
+
+Revision ID: wsopnh02rvet
+Date: 2026-05-01 17:42:56.029278
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+name = "drop unused mongo files collection"
+created_at = arrow.get("2026-05-01 17:42:56.029278")
+revision_id = "wsopnh02rvet"
+
+alembic_down_revision = None
+virtool_down_revision = "3g8rzbqj6k69"
+
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    await ctx.mongo.drop_collection("files")
+    logger.info("dropped unused mongo files collection")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -190,5 +190,12 @@
       'name': 'rename pathoscope bowtie to pathoscope',
       'revision': '3g8rzbqj6k69',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 28,
+      'name': 'drop unused mongo files collection',
+      'revision': 'wsopnh02rvet',
+    }),
   ])
 # ---

--- a/virtool/mongo/core.py
+++ b/virtool/mongo/core.py
@@ -163,7 +163,6 @@ class Mongo:
         self.id_provider = id_provider
 
         self.analyses = self.bind_collection("analyses")
-        self.files = self.bind_collection("files")
         self.groups = self.bind_collection("groups")
         self.history = self.bind_collection("history")
         self.hmm = self.bind_collection("hmm")


### PR DESCRIPTION
## Summary
- Removes the `Mongo.files` collection binding from `virtool/mongo/core.py`, which was made redundant when uploads moved to PostgreSQL via `SQLUpload`
- Adds a migration (`wsopnh02rvet`) that drops the now-unused `files` collection from MongoDB in existing deployments; the drop is idempotent if the collection is already absent
- Updates migration snapshots to reflect the new revision

## Test plan
- [ ] Run migration tests: `mise run test -- tests/migration`
- [ ] Verify no code references `mongo.files` after the binding removal
- [ ] Confirm the migration applies cleanly against a database that has an existing `files` collection and one that does not