### PR TITLE
fix: stop converting StorageKeyNotFoundError to 404

### DIFF
--- a/tests/api/test_streaming.py
+++ b/tests/api/test_streaming.py
@@ -2,7 +2,6 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from virtool.api.errors import APINotFound
 from virtool.api.streaming import stream_storage_response
 from virtool.storage.errors import StorageKeyNotFoundError
 
@@ -12,15 +11,7 @@ async def _missing_stream() -> AsyncIterator[bytes]:
     yield b""
 
 
-async def test_stream_storage_response_uses_default_not_found_message():
-    with pytest.raises(APINotFound) as err:
+async def test_stream_storage_response_propagates_storage_key_not_found():
+    """A missing blob is a server-side bug and must propagate, not become a 404."""
+    with pytest.raises(StorageKeyNotFoundError):
         await stream_storage_response(None, _missing_stream(), {})
-
-    assert err.value.message == "Not found"
-
-
-async def test_stream_storage_response_uses_custom_not_found_message():
-    with pytest.raises(APINotFound) as err:
-        await stream_storage_response(None, _missing_stream(), {}, "File not found")
-
-    assert err.value.message == "File not found"

--- a/tests/caches/test_api.py
+++ b/tests/caches/test_api.py
@@ -48,11 +48,14 @@ class TestGet:
 
         await RespIs.not_found(resp)
 
-    async def test_storage_not_found(
+    async def test_missing_blob_is_server_error(
         self,
         data_layer: DataLayer,
         memory_storage: StorageBackend,
     ):
+        """A cache that resolves but whose blob is missing is a server-side
+        data-integrity bug, returning 500 rather than a client-facing 404.
+        """
         key = "trim-reads-missing-storage"
 
         await data_layer.caches.create(
@@ -66,7 +69,7 @@ class TestGet:
 
         resp = await self.client.get(f"/caches/{key}")
 
-        await RespIs.not_found(resp)
+        assert resp.status == 500
 
 
 class TestPut:

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1572,13 +1572,16 @@ class TestDownloadReads:
 
         assert resp.status == job_resp.status == 404
 
-    async def test_404_file(
+    async def test_missing_blob_is_server_error(
         self,
         mongo: Mongo,
         pg: AsyncEngine,
         spawn_client: ClientSpawner,
         spawn_job_client: JobClientSpawner,
     ):
+        """A reads row that resolves but whose blob is missing is a server-side
+        data-integrity bug, returning 500 rather than a client-facing 404.
+        """
         client = await spawn_client(authenticated=True)
         job_client = await spawn_job_client(authenticated=True)
 
@@ -1590,15 +1593,18 @@ class TestDownloadReads:
         resp = await client.get(f"/samples/foo/reads/{file_name}")
         job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
 
-        assert resp.status == job_resp.status == 404
+        assert resp.status == job_resp.status == 500
 
-    async def test_404_zero_byte_missing_object(
+    async def test_zero_byte_missing_blob_is_server_error(
         self,
         mongo: Mongo,
         pg: AsyncEngine,
         spawn_client: ClientSpawner,
         spawn_job_client: JobClientSpawner,
     ):
+        """A zero-byte reads row whose blob is missing is a server-side
+        data-integrity bug, returning 500 rather than a client-facing 404.
+        """
         client = await spawn_client(authenticated=True)
         job_client = await spawn_job_client(authenticated=True)
 
@@ -1610,7 +1616,7 @@ class TestDownloadReads:
         resp = await client.get(f"/samples/foo/reads/{file_name}")
         job_resp = await job_client.get(f"/samples/foo/reads/{file_name}")
 
-        assert resp.status == job_resp.status == 404
+        assert resp.status == job_resp.status == 500
 
 
 class TestDownloadArtifact:
@@ -1688,12 +1694,15 @@ class TestDownloadArtifact:
 
         assert resp.status == 404
 
-    async def test_404_file(
+    async def test_missing_blob_is_server_error(
         self,
         mongo: Mongo,
         pg: AsyncEngine,
         spawn_job_client: JobClientSpawner,
     ):
+        """An artifact row that resolves but whose blob is missing is a server-side
+        data-integrity bug, returning 500 rather than a client-facing 404.
+        """
         client = await spawn_job_client(authenticated=True)
 
         await self._insert_sample(mongo)
@@ -1701,14 +1710,17 @@ class TestDownloadArtifact:
 
         resp = await client.get("/samples/foo/artifacts/fastqc.txt")
 
-        assert resp.status == 404
+        assert resp.status == 500
 
-    async def test_404_zero_byte_missing_object(
+    async def test_zero_byte_missing_blob_is_server_error(
         self,
         mongo: Mongo,
         pg: AsyncEngine,
         spawn_job_client: JobClientSpawner,
     ):
+        """A zero-byte artifact row whose blob is missing is a server-side
+        data-integrity bug, returning 500 rather than a client-facing 404.
+        """
         client = await spawn_job_client(authenticated=True)
 
         await self._insert_sample(mongo)
@@ -1716,7 +1728,7 @@ class TestDownloadArtifact:
 
         resp = await client.get("/samples/foo/artifacts/fastqc.txt")
 
-        assert resp.status == 404
+        assert resp.status == 500
 
 
 class TestChangeSampleRights:

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -575,14 +575,17 @@ class TestDownloadSubtractionFile:
         assert bowtie_resp.status == 404
         assert fasta_resp.status == 404
 
-    async def test_not_found_path(
+    async def test_missing_blob_is_server_error(
         self,
         fake: DataFaker,
         memory_storage,
         spawn_job_client: JobClientSpawner,
     ):
-        """Test that a 404 response is returned when attempting to download a file
-        that has a database entry but does not exist in storage.
+        """Test that a 500 response is returned when a file has a database entry but
+        its blob is missing from storage.
+
+        A missing blob after the database row has resolved is a server-side
+        data-integrity bug, not a client-facing 404.
         """
         client = await spawn_job_client(authenticated=True)
 
@@ -603,8 +606,8 @@ class TestDownloadSubtractionFile:
             f"/subtractions/{subtraction.id}/files/subtraction.fa.gz",
         )
 
-        assert bowtie_resp.status == 404
-        assert fasta_resp.status == 404
+        assert bowtie_resp.status == 500
+        assert fasta_resp.status == 500
 
 
 async def test_create(

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -32,7 +32,6 @@ from virtool.data.errors import (
     ResourceNotModifiedError,
 )
 from virtool.data.utils import get_data_from_req
-from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.uploads.utils import multipart_file_chunker, naive_validator
 
 routes = Routes()
@@ -273,7 +272,7 @@ class AnalysisFileView(PydanticView):
         if size > 0:
             try:
                 first_chunk = await stream.__anext__()
-            except (StopAsyncIteration, StorageKeyNotFoundError):
+            except StopAsyncIteration:
                 raise APINotFound()
 
             await response.prepare(self.request)

--- a/virtool/api/streaming.py
+++ b/virtool/api/streaming.py
@@ -2,25 +2,16 @@ from collections.abc import AsyncIterator
 
 from aiohttp.web import Request, StreamResponse
 
-from virtool.api.errors import APINotFound
-from virtool.storage.errors import StorageKeyNotFoundError
-
 
 async def stream_storage_response(
     req: Request,
     stream: AsyncIterator[bytes],
     headers: dict[str, str],
-    not_found_message: str = "",
 ) -> StreamResponse:
     response = StreamResponse(headers=headers)
 
     try:
         first_chunk = await anext(stream)
-    except StorageKeyNotFoundError:
-        if not_found_message:
-            raise APINotFound(not_found_message)
-
-        raise APINotFound()
     except StopAsyncIteration:
         first_chunk = None
 

--- a/virtool/caches/api.py
+++ b/virtool/caches/api.py
@@ -38,7 +38,6 @@ class CacheView(PydanticView):
                 "Content-Length": str(hit.size),
                 "Content-Type": "application/octet-stream",
             },
-            not_found_message="Not found",
         )
 
     async def put(self, key: str, /, params: Json[Any] | None = None):

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -19,7 +19,6 @@ from virtool.data.utils import get_data_from_req
 from virtool.hmm.models import HMM, HMMInstalled, HMMSearchResult
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req, get_one_field
-from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
 
@@ -183,7 +182,7 @@ async def get_hmm_annotations(req):
 
     try:
         first_chunk = await stream.__anext__()
-    except (StopAsyncIteration, StorageKeyNotFoundError):
+    except StopAsyncIteration:
         raise APINotFound()
 
     response = StreamResponse(
@@ -216,7 +215,7 @@ async def get_hmm_profiles(req):
 
     try:
         first_chunk = await stream.__anext__()
-    except (StopAsyncIteration, StorageKeyNotFoundError):
+    except StopAsyncIteration:
         raise APINotFound()
 
     response = StreamResponse(

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -148,7 +148,6 @@ class IndexFileView(PydanticView):
                 "Content-Length": str(size),
                 "Content-Type": "application/octet-stream",
             },
-            not_found_message="File not found",
         )
 
 

--- a/virtool/ml/api.py
+++ b/virtool/ml/api.py
@@ -10,7 +10,6 @@ from virtool.api.routes import Routes
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.ml.models import MLModel, MLModelListResult, MLModelReleaseMinimal
-from virtool.storage.errors import StorageKeyNotFoundError
 
 routes = Routes()
 
@@ -77,7 +76,7 @@ class MLModelFileView(PydanticView):
 
         try:
             first_chunk = await stream.__anext__()
-        except (StopAsyncIteration, StorageKeyNotFoundError):
+        except StopAsyncIteration:
             raise APINotFound()
 
         response = StreamResponse(

--- a/virtool/references/tasks.py
+++ b/virtool/references/tasks.py
@@ -11,7 +11,6 @@ from virtool.references.utils import (
     load_reference_file,
     load_reference_from_storage,
 )
-from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.tasks.progress import AccumulatingProgressHandlerWrapper
 from virtool.tasks.task import BaseTask
 from virtool.uploads.utils import upload_file_key
@@ -63,8 +62,6 @@ class ImportReferenceTask(BaseTask):
                 self.data.references._storage,
                 key,
             )
-        except StorageKeyNotFoundError:
-            return await self._set_error("Could not find reference file in storage")
         except json.decoder.JSONDecodeError as err:
             return await self._set_error(str(err))
         except (OSError, EOFError) as err:

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -11,7 +11,6 @@ from virtool.api.schema import schema
 from virtool.authorization.permissions import LegacyPermission
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
-from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.subtractions.models import Subtraction, SubtractionSearchResult
 from virtool.subtractions.oas import (
     CreateSubtractionRequest,
@@ -253,7 +252,7 @@ class SubtractionFileView(PydanticView):
 
         try:
             first_chunk = await stream.__anext__()
-        except (StopAsyncIteration, StorageKeyNotFoundError):
+        except StopAsyncIteration:
             raise APINotFound()
 
         response = StreamResponse(


### PR DESCRIPTION
## Summary

- `StorageKeyNotFoundError` indicates a server-side data-integrity bug (a database row exists but its blob is missing from storage), not a missing resource the client requested. Converting it to a 404 hides the real problem.
- Removed all `StorageKeyNotFoundError` catches that re-raised as `APINotFound`. The error now propagates as a 500, making the failure visible and alerting operators to investigate.
- Updated tests to assert 500 instead of 404 for missing-blob scenarios.