### PR TITLE
backfill mongo subtractions to postgres

### DIFF
--- a/assets/revisions/rev_ztd04qgecm9a_copy_subtractions_to_postgres.py
+++ b/assets/revisions/rev_ztd04qgecm9a_copy_subtractions_to_postgres.py
@@ -1,0 +1,291 @@
+"""copy subtractions to postgres
+
+Revision ID: ztd04qgecm9a
+Date: 2026-06-04 14:58:07.137267
+
+"""
+
+import arrow
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.data.topg import compose_legacy_id_single_expression
+from virtool.jobs.pg import SQLJob
+from virtool.migration import MigrationContext
+from virtool.pg.base import Base
+from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile
+from virtool.uploads.sql import SQLUpload
+from virtool.users.pg import SQLUser
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy subtractions to postgres"
+created_at = arrow.get("2026-06-04 14:58:07.137267")
+revision_id = "ztd04qgecm9a"
+
+alembic_down_revision = "f95b556b3adc"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+#
+# ``895d6315a838`` adds ``subtraction_files.subtraction_id`` and depends on
+# ``f4624eb353b7`` (create subtractions table), so requiring it guarantees both
+# the destination table and the file foreign-key column exist before this runs.
+required_alembic_revision = "895d6315a838"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``subtraction`` document into Postgres.
+
+    One row is written per Mongo document into the ``subtractions`` table,
+    including soft-deleted documents, so the Postgres row count matches the Mongo
+    document count exactly. Documents are processed one at a time and committed
+    individually, so memory stays bounded and a failure part-way through keeps the
+    rows already written rather than rolling back the whole collection.
+
+    The document ``_id`` values are snapshotted up front so the rest of the run
+    fetches one document at a time by id, rather than holding a single Mongo
+    cursor open for the entire migration.
+
+    Documents already present in Postgres (by ``legacy_id``) are skipped, and the
+    insert uses ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of
+    defence, so the migration is safe to re-run after an interruption.
+
+    Unlike the analyses backfill, this migration never fails on a dangling
+    reference. ``user``, ``job``, and ``upload`` references that no longer resolve
+    to a Postgres row are backfilled as ``NULL`` and logged with a warning. These
+    collections used to be deletable, so legacy subtractions can reference rows
+    that have since been removed, and ``NULL`` is the truthful mapping.
+
+    Finally, ``subtraction_files.subtraction_id`` is backfilled with a single
+    set-based ``UPDATE`` join on ``legacy_id``. The collection name is
+    ``subtraction`` (singular); the plural ``subtractions`` collection does not
+    exist.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_result = await session.execute(
+            select(SQLSubtraction.legacy_id).where(
+                SQLSubtraction.legacy_id.isnot(None),
+            ),
+        )
+        existing_legacy_ids = {row[0] for row in existing_result}
+
+        logger.info(
+            "found existing subtractions in postgres",
+            count=len(existing_legacy_ids),
+        )
+
+        subtraction_ids = [
+            document["_id"]
+            async for document in ctx.mongo.subtraction.find({}, projection=["_id"])
+        ]
+
+        migrated_count = 0
+        skipped_count = 0
+
+        user_id_cache: dict[int | str, int | None] = {}
+        job_id_cache: dict[int | str, int | None] = {}
+        upload_id_cache: dict[int | str, int | None] = {}
+
+        for subtraction_id in subtraction_ids:
+            if subtraction_id in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.subtraction.find_one({"_id": subtraction_id})
+
+            if document is None:
+                skipped_count += 1
+                continue
+
+            user_id = await _resolve_user_id(session, document, user_id_cache)
+            job_id = await _resolve_job_id(session, document, job_id_cache)
+            upload_id = await _resolve_upload_id(session, document, upload_id_cache)
+
+            await session.execute(
+                insert(SQLSubtraction)
+                .values(**_build_values(document, user_id, job_id, upload_id))
+                .on_conflict_do_nothing(index_elements=["legacy_id"]),
+            )
+            await session.commit()
+
+            migrated_count += 1
+
+        logger.info(
+            "subtraction migration complete",
+            migrated=migrated_count,
+            skipped=skipped_count,
+        )
+
+        await _backfill_file_subtraction_ids(session)
+
+
+def _build_values(
+    document: dict,
+    user_id: int | None,
+    job_id: int | None,
+    upload_id: int | None,
+) -> dict:
+    """Map a Mongo subtraction document to a ``SQLSubtraction`` values dict.
+
+    The integer ``id`` is omitted so the database assigns the identity surrogate
+    key. The ``space`` field is intentionally dropped. ``user_id``, ``job_id``,
+    and ``upload_id`` are the resolved Postgres integer foreign keys, not the raw
+    Mongo references.
+    """
+    return {
+        "legacy_id": document["_id"],
+        "name": document["name"],
+        "nickname": document.get("nickname") or "",
+        "count": document.get("count"),
+        "gc": document.get("gc"),
+        "created_at": document["created_at"],
+        "deleted": document.get("deleted", False),
+        "ready": document.get("ready", False),
+        "user_id": user_id,
+        "job_id": job_id,
+        "upload_id": upload_id,
+    }
+
+
+async def _resolve_id(
+    session: AsyncSession,
+    model: type[Base],
+    reference: int | str,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a Mongo reference to a Postgres primary key, memoising results.
+
+    The reference may be a legacy string id or a modern integer id. The resolved
+    id (or ``None`` if no row matches) is cached by reference so that subtractions
+    sharing the same user do not each issue a query.
+    """
+    if reference in cache:
+        return cache[reference]
+
+    resolved = (
+        await session.execute(
+            select(model.id).where(
+                compose_legacy_id_single_expression(model, reference),
+            ),
+        )
+    ).scalar_one_or_none()
+
+    cache[reference] = resolved
+
+    return resolved
+
+
+async def _resolve_user_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a document's ``user`` reference to a Postgres ``users.id``.
+
+    Returns ``None`` and logs a warning when the referenced user no longer exists,
+    rather than failing the migration.
+    """
+    user = document.get("user")
+
+    if user is None:
+        return None
+
+    reference = user["id"]
+
+    user_id = await _resolve_id(session, SQLUser, reference, cache)
+
+    if user_id is None:
+        logger.warning(
+            "subtraction references a user that no longer exists; "
+            "backfilling null user_id",
+            subtraction_id=document["_id"],
+            user=reference,
+        )
+
+    return user_id
+
+
+async def _resolve_job_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a document's ``job`` reference to a Postgres ``jobs.id``.
+
+    Returns ``None`` when the document has no job, and also when a job is
+    referenced but no longer exists in Postgres. Dangling references are logged so
+    the migration leaves an audit trail, distinct from the silent legitimate
+    no-job case.
+    """
+    job = document.get("job")
+
+    if job is None:
+        return None
+
+    reference = job["id"]
+
+    job_id = await _resolve_id(session, SQLJob, reference, cache)
+
+    if job_id is None:
+        logger.warning(
+            "subtraction references a job that no longer exists; "
+            "backfilling null job_id",
+            subtraction_id=document["_id"],
+            job=reference,
+        )
+
+    return job_id
+
+
+async def _resolve_upload_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a document's ``upload`` reference to a Postgres ``uploads.id``.
+
+    The ``upload`` field holds the integer upload id directly. Returns ``None``
+    when the document has no upload, and also when the upload no longer exists in
+    Postgres, logging a warning in the latter case. Uploads used to be deletable,
+    so legacy subtractions can reference an upload that has since been removed.
+    """
+    reference = document.get("upload")
+
+    if reference is None:
+        return None
+
+    upload_id = await _resolve_id(session, SQLUpload, reference, cache)
+
+    if upload_id is None:
+        logger.warning(
+            "subtraction references an upload that no longer exists; "
+            "backfilling null upload_id",
+            subtraction_id=document["_id"],
+            upload=reference,
+        )
+
+    return upload_id
+
+
+async def _backfill_file_subtraction_ids(session: AsyncSession) -> None:
+    """Populate ``subtraction_files.subtraction_id`` from ``legacy_id``.
+
+    The legacy ``subtraction`` column holds the Mongo subtraction string id, which
+    matches ``subtractions.legacy_id``. This is a single set-based join, guarded by
+    ``subtraction_id IS NULL`` so re-runs only touch rows not already linked.
+    """
+    result = await session.execute(
+        update(SQLSubtractionFile)
+        .where(
+            SQLSubtractionFile.subtraction_id.is_(None),
+            SQLSubtractionFile.subtraction == SQLSubtraction.legacy_id,
+        )
+        .values(subtraction_id=SQLSubtraction.id),
+    )
+    await session.commit()
+
+    logger.info("backfilled subtraction_files.subtraction_id", linked=result.rowcount)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -365,5 +365,12 @@
       'name': 'add active tasks index',
       'revision': 'f95b556b3adc',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 53,
+      'name': 'copy subtractions to postgres',
+      'revision': 'ztd04qgecm9a',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_subtractions_to_postgres.py
+++ b/tests/migration/test_copy_subtractions_to_postgres.py
@@ -1,0 +1,541 @@
+"""Tests for the copy subtractions to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_ztd04qgecm9a_copy_subtractions_to_postgres import (
+    required_alembic_revision,
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+def static_datetime() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
+    """Create a user in PostgreSQL using raw SQL and return their integer id."""
+    await asyncio.to_thread(apply_alembic, required_alembic_revision)
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES (
+                    'testuser', 'legacy_user_123', true, '', false,
+                    false, :now, :password, '{}'::jsonb
+                )
+                RETURNING id
+            """),
+            {"now": arrow.utcnow().naive, "password": b"hashed_password"},
+        )
+        user_id = result.scalar_one()
+        await session.commit()
+        return user_id
+
+
+async def insert_job(session: AsyncSession, user_id: int, created_at: datetime) -> int:
+    """Insert a job and return its integer primary key."""
+    result = await session.execute(
+        text("""
+            INSERT INTO jobs (legacy_id, workflow, state, user_id, created_at)
+            VALUES ('legacy_job', 'create_subtraction', 'succeeded', :user_id, :now)
+            RETURNING id
+        """),
+        {"user_id": user_id, "now": created_at},
+    )
+    job_id = result.scalar_one()
+    await session.commit()
+    return job_id
+
+
+async def insert_upload(
+    session: AsyncSession,
+    user_id: int,
+    name_on_disk: str,
+) -> int:
+    """Insert an upload and return its integer primary key."""
+    result = await session.execute(
+        text("""
+            INSERT INTO uploads (name, name_on_disk, ready, removed, reserved, type, user_id)
+            VALUES ('subtraction.fa.gz', :name_on_disk, true, false, false,
+                    'subtraction', :user_id)
+            RETURNING id
+        """),
+        {"name_on_disk": name_on_disk, "user_id": user_id},
+    )
+    upload_id = result.scalar_one()
+    await session.commit()
+    return upload_id
+
+
+def make_subtraction_document(
+    subtraction_id: str,
+    user_id: int | str,
+    created_at: datetime,
+    *,
+    name: str = "Arabidopsis thaliana",
+    nickname: str = "Thalecress",
+    count: int | None = 12,
+    gc: dict | None = None,
+    deleted: bool = False,
+    ready: bool = True,
+    job_id: int | str | None = None,
+    upload: int | None = None,
+) -> dict:
+    """Create a MongoDB subtraction document for testing."""
+    return {
+        "_id": subtraction_id,
+        "count": count,
+        "created_at": created_at,
+        "deleted": deleted,
+        "file": {"id": upload, "name": "subtraction.fa.gz"},
+        "gc": gc if gc is not None else {"a": 0.25, "t": 0.25, "g": 0.25, "c": 0.25},
+        "job": {"id": job_id} if job_id is not None else None,
+        "name": name,
+        "nickname": nickname,
+        "ready": ready,
+        "space": {"id": 1},
+        "upload": upload,
+        "user": {"id": user_id},
+    }
+
+
+class TestUpgrade:
+    """Tests for the upgrade function."""
+
+    async def test_field_fidelity(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document's scalar and json fields map correctly."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="subtraction_1",
+                user_id=setup_user,
+                created_at=static_datetime,
+                count=42,
+                gc={"a": 0.3, "t": 0.3, "g": 0.2, "c": 0.2},
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text("""
+                        SELECT id, legacy_id, name, nickname, count, gc, created_at,
+                               deleted, ready, user_id, job_id, upload_id
+                        FROM subtractions WHERE legacy_id = 'subtraction_1'
+                    """),
+                )
+            ).one()
+
+        assert isinstance(row.id, int)
+        assert row.legacy_id == "subtraction_1"
+        assert row.name == "Arabidopsis thaliana"
+        assert row.nickname == "Thalecress"
+        assert row.count == 42
+        assert row.gc == {"a": 0.3, "t": 0.3, "g": 0.2, "c": 0.2}
+        assert row.created_at == static_datetime
+        assert row.deleted is False
+        assert row.ready is True
+        assert row.user_id == setup_user
+        assert row.job_id is None
+        assert row.upload_id is None
+
+    async def test_user_legacy_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A legacy string user id resolves to the user's integer primary key."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="legacy_user_subtraction",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT user_id FROM subtractions "
+                        "WHERE legacy_id = 'legacy_user_subtraction'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == setup_user
+
+    async def test_job_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """An integer job id is written to the job_id foreign key."""
+        async with AsyncSession(ctx.pg) as session:
+            job_id = await insert_job(session, setup_user, static_datetime)
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="job_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id=job_id,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT job_id FROM subtractions "
+                        "WHERE legacy_id = 'job_subtraction'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == job_id
+
+    async def test_upload_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """An integer upload id is written to the upload_id foreign key."""
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(session, setup_user, "subtraction_1.fa.gz")
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="upload_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+                upload=upload_id,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT upload_id FROM subtractions "
+                        "WHERE legacy_id = 'upload_subtraction'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == upload_id
+
+    async def test_no_job_or_upload(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """job_id and upload_id are null when the document has neither."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="bare_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id=None,
+                upload=None,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT job_id, upload_id FROM subtractions "
+                        "WHERE legacy_id = 'bare_subtraction'",
+                    ),
+                )
+            ).one()
+
+        assert row.job_id is None
+        assert row.upload_id is None
+
+    async def test_orphan_user_backfills_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document referencing a missing user is written with a null user_id.
+
+        Unlike the analyses backfill, an unresolvable user reference does not abort
+        the migration: the row is written with ``user_id = NULL``.
+        """
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan_user_subtraction",
+                user_id=setup_user + 9999,
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT user_id FROM subtractions "
+                        "WHERE legacy_id = 'orphan_user_subtraction'",
+                    ),
+                )
+            ).one()
+
+        assert row.user_id is None
+
+    async def test_orphan_job_backfills_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document referencing a deleted job is written with a null job_id."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan_job_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+                job_id="missing_job",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT job_id FROM subtractions "
+                        "WHERE legacy_id = 'orphan_job_subtraction'",
+                    ),
+                )
+            ).one()
+
+        assert row.job_id is None
+
+    async def test_orphan_upload_backfills_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document referencing a deleted upload is written with a null upload_id."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan_upload_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+                upload=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT upload_id FROM subtractions "
+                        "WHERE legacy_id = 'orphan_upload_subtraction'",
+                    ),
+                )
+            ).one()
+
+        assert row.upload_id is None
+
+    async def test_soft_deleted_is_migrated(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A soft-deleted document is migrated with deleted set to True."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="deleted_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+                deleted=True,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT deleted FROM subtractions "
+                        "WHERE legacy_id = 'deleted_subtraction'",
+                    ),
+                )
+            ).one()
+
+        assert row.deleted is True
+
+    async def test_idempotent_rerun(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """Running the migration twice leaves a single row per document."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="repeat_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM subtractions "
+                        "WHERE legacy_id = 'repeat_subtraction'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert count == 1
+
+    async def test_row_count_parity_includes_soft_deleted(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """The Postgres row count matches the Mongo count, including deleted docs."""
+        for i in range(4):
+            await ctx.mongo.subtraction.insert_one(
+                make_subtraction_document(
+                    subtraction_id=f"subtraction_{i}",
+                    user_id=setup_user,
+                    created_at=static_datetime,
+                ),
+            )
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="subtraction_deleted",
+                user_id=setup_user,
+                created_at=static_datetime,
+                deleted=True,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        mongo_count = await ctx.mongo.subtraction.count_documents({})
+
+        async with AsyncSession(ctx.pg) as session:
+            pg_count = (
+                await session.execute(text("SELECT COUNT(*) FROM subtractions"))
+            ).scalar_one()
+
+        assert pg_count == mongo_count == 5
+
+    async def test_file_subtraction_id_backfill(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """subtraction_files.subtraction_id is backfilled via the legacy_id join."""
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text("""
+                    INSERT INTO subtraction_files (name, subtraction, type, size)
+                    VALUES
+                        ('subtraction.fa.gz', 'file_subtraction', 'fasta', 100),
+                        ('subtraction.1.bt2', 'file_subtraction', 'bowtie2', 200)
+                """),
+            )
+            await session.commit()
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="file_subtraction",
+                user_id=setup_user,
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            subtraction_pk = (
+                await session.execute(
+                    text(
+                        "SELECT id FROM subtractions "
+                        "WHERE legacy_id = 'file_subtraction'",
+                    ),
+                )
+            ).scalar_one()
+
+            linked = (
+                (
+                    await session.execute(
+                        text(
+                            "SELECT subtraction_id FROM subtraction_files "
+                            "WHERE subtraction = 'file_subtraction'",
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert linked == [subtraction_pk, subtraction_pk]
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_empty_collection(self, ctx: MigrationContext):
+        """An empty subtraction collection is a no-op."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM subtractions"))
+            ).scalar_one()
+
+        assert count == 0

--- a/tests/migration/test_copy_subtractions_to_postgres.py
+++ b/tests/migration/test_copy_subtractions_to_postgres.py
@@ -14,6 +14,7 @@ from assets.revisions.rev_ztd04qgecm9a_copy_subtractions_to_postgres import (
     upgrade,
 )
 from virtool.migration.ctx import MigrationContext
+from virtool.utils import timestamp
 
 
 @pytest.fixture
@@ -39,7 +40,7 @@ async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
                 )
                 RETURNING id
             """),
-            {"now": arrow.utcnow().naive, "password": b"hashed_password"},
+            {"now": timestamp(), "password": b"hashed_password"},
         )
         user_id = result.scalar_one()
         await session.commit()


### PR DESCRIPTION
## Summary

- Adds a migration revision (`ztd04qgecm9a`) that copies every document from the Mongo `subtraction` collection into the `subtractions` Postgres table, including soft-deleted records.
- Dangling `user`, `job`, and `upload` references (from deleted entities) are backfilled as `NULL` rather than failing the migration, matching the lenient approach taken for other legacy collections.
- After inserting subtraction rows, the migration backfills `subtraction_files.subtraction_id` via a single set-based `UPDATE` join on `legacy_id`, linking file rows to their parent subtraction.