### PR TITLE
Dual-write HMM install/refresh path to Mongo and Postgres

### DIFF
--- a/tests/hmm/__snapshots__/test_tasks.ambr
+++ b/tests/hmm/__snapshots__/test_tasks.ambr
@@ -19,6 +19,7 @@
     dict({
       '_id': 'bf1b993c',
       'cluster': 2,
+      'count': 216,
       'entries': list([
         dict({
           'accession': 'NP_040324.1',
@@ -31,8 +32,18 @@
         'Geminiviridae': 235,
         'None': 2,
       }),
+      'genera': dict({
+        'Begomovirus': 198,
+        'None': 37,
+      }),
       'hidden': False,
       'length': 356,
+      'mean_entropy': 0.52,
+      'names': list([
+        'AL1 protein',
+        'replication protein',
+        'AC1',
+      ]),
       'total_entropy': 185.12,
     }),
   ])

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -2,11 +2,16 @@ import gzip
 import json
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.data.errors import ResourceNotFoundError
+from virtool.errors import GitHubError
 from virtool.fake.next import DataFaker
 from virtool.hmm.data import HMM_ANNOTATIONS_KEY, HMM_PROFILES_KEY, HmmsData
+from virtool.hmm.sql import SQLHMM, SQLHMMStatus
 from virtool.storage.object import ObjectProvider
+from virtool.tasks.progress import AbstractProgressHandler
 
 
 async def test_get_status(
@@ -205,3 +210,283 @@ class TestDownloadAnnotations:
 
         stored = await _drain(storage.read(HMM_ANNOTATIONS_KEY))
         assert stored == regenerated
+
+
+class _NullProgressHandler(AbstractProgressHandler):
+    async def set_error(self, error: str) -> None: ...
+
+    async def set_progress(self, progress: int) -> None: ...
+
+
+async def _profile_bytes():
+    yield b"PROFILE-BYTES"
+
+
+ANNOTATION = {
+    "cluster": 2,
+    "count": 216,
+    "length": 356,
+    "mean_entropy": 0.52,
+    "total_entropy": 185.12,
+    "names": ["AL1 protein", "replication protein", "AC1"],
+    "families": {"Geminiviridae": 235, "None": 2},
+    "genera": {"Begomovirus": 198, "None": 37},
+    "entries": [
+        {
+            "accession": "NP_040324.1",
+            "gi": 9626083,
+            "organism": "Pepper huasteco yellow vein virus",
+            "name": "AL1 protein",
+        },
+    ],
+}
+
+RELEASE = {
+    "id": 1,
+    "name": "v0.2.1",
+    "body": "release notes",
+    "filename": "vthmm.tar.gz",
+    "html_url": "https://github.com/virtool/virtool-hmm/releases/tag/v0.2.1",
+    "newer": True,
+    "published_at": "2017-11-10T19:12:43Z",
+    "size": 85904451,
+}
+
+
+async def _read_pg_status(pg) -> dict | None:
+    async with AsyncSession(pg) as session:
+        status = (
+            await session.execute(select(SQLHMMStatus).where(SQLHMMStatus.id == 1))
+        ).scalar_one_or_none()
+
+        if status is None:
+            return None
+
+        return {
+            "errors": status.errors,
+            "release": status.release,
+            "installed": status.installed,
+            "task_id": status.task_id,
+            "updates": status.updates,
+        }
+
+
+async def _read_pg_hmms(pg) -> list[SQLHMM]:
+    async with AsyncSession(pg) as session:
+        return list((await session.execute(select(SQLHMM))).scalars().all())
+
+
+async def _seed_status(mongo, pg, **overrides) -> None:
+    document = {
+        "_id": "hmm",
+        "errors": [],
+        "installed": None,
+        "release": RELEASE,
+        "updates": [],
+        **overrides,
+    }
+
+    await mongo.status.insert_one(document)
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLHMMStatus(
+                id=1,
+                errors=document["errors"],
+                installed=document["installed"],
+                release=document["release"],
+                updates=document["updates"],
+            ),
+        )
+        await session.commit()
+
+
+class TestInstall:
+    """``install`` dual-writes annotations and status to Mongo and Postgres."""
+
+    async def test_writes_annotations_and_status_to_both(self, data_layer, mongo, pg):
+        """A successful install mirrors annotations and status to Postgres."""
+        await _seed_status(
+            mongo,
+            pg,
+            updates=[{"id": 1, "ready": False, "name": "v0.2.1"}],
+        )
+
+        await data_layer.hmms.install(
+            [ANNOTATION],
+            RELEASE,
+            7,
+            _NullProgressHandler(),
+            _profile_bytes(),
+        )
+
+        mongo_documents = await mongo.hmm.find().to_list(None)
+        pg_hmms = await _read_pg_hmms(pg)
+
+        assert [hmm.legacy_id for hmm in pg_hmms] == [
+            document["_id"] for document in mongo_documents
+        ]
+        assert pg_hmms[0].cluster == ANNOTATION["cluster"]
+        assert pg_hmms[0].count == ANNOTATION["count"]
+        assert pg_hmms[0].names == ANNOTATION["names"]
+        assert pg_hmms[0].families == ANNOTATION["families"]
+        assert pg_hmms[0].genera == ANNOTATION["genera"]
+        assert pg_hmms[0].entries == ANNOTATION["entries"]
+        assert pg_hmms[0].hidden is False
+
+        pg_status = await _read_pg_status(pg)
+        mongo_status = await mongo.status.find_one("hmm")
+
+        # Postgres stores ``installed`` as JSONB, so its datetimes are ISO
+        # strings rather than the ``datetime`` objects Mongo returns. Compare
+        # the scalar fields rather than the whole subdocument.
+        assert pg_status["installed"] is not None
+        assert pg_status["installed"]["id"] == mongo_status["installed"]["id"]
+        assert pg_status["installed"]["ready"] is True
+        assert pg_status["installed"]["user"] == {"id": 7}
+        assert pg_status["updates"][0]["ready"] is True
+        assert mongo_status["updates"][0]["ready"] is True
+
+        assert await _drain(data_layer.hmms._storage.read(HMM_PROFILES_KEY)) == (
+            b"PROFILE-BYTES"
+        )
+
+    async def test_profile_write_failure_rolls_back_both(
+        self, data_layer, mocker, mongo, pg
+    ):
+        """A storage failure rolls back the Mongo and Postgres writes together."""
+        await _seed_status(
+            mongo,
+            pg,
+            updates=[{"id": 1, "ready": False, "name": "v0.2.1"}],
+        )
+
+        mocker.patch.object(
+            data_layer.hmms._storage,
+            "write",
+            side_effect=RuntimeError("storage is down"),
+        )
+
+        with pytest.raises(RuntimeError):
+            await data_layer.hmms.install(
+                [ANNOTATION],
+                RELEASE,
+                7,
+                _NullProgressHandler(),
+                _profile_bytes(),
+            )
+
+        assert await mongo.hmm.count_documents({}) == 0
+        assert await _read_pg_hmms(pg) == []
+
+        pg_status = await _read_pg_status(pg)
+        mongo_status = await mongo.status.find_one("hmm")
+
+        assert pg_status["installed"] is None
+        assert mongo_status["installed"] is None
+        assert pg_status["updates"][0]["ready"] is False
+        assert mongo_status["updates"][0]["ready"] is False
+
+
+class TestCleanStatus:
+    """``clean_status`` dual-writes the status reset to Mongo and Postgres."""
+
+    async def test_resets_both(self, data_layer, mongo, pg):
+        await _seed_status(
+            mongo,
+            pg,
+            installed={"id": 1, "ready": True},
+            updates=[{"id": 1, "ready": True}],
+        )
+
+        await data_layer.hmms.clean_status()
+
+        pg_status = await _read_pg_status(pg)
+        mongo_status = await mongo.status.find_one("hmm")
+
+        assert pg_status["installed"] is None
+        assert pg_status["task_id"] is None
+        assert pg_status["updates"] == []
+
+        assert mongo_status["installed"] is None
+        assert mongo_status["task"] is None
+        assert mongo_status["updates"] == []
+
+
+class TestUpdateRelease:
+    """``update_release`` dual-writes the fetched release to Mongo and Postgres."""
+
+    async def test_creates_postgres_singleton_when_absent(
+        self, data_layer, mocker, mongo
+    ):
+        """A successful fetch upserts the Postgres singleton from nothing."""
+        mocker.patch(
+            "virtool.hmm.db.get_release",
+            mocker.AsyncMock(return_value=None),
+        )
+
+        await mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": ["stale error"],
+                "installed": None,
+                "release": RELEASE,
+                "updates": [],
+            },
+        )
+
+        await data_layer.hmms.update_release()
+
+        pg_status = await _read_pg_status(data_layer.hmms._pg)
+        mongo_status = await mongo.status.find_one("hmm")
+
+        assert pg_status is not None
+        assert pg_status["errors"] == []
+        assert pg_status["release"]["id"] == RELEASE["id"]
+        assert mongo_status["errors"] == []
+
+    async def test_error_path_updates_existing_singleton(
+        self, data_layer, mocker, mongo, pg
+    ):
+        """A non-fatal GitHub error clears errors without touching the release."""
+        mocker.patch(
+            "virtool.hmm.db.get_release",
+            mocker.AsyncMock(side_effect=GitHubError("boom")),
+        )
+
+        await _seed_status(mongo, pg, errors=["stale error"])
+
+        await data_layer.hmms.update_release()
+
+        pg_status = await _read_pg_status(pg)
+        mongo_status = await mongo.status.find_one("hmm")
+
+        assert pg_status["errors"] == []
+        assert pg_status["release"]["id"] == RELEASE["id"]
+        assert mongo_status["errors"] == []
+
+
+class TestInstallUpdate:
+    """``install_update`` dual-writes the queued update to Mongo and Postgres."""
+
+    async def test_pushes_update_to_both(self, data_layer, fake, mocker, mongo, pg):
+        mocker.patch(
+            "virtool.hmm.db.get_release",
+            mocker.AsyncMock(return_value=None),
+        )
+
+        user = await fake.users.create()
+
+        await _seed_status(mongo, pg)
+
+        await data_layer.hmms.install_update(user.id)
+
+        pg_status = await _read_pg_status(pg)
+        mongo_status = await mongo.status.find_one("hmm")
+
+        assert len(pg_status["updates"]) == 1
+        assert pg_status["updates"][0]["ready"] is False
+        assert pg_status["task_id"] == mongo_status["task"]["id"]
+
+        assert len(mongo_status["updates"]) == 1
+        assert mongo_status["updates"][0]["ready"] is False

--- a/tests/hmm/test_tasks.py
+++ b/tests/hmm/test_tasks.py
@@ -2,8 +2,10 @@ import json
 import tarfile
 from pathlib import Path
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from virtool.hmm.sql import SQLHMM
 from virtool.hmm.tasks import HMMInstallTask
 from virtool.tasks.sql import SQLTask
 from virtool.utils import get_temp_dir
@@ -11,6 +13,10 @@ from virtool.utils import get_temp_dir
 annotations = [
     {
         "families": {"None": 2, "Geminiviridae": 235},
+        "genera": {"Begomovirus": 198, "None": 37},
+        "names": ["AL1 protein", "replication protein", "AC1"],
+        "count": 216,
+        "mean_entropy": 0.52,
         "total_entropy": 185.12,
         "length": 356,
         "cluster": 2,
@@ -74,3 +80,15 @@ async def test_hmm_install_task(
         [chunk async for chunk in data_layer.hmms._storage.read("hmm/profiles.hmm")]
     )
     assert raw == b"test_profile"
+
+    async with AsyncSession(pg) as session:
+        hmms = (await session.execute(select(SQLHMM))).scalars().all()
+
+    mongo_documents = await mongo.hmm.find().to_list(None)
+
+    assert [hmm.legacy_id for hmm in hmms] == [
+        document["_id"] for document in mongo_documents
+    ]
+    assert [hmm.cluster for hmm in hmms] == [annotations[0]["cluster"]]
+    assert [hmm.names for hmm in hmms] == [annotations[0]["names"]]
+    assert [hmm.genera for hmm in hmms] == [annotations[0]["genera"]]

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -24,7 +24,7 @@ from virtool.hmm.db import (
     generate_annotations,
 )
 from virtool.hmm.models import HMM, HMMInstalled, HMMSearchResult, HMMStatus
-from virtool.hmm.sql import SQLHMM, SQLHMMStatus
+from virtool.hmm.sql import HMM_STATUS_ID, SQLHMM, SQLHMMStatus
 from virtool.hmm.tasks import HMMInstallTask
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
@@ -147,7 +147,7 @@ class HmmsData(DataLayerDomain):
 
             status = (
                 await pg_session.execute(
-                    select(SQLHMMStatus).where(SQLHMMStatus.id == 1),
+                    select(SQLHMMStatus).where(SQLHMMStatus.id == HMM_STATUS_ID),
                 )
             ).scalar_one_or_none()
 
@@ -180,70 +180,77 @@ class HmmsData(DataLayerDomain):
 
         installed = create_update_subdocument(release, True, user_id)
 
-        async with both_transactions(self._mongo, self._pg) as (
-            mongo_session,
-            pg_session,
-        ):
-            for annotation in annotations:
-                inserted = await self._mongo.hmm.insert_one(
-                    dict(annotation, hidden=False),
+        wrote_profiles = False
+
+        try:
+            async with both_transactions(self._mongo, self._pg) as (
+                mongo_session,
+                pg_session,
+            ):
+                for annotation in annotations:
+                    inserted = await self._mongo.hmm.insert_one(
+                        dict(annotation, hidden=False),
+                        session=mongo_session,
+                    )
+
+                    pg_session.add(
+                        SQLHMM(
+                            legacy_id=inserted["_id"],
+                            cluster=annotation["cluster"],
+                            count=annotation["count"],
+                            length=annotation["length"],
+                            mean_entropy=annotation["mean_entropy"],
+                            total_entropy=annotation["total_entropy"],
+                            hidden=False,
+                            names=annotation["names"],
+                            families=annotation["families"],
+                            genera=annotation["genera"],
+                            entries=annotation["entries"],
+                        ),
+                    )
+
+                    await tracker.add(1)
+
+                await self._mongo.status.update_one(
+                    {"_id": "hmm", "updates.id": release_id},
+                    {"$set": {"installed": installed, "updates.$.ready": True}},
                     session=mongo_session,
                 )
 
-                pg_session.add(
-                    SQLHMM(
-                        legacy_id=inserted["_id"],
-                        cluster=annotation["cluster"],
-                        count=annotation["count"],
-                        length=annotation["length"],
-                        mean_entropy=annotation["mean_entropy"],
-                        total_entropy=annotation["total_entropy"],
-                        hidden=False,
-                        names=annotation["names"],
-                        families=annotation["families"],
-                        genera=annotation["genera"],
-                        entries=annotation["entries"],
-                    ),
-                )
+                # Mirror the conditional Mongo status update: set ``installed``
+                # and flip the matching update's ``ready`` flag only when the
+                # singleton row exists and carries an update for this release.
+                status = (
+                    await pg_session.execute(
+                        select(SQLHMMStatus).where(SQLHMMStatus.id == HMM_STATUS_ID),
+                    )
+                ).scalar_one_or_none()
 
-                await tracker.add(1)
+                if status is not None and any(
+                    update_.get("id") == release_id for update_ in status.updates
+                ):
+                    status.installed = installed
+                    status.updates = [
+                        {**update_, "ready": True}
+                        if update_.get("id") == release_id
+                        else update_
+                        for update_ in status.updates
+                    ]
 
-            await self._mongo.status.update_one(
-                {"_id": "hmm", "updates.id": release_id},
-                {"$set": {"installed": installed, "updates.$.ready": True}},
-                session=mongo_session,
-            )
-
-            # Mirror the conditional Mongo status update: set ``installed`` and
-            # flip the matching update's ``ready`` flag only when the singleton
-            # row exists and carries an update for this release.
-            status = (
-                await pg_session.execute(
-                    select(SQLHMMStatus).where(SQLHMMStatus.id == 1),
-                )
-            ).scalar_one_or_none()
-
-            if status is not None and any(
-                update_.get("id") == release_id for update_ in status.updates
-            ):
-                status.installed = installed
-                status.updates = [
-                    {**update_, "ready": True}
-                    if update_.get("id") == release_id
-                    else update_
-                    for update_ in status.updates
-                ]
-
-            try:
+                wrote_profiles = True
                 await self._storage.write(HMM_PROFILES_KEY, profile_data)
-            except Exception:
-                # obstore.put_async is not atomic from the caller's
-                # perspective: a failure can leave an incomplete multipart
-                # upload on S3 or a partially written file on disk. Cleanup
-                # keeps a retry from being shadowed by orphaned data. Re-raising
-                # rolls back both database transactions.
+        except Exception:
+            # Clean up the profiles blob on any failure from the write attempt
+            # onward, then re-raise. ``write`` is not atomic from the caller's
+            # perspective: a failure can leave an incomplete multipart upload on
+            # S3 or a partially written file on disk. A commit-time failure when
+            # ``both_transactions`` exits rolls back both databases but leaves a
+            # fully written blob orphaned ahead of them. ``wrote_profiles`` gates
+            # the delete so a failure before the write does not destroy a prior
+            # install's profiles file. ``delete`` is idempotent.
+            if wrote_profiles:
                 await self._storage.delete(HMM_PROFILES_KEY)
-                raise
+            raise
 
     async def download_profiles(self) -> tuple[AsyncIterator[bytes], int]:
         try:
@@ -288,7 +295,7 @@ class HmmsData(DataLayerDomain):
 
             await pg_session.execute(
                 update(SQLHMMStatus)
-                .where(SQLHMMStatus.id == 1)
+                .where(SQLHMMStatus.id == HMM_STATUS_ID)
                 .values(installed=None, task_id=None, updates=[]),
             )
 

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 
 from aiohttp import ClientSession
 from multidict import MultiDictProxy
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from virtool.api.utils import compose_regex_query, paginate
@@ -13,6 +14,7 @@ from virtool.data.errors import (
     ResourceError,
     ResourceNotFoundError,
 )
+from virtool.data.topg import both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.github import create_update_subdocument
 from virtool.hmm.db import (
@@ -22,6 +24,7 @@ from virtool.hmm.db import (
     generate_annotations,
 )
 from virtool.hmm.models import HMM, HMMInstalled, HMMSearchResult, HMMStatus
+from virtool.hmm.sql import SQLHMM, SQLHMMStatus
 from virtool.hmm.tasks import HMMInstallTask
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
@@ -113,6 +116,7 @@ class HmmsData(DataLayerDomain):
         await fetch_and_update_release(
             self._client,
             self._mongo,
+            self._pg,
             HMM_REPO_SLUG,
         )
 
@@ -126,15 +130,33 @@ class HmmsData(DataLayerDomain):
             context={"user_id": user_id, "release": release},
         )
 
-        update = create_update_subdocument(release, False, user_id)
+        update_subdocument = create_update_subdocument(release, False, user_id)
 
-        await self._mongo.status.find_one_and_update(
-            {"_id": "hmm"},
-            {"$set": {"task": {"id": task.id}}, "$push": {"updates": update}},
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.status.find_one_and_update(
+                {"_id": "hmm"},
+                {
+                    "$set": {"task": {"id": task.id}},
+                    "$push": {"updates": update_subdocument},
+                },
+                session=mongo_session,
+            )
+
+            status = (
+                await pg_session.execute(
+                    select(SQLHMMStatus).where(SQLHMMStatus.id == 1),
+                )
+            ).scalar_one_or_none()
+
+            if status is not None:
+                status.task_id = task.id
+                status.updates = [*status.updates, update_subdocument]
 
         installed = await apply_transforms(
-            {**release, **update},
+            {**release, **update_subdocument},
             [AttachUserTransform(self._pg)],
             self._pg,
         )
@@ -156,33 +178,70 @@ class HmmsData(DataLayerDomain):
         except TypeError:
             release_id = release["id"]
 
-        async with self._mongo.create_session() as session:
+        installed = create_update_subdocument(release, True, user_id)
+
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
             for annotation in annotations:
-                await self._mongo.hmm.insert_one(
+                inserted = await self._mongo.hmm.insert_one(
                     dict(annotation, hidden=False),
-                    session=session,
+                    session=mongo_session,
                 )
+
+                pg_session.add(
+                    SQLHMM(
+                        legacy_id=inserted["_id"],
+                        cluster=annotation["cluster"],
+                        count=annotation["count"],
+                        length=annotation["length"],
+                        mean_entropy=annotation["mean_entropy"],
+                        total_entropy=annotation["total_entropy"],
+                        hidden=False,
+                        names=annotation["names"],
+                        families=annotation["families"],
+                        genera=annotation["genera"],
+                        entries=annotation["entries"],
+                    ),
+                )
+
                 await tracker.add(1)
 
             await self._mongo.status.update_one(
                 {"_id": "hmm", "updates.id": release_id},
-                {
-                    "$set": {
-                        "installed": create_update_subdocument(release, True, user_id),
-                        "updates.$.ready": True,
-                    },
-                },
-                session=session,
+                {"$set": {"installed": installed, "updates.$.ready": True}},
+                session=mongo_session,
             )
+
+            # Mirror the conditional Mongo status update: set ``installed`` and
+            # flip the matching update's ``ready`` flag only when the singleton
+            # row exists and carries an update for this release.
+            status = (
+                await pg_session.execute(
+                    select(SQLHMMStatus).where(SQLHMMStatus.id == 1),
+                )
+            ).scalar_one_or_none()
+
+            if status is not None and any(
+                update_.get("id") == release_id for update_ in status.updates
+            ):
+                status.installed = installed
+                status.updates = [
+                    {**update_, "ready": True}
+                    if update_.get("id") == release_id
+                    else update_
+                    for update_ in status.updates
+                ]
 
             try:
                 await self._storage.write(HMM_PROFILES_KEY, profile_data)
             except Exception:
-                await session.abort_transaction()
                 # obstore.put_async is not atomic from the caller's
                 # perspective: a failure can leave an incomplete multipart
                 # upload on S3 or a partially written file on disk. Cleanup
-                # keeps a retry from being shadowed by orphaned data.
+                # keeps a retry from being shadowed by orphaned data. Re-raising
+                # rolls back both database transactions.
                 await self._storage.delete(HMM_PROFILES_KEY)
                 raise
 
@@ -217,12 +276,26 @@ class HmmsData(DataLayerDomain):
         return self._storage.read(HMM_ANNOTATIONS_KEY), len(compressed)
 
     async def clean_status(self) -> None:
-        async with self._mongo.create_session() as session:
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
             await self._mongo.status.find_one_and_update(
                 {"_id": "hmm"},
                 {"$set": {"installed": None, "task": None, "updates": []}},
-                session=session,
+                session=mongo_session,
+            )
+
+            await pg_session.execute(
+                update(SQLHMMStatus)
+                .where(SQLHMMStatus.id == 1)
+                .values(installed=None, task_id=None, updates=[]),
             )
 
     async def update_release(self) -> None:
-        await fetch_and_update_release(self._client, self._mongo, HMM_REPO_SLUG)
+        await fetch_and_update_release(
+            self._client,
+            self._mongo,
+            self._pg,
+            HMM_REPO_SLUG,
+        )

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -4,11 +4,16 @@ import json
 
 import aiohttp.client_exceptions
 from aiohttp import ClientSession
+from sqlalchemy import update
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncEngine
 from structlog import get_logger
 
 import virtool.utils
+from virtool.data.topg import both_transactions
 from virtool.errors import GitHubError
 from virtool.github import get_etag, get_release
+from virtool.hmm.sql import SQLHMMStatus
 from virtool.hmm.utils import format_hmm_release
 from virtool.mongo.core import Mongo
 from virtool.types import Document
@@ -33,13 +38,18 @@ HMMS_PROJECTION = ["_id", "cluster", "names", "count", "families"]
 async def fetch_and_update_release(
     http_client: ClientSession,
     mongo,
+    pg: AsyncEngine,
     slug: str,
     ignore_errors: bool = False,
 ) -> Document:
     """Return the HMM install status document or create one if none exists.
 
+    The status is dual-written to the Mongo ``status`` singleton and the
+    Postgres ``legacy_hmm_status`` singleton in one transaction.
+
     :param mongo: the application mongo client
     :param http_client: the application http client
+    :param pg: the application Postgres client
     :param slug: the slug for the HMM GitHub repo
     :param ignore_errors: ignore possible errors when making GitHub request
     :return: the release
@@ -64,24 +74,6 @@ async def fetch_and_update_release(
         # A 304 indicates the release has not changed and `None` is returned from
         # `get_release()`.
         updated = await get_release(http_client, slug, etag)
-
-        # Release is replace with updated release if an update was found on GitHub.
-        if updated:
-            release = format_hmm_release(updated, release, installed)
-
-        release["retrieved_at"] = virtool.utils.timestamp()
-
-        # Set and empty error list since the update check was successful.
-        await mongo.status.update_one(
-            {"_id": "hmm"},
-            {"$set": {"errors": [], "installed": installed, "release": release}},
-            upsert=True,
-        )
-
-        logger.info("fetched and updated hmm release")
-
-        return release
-
     except (
         aiohttp.client_exceptions.ClientConnectorError,
         GitHubError,
@@ -97,12 +89,48 @@ async def fetch_and_update_release(
         if errors and not ignore_errors:
             raise
 
-        await mongo.status.update_one(
-            {"_id": "hmm"},
-            {"$set": {"errors": errors, "installed": installed}},
-        )
+        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+            await mongo.status.update_one(
+                {"_id": "hmm"},
+                {"$set": {"errors": errors, "installed": installed}},
+                session=mongo_session,
+            )
+
+            await pg_session.execute(
+                update(SQLHMMStatus)
+                .where(SQLHMMStatus.id == 1)
+                .values(errors=errors, installed=installed),
+            )
 
         return release
+
+    # Release is replaced with updated release if an update was found on GitHub.
+    if updated:
+        release = format_hmm_release(updated, release, installed)
+
+    release["retrieved_at"] = virtool.utils.timestamp()
+
+    # Set an empty error list since the update check was successful.
+    async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+        await mongo.status.update_one(
+            {"_id": "hmm"},
+            {"$set": {"errors": [], "installed": installed, "release": release}},
+            upsert=True,
+            session=mongo_session,
+        )
+
+        await pg_session.execute(
+            insert(SQLHMMStatus)
+            .values(id=1, errors=[], installed=installed, release=release)
+            .on_conflict_do_update(
+                index_elements=[SQLHMMStatus.id],
+                set_={"errors": [], "installed": installed, "release": release},
+            ),
+        )
+
+    logger.info("fetched and updated hmm release")
+
+    return release
 
 
 async def generate_annotations(mongo: Mongo) -> bytes:

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -4,7 +4,6 @@ import json
 
 import aiohttp.client_exceptions
 from aiohttp import ClientSession
-from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 from structlog import get_logger
@@ -13,7 +12,7 @@ import virtool.utils
 from virtool.data.topg import both_transactions
 from virtool.errors import GitHubError
 from virtool.github import get_etag, get_release
-from virtool.hmm.sql import SQLHMMStatus
+from virtool.hmm.sql import HMM_STATUS_ID, SQLHMMStatus
 from virtool.hmm.utils import format_hmm_release
 from virtool.mongo.core import Mongo
 from virtool.types import Document
@@ -97,9 +96,17 @@ async def fetch_and_update_release(
             )
 
             await pg_session.execute(
-                update(SQLHMMStatus)
-                .where(SQLHMMStatus.id == 1)
-                .values(errors=errors, installed=installed),
+                insert(SQLHMMStatus)
+                .values(
+                    id=HMM_STATUS_ID,
+                    errors=errors,
+                    installed=installed,
+                    release=release,
+                )
+                .on_conflict_do_update(
+                    index_elements=[SQLHMMStatus.id],
+                    set_={"errors": errors, "installed": installed},
+                ),
             )
 
         return release
@@ -121,7 +128,7 @@ async def fetch_and_update_release(
 
         await pg_session.execute(
             insert(SQLHMMStatus)
-            .values(id=1, errors=[], installed=installed, release=release)
+            .values(id=HMM_STATUS_ID, errors=[], installed=installed, release=release)
             .on_conflict_do_update(
                 index_elements=[SQLHMMStatus.id],
                 set_={"errors": [], "installed": installed, "release": release},

--- a/virtool/hmm/sql.py
+++ b/virtool/hmm/sql.py
@@ -4,6 +4,9 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
 
+HMM_STATUS_ID = 1
+"""The fixed primary key of the singleton ``legacy_hmm_status`` row."""
+
 
 class SQLHMMStatus(Base):
     """The singleton row describing the installed HMM data and update state.


### PR DESCRIPTION
## Summary

- Adds a `SQLHMM` ORM model and an Alembic migration (`d28bebf9934b`) that creates the `hmms` Postgres table with columns mirroring the Mongo `hmm` collection.
- Rewrites the HMM install path (`HmmsData.install`) and status operations (`install_update`, `clean_status`, `update_release`, `fetch_and_update_release`) to dual-write annotations and status to both Mongo and Postgres inside `both_transactions`, keeping the two stores in sync with atomic rollback on failure.
- Adds tests covering the dual-write behaviour, including a rollback test that verifies both stores are untouched when a storage write fails mid-install.