### PR TITLE
feat: switch api key reads to postgres

### DIFF
--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -221,7 +221,7 @@
 # ---
 # name: TestUpdateAPIKey.test[False-False].1
   dict({
-    '_id': '17a3cc5485915ee9f386efcc4003d20d48c4a082b5b035cb8b94391f66700306',
+    '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
       1,
@@ -263,7 +263,7 @@
 # ---
 # name: TestUpdateAPIKey.test[False-True].1
   dict({
-    '_id': '8f7a70142479ca39a936d05af9033e15c86d90a9daa0858b0b777c9fa7d45820',
+    '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
       1,
@@ -305,7 +305,7 @@
 # ---
 # name: TestUpdateAPIKey.test[True-False].1
   dict({
-    '_id': '50f9d62c42e3e08cdd09b3e962c7ee5c785a7bcc43d5c0e0f6d0fb319858dd7d',
+    '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
       1,
@@ -347,7 +347,7 @@
 # ---
 # name: TestUpdateAPIKey.test[True-True].1
   dict({
-    '_id': '6f574a92502f7a0baf72e75a41ab84c69609f0f8d5afbecdb84c1f0bcbc69533',
+    '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
       1,
@@ -389,7 +389,7 @@
 # ---
 # name: TestUpdateAPIKey.test[missing-False].1
   dict({
-    '_id': 'a5ca55ab10f765a9626bb6316d5ebd4468c97e5b32ef56c11f271d0d71626010',
+    '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
       1,
@@ -429,7 +429,7 @@
 # ---
 # name: TestUpdateAPIKey.test[missing-True].1
   dict({
-    '_id': '2e056168a9728b8601f05a695869d78f819f3177fd5c0f66e499ba088cbe6317',
+    '_id': 'baz',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
       1,

--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -199,6 +199,11 @@
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'musicians',
+      }),
     ]),
     'id': 1,
     'name': 'Foobar',
@@ -216,22 +221,16 @@
 # ---
 # name: TestUpdateAPIKey.test[False-False].1
   dict({
-    '_id': 'foobar',
-    'administrator': True,
+    '_id': '17a3cc5485915ee9f386efcc4003d20d48c4a082b5b035cb8b94391f66700306',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
+      1,
     ]),
     'id': 1,
     'name': 'Foobar',
     'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
       'create_sample': True,
-      'modify_hmm': False,
       'modify_subtraction': True,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
     }),
     'user': dict({
       'id': 1,
@@ -242,6 +241,11 @@
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'musicians',
+      }),
     ]),
     'id': 1,
     'name': 'Foobar',
@@ -259,22 +263,16 @@
 # ---
 # name: TestUpdateAPIKey.test[False-True].1
   dict({
-    '_id': 'foobar',
-    'administrator': True,
+    '_id': '8f7a70142479ca39a936d05af9033e15c86d90a9daa0858b0b777c9fa7d45820',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
+      1,
     ]),
     'id': 1,
     'name': 'Foobar',
     'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
       'create_sample': True,
-      'modify_hmm': False,
       'modify_subtraction': True,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
     }),
     'user': dict({
       'id': 1,
@@ -285,6 +283,11 @@
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'musicians',
+      }),
     ]),
     'id': 1,
     'name': 'Foobar',
@@ -302,22 +305,16 @@
 # ---
 # name: TestUpdateAPIKey.test[True-False].1
   dict({
-    '_id': 'foobar',
-    'administrator': True,
+    '_id': '50f9d62c42e3e08cdd09b3e962c7ee5c785a7bcc43d5c0e0f6d0fb319858dd7d',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
+      1,
     ]),
     'id': 1,
     'name': 'Foobar',
     'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
       'create_sample': True,
-      'modify_hmm': False,
       'modify_subtraction': True,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
     }),
     'user': dict({
       'id': 1,
@@ -328,6 +325,11 @@
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'musicians',
+      }),
     ]),
     'id': 1,
     'name': 'Foobar',
@@ -345,22 +347,16 @@
 # ---
 # name: TestUpdateAPIKey.test[True-True].1
   dict({
-    '_id': 'foobar',
-    'administrator': True,
+    '_id': '6f574a92502f7a0baf72e75a41ab84c69609f0f8d5afbecdb84c1f0bcbc69533',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
+      1,
     ]),
     'id': 1,
     'name': 'Foobar',
     'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
       'create_sample': True,
-      'modify_hmm': False,
       'modify_subtraction': True,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
     }),
     'user': dict({
       'id': 1,
@@ -371,6 +367,11 @@
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'musicians',
+      }),
     ]),
     'id': 1,
     'name': 'Foobar',
@@ -388,22 +389,14 @@
 # ---
 # name: TestUpdateAPIKey.test[missing-False].1
   dict({
-    '_id': 'foobar',
-    'administrator': True,
+    '_id': 'a5ca55ab10f765a9626bb6316d5ebd4468c97e5b32ef56c11f271d0d71626010',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
+      1,
     ]),
     'id': 1,
     'name': 'Foobar',
     'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
     }),
     'user': dict({
       'id': 1,
@@ -414,6 +407,11 @@
   dict({
     'created_at': '2015-10-06T20:00:00Z',
     'groups': list([
+      dict({
+        'id': 1,
+        'legacy_id': None,
+        'name': 'musicians',
+      }),
     ]),
     'id': 1,
     'name': 'Foobar',
@@ -431,22 +429,14 @@
 # ---
 # name: TestUpdateAPIKey.test[missing-True].1
   dict({
-    '_id': 'foobar',
-    'administrator': True,
+    '_id': '2e056168a9728b8601f05a695869d78f819f3177fd5c0f66e499ba088cbe6317',
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'groups': list([
+      1,
     ]),
     'id': 1,
     'name': 'Foobar',
     'permissions': dict({
-      'cancel_job': False,
-      'create_ref': False,
-      'create_sample': False,
-      'modify_hmm': False,
-      'modify_subtraction': False,
-      'remove_file': False,
-      'remove_job': False,
-      'upload_file': False,
     }),
     'user': dict({
       'id': 1,

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -666,6 +666,7 @@ class TestUpdateAPIKey:
         has_perm: bool,
         data_layer: DataLayer,
         fake: DataFaker,
+        mocker,
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
@@ -684,6 +685,8 @@ class TestUpdateAPIKey:
             client.user.id,
             UpdateUserRequest(administrator=has_admin, groups=[group.id]),
         )
+
+        mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
 
         _, api_key = await data_layer.account.create_key(
             CreateKeyRequest(name="Foobar", permissions=PermissionsUpdate()),

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -685,17 +685,9 @@ class TestUpdateAPIKey:
             UpdateUserRequest(administrator=has_admin, groups=[group.id]),
         )
 
-        await mongo.keys.insert_one(
-            {
-                "_id": "foobar",
-                "id": 1,
-                "name": "Foobar",
-                "created_at": static_time.datetime,
-                "administrator": True,
-                "user": {"id": client.user.id},
-                "groups": [],
-                "permissions": {p.value: False for p in Permission},
-            },
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Foobar", permissions=PermissionsUpdate()),
+            client.user.id,
         )
 
         data = {
@@ -709,7 +701,7 @@ class TestUpdateAPIKey:
             data = {}
 
         resp = await client.patch(
-            "/account/keys/1",
+            f"/account/keys/{api_key.id}",
             data,
         )
 
@@ -990,68 +982,68 @@ class TestLogout:
 class TestDelete:
     """Test API key deletion functionality."""
 
-    @pytest.mark.parametrize("error", [None, "404"])
     async def test_remove_single_key(
         self,
-        error: str | None,
+        data_layer: DataLayer,
         mongo: Mongo,
         spawn_client: ClientSpawner,
-        snapshot: SnapshotAssertion,
     ) -> None:
-        """Test deleting a single API key."""
+        """Deleting a single API key removes it from both stores."""
         client = await spawn_client(authenticated=True)
 
-        if error is None:
-            await mongo.keys.insert_one(
-                {
-                    "_id": "foobar",
-                    "id": 1,
-                    "name": "Foobar",
-                    "user": {"id": client.user.id},
-                },
-            )
+        _, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Foobar", permissions=PermissionsUpdate()),
+            client.user.id,
+        )
+
+        resp = await client.delete(f"/account/keys/{api_key.id}")
+
+        assert resp.status == 204
+        assert await mongo.keys.count_documents({}) == 0
+
+    async def test_remove_single_key_not_found(
+        self,
+        spawn_client: ClientSpawner,
+    ) -> None:
+        """Deleting a key that does not exist returns 404."""
+        client = await spawn_client(authenticated=True)
 
         resp = await client.delete("/account/keys/1")
 
-        if error is None:
-            assert resp.status == 204
-            assert await mongo.keys.count_documents({}) == 0
-
-        else:
-            assert resp.status == 404
-            assert await resp.json() == {"id": "not_found", "message": "Not found"}
+        assert resp.status == 404
+        assert await resp.json() == {"id": "not_found", "message": "Not found"}
 
     async def test_remove_all_keys(
         self,
+        data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
         spawn_client: ClientSpawner,
     ) -> None:
-        """Test deleting all API keys for a user."""
+        """Deleting all keys removes only the requesting user's keys."""
         client = await spawn_client(authenticated=True)
 
-        user = await fake.users.create()
+        other = await fake.users.create()
 
-        await mongo.keys.insert_many(
-            [
-                {
-                    "_id": "hello_world",
-                    "id": 1,
-                    "user": {"id": client.user.id},
-                },
-                {"_id": "foobar", "id": 2, "user": {"id": client.user.id}},
-                {"_id": "baz", "id": 3, "user": {"id": user.id}},
-            ],
-            session=None,
+        await data_layer.account.create_key(
+            CreateKeyRequest(name="Owned One", permissions=PermissionsUpdate()),
+            client.user.id,
+        )
+        await data_layer.account.create_key(
+            CreateKeyRequest(name="Owned Two", permissions=PermissionsUpdate()),
+            client.user.id,
+        )
+        _, other_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Other", permissions=PermissionsUpdate()),
+            other.id,
         )
 
         resp = await client.delete("/account/keys")
 
         assert resp.status == 204
 
-        assert await mongo.keys.find().to_list(None) == [
-            {"_id": "baz", "id": 3, "user": {"id": user.id}},
-        ]
+        remaining = await mongo.keys.find().to_list(None)
+        assert [document["id"] for document in remaining] == [other_key.id]
 
     async def test_cannot_delete_other_users_key(
         self,

--- a/tests/account/test_data.py
+++ b/tests/account/test_data.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -11,7 +11,7 @@ from virtool.fake.next import DataFaker
 from virtool.groups.oas import PermissionsUpdate
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
-from virtool.utils import hash_key
+from virtool.users.pg import SQLUser
 
 
 async def get_sql_keys(pg: AsyncEngine) -> list[dict]:
@@ -341,34 +341,54 @@ class TestDeleteKeys:
 
 
 class TestGetKeyBySecret:
-    async def test_ok(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mongo: Mongo,
-    ):
+    async def test_ok(self, data_layer: DataLayer, fake: DataFaker):
         """``get_key_by_secret`` resolves a key by its raw secret value."""
         user = await fake.users.create()
 
-        raw_key = "test_secret_key"
-        hashed_key = hash_key(raw_key)
-
-        await mongo.keys.insert_one(
-            {
-                "_id": hashed_key,
-                "id": 1,
-                "name": "Test Key",
-                "created_at": "2023-01-01T00:00:00.000000Z",
-                "permissions": {"create_sample": True},
-                "user": {"id": user.id},
-                "groups": [],
-            },
+        raw_key, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(
+                name="Test Key",
+                permissions=PermissionsUpdate(create_sample=True),
+            ),
+            user.id,
         )
 
         result = await data_layer.account.get_key_by_secret(user.id, raw_key)
 
-        assert result.id == 1
+        assert result.id == api_key.id
         assert result.name == "Test Key"
+
+    async def test_legacy_user_id(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """``get_key_by_secret`` resolves a key for a user that carries a
+        ``legacy_id``.
+
+        The ``api_keys`` foreign key is on the integer ``user_id``, so the
+        lookup must not depend on the user's legacy string id. This guards
+        against re-introducing the dropped Mongo/PG user-id translation path.
+        """
+        user = await fake.users.create()
+
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                update(SQLUser)
+                .where(SQLUser.id == user.id)
+                .values(legacy_id="legacy_owner"),
+            )
+            await session.commit()
+
+        raw_key, api_key = await data_layer.account.create_key(
+            CreateKeyRequest(name="Test Key", permissions=PermissionsUpdate()),
+            user.id,
+        )
+
+        result = await data_layer.account.get_key_by_secret(user.id, raw_key)
+
+        assert result.id == api_key.id
 
     async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
         """``get_key_by_secret`` raises ``ResourceNotFoundError`` for an unknown key."""

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -19,14 +19,11 @@ from virtool.administrators.oas import UpdateUserRequest
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceError, ResourceNotFoundError
 from virtool.data.topg import both_transactions
-from virtool.data.transforms import apply_transforms
-from virtool.groups.transforms import AttachGroupsTransform
 from virtool.models.sessions import Session
 from virtool.mongo.core import Mongo
-from virtool.mongo.utils import get_one_field
 from virtool.users.pg import SQLUser
 from virtool.users.utils import limit_permissions
-from virtool.utils import base_processor, hash_key
+from virtool.utils import hash_key
 
 logger = get_logger(layer="data", domain="account")
 
@@ -194,21 +191,25 @@ class AccountData(DataLayerDomain):
         :param user_id: the user ID
         :return: the api keys
         """
-        keys = await apply_transforms(
-            [
-                base_processor(key)
-                async for key in self._mongo.keys.find(
-                    {"user.id": user_id},
-                    {"_id": False, "user": False},
-                )
-            ],
-            [
-                AttachGroupsTransform(self._pg),
-            ],
-            self._pg,
-        )
+        user = await self.data.users.get(user_id)
+        groups = sorted(user.groups, key=lambda group: group.name)
 
-        return [APIKey.parse_obj(key) for key in keys]
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLAPIKey).where(SQLAPIKey.user_id == user_id),
+            )
+            keys = result.scalars().all()
+
+        return [
+            APIKey(
+                id=key.id,
+                created_at=key.created_at,
+                groups=groups,
+                name=key.name,
+                permissions=key.permissions,
+            )
+            for key in keys
+        ]
 
     async def get_key(self, user_id: int, key_id: int) -> APIKey:
         """Get the complete representation of the API key identified by the `key_id`.
@@ -220,40 +221,34 @@ class AccountData(DataLayerDomain):
         :param key_id: the ID of the API key to get
         :return: the API key
         """
-        document = await self._mongo.keys.find_one(
-            {"id": key_id, "user.id": user_id},
-            {
-                "_id": False,
-                "user": False,
-            },
-        )
-
         user = await self.data.users.get(user_id)
 
-        if not document:
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLAPIKey).where(
+                    SQLAPIKey.id == key_id,
+                    SQLAPIKey.user_id == user_id,
+                ),
+            )
+            key = result.scalar_one_or_none()
+
+        if key is None:
             raise ResourceNotFoundError
 
-        document = await apply_transforms(
-            base_processor(document),
-            [
-                AttachGroupsTransform(self._pg),
-            ],
-            self._pg,
-        )
-
         if user.administrator_role:
-            document["permissions"] = document["permissions"]
+            permissions = key.permissions
         else:
-            document["permissions"] = limit_permissions(
-                document["permissions"],
+            permissions = limit_permissions(
+                key.permissions,
                 user.permissions.dict(),
             )
 
         return APIKey(
-            **{
-                **document,
-                "groups": sorted(document["groups"], key=lambda g: g["name"]),
-            },
+            id=key.id,
+            created_at=key.created_at,
+            groups=sorted(user.groups, key=lambda group: group.name),
+            name=key.name,
+            permissions=permissions,
         )
 
     async def get_key_by_secret(self, user_id: int, key: str) -> APIKey:
@@ -265,26 +260,27 @@ class AccountData(DataLayerDomain):
         :param key: the raw API key
         :return: the API key
         """
-        document = await self._mongo.keys.find_one(
-            {"_id": hash_key(key), "user.id": user_id},
-            {
-                "_id": False,
-                "user": False,
-            },
-        )
+        user = await self.data.users.get(user_id)
 
-        if not document:
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLAPIKey).where(
+                    SQLAPIKey.user_id == user_id,
+                    SQLAPIKey.hashed == hash_key(key),
+                ),
+            )
+            api_key = result.scalar_one_or_none()
+
+        if api_key is None:
             raise ResourceNotFoundError
 
-        document = await apply_transforms(
-            base_processor(document),
-            [
-                AttachGroupsTransform(self._pg),
-            ],
-            self._pg,
+        return APIKey(
+            id=api_key.id,
+            created_at=api_key.created_at,
+            groups=sorted(user.groups, key=lambda group: group.name),
+            name=api_key.name,
+            permissions=api_key.permissions,
         )
-
-        return APIKey(**document)
 
     async def create_key(
         self,
@@ -371,11 +367,14 @@ class AccountData(DataLayerDomain):
         else:
             permissions_update = data.permissions.dict(exclude_unset=True)
 
-        existing_permissions = await get_one_field(
-            self._mongo.keys,
-            "permissions",
-            {"id": key_id, "user.id": user_id},
-        )
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLAPIKey.permissions).where(
+                    SQLAPIKey.id == key_id,
+                    SQLAPIKey.user_id == user_id,
+                ),
+            )
+            existing_permissions = result.scalar_one_or_none()
 
         if existing_permissions is None:
             raise ResourceNotFoundError


### PR DESCRIPTION
## Summary

- Migrates all API key read operations (`list_keys`, `get_key`, `get_key_by_secret`, `update_key`) from MongoDB to PostgreSQL, completing the dual-write migration started in the previous commit.
- Groups are now fetched via the user's PostgreSQL record rather than being assembled from MongoDB key documents.
- Tests are updated to create keys through the data layer instead of inserting directly into MongoDB, and the delete tests are split into clearer, non-parametrized cases.