### PR TITLE
fix: serve legacy on-disk index files through fallback storage

### DIFF
--- a/tests/storage/test_factory.py
+++ b/tests/storage/test_factory.py
@@ -5,6 +5,7 @@ import pytest
 from tests.config.test_cls import build_server_config
 from virtool.storage.factory import build_primary_backend, create_storage_backend
 from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 from virtool.storage.object import ObjectProvider
 from virtool.storage.routing import FallbackStorageRouter
 
@@ -21,8 +22,9 @@ class TestCreateStorageBackend:
 
         assert isinstance(backend, FallbackStorageRouter)
         assert isinstance(backend._primary, ObjectProvider)
-        assert isinstance(backend._fallback, FilesystemProvider)
-        assert backend._fallback._base_path == tmp_path.resolve()
+        assert isinstance(backend._fallback, LegacyIndexFilesystemAdapter)
+        assert isinstance(backend._fallback._inner, FilesystemProvider)
+        assert backend._fallback._inner._base_path == tmp_path.resolve()
 
     def test_azure_wraps_with_fallback_at_data_path(self, tmp_path: Path):
         config = build_server_config(
@@ -37,14 +39,15 @@ class TestCreateStorageBackend:
 
         assert isinstance(backend, FallbackStorageRouter)
         assert isinstance(backend._primary, ObjectProvider)
-        assert backend._fallback._base_path == tmp_path.resolve()
+        assert isinstance(backend._fallback, LegacyIndexFilesystemAdapter)
+        assert backend._fallback._inner._base_path == tmp_path.resolve()
 
     def test_fallback_root_is_not_data_path_storage(self, tmp_path: Path):
         config = build_server_config(data_path=tmp_path)
 
         backend = create_storage_backend(config)
 
-        assert backend._fallback._base_path != (tmp_path / "storage").resolve()
+        assert backend._fallback._inner._base_path != (tmp_path / "storage").resolve()
 
 
 class TestBuildPrimaryBackend:

--- a/tests/storage/test_legacy.py
+++ b/tests/storage/test_legacy.py
@@ -170,9 +170,7 @@ class TestWrite:
         adapter could never find.
         """
         with pytest.raises(StorageError, match="cannot write index key"):
-            await adapter.write(
-                "indexes/missing/otus.json.gz", _async_iter(b"x")
-            )
+            await adapter.write("indexes/missing/otus.json.gz", _async_iter(b"x"))
 
 
 class TestCache:

--- a/tests/storage/test_legacy.py
+++ b/tests/storage/test_legacy.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.errors import StorageError, StorageKeyNotFoundError
 from virtool.storage.filesystem import FilesystemProvider
 from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 
@@ -167,6 +167,17 @@ class TestWrite:
         assert (data_path / "samples" / "sample1" / "reads.fq.gz").read_bytes() == (
             b"reads"
         )
+
+    async def test_unknown_index_raises(self, adapter):
+        """A write through the legacy adapter for an unresolvable index_id must
+        fail loudly. Falling back to the untranslated key would create a file
+        at ``indexes/{id}/...`` on disk that subsequent reads through the same
+        adapter could never find.
+        """
+        with pytest.raises(StorageError, match="cannot write index key"):
+            await adapter.write(
+                "indexes/missing/otus.json.gz", _async_iter(b"x")
+            )
 
 
 class TestCache:

--- a/tests/storage/test_legacy.py
+++ b/tests/storage/test_legacy.py
@@ -1,0 +1,188 @@
+from pathlib import Path
+
+import pytest
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.legacy import LegacyIndexFilesystemAdapter
+
+
+@pytest.fixture
+def data_path(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def inner(data_path: Path) -> FilesystemProvider:
+    return FilesystemProvider(data_path)
+
+
+@pytest.fixture
+def adapter(inner: FilesystemProvider, data_path: Path) -> LegacyIndexFilesystemAdapter:
+    return LegacyIndexFilesystemAdapter(inner, data_path)
+
+
+def _seed_legacy_index(
+    data_path: Path, ref_id: str, index_id: str, filename: str, contents: bytes
+) -> Path:
+    path = data_path / "references" / ref_id / index_id / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+    return path
+
+
+async def _async_iter(data: bytes, chunk_size: int = 1024):
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size]
+
+
+async def _collect_bytes(aiter) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
+async def _collect(aiter) -> list:
+    return [item async for item in aiter]
+
+
+class TestRead:
+    async def test_translates_index_key(self, adapter, data_path):
+        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"payload")
+
+        result = await _collect_bytes(adapter.read("indexes/idx1/reference.json.gz"))
+
+        assert result == b"payload"
+
+    async def test_passes_through_non_index_key(self, adapter, data_path):
+        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"reads")
+
+        result = await _collect_bytes(adapter.read("samples/sample1/reads.fq.gz"))
+
+        assert result == b"reads"
+
+    async def test_unknown_index_raises(self, adapter):
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(adapter.read("indexes/missing/reference.json.gz"))
+
+    async def test_index_present_but_file_missing_raises(self, adapter, data_path):
+        (data_path / "references" / "ref1" / "idx1").mkdir(parents=True)
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(adapter.read("indexes/idx1/reference.json.gz"))
+
+
+class TestSize:
+    async def test_translates_index_key(self, adapter, data_path):
+        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"payload")
+
+        assert await adapter.size("indexes/idx1/reference.json.gz") == len(b"payload")
+
+    async def test_unknown_index_raises(self, adapter):
+        with pytest.raises(StorageKeyNotFoundError):
+            await adapter.size("indexes/missing/reference.json.gz")
+
+    async def test_passes_through_non_index_key(self, adapter, data_path):
+        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"reads")
+
+        assert await adapter.size("samples/sample1/reads.fq.gz") == len(b"reads")
+
+
+class TestDelete:
+    async def test_translates_index_key(self, adapter, data_path):
+        path = _seed_legacy_index(
+            data_path, "ref1", "idx1", "reference.json.gz", b"payload"
+        )
+
+        await adapter.delete("indexes/idx1/reference.json.gz")
+
+        assert not path.exists()
+
+    async def test_unknown_index_is_noop(self, adapter):
+        await adapter.delete("indexes/missing/reference.json.gz")
+
+    async def test_passes_through_non_index_key(self, adapter, data_path):
+        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"reads")
+
+        await adapter.delete("samples/sample1/reads.fq.gz")
+
+        assert not path.exists()
+
+
+class TestList:
+    async def test_translates_prefix_and_rewrites_keys(self, adapter, data_path):
+        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"a")
+        _seed_legacy_index(data_path, "ref1", "idx1", "reference.fa.gz", b"bb")
+
+        result = await _collect(adapter.list("indexes/idx1/"))
+
+        keys = sorted(info.key for info in result)
+        assert keys == [
+            "indexes/idx1/reference.fa.gz",
+            "indexes/idx1/reference.json.gz",
+        ]
+
+    async def test_unknown_index_yields_nothing(self, adapter):
+        assert await _collect(adapter.list("indexes/missing/")) == []
+
+    async def test_passes_through_non_index_prefix(self, adapter, data_path):
+        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"reads")
+
+        result = await _collect(adapter.list("samples/sample1/"))
+
+        assert [info.key for info in result] == ["samples/sample1/reads.fq.gz"]
+
+    async def test_does_not_leak_other_indexes(self, adapter, data_path):
+        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"a")
+        _seed_legacy_index(data_path, "ref1", "idx2", "reference.json.gz", b"b")
+
+        result = await _collect(adapter.list("indexes/idx1/"))
+
+        assert [info.key for info in result] == ["indexes/idx1/reference.json.gz"]
+
+
+class TestWrite:
+    async def test_writes_translated_path(self, adapter, data_path):
+        (data_path / "references" / "ref1" / "idx1").mkdir(parents=True)
+
+        size = await adapter.write(
+            "indexes/idx1/otus.json.gz", _async_iter(b"compressed")
+        )
+
+        assert size == len(b"compressed")
+        assert (
+            data_path / "references" / "ref1" / "idx1" / "otus.json.gz"
+        ).read_bytes() == b"compressed"
+
+    async def test_passes_through_non_index_key(self, adapter, data_path):
+        size = await adapter.write("samples/sample1/reads.fq.gz", _async_iter(b"reads"))
+
+        assert size == len(b"reads")
+        assert (data_path / "samples" / "sample1" / "reads.fq.gz").read_bytes() == (
+            b"reads"
+        )
+
+
+class TestCache:
+    async def test_resolves_once_per_index(self, adapter, data_path, mocker):
+        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"a")
+
+        spy = mocker.spy(adapter, "_resolve_ref_id")
+
+        await adapter.size("indexes/idx1/reference.json.gz")
+        await adapter.size("indexes/idx1/reference.json.gz")
+        await _collect(adapter.list("indexes/idx1/"))
+
+        assert spy.call_count == 3
+        assert adapter._cache == {"idx1": "ref1"}
+
+    async def test_caches_negative_lookups(self, adapter):
+        await adapter.delete("indexes/missing/reference.json.gz")
+
+        assert adapter._cache == {"missing": None}

--- a/tests/storage/test_legacy.py
+++ b/tests/storage/test_legacy.py
@@ -8,11 +8,6 @@ from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 
 
 @pytest.fixture
-def data_path(tmp_path: Path) -> Path:
-    return tmp_path
-
-
-@pytest.fixture
 def inner(data_path: Path) -> FilesystemProvider:
     return FilesystemProvider(data_path)
 

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -2,6 +2,7 @@
 
 from virtool.config.cls import ServerConfig
 from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 from virtool.storage.object import ObjectProvider
 from virtool.storage.protocol import StorageBackend
 from virtool.storage.routing import FallbackStorageRouter
@@ -13,14 +14,19 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
     The primary is an object-storage backend (S3 or Azure Blob) determined by
     ``config.storage_backend``. A :class:`FilesystemProvider` rooted at
     ``config.data_path`` is wired in as a read/migration fallback via
-    :class:`FallbackStorageRouter`.
+    :class:`FallbackStorageRouter`, wrapped in
+    :class:`LegacyIndexFilesystemAdapter` so legacy index files at
+    ``references/{ref_id}/{index_id}/...`` are reachable via the new
+    ``indexes/{index_id}/...`` keys.
 
     The fallback exists only to surface legacy on-disk files during the
     migration to object storage and will be removed entirely once that
     migration is complete.
     """
     primary = build_primary_backend(config)
-    fallback = FilesystemProvider(config.data_path)
+    fallback = LegacyIndexFilesystemAdapter(
+        FilesystemProvider(config.data_path), config.data_path
+    )
     return FallbackStorageRouter(primary, fallback)
 
 

--- a/virtool/storage/legacy.py
+++ b/virtool/storage/legacy.py
@@ -1,0 +1,130 @@
+"""Legacy on-disk path translation for the filesystem fallback.
+
+The new index storage key is ``indexes/{index_id}/{filename}``, but legacy
+on-disk files live at ``{data_path}/references/{ref_id}/{index_id}/{filename}``.
+This adapter wraps the fallback :class:`FilesystemProvider` and translates
+``indexes/`` keys into the legacy layout so the migration can find them. The
+mapping ``index_id -> ref_id`` is discovered by walking
+``{data_path}/references/*`` once per ``index_id`` and cached in memory.
+
+The adapter exists only to serve legacy on-disk files during the
+object-storage migration. When the filesystem fallback is removed, delete
+this module and unwire it from :mod:`virtool.storage.factory`.
+"""
+
+import asyncio
+import re
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.protocol import StorageBackend
+from virtool.storage.types import StorageObjectInfo
+
+_INDEX_KEY_RE = re.compile(r"^indexes/(?P<index_id>[^/]+)(?P<rest>/.*)?$")
+
+
+class LegacyIndexFilesystemAdapter:
+    """Rewrites ``indexes/{index_id}/...`` keys to the legacy on-disk layout.
+
+    Wraps a :class:`StorageBackend` (the fallback :class:`FilesystemProvider`)
+    and resolves ``index_id`` to its parent ``ref_id`` by scanning
+    ``{data_path}/references/*``. Non-index keys pass through unchanged. When
+    no matching ``references/*/{index_id}`` directory exists on disk, reads
+    raise :class:`StorageKeyNotFoundError`, deletes are no-ops, and lists
+    yield nothing — matching the behaviour of a key that has never been
+    written.
+    """
+
+    def __init__(self, inner: StorageBackend, data_path: Path) -> None:
+        self._inner = inner
+        self._references_path = (data_path / "references").resolve()
+        self._cache: dict[str, str | None] = {}
+
+    async def _resolve_ref_id(self, index_id: str) -> str | None:
+        if index_id in self._cache:
+            return self._cache[index_id]
+
+        def _scan() -> str | None:
+            if not self._references_path.is_dir():
+                return None
+
+            for ref_dir in self._references_path.iterdir():
+                if (ref_dir / index_id).is_dir():
+                    return ref_dir.name
+
+            return None
+
+        ref_id = await asyncio.to_thread(_scan)
+        self._cache[index_id] = ref_id
+        return ref_id
+
+    async def _translate(self, key: str) -> str | None:
+        """Translate an index key to the legacy on-disk layout.
+
+        Returns the translated key, the original key when no translation
+        applies, or ``None`` when the index_id cannot be resolved on disk.
+        """
+        match = _INDEX_KEY_RE.match(key)
+        if match is None:
+            return key
+
+        index_id = match.group("index_id")
+        rest = match.group("rest") or ""
+
+        ref_id = await self._resolve_ref_id(index_id)
+        if ref_id is None:
+            return None
+
+        return f"references/{ref_id}/{index_id}{rest}"
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        translated = await self._translate(key)
+        if translated is None:
+            raise StorageKeyNotFoundError(key)
+
+        async for chunk in self._inner.read(translated):
+            yield chunk
+
+    async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
+        translated = await self._translate(key)
+        if translated is None:
+            return await self._inner.write(key, data)
+        return await self._inner.write(translated, data)
+
+    async def delete(self, key: str) -> None:
+        translated = await self._translate(key)
+        if translated is None:
+            return
+        await self._inner.delete(translated)
+
+    async def size(self, key: str) -> int:
+        translated = await self._translate(key)
+        if translated is None:
+            raise StorageKeyNotFoundError(key)
+        return await self._inner.size(translated)
+
+    async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        match = _INDEX_KEY_RE.match(prefix)
+        if match is None:
+            async for info in self._inner.list(prefix):
+                yield info
+            return
+
+        index_id = match.group("index_id")
+        rest = match.group("rest") or ""
+
+        ref_id = await self._resolve_ref_id(index_id)
+        if ref_id is None:
+            return
+
+        translated_prefix = f"references/{ref_id}/{index_id}{rest}"
+        translated_root = f"references/{ref_id}/{index_id}/"
+        index_root = f"indexes/{index_id}/"
+
+        async for info in self._inner.list(translated_prefix):
+            yield StorageObjectInfo(
+                key=index_root + info.key.removeprefix(translated_root),
+                size=info.size,
+                last_modified=info.last_modified,
+            )

--- a/virtool/storage/legacy.py
+++ b/virtool/storage/legacy.py
@@ -17,7 +17,7 @@ import re
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.errors import StorageError, StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
 from virtool.storage.types import StorageObjectInfo
 
@@ -31,9 +31,9 @@ class LegacyIndexFilesystemAdapter:
     and resolves ``index_id`` to its parent ``ref_id`` by scanning
     ``{data_path}/references/*``. Non-index keys pass through unchanged. When
     no matching ``references/*/{index_id}`` directory exists on disk, reads
-    raise :class:`StorageKeyNotFoundError`, deletes are no-ops, and lists
-    yield nothing — matching the behaviour of a key that has never been
-    written.
+    raise :class:`StorageKeyNotFoundError`, deletes are no-ops, lists yield
+    nothing, and writes raise :class:`StorageError` — the adapter cannot
+    construct a legacy path without a known ``ref_id``.
     """
 
     def __init__(self, inner: StorageBackend, data_path: Path) -> None:
@@ -89,7 +89,11 @@ class LegacyIndexFilesystemAdapter:
     async def write(self, key: str, data: AsyncIterator[bytes]) -> int:
         translated = await self._translate(key)
         if translated is None:
-            return await self._inner.write(key, data)
+            msg = (
+                f"cannot write index key {key!r} through the legacy fallback: "
+                "no on-disk reference directory contains this index_id"
+            )
+            raise StorageError(msg)
         return await self._inner.write(translated, data)
 
     async def delete(self, key: str) -> None:


### PR DESCRIPTION
## Summary

- Adds `LegacyIndexFilesystemAdapter` to translate new-style `indexes/{index_id}/...` storage keys into the legacy on-disk layout at `references/{ref_id}/{index_id}/...`, enabling the fallback storage router to serve index files written before the object-storage migration
- The adapter resolves `index_id → ref_id` by scanning `data_path/references/*` once per `index_id` and caches the result in memory; non-index keys pass through to the underlying `FilesystemProvider` unchanged
- Wires the adapter into `create_storage_backend` in place of the bare `FilesystemProvider`, and updates factory tests accordingly; adds a comprehensive test suite in `tests/storage/test_legacy.py`

## Test plan

- [ ] Run `mise run test -- tests/storage/` to verify all new and updated storage tests pass
- [ ] Confirm `LegacyIndexFilesystemAdapter` correctly translates read/size/list/write/delete for `indexes/` keys and passes through non-index keys
- [ ] Confirm negative lookups (missing `index_id` directory) produce `StorageKeyNotFoundError` on read/size, no-op on delete, and empty iterator on list
- [ ] Verify the caching spy test: `_resolve_ref_id` called per operation but cache populated after first resolution