### PR TITLE
fix(migration): backfill null job_id for analyses with deleted jobs

### DIFF
--- a/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
+++ b/assets/revisions/rev_1nl7v191h0ba_copy_analyses_to_postgres.py
@@ -52,7 +52,9 @@ async def upgrade(ctx: MigrationContext) -> None:
     defence, so the migration is safe to re-run after an interruption.
 
     Fails loudly on any document it cannot faithfully map: an unresolvable
-    ``user`` or ``job`` reference raises, and a ``"file"`` results marker raises.
+    ``user`` reference raises, and a ``"file"`` results marker raises. A
+    referenced ``job`` that no longer exists is backfilled as ``NULL`` (jobs
+    used to be deletable) and logged, rather than failing the migration.
     """
     async with AsyncSession(ctx.pg) as session:
         existing_result = await session.execute(
@@ -191,8 +193,15 @@ async def _resolve_job_id(
 ) -> int | None:
     """Resolve a document's ``job`` reference to a Postgres ``jobs.id``.
 
-    Returns ``None`` when the document has no job. Raises if a job is referenced
-    but not present in Postgres, rather than silently dropping the association.
+    Returns ``None`` when the document has no job. Also returns ``None`` when a
+    job is referenced but no longer exists in Postgres: jobs used to be
+    deletable, so legacy analyses can reference a job that has since been
+    removed. ``NULL`` is the truthful mapping for such a dangling reference.
+    These orphans are logged so the migration leaves an audit trail, distinct
+    from the silent legitimate no-job case.
+
+    New analyses always have a job (one is created at analysis-creation time and
+    its id is stored), so this nullability only ever applies to backfilled rows.
     """
     job = document.get("job")
 
@@ -204,8 +213,11 @@ async def _resolve_job_id(
     job_id = await _resolve_id(session, SQLJob, reference, cache)
 
     if job_id is None:
-        msg = f"Analysis {document['_id']} references unknown job {reference!r}"
-        raise ValueError(msg)
+        logger.warning(
+            "analysis references a job that no longer exists; backfilling null job_id",
+            analysis_id=document["_id"],
+            job=reference,
+        )
 
     return job_id
 

--- a/tests/migration/test_copy_analyses_to_postgres.py
+++ b/tests/migration/test_copy_analyses_to_postgres.py
@@ -397,13 +397,18 @@ class TestUpgrade:
 
         assert stored == setup_user
 
-    async def test_unknown_job_raises(
+    async def test_orphan_job_backfills_null(
         self,
         ctx: MigrationContext,
         setup_user: int,
         static_datetime: datetime,
     ):
-        """A document referencing a job absent from Postgres aborts loudly."""
+        """A document referencing a deleted job is backfilled with a null job_id.
+
+        Jobs used to be deletable, so legacy analyses can reference a job that no
+        longer exists. The migration writes the row with ``job_id = NULL`` rather
+        than aborting.
+        """
         await ctx.mongo.analyses.insert_one(
             make_analysis_document(
                 analysis_id="orphan_job_analysis",
@@ -413,11 +418,18 @@ class TestUpgrade:
             ),
         )
 
-        with pytest.raises(
-            ValueError,
-            match=r"Analysis orphan_job_analysis references unknown job",
-        ):
-            await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT job_id FROM analyses WHERE legacy_id = 'orphan_job_analysis'"
+                    ),
+                )
+            ).one()
+
+        assert row.job_id is None
 
     async def test_idempotent_rerun(
         self,


### PR DESCRIPTION
## Summary

- Jobs used to be deletable in Virtool, leaving legacy analyses with references to jobs that no longer exist in Postgres
- The `copy_analyses_to_postgres` migration was raising `ValueError` for these orphaned job references, aborting the backfill
- Changed `_resolve_job_id` to write `NULL` for dangling job references and emit a structured warning log instead of failing, making the migration tolerant of this known legacy state