### PR TITLE
feat(migration): create the legacy HMM status postgres table

### DIFF
--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -9,6 +9,7 @@ from virtool.account.sql import SQLAPIKey
 from virtool.analyses.sql import SQLAnalysisFile
 from virtool.blast.sql import SQLNuVsBlast
 from virtool.groups.pg import SQLGroup
+from virtool.hmm.sql import SQLHMMStatus
 from virtool.indexes.sql import SQLIndexFile
 from virtool.labels.sql import SQLLabel
 from virtool.messages.sql import SQLInstanceMessage
@@ -39,6 +40,7 @@ __models__ = (
     SQLAPIKey,
     SQLAnalysisFile,
     SQLGroup,
+    SQLHMMStatus,
     SQLIndexFile,
     SQLInstanceMessage,
     SQLLabel,

--- a/assets/alembic/versions/d12be6ff40c1_create_legacy_hmm_status_table.py
+++ b/assets/alembic/versions/d12be6ff40c1_create_legacy_hmm_status_table.py
@@ -1,0 +1,36 @@
+"""create legacy hmm status table
+
+Revision ID: d12be6ff40c1
+Revises: f95b556b3adc
+Create Date: 2026-06-04 21:06:03.645952+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "d12be6ff40c1"
+down_revision = "f95b556b3adc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "legacy_hmm_status",
+        sa.Column("id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("errors", JSONB(), nullable=False),
+        sa.Column("release", JSONB(), nullable=True),
+        sa.Column("installed", JSONB(), nullable=True),
+        sa.Column("task_id", sa.Integer(), nullable=True),
+        sa.Column("updates", JSONB(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.CheckConstraint("id = 1", name="ck_legacy_hmm_status_singleton"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("legacy_hmm_status")

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -6,6 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 import virtool.account.sql
+import virtool.hmm.sql
 import virtool.messages.sql
 import virtool.settings.sql  # noqa: F401  schema mirror, no app importer
 from virtool.api.custom_json import dump_string

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -372,5 +372,12 @@
       'name': 'copy subtractions to postgres',
       'revision': 'ztd04qgecm9a',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 54,
+      'name': 'create legacy hmm status table',
+      'revision': 'd12be6ff40c1',
+    }),
   ])
 # ---

--- a/tests/migration/test_create_legacy_hmm_status_table.py
+++ b/tests/migration/test_create_legacy_hmm_status_table.py
@@ -73,3 +73,55 @@ class TestCreateLegacyHMMStatusTable:
                         """,
                     ),
                 )
+
+    async def test_accepts_existing_task_id(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO tasks (id, created_at, type)
+                    VALUES (1, '2026-01-01 00:00:00', 'install_hmms')
+                    """,
+                ),
+            )
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO legacy_hmm_status (id, errors, updates, task_id)
+                    VALUES (1, '[]'::jsonb, '[]'::jsonb, 1)
+                    """,
+                ),
+            )
+            await session.commit()
+
+            rows = (
+                (await session.execute(text("SELECT task_id FROM legacy_hmm_status")))
+                .mappings()
+                .all()
+            )
+
+        assert [dict(row) for row in rows] == [{"task_id": 1}]
+
+    async def test_rejects_unknown_task_id(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO legacy_hmm_status (id, errors, updates, task_id)
+                        VALUES (1, '[]'::jsonb, '[]'::jsonb, 999)
+                        """,
+                    ),
+                )

--- a/tests/migration/test_create_legacy_hmm_status_table.py
+++ b/tests/migration/test_create_legacy_hmm_status_table.py
@@ -1,0 +1,75 @@
+"""Tests for the create-legacy-hmm-status-table migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+REVISION = "d12be6ff40c1"
+
+
+class TestCreateLegacyHMMStatusTable:
+    async def test_creates_empty_table(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = (
+                (await session.execute(text("SELECT * FROM legacy_hmm_status")))
+                .mappings()
+                .all()
+            )
+
+        assert rows == []
+
+    async def test_accepts_singleton_row(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO legacy_hmm_status (id, errors, updates)
+                    VALUES (1, '[]'::jsonb, '[]'::jsonb)
+                    """,
+                ),
+            )
+            await session.commit()
+
+            rows = (
+                (await session.execute(text("SELECT id FROM legacy_hmm_status")))
+                .mappings()
+                .all()
+            )
+
+        assert [dict(row) for row in rows] == [{"id": 1}]
+
+    async def test_rejects_non_singleton_id(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO legacy_hmm_status (id, errors, updates)
+                        VALUES (2, '[]'::jsonb, '[]'::jsonb)
+                        """,
+                    ),
+                )

--- a/virtool/hmm/sql.py
+++ b/virtool/hmm/sql.py
@@ -18,8 +18,8 @@ class SQLHMMStatus(Base):
     __table_args__ = (CheckConstraint("id = 1", name="ck_legacy_hmm_status_singleton"),)
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=False)
-    errors: Mapped[list] = mapped_column(JSONB, default=list)
+    errors: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
     release: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     installed: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     task_id: Mapped[int | None] = mapped_column(ForeignKey("tasks.id"), nullable=True)
-    updates: Mapped[list] = mapped_column(JSONB, default=list)
+    updates: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)

--- a/virtool/hmm/sql.py
+++ b/virtool/hmm/sql.py
@@ -1,0 +1,25 @@
+from sqlalchemy import CheckConstraint, ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from virtool.pg.base import Base
+
+
+class SQLHMMStatus(Base):
+    """The singleton row describing the installed HMM data and update state.
+
+    The table is named ``legacy_hmm_status`` because the HMM system will be
+    rearchitected in the near future. It mirrors the stored shape of the Mongo
+    ``status`` singleton rather than the ``HMMStatus`` model: ``updating`` is
+    derived from ``updates`` at read time and is not stored.
+    """
+
+    __tablename__ = "legacy_hmm_status"
+    __table_args__ = (CheckConstraint("id = 1", name="ck_legacy_hmm_status_singleton"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=False)
+    errors: Mapped[list] = mapped_column(JSONB, default=list)
+    release: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    installed: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    task_id: Mapped[int | None] = mapped_column(ForeignKey("tasks.id"), nullable=True)
+    updates: Mapped[list] = mapped_column(JSONB, default=list)


### PR DESCRIPTION
## Summary

- Adds a `SQLHMMStatus` SQLAlchemy model for the `legacy_hmm_status` table, a singleton row (enforced via a check constraint) that mirrors the shape of the MongoDB HMM status document
- Adds an Alembic migration revision (`d12be6ff40c1`) to create the table with JSONB columns for `errors`, `release`, `installed`, and `updates`, plus an optional foreign key to `tasks`
- Registers the model in `alembic/env.py` so autogenerate picks it up