### PR TITLE
feat: switch SettingsData to PostgreSQL

### DIFF
--- a/assets/revisions/rev_q928h2q03qmp_copy_settings_to_postgres.py
+++ b/assets/revisions/rev_q928h2q03qmp_copy_settings_to_postgres.py
@@ -35,6 +35,10 @@ async def upgrade(ctx: MigrationContext) -> None:
     migration safe to re-run and ensuring it never clobbers settings that have
     already been changed in PostgreSQL. Fields dropped from the model
     (``hmm_slug``, ``sample_unique_names``) are ignored if present in MongoDB.
+
+    Legacy documents may carry ``null`` for non-nullable fields (notably
+    ``sample_group``). Such values are skipped so the seeded default stands
+    rather than violating the column constraint.
     """
     mongo_settings = await ctx.mongo.settings.find_one({"_id": "settings"})
 
@@ -45,7 +49,7 @@ async def upgrade(ctx: MigrationContext) -> None:
     backfill = {
         field: mongo_settings[field]
         for field in Settings.__fields__
-        if field in mongo_settings
+        if mongo_settings.get(field) is not None
     }
 
     if not backfill:

--- a/assets/revisions/rev_q928h2q03qmp_copy_settings_to_postgres.py
+++ b/assets/revisions/rev_q928h2q03qmp_copy_settings_to_postgres.py
@@ -1,0 +1,77 @@
+"""Copy settings to postgres.
+
+Revision ID: q928h2q03qmp
+Date: 2026-05-29 16:47:07.468716
+
+"""
+
+import arrow
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.settings.models import Settings
+from virtool.settings.sql import SQLSettings
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy settings to postgres"
+created_at = arrow.get("2026-05-29 16:47:07.468716")
+revision_id = "q928h2q03qmp"
+
+alembic_down_revision = "d16de6e24788"
+virtool_down_revision = None
+
+# The settings table and its seeded singleton row must exist before backfilling.
+required_alembic_revision = "d16de6e24788"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Copy the legacy MongoDB ``settings`` document into the PostgreSQL row.
+
+    Only runs while the PostgreSQL row is still at its seeded defaults, making the
+    migration safe to re-run and ensuring it never clobbers settings that have
+    already been changed in PostgreSQL. Fields dropped from the model
+    (``hmm_slug``, ``sample_unique_names``) are ignored if present in MongoDB.
+    """
+    mongo_settings = await ctx.mongo.settings.find_one({"_id": "settings"})
+
+    if mongo_settings is None:
+        logger.info("no mongodb settings document to backfill")
+        return
+
+    backfill = {
+        field: mongo_settings[field]
+        for field in Settings.__fields__
+        if field in mongo_settings
+    }
+
+    if not backfill:
+        logger.info("mongodb settings document had no fields to backfill")
+        return
+
+    async with AsyncSession(ctx.pg) as session:
+        current = (
+            await session.execute(select(SQLSettings).where(SQLSettings.id == 1))
+        ).scalar()
+
+        if current is None:
+            logger.warning("settings row missing; skipping backfill")
+            return
+
+        current_values = {
+            field: getattr(current, field) for field in Settings.__fields__
+        }
+
+        if current_values != Settings().dict():
+            logger.info("postgres settings already customized; skipping backfill")
+            return
+
+        await session.execute(
+            update(SQLSettings).where(SQLSettings.id == 1).values(**backfill),
+        )
+        await session.commit()
+
+    logger.info("backfilled settings from mongodb", fields=sorted(backfill))

--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -11,7 +11,7 @@ from virtool.storage.protocol import StorageBackend
 
 
 @pytest.fixture
-def data_layer(
+async def data_layer(
     config,
     memory_storage: StorageBackend,
     mocker: MockerFixture,
@@ -19,6 +19,9 @@ def data_layer(
     pg: AsyncEngine,
 ) -> DataLayer:
     """A complete data layer backed by testing instances of MongoDB and PostgreSQL.
+
+    The singleton settings row is seeded to mirror application startup, which
+    always calls ``settings.ensure()`` before serving requests.
 
     Example:
     -------
@@ -28,10 +31,14 @@ def data_layer(
             await data_layer.samples.create(...)
 
     """
-    return create_data_layer(
+    layer = create_data_layer(
         mongo,
         pg,
         config,
         mocker.Mock(spec=ClientSession),
         memory_storage,
     )
+
+    await layer.settings.ensure()
+
+    return layer

--- a/tests/fixtures/settings.py
+++ b/tests/fixtures/settings.py
@@ -1,21 +1,24 @@
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.settings.sql import SQLSettings
 
 
 @pytest.fixture
-async def test_settings(mongo):
-    await mongo.settings.delete_one({"_id": "settings"})
-
-    await mongo.settings.insert_one(
-        {
-            "_id": "settings",
-            "default_source_types": ["isolate", "strain"],
-            "enable_api": True,
-            "enable_sentry": True,
-            "minimum_password_length": 8,
-            "sample_all_read": True,
-            "sample_all_write": False,
-            "sample_group": "none",
-            "sample_group_read": True,
-            "sample_group_write": False,
-        }
-    )
+async def test_settings(pg: AsyncEngine):
+    async with AsyncSession(pg) as session:
+        await session.merge(
+            SQLSettings(
+                id=1,
+                default_source_types=["isolate", "strain"],
+                enable_api=True,
+                enable_sentry=True,
+                minimum_password_length=8,
+                sample_all_read=True,
+                sample_all_write=False,
+                sample_group="none",
+                sample_group_read=True,
+                sample_group_write=False,
+            ),
+        )
+        await session.commit()

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -246,5 +246,12 @@
       'name': 'create settings table',
       'revision': 'd16de6e24788',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 36,
+      'name': 'copy settings to postgres',
+      'revision': 'q928h2q03qmp',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_settings_to_postgres.py
+++ b/tests/migration/test_copy_settings_to_postgres.py
@@ -1,0 +1,86 @@
+"""Tests for the copy settings to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_q928h2q03qmp_copy_settings_to_postgres import upgrade
+from virtool.migration.ctx import MigrationContext
+
+REVISION = "d16de6e24788"
+
+
+async def fetch_settings(ctx: MigrationContext) -> dict:
+    async with AsyncSession(ctx.pg) as session:
+        row = (await session.execute(text("SELECT * FROM settings"))).mappings().one()
+
+    return dict(row)
+
+
+class TestUpgrade:
+    async def test_backfills_from_mongo(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        await ctx.mongo.settings.insert_one(
+            {
+                "_id": "settings",
+                "enable_api": True,
+                "minimum_password_length": 16,
+                "sample_group": "force_choice",
+                "hmm_slug": "virtool/virtool-hmm",
+                "sample_unique_names": True,
+            },
+        )
+
+        await upgrade(ctx)
+
+        settings = await fetch_settings(ctx)
+
+        assert settings["enable_api"] is True
+        assert settings["minimum_password_length"] == 16
+        assert settings["sample_group"] == "force_choice"
+        assert "hmm_slug" not in settings
+        assert "sample_unique_names" not in settings
+
+    async def test_no_mongo_document_is_noop(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        await upgrade(ctx)
+
+        settings = await fetch_settings(ctx)
+
+        assert settings["enable_api"] is False
+        assert settings["minimum_password_length"] == 8
+
+    async def test_skips_when_already_customized(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text("UPDATE settings SET minimum_password_length = 20 WHERE id = 1"),
+            )
+            await session.commit()
+
+        await ctx.mongo.settings.insert_one(
+            {"_id": "settings", "minimum_password_length": 16},
+        )
+
+        await upgrade(ctx)
+
+        settings = await fetch_settings(ctx)
+
+        assert settings["minimum_password_length"] == 20

--- a/tests/migration/test_copy_settings_to_postgres.py
+++ b/tests/migration/test_copy_settings_to_postgres.py
@@ -62,6 +62,28 @@ class TestUpgrade:
         assert settings["enable_api"] is False
         assert settings["minimum_password_length"] == 8
 
+    async def test_skips_null_values(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        await ctx.mongo.settings.insert_one(
+            {
+                "_id": "settings",
+                "sample_group": None,
+                "minimum_password_length": 16,
+            },
+        )
+
+        await upgrade(ctx)
+
+        settings = await fetch_settings(ctx)
+
+        assert settings["sample_group"] == "none"
+        assert settings["minimum_password_length"] == 16
+
     async def test_skips_when_already_customized(
         self,
         ctx: MigrationContext,

--- a/tests/settings/test_data.py
+++ b/tests/settings/test_data.py
@@ -49,6 +49,21 @@ class TestUpdate:
         with pytest.raises(ResourceNotFoundError):
             await settings_data.update(UpdateSettingsRequest(enable_api=True))
 
+    async def test_empty_returns_current(
+        self,
+        pg: AsyncEngine,
+        settings_data: SettingsData,
+    ):
+        await seed_row(pg, enable_api=True, minimum_password_length=16)
+
+        settings = await settings_data.update(UpdateSettingsRequest())
+
+        assert settings == Settings(enable_api=True, minimum_password_length=16)
+
+    async def test_empty_missing_row_raises(self, settings_data: SettingsData):
+        with pytest.raises(ResourceNotFoundError):
+            await settings_data.update(UpdateSettingsRequest())
+
 
 class TestEnsure:
     async def test_seeds_defaults_when_missing(self, settings_data: SettingsData):

--- a/tests/settings/test_data.py
+++ b/tests/settings/test_data.py
@@ -1,27 +1,69 @@
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.errors import ResourceNotFoundError
 from virtool.settings.data import SettingsData
 from virtool.settings.models import Settings
+from virtool.settings.oas import UpdateSettingsRequest
+from virtool.settings.sql import SQLSettings
 
 
 @pytest.fixture
-async def settings_data(mongo) -> SettingsData:
-    return SettingsData(mongo)
+async def settings_data(pg: AsyncEngine) -> SettingsData:
+    return SettingsData(pg)
 
 
-async def test_ensure(mongo, settings_data: SettingsData, snapshot, test_settings):
-    settings = await settings_data.ensure()
+async def seed_row(pg: AsyncEngine, **overrides) -> None:
+    async with AsyncSession(pg) as session:
+        await session.merge(SQLSettings(id=1, **{**Settings().dict(), **overrides}))
+        await session.commit()
 
-    assert settings == Settings(
-        sample_group="none",
-        sample_group_read=True,
-        sample_group_write=False,
-        sample_all_read=True,
-        sample_all_write=False,
-        enable_api=True,
-        enable_sentry=True,
-        minimum_password_length=8,
-        default_source_types=["isolate", "strain"],
-    )
 
-    assert await mongo.settings.find_one() == snapshot
+class TestGetAll:
+    async def test_ok(self, pg: AsyncEngine, settings_data: SettingsData):
+        await seed_row(pg, enable_api=True, minimum_password_length=12)
+
+        assert await settings_data.get_all() == Settings(
+            enable_api=True,
+            minimum_password_length=12,
+        )
+
+    async def test_missing_row_raises(self, settings_data: SettingsData):
+        with pytest.raises(ResourceNotFoundError):
+            await settings_data.get_all()
+
+
+class TestUpdate:
+    async def test_ok(self, pg: AsyncEngine, settings_data: SettingsData):
+        await seed_row(pg)
+
+        settings = await settings_data.update(
+            UpdateSettingsRequest(enable_api=True, minimum_password_length=10),
+        )
+
+        assert settings.enable_api is True
+        assert settings.minimum_password_length == 10
+        assert await settings_data.get_all() == settings
+
+    async def test_missing_row_raises(self, settings_data: SettingsData):
+        with pytest.raises(ResourceNotFoundError):
+            await settings_data.update(UpdateSettingsRequest(enable_api=True))
+
+
+class TestEnsure:
+    async def test_seeds_defaults_when_missing(self, settings_data: SettingsData):
+        settings = await settings_data.ensure()
+
+        assert settings == Settings()
+        assert await settings_data.get_all() == Settings()
+
+    async def test_preserves_existing_row(
+        self,
+        pg: AsyncEngine,
+        settings_data: SettingsData,
+    ):
+        await seed_row(pg, enable_api=True, minimum_password_length=16)
+
+        settings = await settings_data.ensure()
+
+        assert settings == Settings(enable_api=True, minimum_password_length=16)

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -101,7 +101,7 @@ def create_data_layer(
         SamplesData(config, mongo, pg, storage),
         SubtractionsData(config.base_url, mongo, pg, storage),
         SessionData(pg),
-        SettingsData(mongo),
+        SettingsData(pg),
         TasksData(pg),
         UploadsData(config, mongo, pg, storage),
         UsersData(pg),

--- a/virtool/settings/data.py
+++ b/virtool/settings/data.py
@@ -42,12 +42,17 @@ class SettingsData:
         :raises ResourceNotFoundError: if the settings row does not exist
         :return: the application settings
         """
+        update_data = data.dict(exclude_unset=True)
+
+        if not update_data:
+            return await self.get_all()
+
         async with AsyncSession(self._pg) as session:
             updated = (
                 await session.execute(
                     update(SQLSettings)
                     .where(SQLSettings.id == 1)
-                    .values(**data.dict(exclude_unset=True))
+                    .values(**update_data)
                     .returning(SQLSettings),
                 )
             ).scalar()

--- a/virtool/settings/data.py
+++ b/virtool/settings/data.py
@@ -1,56 +1,80 @@
-from virtool.mongo.core import Mongo
+"""PostgreSQL-based application settings data layer."""
+
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.data.errors import ResourceNotFoundError
 from virtool.settings.models import Settings
 from virtool.settings.oas import UpdateSettingsRequest
+from virtool.settings.sql import SQLSettings
 
 
 class SettingsData:
+    """PostgreSQL-based application settings data layer."""
+
     name = "settings"
 
-    def __init__(self, mongo: "Mongo"):
-        self._mongo: Mongo = mongo
+    def __init__(self, pg: AsyncEngine) -> None:
+        """Initialize the settings data layer domain."""
+        self._pg = pg
 
     async def get_all(self) -> Settings:
         """List all settings.
 
+        :raises ResourceNotFoundError: if the settings row does not exist
         :return: the application settings
-
         """
-        settings = await self._mongo.settings.find_one(
-            {"_id": "settings"},
-            projection={"_id": False},
-        )
+        async with AsyncSession(self._pg) as session:
+            settings = (
+                await session.execute(select(SQLSettings).where(SQLSettings.id == 1))
+            ).scalar()
 
         if settings is None:
-            return Settings()
+            raise ResourceNotFoundError
 
-        return Settings(**settings)
+        return Settings(**settings.to_dict())
 
     async def update(self, data: UpdateSettingsRequest) -> Settings:
         """Update the settings.
 
         :param data: updates to the current settings
+        :raises ResourceNotFoundError: if the settings row does not exist
         :return: the application settings
         """
-        updated = await self._mongo.settings.find_one_and_update(
-            {"_id": "settings"},
-            {"$set": data.dict(exclude_unset=True)},
-        )
+        async with AsyncSession(self._pg) as session:
+            updated = (
+                await session.execute(
+                    update(SQLSettings)
+                    .where(SQLSettings.id == 1)
+                    .values(**data.dict(exclude_unset=True))
+                    .returning(SQLSettings),
+                )
+            ).scalar()
 
-        return Settings(**updated)
+            if updated is None:
+                raise ResourceNotFoundError
+
+            settings = Settings(**updated.to_dict())
+            await session.commit()
+
+        return settings
 
     async def ensure(self) -> Settings:
-        """Ensure the settings document is updated and filled with default values.
+        """Ensure the singleton settings row exists, seeding defaults if absent.
+
+        Virgin deployments may not have run the table-seeding migration, so this
+        inserts the default row when it is missing and leaves an existing row
+        untouched.
 
         :return: the application settings
         """
-        existing = await self.get_all()
+        async with AsyncSession(self._pg) as session:
+            await session.execute(
+                insert(SQLSettings)
+                .values(id=1, **Settings().dict())
+                .on_conflict_do_nothing(index_elements=["id"]),
+            )
+            await session.commit()
 
-        settings = {**(Settings().dict()), **existing.dict()}
-
-        await self._mongo.settings.update_one(
-            {"_id": "settings"},
-            {"$set": settings},
-            upsert=True,
-        )
-
-        return Settings(**settings)
+        return await self.get_all()


### PR DESCRIPTION
## Summary

- Migrates `SettingsData` from MongoDB to PostgreSQL, backed by the `SQLSettings` model and the `settings` table created in the previous migration.
- Adds a `copy_settings_to_postgres` migration revision that backfills the existing MongoDB settings document into the new SQL row on first run, skipping if the row has already been customized.
- Updates the `test_settings` fixture, `data_layer` fixture, and all affected unit tests to use PostgreSQL instead of MongoDB.