### PR TITLE
fix: fix download 404s on Azure by replacing list() existence checks with size()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,27 @@ states in the OAS description. The canonical example is `archived` on
 - Ruff enforces all rules (`select = ["ALL"]`) with specific ignores. Test files
   have relaxed type annotation and docstring rules.
 
+## Explicit Configuration, Loud Failures
+
+Prefer explicit wiring and loud errors over silent fallbacks. A required
+dependency that quietly defaults to *something plausible* will mask broken
+configuration for weeks before anyone notices.
+
+- Required constructor and factory parameters must be non-optional with no
+  default. Do not write `dep: X | None = None` and then construct a fallback
+  inside the function — that turns a forgotten caller into silent
+  misbehaviour.
+- Look up required app state with `app["key"]` (which raises `KeyError`), not
+  `app.get("key")` (which returns `None`).
+- Don't add production fallbacks to make tests easier. Tests pass explicit
+  doubles (in-memory backends, tmp paths). Production code stays strict.
+- When adding a new aiohttp entry point (API server, jobs server, task runner,
+  task spawner), audit `on_startup` against the other entry points. A missing
+  `startup_*` is a wiring bug, not a runtime "use a sensible default" moment.
+- Config values that have no safe default should validate at load time and
+  raise. Don't silently coerce empty strings, `None`, or missing env vars to
+  working-but-wrong values.
+
 ## Git
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org).

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -817,6 +817,7 @@ async def test_download(
     example_path: Path,
     memory_storage: StorageBackend,
     mongo: Mongo,
+    pg: AsyncEngine,
     spawn_job_client: JobClientSpawner,
 ):
     client = await spawn_job_client(authenticated=True)
@@ -844,6 +845,17 @@ async def test_download(
         yield expected_bytes
 
     await memory_storage.write(key, _stream())
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLIndexFile(
+                name="reference.1.bt2",
+                index="test_index",
+                type="bowtie2",
+                size=len(expected_bytes),
+            ),
+        )
+        await session.commit()
 
     files_url = "/indexes/test_index/files/"
 

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1489,7 +1489,11 @@ class TestDownloadReads:
         await mongo.samples.insert_one({"_id": "foo", "ready": True})
 
     @staticmethod
-    async def _insert_reads_row(pg: AsyncEngine, file_name: str) -> None:
+    async def _insert_reads_row(
+        pg: AsyncEngine,
+        file_name: str,
+        size: int = 4,
+    ) -> None:
         async with AsyncSession(pg) as session:
             session.add(
                 SQLSampleReads(
@@ -1497,6 +1501,7 @@ class TestDownloadReads:
                     sample="foo",
                     name=file_name,
                     name_on_disk=file_name,
+                    size=size,
                 ),
             )
             await session.commit()
@@ -1587,6 +1592,26 @@ class TestDownloadReads:
 
         assert resp.status == job_resp.status == 404
 
+    async def test_404_zero_byte_missing_object(
+        self,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+        job_client = await spawn_job_client(authenticated=True)
+
+        file_name = "reads_1.fq.gz"
+
+        await self._insert_sample(mongo)
+        await self._insert_reads_row(pg, file_name, size=0)
+
+        resp = await client.get(f"/samples/foo/reads/{file_name}")
+        job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
+
+        assert resp.status == job_resp.status == 404
+
 
 class TestDownloadArtifact:
     @staticmethod
@@ -1601,7 +1626,7 @@ class TestDownloadArtifact:
         await mongo.samples.insert_one({"_id": "foo", "ready": True})
 
     @staticmethod
-    async def _insert_artifact_row(pg: AsyncEngine) -> None:
+    async def _insert_artifact_row(pg: AsyncEngine, size: int = 4) -> None:
         async with AsyncSession(pg) as session:
             session.add(
                 SQLSampleArtifact(
@@ -1610,6 +1635,7 @@ class TestDownloadArtifact:
                     name="fastqc.txt",
                     name_on_disk="fastqc.txt",
                     type="fastq",
+                    size=size,
                 ),
             )
             await session.commit()
@@ -1672,6 +1698,21 @@ class TestDownloadArtifact:
 
         await self._insert_sample(mongo)
         await self._insert_artifact_row(pg)
+
+        resp = await client.get("/samples/foo/artifacts/fastqc.txt")
+
+        assert resp.status == 404
+
+    async def test_404_zero_byte_missing_object(
+        self,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        await self._insert_sample(mongo)
+        await self._insert_artifact_row(pg, size=0)
 
         resp = await client.get("/samples/foo/artifacts/fastqc.txt")
 

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -119,6 +119,25 @@ class TestDelete:
         assert (tmp_path / "a" / "b" / "keep.txt").exists()
 
 
+class TestSize:
+    async def test_ok(self, provider, tmp_path):
+        path = tmp_path / "samples" / "abc" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"hello world")
+
+        assert await provider.size("samples/abc/reads.fq.gz") == 11
+
+    async def test_empty_object(self, provider, tmp_path):
+        path = tmp_path / "empty"
+        path.write_bytes(b"")
+
+        assert await provider.size("empty") == 0
+
+    async def test_nonexistent_key(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.size("does/not/exist")
+
+
 class TestList:
     async def test_with_prefix(self, provider, tmp_path):
         (tmp_path / "samples" / "a").mkdir(parents=True)

--- a/tests/storage/test_integration.py
+++ b/tests/storage/test_integration.py
@@ -124,6 +124,20 @@ class TestList:
         assert info.last_modified is not None
 
 
+class TestSize:
+    async def test_ok(self, provider, request, worker_id):
+        key = _key(request, worker_id, "sized.txt")
+        await provider.write(key, _async_iter(b"hello world"))
+
+        assert await provider.size(key) == 11
+
+    async def test_nonexistent_raises(self, provider, request, worker_id):
+        key = _key(request, worker_id, "never-existed.txt")
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.size(key)
+
+
 class TestErrors:
     async def test_read_nonexistent_raises(self, provider, request, worker_id):
         key = _key(request, worker_id, "never-existed.txt")

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -82,6 +82,22 @@ class TestDelete:
         await provider.delete("does/not/exist")
 
 
+class TestSize:
+    async def test_ok(self, provider):
+        await provider.write("samples/abc/reads.fq.gz", _async_iter(b"hello world"))
+
+        assert await provider.size("samples/abc/reads.fq.gz") == 11
+
+    async def test_empty_object(self, provider):
+        await provider.write("empty", _async_iter(b""))
+
+        assert await provider.size("empty") == 0
+
+    async def test_nonexistent_key(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.size("does/not/exist")
+
+
 class TestList:
     async def test_with_prefix(self, provider):
         await provider.write("samples/a/reads.fq.gz", _async_iter(b"a"))

--- a/tests/storage/test_object.py
+++ b/tests/storage/test_object.py
@@ -37,6 +37,22 @@ class TestErrorTranslation:
         await provider.delete("does/not/exist")
 
 
+class TestSize:
+    async def test_ok(self, provider):
+        await provider.write("samples/abc/reads.fq.gz", _async_iter(b"hello world"))
+
+        assert await provider.size("samples/abc/reads.fq.gz") == 11
+
+    async def test_empty_object(self, provider):
+        await provider.write("empty", _async_iter(b""))
+
+        assert await provider.size("empty") == 0
+
+    async def test_nonexistent_key(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.size("does/not/exist")
+
+
 class TestRoundtrip:
     async def test_write_then_read(self, provider):
         await provider.write("samples/abc/reads.fq.gz", _async_iter(b"hello"))

--- a/tests/storage/test_routing.py
+++ b/tests/storage/test_routing.py
@@ -109,6 +109,28 @@ class TestDelete:
         await router.delete("missing")
 
 
+class TestSize:
+    async def test_primary_hit(self, primary, router):
+        await primary.write("key", _async_iter(b"primary"))
+
+        assert await router.size("key") == 7
+
+    async def test_falls_back_to_fallback(self, fallback, router):
+        await fallback.write("key", _async_iter(b"fallback data"))
+
+        assert await router.size("key") == 13
+
+    async def test_primary_takes_precedence(self, primary, fallback, router):
+        await primary.write("key", _async_iter(b"short"))
+        await fallback.write("key", _async_iter(b"a longer value"))
+
+        assert await router.size("key") == 5
+
+    async def test_missing_from_both_raises(self, router):
+        with pytest.raises(StorageKeyNotFoundError):
+            await router.size("missing")
+
+
 class TestList:
     async def test_merges_results(self, primary, fallback, router):
         await primary.write("a/1", _async_iter(b"p"))

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -438,11 +438,7 @@ class AnalysisData(DataLayerDomain):
 
         key = analysis_file_key(analysis_file.name_on_disk)
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), info.size, analysis_file.name
-
-        raise ResourceNotFoundError()
+        return self._storage.read(key), analysis_file.size, analysis_file.name
 
     async def download(
         self,

--- a/virtool/api/streaming.py
+++ b/virtool/api/streaming.py
@@ -9,7 +9,6 @@ from virtool.storage.errors import StorageKeyNotFoundError
 async def stream_storage_response(
     req: Request,
     stream: AsyncIterator[bytes],
-    size: int,
     headers: dict[str, str],
     not_found_message: str = "",
 ) -> StreamResponse:

--- a/virtool/api/streaming.py
+++ b/virtool/api/streaming.py
@@ -15,18 +15,19 @@ async def stream_storage_response(
 ) -> StreamResponse:
     response = StreamResponse(headers=headers)
 
-    if size > 0:
-        try:
-            first_chunk = await anext(stream)
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound(not_found_message or None)
+    try:
+        first_chunk = await anext(stream)
+    except StorageKeyNotFoundError:
+        raise APINotFound(not_found_message or None)
+    except StopAsyncIteration:
+        first_chunk = None
 
-        await response.prepare(req)
+    await response.prepare(req)
+
+    if first_chunk is not None:
         await response.write(first_chunk)
 
         async for chunk in stream:
             await response.write(chunk)
-    else:
-        await response.prepare(req)
 
     return response

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -171,6 +171,7 @@ def tasks() -> None:
 @no_revision_check_option
 @postgres_connection_string_option
 @sentry_dsn_option
+@storage_options
 def start_task_runner(dev: bool, **kwargs) -> None:
     """Start the task runner service."""
     configure_logging(bool(kwargs["sentry_dsn"]))

--- a/virtool/config/cls.py
+++ b/virtool/config/cls.py
@@ -115,6 +115,17 @@ class TaskRunnerConfig:
     port: int
     postgres_connection_string: str
     sentry_dsn: str
+    storage_backend: StorageBackendName = "filesystem"
+    storage_filesystem_path: Path | None = None
+    storage_s3_bucket: str = ""
+    storage_s3_region: str = ""
+    storage_s3_endpoint: str = ""
+    storage_s3_access_key_id: str = ""
+    storage_s3_secret_access_key: str = ""
+    storage_azure_account: str = ""
+    storage_azure_container: str = ""
+    storage_azure_access_key: str = ""
+    storage_azure_endpoint: str = ""
 
     @property
     def mongodb_database(self) -> str:
@@ -126,6 +137,26 @@ class TaskRunnerConfig:
 
     def __post_init__(self):
         self.data_path = Path(self.data_path)
+
+        if self.storage_filesystem_path is None:
+            self.storage_filesystem_path = self.data_path / "storage"
+        else:
+            self.storage_filesystem_path = Path(self.storage_filesystem_path)
+
+        if self.storage_backend == "s3" and not self.storage_s3_bucket:
+            raise ValueError(
+                "storage_backend=s3 requires --storage-s3-bucket",
+            )
+
+        if self.storage_backend == "azure":
+            if not self.storage_azure_account:
+                raise ValueError(
+                    "storage_backend=azure requires --storage-azure-account",
+                )
+            if not self.storage_azure_container:
+                raise ValueError(
+                    "storage_backend=azure requires --storage-azure-container",
+                )
 
 
 @dataclass

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -71,7 +71,7 @@ def create_data_layer(
     pg: AsyncEngine,
     config: Config,
     client: ClientSession,
-    storage: StorageBackend | None = None,
+    storage: StorageBackend,
 ) -> DataLayer:
     """Create and return a data layer object.
 
@@ -83,11 +83,6 @@ def create_data_layer(
     :return: the application data layer
     """
     http_client = HTTPClient(client)
-
-    if storage is None:
-        from virtool.storage.filesystem import FilesystemProvider
-
-        storage = FilesystemProvider(config.data_path / "storage")
 
     return DataLayer(
         AccountData(mongo, pg),

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -101,7 +101,6 @@ async def download_otus_json(req):
     return await stream_storage_response(
         req,
         stream,
-        size,
         {
             "Content-Disposition": "attachment; filename=otus.json.gz",
             "Content-Length": str(size),
@@ -144,7 +143,6 @@ class IndexFileView(PydanticView):
         return await stream_storage_response(
             self.request,
             stream,
-            size,
             {
                 "Content-Disposition": f"attachment; filename={filename}",
                 "Content-Length": str(size),
@@ -175,7 +173,6 @@ async def download_index_file_for_jobs(req: Request):
     return await stream_storage_response(
         req,
         stream,
-        size,
         {
             "Content-Length": str(size),
             "Content-Type": "application/octet-stream",

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -3,6 +3,7 @@ import gzip
 from collections.abc import AsyncIterator
 
 from multidict import MultiDictProxy
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
@@ -37,6 +38,7 @@ from virtool.pg.utils import get_rows
 from virtool.references.db import compose_archived_filter, lookup_nested_reference_by_id
 from virtool.references.models import ReferenceNested
 from virtool.references.transforms import AttachReferenceTransform
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
 from virtool.uploads.utils import multipart_file_chunker
 from virtool.users.transforms import AttachUserTransform
@@ -195,22 +197,23 @@ class IndexData:
 
         key = compose_index_file_key(index_id, "otus.json.gz")
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), info.size
+        try:
+            size = await self._storage.size(key)
+        except StorageKeyNotFoundError:
+            patched_otus = await virtool.indexes.db.get_patched_otus(
+                self._mongo,
+                self._storage,
+                index["manifest"],
+            )
 
-        patched_otus = await virtool.indexes.db.get_patched_otus(
-            self._mongo,
-            self._storage,
-            index["manifest"],
-        )
+            compressed = await asyncio.to_thread(
+                gzip.compress, dump_bytes(patched_otus)
+            )
 
-        compressed = await asyncio.to_thread(gzip.compress, dump_bytes(patched_otus))
+            async def _stream():
+                yield compressed
 
-        async def _stream():
-            yield compressed
-
-        size = await self._storage.write(key, _stream())
+            size = await self._storage.write(key, _stream())
 
         return self._storage.read(key), size
 
@@ -273,13 +276,19 @@ class IndexData:
         if filename not in INDEX_FILE_NAMES:
             raise ResourceNotFoundError
 
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLIndexFile).filter_by(index=index_id, name=filename),
+                )
+            ).scalar()
+
+        if row is None:
+            raise ResourceNotFoundError
+
         key = compose_index_file_key(index_id, filename)
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), info.size
-
-        raise ResourceNotFoundError
+        return self._storage.read(key), row.size
 
     @emits(Operation.UPDATE)
     async def finalize(self, index_id: str) -> Index:

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -597,7 +597,6 @@ async def download_reads(req: Request):
     return await stream_storage_response(
         req,
         stream,
-        size,
         {
             "Content-Length": str(size),
             "Content-Type": "application/gzip",
@@ -626,7 +625,6 @@ async def download_artifact(req: Request):
     return await stream_storage_response(
         req,
         stream,
-        size,
         {
             "Content-Length": str(size),
             "Content-Type": "application/gzip",

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -3,7 +3,6 @@ import asyncio
 from aiohttp.web import (
     Request,
     Response,
-    StreamResponse,
 )
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404, r409
@@ -26,6 +25,7 @@ from virtool.api.errors import (
 from virtool.api.policy import PermissionRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.api.schema import schema
+from virtool.api.streaming import stream_storage_response
 from virtool.authorization.permissions import LegacyPermission
 from virtool.data.errors import (
     ResourceConflictError,
@@ -54,7 +54,6 @@ from virtool.samples.oas import (
 )
 from virtool.samples.sql import SQLSampleReads
 from virtool.samples.utils import SampleRight
-from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.uploads.utils import (
     multipart_file_chunker,
     naive_validator,
@@ -595,28 +594,15 @@ async def download_reads(req: Request):
     except ResourceNotFoundError:
         raise APINotFound()
 
-    response = StreamResponse(
-        headers={
+    return await stream_storage_response(
+        req,
+        stream,
+        size,
+        {
             "Content-Length": str(size),
             "Content-Type": "application/gzip",
         },
     )
-
-    if size > 0:
-        try:
-            first_chunk = await anext(stream)
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound()
-
-        await response.prepare(req)
-        await response.write(first_chunk)
-
-        async for chunk in stream:
-            await response.write(chunk)
-    else:
-        await response.prepare(req)
-
-    return response
 
 
 @routes.jobs_api.get("/samples/{sample_id}/artifacts/{filename}")
@@ -637,25 +623,12 @@ async def download_artifact(req: Request):
     except ResourceNotFoundError:
         raise APINotFound()
 
-    response = StreamResponse(
-        headers={
+    return await stream_storage_response(
+        req,
+        stream,
+        size,
+        {
             "Content-Length": str(size),
             "Content-Type": "application/gzip",
         },
     )
-
-    if size > 0:
-        try:
-            first_chunk = await anext(stream)
-        except (StopAsyncIteration, StorageKeyNotFoundError):
-            raise APINotFound()
-
-        await response.prepare(req)
-        await response.write(first_chunk)
-
-        async for chunk in stream:
-            await response.write(chunk)
-    else:
-        await response.prepare(req)
-
-    return response

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -47,7 +47,6 @@ from virtool.samples.db import (
 from virtool.samples.files import (
     create_artifact_file,
     create_reads_file,
-    get_existing_reads,
 )
 from virtool.samples.models import Sample, SampleSearchResult
 from virtool.samples.oas import CreateSampleRequest, UpdateSampleRequest
@@ -665,18 +664,22 @@ class SamplesData(DataLayerDomain):
         if not await self._mongo.samples.find_one(sample_id):
             raise ResourceNotFoundError
 
-        existing_reads = await get_existing_reads(self._pg, sample_id)
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLSampleReads).filter_by(
+                        sample=sample_id,
+                        name=filename,
+                    ),
+                )
+            ).scalar()
 
-        if filename not in existing_reads:
+        if row is None:
             raise ResourceNotFoundError
 
         key = sample_file_key(sample_id, filename)
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), info.size, filename
-
-        raise ResourceNotFoundError
+        return self._storage.read(key), row.size, filename
 
     async def get_artifact_file(
         self,
@@ -702,8 +705,4 @@ class SamplesData(DataLayerDomain):
         artifact = result.to_dict()
         key = sample_file_key(sample_id, artifact["name_on_disk"])
 
-        async for info in self._storage.list(key):
-            if info.key == key:
-                return self._storage.read(key), info.size
-
-        raise ResourceNotFoundError
+        return self._storage.read(key), result.size

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -59,7 +59,7 @@ async def startup_data(app: App) -> None:
         app["pg"],
         get_config_from_app(app),
         get_http_session_from_app(app),
-        app.get("storage"),
+        app["storage"],
     )
 
 

--- a/virtool/storage/filesystem.py
+++ b/virtool/storage/filesystem.py
@@ -91,6 +91,20 @@ class FilesystemProvider:
                 break
             parent = parent.parent
 
+    async def size(self, key: str) -> int:
+        """Return the size in bytes of the object at ``key``."""
+        path = await self._resolve(key)
+
+        if not await asyncio.to_thread(path.is_file):
+            raise StorageKeyNotFoundError(key)
+
+        try:
+            stat = await asyncio.to_thread(path.stat)
+        except FileNotFoundError as exc:
+            raise StorageKeyNotFoundError(key) from exc
+
+        return stat.st_size
+
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
         """List objects whose keys start with ``prefix``."""
 

--- a/virtool/storage/memory.py
+++ b/virtool/storage/memory.py
@@ -47,6 +47,12 @@ class MemoryStorageProvider:
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 
+    async def size(self, key: str) -> int:
+        try:
+            return len(self._store[key].data)
+        except KeyError as exc:
+            raise StorageKeyNotFoundError(key) from exc
+
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
         for key, obj in list(self._store.items()):
             if key.startswith(prefix):

--- a/virtool/storage/object.py
+++ b/virtool/storage/object.py
@@ -133,6 +133,15 @@ class ObjectProvider:
         except Exception as exc:
             raise StorageError(str(exc)) from exc
 
+    async def size(self, key: str) -> int:
+        """Return the size in bytes of the object at ``key``."""
+        try:
+            meta = await obs.head_async(self._store, key)
+        except FileNotFoundError as exc:
+            raise StorageKeyNotFoundError(key) from exc
+
+        return meta["size"]
+
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
         """List objects whose keys start with ``prefix``."""
         async for batch in obs.list(self._store, prefix=prefix):

--- a/virtool/storage/protocol.py
+++ b/virtool/storage/protocol.py
@@ -47,3 +47,11 @@ class StorageBackend(Protocol):
         matching object.
         """
         ...
+
+    async def size(self, key: str) -> int:
+        """Return the size in bytes of the object at ``key``.
+
+        Raises :class:`~virtool.storage.errors.StorageKeyNotFoundError` if the
+        key does not exist.
+        """
+        ...

--- a/virtool/storage/routing.py
+++ b/virtool/storage/routing.py
@@ -45,6 +45,12 @@ class FallbackStorageRouter:
         await self._primary.delete(key)
         await self._fallback.delete(key)
 
+    async def size(self, key: str) -> int:
+        try:
+            return await self._primary.size(key)
+        except StorageKeyNotFoundError:
+            return await self._fallback.size(key)
+
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
         seen: set[str] = set()
 

--- a/virtool/tasks/main.py
+++ b/virtool/tasks/main.py
@@ -18,6 +18,7 @@ from virtool.startup import (
     startup_executors,
     startup_http_client_session,
     startup_sentry,
+    startup_storage,
     startup_task_runner,
     startup_version,
 )
@@ -47,6 +48,7 @@ def run_task_runner(config: TaskRunnerConfig) -> None:
             startup_http_client_session,
             startup_databases,
             startup_executors,
+            startup_storage,
             startup_data,
             startup_events,
             startup_task_runner,

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -99,7 +99,6 @@ class UploadView(PydanticView):
         return await stream_storage_response(
             self.request,
             stream,
-            size,
             {
                 "Content-Disposition": f"attachment; filename={name}",
                 "Content-Type": "application/octet-stream",
@@ -145,7 +144,6 @@ async def download(req):
     return await stream_storage_response(
         req,
         stream,
-        size,
         {
             "Content-Disposition": f"attachment; filename={name}",
             "Content-Type": "application/octet-stream",


### PR DESCRIPTION
## Summary

- Adds a `size()` method to the `StorageBackend` protocol and all implementations (filesystem, object/S3, memory, routing) that uses `head` metadata rather than `list()` — fixing 404 errors on Azure Storage where `list()` can silently miss objects
- Replaces all `list()`-based existence checks in download paths (analyses, indexes, samples reads/artifacts) with a direct `size()` call or a SQL row lookup, so files are served without a spurious round-trip that fails on Azure
- Wires `startup_storage` into the task runner entry point and makes `storage` a required (non-optional) parameter of `create_data_layer`, enforcing explicit configuration at startup

## Test plan

- [ ] Run `mise run test -- tests/storage` to verify `TestSize` passes for all providers (memory, object, filesystem, routing)
- [ ] Run `mise run test -- tests/samples/test_api.py` — includes new `test_404_zero_byte_missing_object` cases for reads and artifacts
- [ ] Run `mise run test -- tests/indexes/test_api.py` — includes updated `test_download` with SQL row fixture
- [ ] Verify on a deployment backed by Azure Blob Storage that downloading sample reads, artifacts, and index files no longer returns 404