### PR TITLE
feat(migration): add user_id FK to uploads table (phase 1)

### DIFF
--- a/assets/alembic/versions/d7f8f4569939_add_uploads_user_id.py
+++ b/assets/alembic/versions/d7f8f4569939_add_uploads_user_id.py
@@ -1,0 +1,127 @@
+"""add uploads user_id
+
+Phase 1 of converting ``uploads."user"`` (VARCHAR) to
+``uploads.user_id`` (INTEGER FK to ``users.id``). Purely additive so the
+schema is compatible with both old and new application code during the
+deploy window.
+
+The migration:
+
+- adds a nullable ``user_id INTEGER REFERENCES users(id)`` column,
+- backfills it from the existing ``"user"`` column (digit-string →
+  ``users.id``, otherwise → ``users.legacy_id``),
+- raises if any row remains with NULL ``user_id`` (the production audit
+  found zero such rows; this is a tripwire, not a fallback),
+- installs a trigger that keeps ``user_id`` in sync on INSERT and on
+  UPDATE OF ``"user"`` for as long as the old code path is still writing
+  the string column.
+
+Phase 2 will switch the model and data layer to ``user_id``. Phase 3 will
+drop the trigger, set ``user_id`` NOT NULL, and drop the ``"user"``
+column.
+
+Revision ID: d7f8f4569939
+Revises: c3a7e9b4d1f2
+Create Date: 2026-05-25 22:24:47.242433+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d7f8f4569939"
+down_revision = "c3a7e9b4d1f2"
+branch_labels = None
+depends_on = None
+
+
+BACKFILL_BY_ID_SQL = """
+UPDATE uploads
+SET user_id = u.id
+FROM users u
+WHERE uploads.user_id IS NULL
+  AND u.id = CASE
+      WHEN uploads."user" ~ '^[0-9]+$' THEN uploads."user"::int
+  END
+"""
+
+BACKFILL_BY_LEGACY_ID_SQL = """
+UPDATE uploads
+SET user_id = u.id
+FROM users u
+WHERE uploads.user_id IS NULL
+  AND u.legacy_id = uploads."user"
+"""
+
+COUNT_UNMAPPED_SQL = """
+SELECT COUNT(*) FROM uploads WHERE user_id IS NULL
+"""
+
+CREATE_TRIGGER_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION sync_uploads_user_id() RETURNS trigger AS $$
+DECLARE
+    resolved_id INTEGER;
+BEGIN
+    IF NEW."user" IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW."user" ~ '^[0-9]+$' THEN
+        SELECT id INTO resolved_id FROM users WHERE id = NEW."user"::int;
+    END IF;
+
+    IF resolved_id IS NULL THEN
+        SELECT id INTO resolved_id FROM users WHERE legacy_id = NEW."user";
+    END IF;
+
+    IF resolved_id IS NULL THEN
+        RAISE EXCEPTION
+            'uploads."user" value % does not resolve to a users row',
+            NEW."user";
+    END IF;
+
+    NEW.user_id := resolved_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+"""
+
+CREATE_TRIGGER_SQL = """
+CREATE TRIGGER uploads_sync_user_id
+BEFORE INSERT OR UPDATE OF "user" ON uploads
+FOR EACH ROW
+EXECUTE FUNCTION sync_uploads_user_id()
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "uploads",
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+    )
+
+    op.execute(BACKFILL_BY_ID_SQL)
+    op.execute(BACKFILL_BY_LEGACY_ID_SQL)
+
+    unmapped = op.get_bind().execute(sa.text(COUNT_UNMAPPED_SQL)).scalar()
+
+    if unmapped:
+        msg = (
+            f"{unmapped} uploads row(s) could not be mapped to a users.id; "
+            "refusing to proceed"
+        )
+        raise RuntimeError(msg)
+
+    op.execute(CREATE_TRIGGER_FUNCTION_SQL)
+    op.execute(CREATE_TRIGGER_SQL)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS uploads_sync_user_id ON uploads")
+    op.execute("DROP FUNCTION IF EXISTS sync_uploads_user_id()")
+    op.drop_column("uploads", "user_id")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -211,5 +211,12 @@
       'name': 'create caches table',
       'revision': 'c3a7e9b4d1f2',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 31,
+      'name': 'add uploads user_id',
+      'revision': 'd7f8f4569939',
+    }),
   ])
 # ---

--- a/tests/migration/test_add_uploads_user_id.py
+++ b/tests/migration/test_add_uploads_user_id.py
@@ -1,0 +1,184 @@
+"""Tests for the add-uploads-user-id (phase 1) migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_users(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic up to the revision before this migration and seed two users.
+
+    Returns a mapping of ``legacy_id`` → ``users.id`` for the seeded users.
+    """
+    await asyncio.to_thread(apply_alembic, "c3a7e9b4d1f2")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES
+                    ('alice', 'alice_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb),
+                    ('bob', 'bob_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return user_ids
+
+
+async def _insert_upload(ctx: MigrationContext, name: str, user_value: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO uploads (name, ready, removed, reserved, "user")
+                VALUES (:name, false, false, false, :user)
+                RETURNING id
+            """),
+            {"name": name, "user": user_value},
+        )
+        upload_id = result.scalar_one()
+        await session.commit()
+    return upload_id
+
+
+async def _fetch_user_id(ctx: MigrationContext, upload_id: int) -> int | None:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("SELECT user_id FROM uploads WHERE id = :id"),
+            {"id": upload_id},
+        )
+        return result.scalar_one()
+
+
+class TestBackfill:
+    async def test_resolves_digit_string_via_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        alice = setup_users["alice_legacy"]
+        upload_id = await _insert_upload(ctx, "by_id.txt", str(alice))
+
+        await asyncio.to_thread(apply_alembic, "head")
+
+        assert await _fetch_user_id(ctx, upload_id) == alice
+
+    async def test_resolves_non_digit_via_legacy_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        bob = setup_users["bob_legacy"]
+        upload_id = await _insert_upload(ctx, "by_legacy.txt", "bob_legacy")
+
+        await asyncio.to_thread(apply_alembic, "head")
+
+        assert await _fetch_user_id(ctx, upload_id) == bob
+
+    async def test_unmappable_row_raises(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await _insert_upload(ctx, "orphan.txt", "ghost_user")
+
+        with pytest.raises(RuntimeError, match="could not be mapped"):
+            await asyncio.to_thread(apply_alembic, "head")
+
+
+class TestTrigger:
+    async def test_insert_resolves_digit_string(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "head")
+
+        alice = setup_users["alice_legacy"]
+        upload_id = await _insert_upload(ctx, "post.txt", str(alice))
+
+        assert await _fetch_user_id(ctx, upload_id) == alice
+
+    async def test_insert_resolves_legacy_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "head")
+
+        bob = setup_users["bob_legacy"]
+        upload_id = await _insert_upload(ctx, "post_legacy.txt", "bob_legacy")
+
+        assert await _fetch_user_id(ctx, upload_id) == bob
+
+    async def test_insert_with_null_user_preserves_user_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "head")
+
+        alice = setup_users["alice_legacy"]
+
+        async with AsyncSession(ctx.pg) as session:
+            result = await session.execute(
+                text("""
+                    INSERT INTO uploads (name, ready, removed, reserved, user_id)
+                    VALUES ('phase2.txt', false, false, false, :user_id)
+                    RETURNING id
+                """),
+                {"user_id": alice},
+            )
+            upload_id = result.scalar_one()
+            await session.commit()
+
+        assert await _fetch_user_id(ctx, upload_id) == alice
+
+    async def test_update_user_column_updates_user_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        alice = setup_users["alice_legacy"]
+        bob = setup_users["bob_legacy"]
+
+        upload_id = await _insert_upload(ctx, "switch.txt", "alice_legacy")
+
+        await asyncio.to_thread(apply_alembic, "head")
+
+        assert await _fetch_user_id(ctx, upload_id) == alice
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text('UPDATE uploads SET "user" = :user WHERE id = :id'),
+                {"user": str(bob), "id": upload_id},
+            )
+            await session.commit()
+
+        assert await _fetch_user_id(ctx, upload_id) == bob


### PR DESCRIPTION
## Summary

- Adds a nullable `user_id INTEGER REFERENCES users(id)` column to the `uploads` table as phase 1 of migrating away from the legacy string `"user"` column
- Backfills `user_id` from the existing `"user"` column (digit-string → `users.id`, otherwise → `users.legacy_id`), and raises if any row cannot be mapped
- Installs a `BEFORE INSERT OR UPDATE` trigger (`sync_uploads_user_id`) to keep `user_id` in sync while old code paths still write the string column

## Test plan

- [ ] Run the migration against a copy of production data and verify zero unmapped rows
- [ ] Verify `mise run test -- tests/migration/test_add_uploads_user_id.py` passes (backfill and trigger scenarios covered)
- [ ] Verify `mise run test -- tests/migration/test_apply.py` snapshot is updated correctly
- [ ] Confirm `downgrade()` cleanly drops the trigger, function, and column