### PR TITLE
fix(hmm): probe exact storage key when downloading HMM files

### DIFF
--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -1,8 +1,11 @@
+import gzip
+import json
+
 import pytest
 
 from virtool.data.errors import ResourceNotFoundError
 from virtool.fake.next import DataFaker
-from virtool.hmm.data import HmmsData
+from virtool.hmm.data import HMM_ANNOTATIONS_KEY, HMM_PROFILES_KEY, HmmsData
 from virtool.storage.object import ObjectProvider
 
 
@@ -71,7 +74,7 @@ class TestDownloadProfiles:
         async def _data():
             yield b"PROFILE-BYTES"
 
-        await storage.write("hmm/profiles.hmm", _data())
+        await storage.write(HMM_PROFILES_KEY, _data())
 
         hmms = HmmsData(None, None, None, storage)
 
@@ -95,7 +98,7 @@ class TestDownloadAnnotations:
         async def _data():
             yield b"STORED-ANNOTATIONS"
 
-        await storage.write("hmm/annotations.json.gz", _data())
+        await storage.write(HMM_ANNOTATIONS_KEY, _data())
 
         hmms = HmmsData(None, None, None, storage)
 
@@ -103,3 +106,30 @@ class TestDownloadAnnotations:
 
         assert size == len(b"STORED-ANNOTATIONS")
         assert await _drain(stream) == b"STORED-ANNOTATIONS"
+
+    async def test_regenerates_and_stores_when_missing(self, mongo):
+        """When no object exists, annotations are regenerated from Mongo and stored."""
+        storage = ObjectProvider.for_memory()
+
+        await mongo.hmm.insert_many(
+            [
+                {"_id": "annotation_alpha", "cluster": 1, "hidden": False},
+                {"_id": "annotation_beta", "cluster": 2, "hidden": False},
+            ],
+            session=None,
+        )
+
+        hmms = HmmsData(None, mongo, None, storage)
+
+        stream, size = await hmms.download_annotations()
+
+        assert size > 0
+
+        regenerated = await _drain(stream)
+        assert size == len(regenerated)
+
+        clusters = {a["cluster"] for a in json.loads(gzip.decompress(regenerated))}
+        assert clusters == {1, 2}
+
+        stored = await _drain(storage.read(HMM_ANNOTATIONS_KEY))
+        assert stored == regenerated

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -1,4 +1,9 @@
+import pytest
+
+from virtool.data.errors import ResourceNotFoundError
 from virtool.fake.next import DataFaker
+from virtool.hmm.data import HmmsData
+from virtool.storage.object import ObjectProvider
 
 
 async def test_get_status(
@@ -44,3 +49,57 @@ async def test_get_status(
     )
 
     assert await data_layer.hmms.get_status() == snapshot
+
+
+async def _drain(stream) -> bytes:
+    return b"".join([chunk async for chunk in stream])
+
+
+class TestDownloadProfiles:
+    """``download_profiles`` must find the object by exact key.
+
+    These run against a real ``obstore``-backed provider, whose ``list``
+    evaluates prefixes on path-segment boundaries. Listing the full key
+    ``hmm/profiles.hmm`` as a prefix returns nothing even when the object
+    exists, so the method must probe the exact key instead — the regression
+    behind VIR-2418.
+    """
+
+    async def test_returns_stored_object(self):
+        storage = ObjectProvider.for_memory()
+
+        async def _data():
+            yield b"PROFILE-BYTES"
+
+        await storage.write("hmm/profiles.hmm", _data())
+
+        hmms = HmmsData(None, None, None, storage)
+
+        stream, size = await hmms.download_profiles()
+
+        assert size == len(b"PROFILE-BYTES")
+        assert await _drain(stream) == b"PROFILE-BYTES"
+
+    async def test_missing_raises_not_found(self):
+        hmms = HmmsData(None, None, None, ObjectProvider.for_memory())
+
+        with pytest.raises(ResourceNotFoundError):
+            await hmms.download_profiles()
+
+
+class TestDownloadAnnotations:
+    async def test_returns_stored_object_without_regenerating(self):
+        """A present annotations object is served, not regenerated from Mongo."""
+        storage = ObjectProvider.for_memory()
+
+        async def _data():
+            yield b"STORED-ANNOTATIONS"
+
+        await storage.write("hmm/annotations.json.gz", _data())
+
+        hmms = HmmsData(None, None, None, storage)
+
+        stream, size = await hmms.download_annotations()
+
+        assert size == len(b"STORED-ANNOTATIONS")
+        assert await _drain(stream) == b"STORED-ANNOTATIONS"

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -25,6 +25,7 @@ from virtool.hmm.models import HMM, HMMInstalled, HMMSearchResult, HMMStatus
 from virtool.hmm.tasks import HMMInstallTask
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
 from virtool.tasks.progress import (
     AbstractProgressHandler,
@@ -180,19 +181,20 @@ class HmmsData(DataLayerDomain):
                 raise
 
     async def download_profiles(self) -> tuple[AsyncIterator[bytes], int]:
-        info = None
-        async for item in self._storage.list("hmm/profiles.hmm"):
-            info = item
-            break
+        try:
+            size = await self._storage.size("hmm/profiles.hmm")
+        except StorageKeyNotFoundError as err:
+            raise ResourceNotFoundError("Profiles file could not be found") from err
 
-        if info is None:
-            raise ResourceNotFoundError("Profiles file could not be found")
-
-        return self._storage.read("hmm/profiles.hmm"), info.size
+        return self._storage.read("hmm/profiles.hmm"), size
 
     async def download_annotations(self) -> tuple[AsyncIterator[bytes], int]:
-        async for info in self._storage.list("hmm/annotations.json.gz"):
-            return self._storage.read("hmm/annotations.json.gz"), info.size
+        try:
+            size = await self._storage.size("hmm/annotations.json.gz")
+        except StorageKeyNotFoundError:
+            pass
+        else:
+            return self._storage.read("hmm/annotations.json.gz"), size
 
         annotations_bytes = await generate_annotations(self._mongo)
         compressed = await asyncio.to_thread(

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -34,6 +34,12 @@ from virtool.tasks.progress import (
 from virtool.tasks.transforms import AttachTaskTransform
 from virtool.users.transforms import AttachUserTransform
 
+HMM_PROFILES_KEY = "hmm/profiles.hmm"
+"""The storage key for the HMM profiles file."""
+
+HMM_ANNOTATIONS_KEY = "hmm/annotations.json.gz"
+"""The storage key for the gzipped HMM annotations file."""
+
 
 class HmmsData(DataLayerDomain):
     name = "hmms"
@@ -170,31 +176,31 @@ class HmmsData(DataLayerDomain):
             )
 
             try:
-                await self._storage.write("hmm/profiles.hmm", profile_data)
+                await self._storage.write(HMM_PROFILES_KEY, profile_data)
             except Exception:
                 await session.abort_transaction()
                 # obstore.put_async is not atomic from the caller's
                 # perspective: a failure can leave an incomplete multipart
                 # upload on S3 or a partially written file on disk. Cleanup
                 # keeps a retry from being shadowed by orphaned data.
-                await self._storage.delete("hmm/profiles.hmm")
+                await self._storage.delete(HMM_PROFILES_KEY)
                 raise
 
     async def download_profiles(self) -> tuple[AsyncIterator[bytes], int]:
         try:
-            size = await self._storage.size("hmm/profiles.hmm")
+            size = await self._storage.size(HMM_PROFILES_KEY)
         except StorageKeyNotFoundError as err:
             raise ResourceNotFoundError("Profiles file could not be found") from err
 
-        return self._storage.read("hmm/profiles.hmm"), size
+        return self._storage.read(HMM_PROFILES_KEY), size
 
     async def download_annotations(self) -> tuple[AsyncIterator[bytes], int]:
         try:
-            size = await self._storage.size("hmm/annotations.json.gz")
+            size = await self._storage.size(HMM_ANNOTATIONS_KEY)
         except StorageKeyNotFoundError:
             pass
         else:
-            return self._storage.read("hmm/annotations.json.gz"), size
+            return self._storage.read(HMM_ANNOTATIONS_KEY), size
 
         annotations_bytes = await generate_annotations(self._mongo)
         compressed = await asyncio.to_thread(
@@ -206,9 +212,9 @@ class HmmsData(DataLayerDomain):
         async def _data():
             yield compressed
 
-        await self._storage.write("hmm/annotations.json.gz", _data())
+        await self._storage.write(HMM_ANNOTATIONS_KEY, _data())
 
-        return self._storage.read("hmm/annotations.json.gz"), len(compressed)
+        return self._storage.read(HMM_ANNOTATIONS_KEY), len(compressed)
 
     async def clean_status(self) -> None:
         async with self._mongo.create_session() as session:


### PR DESCRIPTION
## Summary

- `download_profiles` and `download_annotations` used `storage.list()` with the full key as a prefix to check existence; `obstore` evaluates list prefixes on path-segment boundaries, so listing `hmm/profiles.hmm` returns nothing even when that exact object exists
- Replaced the list-based existence check with `storage.size()`, which probes the exact key and raises `StorageKeyNotFoundError` when the object is absent, fixing the `FixtureBindingError` in tests and the broken download path in production

Closes VIR-2418.