### PR TITLE
refactor(uploads): migrate user column from string to integer foreign key

### DIFF
--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -176,6 +176,29 @@ class TestFind:
         assert resp.status == HTTPStatus.OK
         assert await resp.json() == snapshot
 
+    async def test_filters_by_user(
+        self,
+        fake: DataFaker,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+
+        matching_user = await fake.users.create()
+        other_user = await fake.users.create()
+
+        matching_upload = await fake.uploads.create(user=matching_user)
+        await fake.uploads.create(user=other_user)
+
+        resp = await client.get(f"/uploads?user={matching_user.id}")
+
+        assert resp.status == HTTPStatus.OK
+
+        body = await resp.json()
+
+        assert body["found_count"] == 1
+        assert body["items"][0]["id"] == matching_upload.id
+        assert body["items"][0]["user"]["id"] == matching_user.id
+
 
 async def test_get(
     example_path: Path,

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -28,7 +28,7 @@ async def test_create(
         fake_file_chunker(fake_file_path),
         "sample_1.fq.gz",
         UploadType.reads,
-        user=user.id,
+        user_id=user.id,
     )
 
     assert upload.name == "sample_1.fq.gz"

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -49,6 +49,7 @@ from virtool.releases import (
 )
 from virtool.settings.models import Settings
 from virtool.types import Document
+from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
@@ -643,7 +644,7 @@ async def create_import(
 
     upload = await get_row(pg, SQLUpload, ("name_on_disk", import_from))
 
-    document["imported_from"] = upload.to_dict()
+    document["imported_from"] = serialize_upload(upload)
 
     return document
 

--- a/virtool/references/transforms.py
+++ b/virtool/references/transforms.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.pg.utils import get_row_by_id
 from virtool.types import Document
+from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor, get_safely
@@ -78,7 +79,7 @@ class AttachImportedFromTransform(AbstractTransform):
         row = await get_row_by_id(self._pg, SQLUpload, upload_id)
 
         return await apply_transforms(
-            row.to_dict(), [AttachUserTransform(self._pg)], self._pg
+            serialize_upload(row), [AttachUserTransform(self._pg)], self._pg
         )
 
     async def attach_one(

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -23,6 +23,7 @@ from virtool.samples.models import WorkflowState
 from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
 from virtool.settings.models import Settings
 from virtool.types import Document
+from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
@@ -70,13 +71,13 @@ class AttachArtifactsAndReadsTransform(AbstractTransform):
 
         for reads_file in reads:
             if upload := reads_file.get("upload"):
-                reads_file["upload"] = (
+                reads_file["upload"] = serialize_upload(
                     (
                         await session.execute(
                             select(SQLUpload).filter_by(id=upload),
                         )
                     ).scalar()
-                ).to_dict()
+                )
 
             reads_file["download_url"] = str(
                 URL("/samples") / sample_id / "reads" / reads_file["name"]
@@ -115,7 +116,7 @@ class AttachUploadsTransform(AbstractTransform):
             select(SQLUpload).where(SQLUpload.id.in_(upload_ids)),
         )
 
-        upload_dicts = [upload.to_dict() for upload in result.scalars()]
+        upload_dicts = [serialize_upload(upload) for upload in result.scalars()]
 
         upload_dicts = await apply_transforms(
             upload_dicts,
@@ -144,7 +145,7 @@ class AttachUploadsTransform(AbstractTransform):
             select(SQLUpload).where(SQLUpload.id.in_(list(all_upload_ids))),
         )
 
-        upload_dicts = [upload.to_dict() for upload in result.scalars()]
+        upload_dicts = [serialize_upload(upload) for upload in result.scalars()]
 
         upload_dicts = await apply_transforms(
             upload_dicts,

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -22,7 +22,7 @@ routes = Routes()
 class UploadsView(PydanticView):
     async def get(
         self,
-        user: str | None = None,
+        user: int | None = None,
         page: conint(ge=1) = 1,
         per_page: conint(ge=1, le=100) = 25,
         upload_type: str | None = None,
@@ -64,7 +64,7 @@ class UploadsView(PydanticView):
             multipart_file_chunker(await self.request.multipart()),
             name,
             upload_type,
-            user=str(self.request["client"].user_id),
+            user_id=self.request["client"].user_id,
         )
 
         return json_response(

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -21,6 +21,24 @@ if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
 
 
+def serialize(upload: SQLUpload) -> dict:
+    return {
+        "id": upload.id,
+        "created_at": upload.created_at,
+        "name": upload.name,
+        "name_on_disk": upload.name_on_disk,
+        "ready": upload.ready,
+        "removed": upload.removed,
+        "removed_at": upload.removed_at,
+        "reserved": upload.reserved,
+        "size": upload.size,
+        "space": upload.space,
+        "type": upload.type.value if upload.type is not None else None,
+        "uploaded_at": upload.uploaded_at,
+        "user": {"id": upload.user_id} if upload.user_id is not None else None,
+    }
+
+
 class UploadsData(DataLayerDomain):
     name = "uploads"
 
@@ -34,7 +52,7 @@ class UploadsData(DataLayerDomain):
 
     async def find(
         self,
-        user,
+        user_id: int | None,
         page: int,
         per_page: int,
         upload_type,
@@ -48,8 +66,8 @@ class UploadsData(DataLayerDomain):
 
         filters = []
 
-        if user:
-            filters.append(SQLUpload.user == str(user))  # skipcq: PTC-W0068,PYL-R1714
+        if user_id is not None:
+            filters.append(SQLUpload.user_id == user_id)  # skipcq: PTC-W0068,PYL-R1714
 
         if upload_type:
             filters.append(SQLUpload.type == upload_type)  # skipcq: PTC-W0068,PYL-R1714
@@ -88,7 +106,7 @@ class UploadsData(DataLayerDomain):
             )
 
             uploads = [
-                row.to_dict()
+                serialize(row)
                 for row in (await session.execute(query)).unique().scalars()
             ]
 
@@ -111,7 +129,7 @@ class UploadsData(DataLayerDomain):
         chunker,
         name: str,
         upload_type: UploadType,
-        user: int | None = None,
+        user_id: int | None = None,
     ) -> Upload:
         """Create an upload."""
         created_at = virtool.utils.timestamp()
@@ -133,14 +151,14 @@ class UploadsData(DataLayerDomain):
                 size=size,
                 type=upload_type,
                 uploaded_at=virtool.utils.timestamp(),
-                user=str(user) if user is not None else None,
+                user_id=user_id,
             )
 
             session.add(upload)
             await session.commit()
             await session.refresh(upload)
 
-            upload_dict = upload.to_dict()
+            upload_dict = serialize(upload)
 
         return Upload(
             **await apply_transforms(
@@ -166,7 +184,7 @@ class UploadsData(DataLayerDomain):
 
         return Upload(
             **await apply_transforms(
-                upload.to_dict(),
+                serialize(upload),
                 [AttachUserTransform(self._pg)],
                 self._pg,
             ),
@@ -219,7 +237,7 @@ class UploadsData(DataLayerDomain):
             upload.removed_at = virtool.utils.timestamp()
 
             name_on_disk = upload.name_on_disk
-            upload = upload.to_dict()
+            upload = serialize(upload)
 
             await session.commit()
 

--- a/virtool/uploads/db.py
+++ b/virtool/uploads/db.py
@@ -5,6 +5,7 @@ import virtool.utils
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.pg.base import Base
 from virtool.types import Document
+from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
 
@@ -33,7 +34,7 @@ class AttachUploadTransform(AbstractTransform):
             return None
 
         upload_dicts = await apply_transforms(
-            [upload.to_dict()],
+            [serialize_upload(upload)],
             [AttachUserTransform(self._pg, ignore_errors=True)],
             self._pg,
         )
@@ -56,7 +57,7 @@ class AttachUploadTransform(AbstractTransform):
             select(SQLUpload).where(SQLUpload.id.in_(list(upload_ids))),
         )
 
-        upload_dicts = [upload.to_dict() for upload in result.scalars()]
+        upload_dicts = [serialize_upload(upload) for upload in result.scalars()]
 
         upload_dicts = await apply_transforms(
             upload_dicts,

--- a/virtool/uploads/sql.py
+++ b/virtool/uploads/sql.py
@@ -8,7 +8,7 @@ from sqlalchemy import (
     Integer,
     String,
 )
-from sqlalchemy.orm import Mapped, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
@@ -40,5 +40,5 @@ class SQLUpload(Base):
     size: Column = Column(BigInteger)
     space: Mapped[int] = Column(Integer, ForeignKey("spaces.id"), nullable=True)
     type: Column = Column(Enum(UploadType))
-    user: Column = Column(String)
+    user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
     uploaded_at: Column = Column(DateTime)


### PR DESCRIPTION
## Summary
- Replaces the legacy `user` string column on `SQLUpload` with a proper `user_id` integer foreign key referencing the `users` table
- Introduces a `serialize()` function in `virtool/uploads/data.py` to centralize upload serialization, replacing scattered `.to_dict()` calls across the codebase
- Updates `UploadsData.find()` and `UploadsData.create()` signatures to use `user_id: int | None` instead of `user: str`, and fixes the `GET /uploads?user=` query parameter to accept an integer

## Test plan
- [ ] Run `mise run test -- tests/uploads` to verify uploads tests pass
- [ ] Run `mise run test -- tests/samples` and `tests/references` to confirm transforms using `serialize_upload` still behave correctly
- [ ] Confirm `GET /uploads?user=<int>` filters correctly by user ID
- [ ] Run `mise run format:check` to ensure no lint issues