### PR TITLE
feat(migration): add user_id FK to instance_messages (phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,16 @@ mise run oas
 
 ### Migrations
 
-Use `virtool migration create` to write new Virtool migrations (Alembic-based).
+Create new Alembic revisions with the alembic CLI:
+
+```bash
+uv run alembic revision -m "short summary"
+```
+
+This writes a stub at `assets/alembic/versions/<id>_<slug>.py` with the next
+revision ID and the current head as `down_revision`. Fill in `upgrade()` and
+`downgrade()` afterward. Do not hand-write revision files or invent revision
+IDs — let alembic generate them so the chain stays consistent.
 
 ## Architecture
 

--- a/assets/alembic/versions/c24b524f77e3_add_instance_messages_user_id.py
+++ b/assets/alembic/versions/c24b524f77e3_add_instance_messages_user_id.py
@@ -1,0 +1,129 @@
+"""add instance_messages user_id
+
+Phase 1 of converting ``instance_messages."user"`` (VARCHAR) to
+``instance_messages.user_id`` (INTEGER FK to ``users.id``). Purely
+additive so the schema is compatible with both old and new application
+code during the deploy window.
+
+The migration:
+
+- adds a nullable ``user_id INTEGER REFERENCES users(id)`` column,
+- backfills it from the existing ``"user"`` column (digit-string →
+  ``users.id``, otherwise → ``users.legacy_id``),
+- raises if any row remains with NULL ``user_id`` (the production audit
+  found zero such rows; this is a tripwire, not a fallback),
+- installs a trigger that keeps ``user_id`` in sync on INSERT and on
+  UPDATE OF ``"user"`` for as long as the old code path is still writing
+  the string column.
+
+Phase 2 will switch the model and data layer to ``user_id``. Phase 3 will
+drop the trigger, set ``user_id`` NOT NULL, and drop the ``"user"``
+column.
+
+Revision ID: c24b524f77e3
+Revises: a4f9c1e82b56
+Create Date: 2026-05-26 17:25:32.048944+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c24b524f77e3"
+down_revision = "a4f9c1e82b56"
+branch_labels = None
+depends_on = None
+
+
+BACKFILL_BY_ID_SQL = """
+UPDATE instance_messages
+SET user_id = u.id
+FROM users u
+WHERE instance_messages.user_id IS NULL
+  AND u.id = CASE
+      WHEN instance_messages."user" ~ '^[0-9]+$' THEN instance_messages."user"::int
+  END
+"""
+
+BACKFILL_BY_LEGACY_ID_SQL = """
+UPDATE instance_messages
+SET user_id = u.id
+FROM users u
+WHERE instance_messages.user_id IS NULL
+  AND u.legacy_id = instance_messages."user"
+"""
+
+COUNT_UNMAPPED_SQL = """
+SELECT COUNT(*) FROM instance_messages WHERE user_id IS NULL
+"""
+
+CREATE_TRIGGER_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION sync_instance_messages_user_id() RETURNS trigger AS $$
+DECLARE
+    resolved_id INTEGER;
+BEGIN
+    IF NEW."user" IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW."user" ~ '^[0-9]+$' THEN
+        SELECT id INTO resolved_id FROM users WHERE id = NEW."user"::int;
+    END IF;
+
+    IF resolved_id IS NULL THEN
+        SELECT id INTO resolved_id FROM users WHERE legacy_id = NEW."user";
+    END IF;
+
+    IF resolved_id IS NULL THEN
+        RAISE EXCEPTION
+            'instance_messages."user" value % does not resolve to a users row',
+            NEW."user";
+    END IF;
+
+    NEW.user_id := resolved_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+"""
+
+CREATE_TRIGGER_SQL = """
+CREATE TRIGGER instance_messages_sync_user_id
+BEFORE INSERT OR UPDATE OF "user" ON instance_messages
+FOR EACH ROW
+EXECUTE FUNCTION sync_instance_messages_user_id()
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "instance_messages",
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+    )
+
+    op.execute(BACKFILL_BY_ID_SQL)
+    op.execute(BACKFILL_BY_LEGACY_ID_SQL)
+
+    unmapped = op.get_bind().execute(sa.text(COUNT_UNMAPPED_SQL)).scalar()
+
+    if unmapped:
+        msg = (
+            f"{unmapped} instance_messages row(s) could not be mapped to a "
+            "users.id; refusing to proceed"
+        )
+        raise RuntimeError(msg)
+
+    op.execute(CREATE_TRIGGER_FUNCTION_SQL)
+    op.execute(CREATE_TRIGGER_SQL)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP TRIGGER IF EXISTS instance_messages_sync_user_id ON instance_messages",
+    )
+    op.execute("DROP FUNCTION IF EXISTS sync_instance_messages_user_id()")
+    op.drop_column("instance_messages", "user_id")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -232,5 +232,12 @@
       'name': 'drop uploads user column',
       'revision': 'a4f9c1e82b56',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 34,
+      'name': 'add instance_messages user_id',
+      'revision': 'c24b524f77e3',
+    }),
   ])
 # ---

--- a/tests/migration/test_add_instance_messages_user_id.py
+++ b/tests/migration/test_add_instance_messages_user_id.py
@@ -1,0 +1,186 @@
+"""Tests for the add-instance-messages-user-id (phase 1) migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_users(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic up to the revision before this migration and seed two users.
+
+    Returns a mapping of ``legacy_id`` → ``users.id`` for the seeded users.
+    """
+    await asyncio.to_thread(apply_alembic, "a4f9c1e82b56")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES
+                    ('alice', 'alice_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb),
+                    ('bob', 'bob_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return user_ids
+
+
+async def _insert_message(ctx: MigrationContext, message: str, user_value: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO instance_messages (active, color, message, "user")
+                VALUES (false, 'blue', :message, :user)
+                RETURNING id
+            """),
+            {"message": message, "user": user_value},
+        )
+        message_id = result.scalar_one()
+        await session.commit()
+    return message_id
+
+
+async def _fetch_user_id(ctx: MigrationContext, message_id: int) -> int | None:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("SELECT user_id FROM instance_messages WHERE id = :id"),
+            {"id": message_id},
+        )
+        return result.scalar_one()
+
+
+class TestBackfill:
+    async def test_resolves_digit_string_via_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        alice = setup_users["alice_legacy"]
+        message_id = await _insert_message(ctx, "by id", str(alice))
+
+        await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+        assert await _fetch_user_id(ctx, message_id) == alice
+
+    async def test_resolves_non_digit_via_legacy_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        bob = setup_users["bob_legacy"]
+        message_id = await _insert_message(ctx, "by legacy", "bob_legacy")
+
+        await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+        assert await _fetch_user_id(ctx, message_id) == bob
+
+    async def test_unmappable_row_raises(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await _insert_message(ctx, "orphan", "ghost_user")
+
+        with pytest.raises(RuntimeError, match="could not be mapped"):
+            await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+
+class TestTrigger:
+    async def test_insert_resolves_digit_string(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+        alice = setup_users["alice_legacy"]
+        message_id = await _insert_message(ctx, "post", str(alice))
+
+        assert await _fetch_user_id(ctx, message_id) == alice
+
+    async def test_insert_resolves_legacy_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+        bob = setup_users["bob_legacy"]
+        message_id = await _insert_message(ctx, "post legacy", "bob_legacy")
+
+        assert await _fetch_user_id(ctx, message_id) == bob
+
+    async def test_insert_with_null_user_preserves_user_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+        alice = setup_users["alice_legacy"]
+
+        async with AsyncSession(ctx.pg) as session:
+            result = await session.execute(
+                text("""
+                    INSERT INTO instance_messages (active, color, message, user_id)
+                    VALUES (false, 'blue', 'phase2', :user_id)
+                    RETURNING id
+                """),
+                {"user_id": alice},
+            )
+            message_id = result.scalar_one()
+            await session.commit()
+
+        assert await _fetch_user_id(ctx, message_id) == alice
+
+    async def test_update_user_column_updates_user_id(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+        apply_alembic: Callable,
+    ):
+        alice = setup_users["alice_legacy"]
+        bob = setup_users["bob_legacy"]
+
+        message_id = await _insert_message(ctx, "switch", "alice_legacy")
+
+        await asyncio.to_thread(apply_alembic, "c24b524f77e3")
+
+        assert await _fetch_user_id(ctx, message_id) == alice
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text(
+                    'UPDATE instance_messages SET "user" = :user WHERE id = :id',
+                ),
+                {"user": str(bob), "id": message_id},
+            )
+            await session.commit()
+
+        assert await _fetch_user_id(ctx, message_id) == bob


### PR DESCRIPTION
## Summary

- Adds a new `user_id INTEGER REFERENCES users(id)` column to the `instance_messages` table as a nullable column (phase 1 of the string-to-integer FK migration)
- Backfills `user_id` from the existing `"user"` VARCHAR column (digit strings resolve via `users.id`, all others via `users.legacy_id`); raises if any row cannot be mapped
- Installs a PostgreSQL trigger to keep `user_id` in sync with the legacy `"user"` column during the deploy window, allowing old and new code to coexist

## Test plan

- [ ] Run migration tests: `mise run test -- tests/migration/test_add_instance_messages_user_id.py`
- [ ] Verify backfill resolves digit-string user values via `users.id`
- [ ] Verify backfill resolves legacy-id strings via `users.legacy_id`
- [ ] Verify an unmappable row causes the migration to raise
- [ ] Verify the trigger keeps `user_id` in sync on INSERT and UPDATE of the `"user"` column
- [ ] Run full migration apply snapshot test: `mise run test -- tests/migration/test_apply.py`