### PR TITLE
test: remove data_path fixture in favor of tmp_path

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -268,7 +268,7 @@ class ClientSpawner(Protocol):
 def spawn_client(
     aiohttp_client,
     data_layer: DataLayer,
-    data_path: Path,
+    tmp_path: Path,
     fake: DataFaker,
     memory_storage,
     mocker,
@@ -404,7 +404,7 @@ def spawn_client(
         """
         config = ServerConfig(
             base_url=base_url,
-            data_path=data_path,
+            data_path=tmp_path,
             dev=dev,
             flags=[],
             host="localhost",
@@ -489,7 +489,7 @@ def spawn_client(
 @pytest.fixture
 def spawn_job_client(
     aiohttp_client,
-    data_path: Path,
+    tmp_path: Path,
     memory_storage,
     mongo: Mongo,
     mongo_connection_string,
@@ -549,7 +549,7 @@ def spawn_job_client(
         app = await virtool.jobs.main.create_app(
             ServerConfig(
                 base_url=base_url,
-                data_path=data_path,
+                data_path=tmp_path,
                 dev=dev,
                 flags=[],
                 host="localhost",

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -4,16 +4,10 @@ import pytest
 
 
 @pytest.fixture
-def data_path(tmp_path) -> Path:
-    """A temporary ``data_path`` directory that is cleaned up after the test."""
-    return Path(tmp_path)
-
-
-@pytest.fixture
-def config(data_path: Path, mocker):
+def config(tmp_path: Path, mocker):
     """A mocked Virtool configuration object."""
     config = mocker.Mock()
     config.base_url = "https://virtool.example.com/api"
-    config.data_path = data_path
+    config.data_path = tmp_path
 
     return config

--- a/tests/fixtures/migration.py
+++ b/tests/fixtures/migration.py
@@ -108,7 +108,7 @@ def migration_mongo_name(worker_id: str) -> str:
 
 @pytest.fixture
 def migration_config(
-    data_path: Path,
+    tmp_path: Path,
     migration_pg_connection_string: str,
     mongo_connection_string: str,
     migration_mongo_name: str,
@@ -118,7 +118,7 @@ def migration_config(
 
     """
     return MigrationConfig(
-        data_path=data_path,
+        data_path=tmp_path,
         mongodb_connection_string=f"{mongo_connection_string}/{migration_mongo_name}?authSource=admin",
         postgres_connection_string=migration_pg_connection_string,
     )

--- a/tests/storage/test_legacy.py
+++ b/tests/storage/test_legacy.py
@@ -8,19 +8,19 @@ from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 
 
 @pytest.fixture
-def inner(data_path: Path) -> FilesystemProvider:
-    return FilesystemProvider(data_path)
+def inner(tmp_path: Path) -> FilesystemProvider:
+    return FilesystemProvider(tmp_path)
 
 
 @pytest.fixture
-def adapter(inner: FilesystemProvider, data_path: Path) -> LegacyIndexFilesystemAdapter:
-    return LegacyIndexFilesystemAdapter(inner, data_path)
+def adapter(inner: FilesystemProvider, tmp_path: Path) -> LegacyIndexFilesystemAdapter:
+    return LegacyIndexFilesystemAdapter(inner, tmp_path)
 
 
 def _seed_legacy_index(
-    data_path: Path, ref_id: str, index_id: str, filename: str, contents: bytes
+    tmp_path: Path, ref_id: str, index_id: str, filename: str, contents: bytes
 ) -> Path:
-    path = data_path / "references" / ref_id / index_id / filename
+    path = tmp_path / "references" / ref_id / index_id / filename
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(contents)
     return path
@@ -40,15 +40,15 @@ async def _collect(aiter) -> list:
 
 
 class TestRead:
-    async def test_translates_index_key(self, adapter, data_path):
-        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"payload")
+    async def test_translates_index_key(self, adapter, tmp_path):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"payload")
 
         result = await _collect_bytes(adapter.read("indexes/idx1/reference.json.gz"))
 
         assert result == b"payload"
 
-    async def test_passes_through_non_index_key(self, adapter, data_path):
-        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+    async def test_passes_through_non_index_key(self, adapter, tmp_path):
+        path = tmp_path / "samples" / "sample1" / "reads.fq.gz"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"reads")
 
@@ -60,16 +60,16 @@ class TestRead:
         with pytest.raises(StorageKeyNotFoundError):
             await _collect_bytes(adapter.read("indexes/missing/reference.json.gz"))
 
-    async def test_index_present_but_file_missing_raises(self, adapter, data_path):
-        (data_path / "references" / "ref1" / "idx1").mkdir(parents=True)
+    async def test_index_present_but_file_missing_raises(self, adapter, tmp_path):
+        (tmp_path / "references" / "ref1" / "idx1").mkdir(parents=True)
 
         with pytest.raises(StorageKeyNotFoundError):
             await _collect_bytes(adapter.read("indexes/idx1/reference.json.gz"))
 
 
 class TestSize:
-    async def test_translates_index_key(self, adapter, data_path):
-        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"payload")
+    async def test_translates_index_key(self, adapter, tmp_path):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"payload")
 
         assert await adapter.size("indexes/idx1/reference.json.gz") == len(b"payload")
 
@@ -77,8 +77,8 @@ class TestSize:
         with pytest.raises(StorageKeyNotFoundError):
             await adapter.size("indexes/missing/reference.json.gz")
 
-    async def test_passes_through_non_index_key(self, adapter, data_path):
-        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+    async def test_passes_through_non_index_key(self, adapter, tmp_path):
+        path = tmp_path / "samples" / "sample1" / "reads.fq.gz"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"reads")
 
@@ -86,9 +86,9 @@ class TestSize:
 
 
 class TestDelete:
-    async def test_translates_index_key(self, adapter, data_path):
+    async def test_translates_index_key(self, adapter, tmp_path):
         path = _seed_legacy_index(
-            data_path, "ref1", "idx1", "reference.json.gz", b"payload"
+            tmp_path, "ref1", "idx1", "reference.json.gz", b"payload"
         )
 
         await adapter.delete("indexes/idx1/reference.json.gz")
@@ -98,8 +98,8 @@ class TestDelete:
     async def test_unknown_index_is_noop(self, adapter):
         await adapter.delete("indexes/missing/reference.json.gz")
 
-    async def test_passes_through_non_index_key(self, adapter, data_path):
-        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+    async def test_passes_through_non_index_key(self, adapter, tmp_path):
+        path = tmp_path / "samples" / "sample1" / "reads.fq.gz"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"reads")
 
@@ -109,9 +109,9 @@ class TestDelete:
 
 
 class TestList:
-    async def test_translates_prefix_and_rewrites_keys(self, adapter, data_path):
-        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"a")
-        _seed_legacy_index(data_path, "ref1", "idx1", "reference.fa.gz", b"bb")
+    async def test_translates_prefix_and_rewrites_keys(self, adapter, tmp_path):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"a")
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.fa.gz", b"bb")
 
         result = await _collect(adapter.list("indexes/idx1/"))
 
@@ -124,8 +124,8 @@ class TestList:
     async def test_unknown_index_yields_nothing(self, adapter):
         assert await _collect(adapter.list("indexes/missing/")) == []
 
-    async def test_passes_through_non_index_prefix(self, adapter, data_path):
-        path = data_path / "samples" / "sample1" / "reads.fq.gz"
+    async def test_passes_through_non_index_prefix(self, adapter, tmp_path):
+        path = tmp_path / "samples" / "sample1" / "reads.fq.gz"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"reads")
 
@@ -133,9 +133,9 @@ class TestList:
 
         assert [info.key for info in result] == ["samples/sample1/reads.fq.gz"]
 
-    async def test_does_not_leak_other_indexes(self, adapter, data_path):
-        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"a")
-        _seed_legacy_index(data_path, "ref1", "idx2", "reference.json.gz", b"b")
+    async def test_does_not_leak_other_indexes(self, adapter, tmp_path):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"a")
+        _seed_legacy_index(tmp_path, "ref1", "idx2", "reference.json.gz", b"b")
 
         result = await _collect(adapter.list("indexes/idx1/"))
 
@@ -143,8 +143,8 @@ class TestList:
 
 
 class TestWrite:
-    async def test_writes_translated_path(self, adapter, data_path):
-        (data_path / "references" / "ref1" / "idx1").mkdir(parents=True)
+    async def test_writes_translated_path(self, adapter, tmp_path):
+        (tmp_path / "references" / "ref1" / "idx1").mkdir(parents=True)
 
         size = await adapter.write(
             "indexes/idx1/otus.json.gz", _async_iter(b"compressed")
@@ -152,14 +152,14 @@ class TestWrite:
 
         assert size == len(b"compressed")
         assert (
-            data_path / "references" / "ref1" / "idx1" / "otus.json.gz"
+            tmp_path / "references" / "ref1" / "idx1" / "otus.json.gz"
         ).read_bytes() == b"compressed"
 
-    async def test_passes_through_non_index_key(self, adapter, data_path):
+    async def test_passes_through_non_index_key(self, adapter, tmp_path):
         size = await adapter.write("samples/sample1/reads.fq.gz", _async_iter(b"reads"))
 
         assert size == len(b"reads")
-        assert (data_path / "samples" / "sample1" / "reads.fq.gz").read_bytes() == (
+        assert (tmp_path / "samples" / "sample1" / "reads.fq.gz").read_bytes() == (
             b"reads"
         )
 
@@ -174,8 +174,8 @@ class TestWrite:
 
 
 class TestCache:
-    async def test_resolves_once_per_index(self, adapter, data_path, mocker):
-        _seed_legacy_index(data_path, "ref1", "idx1", "reference.json.gz", b"a")
+    async def test_resolves_once_per_index(self, adapter, tmp_path, mocker):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"a")
 
         spy = mocker.spy(adapter, "_resolve_ref_id")
 


### PR DESCRIPTION
## Summary

- Drops the custom `data_path` fixture from test fixtures in favor of pytest's built-in `tmp_path`, eliminating an unnecessary indirection layer.
- Updates all fixture consumers in `tests/fixtures/client.py`, `tests/fixtures/config.py`, `tests/fixtures/migration.py`, and `tests/storage/test_legacy.py` to use `tmp_path` directly.