### PR TITLE
feat(account): create api_keys postgres table

### DIFF
--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -5,6 +5,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from virtool.account.sql import SQLAPIKey
 from virtool.analyses.sql import SQLAnalysisFile
 from virtool.blast.sql import SQLNuVsBlast
 from virtool.groups.pg import SQLGroup
@@ -35,6 +36,7 @@ config = context.config
 target_metadata = Base.metadata
 
 __models__ = (
+    SQLAPIKey,
     SQLAnalysisFile,
     SQLGroup,
     SQLIndexFile,

--- a/assets/alembic/versions/12c20b71cffc_create_api_keys_table.py
+++ b/assets/alembic/versions/12c20b71cffc_create_api_keys_table.py
@@ -1,0 +1,38 @@
+"""create api_keys table
+
+Revision ID: 12c20b71cffc
+Revises: d16de6e24788
+Create Date: 2026-05-29 18:01:54.434189+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "12c20b71cffc"
+down_revision = "d16de6e24788"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("hashed", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "permissions", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("hashed"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_keys")

--- a/assets/alembic/versions/12c20b71cffc_create_api_keys_table.py
+++ b/assets/alembic/versions/12c20b71cffc_create_api_keys_table.py
@@ -33,6 +33,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
     )
 
+    op.create_index("idx_api_keys_user_id", "api_keys", ["user_id"])
+
 
 def downgrade() -> None:
+    op.drop_index("idx_api_keys_user_id", table_name="api_keys")
     op.drop_table("api_keys")

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
+import virtool.account.sql  # noqa: F401  schema mirror, no app importer
 import virtool.messages.sql
 import virtool.settings.sql  # noqa: F401  schema mirror, no app importer
 from virtool.api.custom_json import dump_string

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
-import virtool.account.sql  # noqa: F401  schema mirror, no app importer
+import virtool.account.sql
 import virtool.messages.sql
 import virtool.settings.sql  # noqa: F401  schema mirror, no app importer
 from virtool.api.custom_json import dump_string

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -253,5 +253,12 @@
       'name': 'copy settings to postgres',
       'revision': 'q928h2q03qmp',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 37,
+      'name': 'create api_keys table',
+      'revision': '12c20b71cffc',
+    }),
   ])
 # ---

--- a/virtool/account/sql.py
+++ b/virtool/account/sql.py
@@ -18,5 +18,7 @@ class SQLAPIKey(Base):
     hashed: Mapped[str] = mapped_column(unique=True)
     name: Mapped[str]
     created_at: Mapped[datetime]
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
     permissions: Mapped[dict] = mapped_column(JSONB)

--- a/virtool/account/sql.py
+++ b/virtool/account/sql.py
@@ -1,0 +1,22 @@
+"""SQLAlchemy models for account API keys."""
+
+from datetime import datetime
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from virtool.pg.base import Base
+
+
+class SQLAPIKey(Base):
+    """An API key used to authenticate requests on behalf of a user."""
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    hashed: Mapped[str] = mapped_column(unique=True)
+    name: Mapped[str]
+    created_at: Mapped[datetime]
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    permissions: Mapped[dict] = mapped_column(JSONB)


### PR DESCRIPTION
## Summary

- Adds `SQLAPIKey` SQLAlchemy model in `virtool/account/sql.py` with columns for `id`, `hashed`, `name`, `created_at`, `user_id` (FK to `users.id` with cascade delete), and `permissions` (JSONB)
- Adds an Alembic migration (`12c20b71cffc`) that creates the `api_keys` table
- Registers the model in `alembic/env.py` and the test PG fixtures so the table is created in test databases