### PR TITLE
feat: expose /jobs/counts on the jobs API server

### DIFF
--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -172,7 +172,7 @@ class TestGetCounts:
         assert sum(c for counts in body.values() for c in counts.values()) == 0
 
     async def test_jobs_api(self, fake: DataFaker, spawn_job_client: JobClientSpawner):
-        client = await spawn_job_client(authenticated=True)
+        client = await spawn_job_client(authenticated=False)
 
         user = await fake.users.create()
 
@@ -190,6 +190,8 @@ class TestGetCounts:
         assert body["pending"]["nuvs"] == 2
         assert body["running"]["pathoscope"] == 1
         assert body["succeeded"]["nuvs"] == 1
+
+        assert sum(c for counts in body.values() for c in counts.values()) == 4
 
 
 @pytest.mark.parametrize("error", [None, "404"])

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -171,6 +171,26 @@ class TestGetCounts:
 
         assert sum(c for counts in body.values() for c in counts.values()) == 0
 
+    async def test_jobs_api(self, fake: DataFaker, spawn_job_client: JobClientSpawner):
+        client = await spawn_job_client(authenticated=True)
+
+        user = await fake.users.create()
+
+        await fake.jobs.create(user=user, state=JobState.PENDING, workflow="nuvs")
+        await fake.jobs.create(user=user, state=JobState.PENDING, workflow="nuvs")
+        await fake.jobs.create(user=user, state=JobState.RUNNING, workflow="pathoscope")
+        await fake.jobs.create(user=user, state=JobState.SUCCEEDED, workflow="nuvs")
+
+        resp = await client.get("/jobs/counts")
+
+        assert resp.status == HTTPStatus.OK
+
+        body = await resp.json()
+
+        assert body["pending"]["nuvs"] == 2
+        assert body["running"]["pathoscope"] == 1
+        assert body["succeeded"]["nuvs"] == 1
+
 
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(error, fake: DataFaker, snapshot, spawn_client):

--- a/virtool/jobs/api.py
+++ b/virtool/jobs/api.py
@@ -76,6 +76,7 @@ class JobsView(PydanticView):
 
 
 @routes.view("/jobs/counts")
+@routes.jobs_api.view("/jobs/counts")
 class JobsCountsView(PydanticView):
     @policy(PublicRoutePolicy)
     async def get(self) -> r200[JobCounts]:


### PR DESCRIPTION
## Summary

- Adds `@routes.jobs_api.view("/jobs/counts")` decorator to `JobsCountsView` so `GET /jobs/counts` is also served on the jobs API server, not just the web API server
- Workflow runners can now read job counts directly via the jobs API server without authenticating as a user against the web API
- Covers the simpler single-class dual-decorator approach rather than a paired-class pattern, since the view implementation is identical for both route tables

Closes VIR-2341.

## Test plan

- [ ] `GET /jobs/counts` returns correct `JobCounts` payload on the jobs API server (new `test_jobs_api` test in `TestGetCounts`)
- [ ] Existing `test_ok` and `test_empty` tests continue to pass on the web API server
- [ ] Run `mise run oas` to verify OpenAPI spec regenerates cleanly
- [ ] Run `mise run test -- tests/jobs` for the full jobs test suite