### PR TITLE
Prevent duplicate periodic task spawning with advisory lock

### DIFF
--- a/tests/tasks/test_data.py
+++ b/tests/tasks/test_data.py
@@ -1,8 +1,12 @@
+import asyncio
+from datetime import timedelta
+
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy.assertion import SnapshotAssertion
 
+import virtool.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.jobs.tasks import JobsTimeoutTask
@@ -107,6 +111,80 @@ class TestComplete:
         """Test that completing a non-existent task raises ResourceNotFoundError."""
         with pytest.raises(ResourceNotFoundError):
             await data_layer.tasks.complete(999)
+
+
+async def _count_tasks(pg: AsyncEngine, task_type: str) -> int:
+    async with AsyncSession(pg) as session:
+        return await session.scalar(
+            select(func.count()).select_from(SQLTask).filter_by(type=task_type)
+        )
+
+
+class TestCreatePeriodic:
+    async def test_spawns_when_none_exists(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+    ):
+        """Spawn a task when no recent task of the type exists."""
+        task = await data_layer.tasks.create_periodic(DummyTask, 600)
+
+        assert task is not None
+        assert task.type == DummyTask.name
+        assert await _count_tasks(pg, DummyTask.name) == 1
+
+    async def test_skips_when_recent_exists(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+    ):
+        """Do not spawn when a task was created within the interval."""
+        await data_layer.tasks.create(DummyTask, {})
+
+        task = await data_layer.tasks.create_periodic(DummyTask, 600)
+
+        assert task is None
+        assert await _count_tasks(pg, DummyTask.name) == 1
+
+    async def test_spawns_when_existing_is_stale(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+    ):
+        """Spawn when the most recent task is older than the interval."""
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLTask(
+                    complete=True,
+                    context={},
+                    count=0,
+                    created_at=virtool.utils.timestamp() - timedelta(seconds=700),
+                    progress=100,
+                    step=DummyTask.name,
+                    type=DummyTask.name,
+                )
+            )
+            await session.commit()
+
+        task = await data_layer.tasks.create_periodic(DummyTask, 600)
+
+        assert task is not None
+        assert await _count_tasks(pg, DummyTask.name) == 2
+
+    async def test_concurrent_callers_spawn_once(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+    ):
+        """Only one of many concurrent callers spawns the task."""
+        results = await asyncio.gather(
+            *(data_layer.tasks.create_periodic(DummyTask, 600) for _ in range(8))
+        )
+
+        spawned = [task for task in results if task is not None]
+
+        assert len(spawned) == 1
+        assert await _count_tasks(pg, DummyTask.name) == 1
 
 
 class TestAcquire:

--- a/tests/tasks/test_data.py
+++ b/tests/tasks/test_data.py
@@ -171,6 +171,16 @@ class TestCreatePeriodic:
         assert task is not None
         assert await _count_tasks(pg, DummyTask.name) == 2
 
+    @pytest.mark.parametrize("interval", [0, -1])
+    async def test_rejects_non_positive_interval(
+        self,
+        interval: int,
+        data_layer: DataLayer,
+    ):
+        """Reject a non-positive interval rather than silently never spawning."""
+        with pytest.raises(ValueError, match="positive number of seconds"):
+            await data_layer.tasks.create_periodic(DummyTask, interval)
+
     async def test_concurrent_callers_spawn_once(
         self,
         data_layer: DataLayer,

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -202,7 +202,7 @@ async def startup_periodic_tasks(app: App) -> None:
         (SampleWorkflowsUpdateTask, 3600),
     ]
 
-    spawner = PeriodicTaskSpawner(app["pg"], app["data"].tasks)
+    spawner = PeriodicTaskSpawner(app["data"].tasks)
     task = asyncio.create_task(spawner.run(periodic_tasks))
     app.setdefault("background_tasks", []).append(task)
 

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -123,7 +123,7 @@ class TasksData:
             raise ResourceNotFoundError
 
     @staticmethod
-    def _new_sql_task(task_class: type[BaseTask], context: dict | None) -> SQLTask:
+    def _create_sql_task(task_class: type[BaseTask], context: dict | None) -> SQLTask:
         """Build an unsaved :class:`SQLTask` for a new task of ``task_class``."""
         return SQLTask(
             complete=False,
@@ -148,7 +148,7 @@ class TasksData:
         :return: the task record
 
         """
-        sql_task = self._new_sql_task(task_class, context)
+        sql_task = self._create_sql_task(task_class, context)
 
         async with AsyncSession(self._pg) as session:
             session.add(sql_task)
@@ -197,7 +197,7 @@ class TasksData:
             if existing_task is not None:
                 return None
 
-            sql_task = self._new_sql_task(task_class, None)
+            sql_task = self._create_sql_task(task_class, None)
 
             session.add(sql_task)
             await session.flush()

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -1,12 +1,14 @@
 """The data layer piece for tasks."""
 
-from sqlalchemy import desc, select, text, update
+from datetime import timedelta
+
+from sqlalchemy import desc, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
 import virtool.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
-from virtool.data.events import Operation, emits
+from virtool.data.events import Operation, emit, emits
 from virtool.tasks.models import Task
 from virtool.tasks.oas import UpdateTaskRequest
 from virtool.tasks.sql import SQLTask
@@ -148,6 +150,61 @@ class TasksData:
             await session.flush()
             task = Task(**sql_task.to_dict())
             await session.commit()
+
+        return task
+
+    async def create_periodic(
+        self,
+        task_class: type[BaseTask],
+        interval: int,
+    ) -> Task | None:
+        """Atomically spawn a periodic task if one is due.
+
+        A Postgres transaction-scoped advisory lock keyed on the task type
+        serializes the decision across API replicas. The lock is held across the
+        recency check and the insert, so only one replica can spawn a given task
+        type per cycle and no duplicate is created.
+
+        :param task_class: the task class to spawn
+        :param interval: the minimum interval in seconds between tasks
+        :return: the spawned task, or ``None`` if a task was not due or another
+            replica held the lock
+        """
+        async with AsyncSession(self._pg) as session:
+            locked = await session.scalar(
+                select(func.pg_try_advisory_xact_lock(func.hashtext(task_class.name)))
+            )
+
+            if not locked:
+                return None
+
+            cutoff_time = virtool.utils.timestamp() - timedelta(seconds=interval)
+
+            existing_task = await session.scalar(
+                select(SQLTask)
+                .filter_by(type=task_class.name)
+                .filter(SQLTask.created_at > cutoff_time)
+            )
+
+            if existing_task is not None:
+                return None
+
+            sql_task = SQLTask(
+                complete=False,
+                context={},
+                step=task_class.name,
+                count=0,
+                created_at=virtool.utils.timestamp(),
+                progress=0,
+                type=task_class.name,
+            )
+
+            session.add(sql_task)
+            await session.flush()
+            task = Task(**sql_task.to_dict())
+            await session.commit()
+
+        emit(task, self.name, "create", Operation.CREATE)
 
         return task
 

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -122,6 +122,19 @@ class TasksData:
 
             raise ResourceNotFoundError
 
+    @staticmethod
+    def _new_sql_task(task_class: type[BaseTask], context: dict | None) -> SQLTask:
+        """Build an unsaved :class:`SQLTask` for a new task of ``task_class``."""
+        return SQLTask(
+            complete=False,
+            context=context or {},
+            step=task_class.name,
+            count=0,
+            created_at=virtool.utils.timestamp(),
+            progress=0,
+            type=task_class.name,
+        )
+
     @emits(Operation.CREATE)
     async def create(
         self,
@@ -135,15 +148,7 @@ class TasksData:
         :return: the task record
 
         """
-        sql_task = SQLTask(
-            complete=False,
-            context=context or {},
-            step=task_class.name,
-            count=0,
-            created_at=virtool.utils.timestamp(),
-            progress=0,
-            type=task_class.name,
-        )
+        sql_task = self._new_sql_task(task_class, context)
 
         async with AsyncSession(self._pg) as session:
             session.add(sql_task)
@@ -170,6 +175,9 @@ class TasksData:
         :return: the spawned task, or ``None`` if a task was not due or another
             replica held the lock
         """
+        if interval <= 0:
+            raise ValueError("interval must be a positive number of seconds")
+
         async with AsyncSession(self._pg) as session:
             locked = await session.scalar(
                 select(func.pg_try_advisory_xact_lock(func.hashtext(task_class.name)))
@@ -189,15 +197,7 @@ class TasksData:
             if existing_task is not None:
                 return None
 
-            sql_task = SQLTask(
-                complete=False,
-                context={},
-                step=task_class.name,
-                count=0,
-                created_at=virtool.utils.timestamp(),
-                progress=0,
-                type=task_class.name,
-            )
+            sql_task = self._new_sql_task(task_class, None)
 
             session.add(sql_task)
             await session.flush()

--- a/virtool/tasks/periodic.py
+++ b/virtool/tasks/periodic.py
@@ -1,15 +1,10 @@
 import asyncio
 from asyncio import CancelledError
-from datetime import timedelta
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
 from virtool.tasks.data import TasksData
-from virtool.tasks.sql import SQLTask
 from virtool.tasks.task import BaseTask
-from virtool.utils import timestamp
 
 logger = get_logger("periodic_spawner")
 
@@ -17,8 +12,7 @@ logger = get_logger("periodic_spawner")
 class PeriodicTaskSpawner:
     """Spawns periodic tasks for API servers with PostgreSQL-based deduplication."""
 
-    def __init__(self, pg: AsyncEngine, tasks_datalayer: TasksData):
-        self._pg = pg
+    def __init__(self, tasks_datalayer: TasksData):
         self._tasks_datalayer = tasks_datalayer
 
     async def run(self, tasks: list[tuple[type[BaseTask], int]]) -> None:
@@ -33,30 +27,14 @@ class PeriodicTaskSpawner:
 
             while True:
                 for task_class, interval in tasks:
-                    if await self._should_spawn(task_class, interval):
-                        logger.info("spawning periodic task", name=task_class.name)
-                        await self._tasks_datalayer.create(task_class)
+                    task = await self._tasks_datalayer.create_periodic(
+                        task_class, interval
+                    )
+
+                    if task is not None:
+                        logger.info("spawned periodic task", name=task_class.name)
 
                 await asyncio.sleep(30)
 
         except CancelledError:
             logger.info("stopped periodic task spawner")
-
-    async def _should_spawn(self, task_class: type[BaseTask], interval: int) -> bool:
-        """Check if we should spawn a task based on existing incomplete tasks.
-
-        :param task_class: The task class to check
-        :param interval: The minimum interval in seconds between tasks
-        :return: True if a new task should be spawned
-        """
-        cutoff_time = timestamp() - timedelta(seconds=interval)
-
-        async with AsyncSession(self._pg) as session:
-            result = await session.execute(
-                select(SQLTask)
-                .filter_by(type=task_class.name)
-                .filter(SQLTask.created_at > cutoff_time)
-            )
-
-            existing_task = result.scalar()
-            return existing_task is None


### PR DESCRIPTION
## Summary

- Moves the periodic task spawn logic into `TasksData.create_periodic`, which holds a Postgres transaction-scoped advisory lock (keyed on `hashtext(task_class.name)`) across the recency check and insert, eliminating the race condition where multiple API replicas could create duplicate tasks for the same cycle.
- Removes the `pg` engine parameter from `PeriodicTaskSpawner` since all DB access now goes through the data layer.
- Adds tests covering the no-recent-task, recent-task, stale-task, and concurrent-callers scenarios for `create_periodic`.