### PR TITLE
fix(references): treat read right as implicit membership

### DIFF
--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -22,6 +22,7 @@ from virtool.references.db import (
     get_reference_groups,
     populate_insert_only_reference,
 )
+from virtool.references.models import ReferenceRights
 from virtool.startup import startup_http_client_session
 
 
@@ -64,6 +65,13 @@ async def test_check_right(
     mock_req["client"].user_id = "bar"
     mock_req["client"].groups = ["foo"]
 
+    rights = ReferenceRights(
+        build=False,
+        modify=False,
+        modify_otu=True,
+        remove=False,
+    ).dict()
+
     await mongo.references.insert_one(
         {
             "_id": "baz",
@@ -71,17 +79,13 @@ async def test_check_right(
             "groups": [
                 {
                     "id": "foo" if membership == "group" else "none",
-                    "read": True,
-                    "modify": False,
-                    "modify_otu": True,
+                    **rights,
                 },
             ],
             "users": [
                 {
                     "id": "bar" if membership == "user" else "none",
-                    "read": True,
-                    "modify": False,
-                    "modify_otu": True,
+                    **rights,
                 },
             ],
         },

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -210,6 +210,12 @@ async def check_right(req: Request, ref_id: str, right: str) -> bool:
     groups: list[dict] = reference["groups"]
     users: list[dict] = reference["users"]
 
+    if right == "read":
+        if any(user["id"] == client.user_id for user in users):
+            return True
+
+        return any(group["id"] in client.groups for group in groups)
+
     for user in users:
         if user["id"] == client.user_id:
             if user[right]:


### PR DESCRIPTION
## Summary

- Fixes `KeyError: 'read'` (Sentry CLOUD-BACKEND-44 / VIR-2355) caused by `check_right` looking up `group['read']` or `user['read']` on documents that don't store a `read` field
- `read` access is now treated as implicit membership: a user or group with any entry in the reference's `users`/`groups` lists is considered to have read access, so the key lookup is bypassed entirely
- Updates the `test_check_right` test to use `ReferenceRights` for building member dicts, keeping the fixture consistent with the model

## Test plan

- [ ] Existing `test_check_right` tests pass with the new implicit-read logic
- [ ] Confirm that `GET /indexes` (or any endpoint calling `check_right(..., "read")`) no longer raises `KeyError` for references whose member documents lack a `read` field