### PR TITLE
Add health check endpoints to task runner

### DIFF
--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -11,9 +11,10 @@ from aiohttp.web import RouteTableDef
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.jobs.main
+import virtool.tasks.main
 from virtool.api.custom_json import dump_string
 from virtool.app import create_app
-from virtool.config.cls import ServerConfig
+from virtool.config.cls import ServerConfig, TaskRunnerConfig
 from virtool.data.layer import DataLayer
 from virtool.data.utils import get_data_from_app
 from virtool.fake.next import DataFaker
@@ -573,5 +574,59 @@ def spawn_job_client(
             client.app["flags"] = FeatureFlags(flags)
 
         return client
+
+    return func
+
+
+class TaskRunnerClientSpawner(Protocol):
+    """A protocol describing a function that spawns a task runner test client.
+
+    The fixture :func:`spawn_task_runner_client` returns a function that conforms to
+    this protocol.
+    """
+
+    async def __call__(self) -> VirtoolTestClient:
+        """Spawn a test client for the task runner app.
+
+        :return: the test client
+        """
+        ...
+
+
+@pytest.fixture
+def spawn_task_runner_client(
+    aiohttp_client,
+    memory_storage,
+    mongo: Mongo,
+    mongo_connection_string,
+    mongo_name: str,
+    pg: AsyncEngine,
+    pg_connection_string: str,
+    mocker,
+) -> TaskRunnerClientSpawner:
+    """A factory method for creating an aiohttp client backed by the task runner app."""
+
+    async def func():
+        mocker.patch("virtool.startup.connect_pg", return_value=pg)
+        mocker.patch(
+            "virtool.startup.create_storage_backend",
+            return_value=memory_storage,
+        )
+
+        app = await virtool.tasks.main.create_app(
+            TaskRunnerConfig(
+                base_url="",
+                host="localhost",
+                mongodb_connection_string=f"{mongo_connection_string}/{mongo_name}?authSource=admin",
+                no_revision_check=True,
+                port=9950,
+                postgres_connection_string=pg_connection_string,
+                sentry_dsn="",
+                storage_backend="s3",
+                storage_s3_bucket="test-bucket",
+            ),
+        )
+
+        return await aiohttp_client(app, auto_decompress=False)
 
     return func

--- a/tests/health/test_api.py
+++ b/tests/health/test_api.py
@@ -1,6 +1,10 @@
 from pytest_mock import MockerFixture
 
-from tests.fixtures.client import ClientSpawner, JobClientSpawner
+from tests.fixtures.client import (
+    ClientSpawner,
+    JobClientSpawner,
+    TaskRunnerClientSpawner,
+)
 from virtool.health.models import Readiness, ReadinessChecks
 
 
@@ -73,6 +77,29 @@ class TestJobsServer:
 
     async def test_ready(self, spawn_job_client: JobClientSpawner):
         client = await spawn_job_client()
+
+        resp = await client.get("/health/ready")
+
+        assert resp.status == 200
+        assert await resp.json() == {
+            "ready": True,
+            "checks": {"mongodb": True, "postgres": True},
+        }
+
+
+class TestTaskRunner:
+    """The endpoints are also served, unauthenticated, by the task runner."""
+
+    async def test_live(self, spawn_task_runner_client: TaskRunnerClientSpawner):
+        client = await spawn_task_runner_client()
+
+        resp = await client.get("/health/live")
+
+        assert resp.status == 200
+        assert await resp.json() == {"status": "alive"}
+
+    async def test_ready(self, spawn_task_runner_client: TaskRunnerClientSpawner):
+        client = await spawn_task_runner_client()
 
         resp = await client.get("/health/ready")
 

--- a/virtool/tasks/main.py
+++ b/virtool/tasks/main.py
@@ -3,6 +3,7 @@ import aiohttp.web
 from aiohttp.web import Application
 from structlog import get_logger
 
+import virtool.health.api
 from virtool.api.accept import accept_middleware
 from virtool.api.errors import error_middleware
 from virtool.config.cls import TaskRunnerConfig, TaskSpawnerConfig
@@ -30,8 +31,8 @@ from virtool.tasks.startup import (
 )
 
 
-def run_task_runner(config: TaskRunnerConfig) -> None:
-    """Run the task runner service.
+async def create_app(config: TaskRunnerConfig) -> Application:
+    """Create the :class:`aiohttp.web.Application` for the task runner process.
 
     :param config: the task runner configuration object
     """
@@ -41,6 +42,7 @@ def run_task_runner(config: TaskRunnerConfig) -> None:
     app["mode"] = "task_runner"
 
     app.add_routes([aiohttp.web.view("/", TaskServicesRootView)])
+    app.add_routes(virtool.health.api.routes)
 
     app.on_startup.extend(
         [
@@ -64,7 +66,15 @@ def run_task_runner(config: TaskRunnerConfig) -> None:
         ],
     )
 
-    aiohttp.web.run_app(app=app, host=config.host, port=config.port)
+    return app
+
+
+def run_task_runner(config: TaskRunnerConfig) -> None:
+    """Run the task runner service.
+
+    :param config: the task runner configuration object
+    """
+    aiohttp.web.run_app(app=create_app(config), host=config.host, port=config.port)
 
 
 def run_task_spawner(config: TaskSpawnerConfig) -> None:


### PR DESCRIPTION
## Summary

- Refactors `run_task_runner` to extract a `create_app` factory, mirroring the pattern used by the API and jobs servers
- Registers the existing `health.api` routes on the task runner app so `/health/live` and `/health/ready` are served unauthenticated
- Adds a `spawn_task_runner_client` test fixture and `TestTaskRunner` test class covering both endpoints