### PR TITLE
feat(config): make storage_fallback_path optional, drop required data_path

### DIFF
--- a/tests/config/test_cls.py
+++ b/tests/config/test_cls.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from virtool.config.cls import ServerConfig
@@ -22,6 +24,26 @@ def build_server_config(**overrides) -> ServerConfig:
     }
     defaults.update(overrides)
     return ServerConfig(**defaults)
+
+
+class TestFallbackPathValidation:
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="empty string"):
+            build_server_config(storage_fallback_path="")
+
+    def test_nonexistent_path_raises(self):
+        with pytest.raises(ValueError, match="does not exist"):
+            build_server_config(storage_fallback_path="/nonexistent/path/xyz")
+
+    def test_file_path_raises(self, tmp_path: Path):
+        f = tmp_path / "not_a_dir.txt"
+        f.write_text("x")
+        with pytest.raises(ValueError, match="not a directory"):
+            build_server_config(storage_fallback_path=f)
+
+    def test_valid_directory_ok(self, tmp_path: Path):
+        config = build_server_config(storage_fallback_path=tmp_path)
+        assert config.storage_fallback_path == tmp_path
 
 
 class TestStorageBackendRequired:

--- a/tests/config/test_cls.py
+++ b/tests/config/test_cls.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from virtool.config.cls import ServerConfig
@@ -8,7 +6,6 @@ from virtool.config.cls import ServerConfig
 def build_server_config(**overrides) -> ServerConfig:
     defaults = {
         "base_url": "",
-        "data_path": Path("./data"),
         "dev": False,
         "flags": [],
         "host": "localhost",
@@ -32,7 +29,6 @@ class TestStorageBackendRequired:
         with pytest.raises(TypeError, match="storage_backend"):
             ServerConfig(
                 base_url="",
-                data_path=Path("./data"),
                 dev=False,
                 flags=[],
                 host="localhost",

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -404,7 +404,6 @@ def spawn_client(
         """
         config = ServerConfig(
             base_url=base_url,
-            data_path=tmp_path,
             dev=dev,
             flags=[],
             host="localhost",
@@ -549,7 +548,6 @@ def spawn_job_client(
         app = await virtool.jobs.main.create_app(
             ServerConfig(
                 base_url=base_url,
-                data_path=tmp_path,
                 dev=dev,
                 flags=[],
                 host="localhost",

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -8,6 +8,6 @@ def config(tmp_path: Path, mocker):
     """A mocked Virtool configuration object."""
     config = mocker.Mock()
     config.base_url = "https://virtool.example.com/api"
-    config.data_path = tmp_path
+    config.storage_fallback_path = tmp_path
 
     return config

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -15,7 +15,6 @@ import hmac
 import os
 from collections.abc import AsyncIterator
 from email.utils import formatdate
-from pathlib import Path
 
 import aiohttp
 import pytest
@@ -80,10 +79,8 @@ async def _ensure_azurite_container(
 
 
 @pytest.fixture(scope="session")
-def _s3_provider(tmp_path_factory: pytest.TempPathFactory) -> ObjectProvider:
-    data_path: Path = tmp_path_factory.mktemp("storage_factory_s3_fallback")
+def _s3_provider() -> ObjectProvider:
     config = build_server_config(
-        data_path=data_path,
         storage_backend="s3",
         storage_s3_bucket=os.environ["VT_TEST_S3_BUCKET"],
         storage_s3_endpoint=os.environ["VT_TEST_S3_ENDPOINT"],
@@ -97,9 +94,7 @@ def _s3_provider(tmp_path_factory: pytest.TempPathFactory) -> ObjectProvider:
 
 
 @pytest.fixture(scope="session")
-async def _azure_provider(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> ObjectProvider:
+async def _azure_provider() -> ObjectProvider:
     account = os.environ["VT_TEST_AZURE_ACCOUNT"]
     key = os.environ["VT_TEST_AZURE_KEY"]
     endpoint = os.environ["VT_TEST_AZURE_ENDPOINT"]
@@ -107,9 +102,7 @@ async def _azure_provider(
 
     await _ensure_azurite_container(account, key, endpoint, container)
 
-    data_path: Path = tmp_path_factory.mktemp("storage_factory_azure_fallback")
     config = build_server_config(
-        data_path=data_path,
         storage_backend="azure",
         storage_azure_account=account,
         storage_azure_container=container,

--- a/tests/storage/test_factory.py
+++ b/tests/storage/test_factory.py
@@ -11,9 +11,19 @@ from virtool.storage.routing import FallbackStorageRouter
 
 
 class TestCreateStorageBackend:
-    def test_s3_wraps_with_fallback_at_data_path(self, tmp_path: Path):
+    def test_no_fallback_path_returns_bare_primary(self):
         config = build_server_config(
-            data_path=tmp_path,
+            storage_backend="s3",
+            storage_s3_bucket="bucket",
+        )
+
+        backend = create_storage_backend(config)
+
+        assert isinstance(backend, ObjectProvider)
+
+    def test_s3_wraps_with_fallback_at_path(self, tmp_path: Path):
+        config = build_server_config(
+            storage_fallback_path=tmp_path,
             storage_backend="s3",
             storage_s3_bucket="bucket",
         )
@@ -26,9 +36,9 @@ class TestCreateStorageBackend:
         assert isinstance(backend._fallback._inner, FilesystemProvider)
         assert backend._fallback._inner._base_path == tmp_path.resolve()
 
-    def test_azure_wraps_with_fallback_at_data_path(self, tmp_path: Path):
+    def test_azure_wraps_with_fallback_at_path(self, tmp_path: Path):
         config = build_server_config(
-            data_path=tmp_path,
+            storage_fallback_path=tmp_path,
             storage_backend="azure",
             storage_s3_bucket="",
             storage_azure_account="account",
@@ -42,8 +52,8 @@ class TestCreateStorageBackend:
         assert isinstance(backend._fallback, LegacyIndexFilesystemAdapter)
         assert backend._fallback._inner._base_path == tmp_path.resolve()
 
-    def test_fallback_root_is_not_data_path_storage(self, tmp_path: Path):
-        config = build_server_config(data_path=tmp_path)
+    def test_fallback_root_is_not_storage_subdir(self, tmp_path: Path):
+        config = build_server_config(storage_fallback_path=tmp_path)
 
         backend = create_storage_backend(config)
 
@@ -51,17 +61,16 @@ class TestCreateStorageBackend:
 
 
 class TestBuildPrimaryBackend:
-    def test_s3(self, tmp_path: Path):
+    def test_s3(self):
         config = build_server_config(
-            data_path=tmp_path,
             storage_backend="s3",
             storage_s3_bucket="bucket",
         )
 
         assert isinstance(build_primary_backend(config), ObjectProvider)
 
-    def test_unknown_raises(self, tmp_path: Path):
-        config = build_server_config(data_path=tmp_path)
+    def test_unknown_raises(self):
+        config = build_server_config()
         config.storage_backend = "nonsense"
 
         with pytest.raises(ValueError, match="Unknown storage_backend"):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -38,8 +38,8 @@ async def test_startup_http_client_headers(mocker, fake_app):
     )
 
 
-async def test_startup_storage(fake_app, tmp_path, mocker):
-    fake_app["config"] = build_server_config(data_path=tmp_path)
+async def test_startup_storage(fake_app, mocker):
+    fake_app["config"] = build_server_config()
 
     backend = mocker.Mock()
     mocker.patch(

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -29,6 +29,7 @@ from virtool.config.options import (
     postgres_connection_string_option,
     real_ip_header_option,
     sentry_dsn_option,
+    storage_fallback_path_option,
     storage_options,
 )
 from virtool.jobs.main import run_jobs_server
@@ -72,7 +73,7 @@ def server() -> None:
 @server.command("api")
 @address_options
 @base_url_option
-@data_path_option
+@storage_fallback_path_option
 @dev_option
 @flags_option
 @mongodb_connection_string_option
@@ -93,7 +94,7 @@ def start_api_server(**kwargs) -> None:
 
 @server.command("jobs")
 @address_options
-@data_path_option
+@storage_fallback_path_option
 @dev_option
 @flags_option
 @mongodb_connection_string_option
@@ -232,7 +233,7 @@ def tasks() -> None:
 
 @tasks.command("runner")
 @address_options
-@data_path_option
+@storage_fallback_path_option
 @dev_option
 @mongodb_connection_string_option
 @no_revision_check_option

--- a/virtool/config/cls.py
+++ b/virtool/config/cls.py
@@ -19,6 +19,23 @@ from virtool.pg.utils import PgOptions
 StorageBackendName = Literal["s3", "azure"]
 
 
+def _validate_fallback_path(value: str | Path) -> Path:
+    raw = str(value)
+
+    if not raw:
+        raise ValueError("storage_fallback_path cannot be an empty string")
+
+    path = Path(raw)
+
+    if not path.exists():
+        raise ValueError(f"storage_fallback_path does not exist: {path}")
+
+    if not path.is_dir():
+        raise ValueError(f"storage_fallback_path is not a directory: {path}")
+
+    return path
+
+
 def _validate_s3_credentials(access_key_id: str, secret_access_key: str) -> None:
     """Reject partial S3 credential config.
 
@@ -95,7 +112,9 @@ class ServerConfig:
 
     def __post_init__(self):
         if self.storage_fallback_path is not None:
-            self.storage_fallback_path = Path(self.storage_fallback_path)
+            self.storage_fallback_path = _validate_fallback_path(
+                self.storage_fallback_path,
+            )
 
         if self.storage_backend == "s3" and not self.storage_s3_bucket:
             raise ValueError(
@@ -152,7 +171,9 @@ class TaskRunnerConfig:
 
     def __post_init__(self):
         if self.storage_fallback_path is not None:
-            self.storage_fallback_path = Path(self.storage_fallback_path)
+            self.storage_fallback_path = _validate_fallback_path(
+                self.storage_fallback_path,
+            )
 
         if self.storage_backend == "s3" and not self.storage_s3_bucket:
             raise ValueError(

--- a/virtool/config/cls.py
+++ b/virtool/config/cls.py
@@ -62,7 +62,6 @@ class MigrationConfig:
 @dataclass
 class ServerConfig:
     base_url: str
-    data_path: Path
     dev: bool
     flags: list[FlagName]
     host: str
@@ -75,6 +74,7 @@ class ServerConfig:
     real_ip_header: str
     sentry_dsn: str | None
     storage_backend: StorageBackendName
+    storage_fallback_path: Path | None = None
     storage_s3_bucket: str = ""
     storage_s3_region: str = ""
     storage_s3_endpoint: str = ""
@@ -94,7 +94,8 @@ class ServerConfig:
         return PgOptions.from_connection_string(self.postgres_connection_string)
 
     def __post_init__(self):
-        self.data_path = Path(self.data_path)
+        if self.storage_fallback_path is not None:
+            self.storage_fallback_path = Path(self.storage_fallback_path)
 
         if self.storage_backend == "s3" and not self.storage_s3_bucket:
             raise ValueError(
@@ -123,7 +124,6 @@ class TaskRunnerConfig:
     """Configuration for the task runner service."""
 
     base_url: str
-    data_path: Path
     host: str
     mongodb_connection_string: str
     no_revision_check: bool
@@ -131,6 +131,7 @@ class TaskRunnerConfig:
     postgres_connection_string: str
     sentry_dsn: str
     storage_backend: StorageBackendName
+    storage_fallback_path: Path | None = None
     storage_s3_bucket: str = ""
     storage_s3_region: str = ""
     storage_s3_endpoint: str = ""
@@ -150,7 +151,8 @@ class TaskRunnerConfig:
         return PgOptions.from_connection_string(self.postgres_connection_string)
 
     def __post_init__(self):
-        self.data_path = Path(self.data_path)
+        if self.storage_fallback_path is not None:
+            self.storage_fallback_path = Path(self.storage_fallback_path)
 
         if self.storage_backend == "s3" and not self.storage_s3_bucket:
             raise ValueError(

--- a/virtool/config/options.py
+++ b/virtool/config/options.py
@@ -11,6 +11,7 @@ def my_command(host, port):
 """
 
 import os
+from pathlib import Path
 
 import click
 
@@ -53,6 +54,17 @@ data_path_option = click.option(
     default=get_from_environment("data_path", "./data"),
     help="The path to the application data directory",
     type=click.Path(exists=True),
+)
+
+storage_fallback_path_option = click.option(
+    "--storage-fallback-path",
+    default=get_from_environment("storage_fallback_path", None),
+    help=(
+        "Path to a legacy on-disk data directory used as a read fallback. When "
+        "set, the object-storage backend is wrapped with the legacy filesystem "
+        "fallback. Leave unset for blob-only storage (the default)."
+    ),
+    type=click.Path(exists=True, path_type=Path),
 )
 
 dev_option = click.option(

--- a/virtool/storage/factory.py
+++ b/virtool/storage/factory.py
@@ -2,12 +2,16 @@
 
 from typing import Protocol
 
+from structlog import get_logger
+
 from virtool.config.cls import ServerConfig, StorageBackendName
 from virtool.storage.filesystem import FilesystemProvider
 from virtool.storage.legacy import LegacyIndexFilesystemAdapter
 from virtool.storage.object import ObjectProvider
 from virtool.storage.protocol import StorageBackend
 from virtool.storage.routing import FallbackStorageRouter
+
+logger = get_logger("storage")
 
 
 class StorageBackendConfig(Protocol):
@@ -33,8 +37,10 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
     """Create the configured storage backend.
 
     The primary is an object-storage backend (S3 or Azure Blob) determined by
-    ``config.storage_backend``. A :class:`FilesystemProvider` rooted at
-    ``config.data_path`` is wired in as a read/migration fallback via
+    ``config.storage_backend``. Storage is blob-only by default.
+
+    When ``config.storage_fallback_path`` is set, a :class:`FilesystemProvider`
+    rooted at that path is wired in as a read/migration fallback via
     :class:`FallbackStorageRouter`, wrapped in
     :class:`LegacyIndexFilesystemAdapter` so legacy index files at
     ``references/{ref_id}/{index_id}/...`` are reachable via the new
@@ -45,9 +51,20 @@ def create_storage_backend(config: ServerConfig) -> StorageBackend:
     migration is complete.
     """
     primary = build_primary_backend(config)
-    fallback = LegacyIndexFilesystemAdapter(
-        FilesystemProvider(config.data_path), config.data_path
+
+    if config.storage_fallback_path is None:
+        return primary
+
+    logger.warning(
+        "legacy filesystem fallback is enabled; storage is not blob-only",
+        storage_fallback_path=str(config.storage_fallback_path),
     )
+
+    fallback = LegacyIndexFilesystemAdapter(
+        FilesystemProvider(config.storage_fallback_path),
+        config.storage_fallback_path,
+    )
+
     return FallbackStorageRouter(primary, fallback)
 
 


### PR DESCRIPTION
## Summary

- Renames `data_path` to `storage_fallback_path` in `ServerConfig` and `TaskRunnerConfig`, making it optional (`Path | None = None`) instead of required.
- When `storage_fallback_path` is unset the storage factory returns the bare primary backend (blob-only); when set it wraps the primary with the legacy filesystem fallback and logs a warning.
- Removes `data_path` from all CLI options, test fixtures, and config helpers; adds a new `--storage-fallback-path` CLI option.