### PR TITLE
drop resolve_user_id and legacy string user id handling

### DIFF
--- a/assets/revisions/rev_31su1xw351h2_copy_api_keys_to_postgres.py
+++ b/assets/revisions/rev_31su1xw351h2_copy_api_keys_to_postgres.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from virtool.account.sql import SQLAPIKey
-from virtool.data.topg import resolve_user_id
 from virtool.migration import MigrationContext
 
 logger = get_logger("migration")
@@ -53,7 +52,7 @@ async def upgrade(ctx: MigrationContext) -> None:
                 hashed=document["_id"],
                 name=document["name"],
                 created_at=arrow.get(document["created_at"]).naive,
-                user_id=await resolve_user_id(session, document["user"]["id"]),
+                user_id=int(document["user"]["id"]),
                 permissions=document["permissions"],
             )
 

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -272,7 +272,7 @@ class TestCreate:
     ):
         """A failure writing the Postgres row rolls back the Mongo write too."""
         mocker.patch(
-            "virtool.analyses.data.resolve_user_id",
+            "virtool.analyses.data.insert",
             side_effect=RuntimeError("boom"),
         )
 

--- a/tests/migration/test_copy_api_keys_to_postgres.py
+++ b/tests/migration/test_copy_api_keys_to_postgres.py
@@ -106,14 +106,14 @@ class TestUpgrade:
         assert first["id"] == api_keys[0]["id"]
         assert second["id"] == api_keys[1]["id"]
 
-    async def test_resolves_legacy_string_user_and_date(
+    async def test_coerces_string_created_at(
         self,
         ctx: MigrationContext,
         apply_alembic: Callable,
     ):
         await asyncio.to_thread(apply_alembic, REVISION)
 
-        user_id = await create_user(ctx, legacy_id="bob")
+        user_id = await create_user(ctx)
 
         await ctx.mongo.keys.insert_one(
             {
@@ -123,7 +123,7 @@ class TestUpgrade:
                 "created_at": "2023-01-01T00:00:00Z",
                 "groups": [],
                 "permissions": {"create_sample": True},
-                "user": {"id": "bob"},
+                "user": {"id": user_id},
             },
         )
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -36,7 +36,7 @@ from virtool.data.errors import (
     ResourceNotFoundError,
 )
 from virtool.data.events import Operation, emit, emits
-from virtool.data.topg import both_transactions, resolve_user_id
+from virtool.data.topg import both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.indexes.db import get_current_id_and_version
 from virtool.jobs.transforms import AttachJobTransform
@@ -313,7 +313,7 @@ class AnalysisData(DataLayerDomain):
                     reference=data.ref_id,
                     index=index_id,
                     subtractions=subtractions,
-                    user_id=await resolve_user_id(pg_session, user_id),
+                    user_id=user_id,
                     job_id=job.id,
                     ml_id=data.ml,
                 ),

--- a/virtool/data/topg.py
+++ b/virtool/data/topg.py
@@ -5,11 +5,10 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, TypeVar
 
 from pymongo.errors import OperationFailure
-from sqlalchemy import ColumnExpressionArgument, or_, select
+from sqlalchemy import ColumnExpressionArgument, or_
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.pg.base import HasLegacyAndModernIDs
-from virtool.users.pg import SQLUser
 
 if TYPE_CHECKING:
     from motor.motor_asyncio import AsyncIOMotorClientSession as ClientSession
@@ -134,26 +133,3 @@ def compose_legacy_id_single_expression(
         return model.id == int(id_)
 
     return model.legacy_id == id_
-
-
-async def resolve_user_id(session: AsyncSession, user_id: int | str) -> int:
-    """Resolve a user ID to its Postgres integer ID.
-
-    Use this within an existing session (e.g., inside both_transactions).
-
-    :param session: an async SQLAlchemy session
-    :param user_id: a user ID (modern int or legacy string)
-    :return: the Postgres integer user ID
-    :raises NoResultFound: if no user is found
-    """
-    if isinstance(user_id, int):
-        return user_id
-
-    if isinstance(user_id, str) and user_id.isdigit():
-        return int(user_id)
-
-    result = await session.execute(
-        select(SQLUser.id).where(SQLUser.legacy_id == user_id),
-    )
-
-    return result.scalar_one()

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -9,7 +9,6 @@ from structlog import get_logger
 import virtool.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
-from virtool.data.topg import resolve_user_id
 from virtool.data.transforms import apply_transforms
 from virtool.jobs.models import (
     CreateJobClaimRequest,
@@ -195,13 +194,11 @@ class JobsData:
         :param space_id: the space that the job belongs to
         """
         async with AsyncSession(self._pg) as session:
-            pg_user_id = await resolve_user_id(session, user_id)
-
             sql_job = SQLJob(
                 acquired=False,
                 created_at=virtool.utils.timestamp(),
                 state="pending",
-                user_id=pg_user_id,
+                user_id=user_id,
                 workflow=workflow,
             )
             session.add(sql_job)


### PR DESCRIPTION
## Summary
- Removes the `resolve_user_id` helper from `virtool/data/topg.py`, which previously handled the case where a user ID could be a legacy string (MongoDB ID) rather than a Postgres integer
- Updates the API key migration and jobs data layer to use integer user IDs directly, since all user IDs are now guaranteed to be Postgres integers
- Simplifies the migration test to remove the legacy string user ID scenario that no longer applies