### PR TITLE
refactor(uploads): complete user column migration to integer FK

### DIFF
--- a/assets/alembic/versions/a4f9c1e82b56_drop_uploads_user_column.py
+++ b/assets/alembic/versions/a4f9c1e82b56_drop_uploads_user_column.py
@@ -1,0 +1,57 @@
+"""drop uploads user column
+
+Phase 3 of converting ``uploads."user"`` (VARCHAR) to
+``uploads.user_id`` (INTEGER FK to ``users.id``). Destructive schema
+cleanup that runs only after Phase 2 has been live long enough that
+rolling back past it is unacceptable.
+
+The migration:
+
+- drops the ``uploads_sync_user_id`` trigger and its
+  ``sync_uploads_user_id()`` function installed in Phase 1 (trigger
+  first so it cannot fire spuriously during the column drop),
+- raises if any row still has NULL ``user_id`` (tripwire; Phase 1
+  backfilled everything and the trigger has been populating new rows),
+- sets ``user_id`` NOT NULL,
+- drops the legacy ``"user"`` column.
+
+Rolling back past this migration requires restoring the column and
+re-running the Phase 1 backfill.
+
+Revision ID: a4f9c1e82b56
+Revises: d7f8f4569939
+Create Date: 2026-05-26 00:47:17.514003+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a4f9c1e82b56"
+down_revision = "d7f8f4569939"
+branch_labels = None
+depends_on = None
+
+
+COUNT_NULL_USER_ID_SQL = """
+SELECT COUNT(*) FROM uploads WHERE user_id IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS uploads_sync_user_id ON uploads")
+    op.execute("DROP FUNCTION IF EXISTS sync_uploads_user_id()")
+
+    null_count = op.get_bind().execute(sa.text(COUNT_NULL_USER_ID_SQL)).scalar()
+
+    if null_count:
+        msg = f"{null_count} uploads row(s) have NULL user_id; refusing to set NOT NULL"
+        raise RuntimeError(msg)
+
+    op.alter_column("uploads", "user_id", nullable=False)
+    op.drop_column("uploads", "user")
+
+
+def downgrade() -> None:
+    op.add_column("uploads", sa.Column("user", sa.String(), nullable=True))
+    op.alter_column("uploads", "user_id", nullable=True)

--- a/assets/alembic/versions/a4f9c1e82b56_drop_uploads_user_column.py
+++ b/assets/alembic/versions/a4f9c1e82b56_drop_uploads_user_column.py
@@ -15,8 +15,9 @@ The migration:
 - sets ``user_id`` NOT NULL,
 - drops the legacy ``"user"`` column.
 
-Rolling back past this migration requires restoring the column and
-re-running the Phase 1 backfill.
+This migration is irreversible: ``downgrade`` raises ``CommandError``
+because restoring the dropped ``"user"`` column would require re-running
+the Phase 1 backfill against archived legacy data.
 
 Revision ID: a4f9c1e82b56
 Revises: d7f8f4569939
@@ -26,6 +27,7 @@ Create Date: 2026-05-26 00:47:17.514003+00:00
 
 import sqlalchemy as sa
 from alembic import op
+from alembic.util.exc import CommandError
 
 revision = "a4f9c1e82b56"
 down_revision = "d7f8f4569939"
@@ -53,5 +55,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.add_column("uploads", sa.Column("user", sa.String(), nullable=True))
-    op.alter_column("uploads", "user_id", nullable=True)
+    msg = (
+        "a4f9c1e82b56 is irreversible: restoring the dropped 'user' column "
+        "requires re-running the Phase 1 backfill against archived legacy data, "
+        "which Alembic cannot do automatically."
+    )
+    raise CommandError(msg)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -225,5 +225,12 @@
       'name': 'add uploads user_id',
       'revision': 'd7f8f4569939',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 33,
+      'name': 'drop uploads user column',
+      'revision': 'a4f9c1e82b56',
+    }),
   ])
 # ---

--- a/tests/migration/test_add_uploads_user_id.py
+++ b/tests/migration/test_add_uploads_user_id.py
@@ -79,7 +79,7 @@ class TestBackfill:
         alice = setup_users["alice_legacy"]
         upload_id = await _insert_upload(ctx, "by_id.txt", str(alice))
 
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
         assert await _fetch_user_id(ctx, upload_id) == alice
 
@@ -92,7 +92,7 @@ class TestBackfill:
         bob = setup_users["bob_legacy"]
         upload_id = await _insert_upload(ctx, "by_legacy.txt", "bob_legacy")
 
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
         assert await _fetch_user_id(ctx, upload_id) == bob
 
@@ -105,7 +105,7 @@ class TestBackfill:
         await _insert_upload(ctx, "orphan.txt", "ghost_user")
 
         with pytest.raises(RuntimeError, match="could not be mapped"):
-            await asyncio.to_thread(apply_alembic, "head")
+            await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
 
 class TestTrigger:
@@ -115,7 +115,7 @@ class TestTrigger:
         setup_users: dict[str, int],
         apply_alembic: Callable,
     ):
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
         alice = setup_users["alice_legacy"]
         upload_id = await _insert_upload(ctx, "post.txt", str(alice))
@@ -128,7 +128,7 @@ class TestTrigger:
         setup_users: dict[str, int],
         apply_alembic: Callable,
     ):
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
         bob = setup_users["bob_legacy"]
         upload_id = await _insert_upload(ctx, "post_legacy.txt", "bob_legacy")
@@ -141,7 +141,7 @@ class TestTrigger:
         setup_users: dict[str, int],
         apply_alembic: Callable,
     ):
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
         alice = setup_users["alice_legacy"]
 
@@ -170,7 +170,7 @@ class TestTrigger:
 
         upload_id = await _insert_upload(ctx, "switch.txt", "alice_legacy")
 
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "d7f8f4569939")
 
         assert await _fetch_user_id(ctx, upload_id) == alice
 

--- a/tests/migration/test_drop_uploads_user_column.py
+++ b/tests/migration/test_drop_uploads_user_column.py
@@ -86,7 +86,7 @@ class TestSchemaCleanup:
             ).scalar_one()
             assert before == 1
 
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "a4f9c1e82b56")
 
         async with AsyncSession(ctx.pg) as session:
             after = (
@@ -116,7 +116,7 @@ class TestSchemaCleanup:
         setup_phase_2: dict[str, int],
         apply_alembic: Callable,
     ):
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "a4f9c1e82b56")
 
         async with AsyncSession(ctx.pg) as session:
             column_count = (
@@ -135,7 +135,7 @@ class TestSchemaCleanup:
         setup_phase_2: dict[str, int],
         apply_alembic: Callable,
     ):
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "a4f9c1e82b56")
 
         async with AsyncSession(ctx.pg) as session:
             is_nullable = (
@@ -159,7 +159,7 @@ class TestSchemaCleanup:
             ctx, "alice_upload.txt", str(alice)
         )
 
-        await asyncio.to_thread(apply_alembic, "head")
+        await asyncio.to_thread(apply_alembic, "a4f9c1e82b56")
 
         async with AsyncSession(ctx.pg) as session:
             user_id = (
@@ -190,4 +190,4 @@ class TestTripwire:
             await session.commit()
 
         with pytest.raises(RuntimeError, match="NULL user_id"):
-            await asyncio.to_thread(apply_alembic, "head")
+            await asyncio.to_thread(apply_alembic, "a4f9c1e82b56")

--- a/tests/migration/test_drop_uploads_user_column.py
+++ b/tests/migration/test_drop_uploads_user_column.py
@@ -1,0 +1,193 @@
+"""Tests for the drop-uploads-user-column (phase 3) migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_phase_2(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic up to the Phase 1 head and seed two users.
+
+    This leaves the database in the state Phase 2 expects: both columns
+    present, the ``uploads_sync_user_id`` trigger installed, and any
+    inserted rows backfilled with ``user_id``.
+
+    Returns a mapping of ``legacy_id`` → ``users.id`` for the seeded users.
+    """
+    await asyncio.to_thread(apply_alembic, "d7f8f4569939")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES
+                    ('alice', 'alice_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb),
+                    ('bob', 'bob_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return user_ids
+
+
+async def _insert_upload_via_trigger(
+    ctx: MigrationContext, name: str, user_value: str
+) -> int:
+    """Insert via the legacy ``"user"`` column; the Phase 1 trigger fills ``user_id``."""
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO uploads (name, ready, removed, reserved, "user")
+                VALUES (:name, false, false, false, :user)
+                RETURNING id
+            """),
+            {"name": name, "user": user_value},
+        )
+        upload_id = result.scalar_one()
+        await session.commit()
+    return upload_id
+
+
+class TestSchemaCleanup:
+    async def test_trigger_is_dropped(
+        self,
+        ctx: MigrationContext,
+        setup_phase_2: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        async with AsyncSession(ctx.pg) as session:
+            before = (
+                await session.execute(
+                    text("""
+                        SELECT COUNT(*) FROM pg_trigger
+                        WHERE tgname = 'uploads_sync_user_id'
+                          AND NOT tgisinternal
+                    """),
+                )
+            ).scalar_one()
+            assert before == 1
+
+        await asyncio.to_thread(apply_alembic, "head")
+
+        async with AsyncSession(ctx.pg) as session:
+            after = (
+                await session.execute(
+                    text("""
+                        SELECT COUNT(*) FROM pg_trigger
+                        WHERE tgname = 'uploads_sync_user_id'
+                          AND NOT tgisinternal
+                    """),
+                )
+            ).scalar_one()
+            assert after == 0
+
+            function_count = (
+                await session.execute(
+                    text("""
+                        SELECT COUNT(*) FROM pg_proc
+                        WHERE proname = 'sync_uploads_user_id'
+                    """),
+                )
+            ).scalar_one()
+            assert function_count == 0
+
+    async def test_user_column_is_dropped(
+        self,
+        ctx: MigrationContext,
+        setup_phase_2: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "head")
+
+        async with AsyncSession(ctx.pg) as session:
+            column_count = (
+                await session.execute(
+                    text("""
+                        SELECT COUNT(*) FROM information_schema.columns
+                        WHERE table_name = 'uploads' AND column_name = 'user'
+                    """),
+                )
+            ).scalar_one()
+            assert column_count == 0
+
+    async def test_user_id_is_not_null(
+        self,
+        ctx: MigrationContext,
+        setup_phase_2: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "head")
+
+        async with AsyncSession(ctx.pg) as session:
+            is_nullable = (
+                await session.execute(
+                    text("""
+                        SELECT is_nullable FROM information_schema.columns
+                        WHERE table_name = 'uploads' AND column_name = 'user_id'
+                    """),
+                )
+            ).scalar_one()
+            assert is_nullable == "NO"
+
+    async def test_existing_rows_survive(
+        self,
+        ctx: MigrationContext,
+        setup_phase_2: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        alice = setup_phase_2["alice_legacy"]
+        upload_id = await _insert_upload_via_trigger(
+            ctx, "alice_upload.txt", str(alice)
+        )
+
+        await asyncio.to_thread(apply_alembic, "head")
+
+        async with AsyncSession(ctx.pg) as session:
+            user_id = (
+                await session.execute(
+                    text("SELECT user_id FROM uploads WHERE id = :id"),
+                    {"id": upload_id},
+                )
+            ).scalar_one()
+            assert user_id == alice
+
+
+class TestTripwire:
+    async def test_null_user_id_raises(
+        self,
+        ctx: MigrationContext,
+        setup_phase_2: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(text("ALTER TABLE uploads DISABLE TRIGGER ALL"))
+            await session.execute(
+                text("""
+                    INSERT INTO uploads (name, ready, removed, reserved)
+                    VALUES ('orphan.txt', false, false, false)
+                """),
+            )
+            await session.execute(text("ALTER TABLE uploads ENABLE TRIGGER ALL"))
+            await session.commit()
+
+        with pytest.raises(RuntimeError, match="NULL user_id"):
+            await asyncio.to_thread(apply_alembic, "head")


### PR DESCRIPTION
## Summary

- Adds Phase 3 Alembic migration (`a4f9c1e82b56`) that drops the legacy `uploads."user"` VARCHAR column and the `uploads_sync_user_id` trigger/function installed in Phase 1, then enforces `NOT NULL` on the new `user_id` integer FK
- Includes a tripwire check that raises `RuntimeError` at migration time if any row still has a `NULL user_id`, preventing silent data loss
- Updates Phase 2 migration tests to target revision `d7f8f4569939` explicitly (rather than `head`) and adds a full test suite for Phase 3 covering trigger removal, column drop, NOT NULL enforcement, data survival, and the tripwire

## Test plan

- [ ] Run `mise run test -- tests/migration/test_drop_uploads_user_column.py` to verify all Phase 3 migration tests pass
- [ ] Run `mise run test -- tests/migration/test_add_uploads_user_id.py` to confirm Phase 2 tests still pass with pinned revision
- [ ] Run `mise run test -- tests/migration/test_apply.ambr` or snapshot update (`--su`) if the migration list snapshot needs refreshing
- [ ] Verify full test suite (`mise run test`) passes without regressions