### PR TITLE
feat(migration): backfill historical mongo analyses to postgres

### DIFF
--- a/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
+++ b/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
@@ -37,6 +37,12 @@ async def upgrade(ctx: MigrationContext) -> None:
     failure part-way through keeps the rows already written rather than rolling
     back the entire collection.
 
+    The document ``_id`` values are snapshotted up front so the rest of the run
+    fetches one document at a time by id, rather than holding a single Mongo
+    cursor open for the whole migration. With large documents that each take real
+    time to write, a long-lived cursor would risk the server idle/lifetime
+    timeout.
+
     Documents already present in Postgres (by ``legacy_id``) are skipped, and the
     insert uses ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of
     defence, so the migration is safe to re-run after an interruption.
@@ -55,11 +61,22 @@ async def upgrade(ctx: MigrationContext) -> None:
             count=len(existing_legacy_ids),
         )
 
+        analysis_ids = [
+            document["_id"]
+            async for document in ctx.mongo.analyses.find({}, projection=["_id"])
+        ]
+
         migrated_count = 0
         skipped_count = 0
 
-        async for document in ctx.mongo.analyses.find():
-            if document["_id"] in existing_legacy_ids:
+        for analysis_id in analysis_ids:
+            if analysis_id in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.analyses.find_one({"_id": analysis_id})
+
+            if document is None:
                 skipped_count += 1
                 continue
 

--- a/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
+++ b/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
@@ -1,0 +1,139 @@
+"""copy analyses to postgres
+
+Revision ID: 1nl7v191h0ba
+Date: 2026-06-03 00:10:43.710684
+
+"""
+
+import arrow
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy analyses to postgres"
+created_at = arrow.get("2026-06-03 00:10:43.710684")
+revision_id = "1nl7v191h0ba"
+
+alembic_down_revision = "1e6490edc217"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = "1e6490edc217"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``analyses`` document into the Postgres ``analyses`` table.
+
+    One row is written per Mongo document, including result content. Documents
+    are processed one at a time and committed individually, so memory stays
+    bounded to a single document and its (potentially large) result body, and a
+    failure part-way through keeps the rows already written rather than rolling
+    back the entire collection.
+
+    Documents already present in Postgres (by ``legacy_id``) are skipped, and the
+    insert uses ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of
+    defence, so the migration is safe to re-run after an interruption.
+
+    Fails loudly on any document it cannot faithfully map: an unknown ``user_id``
+    violates the ``users`` foreign key, and a ``"file"`` results marker raises.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_result = await session.execute(
+            select(SQLAnalysis.legacy_id).where(SQLAnalysis.legacy_id.isnot(None)),
+        )
+        existing_legacy_ids = {row[0] for row in existing_result}
+
+        logger.info(
+            "found existing analyses in postgres",
+            count=len(existing_legacy_ids),
+        )
+
+        migrated_count = 0
+        skipped_count = 0
+
+        async for document in ctx.mongo.analyses.find():
+            if document["_id"] in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            results = await _resolve_results(session, document)
+
+            await session.execute(
+                insert(SQLAnalysis)
+                .values(**_build_values(document, results))
+                .on_conflict_do_nothing(index_elements=["legacy_id"]),
+            )
+            await session.commit()
+
+            migrated_count += 1
+
+        logger.info(
+            "analysis migration complete",
+            migrated=migrated_count,
+            skipped=skipped_count,
+        )
+
+
+def _build_values(document: dict, results: dict | None) -> dict:
+    """Map a Mongo analysis document to a ``SQLAnalysis`` values dict.
+
+    The integer ``id`` is omitted so the database assigns the identity surrogate
+    key. The ``space`` field is intentionally dropped.
+    """
+    job = document.get("job")
+
+    return {
+        "legacy_id": document["_id"],
+        "created_at": document["created_at"],
+        "updated_at": document.get("updated_at") or document["created_at"],
+        "workflow": document["workflow"],
+        "ready": document["ready"],
+        "results": results,
+        "sample": document["sample"]["id"],
+        "reference": document["reference"]["id"],
+        "index": document["index"]["id"],
+        "subtractions": document.get("subtractions") or [],
+        "user_id": document["user"]["id"],
+        "job_id": job["id"] if job else None,
+        "ml_id": document.get("ml"),
+    }
+
+
+async def _resolve_results(session: AsyncSession, document: dict) -> dict | None:
+    """Resolve the actual results content from a document's results marker.
+
+    - ``None`` / absent -> ``None``
+    - ``"sql"`` -> content from the ``analysis_results`` table for this document
+    - inline ``dict`` -> the dict itself
+    - ``"file"`` -> raise; result content lives in object storage and must never
+      be read here (production count is 0).
+    """
+    results = document.get("results")
+
+    if results is None:
+        return None
+
+    if results == "sql":
+        result = await session.execute(
+            select(SQLAnalysisResult.results).where(
+                SQLAnalysisResult.analysis_id == document["_id"],
+            ),
+        )
+        return result.scalar_one()
+
+    if results == "file":
+        msg = f"Analysis {document['_id']} has file-backed results; cannot migrate"
+        raise ValueError(msg)
+
+    if isinstance(results, dict):
+        return results
+
+    msg = f"Analysis {document['_id']} has unexpected results value {results!r}"
+    raise ValueError(msg)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -337,5 +337,12 @@
       'name': 'switch analyses to integer id with legacy_id',
       'revision': '1e6490edc217',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 49,
+      'name': 'copy analyses to postgres',
+      'revision': '1nl7v191h0ba',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_analyses_to_postgres.py
+++ b/tests/migration/test_copy_analyses_to_postgres.py
@@ -10,11 +10,12 @@ from sqlalchemy import insert, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from assets.revisions.rev_1nl7v191h0ba_copy_analyses_to_postgres import upgrade
+from assets.revisions.rev_1nl7v191h0ba_copy_analyses_to_postgres import (
+    required_alembic_revision,
+    upgrade,
+)
 from virtool.analyses.sql import SQLAnalysisResult
 from virtool.migration.ctx import MigrationContext
-
-ALEMBIC_REVISION = "1e6490edc217"
 
 
 @pytest.fixture
@@ -25,7 +26,7 @@ def static_datetime() -> datetime:
 @pytest.fixture
 async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
     """Create a user in PostgreSQL using raw SQL and return their integer ID."""
-    await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+    await asyncio.to_thread(apply_alembic, required_alembic_revision)
 
     async with AsyncSession(ctx.pg) as session:
         result = await session.execute(
@@ -400,6 +401,25 @@ class TestUpgrade:
         )
 
         with pytest.raises(ValueError, match="file-backed results"):
+            await upgrade(ctx)
+
+    async def test_unexpected_results_value_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document with an unrecognized results marker aborts loudly."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="bad_marker_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                results="unknown_marker",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="unexpected results value"):
             await upgrade(ctx)
 
     async def test_unknown_user_raises(

--- a/tests/migration/test_copy_analyses_to_postgres.py
+++ b/tests/migration/test_copy_analyses_to_postgres.py
@@ -1,0 +1,433 @@
+"""Tests for the copy analyses to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import insert, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_1nl7v191h0ba_copy_analyses_to_postgres import upgrade
+from virtool.analyses.sql import SQLAnalysisResult
+from virtool.migration.ctx import MigrationContext
+
+ALEMBIC_REVISION = "1e6490edc217"
+
+
+@pytest.fixture
+def static_datetime() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
+    """Create a user in PostgreSQL using raw SQL and return their integer ID."""
+    await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES (
+                    'testuser', 'legacy_user_123', true, '', false,
+                    false, :now, :password, '{}'::jsonb
+                )
+                RETURNING id
+            """),
+            {"now": arrow.utcnow().naive, "password": b"hashed_password"},
+        )
+        user_id = result.scalar_one()
+        await session.commit()
+        return user_id
+
+
+def make_analysis_document(
+    analysis_id: str,
+    user_id: int,
+    created_at: datetime,
+    *,
+    workflow: str = "pathoscope",
+    ready: bool = True,
+    results: dict | str | None = None,
+    subtractions: list | None = None,
+    job_id: int | None = None,
+    ml: int | None = None,
+) -> dict:
+    """Create a MongoDB analysis document for testing."""
+    return {
+        "_id": analysis_id,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "files": [],
+        "index": {"id": "index_1", "version": 3},
+        "job": {"id": job_id} if job_id is not None else None,
+        "ml": ml,
+        "reference": {"id": "reference_1"},
+        "ready": ready,
+        "results": results,
+        "sample": {"id": "sample_1"},
+        "space": {"id": 1},
+        "subtractions": subtractions if subtractions is not None else [],
+        "user": {"id": user_id},
+        "workflow": workflow,
+    }
+
+
+class TestUpgrade:
+    """Tests for the upgrade function."""
+
+    async def test_field_fidelity(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document's scalar and string-id fields map correctly."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="analysis_1",
+                user_id=setup_user,
+                created_at=static_datetime,
+                workflow="nuvs",
+                ml=None,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text("""
+                        SELECT id, legacy_id, created_at, updated_at, workflow, ready,
+                               sample, reference, index, user_id, job_id, ml_id
+                        FROM analyses WHERE legacy_id = 'analysis_1'
+                    """),
+                )
+            ).one()
+
+        assert isinstance(row.id, int)
+        assert row.legacy_id == "analysis_1"
+        assert row.created_at == static_datetime
+        assert row.updated_at == static_datetime
+        assert row.workflow == "nuvs"
+        assert row.ready is True
+        assert row.sample == "sample_1"
+        assert row.reference == "reference_1"
+        assert row.index == "index_1"
+        assert row.user_id == setup_user
+        assert row.ml_id is None
+
+    async def test_inline_dict_results(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document with inline dict results stores them verbatim."""
+        results = {"hits": [{"id": "otu_1", "pi": 0.5}]}
+
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="inline_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                results=results,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT results FROM analyses WHERE legacy_id = 'inline_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == results
+
+    async def test_sql_marker_results(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A "sql"-marker document pulls results from the analysis_results table."""
+        results = {"hits": [{"id": "otu_2", "pi": 0.9}]}
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                insert(SQLAnalysisResult).values(
+                    analysis_id="sql_analysis",
+                    results=results,
+                ),
+            )
+            await session.commit()
+
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="sql_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                results="sql",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT results FROM analyses WHERE legacy_id = 'sql_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == results
+
+    async def test_no_results(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document with no results stores NULL."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="pending_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                ready=False,
+                results=None,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT results FROM analyses WHERE legacy_id = 'pending_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored is None
+
+    async def test_none_subtractions_become_empty_list(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document with None subtractions stores an empty list."""
+        document = make_analysis_document(
+            analysis_id="iimi_analysis",
+            user_id=setup_user,
+            created_at=static_datetime,
+        )
+        document["subtractions"] = None
+
+        await ctx.mongo.analyses.insert_one(document)
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT subtractions FROM analyses WHERE legacy_id = 'iimi_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == []
+
+    async def test_null_job_and_ml(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """job_id and ml_id are null when the document has no job or ml."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="no_job_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id=None,
+                ml=None,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT job_id, ml_id FROM analyses WHERE legacy_id = 'no_job_analysis'"
+                    ),
+                )
+            ).one()
+
+        assert row.job_id is None
+        assert row.ml_id is None
+
+    async def test_job_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """An integer job id is written to the job_id foreign key."""
+        async with AsyncSession(ctx.pg) as session:
+            job_id = (
+                await session.execute(
+                    text("""
+                        INSERT INTO jobs (legacy_id, workflow, state, user_id, created_at)
+                        VALUES ('legacy_job', 'pathoscope', 'succeeded', :user_id, :now)
+                        RETURNING id
+                    """),
+                    {"user_id": setup_user, "now": static_datetime},
+                )
+            ).scalar_one()
+            await session.commit()
+
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="job_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id=job_id,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT job_id FROM analyses WHERE legacy_id = 'job_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == job_id
+
+    async def test_idempotent_rerun(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """Running the migration twice leaves a single row per document."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="repeat_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM analyses WHERE legacy_id = 'repeat_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert count == 1
+
+    async def test_row_count_parity(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """The Postgres row count matches the number of Mongo documents."""
+        for i in range(5):
+            await ctx.mongo.analyses.insert_one(
+                make_analysis_document(
+                    analysis_id=f"analysis_{i}",
+                    user_id=setup_user,
+                    created_at=static_datetime,
+                ),
+            )
+
+        await upgrade(ctx)
+
+        mongo_count = await ctx.mongo.analyses.count_documents({})
+
+        async with AsyncSession(ctx.pg) as session:
+            pg_count = (
+                await session.execute(text("SELECT COUNT(*) FROM analyses"))
+            ).scalar_one()
+
+        assert pg_count == mongo_count == 5
+
+    async def test_file_marker_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A "file"-marker document aborts the migration loudly."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="file_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                results="file",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="file-backed results"):
+            await upgrade(ctx)
+
+    async def test_unknown_user_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document referencing an unknown user violates the foreign key."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="orphan_analysis",
+                user_id=setup_user + 9999,
+                created_at=static_datetime,
+            ),
+        )
+
+        with pytest.raises(IntegrityError):
+            await upgrade(ctx)
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_empty_collection(self, ctx: MigrationContext):
+        """An empty analyses collection is a no-op."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM analyses"))
+            ).scalar_one()
+
+        assert count == 0


### PR DESCRIPTION
## Summary

- Adds a migration revision (`1nl7v191h0ba`) that copies every document in the Mongo `analyses` collection into the new Postgres `analyses` table
- Documents are processed and committed one at a time so memory stays bounded and partial progress is preserved on interruption; the migration is safe to re-run via `ON CONFLICT (legacy_id) DO NOTHING`
- Handles all known results variants: inline dicts, `"sql"` markers (resolved from `analysis_results`), absent/`None`; raises loudly on unsupported `"file"`-backed results