### PR TITLE
fix(migration): re-backfill user ids to prevent TypeError on string user fields

### DIFF
--- a/assets/revisions/rev_nmqvw9wu298b_rebackfill_user_ids_to_integers.py
+++ b/assets/revisions/rev_nmqvw9wu298b_rebackfill_user_ids_to_integers.py
@@ -1,0 +1,240 @@
+"""Re-backfill MongoDB user and group ids to integers.
+
+A repeat of the ``ie7r3vdaf5mu`` backfill. That revision was recorded as applied
+on environments where the Mongo data was never actually rewritten (it was skipped
+by the old position-based apply logic), leaving legacy string ``user.id`` values
+in collections like ``subtractions`` that crash the user transform.
+
+Because ``ie7r3vdaf5mu`` is already recorded as applied, it cannot be re-run under
+its own id. This new revision re-runs the same backfill so those environments
+converge.
+
+Rewrites legacy string user ids to the matching ``SQLUser.id`` integer in every
+Mongo collection that carries a denormalized top-level ``user.id``, the
+``references`` ``users`` array, and the legacy group id strings in the ``groups``
+array of the ``users`` collection.
+
+Idempotent: integer ids are passed through unchanged, so this is a no-op on
+environments that were already backfilled.
+
+Revision ID: nmqvw9wu298b
+Date: 2026-06-01 19:33:57.580352
+
+"""
+
+from typing import TYPE_CHECKING
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "re-backfill user ids to integers"
+created_at = arrow.get("2026-06-01 19:33:57.580352")
+revision_id = "nmqvw9wu298b"
+
+alembic_down_revision = None
+virtool_down_revision = "6k51od8ta28a"
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+SIMPLE_USER_COLLECTIONS = (
+    "keys",
+    "samples",
+    "subtractions",
+    "analyses",
+    "otus",
+    "history",
+    "indexes",
+)
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        user_result = await pg_session.execute(
+            text("SELECT id, legacy_id FROM users WHERE legacy_id IS NOT NULL"),
+        )
+        user_map: dict[str, int] = {row.legacy_id: row.id for row in user_result}
+
+        group_result = await pg_session.execute(
+            text("SELECT id, legacy_id FROM groups WHERE legacy_id IS NOT NULL"),
+        )
+        group_map: dict[str, int] = {row.legacy_id: row.id for row in group_result}
+
+    logger.info(
+        "built id maps",
+        users=len(user_map),
+        groups=len(group_map),
+    )
+
+    for collection_name in SIMPLE_USER_COLLECTIONS:
+        await _backfill_user_field(ctx.mongo, collection_name, user_map)
+
+    await _backfill_references(ctx.mongo, user_map)
+    await _backfill_users_groups(ctx.mongo, group_map)
+
+
+def _coerce_id(value: int | str, id_map: dict[str, int], resource_name: str) -> int:
+    if isinstance(value, int):
+        return value
+
+    if value in id_map:
+        return id_map[value]
+
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+
+    msg = f"{resource_name} legacy id {value!r} not found in postgres"
+    raise ValueError(msg)
+
+
+def _coerce_user_id(value: int | str, user_map: dict[str, int]) -> int:
+    return _coerce_id(value, user_map, "User")
+
+
+def _coerce_group_id(value: int | str, group_map: dict[str, int]) -> int:
+    return _coerce_id(value, group_map, "Group")
+
+
+async def _backfill_user_field(
+    mongo: "AsyncIOMotorDatabase",
+    collection_name: str,
+    user_map: dict[str, int],
+) -> None:
+    collection = mongo[collection_name]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find({}, projection={"user": 1}):
+        user = doc.get("user")
+        if not user or "id" not in user:
+            skipped += 1
+            continue
+
+        current = user["id"]
+        new = _coerce_user_id(current, user_map)
+
+        if new == current and isinstance(current, int):
+            unchanged += 1
+            continue
+
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"user.id": new}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled user.id",
+        collection=collection_name,
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )
+
+
+async def _backfill_references(
+    mongo: "AsyncIOMotorDatabase",
+    user_map: dict[str, int],
+) -> None:
+    collection = mongo["references"]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find({}, projection={"user": 1, "users": 1}):
+        update: dict = {}
+
+        user = doc.get("user")
+        users_list = doc.get("users")
+
+        if not (user and "id" in user) and users_list is None:
+            skipped += 1
+            continue
+
+        if user and "id" in user:
+            current = user["id"]
+            new = _coerce_user_id(current, user_map)
+            if not (isinstance(current, int) and new == current):
+                update["user.id"] = new
+
+        users = users_list or []
+        new_users = []
+        users_changed = False
+
+        for entry in users:
+            if "id" not in entry:
+                new_users.append(entry)
+                continue
+            current = entry["id"]
+            new = _coerce_user_id(current, user_map)
+            if not (isinstance(current, int) and new == current):
+                users_changed = True
+            new_entry = {**entry, "id": new}
+            new_users.append(new_entry)
+
+        if users_changed:
+            update["users"] = new_users
+
+        if not update:
+            unchanged += 1
+            continue
+
+        await collection.update_one({"_id": doc["_id"]}, {"$set": update})
+        migrated += 1
+
+    logger.info(
+        "backfilled references",
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )
+
+
+async def _backfill_users_groups(
+    mongo: "AsyncIOMotorDatabase",
+    group_map: dict[str, int],
+) -> None:
+    collection = mongo["users"]
+
+    migrated = 0
+    unchanged = 0
+    skipped = 0
+
+    async for doc in collection.find({}, projection={"groups": 1}):
+        groups = doc.get("groups")
+        if groups is None:
+            skipped += 1
+            continue
+
+        new_groups = [_coerce_group_id(g, group_map) for g in groups]
+
+        if new_groups == groups and all(isinstance(g, int) for g in groups):
+            unchanged += 1
+            continue
+
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"groups": new_groups}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled users.groups",
+        migrated=migrated,
+        unchanged=unchanged,
+        skipped=skipped,
+    )

--- a/assets/revisions/rev_nmqvw9wu298b_rebackfill_user_ids_to_integers.py
+++ b/assets/revisions/rev_nmqvw9wu298b_rebackfill_user_ids_to_integers.py
@@ -91,9 +91,6 @@ def _coerce_id(value: int | str, id_map: dict[str, int], resource_name: str) -> 
     if value in id_map:
         return id_map[value]
 
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-
     msg = f"{resource_name} legacy id {value!r} not found in postgres"
     raise ValueError(msg)
 
@@ -117,7 +114,10 @@ async def _backfill_user_field(
     unchanged = 0
     skipped = 0
 
-    async for doc in collection.find({}, projection={"user": 1}):
+    async for doc in collection.find(
+        {"user.id": {"$type": "string"}},
+        projection={"user": 1},
+    ):
         user = doc.get("user")
         if not user or "id" not in user:
             skipped += 1
@@ -155,7 +155,10 @@ async def _backfill_references(
     unchanged = 0
     skipped = 0
 
-    async for doc in collection.find({}, projection={"user": 1, "users": 1}):
+    async for doc in collection.find(
+        {"$or": [{"user.id": {"$type": "string"}}, {"users.id": {"$type": "string"}}]},
+        projection={"user": 1, "users": 1},
+    ):
         update: dict = {}
 
         user = doc.get("user")
@@ -214,7 +217,10 @@ async def _backfill_users_groups(
     unchanged = 0
     skipped = 0
 
-    async for doc in collection.find({}, projection={"groups": 1}):
+    async for doc in collection.find(
+        {"groups": {"$type": "string"}},
+        projection={"groups": 1},
+    ):
         groups = doc.get("groups")
         if groups is None:
             skipped += 1

--- a/scripts/check_legacy_user_ids.py
+++ b/scripts/check_legacy_user_ids.py
@@ -1,0 +1,115 @@
+"""Report legacy (string) user ids still present in Mongo collections.
+
+Run inside a Virtool container (reads VT_MONGODB_CONNECTION_STRING):
+
+    python scripts/check_legacy_user_ids.py
+
+Read-only: it only counts and samples; it never writes. Buckets the BSON type
+of every denormalized ``user.id`` (and the nested ``installed`` user ids in
+``status``/``references``) so you can see which collections still hold legacy
+string ids that crash the user transform.
+"""
+
+import os
+
+from pymongo import MongoClient
+from pymongo.uri_parser import parse_uri
+
+SIMPLE_USER_COLLECTIONS = (
+    "keys",
+    "samples",
+    "subtractions",
+    "analyses",
+    "otus",
+    "history",
+    "indexes",
+)
+
+SAMPLE_LIMIT = 10
+
+
+def _type_counts(collection, id_path: str, match: dict) -> list[dict]:
+    """Group a field by BSON type, with a sample of string values."""
+    return list(
+        collection.aggregate(
+            [
+                {"$match": match},
+                {
+                    "$group": {
+                        "_id": {"$type": f"${id_path}"},
+                        "count": {"$sum": 1},
+                        "samples": {"$addToSet": f"${id_path}"},
+                    },
+                },
+                {"$sort": {"count": -1}},
+            ],
+        ),
+    )
+
+
+def _report(name: str, rows: list[dict]) -> None:
+    if not rows:
+        print(f"  {name}: (no documents carry this field)")
+        return
+
+    for row in rows:
+        bson_type = row["_id"]
+        line = f"  {name}: type={bson_type:<10} count={row['count']}"
+        if bson_type == "string":
+            sample = sorted(str(s) for s in row["samples"])[:SAMPLE_LIMIT]
+            line += f"  legacy ids (sample): {sample}"
+        print(line)
+
+
+def main() -> None:
+    connection_string = os.environ["VT_MONGODB_CONNECTION_STRING"]
+    db_name = parse_uri(connection_string)["database"]
+
+    client = MongoClient(connection_string, serverSelectionTimeoutMS=6000)
+    db = client[db_name]
+
+    print(f"Database: {db_name}\n")
+
+    print("Top-level `user` field shape by type:")
+    for collection_name in SIMPLE_USER_COLLECTIONS:
+        _report(
+            collection_name,
+            _type_counts(db[collection_name], "user", {"user": {"$exists": True}}),
+        )
+
+    print("\nTop-level user.id by type (where `user` is an object):")
+    for collection_name in SIMPLE_USER_COLLECTIONS:
+        _report(
+            collection_name,
+            _type_counts(db[collection_name], "user.id", {"user": {"$type": "object"}}),
+        )
+
+    print("\nreferences user.id / installed.user.id by type:")
+    _report(
+        "references.user.id",
+        _type_counts(db.references, "user.id", {"user": {"$type": "object"}}),
+    )
+    _report(
+        "references.installed.user.id",
+        _type_counts(
+            db.references,
+            "installed.user.id",
+            {"installed": {"$type": "object"}},
+        ),
+    )
+
+    print("\nstatus (hmm) nested user.id by type:")
+    _report(
+        "status.installed.user.id",
+        _type_counts(
+            db.status,
+            "installed.user.id",
+            {"installed": {"$type": "object"}},
+        ),
+    )
+
+    print("\nDone. Any 'type=string' rows above are unmigrated legacy user ids.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -281,5 +281,12 @@
       'name': 'backfill nested user ids in status and references',
       'revision': '6k51od8ta28a',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 41,
+      'name': 're-backfill user ids to integers',
+      'revision': 'nmqvw9wu298b',
+    }),
   ])
 # ---

--- a/tests/migration/test_apply.py
+++ b/tests/migration/test_apply.py
@@ -76,3 +76,37 @@ async def test_apply_revisions_with_missing_last_applied(
     # All real revisions should be present.
     for revision in all_revisions:
         assert any(r.revision == revision.id for r in applied)
+
+
+async def test_apply_fills_in_missed_earlier_revision(
+    migration_config: MigrationConfig,
+    migration_pg: AsyncEngine,
+):
+    """A revision missing from the table is applied even when a later revision is
+    already recorded.
+
+    Recording only the head revision simulates a history where revisions were
+    applied out of order: every earlier revision is unrecorded. The position-based
+    scan used to skip all of them because they sort before the recorded head; now
+    each unrecorded revision is filled in.
+    """
+    all_revisions = load_all_revisions()
+    head = all_revisions[-1]
+
+    async with AsyncSession(migration_pg) as session:
+        session.add(
+            SQLRevision(
+                applied_at=arrow.utcnow().naive,
+                created_at=head.created_at,
+                name=head.name,
+                revision=head.id,
+            ),
+        )
+        await session.commit()
+
+    await apply(migration_config)
+
+    applied_ids = {r.revision for r in await list_applied_revisions(migration_pg)}
+
+    for revision in all_revisions:
+        assert revision.id in applied_ids

--- a/tests/migration/test_re_backfill_user_ids_to_integers.py
+++ b/tests/migration/test_re_backfill_user_ids_to_integers.py
@@ -1,0 +1,179 @@
+"""Tests for the re-backfill-user-ids-to-integers migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_nmqvw9wu298b_rebackfill_user_ids_to_integers import upgrade
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_users_and_groups(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed two users + two groups with legacy ids."""
+    await asyncio.to_thread(apply_alembic, "head")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES
+                    ('alice', 'alice_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb),
+                    ('bob', 'bob_legacy', true, '',
+                     false, false, :now, :pw, '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive, "pw": b"hashed"},
+        )
+        user_ids = {row.legacy_id: row.id for row in result}
+
+        result = await session.execute(
+            text("""
+                INSERT INTO groups (legacy_id, name, permissions)
+                VALUES
+                    ('admins_legacy', 'admins', '{}'::jsonb),
+                    ('readers_legacy', 'readers', '{}'::jsonb)
+                RETURNING id, legacy_id
+            """),
+        )
+        group_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return {**user_ids, **group_ids}
+
+
+class TestSimpleCollections:
+    @pytest.mark.parametrize(
+        "collection_name",
+        ["keys", "samples", "subtractions", "analyses", "otus", "history", "indexes"],
+    )
+    async def test_legacy_string_converts(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+        collection_name: str,
+    ):
+        await ctx.mongo[collection_name].insert_one(
+            {"_id": "doc1", "user": {"id": "alice_legacy"}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo[collection_name].find_one({"_id": "doc1"})
+        assert doc["user"]["id"] == setup_users_and_groups["alice_legacy"]
+        assert isinstance(doc["user"]["id"], int)
+
+    async def test_already_int_passthrough(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        pg_id = setup_users_and_groups["bob_legacy"]
+        await ctx.mongo.subtractions.insert_one({"_id": "s1", "user": {"id": pg_id}})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.subtractions.find_one({"_id": "s1"})
+        assert doc["user"]["id"] == pg_id
+
+    async def test_numeric_legacy_id_maps_via_user_map(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        """A numeric legacy id resolves via the map, not raw int coercion."""
+        async with AsyncSession(ctx.pg) as session:
+            result = await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES
+                        ('carol', '123', true, '',
+                         false, false, :now, :pw, '{}'::jsonb)
+                    RETURNING id
+                """),
+                {"now": arrow.utcnow().naive, "pw": b"hashed"},
+            )
+            carol = result.first().id
+            await session.commit()
+
+        assert carol != 123
+
+        await ctx.mongo.subtractions.insert_one(
+            {"_id": "s2", "user": {"id": "123"}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.subtractions.find_one({"_id": "s2"})
+        assert doc["user"]["id"] == carol
+
+    @pytest.mark.usefixtures("setup_users_and_groups")
+    async def test_unmapped_legacy_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.subtractions.insert_one(
+            {"_id": "orphan", "user": {"id": "ghost_user"}},
+        )
+
+        with pytest.raises(ValueError, match="ghost_user"):
+            await upgrade(ctx)
+
+
+class TestReferencesAndGroups:
+    async def test_references_user_and_users_array_convert(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        alice = setup_users_and_groups["alice_legacy"]
+        bob = setup_users_and_groups["bob_legacy"]
+
+        await ctx.mongo.references.insert_one(
+            {
+                "_id": "ref1",
+                "user": {"id": "alice_legacy"},
+                "users": [
+                    {"id": "alice_legacy", "build": True},
+                    {"id": "bob_legacy", "build": False},
+                ],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.references.find_one({"_id": "ref1"})
+        assert doc["user"]["id"] == alice
+        assert [u["id"] for u in doc["users"]] == [alice, bob]
+
+    async def test_users_groups_convert(
+        self,
+        ctx: MigrationContext,
+        setup_users_and_groups: dict[str, int],
+    ):
+        admins = setup_users_and_groups["admins_legacy"]
+        readers = setup_users_and_groups["readers_legacy"]
+
+        await ctx.mongo.users.insert_one(
+            {"_id": "u1", "groups": ["admins_legacy", "readers_legacy"]},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.users.find_one({"_id": "u1"})
+        assert doc["groups"] == [admins, readers]

--- a/virtool/migration/apply.py
+++ b/virtool/migration/apply.py
@@ -14,7 +14,6 @@ from virtool.migration.cls import GenericRevision, RevisionSource
 from virtool.migration.ctx import MigrationContext, create_migration_context
 from virtool.migration.pg import (
     SQLRevision,
-    fetch_last_applied_revision,
     list_applied_revisions,
 )
 from virtool.migration.show import load_all_revisions
@@ -29,7 +28,8 @@ async def apply(config: MigrationConfig) -> None:
     The following safety measures are taken:
     * Revisions that have already been successfully applied will not be reapplied.
     * When a revision fails to apply, the entire migration process will stop.
-    * Revisions will start applied after the last successfully applied revision.
+    * Every revision not yet recorded as applied is applied, in dependency order,
+      so a revision that was missed in the past is filled in rather than skipped.
 
     :param config: the configuration values for migration
     """
@@ -51,46 +51,26 @@ async def apply(config: MigrationConfig) -> None:
 
     await ensure_revisions_table(ctx.pg)
 
-    last_applied_revision = await fetch_last_applied_revision(ctx.pg)
+    applied_revisions = await list_applied_revisions(ctx.pg)
+    applied_revision_ids = {revision.revision for revision in applied_revisions}
 
-    if last_applied_revision:
-        logger.info(
-            "Found last applied revision",
-            revision=last_applied_revision.revision,
-            name=last_applied_revision.name,
-        )
+    if applied_revisions:
+        logger.info("Found applied revisions", count=len(applied_revisions))
     else:
         logger.info("No revisions have been applied yet")
 
-    applied_revision_ids = {
-        revision.revision for revision in await list_applied_revisions(ctx.pg)
-    }
-
-    all_revision_ids = {r.id for r in all_revisions}
-
-    # If the last applied revision no longer exists in the codebase, start from the
-    # beginning and rely on applied_revision_ids to skip already-applied revisions.
-    if last_applied_revision and last_applied_revision.revision not in all_revision_ids:
-        logger.warning(
-            "Last applied revision not found in codebase, "
-            "will skip already-applied revisions",
-            revision=last_applied_revision.revision,
-        )
-        start_applying = True
-    else:
-        start_applying = last_applied_revision is None
-
+    # Apply every revision that has not been recorded as applied, iterating in
+    # dependency order.
+    #
+    # We decide revision-by-revision against the set of applied revision ids
+    # rather than scanning forward from a single "last applied" position. A
+    # position-based scan assumes every revision ordered before the latest
+    # record was applied, which silently skips any earlier revision that was
+    # never run -- for example when a past, buggy version applied revisions out
+    # of order. Checking each revision guarantees a missed one is filled in, and
+    # the dependency-ordered iteration guarantees it is applied in the correct
+    # order relative to the revisions around it.
     for revision in all_revisions:
-        if not start_applying:
-            if revision.id == last_applied_revision.revision:
-                start_applying = True
-
-            continue
-
-        logger.info("Checking revision", id=revision.id, name=revision.name)
-
-        # This is necessary because buggy versions of the migration may have applied
-        # revisions in the wrong order.
         if revision.id in applied_revision_ids:
             logger.info(
                 "Revision is already applied",


### PR DESCRIPTION
## Summary

- Adds a new migration revision (`nmqvw9wu298b`) that re-runs the `ie7r3vdaf5mu` user-id backfill for environments where that earlier revision was recorded as applied but never actually rewrote the Mongo data, leaving legacy string `user.id` values that crash the user transform at runtime.
- Fixes the migration apply logic to check every unrecorded revision individually (in dependency order) rather than scanning forward from the last recorded position, so a missed revision is filled in instead of silently skipped.
- Adds a diagnostic script (`scripts/check_legacy_user_ids.py`) to report which Mongo collections still carry legacy string user ids.