### PR TITLE
fix: make if_modified_since optional in AnalysisData.get

### DIFF
--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -160,6 +160,28 @@ async def test_create_analysis_id(
     )
 
 
+async def test_get_without_if_modified_since(
+    data_layer: DataLayer,
+    setup_sample: str,
+):
+    """Test that an analysis can be fetched without an HTTP cache validator."""
+    analysis = await data_layer.analyses.create(
+        CreateAnalysisRequest(
+            ml=None,
+            ref_id="test_ref",
+            subtractions=["subtraction_1", "subtraction_2"],
+            workflow=AnalysisWorkflow.nuvs,
+        ),
+        "test_sample",
+        setup_sample,
+        0,
+    )
+
+    fetched = await data_layer.analyses.get(analysis.id)
+
+    assert fetched.id == analysis.id
+
+
 async def test_upload_file(
     data_layer: DataLayer,
     example_path: Path,

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -171,7 +171,7 @@ class AnalysisData(DataLayerDomain):
     async def get(
         self,
         analysis_id: str,
-        if_modified_since: datetime | None,
+        if_modified_since: datetime | None = None,
     ) -> Analysis:
         """Get a single analysis by its ID.
 


### PR DESCRIPTION
## Summary
- AnalysisData.get required if_modified_since as a positional argument, causing a TypeError when called without it (e.g. from websocket analysis fetches)
- Made if_modified_since optional with a default of None so the method can be called with only the analysis ID
- Added a regression test covering the case where get is called without a cache validator

## Test plan
- [ ] Run mise run test -- tests/analyses/test_data.py to verify the new test passes
- [ ] Confirm websocket analysis fetches no longer raise TypeError