### PR TITLE
feat: dual-write api keys to mongo and postgres

### DIFF
--- a/assets/revisions/rev_31su1xw351h2_copy_api_keys_to_postgres.py
+++ b/assets/revisions/rev_31su1xw351h2_copy_api_keys_to_postgres.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from virtool.account.sql import SQLAPIKey
+from virtool.data.topg import resolve_user_id
 from virtool.migration import MigrationContext
 
 logger = get_logger("migration")
@@ -51,8 +52,8 @@ async def upgrade(ctx: MigrationContext) -> None:
             sql_key = SQLAPIKey(
                 hashed=document["_id"],
                 name=document["name"],
-                created_at=document["created_at"],
-                user_id=document["user"]["id"],
+                created_at=arrow.get(document["created_at"]).naive,
+                user_id=await resolve_user_id(session, document["user"]["id"]),
                 permissions=document["permissions"],
             )
 

--- a/assets/revisions/rev_31su1xw351h2_copy_api_keys_to_postgres.py
+++ b/assets/revisions/rev_31su1xw351h2_copy_api_keys_to_postgres.py
@@ -1,0 +1,71 @@
+"""copy api keys to postgres
+
+Revision ID: 31su1xw351h2
+Date: 2026-05-29 21:40:41.278957
+
+"""
+
+import arrow
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.account.sql import SQLAPIKey
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy api keys to postgres"
+created_at = arrow.get("2026-05-29 21:40:41.278957")
+revision_id = "31su1xw351h2"
+
+alembic_down_revision = "12c20b71cffc"
+virtool_down_revision = None
+
+# The api_keys table must exist before backfilling.
+required_alembic_revision = "12c20b71cffc"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Copy legacy MongoDB API keys into the PostgreSQL ``api_keys`` table.
+
+    For each Mongo key document a matching ``SQLAPIKey`` row is created and the
+    Mongo document's ``id`` is rewritten from its legacy string value to the
+    integer primary key assigned by PostgreSQL. The Mongo ``_id`` (hashed secret)
+    stays the cross-store handle, so the migration is idempotent: keys that
+    already have a PostgreSQL row are skipped, leaving their integer ``id``
+    untouched.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_hashes = set(
+            (await session.execute(select(SQLAPIKey.hashed))).scalars(),
+        )
+
+        copied = 0
+
+        async for document in ctx.mongo.keys.find():
+            if document["_id"] in existing_hashes:
+                continue
+
+            sql_key = SQLAPIKey(
+                hashed=document["_id"],
+                name=document["name"],
+                created_at=document["created_at"],
+                user_id=document["user"]["id"],
+                permissions=document["permissions"],
+            )
+
+            session.add(sql_key)
+            await session.flush()
+
+            await ctx.mongo.keys.update_one(
+                {"_id": document["_id"]},
+                {"$set": {"id": sql_key.id}},
+            )
+
+            copied += 1
+
+        await session.commit()
+
+    logger.info("backfilled api keys from mongodb", count=copied)

--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -200,7 +200,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -221,7 +221,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -243,7 +243,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -264,7 +264,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -286,7 +286,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -307,7 +307,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -329,7 +329,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -350,7 +350,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -372,7 +372,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -393,7 +393,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -415,7 +415,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -436,7 +436,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
     ]),
-    'id': 'foobar_0',
+    'id': 1,
     'name': 'Foobar',
     'permissions': dict({
       'cancel_job': False,
@@ -551,7 +551,7 @@
       'created_at': 'approximately_now_isoformat',
       'groups': list([
       ]),
-      'id': 'foobar_0',
+      'id': 1,
       'name': 'Foobar',
       'permissions': dict({
         'cancel_job': False,
@@ -568,7 +568,7 @@
       'created_at': 'approximately_now_isoformat',
       'groups': list([
       ]),
-      'id': 'baz_0',
+      'id': 2,
       'name': 'Baz',
       'permissions': dict({
         'cancel_job': False,

--- a/tests/account/__snapshots__/test_data.ambr
+++ b/tests/account/__snapshots__/test_data.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_create_api_key[does_not_have_permission][data]
+# name: TestCreateKey.test_ok[does_not_have_permission][data]
   dict({
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
@@ -14,7 +14,7 @@
         'name': 'musicians',
       }),
     ]),
-    'id': 'foo_0',
+    'id': 1,
     'name': 'Foo',
     'permissions': dict({
       'cancel_job': False,
@@ -28,7 +28,7 @@
     }),
   })
 # ---
-# name: test_create_api_key[does_not_have_permission][mongo]
+# name: TestCreateKey.test_ok[does_not_have_permission][mongo]
   dict({
     '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
@@ -36,7 +36,7 @@
       2,
       1,
     ]),
-    'id': 'foo_0',
+    'id': 1,
     'name': 'Foo',
     'permissions': dict({
       'create_sample': True,
@@ -47,7 +47,22 @@
     }),
   })
 # ---
-# name: test_create_api_key[has_permission][data]
+# name: TestCreateKey.test_ok[does_not_have_permission][pg]
+  list([
+    dict({
+      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+      'hashed': 'baz',
+      'id': 1,
+      'name': 'Foo',
+      'permissions': dict({
+        'create_sample': True,
+        'modify_subtraction': True,
+      }),
+      'user_id': 1,
+    }),
+  ])
+# ---
+# name: TestCreateKey.test_ok[has_permission][data]
   dict({
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
@@ -62,7 +77,7 @@
         'name': 'musicians',
       }),
     ]),
-    'id': 'foo_0',
+    'id': 1,
     'name': 'Foo',
     'permissions': dict({
       'cancel_job': False,
@@ -76,7 +91,7 @@
     }),
   })
 # ---
-# name: test_create_api_key[has_permission][mongo]
+# name: TestCreateKey.test_ok[has_permission][mongo]
   dict({
     '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
@@ -84,7 +99,7 @@
       2,
       1,
     ]),
-    'id': 'foo_0',
+    'id': 1,
     'name': 'Foo',
     'permissions': dict({
       'create_sample': True,
@@ -94,4 +109,19 @@
       'id': 1,
     }),
   })
+# ---
+# name: TestCreateKey.test_ok[has_permission][pg]
+  list([
+    dict({
+      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
+      'hashed': 'baz',
+      'id': 1,
+      'name': 'Foo',
+      'permissions': dict({
+        'create_sample': True,
+        'modify_subtraction': True,
+      }),
+      'user_id': 1,
+    }),
+  ])
 # ---

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -778,7 +778,10 @@ class TestUpdateAPIKey:
             {"permissions": {Permission.create_sample.value: True}},
         )
 
-        assert resp.status == 500
+        assert resp.status == 404
+
+        unchanged = await data_layer.account.get_key(other_user.id, other_key.id)
+        assert unchanged.permissions.create_sample is False
 
     async def test_permission_revocation(
         self,

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -487,20 +487,22 @@ class TestCreateAPIKey:
         self,
         spawn_client: ClientSpawner,
     ) -> None:
-        """Test that uniqueness is ensured on the ``id`` field."""
+        """Test that keys sharing a name receive distinct integer ids."""
         client = await spawn_client(authenticated=True)
 
         resp_1 = await client.post("/account/keys", {"name": "Foobar"})
         assert resp_1.status == 201
         data_1 = await resp_1.json()
-        assert data_1["id"] == "foobar_0"
+        assert isinstance(data_1["id"], int)
         assert data_1["name"] == "Foobar"
 
         resp_2 = await client.post("/account/keys", {"name": "Foobar"})
         assert resp_2.status == 201
         data_2 = await resp_2.json()
-        assert data_2["id"] == "foobar_1"
+        assert isinstance(data_2["id"], int)
         assert data_2["name"] == "Foobar"
+
+        assert data_1["id"] != data_2["id"]
 
     async def test_permission_exceeds_user_create(
         self,
@@ -686,7 +688,7 @@ class TestUpdateAPIKey:
         await mongo.keys.insert_one(
             {
                 "_id": "foobar",
-                "id": "foobar_0",
+                "id": 1,
                 "name": "Foobar",
                 "created_at": static_time.datetime,
                 "administrator": True,
@@ -707,7 +709,7 @@ class TestUpdateAPIKey:
             data = {}
 
         resp = await client.patch(
-            "/account/keys/foobar_0",
+            "/account/keys/1",
             data,
         )
 
@@ -722,7 +724,7 @@ class TestUpdateAPIKey:
         client = await spawn_client(authenticated=True)
 
         resp = await client.patch(
-            "/account/keys/foobar_0",
+            "/account/keys/1",
             {"permissions": {Permission.create_sample.value: True}},
         )
 
@@ -1000,13 +1002,13 @@ class TestDelete:
             await mongo.keys.insert_one(
                 {
                     "_id": "foobar",
-                    "id": "foobar_0",
+                    "id": 1,
                     "name": "Foobar",
                     "user": {"id": client.user.id},
                 },
             )
 
-        resp = await client.delete("/account/keys/foobar_0")
+        resp = await client.delete("/account/keys/1")
 
         if error is None:
             assert resp.status == 204
@@ -1031,11 +1033,11 @@ class TestDelete:
             [
                 {
                     "_id": "hello_world",
-                    "id": "hello_world_0",
+                    "id": 1,
                     "user": {"id": client.user.id},
                 },
-                {"_id": "foobar", "id": "foobar_0", "user": {"id": client.user.id}},
-                {"_id": "baz", "id": "baz_0", "user": {"id": user.id}},
+                {"_id": "foobar", "id": 2, "user": {"id": client.user.id}},
+                {"_id": "baz", "id": 3, "user": {"id": user.id}},
             ],
             session=None,
         )
@@ -1045,7 +1047,7 @@ class TestDelete:
         assert resp.status == 204
 
         assert await mongo.keys.find().to_list(None) == [
-            {"_id": "baz", "id": "baz_0", "user": {"id": user.id}},
+            {"_id": "baz", "id": 3, "user": {"id": user.id}},
         ]
 
     async def test_cannot_delete_other_users_key(
@@ -1084,8 +1086,8 @@ class TestDelete:
         ("PATCH", "/account/settings"),
         ("GET", "/account/keys"),
         ("POST", "/account/keys"),
-        ("PATCH", "/account/keys/foobar"),
-        ("DELETE", "/account/keys/foobar"),
+        ("PATCH", "/account/keys/1"),
+        ("DELETE", "/account/keys/1"),
         ("DELETE", "/account/keys"),
     ],
 )
@@ -1134,7 +1136,7 @@ async def test_is_permission_dict(
 
     data = {"permissions": permissions}
 
-    resp = await client.patch("/account/keys/foo", data=data)
+    resp = await client.patch("/account/keys/1", data=data)
 
     if value == "valid_permissions":
         await resp_is.not_found(resp)

--- a/tests/account/test_data.py
+++ b/tests/account/test_data.py
@@ -1,8 +1,10 @@
 import pytest
-from aiohttp.test_utils import make_mocked_coro
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
-from virtool.account.oas import CreateKeyRequest
+from virtool.account.oas import CreateKeyRequest, UpdateKeyRequest
+from virtool.account.sql import SQLAPIKey
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
@@ -12,48 +14,330 @@ from virtool.mongo.core import Mongo
 from virtool.utils import hash_key
 
 
-@pytest.mark.parametrize(
-    "has_permission",
-    [True, False],
-    ids=["has_permission", "does_not_have_permission"],
-)
-async def test_create_api_key(
-    has_permission: bool,
-    data_layer: DataLayer,
-    fake: DataFaker,
-    mocker,
-    mongo: Mongo,
-    snapshot: SnapshotAssertion,
-    static_time,
-):
-    """Test that an API key is created correctly with varying key owner administrator
-    status and permissions.
-    """
-    mocker.patch("virtool.account.data._get_alternate_id", make_mocked_coro("foo_0"))
-    mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
+async def get_sql_keys(pg: AsyncEngine) -> list[dict]:
+    """Return every ``api_keys`` row as a plain dict, ordered by id."""
+    async with AsyncSession(pg) as session:
+        rows = (
+            (await session.execute(select(SQLAPIKey).order_by(SQLAPIKey.id)))
+            .scalars()
+            .all()
+        )
 
-    group_1 = await fake.groups.create()
-    group_2 = await fake.groups.create(
-        PermissionsUpdate(
-            **{
-                Permission.create_sample: True,
-                Permission.modify_subtraction: has_permission,
-            },
-        ),
+        return [
+            {
+                "id": row.id,
+                "hashed": row.hashed,
+                "name": row.name,
+                "created_at": row.created_at,
+                "user_id": row.user_id,
+                "permissions": row.permissions,
+            }
+            for row in rows
+        ]
+
+
+class TestCreateKey:
+    @pytest.mark.parametrize(
+        "has_permission",
+        [True, False],
+        ids=["has_permission", "does_not_have_permission"],
     )
+    async def test_ok(
+        self,
+        has_permission: bool,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        snapshot: SnapshotAssertion,
+        static_time,
+    ):
+        """A created key is written to both MongoDB and PostgreSQL, sharing the
+        PostgreSQL integer id, with permissions limited to those the owner holds.
+        """
+        mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
 
-    user = await fake.users.create(groups=[group_1, group_2])
+        group_1 = await fake.groups.create()
+        group_2 = await fake.groups.create(
+            PermissionsUpdate(
+                **{
+                    Permission.create_sample: True,
+                    Permission.modify_subtraction: has_permission,
+                },
+            ),
+        )
 
-    _, api_key = await data_layer.account.create_key(
-        CreateKeyRequest(
-            name="Foo",
-            permissions=PermissionsUpdate(create_sample=True, modify_subtraction=True),
-        ),
-        user.id,
-    )
+        user = await fake.users.create(groups=[group_1, group_2])
 
-    assert api_key == snapshot(name="data")
-    assert await mongo.keys.find_one() == snapshot(name="mongo")
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(
+                name="Foo",
+                permissions=PermissionsUpdate(
+                    create_sample=True, modify_subtraction=True
+                ),
+            ),
+            user.id,
+        )
+
+        assert api_key == snapshot(name="data")
+
+        mongo_document = await mongo.keys.find_one()
+        assert mongo_document == snapshot(name="mongo")
+
+        sql_keys = await get_sql_keys(pg)
+        assert sql_keys == snapshot(name="pg")
+
+        assert mongo_document["id"] == sql_keys[0]["id"] == api_key.id
+        assert mongo_document["_id"] == sql_keys[0]["hashed"]
+
+    async def test_rollback(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """When the PostgreSQL write fails, the MongoDB write is rolled back and no
+        key is left in either store.
+        """
+        mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
+
+        user = await fake.users.create()
+
+        mocker.patch.object(
+            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
+        )
+
+        with pytest.raises(RuntimeError, match="postgres down"):
+            await data_layer.account.create_key(
+                CreateKeyRequest(name="Foo", permissions=PermissionsUpdate()),
+                user.id,
+            )
+
+        assert await mongo.keys.count_documents({}) == 0
+        assert await get_sql_keys(pg) == []
+
+
+class TestUpdateKey:
+    async def test_ok(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Updating permissions is reflected in both MongoDB and PostgreSQL."""
+        user = await fake.users.create(
+            groups=[
+                await fake.groups.create(
+                    PermissionsUpdate(create_sample=True, modify_subtraction=True),
+                ),
+            ],
+        )
+
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(
+                name="Foo", permissions=PermissionsUpdate(create_sample=True)
+            ),
+            user.id,
+        )
+
+        await data_layer.account.update_key(
+            user.id,
+            api_key.id,
+            UpdateKeyRequest(permissions=PermissionsUpdate(modify_subtraction=True)),
+        )
+
+        mongo_document = await mongo.keys.find_one({"id": api_key.id})
+        assert mongo_document["permissions"]["create_sample"] is True
+        assert mongo_document["permissions"]["modify_subtraction"] is True
+
+        sql_keys = await get_sql_keys(pg)
+        assert sql_keys[0]["permissions"]["create_sample"] is True
+        assert sql_keys[0]["permissions"]["modify_subtraction"] is True
+
+    async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
+        """Updating a key that does not exist raises ``ResourceNotFoundError``."""
+        user = await fake.users.create()
+
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.account.update_key(
+                user.id,
+                999,
+                UpdateKeyRequest(permissions=PermissionsUpdate(create_sample=True)),
+            )
+
+    async def test_rollback(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """When the PostgreSQL write fails, the MongoDB permissions update is rolled
+        back and both stores keep the original permissions.
+        """
+        user = await fake.users.create(
+            groups=[
+                await fake.groups.create(
+                    PermissionsUpdate(create_sample=True, modify_subtraction=True),
+                ),
+            ],
+        )
+
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(
+                name="Foo", permissions=PermissionsUpdate(create_sample=True)
+            ),
+            user.id,
+        )
+
+        mocker.patch.object(
+            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
+        )
+
+        with pytest.raises(RuntimeError, match="postgres down"):
+            await data_layer.account.update_key(
+                user.id,
+                api_key.id,
+                UpdateKeyRequest(
+                    permissions=PermissionsUpdate(modify_subtraction=True)
+                ),
+            )
+
+        mongo_document = await mongo.keys.find_one({"id": api_key.id})
+        assert mongo_document["permissions"].get("modify_subtraction", False) is False
+
+        sql_keys = await get_sql_keys(pg)
+        assert sql_keys[0]["permissions"].get("modify_subtraction", False) is False
+
+
+class TestDeleteKey:
+    async def test_ok(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Deleting a key removes it from both MongoDB and PostgreSQL."""
+        user = await fake.users.create()
+
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Foo", permissions=PermissionsUpdate()),
+            user.id,
+        )
+
+        await data_layer.account.delete_key(user.id, api_key.id)
+
+        assert await mongo.keys.count_documents({}) == 0
+        assert await get_sql_keys(pg) == []
+
+    async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
+        """Deleting a key that does not exist raises ``ResourceNotFoundError``."""
+        user = await fake.users.create()
+
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.account.delete_key(user.id, 999)
+
+    async def test_rollback(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """When the PostgreSQL delete fails, the MongoDB delete is rolled back and the
+        key remains in both stores.
+        """
+        user = await fake.users.create()
+
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Foo", permissions=PermissionsUpdate()),
+            user.id,
+        )
+
+        mocker.patch.object(
+            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
+        )
+
+        with pytest.raises(RuntimeError, match="postgres down"):
+            await data_layer.account.delete_key(user.id, api_key.id)
+
+        assert await mongo.keys.count_documents({"id": api_key.id}) == 1
+        assert len(await get_sql_keys(pg)) == 1
+
+
+class TestDeleteKeys:
+    async def test_ok(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Deleting all of a user's keys removes only that user's keys from both
+        stores, leaving other users' keys intact.
+        """
+        owner = await fake.users.create()
+        other = await fake.users.create()
+
+        await data_layer.account.create_key(
+            CreateKeyRequest(name="Owned One", permissions=PermissionsUpdate()),
+            owner.id,
+        )
+        await data_layer.account.create_key(
+            CreateKeyRequest(name="Owned Two", permissions=PermissionsUpdate()),
+            owner.id,
+        )
+        _, other_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Other", permissions=PermissionsUpdate()),
+            other.id,
+        )
+
+        await data_layer.account.delete_keys(owner.id)
+
+        assert await mongo.keys.count_documents({"user.id": owner.id}) == 0
+
+        sql_keys = await get_sql_keys(pg)
+        assert [key["id"] for key in sql_keys] == [other_key.id]
+        assert sql_keys[0]["user_id"] == other.id
+
+    async def test_rollback(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """When the PostgreSQL delete fails, the MongoDB delete is rolled back and all
+        of the user's keys remain in both stores.
+        """
+        owner = await fake.users.create()
+
+        await data_layer.account.create_key(
+            CreateKeyRequest(name="Owned One", permissions=PermissionsUpdate()),
+            owner.id,
+        )
+        await data_layer.account.create_key(
+            CreateKeyRequest(name="Owned Two", permissions=PermissionsUpdate()),
+            owner.id,
+        )
+
+        mocker.patch.object(
+            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
+        )
+
+        with pytest.raises(RuntimeError, match="postgres down"):
+            await data_layer.account.delete_keys(owner.id)
+
+        assert await mongo.keys.count_documents({"user.id": owner.id}) == 2
+        assert len(await get_sql_keys(pg)) == 2
 
 
 class TestGetKeyBySecret:
@@ -63,7 +347,7 @@ class TestGetKeyBySecret:
         fake: DataFaker,
         mongo: Mongo,
     ):
-        """Test that get_key_by_secret works with current integer user IDs."""
+        """``get_key_by_secret`` resolves a key by its raw secret value."""
         user = await fake.users.create()
 
         raw_key = "test_secret_key"
@@ -72,7 +356,7 @@ class TestGetKeyBySecret:
         await mongo.keys.insert_one(
             {
                 "_id": hashed_key,
-                "id": "test_key",
+                "id": 1,
                 "name": "Test Key",
                 "created_at": "2023-01-01T00:00:00.000000Z",
                 "permissions": {"create_sample": True},
@@ -83,15 +367,11 @@ class TestGetKeyBySecret:
 
         result = await data_layer.account.get_key_by_secret(user.id, raw_key)
 
-        assert result.id == "test_key"
+        assert result.id == 1
         assert result.name == "Test Key"
 
-    async def test_not_found(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-    ):
-        """Test that get_key_by_secret raises ResourceNotFoundError when key doesn't exist."""
+    async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
+        """``get_key_by_secret`` raises ``ResourceNotFoundError`` for an unknown key."""
         user = await fake.users.create()
 
         with pytest.raises(ResourceNotFoundError):

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -267,5 +267,12 @@
       'name': 'create api_keys table',
       'revision': '12c20b71cffc',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 39,
+      'name': 'copy api keys to postgres',
+      'revision': '31su1xw351h2',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_api_keys_to_postgres.py
+++ b/tests/migration/test_copy_api_keys_to_postgres.py
@@ -14,10 +14,11 @@ from virtool.users.pg import SQLUser
 REVISION = "12c20b71cffc"
 
 
-async def create_user(ctx: MigrationContext) -> int:
+async def create_user(ctx: MigrationContext, legacy_id: str | None = None) -> int:
     async with AsyncSession(ctx.pg) as session:
         user = SQLUser(
             handle="key_owner",
+            legacy_id=legacy_id,
             password=b"",
             force_reset=False,
             last_password_change=arrow.utcnow().naive,
@@ -90,6 +91,35 @@ class TestUpgrade:
 
         assert first["id"] == api_keys[0]["id"]
         assert second["id"] == api_keys[1]["id"]
+
+    async def test_resolves_legacy_string_user_and_date(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        user_id = await create_user(ctx, legacy_id="bob")
+
+        await ctx.mongo.keys.insert_one(
+            {
+                "_id": "hashed_one",
+                "id": "first_key_0",
+                "name": "First Key",
+                "created_at": "2023-01-01T00:00:00Z",
+                "groups": [],
+                "permissions": {"create_sample": True},
+                "user": {"id": "bob"},
+            },
+        )
+
+        await upgrade(ctx)
+
+        api_keys = await fetch_api_keys(ctx)
+
+        assert len(api_keys) == 1
+        assert api_keys[0]["user_id"] == user_id
+        assert api_keys[0]["created_at"] == arrow.get("2023-01-01T00:00:00Z").naive
 
     async def test_no_keys_is_noop(
         self,

--- a/tests/migration/test_copy_api_keys_to_postgres.py
+++ b/tests/migration/test_copy_api_keys_to_postgres.py
@@ -1,0 +1,133 @@
+"""Tests for the copy api keys to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_31su1xw351h2_copy_api_keys_to_postgres import upgrade
+from virtool.migration.ctx import MigrationContext
+from virtool.users.pg import SQLUser
+
+REVISION = "12c20b71cffc"
+
+
+async def create_user(ctx: MigrationContext) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        user = SQLUser(
+            handle="key_owner",
+            password=b"",
+            force_reset=False,
+            last_password_change=arrow.utcnow().naive,
+            settings={},
+        )
+        session.add(user)
+        await session.flush()
+        user_id = user.id
+        await session.commit()
+
+    return user_id
+
+
+async def fetch_api_keys(ctx: MigrationContext) -> list[dict]:
+    async with AsyncSession(ctx.pg) as session:
+        rows = (
+            (await session.execute(text("SELECT * FROM api_keys ORDER BY id")))
+            .mappings()
+            .all()
+        )
+
+    return [dict(row) for row in rows]
+
+
+class TestUpgrade:
+    async def test_backfills_from_mongo(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        user_id = await create_user(ctx)
+
+        await ctx.mongo.keys.insert_many(
+            [
+                {
+                    "_id": "hashed_one",
+                    "id": "first_key_0",
+                    "name": "First Key",
+                    "created_at": arrow.get("2023-01-01T00:00:00Z").naive,
+                    "groups": [],
+                    "permissions": {"create_sample": True},
+                    "user": {"id": user_id},
+                },
+                {
+                    "_id": "hashed_two",
+                    "id": "second_key_0",
+                    "name": "Second Key",
+                    "created_at": arrow.get("2023-02-01T00:00:00Z").naive,
+                    "groups": [],
+                    "permissions": {"modify_subtraction": True},
+                    "user": {"id": user_id},
+                },
+            ],
+        )
+
+        await upgrade(ctx)
+
+        api_keys = await fetch_api_keys(ctx)
+
+        assert [(key["hashed"], key["name"], key["user_id"]) for key in api_keys] == [
+            ("hashed_one", "First Key", user_id),
+            ("hashed_two", "Second Key", user_id),
+        ]
+        assert api_keys[0]["permissions"] == {"create_sample": True}
+
+        first = await ctx.mongo.keys.find_one({"_id": "hashed_one"})
+        second = await ctx.mongo.keys.find_one({"_id": "hashed_two"})
+
+        assert first["id"] == api_keys[0]["id"]
+        assert second["id"] == api_keys[1]["id"]
+
+    async def test_no_keys_is_noop(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        await upgrade(ctx)
+
+        assert await fetch_api_keys(ctx) == []
+
+    async def test_idempotent(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        user_id = await create_user(ctx)
+
+        await ctx.mongo.keys.insert_one(
+            {
+                "_id": "hashed_one",
+                "id": "first_key_0",
+                "name": "First Key",
+                "created_at": arrow.get("2023-01-01T00:00:00Z").naive,
+                "groups": [],
+                "permissions": {"create_sample": True},
+                "user": {"id": user_id},
+            },
+        )
+
+        await upgrade(ctx)
+        first_pass = await fetch_api_keys(ctx)
+
+        await upgrade(ctx)
+        second_pass = await fetch_api_keys(ctx)
+
+        assert len(first_pass) == 1
+        assert second_pass == first_pass

--- a/tests/migration/test_copy_api_keys_to_postgres.py
+++ b/tests/migration/test_copy_api_keys_to_postgres.py
@@ -1,6 +1,7 @@
 """Tests for the copy api keys to postgres migration."""
 
 import asyncio
+import json
 from collections.abc import Callable
 
 import arrow
@@ -9,24 +10,37 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from assets.revisions.rev_31su1xw351h2_copy_api_keys_to_postgres import upgrade
 from virtool.migration.ctx import MigrationContext
-from virtool.users.pg import SQLUser
 
 REVISION = "12c20b71cffc"
+
+INSERT_USER = text(
+    """
+    INSERT INTO users (
+        active, email, force_reset, handle, invalidate_sessions,
+        last_password_change, legacy_id, password, settings
+    )
+    VALUES (
+        true, '', false, :handle, false,
+        :last_password_change, :legacy_id, :password, cast(:settings as jsonb)
+    )
+    RETURNING id
+    """,
+)
 
 
 async def create_user(ctx: MigrationContext, legacy_id: str | None = None) -> int:
     async with AsyncSession(ctx.pg) as session:
-        user = SQLUser(
-            handle="key_owner",
-            legacy_id=legacy_id,
-            password=b"",
-            force_reset=False,
-            last_password_change=arrow.utcnow().naive,
-            settings={},
+        result = await session.execute(
+            INSERT_USER,
+            {
+                "handle": "key_owner",
+                "last_password_change": arrow.utcnow().naive,
+                "legacy_id": legacy_id,
+                "password": b"",
+                "settings": json.dumps({}),
+            },
         )
-        session.add(user)
-        await session.flush()
-        user_id = user.id
+        user_id = result.scalar_one()
         await session.commit()
 
     return user_id

--- a/virtool/account/api.py
+++ b/virtool/account/api.py
@@ -197,7 +197,7 @@ class KeysView(PydanticView):
 
 @routes.view("/account/keys/{key_id}")
 class KeyView(PydanticView):
-    async def get(self, key_id: str, /) -> r200[APIKey] | r404:
+    async def get(self, key_id: int, /) -> r200[APIKey] | r404:
         """Get an API key.
 
         Fetches the details for an API key registered on the account associated with
@@ -217,7 +217,7 @@ class KeyView(PydanticView):
         return json_response(key, status=200)
 
     async def patch(
-        self, key_id: str, /, data: UpdateKeyRequest
+        self, key_id: int, /, data: UpdateKeyRequest
     ) -> r200[APIKey] | r400 | r401 | r404:
         """Update an API key.
 
@@ -241,7 +241,7 @@ class KeyView(PydanticView):
 
         return json_response(key)
 
-    async def delete(self, key_id: str, /) -> r204 | r401 | r404:
+    async def delete(self, key_id: int, /) -> r204 | r401 | r404:
         """Delete an API key.
 
         Removes an API key by its 'key id'.

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -1,4 +1,4 @@
-from sqlalchemy import cast, select, update
+from sqlalchemy import cast, delete, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
@@ -14,9 +14,11 @@ from virtool.account.oas import (
     UpdateKeyRequest,
     UpdateSettingsRequest,
 )
+from virtool.account.sql import SQLAPIKey
 from virtool.administrators.oas import UpdateUserRequest
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceError, ResourceNotFoundError
+from virtool.data.topg import both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.groups.transforms import AttachGroupsTransform
 from virtool.models.sessions import Session
@@ -208,7 +210,7 @@ class AccountData(DataLayerDomain):
 
         return [APIKey.parse_obj(key) for key in keys]
 
-    async def get_key(self, user_id: int, key_id: str) -> APIKey:
+    async def get_key(self, user_id: int, key_id: int) -> APIKey:
         """Get the complete representation of the API key identified by the `key_id`.
 
         The internal key ID and secret key value itself are not returned in the
@@ -299,35 +301,62 @@ class AccountData(DataLayerDomain):
 
         raw, hashed = virtool.utils.generate_key()
 
-        id_ = await _get_alternate_id(self._mongo, data.name)
+        created_at = virtool.utils.timestamp()
+        permissions = data.permissions.dict(exclude_unset=True)
 
-        await self._mongo.keys.insert_one(
-            {
-                "_id": hashed,
-                "id": id_,
-                "created_at": virtool.utils.timestamp(),
-                "groups": [group.id for group in user.groups],
-                "name": data.name,
-                "permissions": data.permissions.dict(exclude_unset=True),
-                "user": {"id": user_id},
-            },
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            sql_key = SQLAPIKey(
+                hashed=hashed,
+                name=data.name,
+                created_at=created_at,
+                user_id=user_id,
+                permissions=permissions,
+            )
+            pg_session.add(sql_key)
+            await pg_session.flush()
+            key_id = sql_key.id
+
+            await self._mongo.keys.insert_one(
+                {
+                    "_id": hashed,
+                    "id": key_id,
+                    "created_at": created_at,
+                    "groups": [group.id for group in user.groups],
+                    "name": data.name,
+                    "permissions": permissions,
+                    "user": {"id": user_id},
+                },
+                session=mongo_session,
+            )
 
         logger.info("created key", raw=raw, hashed=hashed)
 
-        return raw, await self.get_key(user_id, id_)
+        return raw, await self.get_key(user_id, key_id)
 
     async def delete_keys(self, user_id: int) -> None:
         """Delete all API keys for the account associated with the requesting session.
 
         :param user_id: the user ID
         """
-        await self._mongo.keys.delete_many({"user.id": user_id})
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.keys.delete_many(
+                {"user.id": user_id},
+                session=mongo_session,
+            )
+            await pg_session.execute(
+                delete(SQLAPIKey).where(SQLAPIKey.user_id == user_id),
+            )
 
     async def update_key(
         self,
         user_id: int,
-        key_id: str,
+        key_id: int,
         data: UpdateKeyRequest,
     ) -> APIKey:
         """Change the permissions for an existing API key.
@@ -338,9 +367,9 @@ class AccountData(DataLayerDomain):
         :return: the API key
         """
         if data.permissions is None:
-            update = {}
+            permissions_update = {}
         else:
-            update = data.permissions.dict(exclude_unset=True)
+            permissions_update = data.permissions.dict(exclude_unset=True)
 
         if not await self._mongo.keys.count_documents({"id": key_id}):
             raise ResourceNotFoundError()
@@ -353,28 +382,50 @@ class AccountData(DataLayerDomain):
                     {"id": key_id, "user.id": user_id},
                 )
             ),
-            **update,
+            **permissions_update,
         }
 
-        await self._mongo.keys.update_one(
-            {"id": key_id},
-            {"$set": {"permissions": new_permissions}},
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.keys.update_one(
+                {"id": key_id},
+                {"$set": {"permissions": new_permissions}},
+                session=mongo_session,
+            )
+            await pg_session.execute(
+                update(SQLAPIKey)
+                .where(SQLAPIKey.id == key_id)
+                .values(permissions=new_permissions),
+            )
 
         return await self.get_key(user_id, key_id)
 
-    async def delete_key(self, user_id: int, key_id: str) -> None:
+    async def delete_key(self, user_id: int, key_id: int) -> None:
         """Delete an API key by its id.
 
         :param user_id: the user ID
         :param key_id: the ID of the API key to delete
         """
-        delete_result = await self._mongo.keys.delete_one(
-            {"id": key_id, "user.id": user_id},
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            delete_result = await self._mongo.keys.delete_one(
+                {"id": key_id, "user.id": user_id},
+                session=mongo_session,
+            )
 
-        if delete_result.deleted_count == 0:
-            raise ResourceNotFoundError()
+            if delete_result.deleted_count == 0:
+                raise ResourceNotFoundError()
+
+            await pg_session.execute(
+                delete(SQLAPIKey).where(
+                    SQLAPIKey.id == key_id,
+                    SQLAPIKey.user_id == user_id,
+                ),
+            )
 
     async def login(self, data: CreateLoginRequest) -> int:
         """Create a new session for the user with `username`.
@@ -466,25 +517,3 @@ class AccountData(DataLayerDomain):
             session.reset.user_id,
             remember=session.reset.remember,
         )
-
-
-async def _get_alternate_id(mongo: Mongo, name: str) -> str:
-    """Get an alternate id for an API key whose provided `name` is not unique. Appends
-    an integer suffix to the end of the `name`.
-
-    :param mongo: the application mongodb client
-    :param name: the API key name
-    :return: an alternate unique id for the key
-
-    """
-    existing_alt_ids = await mongo.keys.distinct("id")
-
-    suffix = 0
-
-    while True:
-        candidate = f"{name.lower()}_{suffix}"
-
-        if candidate not in existing_alt_ids:
-            return candidate
-
-        suffix += 1

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -371,17 +371,17 @@ class AccountData(DataLayerDomain):
         else:
             permissions_update = data.permissions.dict(exclude_unset=True)
 
-        if not await self._mongo.keys.count_documents({"id": key_id}):
-            raise ResourceNotFoundError()
+        existing_permissions = await get_one_field(
+            self._mongo.keys,
+            "permissions",
+            {"id": key_id, "user.id": user_id},
+        )
+
+        if existing_permissions is None:
+            raise ResourceNotFoundError
 
         new_permissions = {
-            **(
-                await get_one_field(
-                    self._mongo.keys,
-                    "permissions",
-                    {"id": key_id, "user.id": user_id},
-                )
-            ),
+            **existing_permissions,
             **permissions_update,
         }
 
@@ -390,13 +390,13 @@ class AccountData(DataLayerDomain):
             pg_session,
         ):
             await self._mongo.keys.update_one(
-                {"id": key_id},
+                {"id": key_id, "user.id": user_id},
                 {"$set": {"permissions": new_permissions}},
                 session=mongo_session,
             )
             await pg_session.execute(
                 update(SQLAPIKey)
-                .where(SQLAPIKey.id == key_id)
+                .where(SQLAPIKey.id == key_id, SQLAPIKey.user_id == user_id)
                 .values(permissions=new_permissions),
             )
 

--- a/virtool/account/models.py
+++ b/virtool/account/models.py
@@ -96,7 +96,7 @@ class Account(User):
 class APIKey(BaseModel):
     """A user's API key."""
 
-    id: str
+    id: int
     created_at: datetime
     groups: list[GroupMinimal]
     name: str
@@ -107,7 +107,7 @@ class APIKey(BaseModel):
             "example": {
                 "created_at": "2015-10-06T20:00:00Z",
                 "groups": [],
-                "id": "foobar_0",
+                "id": 42,
                 "name": "Foobar",
                 "permissions": {
                     "cancel_job": False,

--- a/virtool/account/oas.py
+++ b/virtool/account/oas.py
@@ -94,7 +94,7 @@ class CreateAPIKeyResponse(APIKey):
             "example": {
                 "created_at": "2015-10-06T20:00:00Z",
                 "groups": [],
-                "id": "foobar_0",
+                "id": 42,
                 "key": "raw_key",
                 "name": "Foobar",
                 "permissions": {


### PR DESCRIPTION
## Summary

- Adds a `SQLAPIKey` PostgreSQL model and an Alembic migration to create the `api_keys` table, with a foreign key cascade to `users`
- All API key create, update, and delete operations now write to both MongoDB and PostgreSQL atomically, using the PostgreSQL integer primary key as the canonical `id` (replacing the old slug-style string id)
- Adds a virtool migration revision to backfill existing MongoDB keys into PostgreSQL, and a separate revision to normalize `reference.imported_from` to a plain `{"id": <int>}` shape