### PR TITLE
fix(migration): resolve legacy mongo job and user references in analyses backfill

### DIFF
--- a/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
+++ b/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
@@ -12,7 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
+from virtool.data.topg import compose_legacy_id_single_expression
+from virtool.jobs.pg import SQLJob
 from virtool.migration import MigrationContext
+from virtool.users.pg import SQLUser
 
 logger = get_logger("migration")
 
@@ -47,8 +50,8 @@ async def upgrade(ctx: MigrationContext) -> None:
     insert uses ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of
     defence, so the migration is safe to re-run after an interruption.
 
-    Fails loudly on any document it cannot faithfully map: an unknown ``user_id``
-    violates the ``users`` foreign key, and a ``"file"`` results marker raises.
+    Fails loudly on any document it cannot faithfully map: an unresolvable
+    ``user`` or ``job`` reference raises, and a ``"file"`` results marker raises.
     """
     async with AsyncSession(ctx.pg) as session:
         existing_result = await session.execute(
@@ -81,10 +84,12 @@ async def upgrade(ctx: MigrationContext) -> None:
                 continue
 
             results = await _resolve_results(session, document)
+            user_id = await _resolve_user_id(session, document)
+            job_id = await _resolve_job_id(session, document)
 
             await session.execute(
                 insert(SQLAnalysis)
-                .values(**_build_values(document, results))
+                .values(**_build_values(document, results, user_id, job_id))
                 .on_conflict_do_nothing(index_elements=["legacy_id"]),
             )
             await session.commit()
@@ -98,14 +103,18 @@ async def upgrade(ctx: MigrationContext) -> None:
         )
 
 
-def _build_values(document: dict, results: dict | None) -> dict:
+def _build_values(
+    document: dict,
+    results: dict | None,
+    user_id: int,
+    job_id: int | None,
+) -> dict:
     """Map a Mongo analysis document to a ``SQLAnalysis`` values dict.
 
     The integer ``id`` is omitted so the database assigns the identity surrogate
-    key. The ``space`` field is intentionally dropped.
+    key. The ``space`` field is intentionally dropped. ``user_id`` and ``job_id``
+    are the resolved Postgres integer foreign keys, not the raw Mongo references.
     """
-    job = document.get("job")
-
     return {
         "legacy_id": document["_id"],
         "created_at": document["created_at"],
@@ -117,10 +126,62 @@ def _build_values(document: dict, results: dict | None) -> dict:
         "reference": document["reference"]["id"],
         "index": document["index"]["id"],
         "subtractions": document.get("subtractions") or [],
-        "user_id": document["user"]["id"],
-        "job_id": job["id"] if job else None,
+        "user_id": user_id,
+        "job_id": job_id,
         "ml_id": document.get("ml"),
     }
+
+
+async def _resolve_user_id(session: AsyncSession, document: dict) -> int:
+    """Resolve a document's ``user`` reference to a Postgres ``users.id``.
+
+    The Mongo reference may be a legacy string id or a modern integer id. Raises
+    if the referenced user is not present in Postgres.
+    """
+    reference = document["user"]["id"]
+
+    user_id = (
+        await session.execute(
+            select(SQLUser.id).where(
+                compose_legacy_id_single_expression(SQLUser, reference),
+            ),
+        )
+    ).scalar_one_or_none()
+
+    if user_id is None:
+        msg = f"Analysis {document['_id']} references unknown user {reference!r}"
+        raise ValueError(msg)
+
+    return user_id
+
+
+async def _resolve_job_id(session: AsyncSession, document: dict) -> int | None:
+    """Resolve a document's ``job`` reference to a Postgres ``jobs.id``.
+
+    Returns ``None`` when the document has no job. The Mongo reference may be a
+    legacy string id or a modern integer id. Raises if a job is referenced but
+    not present in Postgres, rather than silently dropping the association.
+    """
+    job = document.get("job")
+
+    if job is None:
+        return None
+
+    reference = job["id"]
+
+    job_id = (
+        await session.execute(
+            select(SQLJob.id).where(
+                compose_legacy_id_single_expression(SQLJob, reference),
+            ),
+        )
+    ).scalar_one_or_none()
+
+    if job_id is None:
+        msg = f"Analysis {document['_id']} references unknown job {reference!r}"
+        raise ValueError(msg)
+
+    return job_id
 
 
 async def _resolve_results(session: AsyncSession, document: dict) -> dict | None:

--- a/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
+++ b/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
@@ -15,6 +15,7 @@ from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
 from virtool.data.topg import compose_legacy_id_single_expression
 from virtool.jobs.pg import SQLJob
 from virtool.migration import MigrationContext
+from virtool.pg.base import Base
 from virtool.users.pg import SQLUser
 
 logger = get_logger("migration")
@@ -72,6 +73,9 @@ async def upgrade(ctx: MigrationContext) -> None:
         migrated_count = 0
         skipped_count = 0
 
+        user_id_cache: dict[int | str, int | None] = {}
+        job_id_cache: dict[int | str, int | None] = {}
+
         for analysis_id in analysis_ids:
             if analysis_id in existing_legacy_ids:
                 skipped_count += 1
@@ -84,8 +88,8 @@ async def upgrade(ctx: MigrationContext) -> None:
                 continue
 
             results = await _resolve_results(session, document)
-            user_id = await _resolve_user_id(session, document)
-            job_id = await _resolve_job_id(session, document)
+            user_id = await _resolve_user_id(session, document, user_id_cache)
+            job_id = await _resolve_job_id(session, document, job_id_cache)
 
             await session.execute(
                 insert(SQLAnalysis)
@@ -132,21 +136,46 @@ def _build_values(
     }
 
 
-async def _resolve_user_id(session: AsyncSession, document: dict) -> int:
-    """Resolve a document's ``user`` reference to a Postgres ``users.id``.
+async def _resolve_id(
+    session: AsyncSession,
+    model: type[Base],
+    reference: int | str,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a Mongo reference to a Postgres primary key, memoising results.
 
-    The Mongo reference may be a legacy string id or a modern integer id. Raises
-    if the referenced user is not present in Postgres.
+    The reference may be a legacy string id or a modern integer id. The resolved
+    id (or ``None`` if no row matches) is cached by reference so that analyses
+    sharing the same user or job do not each issue a query.
     """
-    reference = document["user"]["id"]
+    if reference in cache:
+        return cache[reference]
 
-    user_id = (
+    resolved = (
         await session.execute(
-            select(SQLUser.id).where(
-                compose_legacy_id_single_expression(SQLUser, reference),
+            select(model.id).where(
+                compose_legacy_id_single_expression(model, reference),
             ),
         )
     ).scalar_one_or_none()
+
+    cache[reference] = resolved
+
+    return resolved
+
+
+async def _resolve_user_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int:
+    """Resolve a document's ``user`` reference to a Postgres ``users.id``.
+
+    Raises if the referenced user is not present in Postgres.
+    """
+    reference = document["user"]["id"]
+
+    user_id = await _resolve_id(session, SQLUser, reference, cache)
 
     if user_id is None:
         msg = f"Analysis {document['_id']} references unknown user {reference!r}"
@@ -155,12 +184,15 @@ async def _resolve_user_id(session: AsyncSession, document: dict) -> int:
     return user_id
 
 
-async def _resolve_job_id(session: AsyncSession, document: dict) -> int | None:
+async def _resolve_job_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int | None:
     """Resolve a document's ``job`` reference to a Postgres ``jobs.id``.
 
-    Returns ``None`` when the document has no job. The Mongo reference may be a
-    legacy string id or a modern integer id. Raises if a job is referenced but
-    not present in Postgres, rather than silently dropping the association.
+    Returns ``None`` when the document has no job. Raises if a job is referenced
+    but not present in Postgres, rather than silently dropping the association.
     """
     job = document.get("job")
 
@@ -169,13 +201,7 @@ async def _resolve_job_id(session: AsyncSession, document: dict) -> int | None:
 
     reference = job["id"]
 
-    job_id = (
-        await session.execute(
-            select(SQLJob.id).where(
-                compose_legacy_id_single_expression(SQLJob, reference),
-            ),
-        )
-    ).scalar_one_or_none()
+    job_id = await _resolve_id(session, SQLJob, reference, cache)
 
     if job_id is None:
         msg = f"Analysis {document['_id']} references unknown job {reference!r}"

--- a/tests/migration/test_copy_analyses_to_postgres.py
+++ b/tests/migration/test_copy_analyses_to_postgres.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import arrow
 import pytest
 from sqlalchemy import insert, text
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from assets.revisions.rev_1nl7v191h0ba_copy_analyses_to_postgres import (
@@ -50,14 +49,14 @@ async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
 
 def make_analysis_document(
     analysis_id: str,
-    user_id: int,
+    user_id: int | str,
     created_at: datetime,
     *,
     workflow: str = "pathoscope",
     ready: bool = True,
     results: dict | str | None = None,
     subtractions: list | None = None,
-    job_id: int | None = None,
+    job_id: int | str | None = None,
     ml: int | None = None,
 ) -> dict:
     """Create a MongoDB analysis document for testing."""
@@ -328,6 +327,95 @@ class TestUpgrade:
 
         assert stored == job_id
 
+    async def test_job_legacy_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A legacy string job id resolves to the job's integer primary key."""
+        async with AsyncSession(ctx.pg) as session:
+            job_id = (
+                await session.execute(
+                    text("""
+                        INSERT INTO jobs (legacy_id, workflow, state, user_id, created_at)
+                        VALUES ('legacy_job_abc', 'pathoscope', 'succeeded', :user_id, :now)
+                        RETURNING id
+                    """),
+                    {"user_id": setup_user, "now": static_datetime},
+                )
+            ).scalar_one()
+            await session.commit()
+
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="legacy_job_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id="legacy_job_abc",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT job_id FROM analyses WHERE legacy_id = 'legacy_job_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == job_id
+
+    async def test_user_legacy_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A legacy string user id resolves to the user's integer primary key."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="legacy_user_analysis",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT user_id FROM analyses WHERE legacy_id = 'legacy_user_analysis'"
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == setup_user
+
+    async def test_unknown_job_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document referencing a job absent from Postgres aborts loudly."""
+        await ctx.mongo.analyses.insert_one(
+            make_analysis_document(
+                analysis_id="orphan_job_analysis",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id="missing_job",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="unknown job"):
+            await upgrade(ctx)
+
     async def test_idempotent_rerun(
         self,
         ctx: MigrationContext,
@@ -428,7 +516,7 @@ class TestUpgrade:
         setup_user: int,
         static_datetime: datetime,
     ):
-        """A document referencing an unknown user violates the foreign key."""
+        """A document referencing a user absent from Postgres aborts loudly."""
         await ctx.mongo.analyses.insert_one(
             make_analysis_document(
                 analysis_id="orphan_analysis",
@@ -437,7 +525,7 @@ class TestUpgrade:
             ),
         )
 
-        with pytest.raises(IntegrityError):
+        with pytest.raises(ValueError, match="unknown user"):
             await upgrade(ctx)
 
     @pytest.mark.usefixtures("setup_user")

--- a/tests/migration/test_copy_analyses_to_postgres.py
+++ b/tests/migration/test_copy_analyses_to_postgres.py
@@ -413,7 +413,10 @@ class TestUpgrade:
             ),
         )
 
-        with pytest.raises(ValueError, match="unknown job"):
+        with pytest.raises(
+            ValueError,
+            match=r"Analysis orphan_job_analysis references unknown job",
+        ):
             await upgrade(ctx)
 
     async def test_idempotent_rerun(
@@ -525,7 +528,10 @@ class TestUpgrade:
             ),
         )
 
-        with pytest.raises(ValueError, match="unknown user"):
+        with pytest.raises(
+            ValueError,
+            match=r"Analysis orphan_analysis references unknown user",
+        ):
             await upgrade(ctx)
 
     @pytest.mark.usefixtures("setup_user")


### PR DESCRIPTION
## Summary

- The analyses backfill migration was failing when analysis documents referenced legacy string-form user or job IDs (from old Mongo-native records) instead of integer Postgres IDs.
- Added `_resolve_user_id` and `_resolve_job_id` helpers that use `compose_legacy_id_single_expression` to look up both legacy string IDs and modern integer IDs in Postgres, raising a clear `ValueError` with the offending document ID if the reference cannot be resolved.
- Updated tests to cover legacy string ID mapping for both users and jobs, and to expect `ValueError` (with a descriptive message) rather than `IntegrityError` on missing references.