### PR TITLE
Expose active task counts on the jobs API for KEDA autoscaling

### DIFF
--- a/assets/alembic/versions/f95b556b3adc_add_active_tasks_index.py
+++ b/assets/alembic/versions/f95b556b3adc_add_active_tasks_index.py
@@ -1,0 +1,31 @@
+"""add active tasks index
+
+Revision ID: f95b556b3adc
+Revises: 895d6315a838
+Create Date: 2026-06-03 23:31:51.980425+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f95b556b3adc"
+down_revision = "895d6315a838"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Support counting active (queued and running) tasks for autoscaling without
+    # scanning completed or failed rows, which accumulate unbounded.
+    op.create_index(
+        "idx_tasks_active",
+        "tasks",
+        ["acquired_at"],
+        postgresql_where=sa.text("complete = false AND error IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_tasks_active", table_name="tasks")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -358,5 +358,12 @@
       'name': 'add subtraction_files subtraction_id',
       'revision': '895d6315a838',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 52,
+      'name': 'add active tasks index',
+      'revision': 'f95b556b3adc',
+    }),
   ])
 # ---

--- a/tests/tasks/test_api.py
+++ b/tests/tasks/test_api.py
@@ -5,6 +5,7 @@ from syrupy.assertion import SnapshotAssertion
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.tasks.oas import UpdateTaskRequest
 
 
 async def test_find(
@@ -85,11 +86,36 @@ class TestGetCounts:
         assert resp.status == HTTPStatus.OK
         assert await resp.json() == {"queued": 0, "running": 0}
 
+    async def test_excludes_terminal_tasks(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        spawn_job_client: JobClientSpawner,
+    ):
+        """Test that completed and errored tasks are not counted."""
+        client = await spawn_job_client(authenticated=False)
+
+        completed = await fake.tasks.create()
+        await data_layer.tasks.complete(completed.id)
+
+        errored = await fake.tasks.create()
+        await data_layer.tasks.update(errored.id, UpdateTaskRequest(error="boom"))
+
+        await fake.tasks.create()
+
+        resp = await client.get("/tasks/counts")
+
+        assert resp.status == HTTPStatus.OK
+        assert await resp.json() == {"queued": 1, "running": 0}
+
     async def test_not_on_public_api(self, spawn_client: ClientSpawner):
-        """Test that the endpoint is not served by the public API."""
+        """Test that the endpoint is not served by the public API.
+
+        The public API has no ``/tasks/counts`` route, so the request falls
+        through to ``/tasks/{task_id}`` and is rejected as a non-integer id.
+        """
         client = await spawn_client(authenticated=True)
 
         resp = await client.get("/tasks/counts")
 
-        assert resp.status != HTTPStatus.OK
-        assert "queued" not in await resp.json()
+        assert resp.status == HTTPStatus.BAD_REQUEST

--- a/tests/tasks/test_api.py
+++ b/tests/tasks/test_api.py
@@ -2,7 +2,8 @@ from http import HTTPStatus
 
 from syrupy.assertion import SnapshotAssertion
 
-from tests.fixtures.client import ClientSpawner
+from tests.fixtures.client import ClientSpawner, JobClientSpawner
+from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 
 
@@ -52,3 +53,43 @@ class TestGet:
         resp = await client.get("/tasks/99")
 
         assert resp.status == HTTPStatus.NOT_FOUND
+
+
+class TestGetCounts:
+    async def test_ok(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        spawn_job_client: JobClientSpawner,
+    ):
+        """Test that queued and running tasks are counted on the jobs API."""
+        client = await spawn_job_client(authenticated=False)
+
+        await fake.tasks.create()
+        await fake.tasks.create()
+        await fake.tasks.create()
+
+        await data_layer.tasks.acquire("runner")
+
+        resp = await client.get("/tasks/counts")
+
+        assert resp.status == HTTPStatus.OK
+        assert await resp.json() == {"queued": 2, "running": 1}
+
+    async def test_empty(self, spawn_job_client: JobClientSpawner):
+        """Test that counts are zero when there are no tasks."""
+        client = await spawn_job_client(authenticated=False)
+
+        resp = await client.get("/tasks/counts")
+
+        assert resp.status == HTTPStatus.OK
+        assert await resp.json() == {"queued": 0, "running": 0}
+
+    async def test_not_on_public_api(self, spawn_client: ClientSpawner):
+        """Test that the endpoint is not served by the public API."""
+        client = await spawn_client(authenticated=True)
+
+        resp = await client.get("/tasks/counts")
+
+        assert resp.status != HTTPStatus.OK
+        assert "queued" not in await resp.json()

--- a/virtool/tasks/api.py
+++ b/virtool/tasks/api.py
@@ -5,10 +5,11 @@ from aiohttp_pydantic.oas.typing import r200, r400
 
 from virtool.api.custom_json import json_response
 from virtool.api.errors import APINotFound
+from virtool.api.policy import PublicRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
-from virtool.tasks.models import Task
+from virtool.tasks.models import Task, TaskCounts
 
 routes = Routes()
 
@@ -31,6 +32,27 @@ class TaskServicesRootView(PydanticView):
             pass
 
         return json_response({"version": version})
+
+
+@routes.jobs_api.view("/tasks/counts")
+class TasksCountsView(PydanticView):
+    """Active task counts for KEDA autoscaling.
+
+    Registered on the internal jobs API only. Privacy relies on network
+    isolation, so the route is intentionally absent from the public API.
+    """
+
+    @policy(PublicRoutePolicy)
+    async def get(self) -> r200[TaskCounts]:
+        """Get active task counts.
+
+        Returns the number of queued and running tasks for an in-cluster
+        autoscaler to poll.
+
+        Status Codes:
+            200: Successful operation
+        """
+        return json_response(await get_data_from_req(self.request).tasks.get_counts())
 
 
 @routes.view("/tasks")

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -54,21 +54,16 @@ class TasksData:
 
         """
         async with AsyncSession(self._pg) as session:
-            result = await session.execute(
-                select(SQLTask.acquired_at.is_(None), func.count())
-                .where(SQLTask.complete.is_(False), SQLTask.error.is_(None))
-                .group_by(SQLTask.acquired_at.is_(None)),
-            )
+            queued, running = (
+                await session.execute(
+                    select(
+                        func.count().filter(SQLTask.acquired_at.is_(None)),
+                        func.count().filter(SQLTask.acquired_at.is_not(None)),
+                    ).where(SQLTask.complete.is_(False), SQLTask.error.is_(None)),
+                )
+            ).one()
 
-        counts = TaskCounts()
-
-        for unacquired, count in result.all():
-            if unacquired:
-                counts.queued = count
-            else:
-                counts.running = count
-
-        return counts
+        return TaskCounts(queued=queued, running=running)
 
     async def get(self, task_id: int) -> Task:
         """Get the task corresponding with passed "task_id".

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -9,7 +9,7 @@ from structlog import get_logger
 import virtool.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
-from virtool.tasks.models import Task
+from virtool.tasks.models import Task, TaskCounts
 from virtool.tasks.oas import UpdateTaskRequest
 from virtool.tasks.sql import SQLTask
 from virtool.tasks.task import BaseTask
@@ -40,6 +40,35 @@ class TasksData:
                 .scalars()
                 .all()
             ]
+
+    async def get_counts(self) -> TaskCounts:
+        """Get counts of active tasks for autoscaling.
+
+        ``queued`` mirrors the filter used by :meth:`acquire` and is the primary
+        scaling signal. ``running`` covers acquired-but-unfinished tasks. Both are
+        bounded by outstanding work and served by the ``idx_tasks_active`` partial
+        index, so the query cost does not grow with the table's history of
+        completed or failed tasks.
+
+        :return: the active task counts
+
+        """
+        async with AsyncSession(self._pg) as session:
+            result = await session.execute(
+                select(SQLTask.acquired_at.is_(None), func.count())
+                .where(SQLTask.complete.is_(False), SQLTask.error.is_(None))
+                .group_by(SQLTask.acquired_at.is_(None)),
+            )
+
+        counts = TaskCounts()
+
+        for unacquired, count in result.all():
+            if unacquired:
+                counts.queued = count
+            else:
+                counts.running = count
+
+        return counts
 
     async def get(self, task_id: int) -> Task:
         """Get the task corresponding with passed "task_id".

--- a/virtool/tasks/models.py
+++ b/virtool/tasks/models.py
@@ -39,3 +39,15 @@ class Task(TaskDetailedNested):
 
 
 TaskMinimal = Task
+
+
+class TaskCounts(BaseModel):
+    """Counts of active tasks for autoscaling.
+
+    Only states an autoscaler acts on are exposed. Terminal tasks (complete or
+    failed) are excluded because they accumulate unbounded and are irrelevant to
+    replica count.
+    """
+
+    queued: int = 0
+    running: int = 0


### PR DESCRIPTION
## Summary

- Adds `GET /tasks/counts` to the internal jobs API, returning `queued` and `running` task counts for KEDA to poll when scaling task runner replicas
- Adds a partial index (`idx_tasks_active`) on the `tasks` table scoped to active (incomplete, non-failed) rows so the query cost stays flat as history accumulates
- The endpoint is intentionally absent from the public API; isolation relies on the jobs API being network-internal only