### PR TITLE
feat: add per-category storage migration CLI

### DIFF
--- a/tests/migration/test_storage.py
+++ b/tests/migration/test_storage.py
@@ -1,0 +1,350 @@
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+import virtool.migration.storage as storage_module
+from virtool.cli import cli
+from virtool.migration.storage import (
+    CATEGORY_PREFIXES,
+    StorageMigrationReport,
+    StorageVerificationReport,
+    build_source_backend,
+    migrate_category,
+    run_storage_migration,
+    verify_category,
+)
+from virtool.migration.storage_settings import StorageMigrationSettings
+from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.memory import MemoryStorageProvider
+
+
+async def _async_iter(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+async def _collect_bytes(aiter: AsyncIterator[bytes]) -> bytes:
+    return b"".join([chunk async for chunk in aiter])
+
+
+async def _populate(provider, items: dict[str, bytes]) -> None:
+    for key, value in items.items():
+        await provider.write(key, _async_iter(value))
+
+
+@pytest.fixture
+def source() -> MemoryStorageProvider:
+    return MemoryStorageProvider()
+
+
+@pytest.fixture
+def destination() -> MemoryStorageProvider:
+    return MemoryStorageProvider()
+
+
+class TestMigrateCategory:
+    async def test_empty_source(self, source, destination):
+        report = await migrate_category(source, destination, "samples/")
+
+        assert report == StorageMigrationReport(copied=0, skipped=0, bytes_copied=0)
+
+    async def test_happy_path(self, source, destination):
+        contents = {
+            "samples/a/reads_1.fq.gz": b"aaaa",
+            "samples/a/reads_2.fq.gz": b"bbbbbb",
+            "samples/b/reads_1.fq.gz": b"cc",
+        }
+        await _populate(source, contents)
+
+        report = await migrate_category(source, destination, "samples/")
+
+        assert report == StorageMigrationReport(copied=3, skipped=0, bytes_copied=12)
+
+        for key, value in contents.items():
+            assert await _collect_bytes(destination.read(key)) == value
+
+    async def test_idempotency(self, source, destination):
+        contents = {
+            "samples/a/reads_1.fq.gz": b"aaaa",
+            "samples/a/reads_2.fq.gz": b"bbbbbb",
+        }
+        await _populate(source, contents)
+
+        await migrate_category(source, destination, "samples/")
+        report = await migrate_category(source, destination, "samples/")
+
+        assert report == StorageMigrationReport(copied=0, skipped=2, bytes_copied=0)
+
+    async def test_partial_state(self, source, destination):
+        contents = {
+            "samples/a/reads_1.fq.gz": b"aaaa",
+            "samples/a/reads_2.fq.gz": b"bbbbbb",
+            "samples/b/reads_1.fq.gz": b"cc",
+        }
+        await _populate(source, contents)
+        await _populate(
+            destination,
+            {"samples/a/reads_2.fq.gz": b"bbbbbb"},
+        )
+
+        report = await migrate_category(source, destination, "samples/")
+
+        assert report == StorageMigrationReport(copied=2, skipped=1, bytes_copied=6)
+
+    async def test_dry_run(self, source, destination, mocker):
+        await _populate(source, {"samples/a/reads.fq.gz": b"data"})
+        spy = mocker.spy(destination, "write")
+
+        report = await migrate_category(source, destination, "samples/", dry_run=True)
+
+        assert spy.call_count == 0
+        assert report.copied == 0
+        assert report.skipped == 0
+
+    async def test_prefix_isolation(self, source, destination):
+        await _populate(
+            source,
+            {
+                "samples/a/reads.fq.gz": b"sample",
+                "indexes/x/reference.json.gz": b"index",
+            },
+        )
+
+        await migrate_category(source, destination, "samples/")
+
+        assert (
+            await _collect_bytes(destination.read("samples/a/reads.fq.gz")) == b"sample"
+        )
+
+        info = [info async for info in destination.list("indexes/")]
+        assert info == []
+
+
+class TestVerifyCategory:
+    async def test_matches(self, source, destination):
+        await _populate(source, {"samples/a": b"x", "samples/b": b"yy"})
+        await migrate_category(source, destination, "samples/")
+
+        verification = await verify_category(source, destination, "samples/")
+
+        assert verification == StorageVerificationReport(
+            source_count=2,
+            destination_count=2,
+            missing_keys=[],
+            size_mismatches=[],
+        )
+        assert verification.ok is True
+
+    async def test_missing_and_mismatched(self, source, destination):
+        await _populate(
+            source,
+            {
+                "samples/a": b"x",
+                "samples/b": b"yy",
+                "samples/c": b"zzz",
+            },
+        )
+        await _populate(
+            destination,
+            {
+                "samples/a": b"x",
+                "samples/b": b"WRONG_SIZE",
+            },
+        )
+
+        verification = await verify_category(source, destination, "samples/")
+
+        assert verification.source_count == 3
+        assert verification.destination_count == 2
+        assert verification.missing_keys == ["samples/c"]
+        assert verification.size_mismatches == ["samples/b"]
+        assert verification.ok is False
+
+
+class TestLegacyIndexTranslation:
+    async def test_indexes_category_reads_legacy_layout(self, tmp_path: Path):
+        ref_id = "ref_alpha"
+        index_id = "idx_beta"
+
+        index_dir = tmp_path / "references" / ref_id / index_id
+        index_dir.mkdir(parents=True)
+        (index_dir / "reference.json.gz").write_bytes(b"index-payload")
+
+        settings = _settings(data_path=tmp_path)
+        source = build_source_backend(settings, "indexes")
+        destination = MemoryStorageProvider()
+
+        report = await migrate_category(source, destination, "indexes/")
+
+        assert report.copied == 1
+        assert (
+            await _collect_bytes(
+                destination.read(f"indexes/{index_id}/reference.json.gz")
+            )
+            == b"index-payload"
+        )
+
+    def test_non_indexes_category_uses_plain_filesystem(self, tmp_path: Path):
+        settings = _settings(data_path=tmp_path)
+        source = build_source_backend(settings, "samples")
+        assert isinstance(source, FilesystemProvider)
+
+
+class TestSettings:
+    def test_load_from_env_s3(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VT_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("VT_STORAGE_BACKEND", "s3")
+        monkeypatch.setenv("VT_STORAGE_S3_BUCKET", "my-bucket")
+        monkeypatch.setenv("VT_STORAGE_S3_REGION", "us-west-2")
+
+        settings = StorageMigrationSettings()
+
+        assert settings.data_path == tmp_path
+        assert settings.storage_backend == "s3"
+        assert settings.storage_s3_bucket == "my-bucket"
+        assert settings.storage_s3_region == "us-west-2"
+
+    def test_load_from_env_azure(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VT_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("VT_STORAGE_BACKEND", "azure")
+        monkeypatch.setenv("VT_STORAGE_AZURE_ACCOUNT", "acct")
+        monkeypatch.setenv("VT_STORAGE_AZURE_CONTAINER", "ctnr")
+
+        settings = StorageMigrationSettings()
+
+        assert settings.storage_backend == "azure"
+        assert settings.storage_azure_account == "acct"
+        assert settings.storage_azure_container == "ctnr"
+
+    def test_s3_requires_bucket(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VT_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("VT_STORAGE_BACKEND", "s3")
+        monkeypatch.delenv("VT_STORAGE_S3_BUCKET", raising=False)
+
+        with pytest.raises(ValueError, match="VT_STORAGE_S3_BUCKET"):
+            StorageMigrationSettings()
+
+    def test_s3_partial_credentials_rejected(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VT_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("VT_STORAGE_BACKEND", "s3")
+        monkeypatch.setenv("VT_STORAGE_S3_BUCKET", "bkt")
+        monkeypatch.setenv("VT_STORAGE_S3_ACCESS_KEY_ID", "AKIA...")
+        monkeypatch.setenv("VT_STORAGE_S3_SECRET_ACCESS_KEY", "")
+
+        with pytest.raises(ValueError, match="set together"):
+            StorageMigrationSettings()
+
+    def test_azure_requires_account(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VT_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("VT_STORAGE_BACKEND", "azure")
+        monkeypatch.delenv("VT_STORAGE_AZURE_ACCOUNT", raising=False)
+        monkeypatch.setenv("VT_STORAGE_AZURE_CONTAINER", "ctnr")
+
+        with pytest.raises(ValueError, match="VT_STORAGE_AZURE_ACCOUNT"):
+            StorageMigrationSettings()
+
+    def test_azure_requires_container(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VT_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("VT_STORAGE_BACKEND", "azure")
+        monkeypatch.setenv("VT_STORAGE_AZURE_ACCOUNT", "acct")
+        monkeypatch.delenv("VT_STORAGE_AZURE_CONTAINER", raising=False)
+
+        with pytest.raises(ValueError, match="VT_STORAGE_AZURE_CONTAINER"):
+            StorageMigrationSettings()
+
+
+class TestRunStorageMigration:
+    async def test_success(self, tmp_path, mocker):
+        settings = _settings(data_path=tmp_path)
+        source = MemoryStorageProvider()
+        destination = MemoryStorageProvider()
+        await _populate(source, {"samples/a": b"x"})
+
+        mocker.patch(
+            "virtool.migration.storage.build_source_backend",
+            return_value=source,
+        )
+        mocker.patch(
+            "virtool.migration.storage.build_primary_backend",
+            return_value=destination,
+        )
+
+        await run_storage_migration(settings, "samples", dry_run=False)
+
+        assert await _collect_bytes(destination.read("samples/a")) == b"x"
+
+    async def test_verification_failure_exits_nonzero(self, tmp_path, mocker):
+        settings = _settings(data_path=tmp_path)
+        source = MemoryStorageProvider()
+        destination = MemoryStorageProvider()
+        await _populate(source, {"samples/a": b"x"})
+
+        mocker.patch(
+            "virtool.migration.storage.build_source_backend",
+            return_value=source,
+        )
+        mocker.patch(
+            "virtool.migration.storage.build_primary_backend",
+            return_value=destination,
+        )
+        # Simulate a migration that "succeeds" but writes nothing, so
+        # verification finds a missing key.
+        mocker.patch(
+            "virtool.migration.storage.migrate_category",
+            new=AsyncMock(
+                return_value=StorageMigrationReport(copied=1, skipped=0, bytes_copied=1)
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            await run_storage_migration(settings, "samples", dry_run=False)
+
+        assert exc_info.value.code == 1
+
+    async def test_dry_run_skips_verification(self, tmp_path, mocker):
+        settings = _settings(data_path=tmp_path)
+        source = MemoryStorageProvider()
+        destination = MemoryStorageProvider()
+        await _populate(source, {"samples/a": b"x"})
+
+        mocker.patch(
+            "virtool.migration.storage.build_source_backend",
+            return_value=source,
+        )
+        mocker.patch(
+            "virtool.migration.storage.build_primary_backend",
+            return_value=destination,
+        )
+
+        verify_spy = mocker.spy(storage_module, "verify_category")
+
+        await run_storage_migration(settings, "samples", dry_run=True)
+
+        assert verify_spy.call_count == 0
+
+
+class TestCLI:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migration", "storage", "--help"])
+
+        assert result.exit_code == 0
+        assert "--category" in result.output
+        assert "--dry-run" in result.output
+
+    def test_category_choices(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migration", "storage", "--help"])
+
+        for category in CATEGORY_PREFIXES:
+            assert category in result.output
+
+
+def _settings(data_path: Path) -> StorageMigrationSettings:
+    return StorageMigrationSettings(
+        data_path=data_path,
+        storage_backend="s3",
+        storage_s3_bucket="test-bucket",
+    )

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -37,6 +37,8 @@ from virtool.migration.apply import apply
 from virtool.migration.create import create_revision
 from virtool.migration.depend import depend
 from virtool.migration.show import show_revisions
+from virtool.migration.storage import CATEGORY_PREFIXES, run_storage_migration
+from virtool.migration.storage_settings import StorageMigrationSettings
 from virtool.oas.cmd import show_oas
 from virtool.tasks.main import run_task_runner, run_task_spawner
 from virtool.workflow.runtime.run import start_runtime
@@ -156,6 +158,31 @@ def migration_show(**kwargs) -> None:
     """Apply all pending migrations."""
     configure_logging(False)
     show_revisions()
+
+
+@migration.command("storage")
+@click.option(
+    "--category",
+    required=True,
+    type=click.Choice(sorted(CATEGORY_PREFIXES)),
+    help="Storage category to migrate.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="List files that would be copied without writing.",
+)
+def migration_storage(category: str, dry_run: bool) -> None:
+    """Migrate one storage category from filesystem to object storage.
+
+    Storage configuration is loaded from ``VT_*`` environment variables,
+    matching the rest of the application. The migration bypasses the
+    runtime fallback router and streams files directly into the
+    configured object backend. Source files are never deleted.
+    """
+    configure_logging(False)
+    settings = StorageMigrationSettings()
+    asyncio.run(run_storage_migration(settings, category, dry_run))
 
 
 @cli.group("tasks")

--- a/virtool/migration/storage.py
+++ b/virtool/migration/storage.py
@@ -31,7 +31,6 @@ CATEGORY_PREFIXES: dict[str, str] = {
     "uploads": "files/",
     "subtractions": "subtractions/",
     "ml-models": "ml/",
-    "references": "references/",
     "history": "history/",
     "indexes": "indexes/",
     "samples": "samples/",
@@ -42,6 +41,13 @@ CATEGORY_PREFIXES: dict[str, str] = {
 The on-disk directory names were confirmed against the data-layer modules
 (``virtool/hmm/data.py``, ``virtool/uploads/utils.py`` etc.). Note that the
 ``hmms`` category uses the ``hmm/`` prefix (singular on disk).
+
+There is intentionally no ``references`` category. The on-disk
+``data_path/references/`` tree holds only the legacy index file layout;
+the application reads those files via ``indexes/{index_id}/...`` keys, so
+the ``indexes`` category (with :class:`LegacyIndexFilesystemAdapter`)
+already migrates them to the correct destination keys. A literal
+``references/`` migration would copy them under keys nothing reads.
 """
 
 

--- a/virtool/migration/storage.py
+++ b/virtool/migration/storage.py
@@ -1,0 +1,244 @@
+"""Per-category storage migration from filesystem to object storage.
+
+Provides the implementation behind ``virtool migration storage``. Streams
+files from a :class:`~virtool.storage.filesystem.FilesystemProvider`
+(optionally wrapped in :class:`~virtool.storage.legacy.LegacyIndexFilesystemAdapter`
+for the ``indexes`` category) into the configured object backend obtained
+via :func:`~virtool.storage.factory.build_primary_backend`, bypassing the
+runtime :class:`~virtool.storage.routing.FallbackStorageRouter`.
+
+The migrator is idempotent: it probes the destination for each key and
+skips files already present with a matching byte size. Source files are
+never deleted; operators do that manually after verifying.
+"""
+
+from dataclasses import dataclass
+
+from structlog import get_logger
+
+from virtool.migration.storage_settings import StorageMigrationSettings
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.factory import build_primary_backend
+from virtool.storage.filesystem import FilesystemProvider
+from virtool.storage.legacy import LegacyIndexFilesystemAdapter
+from virtool.storage.protocol import StorageBackend
+
+logger = get_logger("migration")
+
+
+CATEGORY_PREFIXES: dict[str, str] = {
+    "hmms": "hmm/",
+    "uploads": "files/",
+    "subtractions": "subtractions/",
+    "ml-models": "ml/",
+    "references": "references/",
+    "history": "history/",
+    "indexes": "indexes/",
+    "samples": "samples/",
+    "analyses": "analyses/",
+}
+"""Maps a CLI ``--category`` value to its on-disk / storage key prefix.
+
+The on-disk directory names were confirmed against the data-layer modules
+(``virtool/hmm/data.py``, ``virtool/uploads/utils.py`` etc.). Note that the
+``hmms`` category uses the ``hmm/`` prefix (singular on disk).
+"""
+
+
+PROGRESS_LOG_INTERVAL: int = 100
+"""Log a running progress line every N files processed."""
+
+
+@dataclass(frozen=True, slots=True)
+class StorageMigrationReport:
+    """Result of a single ``migrate_category`` invocation."""
+
+    copied: int
+    skipped: int
+    bytes_copied: int
+
+
+@dataclass(frozen=True, slots=True)
+class StorageVerificationReport:
+    """Comparison of source and destination after a migration."""
+
+    source_count: int
+    destination_count: int
+    missing_keys: list[str]
+    size_mismatches: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing_keys and not self.size_mismatches
+
+
+async def migrate_category(
+    source: StorageBackend,
+    destination: StorageBackend,
+    prefix: str,
+    *,
+    dry_run: bool = False,
+) -> StorageMigrationReport:
+    """Stream every object under ``prefix`` from ``source`` to ``destination``.
+
+    Skips objects already present in ``destination`` with the same byte
+    size. When ``dry_run`` is true, logs what would be copied without
+    writing.
+    """
+    copied = 0
+    skipped = 0
+    bytes_copied = 0
+    seen = 0
+
+    async for info in source.list(prefix):
+        seen += 1
+
+        try:
+            destination_size = await destination.size(info.key)
+        except StorageKeyNotFoundError:
+            destination_size = None
+
+        if destination_size == info.size:
+            skipped += 1
+        elif dry_run:
+            logger.info(
+                "would copy",
+                key=info.key,
+                size=info.size,
+                replaces=destination_size is not None,
+            )
+        else:
+            written = await destination.write(info.key, source.read(info.key))
+            copied += 1
+            bytes_copied += written
+
+        if seen % PROGRESS_LOG_INTERVAL == 0:
+            logger.info(
+                "migration progress",
+                prefix=prefix,
+                seen=seen,
+                copied=copied,
+                skipped=skipped,
+                bytes_copied=bytes_copied,
+                dry_run=dry_run,
+            )
+
+    logger.info(
+        "migration finished",
+        prefix=prefix,
+        copied=copied,
+        skipped=skipped,
+        bytes_copied=bytes_copied,
+        dry_run=dry_run,
+    )
+
+    return StorageMigrationReport(
+        copied=copied,
+        skipped=skipped,
+        bytes_copied=bytes_copied,
+    )
+
+
+async def verify_category(
+    source: StorageBackend,
+    destination: StorageBackend,
+    prefix: str,
+) -> StorageVerificationReport:
+    """Compare source and destination listings under ``prefix``.
+
+    For every source key, asserts the destination has the same key with a
+    matching byte size. Catches truncated or partial writes without
+    re-streaming file contents.
+    """
+    source_keys: dict[str, int] = {}
+    async for info in source.list(prefix):
+        source_keys[info.key] = info.size
+
+    destination_keys: dict[str, int] = {}
+    async for info in destination.list(prefix):
+        destination_keys[info.key] = info.size
+
+    missing_keys = sorted(k for k in source_keys if k not in destination_keys)
+    size_mismatches = sorted(
+        k
+        for k, size in source_keys.items()
+        if k in destination_keys and destination_keys[k] != size
+    )
+
+    return StorageVerificationReport(
+        source_count=len(source_keys),
+        destination_count=len(destination_keys),
+        missing_keys=missing_keys,
+        size_mismatches=size_mismatches,
+    )
+
+
+def build_source_backend(
+    settings: StorageMigrationSettings,
+    category: str,
+) -> StorageBackend:
+    """Build the filesystem source backend for ``category``.
+
+    The ``indexes`` category requires :class:`LegacyIndexFilesystemAdapter`
+    to translate ``indexes/{index_id}/...`` keys to the legacy on-disk
+    layout under ``data_path/references/{ref_id}/{index_id}/...``.
+    """
+    filesystem = FilesystemProvider(settings.data_path)
+
+    if category == "indexes":
+        return LegacyIndexFilesystemAdapter(filesystem, settings.data_path)
+
+    return filesystem
+
+
+async def run_storage_migration(
+    settings: StorageMigrationSettings,
+    category: str,
+    dry_run: bool,
+) -> None:
+    """Run ``migrate_category`` then ``verify_category`` for one CLI invocation.
+
+    Raises :class:`SystemExit` with a non-zero status when verification
+    detects missing keys or size mismatches.
+    """
+    prefix = CATEGORY_PREFIXES[category]
+
+    source = build_source_backend(settings, category)
+    destination = build_primary_backend(settings)
+
+    logger.info(
+        "starting storage migration",
+        category=category,
+        prefix=prefix,
+        backend=settings.storage_backend,
+        dry_run=dry_run,
+    )
+
+    report = await migrate_category(source, destination, prefix, dry_run=dry_run)
+
+    if dry_run:
+        return
+
+    verification = await verify_category(source, destination, prefix)
+
+    if verification.ok:
+        logger.info(
+            "verification passed",
+            category=category,
+            source_count=verification.source_count,
+            destination_count=verification.destination_count,
+            copied=report.copied,
+            skipped=report.skipped,
+            bytes_copied=report.bytes_copied,
+        )
+        return
+
+    logger.error(
+        "verification failed",
+        category=category,
+        source_count=verification.source_count,
+        destination_count=verification.destination_count,
+        missing_keys=verification.missing_keys,
+        size_mismatches=verification.size_mismatches,
+    )
+    raise SystemExit(1)

--- a/virtool/migration/storage.py
+++ b/virtool/migration/storage.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from structlog import get_logger
 
 from virtool.migration.storage_settings import StorageMigrationSettings
-from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.factory import build_primary_backend
 from virtool.storage.filesystem import FilesystemProvider
 from virtool.storage.legacy import LegacyIndexFilesystemAdapter
@@ -55,6 +54,15 @@ PROGRESS_LOG_INTERVAL: int = 100
 """Log a running progress line every N files processed."""
 
 
+FAILURE_LOG_SAMPLE: int = 10
+"""Cap the per-list sample of failing keys included in the verification log.
+
+The full :class:`StorageVerificationReport` is still returned to the caller;
+the log line is bounded so a large failure does not produce an unwieldy
+structured log entry.
+"""
+
+
 @dataclass(frozen=True, slots=True)
 class StorageMigrationReport:
     """Result of a single ``migrate_category`` invocation."""
@@ -90,7 +98,15 @@ async def migrate_category(
     Skips objects already present in ``destination`` with the same byte
     size. When ``dry_run`` is true, logs what would be copied without
     writing.
+
+    The destination prefix is enumerated once up-front into an in-memory
+    ``key -> size`` map, so per-file existence checks don't fire an extra
+    metadata round-trip (e.g. an S3 ``HEAD``) for every source object.
     """
+    destination_sizes: dict[str, int] = {
+        info.key: info.size async for info in destination.list(prefix)
+    }
+
     copied = 0
     skipped = 0
     bytes_copied = 0
@@ -99,10 +115,7 @@ async def migrate_category(
     async for info in source.list(prefix):
         seen += 1
 
-        try:
-            destination_size = await destination.size(info.key)
-        except StorageKeyNotFoundError:
-            destination_size = None
+        destination_size = destination_sizes.get(info.key)
 
         if destination_size == info.size:
             skipped += 1
@@ -244,7 +257,9 @@ async def run_storage_migration(
         category=category,
         source_count=verification.source_count,
         destination_count=verification.destination_count,
-        missing_keys=verification.missing_keys,
-        size_mismatches=verification.size_mismatches,
+        missing_count=len(verification.missing_keys),
+        size_mismatch_count=len(verification.size_mismatches),
+        missing_keys_sample=verification.missing_keys[:FAILURE_LOG_SAMPLE],
+        size_mismatches_sample=verification.size_mismatches[:FAILURE_LOG_SAMPLE],
     )
     raise SystemExit(1)

--- a/virtool/migration/storage_settings.py
+++ b/virtool/migration/storage_settings.py
@@ -1,0 +1,61 @@
+"""Environment-variable configuration for the storage migration CLI.
+
+Designed to be populated from Kubernetes ``Secret`` / ``ConfigMap`` env vars
+when ``virtool migration storage`` runs as a ``Job``. Uses Pydantic v1
+``BaseSettings`` because the project is pinned to Pydantic v1; this is the
+same API ``pydantic-settings`` was extracted from at the v1 → v2 split.
+"""
+
+from pathlib import Path
+
+from pydantic import BaseSettings, root_validator
+
+from virtool.config.cls import StorageBackendName, _validate_s3_credentials
+
+
+class StorageMigrationSettings(BaseSettings):
+    """Storage and data-path configuration loaded from ``VT_*`` env vars."""
+
+    data_path: Path
+    storage_backend: StorageBackendName
+
+    storage_s3_bucket: str = ""
+    storage_s3_region: str = ""
+    storage_s3_endpoint: str = ""
+    storage_s3_access_key_id: str = ""
+    storage_s3_secret_access_key: str = ""
+
+    storage_azure_account: str = ""
+    storage_azure_container: str = ""
+    storage_azure_access_key: str = ""
+    storage_azure_endpoint: str = ""
+
+    class Config:
+        env_prefix = "VT_"
+        case_sensitive = False
+
+    @root_validator
+    def _validate(cls, values: dict) -> dict:
+        backend = values.get("storage_backend")
+
+        if backend == "s3":
+            if not values.get("storage_s3_bucket"):
+                raise ValueError(
+                    "storage_backend=s3 requires VT_STORAGE_S3_BUCKET",
+                )
+            _validate_s3_credentials(
+                values.get("storage_s3_access_key_id", ""),
+                values.get("storage_s3_secret_access_key", ""),
+            )
+
+        if backend == "azure":
+            if not values.get("storage_azure_account"):
+                raise ValueError(
+                    "storage_backend=azure requires VT_STORAGE_AZURE_ACCOUNT",
+                )
+            if not values.get("storage_azure_container"):
+                raise ValueError(
+                    "storage_backend=azure requires VT_STORAGE_AZURE_CONTAINER",
+                )
+
+        return values

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -1,11 +1,32 @@
 """Factory for constructing the configured storage backend."""
 
-from virtool.config.cls import ServerConfig
+from typing import Protocol
+
+from virtool.config.cls import ServerConfig, StorageBackendName
 from virtool.storage.filesystem import FilesystemProvider
 from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 from virtool.storage.object import ObjectProvider
 from virtool.storage.protocol import StorageBackend
 from virtool.storage.routing import FallbackStorageRouter
+
+
+class StorageBackendConfig(Protocol):
+    """Structural type for the ``storage_*`` fields ``build_primary_backend`` reads.
+
+    ``ServerConfig``, ``TaskRunnerConfig`` and ``StorageMigrationSettings``
+    all satisfy this without explicit inheritance.
+    """
+
+    storage_backend: StorageBackendName
+    storage_s3_bucket: str
+    storage_s3_region: str
+    storage_s3_endpoint: str
+    storage_s3_access_key_id: str
+    storage_s3_secret_access_key: str
+    storage_azure_account: str
+    storage_azure_container: str
+    storage_azure_access_key: str
+    storage_azure_endpoint: str
 
 
 def create_storage_backend(config: ServerConfig) -> StorageBackend:
@@ -30,11 +51,12 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
     return FallbackStorageRouter(primary, fallback)
 
 
-def build_primary_backend(config: ServerConfig) -> StorageBackend:
+def build_primary_backend(config: StorageBackendConfig) -> StorageBackend:
     """Build the object-storage primary backend.
 
     Exposed for tests that need to drive the remote backend directly without
-    the filesystem fallback wrapper.
+    the filesystem fallback wrapper, and for the storage migration CLI which
+    must bypass the fallback router.
     """
     match config.storage_backend:
         case "s3":

--- a/virtool/storage/legacy.py
+++ b/virtool/storage/legacy.py
@@ -13,8 +13,10 @@ this module and unwire it from :mod:`virtool.storage.factory`.
 """
 
 import asyncio
+import os
 import re
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from pathlib import Path
 
 from virtool.storage.errors import StorageError, StorageKeyNotFoundError
@@ -22,6 +24,7 @@ from virtool.storage.protocol import StorageBackend
 from virtool.storage.types import StorageObjectInfo
 
 _INDEX_KEY_RE = re.compile(r"^indexes/(?P<index_id>[^/]+)(?P<rest>/.*)?$")
+_INDEXES_ROOT_PREFIXES = ("indexes", "indexes/")
 
 
 class LegacyIndexFilesystemAdapter:
@@ -109,6 +112,11 @@ class LegacyIndexFilesystemAdapter:
         return await self._inner.size(translated)
 
     async def list(self, prefix: str) -> AsyncIterator[StorageObjectInfo]:
+        if prefix in _INDEXES_ROOT_PREFIXES:
+            for info in await asyncio.to_thread(self._scan_all_indexes):
+                yield info
+            return
+
         match = _INDEX_KEY_RE.match(prefix)
         if match is None:
             async for info in self._inner.list(prefix):
@@ -132,3 +140,43 @@ class LegacyIndexFilesystemAdapter:
                 size=info.size,
                 last_modified=info.last_modified,
             )
+
+    def _scan_all_indexes(self) -> "list[StorageObjectInfo]":
+        """Enumerate every on-disk index file across all reference directories.
+
+        Used to support listing under just ``indexes/`` (no ``index_id``),
+        which the storage migration CLI needs to discover and migrate every
+        index in one pass. Populates the ``index_id -> ref_id`` cache as a
+        side effect so subsequent reads do not need to re-scan.
+        """
+        results: "list[StorageObjectInfo]" = []
+
+        if not self._references_path.is_dir():
+            return results
+
+        for ref_dir in self._references_path.iterdir():
+            if not ref_dir.is_dir():
+                continue
+
+            for index_dir in ref_dir.iterdir():
+                if not index_dir.is_dir():
+                    continue
+
+                self._cache[index_dir.name] = ref_dir.name
+
+                for dirpath, _, filenames in os.walk(index_dir):
+                    for filename in filenames:
+                        filepath = Path(dirpath) / filename
+                        rel = filepath.relative_to(index_dir).as_posix()
+                        stat = filepath.stat()
+                        results.append(
+                            StorageObjectInfo(
+                                key=f"indexes/{index_dir.name}/{rel}",
+                                size=stat.st_size,
+                                last_modified=datetime.fromtimestamp(
+                                    stat.st_mtime, tz=UTC
+                                ),
+                            )
+                        )
+
+        return results

--- a/virtool/storage/legacy.py
+++ b/virtool/storage/legacy.py
@@ -149,7 +149,7 @@ class LegacyIndexFilesystemAdapter:
         index in one pass. Populates the ``index_id -> ref_id`` cache as a
         side effect so subsequent reads do not need to re-scan.
         """
-        results: "list[StorageObjectInfo]" = []
+        results: list[StorageObjectInfo] = []
 
         if not self._references_path.is_dir():
             return results


### PR DESCRIPTION
## Summary

- Adds a `virtool migration storage --category <name>` CLI command that streams files from the on-disk filesystem into the configured object storage backend (S3 or Azure), bypassing the runtime fallback router.
- Migration is idempotent (skips files already present with matching size) and runs an automatic post-migration verification step; exits non-zero if any keys are missing or size-mismatched.
- The `indexes` category is handled via `LegacyIndexFilesystemAdapter` to translate the legacy `references/{ref_id}/{index_id}/...` on-disk layout into `indexes/{index_id}/...` keys; `references` is intentionally excluded as a standalone category because those files are already covered by `indexes`.

## Test plan

- [ ] `mise run test -- tests/migration/test_storage.py` passes
- [ ] `virtool migration storage --help` shows `--category` choices and `--dry-run`
- [ ] Dry-run against a real data path logs files without writing
- [ ] Run against a populated data path and confirm all categories migrate and verify successfully