### PR TITLE
fix: resolve postgres-stored history diffs in patch_to_version

### DIFF
--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -307,7 +307,7 @@ class TestFinalize:
         """
         mocker.patch(
             "virtool.analyses.format.format_analysis",
-            side_effect=lambda _storage, _mongo, document: document,
+            side_effect=lambda _storage, _mongo, _pg, document: document,
         )
 
         analysis = await data_layer.analyses.create(

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+from unittest.mock import ANY
 
 import pytest
 from sqlalchemy import select
@@ -305,7 +306,7 @@ class TestFinalize:
         """Finalize marks the Postgres row ready and writes results matching the
         ``analysis_results`` row.
         """
-        mocker.patch(
+        m_format_analysis = mocker.patch(
             "virtool.analyses.format.format_analysis",
             side_effect=lambda _storage, _mongo, _pg, document: document,
         )
@@ -344,6 +345,10 @@ class TestFinalize:
         # Mongo stores datetimes at millisecond precision, so the bumped timestamp is
         # compared by advancement rather than exact equality with the Postgres row.
         assert document["updated_at"] > created.updated_at
+
+        # The PostgreSQL engine must be threaded through to format_analysis so it can
+        # resolve Postgres-stored history diffs.
+        m_format_analysis.assert_called_with(ANY, mongo, pg, ANY)
 
     async def test_rolls_back_when_mongo_write_fails(
         self,

--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -195,12 +195,13 @@ async def test_format_analysis(
     )
 
     storage = MemoryStorageProvider()
+    pg = mocker.Mock()
     document = {}
 
     if workflow:
         document["workflow"] = workflow
 
-    coroutine = virtool.analyses.format.format_analysis(storage, mongo, document)
+    coroutine = virtool.analyses.format.format_analysis(storage, mongo, pg, document)
 
     if workflow is None or workflow == "foobar":
         with pytest.raises(ValueError) as err:
@@ -222,5 +223,5 @@ async def test_format_analysis(
             assert not m_format_pathoscope.called
 
         elif workflow == "pathoscope":
-            m_format_pathoscope.assert_called_with(storage, mongo, document)
+            m_format_pathoscope.assert_called_with(storage, mongo, pg, document)
             assert not m_format_nuvs.called

--- a/tests/fixtures/history.py
+++ b/tests/fixtures/history.py
@@ -2,6 +2,8 @@ import datetime
 
 import pytest
 
+from virtool.history.db import bulk_insert_diffs
+
 
 @pytest.fixture
 def test_change(static_time):
@@ -99,7 +101,7 @@ def test_otu_edit():
 
 
 @pytest.fixture
-def create_mock_history(mongo):
+def create_mock_history(mongo, pg):
     async def func(remove):
         documents = [
             {
@@ -264,6 +266,19 @@ def create_mock_history(mongo):
             }
 
             await mongo.otus.insert_one(otu)
+
+        # Mirror production: store the real diff in Postgres and only the
+        # "postgres" sentinel in Mongo.
+        await bulk_insert_diffs(
+            pg,
+            [
+                {"change_id": document["_id"], "diff": document["diff"]}
+                for document in documents
+            ],
+        )
+
+        for document in documents:
+            document["diff"] = "postgres"
 
         await mongo.history.insert_many(documents, session=None)
 

--- a/tests/history/__snapshots__/test_api.ambr
+++ b/tests/history/__snapshots__/test_api.ambr
@@ -165,40 +165,7 @@
       '_id': '6116cba1.0',
       'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 495000),
       'description': 'Description',
-      'diff': dict({
-        '_id': '6116cba1',
-        'abbreviation': 'PVF',
-        'imported': True,
-        'isolates': list([
-          dict({
-            'default': True,
-            'id': 'cab8b360',
-            'sequences': list([
-              dict({
-                '_id': 'KX269872',
-                'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-                'host': 'sweet cherry',
-                'isolate_id': 'cab8b360',
-                'otu_id': '6116cba1',
-                'segment': None,
-                'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-              }),
-            ]),
-            'source_name': '8816-v2',
-            'source_type': 'isolate',
-          }),
-        ]),
-        'last_indexed_version': 0,
-        'lower_name': 'prunus virus f',
-        'name': 'Prunus virus F',
-        'reference': dict({
-          'id': 'hxn167',
-        }),
-        'schema': list([
-        ]),
-        'verified': False,
-        'version': 0,
-      }),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -220,24 +187,7 @@
       '_id': '6116cba1.1',
       'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 600000),
       'description': 'Description',
-      'diff': list([
-        list([
-          'change',
-          'version',
-          list([
-            0,
-            1,
-          ]),
-        ]),
-        list([
-          'change',
-          'abbreviation',
-          list([
-            'PVF',
-            'TST',
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -301,40 +251,7 @@
       '_id': '6116cba1.0',
       'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 495000),
       'description': 'Description',
-      'diff': dict({
-        '_id': '6116cba1',
-        'abbreviation': 'PVF',
-        'imported': True,
-        'isolates': list([
-          dict({
-            'default': True,
-            'id': 'cab8b360',
-            'sequences': list([
-              dict({
-                '_id': 'KX269872',
-                'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-                'host': 'sweet cherry',
-                'isolate_id': 'cab8b360',
-                'otu_id': '6116cba1',
-                'segment': None,
-                'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-              }),
-            ]),
-            'source_name': '8816-v2',
-            'source_type': 'isolate',
-          }),
-        ]),
-        'last_indexed_version': 0,
-        'lower_name': 'prunus virus f',
-        'name': 'Prunus virus F',
-        'reference': dict({
-          'id': 'hxn167',
-        }),
-        'schema': list([
-        ]),
-        'verified': False,
-        'version': 0,
-      }),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
@@ -356,24 +273,7 @@
       '_id': '6116cba1.1',
       'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 600000),
       'description': 'Description',
-      'diff': list([
-        list([
-          'change',
-          'version',
-          list([
-            0,
-            1,
-          ]),
-        ]),
-        list([
-          'change',
-          'abbreviation',
-          list([
-            'PVF',
-            'TST',
-          ]),
-        ]),
-      ]),
+      'diff': 'postgres',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -192,3 +192,20 @@ async def test_patch_to_version(
     assert current == snapshot(name="current")
     assert patched == snapshot(name="patched")
     assert reverted_change_ids == snapshot(name="reverted_change_ids")
+
+
+async def test_patch_to_version_missing_diff(mongo: Mongo, pg: AsyncEngine):
+    """A change with the ``"postgres"`` sentinel but no ``SQLHistoryDiff`` row raises a
+    clear error instead of failing later with a ``KeyError``.
+    """
+    await mongo.history.insert_one(
+        {
+            "_id": "6116cba1.1",
+            "diff": "postgres",
+            "method_name": "update",
+            "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
+        },
+    )
+
+    with pytest.raises(ValueError, match="Missing history_diffs rows.*6116cba1.1"):
+        await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -177,12 +177,14 @@ async def test_patch_to_version(
     remove: bool,
     create_mock_history,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
     await create_mock_history(remove=remove)
 
     current, patched, reverted_change_ids = await virtool.history.db.patch_to_version(
         mongo,
+        pg,
         "6116cba1",
         1,
     )

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -415,6 +415,7 @@ async def test_download_otus_json(
     if not file_exists:
         m_get_patched_otus.assert_called_with(
             get_mongo_from_app(client.app),
+            client.app["pg"],
             manifest,
         )
 

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -94,17 +94,19 @@ async def test_get_patched_otus(mocker: MockerFixture, mongo: Mongo):
         make_mocked_coro((None, {"_id": "foo"}, None)),
     )
 
+    pg = mocker.Mock()
+
     manifest = {"foo": 2, "bar": 10, "baz": 4}
 
-    patched_otus = await get_patched_otus(mongo, manifest)
+    patched_otus = await get_patched_otus(mongo, pg, manifest)
 
     assert list(patched_otus) == [{"_id": "foo"}, {"_id": "foo"}, {"_id": "foo"}]
 
     m.assert_has_calls(
         [
-            mocker.call(mongo, "foo", 2),
-            mocker.call(mongo, "bar", 10),
-            mocker.call(mongo, "baz", 4),
+            mocker.call(mongo, pg, "foo", 2),
+            mocker.call(mongo, pg, "bar", 10),
+            mocker.call(mongo, pg, "baz", 4),
         ],
     )
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -206,6 +206,7 @@ class AnalysisData(DataLayerDomain):
             document = await virtool.analyses.format.format_analysis(
                 self._storage,
                 self._mongo,
+                self._pg,
                 document,
             )
 
@@ -510,6 +511,7 @@ class AnalysisData(DataLayerDomain):
                 await virtool.analyses.format.format_analysis_to_excel(
                     self._storage,
                     self._mongo,
+                    self._pg,
                     document,
                 ),
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -519,6 +521,7 @@ class AnalysisData(DataLayerDomain):
             await virtool.analyses.format.format_analysis_to_csv(
                 self._storage,
                 self._mongo,
+                self._pg,
                 document,
             ),
             "text/csv",

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import openpyxl.styles
 import visvalingamwyatt as vw
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from virtool.analyses.utils import analysis_result_key
 from virtool.history.db import patch_to_version
@@ -73,19 +74,21 @@ async def load_results(
 
 async def format_aodp(
     mongo: "Mongo",
+    pg: AsyncEngine,
     document: dict[str, Any],
 ) -> dict[str, Any]:
     """Format an AODP analysis document by retrieving the detected OTUs and
     incorporating them into the returned document.
 
     :param mongo: the application Mongo object
+    :param pg: the application PostgreSQL database object
     :param document: the document to format
     :return: the formatted document
 
     """
     hits = document["results"]["hits"]
 
-    patched_otus = await gather_patched_otus(mongo, hits)
+    patched_otus = await gather_patched_otus(mongo, pg, hits)
 
     hits_by_sequence_id = defaultdict(list)
 
@@ -109,6 +112,7 @@ async def format_aodp(
 async def format_pathoscope(
     storage: StorageBackend,
     mongo: "Mongo",
+    pg: AsyncEngine,
     document: dict[str, Any],
 ) -> dict[str, Any]:
     """Format a Pathoscope analysis document by retrieving the detected OTUs and
@@ -118,6 +122,7 @@ async def format_pathoscope(
 
     :param storage: the storage backend
     :param mongo: the application Mongo object
+    :param pg: the application PostgreSQL database object
     :param document: the document to format
     :return: the formatted document
 
@@ -136,7 +141,7 @@ async def format_pathoscope(
 
     for otu_specifier, hits in hits_by_otu.items():
         otu_id, otu_version = otu_specifier
-        coros.append(format_pathoscope_hits(mongo, otu_id, otu_version, hits))
+        coros.append(format_pathoscope_hits(mongo, pg, otu_id, otu_version, hits))
 
     return {
         **document,
@@ -146,12 +151,14 @@ async def format_pathoscope(
 
 async def format_pathoscope_hits(
     mongo: "Mongo",
+    pg: AsyncEngine,
     otu_id: str,
     otu_version,
     hits: list[dict],
 ):
     _, patched_otu, _ = await patch_to_version(
         mongo,
+        pg,
         otu_id,
         otu_version,
     )
@@ -261,19 +268,21 @@ async def format_nuvs(
 async def format_analysis_to_excel(
     storage: StorageBackend,
     mongo: "Mongo",
+    pg: AsyncEngine,
     document: dict[str, Any],
 ) -> bytes:
     """Convert a pathoscope analysis document to byte-encoded Excel format for download.
 
     :param storage: the storage backend
     :param mongo: the database object
+    :param pg: the application PostgreSQL database object
     :param document: the document to format
     :return: the formatted Excel workbook
 
     """
     depths = calculate_median_depths(document["results"]["hits"])
 
-    formatted = await format_analysis(storage, mongo, document)
+    formatted = await format_analysis(storage, mongo, pg, document)
 
     output = io.BytesIO()
 
@@ -321,19 +330,21 @@ async def format_analysis_to_excel(
 async def format_analysis_to_csv(
     storage: StorageBackend,
     mongo: "Mongo",
+    pg: AsyncEngine,
     document: dict[str, Any],
 ) -> str:
     """Convert a pathoscope analysis document to CSV format for download.
 
     :param storage: the storage backend
     :param mongo: the app mongo object
+    :param pg: the application PostgreSQL database object
     :param document: the document to format
     :return: the formatted CSV data
 
     """
     depths = calculate_median_depths(document["results"]["hits"])
 
-    formatted = await format_analysis(storage, mongo, document)
+    formatted = await format_analysis(storage, mongo, pg, document)
 
     output = io.StringIO()
 
@@ -362,12 +373,14 @@ async def format_analysis_to_csv(
 async def format_analysis(
     storage: StorageBackend,
     mongo: "Mongo",
+    pg: AsyncEngine,
     document: dict[str, Any],
 ) -> dict[str, any]:
     """Format an analysis document to be returned by the API.
 
     :param storage: the storage backend
     :param mongo: the database object
+    :param pg: the application PostgreSQL database object
     :param document: the analysis document to format
     :return: a formatted document
 
@@ -381,10 +394,10 @@ async def format_analysis(
         return await format_nuvs(storage, mongo, document)
 
     if workflow == AnalysisWorkflow.aodp.value:
-        return await format_aodp(mongo, document)
+        return await format_aodp(mongo, pg, document)
 
     if "pathoscope" in workflow:
-        return await format_pathoscope(storage, mongo, document)
+        return await format_pathoscope(storage, mongo, pg, document)
 
     if workflow == AnalysisWorkflow.iimi.value:
         return document
@@ -394,12 +407,14 @@ async def format_analysis(
 
 async def gather_patched_otus(
     mongo: "Mongo",
+    pg: AsyncEngine,
     results: list[dict],
 ) -> dict[str, dict]:
     """Gather patched OTUs for each result item. Only fetch each id-version combination
     once.
 
     :param mongo: the database object
+    :param pg: the application PostgreSQL database object
     :param results: the results field from a pathoscope analysis document
     :return: a dict containing patched OTUs keyed by the OTU ID
 
@@ -409,7 +424,7 @@ async def gather_patched_otus(
 
     patched_otus = await gather(
         *[
-            patch_to_version(mongo, otu_id, version)
+            patch_to_version(mongo, pg, otu_id, version)
             for otu_id, version in otu_specifiers
         ],
     )

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -84,6 +84,7 @@ class HistoryData:
 
             _, patched, history_to_delete = await patch_to_version(
                 self._mongo,
+                self._pg,
                 otu_id,
                 otu_version - 1,
             )

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import dictdiffer
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -278,8 +278,44 @@ async def get_most_recent_change(
     )
 
 
+async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, object]:
+    """Resolve the ``diff`` for each change, fetching Postgres-stored diffs in one query.
+
+    Changes created since OTU diffs moved to Postgres store the sentinel string
+    ``"postgres"`` in Mongo and the real diff in ``SQLHistoryDiff``. Older inline diffs
+    are returned as-is.
+
+    :param pg: the application PostgreSQL database object
+    :param changes: the change documents to resolve diffs for
+    :return: a mapping of change id to resolved diff
+
+    """
+    resolved: dict[str, object] = {}
+    postgres_change_ids = []
+
+    for change in changes:
+        if change["diff"] == "postgres":
+            postgres_change_ids.append(change["_id"])
+        else:
+            resolved[change["_id"]] = change["diff"]
+
+    if postgres_change_ids:
+        async with AsyncSession(pg) as session:
+            result = await session.execute(
+                select(SQLHistoryDiff.change_id, SQLHistoryDiff.diff).where(
+                    SQLHistoryDiff.change_id.in_(postgres_change_ids),
+                ),
+            )
+
+            for change_id, diff in result.all():
+                resolved[change_id] = diff
+
+    return resolved
+
+
 async def patch_to_version(
     mongo: "Mongo",
+    pg: AsyncEngine,
     otu_id: str,
     version: str | int,
 ) -> tuple:
@@ -288,6 +324,7 @@ async def patch_to_version(
     Uses the diffs in the change documents associated with the otu.
 
     :param mongo: the database object
+    :param pg: the application PostgreSQL database object
     :param otu_id: the id of the otu to patch
     :param version: the version to patch to
     :return: the current joined otu, patched otu, and the ids of reverted changes
@@ -302,25 +339,32 @@ async def patch_to_version(
 
     patched = deepcopy(current)
 
-    # Sort the changes by descending timestamp.
+    # Collect the changes to revert, sorted by descending version.
+    changes_to_revert = []
+
     async for change in mongo.history.find(
         {"otu.id": otu_id},
         sort=[("otu.version", -1)],
     ):
         if change["otu"]["version"] == "removed" or change["otu"]["version"] > version:
-            reverted_history_ids.append(change["_id"])
-
-            if change["method_name"] == "remove":
-                patched = change["diff"]
-
-            elif change["method_name"] == "create":
-                patched = None
-
-            else:
-                diff = dictdiffer.swap(change["diff"])
-                patched = dictdiffer.patch(diff, patched)
+            changes_to_revert.append(change)
         else:
             break
+
+    diffs = await _resolve_diffs(pg, changes_to_revert)
+
+    for change in changes_to_revert:
+        reverted_history_ids.append(change["_id"])
+        diff = diffs[change["_id"]]
+
+        if change["method_name"] == "remove":
+            patched = diff
+
+        elif change["method_name"] == "create":
+            patched = None
+
+        else:
+            patched = dictdiffer.patch(dictdiffer.swap(diff), patched)
 
     if current == {}:
         current = None

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -310,6 +310,15 @@ async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, 
             for change_id, diff in result.all():
                 resolved[change_id] = diff
 
+        missing = [
+            change_id for change_id in postgres_change_ids if change_id not in resolved
+        ]
+
+        if missing:
+            raise ValueError(
+                f"Missing history_diffs rows for changes: {', '.join(missing)}",
+            )
+
     return resolved
 
 

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -203,6 +203,7 @@ class IndexData:
         except StorageKeyNotFoundError:
             patched_otus = await virtool.indexes.db.get_patched_otus(
                 self._mongo,
+                self._pg,
                 index["manifest"],
             )
 

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -320,12 +320,14 @@ async def get_unbuilt_stats(mongo: "Mongo", ref_id: str | None = None) -> dict:
 
 async def get_patched_otus(
     mongo: "Mongo",
+    pg: AsyncEngine,
     manifest: dict[str, int],
 ) -> list[dict]:
     """Get joined OTUs patched to a specific version based on a manifest of OTU ids and
     versions.
 
     :param mongo: the application mongodb client
+    :param pg: the application PostgreSQL database object
     :param manifest: the manifest
 
     """
@@ -335,6 +337,7 @@ async def get_patched_otus(
             *[
                 virtool.history.db.patch_to_version(
                     mongo,
+                    pg,
                     patch_id,
                     patch_version,
                 )

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -957,6 +957,7 @@ class ReferencesData(DataLayerDomain):
         for source_otu_id, version in manifest.items():
             _, patched, _ = await patch_to_version(
                 self._mongo,
+                self._pg,
                 source_otu_id,
                 version,
             )


### PR DESCRIPTION
## Summary

- `patch_to_version` failed to reconstruct OTU history when diffs were stored in
  PostgreSQL (sentinel `"postgres"` in Mongo) because it always read `change["diff"]`
  directly from the Mongo document.
- Adds `_resolve_diffs` to batch-fetch real diffs from `SQLHistoryDiff` in a single
  query, falling back to inline diffs for older changes.
- Threads `pg` through all callers: `patch_to_version`, `format_analysis`,
  `get_patched_otus`, and the analysis formatting helpers (`format_aodp`,
  `format_pathoscope`, `gather_patched_otus`, etc.).
- Updates the `create_mock_history` fixture to mirror production dual-write behaviour
  (real diff in Postgres, sentinel in Mongo) so history tests exercise the full code path.