### PR TITLE
fix: drop unused mongo collections (caches, groups, sessions)

### DIFF
--- a/assets/revisions/rev_k9s3n2p7x4qa_drop_unused_mongo_collections.py
+++ b/assets/revisions/rev_k9s3n2p7x4qa_drop_unused_mongo_collections.py
@@ -1,0 +1,34 @@
+"""Drop unused MongoDB collections.
+
+The ``caches``, ``groups``, and ``sessions`` collections have been superseded
+by other storage and are no longer read by Virtool.
+
+Idempotent: ``drop_collection`` is a no-op if a collection doesn't exist.
+
+Revision ID: k9s3n2p7x4qa
+Date: 2026-05-01 12:16:51.963048
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+name = "drop unused mongo collections"
+created_at = arrow.get("2026-05-01 12:16:51.963048")
+revision_id = "k9s3n2p7x4qa"
+
+alembic_down_revision = None
+virtool_down_revision = "wsopnh02rvet"
+
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    for collection_name in ("caches", "groups", "sessions"):
+        await ctx.mongo.drop_collection(collection_name)
+
+    logger.info("dropped unused mongo collections")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -197,5 +197,12 @@
       'name': 'drop unused mongo files collection',
       'revision': 'wsopnh02rvet',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 29,
+      'name': 'drop unused mongo collections',
+      'revision': 'k9s3n2p7x4qa',
+    }),
   ])
 # ---

--- a/tests/migration/test_drop_unused_mongo_collections.py
+++ b/tests/migration/test_drop_unused_mongo_collections.py
@@ -1,0 +1,31 @@
+"""Tests for the drop-unused-mongo-collections migration."""
+
+from assets.revisions.rev_k9s3n2p7x4qa_drop_unused_mongo_collections import upgrade
+from virtool.migration.ctx import MigrationContext
+
+
+async def test_upgrade_drops_unused_collections(ctx: MigrationContext):
+    for collection_name in ("caches", "groups", "sessions"):
+        await ctx.mongo[collection_name].insert_one({"_id": collection_name})
+
+    await ctx.mongo.retained.insert_one({"_id": "retained"})
+
+    await upgrade(ctx)
+
+    collection_names = await ctx.mongo.list_collection_names()
+
+    assert "caches" not in collection_names
+    assert "groups" not in collection_names
+    assert "sessions" not in collection_names
+    assert "retained" in collection_names
+
+
+async def test_upgrade_is_idempotent(ctx: MigrationContext):
+    await upgrade(ctx)
+    await upgrade(ctx)
+
+    collection_names = await ctx.mongo.list_collection_names()
+
+    assert "caches" not in collection_names
+    assert "groups" not in collection_names
+    assert "sessions" not in collection_names


### PR DESCRIPTION
## Summary
- Adds a migration that drops the `caches`, `groups`, and `sessions` MongoDB collections, which have been superseded by other storage and are no longer read by Virtool
- Migration is idempotent — `drop_collection` is a no-op if a collection doesn't exist

## Test plan
- [ ] Run `mise run test -- tests/migration/test_drop_unused_mongo_collections.py` to verify the migration drops the three collections and is idempotent
- [ ] Run `mise run test -- tests/migration` to confirm the `test_apply` snapshot is up to date