### PR TITLE
feat(subtractions): create subtractions postgres table and SQLSubtraction model

### DIFF
--- a/assets/alembic/versions/f4624eb353b7_create_subtractions_table.py
+++ b/assets/alembic/versions/f4624eb353b7_create_subtractions_table.py
@@ -39,9 +39,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
         sa.ForeignKeyConstraint(["upload_id"], ["uploads.id"]),
     )
-    op.create_index(op.f("ix_subtractions_job_id"), "subtractions", ["job_id"])
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_subtractions_job_id"), table_name="subtractions")
     op.drop_table("subtractions")

--- a/assets/alembic/versions/f4624eb353b7_create_subtractions_table.py
+++ b/assets/alembic/versions/f4624eb353b7_create_subtractions_table.py
@@ -1,0 +1,47 @@
+"""create subtractions table
+
+Revision ID: f4624eb353b7
+Revises: 1e6490edc217
+Create Date: 2026-06-03 19:24:46.151570+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "f4624eb353b7"
+down_revision = "1e6490edc217"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "subtractions",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=True), nullable=False),
+        sa.Column("legacy_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("nickname", sa.String(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=True),
+        sa.Column("gc", JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("deleted", sa.Boolean(), nullable=False),
+        sa.Column("ready", sa.Boolean(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("job_id", sa.Integer(), nullable=True),
+        sa.Column("upload_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("legacy_id"),
+        sa.UniqueConstraint("job_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+        sa.ForeignKeyConstraint(["upload_id"], ["uploads.id"]),
+    )
+    op.create_index(op.f("ix_subtractions_job_id"), "subtractions", ["job_id"])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_subtractions_job_id"), table_name="subtractions")
+    op.drop_table("subtractions")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -344,5 +344,12 @@
       'name': 'copy analyses to postgres',
       'revision': '1nl7v191h0ba',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 50,
+      'name': 'create subtractions table',
+      'revision': 'f4624eb353b7',
+    }),
   ])
 # ---

--- a/virtool/subtractions/pg.py
+++ b/virtool/subtractions/pg.py
@@ -1,4 +1,19 @@
-from sqlalchemy import BigInteger, Column, Enum, Integer, String, UniqueConstraint
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Identity,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
@@ -9,6 +24,38 @@ class SubtractionType(str, SQLEnum):
 
     fasta = "fasta"
     bowtie2 = "bowtie2"
+
+
+class SQLSubtraction(Base):
+    """SQL model for subtraction metadata.
+
+    Column naming convention mirrors :class:`virtool.analyses.sql.SQLAnalysis`:
+
+    - A bare column holds a legacy Mongo string id and has no foreign key,
+      because the referenced collection has not been migrated to Postgres.
+    - An ``{entity}_id`` column is a real foreign key to an existing SQL table.
+
+    ``legacy_id`` is the Mongo ``_id`` and is nullable so subtractions created
+    natively in Postgres can omit it, matching the convention on ``analyses``,
+    ``jobs``, ``users``, and ``groups``. The Mongo ``space`` field is
+    intentionally dropped.
+    """
+
+    __tablename__ = "subtractions"
+    __table_args__ = (UniqueConstraint("job_id"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
+    legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    name: Mapped[str]
+    nickname: Mapped[str] = mapped_column(default="")
+    count: Mapped[int | None]
+    gc: Mapped[dict | None] = mapped_column(JSONB)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    ready: Mapped[bool] = mapped_column(Boolean, default=False)
+    user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
+    job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"), index=True)
+    upload_id: Mapped[int | None] = mapped_column(ForeignKey("uploads.id"))
 
 
 class SQLSubtractionFile(Base):

--- a/virtool/subtractions/pg.py
+++ b/virtool/subtractions/pg.py
@@ -54,7 +54,7 @@ class SQLSubtraction(Base):
     deleted: Mapped[bool] = mapped_column(Boolean, default=False)
     ready: Mapped[bool] = mapped_column(Boolean, default=False)
     user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
-    job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"), index=True)
+    job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"))
     upload_id: Mapped[int | None] = mapped_column(ForeignKey("uploads.id"))
 
 


### PR DESCRIPTION
## Summary

- Adds the `subtractions` Postgres table via a new Alembic migration (`f4624eb353b7`)
- Introduces `SQLSubtraction` ORM model in `virtool/subtractions/pg.py` with foreign keys to `users`, `jobs`, and `uploads` tables and a nullable `legacy_id` for bridging existing Mongo records
- Updates the migration apply snapshot to include the new revision