### PR TITLE
add storage-inspect CLI for pre-deletion migration audit

### DIFF
--- a/tests/migration/test_storage_inspect.py
+++ b/tests/migration/test_storage_inspect.py
@@ -1,0 +1,240 @@
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from virtool.cli import cli
+from virtool.migration.storage import CATEGORY_PREFIXES
+from virtool.migration.storage_inspect import (
+    _classify_remaining,
+    _collect_covered_disk_paths,
+    _walk_disk,
+    run_storage_inspection,
+)
+from virtool.migration.storage_settings import StorageMigrationSettings
+from virtool.storage.memory import MemoryStorageProvider
+
+
+async def _async_iter(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+async def _populate(provider, items: dict[str, bytes]) -> None:
+    for key, value in items.items():
+        await provider.write(key, _async_iter(value))
+
+
+def _settings(data_path: Path) -> StorageMigrationSettings:
+    return StorageMigrationSettings(
+        data_path=data_path,
+        storage_backend="s3",
+        storage_s3_bucket="test-bucket",
+    )
+
+
+def _stage_data_path(data_path: Path) -> dict[str, bytes]:
+    """Drop one file per non-indexes category and one legacy index file."""
+    contents: dict[str, bytes] = {
+        "hmm/profiles.hmm": b"hmm-profile-bytes",
+        "files/upload-1.csv": b"upload-bytes",
+        "subtractions/sub-1/sub.fa.gz": b"subtraction-bytes",
+        "ml/model-1/model.tar.gz": b"ml-bytes",
+        "history/hist-1/diff.json": b"history-bytes",
+        "samples/samp-1/reads_1.fq.gz": b"sample-bytes",
+        "analyses/ana-1/result.json": b"analysis-bytes",
+    }
+
+    for rel, value in contents.items():
+        path = data_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(value)
+
+    ref_id = "ref-1"
+    index_id = "idx-1"
+    index_path = data_path / "references" / ref_id / index_id / "reference.json.gz"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_bytes(b"index-bytes")
+
+    return contents | {f"indexes/{index_id}/reference.json.gz": b"index-bytes"}
+
+
+async def _stage_destination(items: dict[str, bytes]) -> MemoryStorageProvider:
+    destination = MemoryStorageProvider()
+    await _populate(destination, items)
+    return destination
+
+
+class TestHappyPath:
+    async def test_default_sample(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        destination = await _stage_destination(items)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        await run_storage_inspection(
+            _settings(tmp_path),
+            category=None,
+            sample_size=100,
+            full_hash=False,
+        )
+
+    async def test_full_hash_covers_every_key(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        destination = await _stage_destination(items)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        await run_storage_inspection(
+            _settings(tmp_path),
+            category=None,
+            sample_size=1,
+            full_hash=True,
+        )
+
+    async def test_single_category(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        destination = await _stage_destination(items)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        await run_storage_inspection(
+            _settings(tmp_path),
+            category="samples",
+            sample_size=100,
+            full_hash=False,
+        )
+
+
+class TestFailureModes:
+    async def test_missing_destination_key(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        items_without_one = {
+            k: v for k, v in items.items() if k != "samples/samp-1/reads_1.fq.gz"
+        }
+        destination = await _stage_destination(items_without_one)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            await run_storage_inspection(
+                _settings(tmp_path),
+                category=None,
+                sample_size=100,
+                full_hash=True,
+            )
+
+        assert exc_info.value.code == 1
+
+    async def test_size_match_but_content_differs(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        corrupted = dict(items)
+        original = items["samples/samp-1/reads_1.fq.gz"]
+        corrupted["samples/samp-1/reads_1.fq.gz"] = bytes(b ^ 0xFF for b in original)
+        destination = await _stage_destination(corrupted)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            await run_storage_inspection(
+                _settings(tmp_path),
+                category=None,
+                sample_size=100,
+                full_hash=True,
+            )
+
+        assert exc_info.value.code == 1
+
+    async def test_orphan_under_references_top_level(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        (tmp_path / "references" / "spurious.txt").write_bytes(b"orphan")
+        destination = await _stage_destination(items)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            await run_storage_inspection(
+                _settings(tmp_path),
+                category=None,
+                sample_size=100,
+                full_hash=True,
+            )
+
+        assert exc_info.value.code == 1
+
+    async def test_ignored_paths_do_not_fail(self, tmp_path: Path, mocker):
+        items = _stage_data_path(tmp_path)
+        (tmp_path / "caches").mkdir()
+        (tmp_path / "caches" / "stale").write_bytes(b"stale")
+        (tmp_path / "logs").mkdir()
+        (tmp_path / "logs" / "old.log").write_bytes(b"log")
+        (tmp_path / "azcopy_linux_amd64_10.16.1.tar.gz").write_bytes(b"tarball")
+
+        destination = await _stage_destination(items)
+
+        mocker.patch(
+            "virtool.migration.storage_inspect.build_primary_backend",
+            return_value=destination,
+        )
+
+        await run_storage_inspection(
+            _settings(tmp_path),
+            category=None,
+            sample_size=100,
+            full_hash=True,
+        )
+
+
+class TestReport:
+    async def test_classification(self, tmp_path: Path):
+        """Drive the inner helpers directly to assert report fields."""
+        _stage_data_path(tmp_path)
+        (tmp_path / "references" / "spurious.txt").write_bytes(b"orphan")
+        (tmp_path / "caches").mkdir()
+        (tmp_path / "caches" / "stale").write_bytes(b"stale")
+        (tmp_path / "azcopy.tar.gz").write_bytes(b"tarball")
+
+        walked = _walk_disk(tmp_path)
+        covered = await _collect_covered_disk_paths(_settings(tmp_path))
+
+        orphans, ignored = _classify_remaining(walked, covered)
+
+        assert "references/spurious.txt" in orphans
+        assert "caches/stale" in ignored
+        assert "azcopy.tar.gz" in ignored
+
+
+class TestCLI:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migration", "storage-inspect", "--help"])
+
+        assert result.exit_code == 0
+        assert "--category" in result.output
+        assert "--sample-size" in result.output
+        assert "--full-hash" in result.output
+
+    def test_category_choices(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migration", "storage-inspect", "--help"])
+
+        for category in CATEGORY_PREFIXES:
+            assert category in result.output

--- a/tests/migration/test_storage_inspect.py
+++ b/tests/migration/test_storage_inspect.py
@@ -9,6 +9,7 @@ from virtool.migration.storage import CATEGORY_PREFIXES
 from virtool.migration.storage_inspect import (
     _classify_remaining,
     _collect_covered_disk_paths,
+    _hash_sample,
     _walk_disk,
     run_storage_inspection,
 )
@@ -116,6 +117,17 @@ class TestHappyPath:
 
 
 class TestFailureModes:
+    async def test_invalid_data_path(self, tmp_path: Path):
+        with pytest.raises(SystemExit) as exc_info:
+            await run_storage_inspection(
+                _settings(tmp_path / "nonexistent"),
+                category=None,
+                sample_size=100,
+                full_hash=False,
+            )
+
+        assert exc_info.value.code == 1
+
     async def test_missing_destination_key(self, tmp_path: Path, mocker):
         items = _stage_data_path(tmp_path)
         items_without_one = {
@@ -201,6 +213,27 @@ class TestFailureModes:
             sample_size=100,
             full_hash=True,
         )
+
+
+class TestHashSample:
+    async def test_source_missing_key_counts_as_mismatch(self):
+        """A key missing in source is registered as a mismatch, not an exception."""
+        source = MemoryStorageProvider()
+        destination = MemoryStorageProvider()
+        await _populate(destination, {"present.bin": b"data"})
+
+        mismatches = await _hash_sample(source, destination, ["present.bin"])
+
+        assert mismatches == ["present.bin"]
+
+    async def test_destination_missing_key_counts_as_mismatch(self):
+        source = MemoryStorageProvider()
+        destination = MemoryStorageProvider()
+        await _populate(source, {"present.bin": b"data"})
+
+        mismatches = await _hash_sample(source, destination, ["present.bin"])
+
+        assert mismatches == ["present.bin"]
 
 
 class TestReport:

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -38,6 +38,7 @@ from virtool.migration.create import create_revision
 from virtool.migration.depend import depend
 from virtool.migration.show import show_revisions
 from virtool.migration.storage import CATEGORY_PREFIXES, run_storage_migration
+from virtool.migration.storage_inspect import run_storage_inspection
 from virtool.migration.storage_settings import StorageMigrationSettings
 from virtool.oas.cmd import show_oas
 from virtool.tasks.main import run_task_runner, run_task_spawner
@@ -183,6 +184,45 @@ def migration_storage(category: str, dry_run: bool) -> None:
     configure_logging(False)
     settings = StorageMigrationSettings()
     asyncio.run(run_storage_migration(settings, category, dry_run))
+
+
+@migration.command("storage-inspect")
+@click.option(
+    "--category",
+    default=None,
+    type=click.Choice(sorted(CATEGORY_PREFIXES)),
+    help="Limit listing parity and content hashing to a single category.",
+)
+@click.option(
+    "--sample-size",
+    default=100,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Number of random keys per category to hash end-to-end.",
+)
+@click.option(
+    "--full-hash",
+    is_flag=True,
+    help="Hash every key instead of a random sample.",
+)
+def migration_storage_inspect(
+    category: str | None,
+    sample_size: int,
+    full_hash: bool,
+) -> None:
+    """Inspect the on-disk source against object storage before deletion.
+
+    Read-only: walks ``data_path`` for orphaned files, re-verifies the
+    listing parity of every migrated category, and stream-hashes a
+    sample of source objects against the destination. Exits non-zero
+    on any drift so a Kubernetes ``Job`` will land in ``Failed`` and
+    block the operator from running ``rm`` against ``data_path``.
+    """
+    configure_logging(False)
+    settings = StorageMigrationSettings()
+    asyncio.run(
+        run_storage_inspection(settings, category, sample_size, full_hash),
+    )
 
 
 @cli.group("tasks")

--- a/virtool/migration/storage_inspect.py
+++ b/virtool/migration/storage_inspect.py
@@ -1,0 +1,360 @@
+"""Read-only post-migration inspection for the storage migration.
+
+Provides the implementation behind ``virtool migration storage-inspect``.
+The script never deletes from disk or object storage; it produces a
+report and a non-zero exit when any check fails. Three checks run:
+
+1. **Orphan walk.** Every file under ``data_path/`` must be covered by a
+   source-backend listing for one of the configured categories, or fall
+   in an explicit "ignored" bucket (defunct top-level dirs, top-level
+   archive files). Anything left over is an orphan and fails the run.
+2. **Listing parity.** :func:`~virtool.migration.storage.verify_category`
+   re-runs for each requested category — cheap drift detection.
+3. **Content hash sample.** For each requested category, a random sample
+   of source keys is stream-hashed end to end and compared against the
+   destination. ``--full-hash`` upgrades the sample to every key.
+
+This is the gate before deleting the on-disk source: matching listings
+plus matching content hashes give defensible evidence that the migration
+landed correctly.
+"""
+
+import hashlib
+import os
+import random
+import re
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from structlog import get_logger
+
+from virtool.migration.storage import (
+    CATEGORY_PREFIXES,
+    FAILURE_LOG_SAMPLE,
+    StorageVerificationReport,
+    build_source_backend,
+    verify_category,
+)
+from virtool.migration.storage_settings import StorageMigrationSettings
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.factory import build_primary_backend
+from virtool.storage.legacy import LegacyIndexFilesystemAdapter
+from virtool.storage.protocol import StorageBackend
+
+logger = get_logger("migration")
+
+
+DEFUNCT_TOP_LEVEL_DIRS: frozenset[str] = frozenset({"caches", "logs"})
+"""Top-level directories under ``data_path`` that no longer hold live data.
+
+Files under these prefixes are reported in ``ignored`` rather than
+``orphans`` so they do not block a deletion gate. They predate the
+object-storage migration and were never enumerated by any category.
+"""
+
+
+TOP_LEVEL_ARCHIVE_RE = re.compile(r"^[^/]+\.(tar\.gz|tgz|zip)$")
+"""Matches a top-level archive file (e.g. ``azcopy_linux_amd64_10.16.1.tar.gz``).
+
+Operator tooling occasionally lands a tarball at the root of ``data_path``;
+those don't belong to any storage category but are not data corruption.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class StorageInspectionReport:
+    """Aggregated result of a single ``run_storage_inspection`` invocation."""
+
+    orphans: list[str]
+    ignored: list[str]
+    verification: dict[str, StorageVerificationReport]
+    hash_mismatches: dict[str, list[str]]
+    hash_sampled: dict[str, int]
+    walked: int = 0
+    covered: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return (
+            not self.orphans
+            and all(v.ok for v in self.verification.values())
+            and not any(self.hash_mismatches.values())
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _OrphanWalkResult:
+    walked: int
+    covered: int
+    orphans: list[str]
+    ignored: list[str]
+
+
+def _walk_disk(data_path: Path) -> set[str]:
+    """Return every regular file under ``data_path`` as a ``/``-joined string."""
+    paths: set[str] = set()
+
+    for dirpath, _, filenames in os.walk(data_path):
+        for filename in filenames:
+            full = Path(dirpath) / filename
+            paths.add(full.relative_to(data_path).as_posix())
+
+    return paths
+
+
+async def _collect_covered_disk_paths(
+    settings: StorageMigrationSettings,
+) -> set[str]:
+    """Project every category's source listing back to disk-relative paths."""
+    covered: set[str] = set()
+
+    for category in CATEGORY_PREFIXES:
+        prefix = CATEGORY_PREFIXES[category]
+        source = build_source_backend(settings, category)
+
+        if isinstance(source, LegacyIndexFilesystemAdapter):
+            async for info in source.list(prefix):
+                disk_path = await source._translate(info.key)  # noqa: SLF001
+                if disk_path is not None:
+                    covered.add(disk_path)
+        else:
+            async for info in source.list(prefix):
+                covered.add(info.key)
+
+    return covered
+
+
+def _classify_remaining(
+    walked: set[str],
+    covered: set[str],
+) -> tuple[list[str], list[str]]:
+    """Split disk paths not covered by any category into orphans and ignored."""
+    orphans: list[str] = []
+    ignored: list[str] = []
+
+    for path in sorted(walked - covered):
+        top = path.split("/", 1)[0]
+
+        if top in DEFUNCT_TOP_LEVEL_DIRS or TOP_LEVEL_ARCHIVE_RE.match(path):
+            ignored.append(path)
+        else:
+            orphans.append(path)
+
+    return orphans, ignored
+
+
+async def _orphan_walk(settings: StorageMigrationSettings) -> _OrphanWalkResult:
+    """Run the orphan walk and return classified results."""
+    logger.info("orphan walk start", data_path=str(settings.data_path))
+
+    walked = _walk_disk(settings.data_path)
+    covered = await _collect_covered_disk_paths(settings)
+    orphans, ignored = _classify_remaining(walked, covered)
+
+    logger.info(
+        "orphan walk complete",
+        walked=len(walked),
+        covered=len(walked & covered),
+        orphans=len(orphans),
+        ignored=len(ignored),
+    )
+
+    return _OrphanWalkResult(
+        walked=len(walked),
+        covered=len(walked & covered),
+        orphans=orphans,
+        ignored=ignored,
+    )
+
+
+async def _hash_stream(chunks: AsyncIterator[bytes]) -> str:
+    h = hashlib.sha256()
+    async for chunk in chunks:
+        h.update(chunk)
+    return h.hexdigest()
+
+
+def _pick_sample(
+    keys: list[str],
+    sample_size: int,
+    full_hash: bool,
+    rng: random.Random,
+) -> list[str]:
+    if full_hash or sample_size >= len(keys):
+        return keys
+    return rng.sample(keys, sample_size)
+
+
+async def _hash_sample(
+    source: StorageBackend,
+    destination: StorageBackend,
+    keys: list[str],
+) -> list[str]:
+    mismatches: list[str] = []
+
+    for key in keys:
+        source_hash = await _hash_stream(source.read(key))
+
+        try:
+            destination_hash = await _hash_stream(destination.read(key))
+        except StorageKeyNotFoundError:
+            mismatches.append(key)
+            continue
+
+        if source_hash != destination_hash:
+            mismatches.append(key)
+
+    return sorted(mismatches)
+
+
+async def _inspect_category(
+    settings: StorageMigrationSettings,
+    destination: StorageBackend,
+    category: str,
+    sample_size: int,
+    full_hash: bool,
+    rng: random.Random,
+) -> tuple[StorageVerificationReport, list[str], int]:
+    prefix = CATEGORY_PREFIXES[category]
+    source = build_source_backend(settings, category)
+
+    logger.info("inspecting category", category=category, prefix=prefix)
+
+    verification = await verify_category(source, destination, prefix)
+
+    if verification.ok:
+        logger.info(
+            "listing parity ok",
+            category=category,
+            source_count=verification.source_count,
+            destination_count=verification.destination_count,
+        )
+    else:
+        logger.error(
+            "listing parity failed",
+            category=category,
+            source_count=verification.source_count,
+            destination_count=verification.destination_count,
+            missing_count=len(verification.missing_keys),
+            size_mismatch_count=len(verification.size_mismatches),
+            missing_keys_sample=verification.missing_keys[:FAILURE_LOG_SAMPLE],
+            size_mismatches_sample=verification.size_mismatches[:FAILURE_LOG_SAMPLE],
+        )
+
+    source_keys: list[str] = [info.key async for info in source.list(prefix)]
+
+    sample_keys = _pick_sample(source_keys, sample_size, full_hash, rng)
+    mismatches = await _hash_sample(source, destination, sample_keys)
+
+    if mismatches:
+        logger.error(
+            "content sample mismatch",
+            category=category,
+            mismatches=len(mismatches),
+            sampled=len(sample_keys),
+            sample=mismatches[:FAILURE_LOG_SAMPLE],
+        )
+    else:
+        logger.info(
+            "content sample ok",
+            category=category,
+            sampled=len(sample_keys),
+            mismatches=0,
+        )
+
+    return verification, mismatches, len(sample_keys)
+
+
+async def run_storage_inspection(
+    settings: StorageMigrationSettings,
+    category: str | None,
+    sample_size: int,
+    full_hash: bool,
+) -> None:
+    """Run the orphan walk, listing parity, and content sample checks.
+
+    Raises :class:`SystemExit` with a non-zero status if any check fails.
+    """
+    categories: list[str] = (
+        [category] if category is not None else list(CATEGORY_PREFIXES)
+    )
+
+    destination = build_primary_backend(settings)
+
+    logger.info(
+        "starting storage inspection",
+        backend=settings.storage_backend,
+        categories=len(categories),
+        sample_size=sample_size,
+        full_hash=full_hash,
+    )
+
+    orphan_result = await _orphan_walk(settings)
+
+    if orphan_result.orphans:
+        logger.error(
+            "orphans detected",
+            count=len(orphan_result.orphans),
+            sample=orphan_result.orphans[:FAILURE_LOG_SAMPLE],
+        )
+
+    if orphan_result.ignored:
+        logger.info(
+            "ignored paths",
+            count=len(orphan_result.ignored),
+            sample=orphan_result.ignored[:FAILURE_LOG_SAMPLE],
+        )
+
+    rng = random.Random()  # noqa: S311 — sampling for QA, not cryptography
+
+    verification: dict[str, StorageVerificationReport] = {}
+    hash_mismatches: dict[str, list[str]] = {}
+    hash_sampled: dict[str, int] = {}
+
+    for cat in categories:
+        cat_verification, cat_mismatches, cat_sampled = await _inspect_category(
+            settings,
+            destination,
+            cat,
+            sample_size,
+            full_hash,
+            rng,
+        )
+        verification[cat] = cat_verification
+        hash_mismatches[cat] = cat_mismatches
+        hash_sampled[cat] = cat_sampled
+
+    report = StorageInspectionReport(
+        orphans=orphan_result.orphans,
+        ignored=orphan_result.ignored,
+        verification=verification,
+        hash_mismatches=hash_mismatches,
+        hash_sampled=hash_sampled,
+        walked=orphan_result.walked,
+        covered=orphan_result.covered,
+    )
+
+    sampled_total = sum(hash_sampled.values())
+    missing_total = sum(len(v.missing_keys) for v in verification.values())
+    size_mismatch_total = sum(len(v.size_mismatches) for v in verification.values())
+    hash_mismatch_total = sum(len(v) for v in hash_mismatches.values())
+
+    if report.ok:
+        logger.info(
+            "inspection passed",
+            orphans=0,
+            verification_ok=True,
+            hash_mismatches=0,
+            sampled_total=sampled_total,
+        )
+        return
+
+    logger.error(
+        "inspection failed",
+        orphans=len(report.orphans),
+        missing_keys=missing_total,
+        size_mismatches=size_mismatch_total,
+        hash_mismatches=hash_mismatch_total,
+    )
+    raise SystemExit(1)

--- a/virtool/migration/storage_inspect.py
+++ b/virtool/migration/storage_inspect.py
@@ -194,7 +194,11 @@ async def _hash_sample(
     mismatches: list[str] = []
 
     for key in keys:
-        source_hash = await _hash_stream(source.read(key))
+        try:
+            source_hash = await _hash_stream(source.read(key))
+        except StorageKeyNotFoundError:
+            mismatches.append(key)
+            continue
 
         try:
             destination_hash = await _hash_stream(destination.read(key))
@@ -276,6 +280,13 @@ async def run_storage_inspection(
 
     Raises :class:`SystemExit` with a non-zero status if any check fails.
     """
+    if not settings.data_path.is_dir():
+        logger.error(
+            "data_path is not a directory or does not exist",
+            data_path=str(settings.data_path),
+        )
+        raise SystemExit(1)
+
     categories: list[str] = (
         [category] if category is not None else list(CATEGORY_PREFIXES)
     )


### PR DESCRIPTION
## Summary

- Adds `virtool migration storage-inspect` CLI command that performs a read-only audit of the on-disk source against object storage before any deletion occurs
- Three checks run: orphan walk (every disk file must be covered by a category listing or explicitly ignored), listing parity re-verification per category, and stream-based SHA-256 content hashing of a random sample (or all keys with `--full-hash`)
- Exits non-zero on any drift so a Kubernetes `Job` lands in `Failed` and blocks the operator from running `rm` against `data_path`

## Test plan

- [ ] Run `virtool migration storage-inspect --help` and confirm `--category`, `--sample-size`, and `--full-hash` flags are present with correct choices
- [ ] Run `mise run test -- tests/migration/test_storage_inspect.py` to verify all new unit tests pass
- [ ] Verify a missing destination key causes exit code 1
- [ ] Verify a content mismatch (same size, different bytes) causes exit code 1
- [ ] Verify orphan files under `references/` trigger exit code 1
- [ ] Verify files under `caches/`, `logs/`, and top-level archives (`.tar.gz`) are silently ignored and do not fail the run
- [ ] Verify `--full-hash` hashes every key rather than a sample