### PR TITLE
enforce single active instance message

### DIFF
--- a/assets/alembic/versions/6d7a80c99db7_enforce_single_active_instance_message.py
+++ b/assets/alembic/versions/6d7a80c99db7_enforce_single_active_instance_message.py
@@ -1,0 +1,38 @@
+"""enforce single active instance message
+
+Revision ID: 6d7a80c99db7
+Revises: c3a7e9b4d1f2
+Create Date: 2026-05-25 20:35:23.852785+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6d7a80c99db7"
+down_revision = "c3a7e9b4d1f2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE instance_messages SET active = false
+        WHERE active = true
+          AND id NOT IN (SELECT MAX(id) FROM instance_messages WHERE active = true)
+        """,
+    )
+
+    op.create_index(
+        "instance_messages_one_active",
+        "instance_messages",
+        ["active"],
+        unique=True,
+        postgresql_where=sa.text("active = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("instance_messages_one_active", table_name="instance_messages")

--- a/assets/alembic/versions/6d7a80c99db7_enforce_single_active_instance_message.py
+++ b/assets/alembic/versions/6d7a80c99db7_enforce_single_active_instance_message.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
         """
         UPDATE instance_messages SET active = false
         WHERE active = true
-          AND id NOT IN (SELECT MAX(id) FROM instance_messages WHERE active = true)
+          AND id < (SELECT MAX(id) FROM instance_messages WHERE active = true)
         """,
     )
 

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -211,5 +211,12 @@
       'name': 'create caches table',
       'revision': 'c3a7e9b4d1f2',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 31,
+      'name': 'enforce single active instance message',
+      'revision': '6d7a80c99db7',
+    }),
   ])
 # ---


### PR DESCRIPTION
## Summary
- Adds a partial unique index (`instance_messages_one_active`) on the `instance_messages` table so only one active instance message can exist at a time
- Includes a data migration that deactivates all but the most recently created active message before applying the constraint
- Updates the migration apply snapshot to reflect the new revision

## Test plan
- [ ] Run `mise run test -- tests/migration` to confirm the apply snapshot passes
- [ ] Verify the migration upgrades cleanly on a database with zero, one, and multiple active instance messages
- [ ] Verify the migration downgrade drops the index without errors