### PR TITLE
feat: create analyses postgres table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,17 @@ Use **"delete"** for permanently destroying an entity. Use **"remove"** for
 detaching an entity from a parent or collection without destroying it (e.g.,
 removing an isolate from an OTU).
 
+### Datetimes
+
+Datetimes in Virtool are **naive UTC** — no `tzinfo` attached, always
+representing UTC. Generate them with `virtool.utils.timestamp()`
+(`arrow.utcnow().naive`), never `datetime.now()` or aware datetimes.
+
+Postgres datetime columns use plain `DateTime` / `Mapped[datetime]`, **not**
+`DateTime(timezone=True)`. Adding `timezone=True` would diverge from every
+existing model and store offset-aware values that the rest of the codebase does
+not expect.
+
 ### Lifecycle Filter Convention
 
 For list endpoints that expose a boolean lifecycle field (e.g. `archived`),

--- a/assets/alembic/versions/5cb4e85e013f_create_analyses_table.py
+++ b/assets/alembic/versions/5cb4e85e013f_create_analyses_table.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         sa.Column("workflow", sa.String(), nullable=False),
         sa.Column("ready", sa.Boolean(), nullable=False),
         sa.Column("results", JSONB(), nullable=True),
-        sa.Column("sample", sa.String(), nullable=False),
+        sa.Column("sample", sa.String(), nullable=False, index=True),
         sa.Column("reference", sa.String(), nullable=False),
         sa.Column("index", sa.String(), nullable=False),
         sa.Column("subtractions", JSONB(), nullable=False),

--- a/assets/alembic/versions/5cb4e85e013f_create_analyses_table.py
+++ b/assets/alembic/versions/5cb4e85e013f_create_analyses_table.py
@@ -1,0 +1,44 @@
+"""create analyses table
+
+Revision ID: 5cb4e85e013f
+Revises: 12c20b71cffc
+Create Date: 2026-06-01 23:22:54.109921+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "5cb4e85e013f"
+down_revision = "12c20b71cffc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analyses",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("workflow", sa.String(), nullable=False),
+        sa.Column("ready", sa.Boolean(), nullable=False),
+        sa.Column("results", JSONB(), nullable=True),
+        sa.Column("sample", sa.String(), nullable=False),
+        sa.Column("reference", sa.String(), nullable=False),
+        sa.Column("index", sa.String(), nullable=False),
+        sa.Column("subtractions", JSONB(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("job_id", sa.Integer(), nullable=True),
+        sa.Column("ml_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+        sa.ForeignKeyConstraint(["ml_id"], ["ml_model_releases.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("analyses")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -295,5 +295,12 @@
       'name': 'backfill subtraction user ids',
       'revision': 'x602yxtuaeg5',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 43,
+      'name': 'create analyses table',
+      'revision': '5cb4e85e013f',
+    }),
   ])
 # ---

--- a/virtool/analyses/sql.py
+++ b/virtool/analyses/sql.py
@@ -1,5 +1,16 @@
-from sqlalchemy import BigInteger, Column, DateTime, Enum, Integer, String
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+)
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
@@ -15,6 +26,38 @@ class AnalysisFormat(str, SQLEnum):
     csv = "csv"
     tsv = "tsv"
     json = "json"
+
+
+class SQLAnalysis(Base):
+    """SQL model for analysis metadata and results.
+
+    Column naming convention:
+
+    - A bare column (``sample``, ``reference``, ``index``) holds a legacy Mongo
+      string id and has no foreign key, because the referenced collection has
+      not been migrated to Postgres.
+    - An ``{entity}_id`` column is a real foreign key to an existing SQL table.
+
+    The Mongo ``space`` field is intentionally dropped.
+    """
+
+    __tablename__ = "analyses"
+
+    id: Mapped[str] = mapped_column(primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
+    workflow: Mapped[str]
+    ready: Mapped[bool]
+    results: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    sample: Mapped[str]
+    reference: Mapped[str]
+    index: Mapped[str]
+    subtractions: Mapped[list] = mapped_column(JSONB, default=list)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"), nullable=True)
+    ml_id: Mapped[int | None] = mapped_column(
+        ForeignKey("ml_model_releases.id"), nullable=True
+    )
 
 
 class SQLAnalysisResult(Base):

--- a/virtool/analyses/sql.py
+++ b/virtool/analyses/sql.py
@@ -49,7 +49,7 @@ class SQLAnalysis(Base):
     workflow: Mapped[str]
     ready: Mapped[bool]
     results: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    sample: Mapped[str]
+    sample: Mapped[str] = mapped_column(index=True)
     reference: Mapped[str]
     index: Mapped[str]
     subtractions: Mapped[list] = mapped_column(JSONB, default=list)


### PR DESCRIPTION
## Summary

- Adds a `SQLAnalysis` SQLAlchemy model with foreign keys to `users`, `jobs`, and `ml_model_releases`; bare string columns (`sample`, `reference`, `index`) retain Mongo IDs until those collections are migrated
- Adds the corresponding Alembic migration (`5cb4e85e013f`) and updates the migration apply snapshot
- Documents the naive-UTC datetime convention and the `DateTime(timezone=True)` prohibition in `AGENTS.md`