### PR TITLE
fix: correct the hmm status updating flag derivation

### DIFF
--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -17,7 +17,21 @@ async def fake_hmm_status(mongo, fake: DataFaker, static_time):
         {
             "_id": "hmm",
             "updating": False,
-            "updates": [{"id": 231}],
+            "updates": [
+                {
+                    "body": "- remove some annotations that didn't have corresponding profiles",
+                    "created_at": static_time.datetime,
+                    "filename": "vthmm.tar.gz",
+                    "html_url": "https://github.com/virtool/virtool-hmm/releases/tag/v0.2.1",
+                    "id": 1230982,
+                    "name": "v0.2.1",
+                    "newer": False,
+                    "published_at": static_time.datetime,
+                    "ready": True,
+                    "size": 85904451,
+                    "user": {"id": user.id},
+                },
+            ],
             "installed": {
                 "body": "- remove some annotations that didn't have corresponding profiles",
                 "created_at": static_time.datetime,

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -19,7 +19,21 @@ async def test_get_status(
         {
             "_id": "hmm",
             "updating": False,
-            "updates": [{"id": 231}],
+            "updates": [
+                {
+                    "body": "- remove some annotations that didn't have corresponding profiles",
+                    "created_at": static_time.datetime,
+                    "filename": "vthmm.tar.gz",
+                    "html_url": "https://github.com/virtool/virtool-hmm/releases/tag/v0.2.1",
+                    "id": 1230982,
+                    "name": "v0.2.1",
+                    "newer": False,
+                    "published_at": static_time.datetime,
+                    "ready": True,
+                    "size": 85904451,
+                    "user": {"id": user.id},
+                },
+            ],
             "installed": {
                 "body": "- remove some annotations that didn't have corresponding profiles",
                 "created_at": static_time.datetime,
@@ -52,6 +66,64 @@ async def test_get_status(
     )
 
     assert await data_layer.hmms.get_status() == snapshot
+
+
+class TestGetStatusUpdatingFlag:
+    """``updating`` is derived from the latest entry in ``updates``.
+
+    It is ``True`` exactly when ``updates`` is non-empty and the latest entry
+    has ``ready: False`` — matching the install lock in ``install_update`` that
+    refuses to start when any ``updates.ready`` is ``False``. The pre-fix
+    derivation ignored the first install and inverted the ``ready`` check
+    (VIR-2445).
+    """
+
+    @staticmethod
+    async def _insert_status(mongo, updates: list[dict]) -> None:
+        await mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "updates": updates,
+                "installed": None,
+                "release": None,
+                "errors": [],
+            },
+        )
+
+    async def test_single_in_progress_update(self, data_layer, mongo):
+        """A lone unfinished update reports ``updating: True``."""
+        await self._insert_status(mongo, [{"id": 1, "ready": False}])
+
+        status = await data_layer.hmms.get_status()
+
+        assert status.updating is True
+
+    async def test_latest_in_progress_update(self, data_layer, mongo):
+        """A finished update followed by an unfinished one reports ``True``."""
+        await self._insert_status(
+            mongo,
+            [{"id": 1, "ready": True}, {"id": 2, "ready": False}],
+        )
+
+        status = await data_layer.hmms.get_status()
+
+        assert status.updating is True
+
+    async def test_latest_completed_update(self, data_layer, mongo):
+        """A latest finished update reports ``updating: False``."""
+        await self._insert_status(mongo, [{"id": 1, "ready": True}])
+
+        status = await data_layer.hmms.get_status()
+
+        assert status.updating is False
+
+    async def test_no_updates(self, data_layer, mongo):
+        """An empty ``updates`` list reports ``updating: False``."""
+        await self._insert_status(mongo, [])
+
+        status = await data_layer.hmms.get_status()
+
+        assert status.updating is False
 
 
 async def _drain(stream) -> bytes:

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -88,7 +88,7 @@ class HmmsData(DataLayerDomain):
         document = await self._mongo.status.find_one("hmm")
 
         document["updating"] = (
-            len(document["updates"]) > 1 and document["updates"][-1]["ready"]
+            bool(document["updates"]) and not document["updates"][-1]["ready"]
         )
 
         if installed := document.get("installed"):


### PR DESCRIPTION
## Summary

- The `updating` flag on HMM status was derived incorrectly: it required more than one update entry and checked `ready` without negating it, so the flag was never `True` during a real in-progress install.
- Fixed the condition to `bool(updates) and not updates[-1]["ready"]`, which matches the install lock that blocks a new install while any update has `ready: False`.
- Expanded the test fixtures to use full release objects and added a `TestGetStatusUpdatingFlag` class covering the four meaningful states (in-progress lone update, in-progress latest update, completed update, empty list).