### PR TITLE
docs: ban test plan checklists in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,14 @@ Releases are automated with semantic-release.
 - Do not use `git -C` — it breaks allowed tools settings. Run git commands
   from the working directory instead.
 
+### Pull Request Descriptions
+
+Keep PR bodies short. Summarize what changed and why in a few sentences or
+bullets. Do not add a "Test plan" section, a checklist of test commands, or a
+list of behaviours to verify — those belong in the test suite, not the PR
+body. If something genuinely cannot be covered by tests and requires manual
+verification, mention only that specific item.
+
 ## Linear
 
 Team name: Virtool


### PR DESCRIPTION
## Summary

- Adds a guideline to AGENTS.md instructing agents to keep PR bodies concise
- Explicitly bans "Test plan" sections and verification checklists from PR descriptions, since those belong in the test suite
- Allows mentioning manual verification only when something genuinely cannot be covered by tests