### PR TITLE
fix: route sample upload deletion through storage backend

### DIFF
--- a/tests/samples/__snapshots__/test_data.ambr
+++ b/tests/samples/__snapshots__/test_data.ambr
@@ -219,6 +219,31 @@
       ]),
     }),
     'reads': list([
+      dict({
+        'download_url': '/samples/test/reads/reads.fq.gz',
+        'id': 1,
+        'name': 'reads.fq.gz',
+        'name_on_disk': 'reads_1.fq.gz',
+        'sample': 'test',
+        'size': 15,
+        'upload': dict({
+          'created_at': 'not_approximately_now_datetime',
+          'id': 1,
+          'name': 'test.fq.gz',
+          'ready': True,
+          'removed': True,
+          'removed_at': 'not_approximately_now_datetime',
+          'reserved': False,
+          'size': 723988,
+          'type': 'reads',
+          'uploaded_at': 'not_approximately_now_datetime',
+          'user': dict({
+            'handle': 'zwilliams',
+            'id': 2,
+          }),
+        }),
+        'uploaded_at': 'not_approximately_now_datetime',
+      }),
     ]),
     'ready': True,
     'subtractions': list([

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -1,9 +1,11 @@
 import asyncio
+from collections.abc import AsyncIterator
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
+import virtool.utils
 from tests.fixtures.client import ClientSpawner
 from virtool.api.client import UserClient
 from virtool.data.errors import ResourceConflictError
@@ -15,9 +17,13 @@ from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.samples.models import WorkflowState
 from virtool.samples.oas import CreateSampleRequest
+from virtool.samples.sql import SQLSampleReads
 from virtool.samples.utils import SampleRight
 from virtool.settings.oas import UpdateSettingsRequest
+from virtool.storage.errors import StorageKeyNotFoundError
+from virtool.storage.protocol import StorageBackend
 from virtool.uploads.sql import SQLUpload, UploadType
+from virtool.uploads.utils import upload_file_key
 from virtool.users.oas import UpdateUserRequest
 
 
@@ -145,13 +151,42 @@ class TestCreate:
 
 async def test_finalize(
     data_layer: DataLayer,
+    fake: DataFaker,
     get_sample_ready_false,
+    memory_storage: StorageBackend,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot_recent: SnapshotAssertion,
     spawn_client: ClientSpawner,
-    tmp_path,
 ):
-    """Test that sample can be finalized"""
+    """Test that finalizing a sample deletes its upload files from storage."""
+    upload = await fake.uploads.create(user=await fake.users.create())
+
+    upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
+    upload_name_on_disk = upload_row.name_on_disk
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLSampleReads(
+                name="reads.fq.gz",
+                name_on_disk="reads_1.fq.gz",
+                sample="test",
+                size=len(b"upload contents"),
+                upload=upload.id,
+                uploaded_at=virtool.utils.timestamp(),
+            ),
+        )
+
+        await session.commit()
+
+    async def _chunks() -> AsyncIterator[bytes]:
+        yield b"upload contents"
+
+    upload_key = upload_file_key(upload_name_on_disk)
+    await memory_storage.write(upload_key, _chunks())
+
+    assert await memory_storage.size(upload_key) == len(b"upload contents")
+
     quality = {
         "bases": [[1543]],
         "composition": [[6372]],
@@ -162,17 +197,14 @@ async def test_finalize(
         "sequences": [7091],
     }
 
-    assert (
-        await data_layer.samples.finalize(
-            "test",
-            quality,
-        )
-    ).dict() == snapshot_recent()
+    sample = await data_layer.samples.finalize("test", quality)
 
-    sample = await data_layer.samples.get("test")
-
+    assert sample.dict() == snapshot_recent()
     assert sample.quality == quality
     assert sample.ready is True
+
+    with pytest.raises(StorageKeyNotFoundError):
+        await memory_storage.size(upload_key)
 
 
 async def test_finalized_already(get_sample_ready_false, data_layer):

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -458,9 +458,6 @@ class SamplesData(DataLayerDomain):
             for row in rows:
                 names_on_disk.append(row.name_on_disk)
 
-                if isinstance(row.reads, list):
-                    row.reads.clear()
-
                 row.removed = True
                 row.removed_at = virtool.utils.timestamp()
                 session.add(row)

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -2,9 +2,8 @@
 
 import asyncio
 import math
-from asyncio import CancelledError, gather, to_thread
+from asyncio import CancelledError, gather
 from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import suppress
 from typing import Any
 
 from pymongo.results import UpdateResult
@@ -59,7 +58,7 @@ from virtool.subtractions.db import (
     AttachSubtractionsTransform,
 )
 from virtool.uploads.sql import SQLUpload
-from virtool.uploads.utils import is_gzip_compressed
+from virtool.uploads.utils import is_gzip_compressed, upload_file_key
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor, chunk_list, wait_for_checks
 
@@ -441,7 +440,7 @@ class SamplesData(DataLayerDomain):
         if not result.modified_count:
             raise ResourceNotFoundError
 
-        files_to_delete = []
+        names_on_disk = []
 
         async with AsyncSession(self._pg) as session:
             rows = (
@@ -457,11 +456,9 @@ class SamplesData(DataLayerDomain):
             )
 
             for row in rows:
-                files_to_delete.append(
-                    self._config.data_path / "files" / row.name_on_disk
-                )
+                names_on_disk.append(row.name_on_disk)
 
-                if row.reads is not None:
+                if isinstance(row.reads, list):
                     row.reads.clear()
 
                 row.removed = True
@@ -470,11 +467,9 @@ class SamplesData(DataLayerDomain):
 
             await session.commit()
 
-        async def delete_file(path):
-            with suppress(FileNotFoundError):
-                await to_thread(virtool.utils.rm, path)
-
-        await gather(*[delete_file(path) for path in files_to_delete])
+        await gather(
+            *[self._storage.delete(upload_file_key(name)) for name in names_on_disk],
+        )
 
         return await self.get(sample_id)
 

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -71,12 +71,18 @@ class AttachArtifactsAndReadsTransform(AbstractTransform):
 
         for reads_file in reads:
             if upload := reads_file.get("upload"):
-                reads_file["upload"] = serialize_upload(
+                upload_dict = serialize_upload(
                     (
                         await session.execute(
                             select(SQLUpload).filter_by(id=upload),
                         )
                     ).scalar()
+                )
+
+                reads_file["upload"] = await apply_transforms(
+                    upload_dict,
+                    [AttachUserTransform(self._pg, ignore_errors=True)],
+                    self._pg,
                 )
 
             reads_file["download_url"] = str(


### PR DESCRIPTION
## Summary

- When finalizing a sample, upload files are now deleted via the storage backend rather than directly from disk, making deletion consistent with the rest of the storage layer.
- The `AttachArtifactsAndReadsTransform` now attaches user information to the upload dict on reads files.
- The `test_finalize` test is updated to verify that the upload file is removed from the storage backend after finalization.