### PR TITLE
chore(deps): ignore pydantic v2 dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,6 +21,9 @@ updates:
         patterns:
           - "aiohttp"
           - "aiohttp-pydantic"
+    ignore:
+      - dependency-name: "pydantic"
+        versions: [">=2.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- Adds a dependabot ignore rule to prevent automatic updates of pydantic to v2 or above, keeping the project on the current v1 constraint until a deliberate migration is planned.