### PR TITLE
chore: group dependabot updates for pytest, sentry, postgres, aiohttp

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      pytest:
+        patterns:
+          - "pytest*"
+      sentry:
+        patterns:
+          - "sentry-sdk"
+          - "structlog-sentry"
+      postgres:
+        patterns:
+          - "sqlalchemy"
+          - "alembic"
+          - "asyncpg"
+      aiohttp:
+        patterns:
+          - "aiohttp"
+          - "aiohttp-pydantic"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- Adds dependabot grouping configuration so related Python dependency bumps (pytest plugins, sentry, postgres/SQLAlchemy stack, aiohttp) are batched into single PRs rather than one PR per package.

## Test plan

- [ ] Verify dependabot YAML is valid and groups are named correctly
- [ ] Confirm next dependabot run produces grouped PRs for the defined ecosystems