### PR TITLE
fix(samples): reject empty reads upload with 400

### DIFF
--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -2283,7 +2283,7 @@
 # name: TestUploadReads.test_empty
   dict({
     'id': 'bad_request',
-    'message': 'File is not compressed',
+    'message': 'Reads file is empty',
   })
 # ---
 # name: TestUploadReads.test_uncompressed

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -2280,6 +2280,12 @@
     'message': 'Reads file name is already uploaded for this sample',
   })
 # ---
+# name: TestUploadReads.test_empty
+  dict({
+    'id': 'bad_request',
+    'message': 'File is not compressed',
+  })
+# ---
 # name: TestUploadReads.test_uncompressed
   dict({
     'id': 'bad_request',

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1,11 +1,13 @@
 import asyncio
 import gzip
+import io
 from http import HTTPStatus
 from pathlib import Path
 
 import arrow
 import pytest
 from aiohttp.test_utils import make_mocked_coro
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -1474,6 +1476,45 @@ class TestUploadReads:
 
         assert resp.status == 400
         assert await resp.json() == snapshot
+
+    async def test_empty(
+        self,
+        memory_storage,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        snapshot: SnapshotAssertion,
+        spawn_job_client: JobClientSpawner,
+    ):
+        """Test that an empty reads upload is rejected without writing a storage
+        object or a SQL row.
+        """
+        client = await spawn_job_client(authenticated=True)
+
+        await mongo.samples.insert_one(
+            {
+                "_id": "test",
+                "ready": True,
+            },
+        )
+
+        resp = await client.put(
+            "/samples/test/reads/reads_1.fq.gz",
+            data={"file": io.BytesIO(b"")},
+        )
+
+        assert resp.status == 400
+        assert await resp.json() == snapshot
+
+        assert [obj.key async for obj in memory_storage.list("samples/test/")] == []
+
+        async with AsyncSession(pg) as session:
+            rows = (
+                (await session.execute(select(SQLSampleReads).filter_by(sample="test")))
+                .scalars()
+                .all()
+            )
+
+        assert rows == []
 
 
 class TestDownloadReads:

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1451,11 +1451,15 @@ class TestUploadReads:
         self,
         example_path: Path,
         fake: DataFaker,
+        memory_storage,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         spawn_job_client: JobClientSpawner,
     ):
-        """Test that uncompressed sample reads are rejected."""
+        """Test that uncompressed sample reads are rejected without writing a
+        storage object or a SQL row.
+        """
         client = await spawn_job_client(authenticated=True)
 
         await mongo.samples.insert_one(
@@ -1476,6 +1480,17 @@ class TestUploadReads:
 
         assert resp.status == 400
         assert await resp.json() == snapshot
+
+        assert [obj.key async for obj in memory_storage.list("samples/test/")] == []
+
+        async with AsyncSession(pg) as session:
+            rows = (
+                (await session.execute(select(SQLSampleReads).filter_by(sample="test")))
+                .scalars()
+                .all()
+            )
+
+        assert rows == []
 
     async def test_empty(
         self,

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -560,6 +560,8 @@ async def upload_reads(req):
             multipart_file_chunker(await req.multipart()),
             upload_id=upload,
         )
+    except EOFError:
+        raise APIBadRequest("Reads file is empty")
     except OSError:
         raise APIBadRequest("File is not compressed")
     except ResourceConflictError as err:

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -633,8 +633,8 @@ class SamplesData(DataLayerDomain):
 
         first = await anext(chunker, None)
 
-        if first is None:
-            raise OSError("Empty reads file")
+        if not first:
+            raise EOFError("Reads file is empty")
 
         is_gzip_compressed(first)
 

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -631,15 +631,19 @@ class SamplesData(DataLayerDomain):
     ) -> dict:
         key = sample_file_key(sample_id, filename)
 
-        async def _validate_and_stream() -> AsyncIterator[bytearray]:
-            first = True
+        first = await anext(chunker, None)
+
+        if first is None:
+            raise OSError("Empty reads file")
+
+        is_gzip_compressed(first)
+
+        async def _stream() -> AsyncIterator[bytearray]:
+            yield first
             async for chunk in chunker:
-                if first:
-                    is_gzip_compressed(chunk)
-                    first = False
                 yield chunk
 
-        size = await self._storage.write(key, _validate_and_stream())
+        size = await self._storage.write(key, _stream())
 
         try:
             return await create_reads_file(


### PR DESCRIPTION
## Summary
- An empty reads file upload previously bypassed gzip validation and wrote a 0-byte object to storage along with a SQL row
- The fix eagerly reads the first chunk before streaming; if the chunk is absent the upload is rejected with a 400, and if present the gzip header check runs immediately before any data is written
- Added a test that confirms neither a storage object nor a SQL row is created when an empty file is uploaded