### PR TITLE
fix: backfill nested user ids in status and references

### DIFF
--- a/assets/revisions/rev_6k51od8ta28a_backfill_nested_user_ids_in_status_and_references.py
+++ b/assets/revisions/rev_6k51od8ta28a_backfill_nested_user_ids_in_status_and_references.py
@@ -1,0 +1,157 @@
+"""Backfill nested MongoDB user.id fields to integers.
+
+The earlier ``ie7r3vdaf5mu`` backfill only rewrote top-level ``user.id`` fields.
+It missed the nested ``user`` subdocuments written by
+``create_update_subdocument``: ``installed.user.id`` and every
+``updates[].user.id`` in the ``status`` collection's ``hmm`` document and in
+``references`` documents. Those still hold legacy string user ids, which crash
+the user transform.
+
+This rewrites those nested legacy string user ids to the matching
+``SQLUser.id`` integer.
+
+Idempotent: integer ids are passed through unchanged, so a second run is a
+no-op.
+
+Revision ID: 6k51od8ta28a
+Date: 2026-06-01 18:26:22.669463
+
+"""
+
+from typing import TYPE_CHECKING
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill nested user ids in status and references"
+created_at = arrow.get("2026-06-01 18:26:22.669463")
+revision_id = "6k51od8ta28a"
+
+alembic_down_revision = None
+virtool_down_revision = "31su1xw351h2"
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        user_result = await pg_session.execute(
+            text("SELECT id, legacy_id FROM users WHERE legacy_id IS NOT NULL"),
+        )
+        user_map: dict[str, int] = {row.legacy_id: row.id for row in user_result}
+
+    logger.info("built user id map", users=len(user_map))
+
+    await _backfill_nested_user_ids(ctx.mongo, "status", user_map)
+    await _backfill_nested_user_ids(ctx.mongo, "references", user_map)
+
+
+def _coerce_user_id(value: int | str, user_map: dict[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+
+    if value not in user_map:
+        msg = f"User legacy id {value!r} not found in postgres"
+        raise ValueError(msg)
+
+    return user_map[value]
+
+
+def _coerce_nested_user_id(
+    user: dict | None,
+    user_map: dict[str, int],
+) -> tuple[dict | None, bool]:
+    """Coerce ``user.id`` on a single subdocument's ``user`` field.
+
+    Returns the (possibly rewritten) ``user`` value and whether it changed.
+    """
+    if not user or "id" not in user:
+        return user, False
+
+    current = user["id"]
+    new = _coerce_user_id(current, user_map)
+
+    if isinstance(current, int) and new == current:
+        return user, False
+
+    return {**user, "id": new}, True
+
+
+async def _backfill_nested_user_ids(
+    mongo: "AsyncIOMotorDatabase",
+    collection_name: str,
+    user_map: dict[str, int],
+) -> None:
+    collection = mongo[collection_name]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find(
+        {},
+        projection={"installed": 1, "updates": 1},
+    ):
+        installed = doc.get("installed")
+        updates = doc.get("updates")
+
+        has_installed_user = bool(installed and "user" in installed)
+        has_updates = bool(updates)
+
+        if not has_installed_user and not has_updates:
+            skipped += 1
+            continue
+
+        update: dict = {}
+
+        if has_installed_user:
+            new_user, changed = _coerce_nested_user_id(installed["user"], user_map)
+            if changed:
+                update["installed.user"] = new_user
+
+        if has_updates:
+            new_updates = []
+            updates_changed = False
+
+            for entry in updates:
+                new_user, changed = _coerce_nested_user_id(
+                    entry.get("user"),
+                    user_map,
+                )
+                if changed:
+                    updates_changed = True
+                    new_updates.append({**entry, "user": new_user})
+                else:
+                    new_updates.append(entry)
+
+            if updates_changed:
+                update["updates"] = new_updates
+
+        if not update:
+            unchanged += 1
+            continue
+
+        await collection.update_one({"_id": doc["_id"]}, {"$set": update})
+        migrated += 1
+
+    logger.info(
+        "backfilled nested user.id",
+        collection=collection_name,
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )

--- a/assets/revisions/rev_6k51od8ta28a_backfill_nested_user_ids_in_status_and_references.py
+++ b/assets/revisions/rev_6k51od8ta28a_backfill_nested_user_ids_in_status_and_references.py
@@ -61,14 +61,14 @@ def _coerce_user_id(value: int | str, user_map: dict[str, int]) -> int:
     if isinstance(value, int):
         return value
 
+    if value in user_map:
+        return user_map[value]
+
     if isinstance(value, str) and value.isdigit():
         return int(value)
 
-    if value not in user_map:
-        msg = f"User legacy id {value!r} not found in postgres"
-        raise ValueError(msg)
-
-    return user_map[value]
+    msg = f"User legacy id {value!r} not found in postgres"
+    raise ValueError(msg)
 
 
 def _coerce_nested_user_id(

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -274,5 +274,12 @@
       'name': 'copy api keys to postgres',
       'revision': '31su1xw351h2',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 40,
+      'name': 'backfill nested user ids in status and references',
+      'revision': '6k51od8ta28a',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_nested_user_ids_in_status_and_references.py
+++ b/tests/migration/test_backfill_nested_user_ids_in_status_and_references.py
@@ -1,0 +1,213 @@
+"""Tests for the backfill-nested-user-ids migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_6k51od8ta28a_backfill_nested_user_ids_in_status_and_references import (  # noqa: E501
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_users(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed two users with legacy ids.
+
+    Returns a mapping of legacy id -> Postgres id.
+    """
+    await asyncio.to_thread(apply_alembic, "head")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES
+                    ('alice', 'alice_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb),
+                    ('bob', 'bob_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return user_ids
+
+
+class TestStatusHMM:
+    """Nested ``user.id`` rewrites for the ``status`` collection's ``hmm`` doc."""
+
+    async def test_installed_and_updates_convert(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+    ):
+        alice = setup_users["alice_legacy"]
+        bob = setup_users["bob_legacy"]
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "installed": {"id": 0, "user": {"id": "alice_legacy"}},
+                "updates": [
+                    {"id": 0, "ready": True, "user": {"id": "alice_legacy"}},
+                    {"id": 1, "ready": False, "user": {"id": "bob_legacy"}},
+                ],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.status.find_one({"_id": "hmm"})
+        assert doc["installed"]["user"]["id"] == alice
+        assert isinstance(doc["installed"]["user"]["id"], int)
+        assert [u["user"]["id"] for u in doc["updates"]] == [alice, bob]
+        assert doc["updates"][0]["ready"] is True
+        assert doc["updates"][1]["ready"] is False
+
+    async def test_already_int_unchanged(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+    ):
+        alice = setup_users["alice_legacy"]
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "installed": {"id": 0, "user": {"id": alice}},
+                "updates": [{"id": 0, "user": {"id": alice}}],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.status.find_one({"_id": "hmm"})
+        assert doc["installed"]["user"]["id"] == alice
+        assert doc["updates"][0]["user"]["id"] == alice
+
+    async def test_digit_string_coerces(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+    ):
+        alice = setup_users["alice_legacy"]
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "installed": {"id": 0, "user": {"id": str(alice)}},
+                "updates": [],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.status.find_one({"_id": "hmm"})
+        assert doc["installed"]["user"]["id"] == alice
+
+    @pytest.mark.usefixtures("setup_users")
+    async def test_null_installed_is_skipped(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.status.insert_one(
+            {"_id": "hmm", "installed": None, "updates": []},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.status.find_one({"_id": "hmm"})
+        assert doc["installed"] is None
+
+    @pytest.mark.usefixtures("setup_users")
+    async def test_unrelated_status_doc_is_skipped(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.status.insert_one({"_id": "software", "version": "1.0.0"})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.status.find_one({"_id": "software"})
+        assert doc == {"_id": "software", "version": "1.0.0"}
+
+    @pytest.mark.usefixtures("setup_users")
+    async def test_unmapped_legacy_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "installed": {"id": 0, "user": {"id": "ghost_user"}},
+                "updates": [],
+            },
+        )
+
+        with pytest.raises(ValueError, match="ghost_user"):
+            await upgrade(ctx)
+
+
+class TestReferences:
+    """Nested ``user.id`` rewrites for ``references`` ``installed``/``updates``."""
+
+    async def test_installed_and_updates_convert(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+    ):
+        alice = setup_users["alice_legacy"]
+        bob = setup_users["bob_legacy"]
+
+        await ctx.mongo.references.insert_one(
+            {
+                "_id": "ref1",
+                "installed": {"id": 0, "user": {"id": "alice_legacy"}},
+                "updates": [
+                    {"id": 0, "user": {"id": "alice_legacy"}},
+                    {"id": 1, "user": {"id": "bob_legacy"}},
+                ],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.references.find_one({"_id": "ref1"})
+        assert doc["installed"]["user"]["id"] == alice
+        assert [u["user"]["id"] for u in doc["updates"]] == [alice, bob]
+
+    async def test_already_int_unchanged(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+    ):
+        alice = setup_users["alice_legacy"]
+
+        await ctx.mongo.references.insert_one(
+            {
+                "_id": "ref2",
+                "installed": {"id": 0, "user": {"id": alice}},
+                "updates": [{"id": 0, "user": {"id": alice}}],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.references.find_one({"_id": "ref2"})
+        assert doc["installed"]["user"]["id"] == alice
+        assert doc["updates"][0]["user"]["id"] == alice

--- a/tests/migration/test_backfill_nested_user_ids_in_status_and_references.py
+++ b/tests/migration/test_backfill_nested_user_ids_in_status_and_references.py
@@ -120,6 +120,44 @@ class TestStatusHMM:
         doc = await ctx.mongo.status.find_one({"_id": "hmm"})
         assert doc["installed"]["user"]["id"] == alice
 
+    async def test_numeric_legacy_id_maps_via_user_map(
+        self,
+        ctx: MigrationContext,
+        setup_users: dict[str, int],
+    ):
+        """A numeric legacy id must resolve via the map, not raw int coercion."""
+        async with AsyncSession(ctx.pg) as session:
+            result = await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES
+                        ('carol', '123', true, '',
+                         false, false, :now, :pw, '{}'::jsonb)
+                    RETURNING id, legacy_id
+                """),
+                {"now": arrow.utcnow().naive, "pw": b"hashed"},
+            )
+            carol = result.first().id
+            await session.commit()
+
+        assert carol != 123
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "installed": {"id": 0, "user": {"id": "123"}},
+                "updates": [],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.status.find_one({"_id": "hmm"})
+        assert doc["installed"]["user"]["id"] == carol
+
     @pytest.mark.usefixtures("setup_users")
     async def test_null_installed_is_skipped(
         self,


### PR DESCRIPTION
## Summary

- The earlier `ie7r3vdaf5mu` migration only rewrote top-level `user.id` fields but missed the nested `user` subdocuments written by `create_update_subdocument` — specifically `installed.user.id` and `updates[].user.id` in the `status` and `references` collections.
- This adds a new migration (`6k51od8ta28a`) that backfills those nested legacy string user ids to the matching Postgres integer ids, fixing the `TypeError` that occurred when the user transform encountered a string id.
- The migration is idempotent: integer ids are passed through unchanged, and digit-string ids are coerced to integers directly without a map lookup.