### PR TITLE
Add nullable subtraction_id FK to subtraction_files

### DIFF
--- a/assets/alembic/versions/895d6315a838_add_subtraction_files_subtraction_id.py
+++ b/assets/alembic/versions/895d6315a838_add_subtraction_files_subtraction_id.py
@@ -1,0 +1,39 @@
+"""add subtraction_files subtraction_id
+
+Phase 1 of keying ``subtraction_files`` by an integer FK to ``subtractions``
+instead of the legacy Mongo ``subtraction`` string. Purely additive: adds a
+nullable ``subtraction_id BIGINT REFERENCES subtractions(id)`` column,
+leaving the existing ``subtraction`` column and its unique constraint intact.
+
+Backfill, sync trigger, and call-site changes are handled by downstream
+revisions.
+
+Revision ID: 895d6315a838
+Revises: f4624eb353b7
+Create Date: 2026-06-03 20:44:11.573199+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "895d6315a838"
+down_revision = "f4624eb353b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subtraction_files",
+        sa.Column(
+            "subtraction_id",
+            sa.BigInteger(),
+            sa.ForeignKey("subtractions.id"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subtraction_files", "subtraction_id")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -351,5 +351,12 @@
       'name': 'create subtractions table',
       'revision': 'f4624eb353b7',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 51,
+      'name': 'add subtraction_files subtraction_id',
+      'revision': '895d6315a838',
+    }),
   ])
 # ---

--- a/tests/subtractions/__snapshots__/test_files.ambr
+++ b/tests/subtractions/__snapshots__/test_files.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_create_subtraction_files
   list([
-    <SQLSubtractionFile(id=1, name=subtraction.fa.gz, subtraction=foo, type=fasta, size=10)>,
-    <SQLSubtractionFile(id=2, name=subtraction.1.bt2, subtraction=foo, type=bowtie2, size=12)>,
+    <SQLSubtractionFile(id=1, name=subtraction.fa.gz, subtraction=foo, subtraction_id=None, type=fasta, size=10)>,
+    <SQLSubtractionFile(id=2, name=subtraction.1.bt2, subtraction=foo, subtraction_id=None, type=bowtie2, size=12)>,
   ])
 # ---

--- a/tests/subtractions/__snapshots__/test_utils.ambr
+++ b/tests/subtractions/__snapshots__/test_utils.ambr
@@ -6,6 +6,7 @@
       'name': 'subtraction.fq.gz',
       'size': 12345,
       'subtraction': 'foo',
+      'subtraction_id': None,
       'type': 'fasta',
     }),
     dict({
@@ -13,6 +14,7 @@
       'name': 'subtraction.1.bt2',
       'size': 56437,
       'subtraction': 'foo',
+      'subtraction_id': None,
       'type': 'bowtie2',
     }),
     dict({
@@ -20,6 +22,7 @@
       'name': 'subtraction.2.bt2',
       'size': 93845,
       'subtraction': 'foo',
+      'subtraction_id': None,
       'type': 'bowtie2',
     }),
   ])

--- a/virtool/subtractions/pg.py
+++ b/virtool/subtractions/pg.py
@@ -67,5 +67,6 @@ class SQLSubtractionFile(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     subtraction = Column(String)
+    subtraction_id = Column(BigInteger, ForeignKey("subtractions.id"), nullable=True)
     type = Column(Enum(SubtractionType))
     size = Column(BigInteger)


### PR DESCRIPTION
## Summary

- Adds a nullable `subtraction_id BIGINT` column to `subtraction_files` as a foreign key to `subtractions(id)` — phase 1 of migrating away from the legacy Mongo `subtraction` string column
- New Alembic revision (`895d6315a838`) applies the additive schema change; existing column and unique constraint are left intact
- Updates the `SQLSubtractionFile` SQLAlchemy model to reflect the new column