### PR TITLE
drop dormant sample_artifacts_cache and sample_reads_cache tables

### DIFF
--- a/assets/alembic/versions/7ea2f370163c_drop_dormant_sample_cache_tables.py
+++ b/assets/alembic/versions/7ea2f370163c_drop_dormant_sample_cache_tables.py
@@ -1,0 +1,35 @@
+"""drop dormant sample cache tables
+
+Revision ID: 7ea2f370163c
+Revises: 5cb4e85e013f
+Create Date: 2026-06-02 14:47:23.211146+00:00
+
+The ``sample_artifacts_cache`` and ``sample_reads_cache`` tables are leftovers
+from a sample-caching feature whose Python code was removed in May 2024. They
+have been unread and unwritten since, so this migration drops them.
+
+The ``DROP TABLE IF EXISTS`` guards make the migration safe on deployments that
+never had these tables. The ``artifacttype`` enum is intentionally left in
+place: it is still used by the live ``sample_artifacts`` table.
+
+Legacy on-disk cache artifacts under ``{data_path}/caches/`` are handled by a
+separate ops step, not this migration, so no filesystem work happens here.
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7ea2f370163c"
+down_revision = "5cb4e85e013f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS sample_reads_cache")
+    op.execute("DROP TABLE IF EXISTS sample_artifacts_cache")
+
+
+def downgrade() -> None:
+    pass

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -302,5 +302,12 @@
       'name': 'create analyses table',
       'revision': '5cb4e85e013f',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 44,
+      'name': 'drop dormant sample cache tables',
+      'revision': '7ea2f370163c',
+    }),
   ])
 # ---

--- a/tests/migration/test_drop_dormant_sample_cache_tables.py
+++ b/tests/migration/test_drop_dormant_sample_cache_tables.py
@@ -1,0 +1,91 @@
+"""Tests for the drop-dormant-sample-cache-tables migration."""
+
+import asyncio
+from collections.abc import Callable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+DOWN_REVISION = "5cb4e85e013f"
+REVISION = "7ea2f370163c"
+CACHE_TABLES = ("sample_artifacts_cache", "sample_reads_cache")
+
+
+async def _table_exists(session: AsyncSession, name: str) -> bool:
+    return bool(
+        (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM information_schema.tables "
+                    "WHERE table_name = :name",
+                ),
+                {"name": name},
+            )
+        ).scalar_one(),
+    )
+
+
+async def _enum_exists(session: AsyncSession, name: str) -> bool:
+    return bool(
+        (
+            await session.execute(
+                text("SELECT COUNT(*) FROM pg_type WHERE typname = :name"),
+                {"name": name},
+            )
+        ).scalar_one(),
+    )
+
+
+class TestDropCacheTables:
+    async def test_tables_are_dropped(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, DOWN_REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            for table in CACHE_TABLES:
+                assert await _table_exists(session, table)
+
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            for table in CACHE_TABLES:
+                assert not await _table_exists(session, table)
+
+    async def test_idempotent_when_tables_absent(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        """The migration runs cleanly when the tables were never created."""
+        await asyncio.to_thread(apply_alembic, DOWN_REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            for table in CACHE_TABLES:
+                await session.execute(text(f"DROP TABLE {table}"))
+            await session.commit()
+
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            for table in CACHE_TABLES:
+                assert not await _table_exists(session, table)
+
+    async def test_artifacttype_enum_is_preserved(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        """Dropping ``sample_artifacts_cache`` must not drop the shared enum.
+
+        The ``artifacttype`` enum is still used by the live ``sample_artifacts``
+        table.
+        """
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            assert await _enum_exists(session, "artifacttype")

--- a/tests/migration/test_drop_dormant_sample_cache_tables.py
+++ b/tests/migration/test_drop_dormant_sample_cache_tables.py
@@ -19,7 +19,7 @@ async def _table_exists(session: AsyncSession, name: str) -> bool:
             await session.execute(
                 text(
                     "SELECT COUNT(*) FROM information_schema.tables "
-                    "WHERE table_name = :name",
+                    "WHERE table_schema = 'public' AND table_name = :name",
                 ),
                 {"name": name},
             )
@@ -66,7 +66,7 @@ class TestDropCacheTables:
 
         async with AsyncSession(ctx.pg) as session:
             for table in CACHE_TABLES:
-                await session.execute(text(f"DROP TABLE {table}"))
+                await session.execute(text(f"DROP TABLE IF EXISTS {table}"))
             await session.commit()
 
         await asyncio.to_thread(apply_alembic, REVISION)


### PR DESCRIPTION
## Summary

- Adds an Alembic migration that drops `sample_artifacts_cache` and `sample_reads_cache`, two PostgreSQL tables left over from a sample-caching feature whose Python code was removed in May 2024
- Uses `DROP TABLE IF EXISTS` so the migration is safe on deployments that never had these tables; the `artifacttype` enum is intentionally preserved as it is still used by the live `sample_artifacts` table
- Includes tests covering the happy path, idempotent execution when tables are already absent, and preservation of the shared enum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database optimization: Removed dormant and unused cache structures that were no longer required for supporting system operations. This proactive database maintenance improves overall system performance and responsiveness, reduces storage space requirements, and enhances operational efficiency across the entire platform. All existing data integrity, system functionality, application stability, and user experience remain completely unaffected and secure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->