### PR TITLE
Use integer id as outward-facing analysis identifier

### DIFF
--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -211,7 +211,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'files': list([
       dict({
-        'analysis': 'foobar',
+        'analysis': 1,
         'description': None,
         'format': 'fasta',
         'id': 1,
@@ -274,7 +274,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'files': list([
       dict({
-        'analysis': 'foobar',
+        'analysis': 1,
         'description': None,
         'format': 'fasta',
         'id': 1,
@@ -334,7 +334,7 @@
 # ---
 # name: test_upload_file[None]
   dict({
-    'analysis': 'foobar',
+    'analysis': 1,
     'description': None,
     'format': 'fasta',
     'id': 1,
@@ -346,7 +346,7 @@
 # ---
 # name: test_upload_file[None].1
   dict({
-    'analysis': 'foobar',
+    'analysis': 1,
     'description': None,
     'format': 'fasta',
     'id': 2,

--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -4,7 +4,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'files': list([
     ]),
-    'id': 'analysis1',
+    'id': 1,
     'index': dict({
       'id': 'foo',
       'version': 2,
@@ -95,7 +95,7 @@
     'documents': list([
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_3',
+        'id': 3,
         'index': dict({
           'id': 'foo',
           'version': 2,
@@ -122,7 +122,7 @@
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_2',
+        'id': 2,
         'index': dict({
           'id': 'foo',
           'version': 2,
@@ -163,7 +163,7 @@
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_1',
+        'id': 1,
         'index': dict({
           'id': 'foo',
           'version': 2,
@@ -221,7 +221,7 @@
         'uploaded_at': None,
       }),
     ]),
-    'id': 'foobar',
+    'id': 1,
     'index': dict({
       'id': 'bar',
       'version': 3,
@@ -284,7 +284,7 @@
         'uploaded_at': None,
       }),
     ]),
-    'id': 'foobar',
+    'id': 1,
     'index': dict({
       'id': 'bar',
       'version': 3,

--- a/tests/analyses/__snapshots__/test_data.ambr
+++ b/tests/analyses/__snapshots__/test_data.ambr
@@ -331,7 +331,7 @@
 # ---
 # name: test_upload_file
   dict({
-    'analysis': 'bf1b993c',
+    'analysis': 1,
     'description': None,
     'format': 'fasta',
     'id': 1,

--- a/tests/analyses/__snapshots__/test_data.ambr
+++ b/tests/analyses/__snapshots__/test_data.ambr
@@ -37,7 +37,7 @@
   dict({
     'files': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 1,
     'index': dict({
       'id': 'test_index',
       'version': 11,
@@ -118,7 +118,7 @@
   dict({
     'files': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 1,
     'index': dict({
       'id': 'test_index',
       'version': 11,
@@ -177,7 +177,7 @@
     'documents': list([
       dict({
         'created_at': 'approximately_now_datetime',
-        'id': 'fb085f7f',
+        'id': 2,
         'index': dict({
           'id': 'test_index',
           'version': 11,
@@ -233,7 +233,7 @@
     'documents': list([
       dict({
         'created_at': 'approximately_now_datetime',
-        'id': '7cf872dc',
+        'id': 3,
         'index': dict({
           'id': 'test_index',
           'version': 11,
@@ -278,7 +278,7 @@
       }),
       dict({
         'created_at': 'approximately_now_datetime',
-        'id': 'fb085f7f',
+        'id': 2,
         'index': dict({
           'id': 'test_index',
           'version': 11,

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -280,6 +280,71 @@ async def test_get_archived_reference(
     assert body["reference"] == {"id": "baz", "data_type": "genome", "name": "Baz"}
 
 
+async def test_get_by_integer_id(
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    spawn_client: ClientSpawner,
+    static_time: StaticTime,
+):
+    """An analysis resolves by its integer id, the new outward-facing identifier, and
+    the response emits that integer id rather than the legacy Mongo slug.
+    """
+    client = await spawn_client(authenticated=True)
+
+    user = await fake.users.create()
+    job = await fake.jobs.create(user=user, state=JobState.SUCCEEDED)
+
+    await asyncio.gather(
+        mongo.references.insert_one(
+            {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
+        ),
+        mongo.samples.insert_one(
+            {
+                "_id": "baz",
+                "all_read": True,
+                "all_write": False,
+                "group": "tech",
+                "group_read": True,
+                "group_write": True,
+                "labels": [],
+                "subtractions": [],
+                "user": {"id": user.id},
+            },
+        ),
+    )
+
+    await seed_analysis(
+        mongo,
+        pg,
+        {
+            "_id": "legacy_slug",
+            "created_at": static_time.datetime,
+            "index": {"version": 3, "id": "bar"},
+            "job": {"id": job.id},
+            "ready": True,
+            "reference": {"id": "baz"},
+            "results": {"hits": []},
+            "sample": {"id": "baz"},
+            "subtractions": [],
+            "user": {"id": user.id},
+            "workflow": "pathoscope",
+        },
+    )
+
+    async with AsyncSession(pg) as session:
+        analysis_id = (
+            await session.execute(
+                select(SQLAnalysis.id).where(SQLAnalysis.legacy_id == "legacy_slug"),
+            )
+        ).scalar_one()
+
+    resp = await client.get(f"/analyses/{analysis_id}")
+
+    assert resp.status == HTTPStatus.OK
+    assert (await resp.json())["id"] == analysis_id
+
+
 @pytest.mark.parametrize("ready", [True, False])
 async def test_get_304(
     ready: bool,
@@ -434,6 +499,7 @@ async def test_remove(
 @pytest.mark.parametrize("error", [None, 400, 404, 422])
 async def test_upload_file(
     error: str | None,
+    fake: DataFaker,
     get_handle,
     mongo: Mongo,
     pg: AsyncEngine,
@@ -450,8 +516,22 @@ async def test_upload_file(
     format_ = "foo" if error == 400 else "fasta"
 
     if error != 404:
-        await mongo.analyses.insert_one(
-            {"_id": "foobar", "ready": True, "job": {"id": "hello"}},
+        user = await fake.users.create()
+        await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": "foobar",
+                "created_at": static_time.datetime,
+                "index": {"id": "bar", "version": 1},
+                "job": {"id": "hello"},
+                "ready": True,
+                "reference": {"id": "baz"},
+                "sample": {"id": "baz"},
+                "subtractions": [],
+                "user": {"id": user.id},
+                "workflow": "pathoscope",
+            },
         )
 
     if error == 422:
@@ -501,10 +581,13 @@ class TestDownloadAnalysisResult:
     async def test_ok(
         self,
         example_path: Path,
+        fake: DataFaker,
         get_handle,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         spawn_job_client: JobClientSpawner,
+        static_time: StaticTime,
     ):
         """Test that an uploaded analysis result file can subsequently be downloaded."""
         client, job_client = await asyncio.gather(
@@ -512,8 +595,22 @@ class TestDownloadAnalysisResult:
             spawn_job_client(authenticated=True),
         )
 
-        await mongo.analyses.insert_one(
-            {"_id": "foobar", "ready": True, "job": {"id": "hello"}},
+        user = await fake.users.create()
+        await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": "foobar",
+                "created_at": static_time.datetime,
+                "index": {"id": "bar", "version": 1},
+                "job": {"id": "hello"},
+                "ready": True,
+                "reference": {"id": "baz"},
+                "sample": {"id": "baz"},
+                "subtractions": [],
+                "user": {"id": user.id},
+                "workflow": "pathoscope",
+            },
         )
 
         await job_client.put(

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -141,6 +141,7 @@ async def test_find(
 async def test_create(
     data_layer: DataLayer,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     setup_sample: str,
 ):
@@ -161,7 +162,8 @@ async def test_create(
 
     assert analysis == snapshot(name="obj", exclude=props("created_at", "updated_at"))
 
-    assert await mongo.analyses.find_one({"_id": analysis.id}) == snapshot(
+    row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
+    assert await mongo.analyses.find_one({"_id": row.legacy_id}) == snapshot(
         name="mongo",
         exclude=props("created_at", "updated_at"),
     )
@@ -170,6 +172,7 @@ async def test_create(
 async def test_create_analysis_id(
     data_layer: DataLayer,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     setup_sample: str,
 ):
@@ -190,7 +193,8 @@ async def test_create_analysis_id(
 
     assert analysis == snapshot(name="obj", exclude=props("created_at", "updated_at"))
 
-    assert await mongo.analyses.find_one({"_id": analysis.id}) == snapshot(
+    row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
+    assert await mongo.analyses.find_one({"_id": row.legacy_id}) == snapshot(
         name="mongo",
         exclude=props("created_at", "updated_at"),
     )
@@ -223,11 +227,11 @@ class TestCreate:
             0,
         )
 
-        document = await mongo.analyses.find_one({"_id": analysis.id})
-        row = await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id))
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
+        document = await mongo.analyses.find_one({"_id": row.legacy_id})
 
         assert row is not None
-        assert isinstance(row.id, int)
+        assert row.id == analysis.id
         assert row.legacy_id == document["_id"]
         assert row.workflow == document["workflow"]
         assert row.ready is False
@@ -260,7 +264,7 @@ class TestCreate:
             0,
         )
 
-        row = await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id))
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
 
         assert row.subtractions == []
 
@@ -319,13 +323,13 @@ class TestFinalize:
             0,
         )
 
-        created = await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id))
+        created = await get_row(pg, SQLAnalysis, ("id", analysis.id))
 
         results = {"hits": [{"index": 0, "sequence": "ACGT"}]}
 
         await data_layer.analyses.finalize(analysis.id, results)
 
-        row = await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id))
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
 
         assert row.ready is True
         assert row.results == results
@@ -334,12 +338,12 @@ class TestFinalize:
         async with AsyncSession(pg) as session:
             result = await session.execute(
                 select(SQLAnalysisResult.results).where(
-                    SQLAnalysisResult.analysis_id == analysis.id,
+                    SQLAnalysisResult.analysis_id == created.legacy_id,
                 ),
             )
             assert result.scalar_one() == results
 
-        document = await mongo.analyses.find_one({"_id": analysis.id})
+        document = await mongo.analyses.find_one({"_id": created.legacy_id})
 
         assert document["ready"] is True
         assert document["results"] == "sql"
@@ -384,14 +388,14 @@ class TestFinalize:
         with pytest.raises(RuntimeError):
             await data_layer.analyses.finalize(analysis.id, {"hits": []})
 
-        row = await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id))
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
         assert row.ready is False
         assert row.results is None
 
         async with AsyncSession(pg) as session:
             result = await session.execute(
                 select(SQLAnalysisResult).where(
-                    SQLAnalysisResult.analysis_id == analysis.id,
+                    SQLAnalysisResult.analysis_id == row.legacy_id,
                 ),
             )
             assert result.scalars().first() is None
@@ -415,10 +419,12 @@ class TestDelete:
             0,
         )
 
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
+
         await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
 
-        assert await mongo.analyses.find_one({"_id": analysis.id}) is None
-        assert await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id)) is None
+        assert await mongo.analyses.find_one({"_id": row.legacy_id}) is None
+        assert await get_row(pg, SQLAnalysis, ("id", analysis.id)) is None
 
     async def test_rolls_back_when_mongo_delete_fails(
         self,
@@ -445,7 +451,7 @@ class TestDelete:
         with pytest.raises(RuntimeError):
             await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
 
-        assert await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id)) is not None
+        assert await get_row(pg, SQLAnalysis, ("id", analysis.id)) is not None
 
 
 async def test_get_without_if_modified_since(

--- a/tests/fixtures/workflow_api/analyses.py
+++ b/tests/fixtures/workflow_api/analyses.py
@@ -19,7 +19,7 @@ def create_analyses_routes(
         async def get(self):
             id_ = self.request.match_info["analysis_id"]
 
-            if id_ == data.analysis.id:
+            if id_ == str(data.analysis.id):
                 return json_response(
                     data.analysis.dict(), status=200, dumps=custom_dumps
                 )
@@ -29,7 +29,7 @@ def create_analyses_routes(
         async def patch(self):
             analysis_id = self.request.match_info["analysis_id"]
 
-            if analysis_id != data.analysis.id:
+            if analysis_id != str(data.analysis.id):
                 return generate_not_found()
 
             results = (await self.request.json())["results"]
@@ -41,7 +41,7 @@ def create_analyses_routes(
         async def delete(self):
             analysis_id = self.request.match_info["analysis_id"]
 
-            if analysis_id != data.analysis.id:
+            if analysis_id != str(data.analysis.id):
                 return generate_not_found()
 
             if data.analysis.ready is True:

--- a/tests/fixtures/workflow_api/analyses.py
+++ b/tests/fixtures/workflow_api/analyses.py
@@ -19,7 +19,7 @@ def create_analyses_routes(
         async def get(self):
             id_ = self.request.match_info["analysis_id"]
 
-            if id_ == str(data.analysis.id):
+            if data.analysis is not None and id_ == str(data.analysis.id):
                 return json_response(
                     data.analysis.dict(), status=200, dumps=custom_dumps
                 )
@@ -29,7 +29,7 @@ def create_analyses_routes(
         async def patch(self):
             analysis_id = self.request.match_info["analysis_id"]
 
-            if analysis_id != str(data.analysis.id):
+            if data.analysis is None or analysis_id != str(data.analysis.id):
                 return generate_not_found()
 
             results = (await self.request.json())["results"]
@@ -41,7 +41,7 @@ def create_analyses_routes(
         async def delete(self):
             analysis_id = self.request.match_info["analysis_id"]
 
-            if analysis_id != str(data.analysis.id):
+            if data.analysis is None or analysis_id != str(data.analysis.id):
                 return generate_not_found()
 
             if data.analysis.ready is True:

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -4,7 +4,7 @@
     'created_at': '2015-10-06T20:00:00Z',
     'files': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 1,
     'index': dict({
       'id': 'test',
       'version': 4,
@@ -2297,7 +2297,7 @@
     'documents': list([
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_3',
+        'id': 3,
         'index': dict({
           'id': 'foo',
           'version': 2,
@@ -2328,7 +2328,7 @@
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_2',
+        'id': 2,
         'index': dict({
           'id': 'foo',
           'version': 2,
@@ -2359,7 +2359,7 @@
       }),
       dict({
         'created_at': '2015-10-06T20:00:00Z',
-        'id': 'test_1',
+        'id': 1,
         'index': dict({
           'id': 'foo',
           'version': 2,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1222,7 +1222,7 @@ class TestAnalyze:
         resp = await self._post(analyze_client)
 
         assert resp.status == 201
-        assert resp.headers["Location"] == "/analyses/bf1b993c"
+        assert resp.headers["Location"] == "/analyses/1"
         assert await resp.json() == snapshot
 
     async def test_missing_reference(

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -593,17 +593,19 @@ class TestDelete:
 
         await data_layer.analyses.finalize(analysis.id, {"hits": []})
 
-        assert await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id)) is not None
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
+        assert row is not None
+        legacy_id = row.legacy_id
 
         await data_layer.samples.delete("test_sample")
 
-        assert await mongo.analyses.find_one({"_id": analysis.id}) is None
-        assert await get_row(pg, SQLAnalysis, ("legacy_id", analysis.id)) is None
+        assert await mongo.analyses.find_one({"_id": legacy_id}) is None
+        assert await get_row(pg, SQLAnalysis, ("id", analysis.id)) is None
 
         async with AsyncSession(pg) as session:
             result = await session.execute(
                 select(SQLAnalysisResult).where(
-                    SQLAnalysisResult.analysis_id == analysis.id,
+                    SQLAnalysisResult.analysis_id == legacy_id,
                 ),
             )
             assert result.scalar_one_or_none() is None

--- a/virtool/analyses/api.py
+++ b/virtool/analyses/api.py
@@ -73,6 +73,10 @@ class AnalysisView(PydanticView):
 
         Fetches the details of an analysis.
 
+        The analysis is identified by its integer `id`. The legacy Mongo string id is
+        still accepted transitionally and resolved to the same analysis; support for it
+        will be removed once the `legacy_id` bridge is dropped.
+
         Status Codes:
             200: Successful operation
             304: Not modified

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -59,6 +59,7 @@ from virtool.utils import base_processor, wait_for_checks
 logger = get_logger("analyses")
 
 FIND_COLUMNS = (
+    SQLAnalysis.id,
     SQLAnalysis.legacy_id,
     SQLAnalysis.created_at,
     SQLAnalysis.updated_at,
@@ -82,11 +83,15 @@ def _row_to_document(row, *, include_results: bool) -> dict:
     """Shape a ``SQLAnalysis`` row into the Mongo-like document the transforms and
     formatters expect.
 
-    The legacy id is used as ``_id`` so responses stay compatible with the Mongo
-    string ids still present in URLs. ``base_processor`` later renames it to ``id``.
+    The integer ``id`` is the outward-facing identifier; ``base_processor`` later
+    renames ``_id`` to ``id``. The legacy Mongo slug is carried in ``legacy_id`` for
+    internal consumers (storage keys, Mongo dual-writes, and string-keyed SQL tables
+    such as ``analysis_files`` and ``nuvs_blast``) that have not yet been migrated off
+    the slug.
     """
     document = {
-        "_id": row.legacy_id,
+        "_id": row.id,
+        "legacy_id": row.legacy_id,
         "created_at": row.created_at,
         "updated_at": row.updated_at,
         "workflow": row.workflow,
@@ -210,7 +215,9 @@ class AnalysisData(DataLayerDomain):
 
         await wait_for_checks(check_if_analysis_modified(if_modified_since, document))
 
-        document = await attach_analysis_files(self._pg, analysis_id, document)
+        document = await attach_analysis_files(
+            self._pg, document["legacy_id"], document
+        )
 
         if document["ready"]:
             document["results"] = await virtool.analyses.format.format_analysis(
@@ -219,7 +226,7 @@ class AnalysisData(DataLayerDomain):
                 self._pg,
                 workflow=document["workflow"],
                 results=document["results"],
-                legacy_id=document["_id"],
+                legacy_id=document["legacy_id"],
                 sample_id=document["sample"]["id"],
             )
 
@@ -387,32 +394,39 @@ class AnalysisData(DataLayerDomain):
             # Only the jobs API is allowed to delete incomplete analyses.
             raise ResourceConflictError
 
+        async with AsyncSession(self._pg) as session:
+            legacy_id = (
+                await session.execute(
+                    select(SQLAnalysis.legacy_id).where(SQLAnalysis.id == analysis.id),
+                )
+            ).scalar_one()
+
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,
             pg_session,
         ):
             await self._mongo.analyses.delete_one(
-                {"_id": analysis.id},
+                {"_id": legacy_id},
                 session=mongo_session,
             )
 
             await pg_session.execute(
                 delete(SQLAnalysisResult).where(
-                    SQLAnalysisResult.analysis_id == analysis_id,
+                    SQLAnalysisResult.analysis_id == legacy_id,
                 ),
             )
 
             await pg_session.execute(
-                delete(SQLAnalysis).where(SQLAnalysis.legacy_id == analysis_id),
+                delete(SQLAnalysis).where(SQLAnalysis.id == analysis.id),
             )
 
         for key, exc in await delete_prefix(
             self._storage,
-            f"samples/{analysis.sample.id}/analysis/{analysis_id}/",
+            f"samples/{analysis.sample.id}/analysis/{legacy_id}/",
         ):
             logger.error(
                 "storage cleanup failed; file orphaned",
-                analysis_id=analysis_id,
+                analysis_id=analysis.id,
                 sample_id=analysis.sample.id,
                 key=key,
                 error=repr(exc),
@@ -443,14 +457,21 @@ class AnalysisData(DataLayerDomain):
         :param name: the name of the analysis file
         :return: the new analysis file
         """
-        document = await self._mongo.analyses.find_one(analysis_id)
+        async with AsyncSession(self._pg) as session:
+            legacy_id = (
+                await session.execute(
+                    select(SQLAnalysis.legacy_id).where(
+                        compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
+                    ),
+                )
+            ).scalar_one_or_none()
 
-        if document is None:
+        if legacy_id is None:
             raise ResourceNotFoundError
 
         analysis_file = await create_analysis_file(
             self._pg,
-            analysis_id,
+            legacy_id,
             analysis_format,
             name,
         )
@@ -562,6 +583,7 @@ class AnalysisData(DataLayerDomain):
             analysis = (
                 await session.execute(
                     select(
+                        SQLAnalysis.legacy_id,
                         SQLAnalysis.workflow,
                         SQLAnalysis.ready,
                         SQLAnalysis.results,
@@ -573,6 +595,8 @@ class AnalysisData(DataLayerDomain):
 
         if analysis is None:
             raise ResourceNotFoundError()
+
+        legacy_id = analysis.legacy_id
 
         await wait_for_checks(
             check_if_analysis_is_nuvs(analysis.workflow),
@@ -586,13 +610,13 @@ class AnalysisData(DataLayerDomain):
         ):
             await pg_session.execute(
                 delete(SQLNuVsBlast)
-                .where(SQLNuVsBlast.analysis_id == analysis_id)
+                .where(SQLNuVsBlast.analysis_id == legacy_id)
                 .where(SQLNuVsBlast.sequence_index == sequence_index),
             )
             await pg_session.flush()
 
             blast = SQLNuVsBlast(
-                analysis_id=analysis_id,
+                analysis_id=legacy_id,
                 created_at=timestamp,
                 last_checked_at=timestamp,
                 ready=False,
@@ -607,13 +631,13 @@ class AnalysisData(DataLayerDomain):
                 self._mongo,
                 mongo_session,
                 pg_session,
-                analysis_id,
+                legacy_id,
                 timestamp,
             )
 
             await self.data.tasks.create(
                 BLASTTask,
-                {"analysis_id": analysis_id, "sequence_index": sequence_index},
+                {"analysis_id": legacy_id, "sequence_index": sequence_index},
             )
 
             blast_data = blast.to_dict()
@@ -633,7 +657,12 @@ class AnalysisData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             row = (
                 await session.execute(
-                    select(SQLAnalysis.ready, SQLAnalysis.sample).where(
+                    select(
+                        SQLAnalysis.id,
+                        SQLAnalysis.legacy_id,
+                        SQLAnalysis.ready,
+                        SQLAnalysis.sample,
+                    ).where(
                         compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
                     ),
                 )
@@ -653,19 +682,19 @@ class AnalysisData(DataLayerDomain):
         ):
             await pg_session.execute(
                 insert(SQLAnalysisResult).values(
-                    analysis_id=analysis_id,
+                    analysis_id=row.legacy_id,
                     results=results,
                 ),
             )
 
             await pg_session.execute(
                 update(SQLAnalysis)
-                .where(SQLAnalysis.legacy_id == analysis_id)
+                .where(SQLAnalysis.id == row.id)
                 .values(ready=True, results=results, updated_at=updated_at),
             )
 
             await self._mongo.analyses.find_one_and_update(
-                {"_id": analysis_id},
+                {"_id": row.legacy_id},
                 {"$set": {"results": "sql", "ready": True, "updated_at": updated_at}},
                 session=mongo_session,
             )

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -120,6 +120,23 @@ class AnalysisData(DataLayerDomain):
         self._pg = pg
         self._storage = storage
 
+    async def _resolve_ids(self, analysis_id: int | str):
+        """Resolve the integer id and legacy slug for an analysis by either identifier.
+
+        Accepts the outward-facing integer id or the legacy Mongo slug and returns the
+        row's ``(id, legacy_id)``, or ``None`` if no analysis matches. The slug is still
+        needed for Mongo dual-writes and the string-keyed ``analysis_files``,
+        ``nuvs_blast``, and ``analysis_results`` tables.
+        """
+        async with AsyncSession(self._pg) as session:
+            return (
+                await session.execute(
+                    select(SQLAnalysis.id, SQLAnalysis.legacy_id).where(
+                        compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
+                    ),
+                )
+            ).one_or_none()
+
     async def find(
         self,
         page: int,
@@ -394,12 +411,7 @@ class AnalysisData(DataLayerDomain):
             # Only the jobs API is allowed to delete incomplete analyses.
             raise ResourceConflictError
 
-        async with AsyncSession(self._pg) as session:
-            legacy_id = (
-                await session.execute(
-                    select(SQLAnalysis.legacy_id).where(SQLAnalysis.id == analysis.id),
-                )
-            ).scalar_one()
+        legacy_id = (await self._resolve_ids(analysis.id)).legacy_id
 
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,
@@ -457,21 +469,14 @@ class AnalysisData(DataLayerDomain):
         :param name: the name of the analysis file
         :return: the new analysis file
         """
-        async with AsyncSession(self._pg) as session:
-            legacy_id = (
-                await session.execute(
-                    select(SQLAnalysis.legacy_id).where(
-                        compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
-                    ),
-                )
-            ).scalar_one_or_none()
+        ids = await self._resolve_ids(analysis_id)
 
-        if legacy_id is None:
+        if ids is None:
             raise ResourceNotFoundError
 
         analysis_file = await create_analysis_file(
             self._pg,
-            legacy_id,
+            ids.legacy_id,
             analysis_format,
             name,
         )
@@ -495,7 +500,7 @@ class AnalysisData(DataLayerDomain):
             SQLAnalysisFile,
         )
 
-        return AnalysisFile(**analysis_file)
+        return AnalysisFile(**{**analysis_file, "analysis": ids.id})
 
     async def download_file(
         self,

--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -19,7 +19,7 @@ class AnalysisSample(BaseModel):
 
 class AnalysisMinimal(BaseModel):
     created_at: datetime
-    id: str
+    id: int
     index: IndexNested
     job: JobMinimal | None
     ml: MLModelRelease | None
@@ -43,7 +43,7 @@ class AnalysisMinimal(BaseModel):
             "example": [
                 {
                     "created_at": "2022-05-21T01:28:55.441000Z",
-                    "id": "m9ktiz0i",
+                    "id": 142,
                     "index": {"id": "9c5u6wsq", "version": 13},
                     "job": {"id": "bt8nwg9z"},
                     "ready": True,
@@ -93,7 +93,7 @@ class Analysis(AnalysisMinimal):
                         "uploaded_at": "2022-08-15T17:48:02.467000Z",
                     }
                 ],
-                "id": "ofv7rp4v",
+                "id": 3145,
                 "index": {"id": "u3lm1rk8", "version": 14},
                 "job": {"id": "us3toy8j"},
                 "ready": True,

--- a/virtool/analyses/models.py
+++ b/virtool/analyses/models.py
@@ -63,7 +63,7 @@ class AnalysisMinimal(BaseModel):
 
 
 class AnalysisFile(BaseModel):
-    analysis: str
+    analysis: int
     description: str | None = None
     format: str
     id: int
@@ -83,7 +83,7 @@ class Analysis(AnalysisMinimal):
                 "created_at": "2022-08-15T17:42:35.979000Z",
                 "files": [
                     {
-                        "analysis": "ofv7rp4v",
+                        "analysis": 3145,
                         "description": None,
                         "format": "tsv",
                         "id": 3145,

--- a/virtool/analyses/oas.py
+++ b/virtool/analyses/oas.py
@@ -8,7 +8,7 @@ class FindAnalysesResponse(AnalysisSearchResult):
                 "documents": [
                     {
                         "created_at": "2022-08-15T17:42:35.979000Z",
-                        "id": "ofv7rp4v",
+                        "id": 3145,
                         "index": {"id": "u3lm1rk8", "version": 14},
                         "job": {"id": "us3toy8j"},
                         "ready": True,

--- a/virtool/analyses/utils.py
+++ b/virtool/analyses/utils.py
@@ -27,7 +27,8 @@ async def attach_analysis_files(
     `GET` response.
 
     :param pg: PostgreSQL AsyncEngine object
-    :param analysis_id: An id for a specific analysis
+    :param analysis_id: the legacy slug used to look up the still-string-keyed
+        ``analysis_files`` rows
     :param document: The analysis document
     :return: List of file details for each file associated with an analysis
     """
@@ -42,7 +43,12 @@ async def attach_analysis_files(
             .all()
         )
 
-    return {**document, "files": [result.to_dict() for result in results]}
+    return {
+        **document,
+        "files": [
+            {**result.to_dict(), "analysis": document["_id"]} for result in results
+        ],
+    }
 
 
 def find_nuvs_sequence_by_index(

--- a/virtool/blast/transform.py
+++ b/virtool/blast/transform.py
@@ -17,7 +17,9 @@ class AttachNuVsBLAST(AbstractTransform):
 
     async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
         result = await session.execute(
-            select(SQLNuVsBlast).where(SQLNuVsBlast.analysis_id == document["id"])
+            select(SQLNuVsBlast).where(
+                SQLNuVsBlast.analysis_id == document["legacy_id"]
+            )
         )
 
         return {


### PR DESCRIPTION
## Summary

- Flips the analysis API identifier from the legacy Mongo string slug to the PostgreSQL integer `id`, completing the transition started when the integer primary key was introduced.
- Updates `_row_to_document` to emit the integer `id` as `_id` (renamed to `id` by `base_processor`) and carries the Mongo slug in `legacy_id` for internal consumers (storage keys, dual-writes, and string-keyed tables like `analysis_files` and `nuvs_blast`) that have not yet been migrated off the slug.
- Updates all call sites in the data layer, tests, and workflow API fixture to look up and use `legacy_id` where Mongo or string-keyed tables are still needed.