### PR TITLE
refactor: drop SQLJobAnalysis write path, load_results, and storage params from format functions

### DIFF
--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -263,7 +263,7 @@ class TestFinalize:
         """Finalize marks the Postgres row ready and stores the results."""
         m_format_analysis = mocker.patch(
             "virtool.analyses.format.format_analysis",
-            side_effect=lambda _storage, _mongo, _pg, *, results, **_: results,
+            side_effect=lambda _mongo, _pg, *, results, **_: results,
         )
 
         analysis = await data_layer.analyses.create(
@@ -288,13 +288,10 @@ class TestFinalize:
         # The PostgreSQL engine must be threaded through to format_analysis so it can
         # resolve Postgres-stored history diffs.
         m_format_analysis.assert_called_with(
-            ANY,
             mongo,
             pg,
             workflow=ANY,
             results=ANY,
-            legacy_id=ANY,
-            sample_id=ANY,
         )
 
 

--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import json
 
 import openpyxl
 import pytest
@@ -10,46 +9,9 @@ from syrupy import SnapshotAssertion
 import virtool.analyses
 from virtool.analyses.format import (
     CSV_HEADERS,
-    load_results,
     transform_coverage_to_coordinates,
 )
 from virtool.mongo.core import Mongo
-from virtool.storage.memory import MemoryStorageProvider
-
-
-async def test_load_results_from_storage():
-    """Offloaded results are read back from storage when the payload is ``"file"``."""
-    results = {"foo": "bar", "bar": "baz"}
-
-    storage = MemoryStorageProvider()
-
-    async def _data():
-        yield json.dumps(results).encode()
-
-    await storage.write("samples/bar/analysis/foo/results.json", _data())
-
-    result = await load_results(
-        storage,
-        results="file",
-        legacy_id="foo",
-        sample_id="bar",
-    )
-
-    assert result == results
-
-
-async def test_load_results_inline():
-    """Inline results are returned unchanged without touching storage."""
-    storage = MemoryStorageProvider()
-
-    result = await load_results(
-        storage,
-        results={"baz": "foo"},
-        legacy_id="foo",
-        sample_id="bar",
-    )
-
-    assert result == {"baz": "foo"}
 
 
 @pytest.mark.parametrize(
@@ -187,26 +149,20 @@ class TestFormatAnalysis:
         """A ``None`` workflow raises a descriptive ``ValueError``."""
         with pytest.raises(ValueError, match="Analysis has no workflow field"):
             await virtool.analyses.format.format_analysis(
-                MemoryStorageProvider(),
                 mongo,
                 None,
                 workflow=None,
                 results={"hits": []},
-                legacy_id="test_analysis",
-                sample_id="test_sample",
             )
 
     async def test_unknown_workflow(self, mongo: Mongo):
         """An unrecognised workflow raises a descriptive ``ValueError``."""
         with pytest.raises(ValueError, match="Unknown workflow: foobar"):
             await virtool.analyses.format.format_analysis(
-                MemoryStorageProvider(),
                 mongo,
                 None,
                 workflow="foobar",
                 results={"hits": []},
-                legacy_id="test_analysis",
-                sample_id="test_sample",
             )
 
     async def test_nuvs(self, mocker: MockerFixture, mongo: Mongo):
@@ -217,27 +173,17 @@ class TestFormatAnalysis:
         )
         m_format_pathoscope = mocker.patch("virtool.analyses.format.format_pathoscope")
 
-        storage = MemoryStorageProvider()
         results = {"hits": []}
 
         formatted = await virtool.analyses.format.format_analysis(
-            storage,
             mongo,
             mocker.Mock(),
             workflow="nuvs",
             results=results,
-            legacy_id="test_analysis",
-            sample_id="test_sample",
         )
 
         assert formatted == {"is_nuvs": True, "is_pathoscope": False}
-        m_format_nuvs.assert_called_with(
-            storage,
-            mongo,
-            results=results,
-            legacy_id="test_analysis",
-            sample_id="test_sample",
-        )
+        m_format_nuvs.assert_called_with(mongo, results=results)
         assert not m_format_pathoscope.called
 
     async def test_pathoscope(self, mocker: MockerFixture, mongo: Mongo):
@@ -248,47 +194,29 @@ class TestFormatAnalysis:
             return_value={"is_nuvs": False, "is_pathoscope": True},
         )
 
-        storage = MemoryStorageProvider()
         pg = mocker.Mock()
         results = {"hits": []}
 
         formatted = await virtool.analyses.format.format_analysis(
-            storage,
             mongo,
             pg,
             workflow="pathoscope",
             results=results,
-            legacy_id="test_analysis",
-            sample_id="test_sample",
         )
 
         assert formatted == {"is_nuvs": False, "is_pathoscope": True}
-        m_format_pathoscope.assert_called_with(
-            storage,
-            mongo,
-            pg,
-            results=results,
-            legacy_id="test_analysis",
-            sample_id="test_sample",
-        )
+        m_format_pathoscope.assert_called_with(mongo, pg, results=results)
         assert not m_format_nuvs.called
 
 
-class TestDownloadOffloadedResults:
-    """Downloading an analysis whose results were offloaded to storage.
+class TestDownloadResults:
+    """Downloading an analysis to CSV or Excel.
 
-    Regression: the median depths were previously calculated from the unresolved
-    ``"file"`` sentinel, raising a ``TypeError`` before the results were loaded.
+    Median depths are calculated from the raw results before formatting, then the
+    formatted hits drive the rendered rows.
     """
 
-    @staticmethod
-    async def _seed_offloaded(storage: MemoryStorageProvider) -> None:
-        async def _data():
-            yield json.dumps(
-                {"hits": [{"id": "sequence", "align": [1, 2, 3]}]},
-            ).encode()
-
-        await storage.write("samples/sample/analysis/analysis/results.json", _data())
+    results = {"hits": [{"id": "sequence", "align": [1, 2, 3]}]}
 
     @staticmethod
     def _patch_format_analysis(mocker: MockerFixture) -> None:
@@ -319,18 +247,13 @@ class TestDownloadOffloadedResults:
         )
 
     async def test_csv(self, mocker: MockerFixture, mongo: Mongo):
-        storage = MemoryStorageProvider()
-        await self._seed_offloaded(storage)
         self._patch_format_analysis(mocker)
 
         csv_data = await virtool.analyses.format.format_analysis_to_csv(
-            storage,
             mongo,
             mocker.Mock(),
-            results="file",
+            results=self.results,
             workflow="pathoscope",
-            sample_id="sample",
-            legacy_id="analysis",
         )
 
         rows = list(csv.reader(io.StringIO(csv_data)))
@@ -339,18 +262,14 @@ class TestDownloadOffloadedResults:
         assert rows[1] == ["OTU", "Isolate A", "AB000", "3", "0.5", "2", "1.0"]
 
     async def test_excel(self, mocker: MockerFixture, mongo: Mongo):
-        storage = MemoryStorageProvider()
-        await self._seed_offloaded(storage)
         self._patch_format_analysis(mocker)
 
         excel_data = await virtool.analyses.format.format_analysis_to_excel(
-            storage,
             mongo,
             mocker.Mock(),
-            results="file",
+            results=self.results,
             workflow="pathoscope",
             sample_id="sample",
-            legacy_id="analysis",
         )
 
         worksheet = openpyxl.load_workbook(io.BytesIO(excel_data)).active

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -23,7 +23,6 @@ from virtool.jobs.models import (
 )
 from virtool.jobs.pg import (
     SQLJob,
-    SQLJobAnalysis,
     SQLJobIndex,
     SQLJobSample,
     SQLJobSubtraction,
@@ -238,14 +237,14 @@ class TestCreatePostgres:
         assert job_subtraction.subtraction_id == "sub_789"
 
     @pytest.mark.parametrize("workflow", ["aodp", "iimi", "nuvs", "pathoscope"])
-    async def test_analysis_join_table(
+    async def test_analysis_id_resolved_from_analysis(
         self,
         workflow: str,
         jobs_data: JobsData,
         fake: DataFaker,
         pg: AsyncEngine,
     ):
-        """Test that analysis jobs write to job_analyses join table."""
+        """``get`` resolves the analysis id from the analysis row linked by job_id."""
         user = await fake.users.create()
 
         job = await jobs_data.create(
@@ -255,8 +254,6 @@ class TestCreatePostgres:
             0,
         )
 
-        # ``get`` resolves the analysis id from the analysis row linked by
-        # ``job_id``, mirroring the row written when an analysis is created.
         async with AsyncSession(pg) as session:
             session.add(
                 SQLAnalysis(
@@ -274,22 +271,6 @@ class TestCreatePostgres:
                 ),
             )
             await session.commit()
-
-        async with AsyncSession(pg) as session:
-            sql_job = (
-                await session.execute(
-                    select(SQLJob).where(SQLJob.id == job.id),
-                )
-            ).scalar()
-
-            job_analysis = (
-                await session.execute(
-                    select(SQLJobAnalysis).where(SQLJobAnalysis.job_id == sql_job.id),
-                )
-            ).scalar()
-
-        assert job_analysis is not None
-        assert job_analysis.analysis_id == "analysis_abc"
 
         fetched_job = await jobs_data.get(job.id)
         assert fetched_job.args == {"analysis_id": "analysis_abc"}

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -238,13 +238,10 @@ class AnalysisData(DataLayerDomain):
 
         if document["ready"]:
             document["results"] = await virtool.analyses.format.format_analysis(
-                self._storage,
                 self._mongo,
                 self._pg,
                 workflow=document["workflow"],
                 results=document["results"],
-                legacy_id=document["legacy_id"],
-                sample_id=document["sample"]["id"],
             )
 
         transforms = [
@@ -513,26 +510,21 @@ class AnalysisData(DataLayerDomain):
         if extension == "xlsx":
             return (
                 await virtool.analyses.format.format_analysis_to_excel(
-                    self._storage,
                     self._mongo,
                     self._pg,
                     results=analysis.results,
                     workflow=analysis.workflow,
                     sample_id=analysis.sample,
-                    legacy_id=analysis.legacy_id,
                 ),
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
 
         return (
             await virtool.analyses.format.format_analysis_to_csv(
-                self._storage,
                 self._mongo,
                 self._pg,
                 results=analysis.results,
                 workflow=analysis.workflow,
-                sample_id=analysis.sample,
-                legacy_id=analysis.legacy_id,
             ),
             "text/csv",
         )

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -6,7 +6,6 @@ downloads.
 
 import csv
 import io
-import json
 import statistics
 from asyncio import gather
 from collections import defaultdict
@@ -16,11 +15,9 @@ import openpyxl.styles
 import visvalingamwyatt as vw
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from virtool.analyses.utils import analysis_result_key
 from virtool.history.db import patch_to_version
 from virtool.models.enums import AnalysisWorkflow
 from virtool.otus.utils import format_isolate_name
-from virtool.storage.protocol import StorageBackend
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -46,35 +43,6 @@ def calculate_median_depths(hits: list[dict]) -> dict[str, int]:
 
     """
     return {hit["id"]: statistics.median(hit["align"]) for hit in hits}
-
-
-async def load_results(
-    storage: StorageBackend,
-    *,
-    results: dict[str, Any] | str,
-    legacy_id: str,
-    sample_id: str,
-) -> dict:
-    """Load the analysis results from storage when they were too large for MongoDB.
-
-    The results are returned unmodified if loading from storage is not required.
-
-    :param storage: the storage backend
-    :param results: the results payload, or the literal ``"file"`` when offloaded
-    :param legacy_id: the legacy analysis id used to build the storage key
-    :param sample_id: the id of the parent sample used to build the storage key
-    :return: the loaded results dict
-    """
-    if results == "file":
-        key = analysis_result_key(legacy_id, sample_id)
-
-        chunks = []
-        async for chunk in storage.read(key):
-            chunks.append(chunk)
-
-        return json.loads(b"".join(chunks))
-
-    return results
 
 
 async def format_aodp(
@@ -113,35 +81,22 @@ async def format_aodp(
 
 
 async def format_pathoscope(
-    storage: StorageBackend,
     mongo: "Mongo",
     pg: AsyncEngine,
     *,
-    results: dict[str, Any] | str,
-    legacy_id: str,
-    sample_id: str,
+    results: dict[str, Any],
 ) -> dict[str, Any]:
     """Format Pathoscope analysis results by retrieving the detected OTUs and
     incorporating them into the returned results.
 
     Calculate metrics for different organizational levels: OTU, isolate, and sequence.
 
-    :param storage: the storage backend
     :param mongo: the application Mongo object
     :param pg: the application PostgreSQL database object
-    :param results: the results to format, or the literal ``"file"`` when offloaded
-    :param legacy_id: the legacy analysis id used to load offloaded results
-    :param sample_id: the id of the parent sample used to load offloaded results
+    :param results: the results to format
     :return: the formatted results
 
     """
-    results = await load_results(
-        storage,
-        results=results,
-        legacy_id=legacy_id,
-        sample_id=sample_id,
-    )
-
     hits_by_otu = defaultdict(list)
 
     for hit in results["hits"]:
@@ -244,30 +199,17 @@ def format_pathoscope_sequences(
 
 
 async def format_nuvs(
-    storage: StorageBackend,
     mongo: "Mongo",
     *,
-    results: dict[str, Any] | str,
-    legacy_id: str,
-    sample_id: str,
+    results: dict[str, Any],
 ) -> dict[str, Any]:
     """Format NuVs analysis results by attaching the HMM annotation data to the hits.
 
-    :param storage: the storage backend
     :param mongo: the database object
-    :param results: the results to format, or the literal ``"file"`` when offloaded
-    :param legacy_id: the legacy analysis id used to load offloaded results
-    :param sample_id: the id of the parent sample used to load offloaded results
+    :param results: the results to format
     :return: the formatted results
 
     """
-    results = await load_results(
-        storage,
-        results=results,
-        legacy_id=legacy_id,
-        sample_id=sample_id,
-    )
-
     hits = results["hits"]
 
     hit_ids = list({h["hit"] for s in hits for o in s["orfs"] for h in o["hits"]})
@@ -285,44 +227,30 @@ async def format_nuvs(
 
 
 async def format_analysis_to_excel(
-    storage: StorageBackend,
     mongo: "Mongo",
     pg: AsyncEngine,
     *,
-    results: dict[str, Any] | str,
+    results: dict[str, Any],
     workflow: str,
     sample_id: str,
-    legacy_id: str,
 ) -> bytes:
     """Convert pathoscope analysis results to byte-encoded Excel format for download.
 
-    :param storage: the storage backend
     :param mongo: the database object
     :param pg: the application PostgreSQL database object
     :param results: the results to format
     :param workflow: the analysis workflow
     :param sample_id: the id of the parent sample
-    :param legacy_id: the legacy analysis id used to load offloaded results
     :return: the formatted Excel workbook
 
     """
-    loaded_results = await load_results(
-        storage,
-        results=results,
-        legacy_id=legacy_id,
-        sample_id=sample_id,
-    )
-
-    depths = calculate_median_depths(loaded_results["hits"])
+    depths = calculate_median_depths(results["hits"])
 
     formatted = await format_analysis(
-        storage,
         mongo,
         pg,
         workflow=workflow,
-        results=loaded_results,
-        legacy_id=legacy_id,
-        sample_id=sample_id,
+        results=results,
     )
 
     output = io.BytesIO()
@@ -369,44 +297,28 @@ async def format_analysis_to_excel(
 
 
 async def format_analysis_to_csv(
-    storage: StorageBackend,
     mongo: "Mongo",
     pg: AsyncEngine,
     *,
-    results: dict[str, Any] | str,
+    results: dict[str, Any],
     workflow: str,
-    sample_id: str,
-    legacy_id: str,
 ) -> str:
     """Convert pathoscope analysis results to CSV format for download.
 
-    :param storage: the storage backend
     :param mongo: the app mongo object
     :param pg: the application PostgreSQL database object
     :param results: the results to format
     :param workflow: the analysis workflow
-    :param sample_id: the id of the parent sample
-    :param legacy_id: the legacy analysis id used to load offloaded results
     :return: the formatted CSV data
 
     """
-    loaded_results = await load_results(
-        storage,
-        results=results,
-        legacy_id=legacy_id,
-        sample_id=sample_id,
-    )
-
-    depths = calculate_median_depths(loaded_results["hits"])
+    depths = calculate_median_depths(results["hits"])
 
     formatted = await format_analysis(
-        storage,
         mongo,
         pg,
         workflow=workflow,
-        results=loaded_results,
-        legacy_id=legacy_id,
-        sample_id=sample_id,
+        results=results,
     )
 
     output = io.StringIO()
@@ -434,24 +346,18 @@ async def format_analysis_to_csv(
 
 
 async def format_analysis(
-    storage: StorageBackend,
     mongo: "Mongo",
     pg: AsyncEngine,
     *,
     workflow: str | None,
-    results: dict[str, Any] | str,
-    legacy_id: str,
-    sample_id: str,
+    results: dict[str, Any],
 ) -> dict[str, Any]:
     """Format analysis results to be returned by the API.
 
-    :param storage: the storage backend
     :param mongo: the database object
     :param pg: the application PostgreSQL database object
     :param workflow: the analysis workflow used to dispatch formatting
     :param results: the results to format
-    :param legacy_id: the legacy analysis id used to load offloaded results
-    :param sample_id: the id of the parent sample used to load offloaded results
     :return: the formatted results
 
     """
@@ -459,26 +365,13 @@ async def format_analysis(
         raise ValueError("Analysis has no workflow field")
 
     if workflow == AnalysisWorkflow.nuvs.value:
-        return await format_nuvs(
-            storage,
-            mongo,
-            results=results,
-            legacy_id=legacy_id,
-            sample_id=sample_id,
-        )
+        return await format_nuvs(mongo, results=results)
 
     if workflow == AnalysisWorkflow.aodp.value:
         return await format_aodp(mongo, pg, results=results)
 
     if "pathoscope" in workflow:
-        return await format_pathoscope(
-            storage,
-            mongo,
-            pg,
-            results=results,
-            legacy_id=legacy_id,
-            sample_id=sample_id,
-        )
+        return await format_pathoscope(mongo, pg, results=results)
 
     if workflow == AnalysisWorkflow.iimi.value:
         return results

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -27,7 +27,6 @@ from virtool.jobs.models import (
 )
 from virtool.jobs.pg import (
     SQLJob,
-    SQLJobAnalysis,
     SQLJobIndex,
     SQLJobSample,
     SQLJobSubtraction,
@@ -218,16 +217,6 @@ class JobsData:
                     SQLJobSubtraction(
                         job_id=sql_job.id,
                         subtraction_id=job_args["subtraction_id"],
-                    ),
-                )
-            elif (
-                workflow in ("aodp", "iimi", "nuvs", "pathoscope")
-                and "analysis_id" in job_args
-            ):
-                session.add(
-                    SQLJobAnalysis(
-                        job_id=sql_job.id,
-                        analysis_id=job_args["analysis_id"],
                     ),
                 )
 

--- a/virtool/jobs/pg.py
+++ b/virtool/jobs/pg.py
@@ -66,6 +66,13 @@ class SQLJob(Base):
 
 
 class SQLJobAnalysis(Base):
+    """Links a job to the analysis it created.
+
+    No longer written: analyses now reference their job directly via
+    ``SQLAnalysis.job_id``. The model and ``job_analyses`` table are retained
+    pending their drop in VIR-2438.
+    """
+
     __tablename__ = "job_analyses"
 
     job_id: Mapped[int] = mapped_column(ForeignKey("jobs.id"), primary_key=True)


### PR DESCRIPTION
## Summary

- Removes the `SQLJobAnalysis` join-table write path from `JobsData.create` — analyses now reference their job directly via `SQLAnalysis.job_id`, making the join table redundant (retained pending drop in VIR-2438)
- Drops the `load_results` helper and the `"file"` sentinel path that offloaded large analysis results to storage; results are always inline now that MongoDB is no longer the backing store
- Strips the `storage`, `legacy_id`, and `sample_id` parameters from all `format_analysis*` functions, simplifying call sites across the data layer and tests