### PR TITLE
feat: dual-write analysis metadata and results to postgres

### DIFF
--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -333,6 +333,14 @@ class TestDualWriteFinalize:
             )
             assert result.scalar_one() == results
 
+        document = await mongo.analyses.find_one({"_id": analysis.id})
+
+        assert document["ready"] is True
+        assert document["results"] == "sql"
+        # Mongo stores datetimes at millisecond precision, so the bumped timestamp is
+        # compared by advancement rather than exact equality with the Postgres row.
+        assert document["updated_at"] > created.updated_at
+
     async def test_rolls_back_when_mongo_write_fails(
         self,
         data_layer: DataLayer,

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -204,7 +204,9 @@ def _create_request() -> CreateAnalysisRequest:
     )
 
 
-class TestDualWriteCreate:
+class TestCreate:
+    """Creating an analysis dual-writes to Mongo and Postgres."""
+
     async def test_mirrors_mongo(
         self,
         data_layer: DataLayer,
@@ -289,7 +291,9 @@ class TestDualWriteCreate:
             assert result.scalars().first() is None
 
 
-class TestDualWriteFinalize:
+class TestFinalize:
+    """Finalizing an analysis dual-writes results and the ready flag to both backends."""
+
     async def test_mirrors_mongo(
         self,
         data_layer: DataLayer,
@@ -379,7 +383,9 @@ class TestDualWriteFinalize:
             assert result.scalars().first() is None
 
 
-class TestDualWriteDelete:
+class TestDelete:
+    """Deleting an analysis removes it from both Mongo and Postgres."""
+
     async def test_deletes_pg_row(
         self,
         data_layer: DataLayer,

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -2,10 +2,12 @@ import asyncio
 from pathlib import Path
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
-from virtool.analyses.sql import SQLAnalysisFile
+from virtool.analyses.sql import SQLAnalysis, SQLAnalysisFile, SQLAnalysisResult
 from virtool.api.client import UserClient
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
@@ -13,6 +15,7 @@ from virtool.models.enums import AnalysisWorkflow
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.samples.oas import CreateAnalysisRequest
+from virtool.utils import timestamp
 
 
 @pytest.fixture
@@ -20,7 +23,39 @@ async def setup_sample(mongo: "Mongo", fake: DataFaker) -> str:
     user = await fake.users.create()
 
     await asyncio.gather(
-        mongo.samples.insert_one({"_id": "test_sample", "name": "Test Sample"}),
+        mongo.samples.insert_one(
+            {
+                "_id": "test_sample",
+                "all_read": True,
+                "all_write": True,
+                "created_at": timestamp(),
+                "files": [],
+                "format": "fastq",
+                "group": "none",
+                "group_read": True,
+                "group_write": True,
+                "hold": False,
+                "host": "",
+                "is_legacy": False,
+                "isolate": "",
+                "job": None,
+                "labels": [],
+                "library_type": "normal",
+                "locale": "",
+                "name": "Test Sample",
+                "notes": "",
+                "nuvs": False,
+                "pathoscope": True,
+                "ready": True,
+                "subtractions": [],
+                "user": {"id": user.id},
+                "workflows": {
+                    "aodp": "incompatible",
+                    "pathoscope": "complete",
+                    "nuvs": "pending",
+                },
+            },
+        ),
         mongo.indexes.insert_one(
             {
                 "_id": "test_index",
@@ -158,6 +193,231 @@ async def test_create_analysis_id(
         name="mongo",
         exclude=props("created_at", "updated_at"),
     )
+
+
+def _create_request() -> CreateAnalysisRequest:
+    return CreateAnalysisRequest(
+        ml=None,
+        ref_id="test_ref",
+        subtractions=["subtraction_1", "subtraction_2"],
+        workflow=AnalysisWorkflow.nuvs,
+    )
+
+
+class TestDualWriteCreate:
+    async def test_mirrors_mongo(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+    ):
+        """The Postgres row mirrors the Mongo document after create."""
+        analysis = await data_layer.analyses.create(
+            _create_request(),
+            "test_sample",
+            setup_sample,
+            0,
+        )
+
+        document = await mongo.analyses.find_one({"_id": analysis.id})
+        row = await get_row_by_id(pg, SQLAnalysis, analysis.id)
+
+        assert row is not None
+        assert row.id == document["_id"]
+        assert row.workflow == document["workflow"]
+        assert row.ready is False
+        assert row.results is None
+        assert document["results"] is None
+        assert row.sample == document["sample"]["id"]
+        assert row.reference == document["reference"]["id"]
+        assert row.index == document["index"]["id"]
+        assert row.subtractions == document["subtractions"]
+        assert row.job_id == document["job"]["id"]
+        assert row.ml_id == document["ml"]
+        assert row.created_at == row.updated_at
+        assert isinstance(row.user_id, int)
+
+    async def test_subtractions_default_to_list(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+        setup_sample: str,
+    ):
+        """An analysis created without subtractions stores an empty list, not None."""
+        analysis = await data_layer.analyses.create(
+            CreateAnalysisRequest(
+                ml=None,
+                ref_id="test_ref",
+                workflow=AnalysisWorkflow.nuvs,
+            ),
+            "test_sample",
+            setup_sample,
+            0,
+        )
+
+        row = await get_row_by_id(pg, SQLAnalysis, analysis.id)
+
+        assert row.subtractions == []
+
+    async def test_rolls_back_when_pg_write_fails(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+        mocker,
+    ):
+        """A failure writing the Postgres row rolls back the Mongo write too."""
+        mocker.patch(
+            "virtool.analyses.data.resolve_user_id",
+            side_effect=RuntimeError("boom"),
+        )
+
+        with pytest.raises(RuntimeError):
+            await data_layer.analyses.create(
+                _create_request(),
+                "test_sample",
+                setup_sample,
+                0,
+            )
+
+        assert await mongo.analyses.count_documents({}) == 0
+
+        async with AsyncSession(pg) as session:
+            result = await session.execute(select(SQLAnalysis))
+            assert result.scalars().first() is None
+
+
+class TestDualWriteFinalize:
+    async def test_mirrors_mongo(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+        mocker,
+    ):
+        """Finalize marks the Postgres row ready and writes results matching the
+        ``analysis_results`` row.
+        """
+        mocker.patch(
+            "virtool.analyses.format.format_analysis",
+            side_effect=lambda _storage, _mongo, document: document,
+        )
+
+        analysis = await data_layer.analyses.create(
+            _create_request(),
+            "test_sample",
+            setup_sample,
+            0,
+        )
+
+        created = await get_row_by_id(pg, SQLAnalysis, analysis.id)
+
+        results = {"hits": [{"index": 0, "sequence": "ACGT"}]}
+
+        await data_layer.analyses.finalize(analysis.id, results)
+
+        row = await get_row_by_id(pg, SQLAnalysis, analysis.id)
+
+        assert row.ready is True
+        assert row.results == results
+        assert row.updated_at > created.updated_at
+
+        async with AsyncSession(pg) as session:
+            result = await session.execute(
+                select(SQLAnalysisResult.results).where(
+                    SQLAnalysisResult.analysis_id == analysis.id,
+                ),
+            )
+            assert result.scalar_one() == results
+
+    async def test_rolls_back_when_mongo_write_fails(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+        setup_sample: str,
+        mongo: Mongo,
+        mocker,
+    ):
+        """A failure updating Mongo rolls back the Postgres writes."""
+        analysis = await data_layer.analyses.create(
+            _create_request(),
+            "test_sample",
+            setup_sample,
+            0,
+        )
+
+        mocker.patch.object(
+            mongo.analyses,
+            "find_one_and_update",
+            side_effect=RuntimeError("boom"),
+        )
+
+        with pytest.raises(RuntimeError):
+            await data_layer.analyses.finalize(analysis.id, {"hits": []})
+
+        row = await get_row_by_id(pg, SQLAnalysis, analysis.id)
+        assert row.ready is False
+        assert row.results is None
+
+        async with AsyncSession(pg) as session:
+            result = await session.execute(
+                select(SQLAnalysisResult).where(
+                    SQLAnalysisResult.analysis_id == analysis.id,
+                ),
+            )
+            assert result.scalars().first() is None
+
+
+class TestDualWriteDelete:
+    async def test_deletes_pg_row(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+    ):
+        """Delete removes the Postgres row alongside the Mongo document."""
+        analysis = await data_layer.analyses.create(
+            _create_request(),
+            "test_sample",
+            setup_sample,
+            0,
+        )
+
+        await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
+
+        assert await mongo.analyses.find_one({"_id": analysis.id}) is None
+        assert await get_row_by_id(pg, SQLAnalysis, analysis.id) is None
+
+    async def test_rolls_back_when_mongo_delete_fails(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+        mocker,
+    ):
+        """A failure deleting from Mongo leaves the Postgres row in place."""
+        analysis = await data_layer.analyses.create(
+            _create_request(),
+            "test_sample",
+            setup_sample,
+            0,
+        )
+
+        mocker.patch.object(
+            mongo.analyses,
+            "delete_one",
+            side_effect=RuntimeError("boom"),
+        )
+
+        with pytest.raises(RuntimeError):
+            await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
+
+        assert await get_row_by_id(pg, SQLAnalysis, analysis.id) is not None
 
 
 async def test_get_without_if_modified_since(

--- a/tests/blast/test_data.py
+++ b/tests/blast/test_data.py
@@ -6,12 +6,17 @@ from aiohttp import ClientSession
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.analyses.sql import SQLAnalysis
 from virtool.blast.data import BLASTData
 from virtool.blast.sql import SQLNuVsBlast
 from virtool.blast.task import BLASTTask
 from virtool.data.layer import DataLayer
+from virtool.pg.utils import get_row_by_id
 from virtool.tasks.data import TasksData
 from virtool.tasks.sql import SQLTask
+from virtool.users.pg import SQLUser
+
+OLD_TIME = arrow.get("2015-01-01T00:00:00").naive
 
 
 @pytest.fixture
@@ -30,7 +35,33 @@ async def blast_data(mocker, mongo, pg: AsyncEngine, static_time):
     async with AsyncSession(pg) as session:
         task = SQLTask(created_at=static_time.datetime, type="blast")
         session.add(task)
+
+        session.add(
+            SQLUser(
+                id=1,
+                handle="leeashley",
+                last_password_change=static_time.datetime,
+                password=b"hashed",
+                settings={},
+            ),
+        )
         await session.flush()
+
+        session.add(
+            SQLAnalysis(
+                id="analysis",
+                created_at=OLD_TIME,
+                updated_at=OLD_TIME,
+                workflow="nuvs",
+                ready=False,
+                results=None,
+                sample="sample",
+                reference="reference",
+                index="index",
+                subtractions=[],
+                user_id=1,
+            ),
+        )
 
         session.add_all(
             [
@@ -169,3 +200,47 @@ async def test_delete_nuvs_blast(blast_data: BLASTData, pg: AsyncEngine):
 
 async def test_list_by_analysis(blast_data: BLASTData, pg: AsyncEngine, snapshot):
     assert await blast_data.list_by_analysis("analysis_2") == snapshot
+
+
+class TestAnalysisUpdatedAtBump:
+    """The ``analyses`` Postgres row ``updated_at`` is bumped on every BLAST mutation."""
+
+    async def test_create(
+        self,
+        blast_data: BLASTData,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        await blast_data.create_nuvs_blast("analysis", 12)
+
+        row = await get_row_by_id(pg, SQLAnalysis, "analysis")
+        assert row.updated_at == static_time.datetime
+        assert row.updated_at != OLD_TIME
+
+    async def test_check(
+        self,
+        blast_data: BLASTData,
+        pg: AsyncEngine,
+        static_time,
+        mocker,
+    ):
+        mocker.patch("virtool.blast.data.check_rid", return_value=False)
+
+        await blast_data.create_nuvs_blast("analysis", 12)
+        await blast_data.check_nuvs_blast("analysis", 12)
+
+        row = await get_row_by_id(pg, SQLAnalysis, "analysis")
+        assert row.updated_at == static_time.datetime
+        assert row.updated_at != OLD_TIME
+
+    async def test_delete(
+        self,
+        blast_data: BLASTData,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        await blast_data.delete_nuvs_blast("analysis", 21)
+
+        row = await get_row_by_id(pg, SQLAnalysis, "analysis")
+        assert row.updated_at == static_time.datetime
+        assert row.updated_at != OLD_TIME

--- a/tests/blast/test_data.py
+++ b/tests/blast/test_data.py
@@ -203,44 +203,71 @@ async def test_list_by_analysis(blast_data: BLASTData, pg: AsyncEngine, snapshot
 
 
 class TestAnalysisUpdatedAtBump:
-    """The ``analyses`` Postgres row ``updated_at`` is bumped on every BLAST mutation."""
+    """Every BLAST mutation bumps the analysis ``updated_at`` in Postgres and Mongo."""
 
     async def test_create(
         self,
         blast_data: BLASTData,
         pg: AsyncEngine,
         static_time,
+        mongo,
     ):
         await blast_data.create_nuvs_blast("analysis", 12)
 
         row = await get_row_by_id(pg, SQLAnalysis, "analysis")
         assert row.updated_at == static_time.datetime
         assert row.updated_at != OLD_TIME
+
+        mongo_analysis = await mongo.analyses.find_one({"_id": "analysis"})
+        assert mongo_analysis["updated_at"] == row.updated_at
 
     async def test_check(
         self,
         blast_data: BLASTData,
         pg: AsyncEngine,
         static_time,
+        mongo,
         mocker,
     ):
         mocker.patch("virtool.blast.data.check_rid", return_value=False)
 
         await blast_data.create_nuvs_blast("analysis", 12)
+
+        # Reset both backends to an old timestamp so the assertions prove that
+        # ``check_nuvs_blast`` performed the bump, not ``create_nuvs_blast``.
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == "analysis")
+                .values(updated_at=OLD_TIME),
+            )
+            await session.commit()
+
+        await mongo.analyses.update_one(
+            {"_id": "analysis"}, {"$set": {"updated_at": OLD_TIME}}
+        )
+
         await blast_data.check_nuvs_blast("analysis", 12)
 
         row = await get_row_by_id(pg, SQLAnalysis, "analysis")
         assert row.updated_at == static_time.datetime
         assert row.updated_at != OLD_TIME
 
+        mongo_analysis = await mongo.analyses.find_one({"_id": "analysis"})
+        assert mongo_analysis["updated_at"] == row.updated_at
+
     async def test_delete(
         self,
         blast_data: BLASTData,
         pg: AsyncEngine,
         static_time,
+        mongo,
     ):
         await blast_data.delete_nuvs_blast("analysis", 21)
 
         row = await get_row_by_id(pg, SQLAnalysis, "analysis")
         assert row.updated_at == static_time.datetime
         assert row.updated_at != OLD_TIME
+
+        mongo_analysis = await mongo.analyses.find_one({"_id": "analysis"})
+        assert mongo_analysis["updated_at"] == row.updated_at

--- a/tests/blast/test_data.py
+++ b/tests/blast/test_data.py
@@ -113,6 +113,8 @@ async def test_create_nuvs_blast(blast_data: BLASTData, pg, snapshot):
 
 
 class TestCheckNuvsBlast:
+    """Checking a NuVs BLAST syncs its state from NCBI into our records."""
+
     async def test_running(self, blast_data: BLASTData, mocker, pg, snapshot):
         """Check that the ``last_checked_at`` field is updated when the BLAST is still
         running on NCBI.

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -2,21 +2,23 @@ import asyncio
 from collections.abc import AsyncIterator
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 import virtool.utils
 from tests.fixtures.client import ClientSpawner
+from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
 from virtool.api.client import UserClient
 from virtool.data.errors import ResourceConflictError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
-from virtool.models.enums import LibraryType, Permission
+from virtool.models.enums import AnalysisWorkflow, LibraryType, Permission
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.samples.models import WorkflowState
-from virtool.samples.oas import CreateSampleRequest
+from virtool.samples.oas import CreateAnalysisRequest, CreateSampleRequest
 from virtool.samples.sql import SQLSampleReads
 from virtool.samples.utils import SampleRight
 from virtool.settings.oas import UpdateSettingsRequest
@@ -504,3 +506,104 @@ class TestHasResourcesForAnalysisJob:
                 "test_ref",
                 [subtraction_id, "missing"],
             )
+
+
+class TestDelete:
+    """Deleting a sample cascades to its analyses in both Mongo and Postgres."""
+
+    async def _setup(self, fake: DataFaker, mongo: Mongo) -> str:
+        user = await fake.users.create()
+
+        await asyncio.gather(
+            mongo.samples.insert_one(
+                {
+                    "_id": "test_sample",
+                    "all_read": True,
+                    "all_write": True,
+                    "created_at": virtool.utils.timestamp(),
+                    "files": [],
+                    "format": "fastq",
+                    "group": "none",
+                    "group_read": True,
+                    "group_write": True,
+                    "hold": False,
+                    "host": "",
+                    "is_legacy": False,
+                    "isolate": "",
+                    "job": None,
+                    "labels": [],
+                    "library_type": LibraryType.normal.value,
+                    "locale": "",
+                    "name": "Test Sample",
+                    "notes": "",
+                    "nuvs": False,
+                    "pathoscope": True,
+                    "ready": True,
+                    "subtractions": [],
+                    "user": {"id": user.id},
+                    "workflows": {
+                        "aodp": WorkflowState.INCOMPATIBLE.value,
+                        "pathoscope": WorkflowState.COMPLETE.value,
+                        "nuvs": WorkflowState.PENDING.value,
+                    },
+                },
+            ),
+            mongo.indexes.insert_one(
+                {
+                    "_id": "test_index",
+                    "version": 11,
+                    "ready": True,
+                    "reference": {"id": "test_ref"},
+                },
+            ),
+            mongo.references.insert_one(
+                {
+                    "_id": "test_ref",
+                    "archived": False,
+                    "data_type": "genome",
+                    "name": "Test Reference",
+                },
+            ),
+        )
+
+        return user.id
+
+    async def test_deletes_analysis_pg_rows(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Deleting a sample removes its analyses' Postgres rows and result rows."""
+        user_id = await self._setup(fake, mongo)
+
+        analysis = await data_layer.analyses.create(
+            CreateAnalysisRequest(
+                ml=None,
+                ref_id="test_ref",
+                subtractions=[],
+                workflow=AnalysisWorkflow.nuvs,
+            ),
+            "test_sample",
+            user_id,
+            0,
+        )
+
+        await data_layer.analyses.finalize(analysis.id, {"hits": []})
+
+        assert await get_row_by_id(pg, SQLAnalysis, analysis.id) is not None
+
+        await data_layer.samples.delete("test_sample")
+
+        assert await mongo.analyses.find_one({"_id": analysis.id}) is None
+        assert await get_row_by_id(pg, SQLAnalysis, analysis.id) is None
+
+        async with AsyncSession(pg) as session:
+            result = await session.execute(
+                select(SQLAnalysisResult).where(
+                    SQLAnalysisResult.analysis_id == analysis.id,
+                ),
+            )
+            assert result.scalar_one_or_none() is None

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 
 import sentry_sdk
-from sqlalchemy import delete, insert, select
+from sqlalchemy import delete, insert, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
@@ -19,7 +19,7 @@ from virtool.analyses.checks import (
 from virtool.analyses.db import filter_analyses_by_sample_rights
 from virtool.analyses.files import create_analysis_file
 from virtool.analyses.models import Analysis, AnalysisFile, AnalysisSearchResult
-from virtool.analyses.sql import SQLAnalysisFile, SQLAnalysisResult
+from virtool.analyses.sql import SQLAnalysis, SQLAnalysisFile, SQLAnalysisResult
 from virtool.analyses.utils import (
     analysis_file_key,
     attach_analysis_files,
@@ -33,7 +33,7 @@ from virtool.data.errors import (
     ResourceNotFoundError,
 )
 from virtool.data.events import Operation, emit, emits
-from virtool.data.topg import both_transactions
+from virtool.data.topg import both_transactions, resolve_user_id
 from virtool.data.transforms import apply_transforms
 from virtool.indexes.db import get_current_id_and_version
 from virtool.jobs.transforms import AttachJobTransform
@@ -267,29 +267,54 @@ class AnalysisData(DataLayerDomain):
             space_id,
         )
 
-        await self._mongo.analyses.insert_one(
-            {
-                "_id": analysis_id,
-                "created_at": created_at,
-                "files": [],
-                "index": {"id": index_id, "version": index_version},
-                "job": {"id": job.id},
-                "ml": data.ml,
-                "reference": {
-                    "id": data.ref_id,
+        subtractions = data.subtractions if data.subtractions is not None else []
+
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.analyses.insert_one(
+                {
+                    "_id": analysis_id,
+                    "created_at": created_at,
+                    "files": [],
+                    "index": {"id": index_id, "version": index_version},
+                    "job": {"id": job.id},
+                    "ml": data.ml,
+                    "reference": {
+                        "id": data.ref_id,
+                    },
+                    "ready": False,
+                    "results": None,
+                    "sample": {"id": sample_id},
+                    "space": {"id": space_id},
+                    "subtractions": subtractions,
+                    "updated_at": created_at,
+                    "user": {
+                        "id": user_id,
+                    },
+                    "workflow": data.workflow.value,
                 },
-                "ready": False,
-                "results": None,
-                "sample": {"id": sample_id},
-                "space": {"id": space_id},
-                "subtractions": data.subtractions,
-                "updated_at": created_at,
-                "user": {
-                    "id": user_id,
-                },
-                "workflow": data.workflow.value,
-            },
-        )
+                session=mongo_session,
+            )
+
+            await pg_session.execute(
+                insert(SQLAnalysis).values(
+                    id=analysis_id,
+                    created_at=created_at,
+                    updated_at=created_at,
+                    workflow=data.workflow.value,
+                    ready=False,
+                    results=None,
+                    sample=sample_id,
+                    reference=data.ref_id,
+                    index=index_id,
+                    subtractions=subtractions,
+                    user_id=await resolve_user_id(pg_session, user_id),
+                    job_id=job.id,
+                    ml_id=data.ml,
+                ),
+            )
 
         return await self.get(analysis_id, None)
 
@@ -357,6 +382,9 @@ class AnalysisData(DataLayerDomain):
                     delete(SQLAnalysisResult).where(
                         SQLAnalysisResult.analysis_id == analysis_id,
                     ),
+                ),
+                pg_session.execute(
+                    delete(SQLAnalysis).where(SQLAnalysis.id == analysis_id),
                 ),
             )
 
@@ -523,20 +551,16 @@ class AnalysisData(DataLayerDomain):
             check_analysis_nuvs_sequence(document, sequence_index),
         )
 
-        async with AsyncSession(self._pg) as session:
-            await session.execute(
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await pg_session.execute(
                 delete(SQLNuVsBlast)
                 .where(SQLNuVsBlast.analysis_id == analysis_id)
                 .where(SQLNuVsBlast.sequence_index == sequence_index),
             )
-            await session.commit()
-
-            await self._mongo.analyses.update_one(
-                {"_id": analysis_id},
-                {"$set": {"updated_at": virtool.utils.timestamp()}},
-            )
-
-            await session.flush()
+            await pg_session.flush()
 
             blast = SQLNuVsBlast(
                 analysis_id=analysis_id,
@@ -547,8 +571,20 @@ class AnalysisData(DataLayerDomain):
                 updated_at=timestamp,
             )
 
-            session.add(blast)
-            await session.flush()
+            pg_session.add(blast)
+            await pg_session.flush()
+
+            await pg_session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis_id)
+                .values(updated_at=timestamp),
+            )
+
+            await self._mongo.analyses.update_one(
+                {"_id": analysis_id},
+                {"$set": {"updated_at": timestamp}},
+                session=mongo_session,
+            )
 
             await self.data.tasks.create(
                 BLASTTask,
@@ -556,7 +592,6 @@ class AnalysisData(DataLayerDomain):
             )
 
             blast_data = blast.to_dict()
-            await session.commit()
 
         return blast_data
 
@@ -587,6 +622,12 @@ class AnalysisData(DataLayerDomain):
                     analysis_id=analysis_id,
                     results=results,
                 ),
+            )
+
+            await pg_session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis_id)
+                .values(ready=True, results=results, updated_at=updated_at),
             )
 
             document = await self._mongo.analyses.find_one_and_update(

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -16,7 +16,10 @@ from virtool.analyses.checks import (
     check_if_analysis_is_running,
     check_if_analysis_modified,
 )
-from virtool.analyses.db import filter_analyses_by_sample_rights
+from virtool.analyses.db import (
+    bump_analysis_updated_at,
+    filter_analyses_by_sample_rights,
+)
 from virtool.analyses.files import create_analysis_file
 from virtool.analyses.models import Analysis, AnalysisFile, AnalysisSearchResult
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisFile, SQLAnalysisResult
@@ -373,19 +376,19 @@ class AnalysisData(DataLayerDomain):
             mongo_session,
             pg_session,
         ):
-            await asyncio.gather(
-                self._mongo.analyses.delete_one(
-                    {"_id": analysis.id},
-                    session=mongo_session,
+            await self._mongo.analyses.delete_one(
+                {"_id": analysis.id},
+                session=mongo_session,
+            )
+
+            await pg_session.execute(
+                delete(SQLAnalysisResult).where(
+                    SQLAnalysisResult.analysis_id == analysis_id,
                 ),
-                pg_session.execute(
-                    delete(SQLAnalysisResult).where(
-                        SQLAnalysisResult.analysis_id == analysis_id,
-                    ),
-                ),
-                pg_session.execute(
-                    delete(SQLAnalysis).where(SQLAnalysis.id == analysis_id),
-                ),
+            )
+
+            await pg_session.execute(
+                delete(SQLAnalysis).where(SQLAnalysis.id == analysis_id),
             )
 
         for key, exc in await delete_prefix(
@@ -574,16 +577,12 @@ class AnalysisData(DataLayerDomain):
             pg_session.add(blast)
             await pg_session.flush()
 
-            await pg_session.execute(
-                update(SQLAnalysis)
-                .where(SQLAnalysis.id == analysis_id)
-                .values(updated_at=timestamp),
-            )
-
-            await self._mongo.analyses.update_one(
-                {"_id": analysis_id},
-                {"$set": {"updated_at": timestamp}},
-                session=mongo_session,
+            await bump_analysis_updated_at(
+                self._mongo,
+                mongo_session,
+                pg_session,
+                analysis_id,
+                timestamp,
             )
 
             await self.data.tasks.create(

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -1,15 +1,49 @@
 """Work with analyses in the database."""
 
+from datetime import datetime
 from typing import Any
 
-from sqlalchemy import select
+from motor.motor_asyncio import AsyncIOMotorClientSession
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.analyses.sql import SQLAnalysisFile
+from virtool.analyses.sql import SQLAnalysis, SQLAnalysisFile
 from virtool.data.transforms import AbstractTransform
 from virtool.mongo.core import Mongo
 from virtool.samples.utils import get_sample_rights
 from virtool.types import Document
+
+
+async def bump_analysis_updated_at(
+    mongo: Mongo,
+    mongo_session: AsyncIOMotorClientSession,
+    pg_session: AsyncSession,
+    analysis_id: str,
+    updated_at: datetime,
+) -> None:
+    """Bump an analysis ``updated_at`` timestamp in both Postgres and Mongo.
+
+    This keeps the two backends in sync during the MongoDB-to-Postgres migration and
+    must be called within a :func:`both_transactions` block so the writes commit
+    together.
+
+    :param mongo: the application MongoDB client
+    :param mongo_session: the active Mongo transaction session
+    :param pg_session: the active Postgres transaction session
+    :param analysis_id: the ID of the analysis to bump
+    :param updated_at: the timestamp to set
+    """
+    await pg_session.execute(
+        update(SQLAnalysis)
+        .where(SQLAnalysis.id == analysis_id)
+        .values(updated_at=updated_at),
+    )
+
+    await mongo.analyses.update_one(
+        {"_id": analysis_id},
+        {"$set": {"updated_at": updated_at}},
+        session=mongo_session,
+    )
 
 
 class AttachAnalysisFileTransform(AbstractTransform):

--- a/virtool/blast/data.py
+++ b/virtool/blast/data.py
@@ -2,11 +2,11 @@ from typing import TYPE_CHECKING
 from zipfile import BadZipFile
 
 from aiohttp import ClientSession
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
-from virtool.analyses.sql import SQLAnalysis
+from virtool.analyses.db import bump_analysis_updated_at
 from virtool.analyses.utils import find_nuvs_sequence_by_index
 from virtool.blast.db import delete_nuvs_blast, get_nuvs_blast
 from virtool.blast.models import NuvsBlast
@@ -75,16 +75,12 @@ class BLASTData(DataLayerDomain):
             pg_session.add(blast_row)
             await pg_session.flush()
 
-            await pg_session.execute(
-                update(SQLAnalysis)
-                .where(SQLAnalysis.id == analysis_id)
-                .values(updated_at=created_at),
-            )
-
-            await self._mongo.analyses.update_one(
-                {"_id": analysis_id},
-                {"$set": {"updated_at": created_at}},
-                session=mongo_session,
+            await bump_analysis_updated_at(
+                self._mongo,
+                mongo_session,
+                pg_session,
+                analysis_id,
+                created_at,
             )
 
             await self.data.tasks.create(
@@ -186,6 +182,9 @@ class BLASTData(DataLayerDomain):
         ):
             blast_row = await get_nuvs_blast(pg_session, analysis_id, sequence_index)
 
+            if blast_row is None:
+                raise ResourceNotFoundError
+
             blast_row.last_checked_at = updated_at
             blast_row.updated_at = updated_at
 
@@ -196,16 +195,12 @@ class BLASTData(DataLayerDomain):
                     blast_row.result = result
                     blast_row.ready = True
 
-            await pg_session.execute(
-                update(SQLAnalysis)
-                .where(SQLAnalysis.id == analysis_id)
-                .values(updated_at=updated_at),
-            )
-
-            await self._mongo.analyses.update_one(
-                {"_id": analysis_id},
-                {"$set": {"updated_at": updated_at}},
-                session=mongo_session,
+            await bump_analysis_updated_at(
+                self._mongo,
+                mongo_session,
+                pg_session,
+                analysis_id,
+                updated_at,
             )
 
         return await self.get_nuvs_blast(analysis_id, sequence_index)
@@ -227,16 +222,12 @@ class BLASTData(DataLayerDomain):
                 pg_session, analysis_id, sequence_index
             )
 
-            await pg_session.execute(
-                update(SQLAnalysis)
-                .where(SQLAnalysis.id == analysis_id)
-                .values(updated_at=updated_at),
-            )
-
-            await self._mongo.analyses.update_one(
-                {"_id": analysis_id},
-                {"$set": {"updated_at": updated_at}},
-                session=mongo_session,
+            await bump_analysis_updated_at(
+                self._mongo,
+                mongo_session,
+                pg_session,
+                analysis_id,
+                updated_at,
             )
 
         return deleted_count

--- a/virtool/blast/data.py
+++ b/virtool/blast/data.py
@@ -2,10 +2,11 @@ from typing import TYPE_CHECKING
 from zipfile import BadZipFile
 
 from aiohttp import ClientSession
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
+from virtool.analyses.sql import SQLAnalysis
 from virtool.analyses.utils import find_nuvs_sequence_by_index
 from virtool.blast.db import delete_nuvs_blast, get_nuvs_blast
 from virtool.blast.models import NuvsBlast
@@ -20,6 +21,7 @@ from virtool.blast.utils import (
 )
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceNotFoundError
+from virtool.data.topg import both_transactions
 from virtool.types import Document
 
 if TYPE_CHECKING:
@@ -54,9 +56,12 @@ class BLASTData(DataLayerDomain):
         """
         created_at = virtool.utils.timestamp()
 
-        async with AsyncSession(self._pg) as session:
-            await delete_nuvs_blast(session, analysis_id, sequence_index)
-            await session.flush()
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await delete_nuvs_blast(pg_session, analysis_id, sequence_index)
+            await pg_session.flush()
 
             blast_row = SQLNuVsBlast(
                 analysis_id=analysis_id,
@@ -67,8 +72,20 @@ class BLASTData(DataLayerDomain):
                 updated_at=created_at,
             )
 
-            session.add(blast_row)
-            await session.flush()
+            pg_session.add(blast_row)
+            await pg_session.flush()
+
+            await pg_session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis_id)
+                .values(updated_at=created_at),
+            )
+
+            await self._mongo.analyses.update_one(
+                {"_id": analysis_id},
+                {"$set": {"updated_at": created_at}},
+                session=mongo_session,
+            )
 
             await self.data.tasks.create(
                 BLASTTask,
@@ -76,13 +93,6 @@ class BLASTData(DataLayerDomain):
             )
 
             blast = NuvsBlast(**blast_row.to_dict())
-
-            # Don't commit until the task has been created.
-            await session.commit()
-
-        await self._mongo.analyses.update_one(
-            {"_id": analysis_id}, {"$set": {"updated_at": created_at}}
-        )
 
         return blast
 
@@ -170,8 +180,11 @@ class BLASTData(DataLayerDomain):
             except BadZipFile:
                 error = "Unable to interpret NCBI result"
 
-        async with AsyncSession(self._pg) as session:
-            blast_row = await get_nuvs_blast(session, analysis_id, sequence_index)
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            blast_row = await get_nuvs_blast(pg_session, analysis_id, sequence_index)
 
             blast_row.last_checked_at = updated_at
             blast_row.updated_at = updated_at
@@ -183,12 +196,17 @@ class BLASTData(DataLayerDomain):
                     blast_row.result = result
                     blast_row.ready = True
 
-            await session.commit()
+            await pg_session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis_id)
+                .values(updated_at=updated_at),
+            )
 
-        await self._mongo.analyses.update_one(
-            {"_id": analysis_id},
-            {"$set": {"updated_at": updated_at}},
-        )
+            await self._mongo.analyses.update_one(
+                {"_id": analysis_id},
+                {"$set": {"updated_at": updated_at}},
+                session=mongo_session,
+            )
 
         return await self.get_nuvs_blast(analysis_id, sequence_index)
 
@@ -199,15 +217,27 @@ class BLASTData(DataLayerDomain):
         :param sequence_index: the index of the BLASTed NuVs sequence
         :return: the number of deleted records
         """
-        async with AsyncSession(self._pg) as session:
-            deleted_count = await delete_nuvs_blast(
-                session, analysis_id, sequence_index
-            )
-            await session.commit()
+        updated_at = virtool.utils.timestamp()
 
-        await self._mongo.analyses.update_one(
-            {"_id": analysis_id}, {"$set": {"updated_at": virtool.utils.timestamp()}}
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            deleted_count = await delete_nuvs_blast(
+                pg_session, analysis_id, sequence_index
+            )
+
+            await pg_session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis_id)
+                .values(updated_at=updated_at),
+            )
+
+            await self._mongo.analyses.update_one(
+                {"_id": analysis_id},
+                {"$set": {"updated_at": updated_at}},
+                session=mongo_session,
+            )
 
         return deleted_count
 

--- a/virtool/blast/db.py
+++ b/virtool/blast/db.py
@@ -29,6 +29,4 @@ async def delete_nuvs_blast(
         .where(SQLNuVsBlast.sequence_index == sequence_index),
     )
 
-    await session.commit()
-
     return result.rowcount

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -7,19 +7,20 @@ from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
 from pymongo.results import UpdateResult
-from sqlalchemy import exc, select
+from sqlalchemy import delete, exc, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
 import virtool.uploads.db
 import virtool.utils
+from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
 from virtool.api.client import UserClient
 from virtool.api.utils import compose_regex_query
 from virtool.config.cls import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emits
-from virtool.data.topg import compose_legacy_id_multi_expression
+from virtool.data.topg import both_transactions, compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.groups.models import GroupMinimal
 from virtool.groups.pg import SQLGroup
@@ -385,13 +386,27 @@ class SamplesData(DataLayerDomain):
         """
         sample = await self.get(sample_id)
 
-        async with self._mongo.create_session() as session:
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
             result = await self._mongo.samples.delete_one(
-                {"_id": sample_id}, session=session
+                {"_id": sample_id}, session=mongo_session
             )
             await self._mongo.analyses.delete_many(
                 {"sample.id": sample_id},
-                session=session,
+                session=mongo_session,
+            )
+
+            await pg_session.execute(
+                delete(SQLAnalysisResult).where(
+                    SQLAnalysisResult.analysis_id.in_(
+                        select(SQLAnalysis.id).where(SQLAnalysis.sample == sample_id),
+                    ),
+                ),
+            )
+            await pg_session.execute(
+                delete(SQLAnalysis).where(SQLAnalysis.sample == sample_id),
             )
 
         if result.deleted_count:


### PR DESCRIPTION
## Summary

- Adds a `SQLAnalysis` Postgres table (via Alembic migration) to store analysis metadata alongside the existing Mongo collection
- Wraps `create`, `finalize`, and `delete` operations in `both_transactions` so Mongo and Postgres writes are kept in sync with rollback on failure
- Updates `BLASTData` mutations to bump `SQLAnalysis.updated_at` within the same dual-write transaction as the Mongo `updated_at` write

## Summary by Sourcery

Ensure analysis and BLAST operations dual-write analysis metadata and results to Postgres while keeping Mongo and Postgres in sync using shared transactions.

New Features:
- Persist analysis metadata and results in a new Postgres-backed SQLAnalysis model alongside existing Mongo documents.
- Track analysis updated_at timestamps in Postgres and bump them on all BLAST-related mutations.

Bug Fixes:
- Prevent None subtractions from being stored by defaulting to an empty list in new analysis records.
- Guarantee rollback of analysis creation, finalization, and deletion when either Mongo or Postgres writes fail, avoiding cross-database inconsistencies.

Enhancements:
- Wrap analysis and BLAST mutations in coordinated Mongo/Postgres transactions to keep dual writes consistent.
- Align BLAST data-layer operations to update both SQLAnalysis and Mongo analysis documents within the same transactional context.

Tests:
- Add dual-write tests for analysis creation, finalization, and deletion to verify Postgres rows mirror Mongo documents and roll back on failures.
- Add BLAST tests to verify SQLAnalysis.updated_at is updated on create, check, and delete of NuVs BLAST records and remains in sync with Mongo.
- Extend test fixtures to create realistic sample, user, analysis, and BLAST records for the new Postgres-backed behavior.