### PR TITLE
chore: request reviews from igboyes on dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "igboyes"
     groups:
       pytest:
         patterns:
@@ -25,3 +27,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    reviewers:
+      - "igboyes"


### PR DESCRIPTION
## Summary

- Adds `igboyes` as a reviewer to both the pip and GitHub Actions dependabot update configurations so that dependency bump PRs automatically request a review.