### PR TITLE
fix: persist analysis_id for iimi jobs

### DIFF
--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -224,8 +224,10 @@ class TestCreatePostgres:
         assert job_subtraction is not None
         assert job_subtraction.subtraction_id == "sub_789"
 
+    @pytest.mark.parametrize("workflow", ["aodp", "iimi", "nuvs", "pathoscope"])
     async def test_analysis_join_table(
         self,
+        workflow: str,
         jobs_data: JobsData,
         fake: DataFaker,
         pg: AsyncEngine,
@@ -234,7 +236,7 @@ class TestCreatePostgres:
         user = await fake.users.create()
 
         job = await jobs_data.create(
-            "nuvs",
+            workflow,
             {"analysis_id": "analysis_abc"},
             user.id,
             0,
@@ -255,6 +257,9 @@ class TestCreatePostgres:
 
         assert job_analysis is not None
         assert job_analysis.analysis_id == "analysis_abc"
+
+        fetched_job = await jobs_data.get(job.id)
+        assert fetched_job.args == {"analysis_id": "analysis_abc"}
 
 
 class TestStartStepPostgres:

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -223,7 +223,8 @@ class JobsData:
                     ),
                 )
             elif (
-                workflow in ("aodp", "nuvs", "pathoscope") and "analysis_id" in job_args
+                workflow in ("aodp", "iimi", "nuvs", "pathoscope")
+                and "analysis_id" in job_args
             ):
                 session.add(
                     SQLJobAnalysis(


### PR DESCRIPTION
## Summary
- Adds `iimi` to the list of workflows that persist the `analysis_id` join table entry when creating a job, fixing a bug where iimi analyses were not tracked in PostgreSQL
- Extends the `test_analysis_join_table` test to be parametrized over all analysis workflows (`aodp`, `iimi`, `nuvs`, `pathoscope`) and adds an assertion that the job args are correctly stored

## Test plan
- [ ] Run `mise run test -- tests/jobs/test_data.py` to verify all parametrized `test_analysis_join_table` cases pass
- [ ] Confirm that iimi jobs correctly record their `analysis_id` in the `job_analysis` join table after the fix