### PR TITLE
Switch subtraction reads from MongoDB to Postgres

### DIFF
--- a/tests/subtractions/__snapshots__/test_api.ambr
+++ b/tests/subtractions/__snapshots__/test_api.ambr
@@ -843,10 +843,10 @@
           'id': 1,
           'name': 'test.fq.gz',
         }),
-        'id': 'bf1b993c',
+        'id': '7cf872dc',
         'job': dict({
           'created_at': 'approximately_now_isoformat',
-          'id': 1,
+          'id': 3,
           'progress': 0,
           'state': 'pending',
           'user': dict({
@@ -870,10 +870,10 @@
           'id': 1,
           'name': 'test.fq.gz',
         }),
-        'id': '7cf872dc',
+        'id': '3cbb22cc',
         'job': dict({
           'created_at': 'approximately_now_isoformat',
-          'id': 3,
+          'id': 4,
           'progress': 0,
           'state': 'pending',
           'user': dict({

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -102,6 +102,89 @@ class TestFind:
 
         assert result == [{"id": subtraction.id, "name": "foo", "ready": True}]
 
+    async def test_search_escapes_sql_wildcards(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        """Search treats ``%``, ``_``, and ``\\`` as literals, not LIKE wildcards."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        async def named(name: str) -> str:
+            subtraction = await fake.subtractions.create(user=user, upload=upload)
+            await data_layer.subtractions.update(
+                subtraction.id,
+                UpdateSubtractionRequest(name=name, nickname=""),
+            )
+            return subtraction.id
+
+        literal_percent = await named("foo%bar")
+        await named("fooXbar")
+        literal_underscore = await named("baz_qux")
+        await named("bazYqux")
+        literal_backslash = await named("qux\\end")
+        await named("quxend")
+
+        percent = await data_layer.subtractions.find(
+            "foo%bar", False, False, _empty_query()
+        )
+        assert [d.id for d in percent.documents] == [literal_percent]
+
+        underscore = await data_layer.subtractions.find(
+            "baz_qux", False, False, _empty_query()
+        )
+        assert [d.id for d in underscore.documents] == [literal_underscore]
+
+        backslash = await data_layer.subtractions.find(
+            "qux\\end", False, False, _empty_query()
+        )
+        assert [d.id for d in backslash.documents] == [literal_backslash]
+
+    async def test_ready_filter_with_search_term(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        """``ready=True`` and a search term compose; counts reflect each filter."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        ready_match = await fake.subtractions.create(
+            user=user, upload=upload, finalized=True
+        )
+        await data_layer.subtractions.update(
+            ready_match.id,
+            UpdateSubtractionRequest(name="Arabidopsis thaliana", nickname=""),
+        )
+
+        await fake.subtractions.create(user=user, upload=upload, finalized=True)
+
+        not_ready_match = await fake.subtractions.create(
+            user=user, upload=upload, finalized=False
+        )
+        await data_layer.subtractions.update(
+            not_ready_match.id,
+            UpdateSubtractionRequest(name="Arabidopsis other", nickname=""),
+        )
+
+        await fake.subtractions.create(user=user, upload=upload, finalized=False)
+
+        result = await data_layer.subtractions.find(
+            "arabidopsis", False, True, _empty_query()
+        )
+
+        assert [d.id for d in result.documents] == [ready_match.id]
+        assert result.found_count == 1
+        assert result.ready_count == 2
+        assert result.total_count == 4
+
 
 async def test_finalize(
     fake: DataFaker,

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -1,10 +1,106 @@
+from multidict import MultiDict, MultiDictProxy
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
+from virtool.subtractions.oas import UpdateSubtractionRequest
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.uploads.sql import UploadType
+
+
+def _empty_query() -> MultiDictProxy:
+    return MultiDictProxy(MultiDict())
+
+
+class TestFind:
+    """Reads served from Postgres by ``SubtractionsData.find``."""
+
+    async def test_search_matches_name_and_nickname(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        """The case-insensitive ``find`` term matches both name and nickname."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        arabidopsis = await fake.subtractions.create(user=user, upload=upload)
+        await data_layer.subtractions.update(
+            arabidopsis.id,
+            UpdateSubtractionRequest(name="Arabidopsis thaliana", nickname="cress"),
+        )
+
+        malus = await fake.subtractions.create(user=user, upload=upload)
+        await data_layer.subtractions.update(
+            malus.id,
+            UpdateSubtractionRequest(name="Malus domestica", nickname="apple"),
+        )
+
+        by_name = await data_layer.subtractions.find(
+            "MALUS", False, False, _empty_query()
+        )
+        assert [d.id for d in by_name.documents] == [malus.id]
+        assert by_name.found_count == 1
+        assert by_name.total_count == 2
+
+        by_nickname = await data_layer.subtractions.find(
+            "cress", False, False, _empty_query()
+        )
+        assert [d.id for d in by_nickname.documents] == [arabidopsis.id]
+
+    async def test_ready_filter(self, data_layer: DataLayer, fake: DataFaker):
+        """``ready=True`` returns only finalized subtractions but counts both."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        ready = await fake.subtractions.create(user=user, upload=upload, finalized=True)
+        await fake.subtractions.create(user=user, upload=upload, finalized=False)
+
+        result = await data_layer.subtractions.find(None, False, True, _empty_query())
+
+        assert [d.id for d in result.documents] == [ready.id]
+        assert result.found_count == 1
+        assert result.ready_count == 1
+        assert result.total_count == 2
+
+    async def test_deleted_excluded(self, data_layer: DataLayer, fake: DataFaker):
+        """Soft-deleted subtractions never appear in find results or counts."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        kept = await fake.subtractions.create(user=user, upload=upload)
+        removed = await fake.subtractions.create(user=user, upload=upload)
+        await data_layer.subtractions.delete(removed.id)
+
+        result = await data_layer.subtractions.find(None, False, False, _empty_query())
+
+        assert [d.id for d in result.documents] == [kept.id]
+        assert result.total_count == 1
+
+    async def test_short(self, data_layer: DataLayer, fake: DataFaker):
+        """Short mode returns a flat list of id/name/ready dicts."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        result = await data_layer.subtractions.find(None, True, False, _empty_query())
+
+        assert result == [{"id": subtraction.id, "name": "foo", "ready": True}]
 
 
 async def test_finalize(

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -4,18 +4,17 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
 from multidict import MultiDictProxy
-from sqlalchemy import select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
 import virtool.mongo.utils
 import virtool.utils
-from virtool.api.utils import compose_regex_query
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emits
-from virtool.data.topg import both_transactions
+from virtool.data.topg import both_transactions, compose_legacy_id_single_expression
 from virtool.data.transforms import apply_transforms
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.utils import get_one_field
@@ -24,6 +23,7 @@ from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.db import (
     attach_computed,
+    map_subtraction_row,
     unlink_default_subtractions,
 )
 from virtool.subtractions.models import (
@@ -54,6 +54,22 @@ if TYPE_CHECKING:
 logger = get_logger("subtractions")
 
 
+def _compose_subtraction_search_filter(term: str):
+    """Compose a case-insensitive substring match on ``name`` and ``nickname``.
+
+    Mirrors the Mongo ``compose_regex_query`` behaviour the find endpoint used
+    before reading from Postgres: the term is matched literally, so SQL ``LIKE``
+    wildcards in the term are escaped rather than interpreted.
+    """
+    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped}%"
+
+    return or_(
+        SQLSubtraction.name.ilike(pattern, escape="\\"),
+        SQLSubtraction.nickname.ilike(pattern, escape="\\"),
+    )
+
+
 class SubtractionsData(DataLayerDomain):
     name = "subtractions"
 
@@ -70,106 +86,79 @@ class SubtractionsData(DataLayerDomain):
         self._storage = storage
 
     async def find(self, find: str, short: bool, ready: bool, query: MultiDictProxy):
-        db_query = {}
+        not_deleted = SQLSubtraction.deleted.is_(False)
+
+        filters = [not_deleted]
 
         if find:
-            db_query = compose_regex_query(find, ["name", "nickname"])
+            filters.append(_compose_subtraction_search_filter(find))
 
         if ready:
-            db_query["ready"] = True
+            filters.append(SQLSubtraction.ready.is_(True))
 
         if short:
+            async with AsyncSession(self._pg) as session:
+                rows = (
+                    await session.execute(
+                        select(
+                            SQLSubtraction.legacy_id,
+                            SQLSubtraction.name,
+                            SQLSubtraction.ready,
+                        )
+                        .where(*filters)
+                        .order_by(SQLSubtraction.name, SQLSubtraction.id),
+                    )
+                ).all()
+
             return [
-                base_processor(document)
-                async for document in self._mongo.subtraction.find(
-                    {**db_query, "deleted": False},
-                    ["name", "ready"],
-                ).sort("name")
+                {"id": legacy_id, "name": name, "ready": is_ready}
+                for legacy_id, name, is_ready in rows
             ]
 
         page = int(query.get("page", 1))
         per_page = int(query.get("per_page", 25))
 
-        data = await self._mongo.subtraction.aggregate(
+        async with AsyncSession(self._pg) as session:
+            total_count = await session.scalar(
+                select(func.count()).select_from(SQLSubtraction).where(not_deleted),
+            )
+            ready_count = await session.scalar(
+                select(func.count())
+                .select_from(SQLSubtraction)
+                .where(not_deleted, SQLSubtraction.ready.is_(True)),
+            )
+            found_count = await session.scalar(
+                select(func.count()).select_from(SQLSubtraction).where(*filters),
+            )
+
+            rows = (
+                await session.execute(
+                    select(SQLSubtraction, SQLUpload)
+                    .outerjoin(SQLUpload, SQLSubtraction.upload_id == SQLUpload.id)
+                    .where(*filters)
+                    .order_by(SQLSubtraction.name, SQLSubtraction.id)
+                    .offset(per_page * (page - 1))
+                    .limit(per_page),
+                )
+            ).all()
+
+        documents = await apply_transforms(
             [
-                {"$match": {"deleted": False}},
-                {
-                    "$facet": {
-                        "total_count": [{"$count": "total_count"}],
-                        "ready_count": [
-                            {"$match": {"ready": True}},
-                            {"$count": "ready_count"},
-                        ],
-                        "found_count": [
-                            {"$match": db_query},
-                            {"$count": "found_count"},
-                        ],
-                        "documents": [
-                            {"$match": db_query},
-                            {"$sort": {"name": 1}},
-                            {"$skip": per_page * (page - 1)},
-                            {"$limit": per_page},
-                            {
-                                "$project": {
-                                    "id": "$_id",
-                                    "_id": False,
-                                    "count": True,
-                                    "created_at": True,
-                                    "file": True,
-                                    "ready": True,
-                                    "job": True,
-                                    "name": True,
-                                    "nickname": True,
-                                    "user": True,
-                                    "subtraction_id": True,
-                                    "gc": True,
-                                },
-                            },
-                        ],
-                    },
-                },
-                {
-                    "$project": {
-                        "documents": True,
-                        "total_count": {
-                            "$ifNull": [
-                                {"$arrayElemAt": ["$total_count.total_count", 0]},
-                                0,
-                            ],
-                        },
-                        "found_count": {
-                            "$ifNull": [
-                                {"$arrayElemAt": ["$found_count.found_count", 0]},
-                                0,
-                            ],
-                        },
-                        "ready_count": {
-                            "$ifNull": [
-                                {"$arrayElemAt": ["$ready_count.ready_count", 0]},
-                                0,
-                            ],
-                        },
-                    },
-                },
+                base_processor(map_subtraction_row(subtraction, upload))
+                for subtraction, upload in rows
             ],
-        ).to_list(length=1)
-
-        if len(data) == 0:
-            raise ResourceNotFoundError
-
-        data = data[0]
-
-        data["documents"] = await apply_transforms(
-            [base_processor(d) for d in data["documents"]],
             [AttachJobTransform(self._pg), AttachUserTransform(self._pg)],
             self._pg,
         )
 
         return SubtractionSearchResult(
-            **data,
+            documents=documents,
+            found_count=found_count,
+            total_count=total_count,
+            ready_count=ready_count,
             page=page,
             per_page=per_page,
-            page_count=math.ceil(data["found_count"] / per_page),
+            page_count=math.ceil(found_count / per_page),
         )
 
     @emits(Operation.CREATE)
@@ -246,51 +235,45 @@ class SubtractionsData(DataLayerDomain):
 
         return await self.get(new_subtraction_id)
 
-    async def get(self, subtraction_id: str) -> Subtraction:
+    async def get(self, subtraction_id: int | str) -> Subtraction:
         """Get a subtraction by its id."""
-        result = await self._mongo.subtraction.aggregate(
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLSubtraction, SQLUpload)
+                    .outerjoin(SQLUpload, SQLSubtraction.upload_id == SQLUpload.id)
+                    .where(
+                        compose_legacy_id_single_expression(
+                            SQLSubtraction,
+                            subtraction_id,
+                        ),
+                    ),
+                )
+            ).first()
+
+        if row is None:
+            raise ResourceNotFoundError
+
+        subtraction, upload = row
+
+        document = await attach_computed(
+            self._mongo,
+            self._pg,
+            self._base_url,
+            map_subtraction_row(subtraction, upload),
+        )
+
+        document = await apply_transforms(
+            base_processor(document),
             [
-                {"$match": {"_id": subtraction_id}},
-                {
-                    "$project": {
-                        "_id": True,
-                        "count": True,
-                        "created_at": True,
-                        "file": True,
-                        "gc": True,
-                        "ready": True,
-                        "job": True,
-                        "name": True,
-                        "nickname": True,
-                        "upload": True,
-                        "user": True,
-                        "subtraction_id": True,
-                    },
-                },
+                AttachJobTransform(self._pg),
+                AttachUploadTransform(self._pg),
+                AttachUserTransform(self._pg, ignore_errors=True),
             ],
-        ).to_list(length=1)
+            self._pg,
+        )
 
-        if result:
-            document = await attach_computed(
-                self._mongo,
-                self._pg,
-                self._base_url,
-                result[0],
-            )
-
-            document = await apply_transforms(
-                base_processor(document),
-                [
-                    AttachJobTransform(self._pg),
-                    AttachUploadTransform(self._pg),
-                    AttachUserTransform(self._pg, ignore_errors=True),
-                ],
-                self._pg,
-            )
-
-            return Subtraction(**document)
-
-        raise ResourceNotFoundError
+        return Subtraction(**document)
 
     @emits(Operation.UPDATE)
     async def update(

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -9,9 +9,43 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.data.transforms import AbstractTransform
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
+from virtool.subtractions.pg import SQLSubtraction
 from virtool.subtractions.utils import get_subtraction_files
 from virtool.types import Document
+from virtool.uploads.sql import SQLUpload
 from virtool.utils import base_processor
+
+
+def map_subtraction_row(
+    subtraction: SQLSubtraction,
+    upload: SQLUpload | None,
+) -> Document:
+    """Build a legacy-shaped subtraction document from Postgres rows.
+
+    The returned document mirrors the Mongo document shape that
+    :func:`attach_computed` and the subtraction transforms consume: ``_id`` is the
+    legacy slug, and the ``file``, ``job``, ``upload``, and ``user`` fields carry
+    the reference shapes the ``AttachUploadTransform``, ``AttachJobTransform``, and
+    ``AttachUserTransform`` expect.
+
+    Postgres does not store the ``file`` snapshot, so it is rebuilt from the joined
+    upload row, which is the same upload the subtraction was created against.
+    """
+    return {
+        "_id": subtraction.legacy_id,
+        "count": subtraction.count,
+        "created_at": subtraction.created_at,
+        "file": {"id": upload.id, "name": upload.name} if upload else None,
+        "gc": subtraction.gc,
+        "job": {"id": subtraction.job_id} if subtraction.job_id is not None else None,
+        "name": subtraction.name,
+        "nickname": subtraction.nickname,
+        "ready": subtraction.ready,
+        "upload": subtraction.upload_id,
+        "user": {"id": subtraction.user_id}
+        if subtraction.user_id is not None
+        else None,
+    }
 
 
 def subtraction_processor(document: Document) -> Document:


### PR DESCRIPTION
## Summary

- `SubtractionsData.find` and `SubtractionsData.get` now read entirely from Postgres rather than MongoDB, completing the subtraction migration for read paths
- Added `map_subtraction_row` helper in `virtool/subtractions/db.py` to convert joined `SQLSubtraction`/`SQLUpload` rows into the legacy document shape consumed by existing transforms
- Replaced the Mongo aggregation pipeline in `find` with four targeted SQL queries (total count, ready count, found count, paginated rows); case-insensitive name/nickname search is now done via SQL `ILIKE`