### PR TITLE
refactor(otus): drop unused data_path arg from OTUData

### DIFF
--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -99,7 +99,7 @@ def create_data_layer(
         LabelsData(mongo, pg),
         MessagesData(pg),
         MLData(http_client, pg, storage),
-        OTUData(config.data_path, mongo, pg),
+        OTUData(mongo, pg),
         ReferencesData(mongo, pg, config, client, storage),
         SamplesData(config, mongo, pg, storage),
         SubtractionsData(config.base_url, mongo, pg, storage),

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections.abc import Mapping
 from copy import deepcopy
-from pathlib import Path
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -47,8 +46,7 @@ class OTUData:
 
     name = "otus"
 
-    def __init__(self, data_path: Path, mongo: Mongo, pg: AsyncEngine) -> None:
-        self._data_path = data_path
+    def __init__(self, mongo: Mongo, pg: AsyncEngine) -> None:
         self._mongo = mongo
         self._pg = pg
 


### PR DESCRIPTION
## Summary

- `OTUData` accepted a `data_path: Path` argument and stored it as `self._data_path`, but the attribute was never used anywhere in the class.
- Removes the parameter from `__init__` and the corresponding call-site in `create_data_layer`.