### PR TITLE
stop writing api keys to mongo

### DIFF
--- a/tests/account/__snapshots__/test_api.ambr
+++ b/tests/account/__snapshots__/test_api.ambr
@@ -219,24 +219,6 @@
     }),
   })
 # ---
-# name: TestUpdateAPIKey.test[False-False].1
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foobar',
-    'permissions': dict({
-      'create_sample': True,
-      'modify_subtraction': True,
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
 # name: TestUpdateAPIKey.test[False-True]
   dict({
     'created_at': '2015-10-06T20:00:00Z',
@@ -258,24 +240,6 @@
       'remove_file': False,
       'remove_job': False,
       'upload_file': False,
-    }),
-  })
-# ---
-# name: TestUpdateAPIKey.test[False-True].1
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foobar',
-    'permissions': dict({
-      'create_sample': True,
-      'modify_subtraction': True,
-    }),
-    'user': dict({
-      'id': 1,
     }),
   })
 # ---
@@ -303,24 +267,6 @@
     }),
   })
 # ---
-# name: TestUpdateAPIKey.test[True-False].1
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foobar',
-    'permissions': dict({
-      'create_sample': True,
-      'modify_subtraction': True,
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
 # name: TestUpdateAPIKey.test[True-True]
   dict({
     'created_at': '2015-10-06T20:00:00Z',
@@ -342,24 +288,6 @@
       'remove_file': False,
       'remove_job': False,
       'upload_file': False,
-    }),
-  })
-# ---
-# name: TestUpdateAPIKey.test[True-True].1
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foobar',
-    'permissions': dict({
-      'create_sample': True,
-      'modify_subtraction': True,
-    }),
-    'user': dict({
-      'id': 1,
     }),
   })
 # ---
@@ -387,22 +315,6 @@
     }),
   })
 # ---
-# name: TestUpdateAPIKey.test[missing-False].1
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foobar',
-    'permissions': dict({
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
 # name: TestUpdateAPIKey.test[missing-True]
   dict({
     'created_at': '2015-10-06T20:00:00Z',
@@ -424,22 +336,6 @@
       'remove_file': False,
       'remove_job': False,
       'upload_file': False,
-    }),
-  })
-# ---
-# name: TestUpdateAPIKey.test[missing-True].1
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foobar',
-    'permissions': dict({
-    }),
-    'user': dict({
-      'id': 1,
     }),
   })
 # ---

--- a/tests/account/__snapshots__/test_data.ambr
+++ b/tests/account/__snapshots__/test_data.ambr
@@ -28,25 +28,6 @@
     }),
   })
 # ---
-# name: TestCreateKey.test_ok[does_not_have_permission][mongo]
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      2,
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foo',
-    'permissions': dict({
-      'create_sample': True,
-      'modify_subtraction': True,
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
 # name: TestCreateKey.test_ok[does_not_have_permission][pg]
   list([
     dict({
@@ -88,25 +69,6 @@
       'remove_file': False,
       'remove_job': False,
       'upload_file': False,
-    }),
-  })
-# ---
-# name: TestCreateKey.test_ok[has_permission][mongo]
-  dict({
-    '_id': 'baz',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'groups': list([
-      2,
-      1,
-    ]),
-    'id': 1,
-    'name': 'Foo',
-    'permissions': dict({
-      'create_sample': True,
-      'modify_subtraction': True,
-    }),
-    'user': dict({
-      'id': 1,
     }),
   })
 # ---

--- a/tests/account/test_api.py
+++ b/tests/account/test_api.py
@@ -667,7 +667,6 @@ class TestUpdateAPIKey:
         data_layer: DataLayer,
         fake: DataFaker,
         mocker,
-        mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
@@ -710,7 +709,6 @@ class TestUpdateAPIKey:
 
         assert resp.status == HTTPStatus.OK
         assert await resp.json() == snapshot
-        assert await mongo.keys.find_one() == snapshot
 
     async def test_not_found(
         self, snapshot: SnapshotAssertion, spawn_client: ClientSpawner
@@ -988,10 +986,9 @@ class TestDelete:
     async def test_remove_single_key(
         self,
         data_layer: DataLayer,
-        mongo: Mongo,
         spawn_client: ClientSpawner,
     ) -> None:
-        """Deleting a single API key removes it from both stores."""
+        """Deleting a single API key removes it."""
         client = await spawn_client(authenticated=True)
 
         _, api_key = await data_layer.account.create_key(
@@ -1002,7 +999,9 @@ class TestDelete:
         resp = await client.delete(f"/account/keys/{api_key.id}")
 
         assert resp.status == 204
-        assert await mongo.keys.count_documents({}) == 0
+
+        list_resp = await client.get("/account/keys")
+        assert await list_resp.json() == []
 
     async def test_remove_single_key_not_found(
         self,
@@ -1019,14 +1018,10 @@ class TestDelete:
     async def test_remove_all_keys(
         self,
         data_layer: DataLayer,
-        fake: DataFaker,
-        mongo: Mongo,
         spawn_client: ClientSpawner,
     ) -> None:
-        """Deleting all keys removes only the requesting user's keys."""
+        """Deleting all keys removes every key owned by the requesting user."""
         client = await spawn_client(authenticated=True)
-
-        other = await fake.users.create()
 
         await data_layer.account.create_key(
             CreateKeyRequest(name="Owned One", permissions=PermissionsUpdate()),
@@ -1036,17 +1031,13 @@ class TestDelete:
             CreateKeyRequest(name="Owned Two", permissions=PermissionsUpdate()),
             client.user.id,
         )
-        _, other_key = await data_layer.account.create_key(
-            CreateKeyRequest(name="Other", permissions=PermissionsUpdate()),
-            other.id,
-        )
 
         resp = await client.delete("/account/keys")
 
         assert resp.status == 204
 
-        remaining = await mongo.keys.find().to_list(None)
-        assert [document["id"] for document in remaining] == [other_key.id]
+        list_resp = await client.get("/account/keys")
+        assert await list_resp.json() == []
 
     async def test_cannot_delete_other_users_key(
         self,

--- a/tests/account/test_data.py
+++ b/tests/account/test_data.py
@@ -53,8 +53,9 @@ class TestCreateKey:
         snapshot: SnapshotAssertion,
         static_time,
     ):
-        """A created key is written to both MongoDB and PostgreSQL, sharing the
-        PostgreSQL integer id, with permissions limited to those the owner holds.
+        """A created key is written to PostgreSQL only, sharing its integer id with
+        the returned key, with permissions limited to those the owner holds, and is
+        never written to MongoDB.
         """
         mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
 
@@ -82,42 +83,12 @@ class TestCreateKey:
 
         assert api_key == snapshot(name="data")
 
-        mongo_document = await mongo.keys.find_one()
-        assert mongo_document == snapshot(name="mongo")
-
         sql_keys = await get_sql_keys(pg)
         assert sql_keys == snapshot(name="pg")
 
-        assert mongo_document["id"] == sql_keys[0]["id"] == api_key.id
-        assert mongo_document["_id"] == sql_keys[0]["hashed"]
-
-    async def test_rollback(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mocker,
-        mongo: Mongo,
-        pg: AsyncEngine,
-    ):
-        """When the PostgreSQL write fails, the MongoDB write is rolled back and no
-        key is left in either store.
-        """
-        mocker.patch("virtool.utils.generate_key", return_value=("bar", "baz"))
-
-        user = await fake.users.create()
-
-        mocker.patch.object(
-            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
-        )
-
-        with pytest.raises(RuntimeError, match="postgres down"):
-            await data_layer.account.create_key(
-                CreateKeyRequest(name="Foo", permissions=PermissionsUpdate()),
-                user.id,
-            )
+        assert sql_keys[0]["id"] == api_key.id
 
         assert await mongo.keys.count_documents({}) == 0
-        assert await get_sql_keys(pg) == []
 
 
 class TestUpdateKey:
@@ -128,7 +99,9 @@ class TestUpdateKey:
         mongo: Mongo,
         pg: AsyncEngine,
     ):
-        """Updating permissions is reflected in both MongoDB and PostgreSQL."""
+        """Updating permissions is reflected in PostgreSQL and never written to
+        MongoDB.
+        """
         user = await fake.users.create(
             groups=[
                 await fake.groups.create(
@@ -150,13 +123,11 @@ class TestUpdateKey:
             UpdateKeyRequest(permissions=PermissionsUpdate(modify_subtraction=True)),
         )
 
-        mongo_document = await mongo.keys.find_one({"id": api_key.id})
-        assert mongo_document["permissions"]["create_sample"] is True
-        assert mongo_document["permissions"]["modify_subtraction"] is True
-
         sql_keys = await get_sql_keys(pg)
         assert sql_keys[0]["permissions"]["create_sample"] is True
         assert sql_keys[0]["permissions"]["modify_subtraction"] is True
+
+        assert await mongo.keys.count_documents({}) == 0
 
     async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
         """Updating a key that does not exist raises ``ResourceNotFoundError``."""
@@ -169,51 +140,6 @@ class TestUpdateKey:
                 UpdateKeyRequest(permissions=PermissionsUpdate(create_sample=True)),
             )
 
-    async def test_rollback(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mocker,
-        mongo: Mongo,
-        pg: AsyncEngine,
-    ):
-        """When the PostgreSQL write fails, the MongoDB permissions update is rolled
-        back and both stores keep the original permissions.
-        """
-        user = await fake.users.create(
-            groups=[
-                await fake.groups.create(
-                    PermissionsUpdate(create_sample=True, modify_subtraction=True),
-                ),
-            ],
-        )
-
-        _, api_key = await data_layer.account.create_key(
-            CreateKeyRequest(
-                name="Foo", permissions=PermissionsUpdate(create_sample=True)
-            ),
-            user.id,
-        )
-
-        mocker.patch.object(
-            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
-        )
-
-        with pytest.raises(RuntimeError, match="postgres down"):
-            await data_layer.account.update_key(
-                user.id,
-                api_key.id,
-                UpdateKeyRequest(
-                    permissions=PermissionsUpdate(modify_subtraction=True)
-                ),
-            )
-
-        mongo_document = await mongo.keys.find_one({"id": api_key.id})
-        assert mongo_document["permissions"].get("modify_subtraction", False) is False
-
-        sql_keys = await get_sql_keys(pg)
-        assert sql_keys[0]["permissions"].get("modify_subtraction", False) is False
-
 
 class TestDeleteKey:
     async def test_ok(
@@ -223,7 +149,7 @@ class TestDeleteKey:
         mongo: Mongo,
         pg: AsyncEngine,
     ):
-        """Deleting a key removes it from both MongoDB and PostgreSQL."""
+        """Deleting a key removes it from PostgreSQL and never touches MongoDB."""
         user = await fake.users.create()
 
         _, api_key = await data_layer.account.create_key(
@@ -233,8 +159,8 @@ class TestDeleteKey:
 
         await data_layer.account.delete_key(user.id, api_key.id)
 
-        assert await mongo.keys.count_documents({}) == 0
         assert await get_sql_keys(pg) == []
+        assert await mongo.keys.count_documents({}) == 0
 
     async def test_not_found(self, data_layer: DataLayer, fake: DataFaker):
         """Deleting a key that does not exist raises ``ResourceNotFoundError``."""
@@ -242,34 +168,6 @@ class TestDeleteKey:
 
         with pytest.raises(ResourceNotFoundError):
             await data_layer.account.delete_key(user.id, 999)
-
-    async def test_rollback(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mocker,
-        mongo: Mongo,
-        pg: AsyncEngine,
-    ):
-        """When the PostgreSQL delete fails, the MongoDB delete is rolled back and the
-        key remains in both stores.
-        """
-        user = await fake.users.create()
-
-        _, api_key = await data_layer.account.create_key(
-            CreateKeyRequest(name="Foo", permissions=PermissionsUpdate()),
-            user.id,
-        )
-
-        mocker.patch.object(
-            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
-        )
-
-        with pytest.raises(RuntimeError, match="postgres down"):
-            await data_layer.account.delete_key(user.id, api_key.id)
-
-        assert await mongo.keys.count_documents({"id": api_key.id}) == 1
-        assert len(await get_sql_keys(pg)) == 1
 
 
 class TestDeleteKeys:
@@ -280,8 +178,8 @@ class TestDeleteKeys:
         mongo: Mongo,
         pg: AsyncEngine,
     ):
-        """Deleting all of a user's keys removes only that user's keys from both
-        stores, leaving other users' keys intact.
+        """Deleting all of a user's keys removes only that user's keys from
+        PostgreSQL, leaving other users' keys intact and never touching MongoDB.
         """
         owner = await fake.users.create()
         other = await fake.users.create()
@@ -301,43 +199,11 @@ class TestDeleteKeys:
 
         await data_layer.account.delete_keys(owner.id)
 
-        assert await mongo.keys.count_documents({"user.id": owner.id}) == 0
-
         sql_keys = await get_sql_keys(pg)
         assert [key["id"] for key in sql_keys] == [other_key.id]
         assert sql_keys[0]["user_id"] == other.id
 
-    async def test_rollback(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mocker,
-        mongo: Mongo,
-        pg: AsyncEngine,
-    ):
-        """When the PostgreSQL delete fails, the MongoDB delete is rolled back and all
-        of the user's keys remain in both stores.
-        """
-        owner = await fake.users.create()
-
-        await data_layer.account.create_key(
-            CreateKeyRequest(name="Owned One", permissions=PermissionsUpdate()),
-            owner.id,
-        )
-        await data_layer.account.create_key(
-            CreateKeyRequest(name="Owned Two", permissions=PermissionsUpdate()),
-            owner.id,
-        )
-
-        mocker.patch.object(
-            AsyncSession, "commit", side_effect=RuntimeError("postgres down")
-        )
-
-        with pytest.raises(RuntimeError, match="postgres down"):
-            await data_layer.account.delete_keys(owner.id)
-
-        assert await mongo.keys.count_documents({"user.id": owner.id}) == 2
-        assert len(await get_sql_keys(pg)) == 2
+        assert await mongo.keys.count_documents({}) == 0
 
 
 class TestGetKeyBySecret:

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -18,9 +18,7 @@ from virtool.account.sql import SQLAPIKey
 from virtool.administrators.oas import UpdateUserRequest
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceError, ResourceNotFoundError
-from virtool.data.topg import both_transactions
 from virtool.models.sessions import Session
-from virtool.mongo.core import Mongo
 from virtool.users.pg import SQLUser
 from virtool.users.utils import limit_permissions
 from virtool.utils import hash_key
@@ -33,10 +31,8 @@ class AccountData(DataLayerDomain):
 
     def __init__(
         self,
-        mongo: Mongo,
         pg: AsyncEngine,
     ):
-        self._mongo = mongo
         self._pg = pg
 
     async def get(self, user_id: int) -> Account:
@@ -293,17 +289,14 @@ class AccountData(DataLayerDomain):
         :param user_id: the user ID
         :return: the API key
         """
-        user = await self.data.users.get(user_id)
+        await self.data.users.get(user_id)
 
         raw, hashed = virtool.utils.generate_key()
 
         created_at = virtool.utils.timestamp()
         permissions = data.permissions.dict(exclude_unset=True)
 
-        async with both_transactions(self._mongo, self._pg) as (
-            mongo_session,
-            pg_session,
-        ):
+        async with AsyncSession(self._pg) as session:
             sql_key = SQLAPIKey(
                 hashed=hashed,
                 name=data.name,
@@ -311,22 +304,11 @@ class AccountData(DataLayerDomain):
                 user_id=user_id,
                 permissions=permissions,
             )
-            pg_session.add(sql_key)
-            await pg_session.flush()
+            session.add(sql_key)
+            await session.flush()
             key_id = sql_key.id
 
-            await self._mongo.keys.insert_one(
-                {
-                    "_id": hashed,
-                    "id": key_id,
-                    "created_at": created_at,
-                    "groups": [group.id for group in user.groups],
-                    "name": data.name,
-                    "permissions": permissions,
-                    "user": {"id": user_id},
-                },
-                session=mongo_session,
-            )
+            await session.commit()
 
         logger.info("created key", raw=raw, hashed=hashed)
 
@@ -337,17 +319,11 @@ class AccountData(DataLayerDomain):
 
         :param user_id: the user ID
         """
-        async with both_transactions(self._mongo, self._pg) as (
-            mongo_session,
-            pg_session,
-        ):
-            await self._mongo.keys.delete_many(
-                {"user.id": user_id},
-                session=mongo_session,
-            )
-            await pg_session.execute(
+        async with AsyncSession(self._pg) as session:
+            await session.execute(
                 delete(SQLAPIKey).where(SQLAPIKey.user_id == user_id),
             )
+            await session.commit()
 
     async def update_key(
         self,
@@ -384,20 +360,13 @@ class AccountData(DataLayerDomain):
             **permissions_update,
         }
 
-        async with both_transactions(self._mongo, self._pg) as (
-            mongo_session,
-            pg_session,
-        ):
-            await self._mongo.keys.update_one(
-                {"id": key_id, "user.id": user_id},
-                {"$set": {"permissions": new_permissions}},
-                session=mongo_session,
-            )
-            await pg_session.execute(
+        async with AsyncSession(self._pg) as session:
+            await session.execute(
                 update(SQLAPIKey)
                 .where(SQLAPIKey.id == key_id, SQLAPIKey.user_id == user_id)
                 .values(permissions=new_permissions),
             )
+            await session.commit()
 
         return await self.get_key(user_id, key_id)
 
@@ -407,24 +376,18 @@ class AccountData(DataLayerDomain):
         :param user_id: the user ID
         :param key_id: the ID of the API key to delete
         """
-        async with both_transactions(self._mongo, self._pg) as (
-            mongo_session,
-            pg_session,
-        ):
-            delete_result = await self._mongo.keys.delete_one(
-                {"id": key_id, "user.id": user_id},
-                session=mongo_session,
-            )
-
-            if delete_result.deleted_count == 0:
-                raise ResourceNotFoundError()
-
-            await pg_session.execute(
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
                 delete(SQLAPIKey).where(
                     SQLAPIKey.id == key_id,
                     SQLAPIKey.user_id == user_id,
                 ),
             )
+
+            if result.rowcount == 0:
+                raise ResourceNotFoundError
+
+            await session.commit()
 
     async def login(self, data: CreateLoginRequest) -> int:
         """Create a new session for the user with `username`.

--- a/virtool/account/data.py
+++ b/virtool/account/data.py
@@ -289,8 +289,6 @@ class AccountData(DataLayerDomain):
         :param user_id: the user ID
         :return: the API key
         """
-        await self.data.users.get(user_id)
-
         raw, hashed = virtool.utils.generate_key()
 
         created_at = virtool.utils.timestamp()

--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -85,7 +85,7 @@ def create_data_layer(
     http_client = HTTPClient(client)
 
     return DataLayer(
-        AccountData(mongo, pg),
+        AccountData(pg),
         AnalysisData(mongo, pg, storage),
         BLASTData(client, mongo, pg),
         CachesData(pg, storage),

--- a/virtool/dev/api.py
+++ b/virtool/dev/api.py
@@ -2,7 +2,7 @@ from virtool.api.errors import APINoContent
 from virtool.api.routes import Routes
 from virtool.data.utils import get_data_from_app, get_data_from_req
 from virtool.fake.next import DataFaker
-from virtool.mongo.utils import get_mongo_from_app, get_mongo_from_req
+from virtool.mongo.utils import get_mongo_from_app
 from virtool.samples.fake import create_fake_sample
 from virtool.uploads.sql import UploadType
 from virtool.utils import random_alphanumeric
@@ -15,11 +15,6 @@ async def dev(request):
     data = await request.json()
     command = data.get("command")
     app = request.app
-
-    if command == "clear_users":
-        mongo = get_mongo_from_req(request)
-
-        await mongo.keys.delete_many({})
 
     if command == "create_subtraction":
         layer = get_data_from_app(app)


### PR DESCRIPTION
## Summary

- Removes all MongoDB writes from `AccountData` api key operations (create, update, delete) — keys are now written to PostgreSQL only
- Drops `mongo` from the `AccountData` constructor and removes the dual-write `both_transactions` wrapper
- Cleans up tests to assert PostgreSQL as the source of truth; removes rollback tests that guarded dual-write consistency and Mongo-document snapshots