### PR TITLE
Restrict allowed commit scopes to deps and migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,8 @@ Commits follow [Conventional Commits](https://www.conventionalcommits.org).
 Releases are automated with semantic-release.
 
 - Use imperative mood: "fix bug" not "fixed bug"
-- Scope is optional: `feat:`, `fix:`, `chore(deps):`, etc.
+- Scope is optional. Allowed scopes: `deps` (dependency changes), `migration`
+  (commit adds or modifies a migration). Do not scope by domain.
 - Keep titles concise, lowercase
 - Include a body only when useful; keep it brief
 - Only push or create PRs when asked


### PR DESCRIPTION
## Summary

- Clarifies that commit scopes are optional but, when used, must be either `deps` (dependency changes) or `migration` (migration additions/modifications)
- Explicitly discourages domain-based scoping (e.g. `fix(samples):`) to keep commit messages consistent and machine-readable for semantic-release