### PR TITLE
feat(migration): backfill hmm status singleton to postgres

### DIFF
--- a/assets/revisions/rev_ld2t6tbwulbd_copy_hmm_status_to_postgres.py
+++ b/assets/revisions/rev_ld2t6tbwulbd_copy_hmm_status_to_postgres.py
@@ -1,0 +1,87 @@
+"""copy hmm status to postgres
+
+Revision ID: ld2t6tbwulbd
+Date: 2026-06-05 16:11:15.744084
+
+"""
+
+import arrow
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.hmm.sql import HMM_STATUS_ID, SQLHMMStatus
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy hmm status to postgres"
+created_at = arrow.get("2026-06-05 16:11:15.744084")
+revision_id = "ld2t6tbwulbd"
+
+alembic_down_revision = "d28bebf9934b"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = "d12be6ff40c1"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill the Mongo ``status`` singleton into the Postgres ``legacy_hmm_status`` row.
+
+    There is exactly one source document (``_id: "hmm"``) and exactly one target
+    row (``id = 1``). The stored Mongo shape is mapped straight across, with two
+    exceptions:
+
+    - ``installed`` is polymorphic. ``None`` means nothing is installed; a
+      subdocument is the installed release; the legacy boolean ``True`` means the
+      latest queued update (``updates[0]``) is installed. ``True`` is normalised
+      to ``updates[0]``, failing loudly if ``updates`` is empty since there is
+      then no release the boolean could refer to.
+    - ``updating`` is derived from ``updates`` at read time and is never stored,
+      so it is not written here.
+
+    The insert upserts on the singleton primary key, so the migration tolerates a
+    row already written by the live dual-write and is safe to re-run.
+    """
+    document = await ctx.mongo.status.find_one({"_id": "hmm"})
+
+    if document is None:
+        logger.info("no hmm status singleton to migrate")
+        return
+
+    installed = document.get("installed")
+
+    if installed is True:
+        updates = document.get("updates") or []
+
+        if not updates:
+            msg = "HMM status singleton has installed=True but no updates to resolve"
+            raise ValueError(msg)
+
+        installed = updates[0]
+
+    task = document.get("task")
+
+    values = {
+        "id": HMM_STATUS_ID,
+        "errors": document.get("errors") or [],
+        "release": document.get("release"),
+        "installed": installed,
+        "task_id": task["id"] if task else None,
+        "updates": document.get("updates") or [],
+    }
+
+    async with AsyncSession(ctx.pg) as session:
+        await session.execute(
+            insert(SQLHMMStatus)
+            .values(**values)
+            .on_conflict_do_update(
+                index_elements=[SQLHMMStatus.id],
+                set_={k: v for k, v in values.items() if k != "id"},
+            ),
+        )
+        await session.commit()
+
+    logger.info("hmm status migration complete")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -393,5 +393,12 @@
       'name': 'create hmms table',
       'revision': 'd28bebf9934b',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 57,
+      'name': 'copy hmm status to postgres',
+      'revision': 'ld2t6tbwulbd',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_hmm_status_to_postgres.py
+++ b/tests/migration/test_copy_hmm_status_to_postgres.py
@@ -13,6 +13,7 @@ from assets.revisions.rev_ld2t6tbwulbd_copy_hmm_status_to_postgres import (
     required_alembic_revision,
     upgrade,
 )
+from virtool.hmm.sql import HMM_STATUS_ID
 from virtool.migration.ctx import MigrationContext
 
 
@@ -79,7 +80,7 @@ class TestUpgrade:
                 )
             ).one()
 
-        assert row.id == 1
+        assert row.id == HMM_STATUS_ID
         assert row.errors == ["boom"]
         assert row.release == release
         assert row.installed == installed

--- a/tests/migration/test_copy_hmm_status_to_postgres.py
+++ b/tests/migration/test_copy_hmm_status_to_postgres.py
@@ -1,0 +1,260 @@
+"""Tests for the copy hmm status to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_ld2t6tbwulbd_copy_hmm_status_to_postgres import (
+    required_alembic_revision,
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+def static_datetime() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def apply_table(ctx: MigrationContext, apply_alembic: Callable) -> None:
+    """Create the ``legacy_hmm_status`` table the backfill writes into."""
+    await asyncio.to_thread(apply_alembic, required_alembic_revision)
+
+
+def make_release(release_id: int = 1) -> dict:
+    """Create an HMM release subdocument for testing."""
+    return {
+        "id": release_id,
+        "name": "v1.0",
+        "body": "notes",
+        "filename": "annotations.json.gz",
+        "html_url": "https://example.com/release",
+        "size": 1234,
+        "newer": True,
+    }
+
+
+def make_installed(release_id: int = 1) -> dict:
+    """Create an installed-release subdocument for testing."""
+    return {
+        **make_release(release_id),
+        "ready": True,
+        "user": {"id": "bob"},
+    }
+
+
+class TestUpgrade:
+    @pytest.mark.usefixtures("apply_table")
+    async def test_field_fidelity(self, ctx: MigrationContext):
+        """Scalar and subdocument fields map straight across."""
+        release = make_release()
+        installed = make_installed()
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": ["boom"],
+                "installed": installed,
+                "release": release,
+                "task": None,
+                "updates": [installed],
+            },
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT id, errors, release, installed, task_id, updates "
+                        "FROM legacy_hmm_status WHERE id = 1",
+                    ),
+                )
+            ).one()
+
+        assert row.id == 1
+        assert row.errors == ["boom"]
+        assert row.release == release
+        assert row.installed == installed
+        assert row.task_id is None
+        assert row.updates == [installed]
+
+    @pytest.mark.usefixtures("apply_table")
+    async def test_installed_none(self, ctx: MigrationContext):
+        """A ``None`` installed field is written as NULL."""
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": [],
+                "installed": None,
+                "release": None,
+                "task": None,
+                "updates": [],
+            },
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT installed, release, errors, updates "
+                        "FROM legacy_hmm_status WHERE id = 1",
+                    ),
+                )
+            ).one()
+
+        assert row.installed is None
+        assert row.release is None
+        assert row.errors == []
+        assert row.updates == []
+
+    @pytest.mark.usefixtures("apply_table")
+    async def test_installed_true_resolves_to_first_update(
+        self,
+        ctx: MigrationContext,
+    ):
+        """The legacy boolean ``installed=True`` resolves to ``updates[0]``."""
+        first = make_installed(1)
+        second = make_installed(2)
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": [],
+                "installed": True,
+                "release": make_release(2),
+                "task": None,
+                "updates": [first, second],
+            },
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text("SELECT installed FROM legacy_hmm_status WHERE id = 1"),
+                )
+            ).scalar_one()
+
+        assert stored == first
+
+    @pytest.mark.usefixtures("apply_table")
+    async def test_installed_true_without_updates_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        """``installed=True`` with no updates aborts loudly."""
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": [],
+                "installed": True,
+                "release": None,
+                "task": None,
+                "updates": [],
+            },
+        )
+
+        with pytest.raises(ValueError, match="installed=True but no updates"):
+            await upgrade(ctx)
+
+    @pytest.mark.usefixtures("apply_table")
+    async def test_task_id_mapping(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """A ``task`` reference maps to the ``task_id`` foreign key."""
+        async with AsyncSession(ctx.pg) as session:
+            task_id = (
+                await session.execute(
+                    text(
+                        "INSERT INTO tasks (created_at, type, complete) "
+                        "VALUES (:now, 'install_hmms', false) RETURNING id",
+                    ),
+                    {"now": static_datetime},
+                )
+            ).scalar_one()
+            await session.commit()
+
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": [],
+                "installed": None,
+                "release": None,
+                "task": {"id": task_id},
+                "updates": [],
+            },
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text("SELECT task_id FROM legacy_hmm_status WHERE id = 1"),
+                )
+            ).scalar_one()
+
+        assert stored == task_id
+
+    @pytest.mark.usefixtures("apply_table")
+    async def test_idempotent_rerun_reconciles(self, ctx: MigrationContext):
+        """Re-running upserts the singleton rather than failing or duplicating."""
+        await ctx.mongo.status.insert_one(
+            {
+                "_id": "hmm",
+                "errors": ["stale"],
+                "installed": None,
+                "release": None,
+                "task": None,
+                "updates": [],
+            },
+        )
+
+        await upgrade(ctx)
+
+        await ctx.mongo.status.update_one(
+            {"_id": "hmm"},
+            {"$set": {"errors": ["fresh"]}},
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = (
+                (
+                    await session.execute(
+                        text("SELECT errors FROM legacy_hmm_status"),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert rows == [["fresh"]]
+
+    @pytest.mark.usefixtures("apply_table")
+    async def test_missing_singleton_is_noop(self, ctx: MigrationContext):
+        """An absent status singleton leaves the table empty."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM legacy_hmm_status"),
+                )
+            ).scalar_one()
+
+        assert count == 0


### PR DESCRIPTION
## Summary

- Adds a migration (`ld2t6tbwulbd`) that copies the MongoDB `status` singleton (`_id: "hmm"`) into the `legacy_hmm_status` Postgres table.
- Normalises the legacy `installed=True` boolean (used in older documents) to the first entry in `updates`, raising loudly if `updates` is empty.
- The insert upserts on the singleton primary key so the migration is safe to re-run and tolerates a row already written by the live dual-write path.