### PR TITLE
feat(migration): create postgres settings table

### DIFF
--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -15,6 +15,7 @@ from virtool.ml.pg import SQLMLModel, SQLMLModelRelease
 from virtool.pg.base import Base
 from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
 from virtool.sessions.models import SQLSession
+from virtool.settings.sql import SQLSettings
 from virtool.spaces.sql import SQLSpace
 from virtool.subtractions.pg import SQLSubtractionFile
 from virtool.uploads.sql import SQLUpload
@@ -45,6 +46,7 @@ __models__ = (
     SQLSampleArtifact,
     SQLSampleReads,
     SQLSession,
+    SQLSettings,
     SQLSpace,
     SQLSubtractionFile,
     SQLUpload,

--- a/assets/alembic/versions/d16de6e24788_create_settings_table.py
+++ b/assets/alembic/versions/d16de6e24788_create_settings_table.py
@@ -1,0 +1,73 @@
+"""create settings table
+
+Revision ID: d16de6e24788
+Revises: c24b524f77e3
+Create Date: 2026-05-29 05:13:09.463816+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "d16de6e24788"
+down_revision = "c24b524f77e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "settings",
+        sa.Column("id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("default_source_types", JSONB(), nullable=False),
+        sa.Column("enable_api", sa.Boolean(), nullable=False),
+        sa.Column("enable_sentry", sa.Boolean(), nullable=False),
+        sa.Column("minimum_password_length", sa.Integer(), nullable=False),
+        sa.Column("sample_all_read", sa.Boolean(), nullable=False),
+        sa.Column("sample_all_write", sa.Boolean(), nullable=False),
+        sa.Column("sample_group", sa.String(), nullable=False),
+        sa.Column("sample_group_read", sa.Boolean(), nullable=False),
+        sa.Column("sample_group_write", sa.Boolean(), nullable=False),
+        sa.CheckConstraint("id = 1", name="ck_settings_singleton"),
+        sa.CheckConstraint(
+            "sample_group IN ('none', 'force_choice', 'users_primary_group')",
+            name="ck_settings_sample_group",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.bulk_insert(
+        sa.table(
+            "settings",
+            sa.column("id", sa.Integer),
+            sa.column("default_source_types", JSONB),
+            sa.column("enable_api", sa.Boolean),
+            sa.column("enable_sentry", sa.Boolean),
+            sa.column("minimum_password_length", sa.Integer),
+            sa.column("sample_all_read", sa.Boolean),
+            sa.column("sample_all_write", sa.Boolean),
+            sa.column("sample_group", sa.String),
+            sa.column("sample_group_read", sa.Boolean),
+            sa.column("sample_group_write", sa.Boolean),
+        ),
+        [
+            {
+                "id": 1,
+                "default_source_types": ["isolate", "strain"],
+                "enable_api": False,
+                "enable_sentry": True,
+                "minimum_password_length": 8,
+                "sample_all_read": True,
+                "sample_all_write": False,
+                "sample_group": "none",
+                "sample_group_read": True,
+                "sample_group_write": False,
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -5,7 +5,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
-import virtool.messages.sql  # noqa: F401  schema mirror, no app importer
+import virtool.messages.sql
+import virtool.settings.sql  # noqa: F401  schema mirror, no app importer
 from virtool.api.custom_json import dump_string
 from virtool.pg.utils import Base, PgOptions, get_sqlalchemy_url
 

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -239,5 +239,12 @@
       'name': 'add instance_messages user_id',
       'revision': 'c24b524f77e3',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 35,
+      'name': 'create settings table',
+      'revision': 'd16de6e24788',
+    }),
   ])
 # ---

--- a/tests/migration/test_create_settings_table.py
+++ b/tests/migration/test_create_settings_table.py
@@ -1,0 +1,79 @@
+"""Tests for the create-settings-table migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+REVISION = "d16de6e24788"
+
+
+class TestCreateSettingsTable:
+    async def test_seeds_default_singleton_row(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = (
+                (await session.execute(text("SELECT * FROM settings"))).mappings().all()
+            )
+
+        assert len(rows) == 1
+        assert dict(rows[0]) == {
+            "id": 1,
+            "default_source_types": ["isolate", "strain"],
+            "enable_api": False,
+            "enable_sentry": True,
+            "minimum_password_length": 8,
+            "sample_all_read": True,
+            "sample_all_write": False,
+            "sample_group": "none",
+            "sample_group_read": True,
+            "sample_group_write": False,
+        }
+
+    async def test_rejects_second_row(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO settings (
+                            id, default_source_types, enable_api, enable_sentry,
+                            minimum_password_length, sample_all_read, sample_all_write,
+                            sample_group, sample_group_read, sample_group_write
+                        )
+                        VALUES (
+                            2, '[]'::jsonb, false, true, 8, true, false,
+                            'none', true, false
+                        )
+                        """,
+                    ),
+                )
+
+    async def test_rejects_unknown_sample_group(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    text("UPDATE settings SET sample_group = 'invalid' WHERE id = 1"),
+                )

--- a/virtool/settings/models.py
+++ b/virtool/settings/models.py
@@ -8,7 +8,7 @@ class Settings(BaseModel):
     minimum_password_length: int = 8
     sample_all_read: bool = True
     sample_all_write: bool = False
-    sample_group: int | str | None = None
+    sample_group: str = "none"
     sample_group_read: bool = True
     sample_group_write: bool = False
 

--- a/virtool/settings/sql.py
+++ b/virtool/settings/sql.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Boolean, CheckConstraint, Column, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
+
+from virtool.pg.base import Base
+
+
+class SQLSettings(Base):
+    """The single row of application settings.
+
+    The table holds exactly one row, enforced by the ``id = 1`` check
+    constraint. Its columns mirror :class:`virtool.settings.models.Settings`.
+    """
+
+    __tablename__ = "settings"
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_settings_singleton"),
+        CheckConstraint(
+            "sample_group IN ('none', 'force_choice', 'users_primary_group')",
+            name="ck_settings_sample_group",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=False)
+    default_source_types = Column(JSONB, nullable=False)
+    enable_api = Column(Boolean, nullable=False)
+    enable_sentry = Column(Boolean, nullable=False)
+    minimum_password_length = Column(Integer, nullable=False)
+    sample_all_read = Column(Boolean, nullable=False)
+    sample_all_write = Column(Boolean, nullable=False)
+    sample_group = Column(String, nullable=False)
+    sample_group_read = Column(Boolean, nullable=False)
+    sample_group_write = Column(Boolean, nullable=False)

--- a/virtool/settings/sql.py
+++ b/virtool/settings/sql.py
@@ -1,16 +1,11 @@
-from sqlalchemy import Boolean, CheckConstraint, Column, Integer, String
+from sqlalchemy import CheckConstraint, String
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
 
 
 class SQLSettings(Base):
-    """The single row of application settings.
-
-    The table holds exactly one row, enforced by the ``id = 1`` check
-    constraint. Its columns mirror :class:`virtool.settings.models.Settings`.
-    """
-
     __tablename__ = "settings"
     __table_args__ = (
         CheckConstraint("id = 1", name="ck_settings_singleton"),
@@ -20,13 +15,13 @@ class SQLSettings(Base):
         ),
     )
 
-    id = Column(Integer, primary_key=True, autoincrement=False)
-    default_source_types = Column(JSONB, nullable=False)
-    enable_api = Column(Boolean, nullable=False)
-    enable_sentry = Column(Boolean, nullable=False)
-    minimum_password_length = Column(Integer, nullable=False)
-    sample_all_read = Column(Boolean, nullable=False)
-    sample_all_write = Column(Boolean, nullable=False)
-    sample_group = Column(String, nullable=False)
-    sample_group_read = Column(Boolean, nullable=False)
-    sample_group_write = Column(Boolean, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=False)
+    default_source_types: Mapped[list] = mapped_column(JSONB)
+    enable_api: Mapped[bool]
+    enable_sentry: Mapped[bool]
+    minimum_password_length: Mapped[int]
+    sample_all_read: Mapped[bool]
+    sample_all_write: Mapped[bool]
+    sample_group: Mapped[str] = mapped_column(String)
+    sample_group_read: Mapped[bool]
+    sample_group_write: Mapped[bool]


### PR DESCRIPTION
## Summary

- Adds a `SQLSettings` SQLAlchemy model representing a singleton settings row in PostgreSQL, enforced by a `CHECK (id = 1)` constraint and a `CHECK` constraint on the `sample_group` enum values.
- Adds an Alembic migration (`d16de6e24788`) that creates the `settings` table and seeds it with default values.
- Registers `SQLSettings` in the Alembic env so future autogenerated revisions stay in sync.