### PR TITLE
Allow subtractions to be addressed by integer id or legacy string id

### DIFF
--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -1,17 +1,31 @@
+import pytest
 from multidict import MultiDict, MultiDictProxy
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
-from virtool.subtractions.oas import UpdateSubtractionRequest
+from virtool.subtractions.oas import (
+    FinalizeSubtractionRequest,
+    NucleotideComposition,
+    UpdateSubtractionRequest,
+)
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.uploads.sql import UploadType
 
 
 def _empty_query() -> MultiDictProxy:
     return MultiDictProxy(MultiDict())
+
+
+async def _modern_id(pg: AsyncEngine, legacy_id: str) -> int:
+    """Look up the integer Postgres id for a subtraction's legacy string id."""
+    async with AsyncSession(pg) as session:
+        return await session.scalar(
+            select(SQLSubtraction.id).where(SQLSubtraction.legacy_id == legacy_id),
+        )
 
 
 class TestFind:
@@ -209,3 +223,129 @@ async def test_finalize(
 
     assert row.to_dict() == snapshot_recent(name="pg")
     assert row.legacy_id == subtraction.id
+
+
+class TestAddressByModernId:
+    """Single-subtraction lookups resolve a modern integer id as well as the legacy
+    string id. The response ``id`` field still emits the legacy string.
+    """
+
+    async def test_get(self, data_layer: DataLayer, fake: DataFaker, pg: AsyncEngine):
+        """``get`` accepts the modern integer id and returns the legacy-shaped model."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        by_modern = await data_layer.subtractions.get(
+            await _modern_id(pg, subtraction.id)
+        )
+
+        assert by_modern == subtraction
+        assert by_modern.id == subtraction.id
+
+    async def test_update(
+        self, data_layer: DataLayer, fake: DataFaker, mongo: Mongo, pg: AsyncEngine
+    ):
+        """``update`` by the modern id writes through to Mongo and Postgres."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        updated = await data_layer.subtractions.update(
+            await _modern_id(pg, subtraction.id),
+            UpdateSubtractionRequest(name="Malus domestica", nickname="apple"),
+        )
+
+        assert updated.id == subtraction.id
+        assert updated.name == "Malus domestica"
+
+        mongo_document = await mongo.subtraction.find_one({"_id": subtraction.id})
+        assert mongo_document["name"] == "Malus domestica"
+
+    async def test_delete(
+        self, data_layer: DataLayer, fake: DataFaker, mongo: Mongo, pg: AsyncEngine
+    ):
+        """``delete`` addressed by the modern id soft-deletes in both stores."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        await data_layer.subtractions.delete(await _modern_id(pg, subtraction.id))
+
+        result = await data_layer.subtractions.find(None, False, False, _empty_query())
+        assert subtraction.id not in [d.id for d in result.documents]
+
+        mongo_document = await mongo.subtraction.find_one({"_id": subtraction.id})
+        assert mongo_document["deleted"] is True
+
+        async with AsyncSession(pg) as session:
+            deleted = await session.scalar(
+                select(SQLSubtraction.deleted).where(
+                    SQLSubtraction.legacy_id == subtraction.id,
+                ),
+            )
+        assert deleted is True
+
+    async def test_finalize(
+        self, data_layer: DataLayer, fake: DataFaker, pg: AsyncEngine
+    ):
+        """``finalize`` addressed by the modern id marks the subtraction ready."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(
+            user=user, upload=upload, finalized=False
+        )
+
+        finalized = await data_layer.subtractions.finalize(
+            await _modern_id(pg, subtraction.id),
+            FinalizeSubtractionRequest(
+                count=1,
+                gc=NucleotideComposition(**dict.fromkeys("actgn", 0.2)),
+            ),
+        )
+
+        assert finalized.id == subtraction.id
+        assert finalized.ready is True
+
+    async def test_get_file(
+        self, data_layer: DataLayer, fake: DataFaker, pg: AsyncEngine
+    ):
+        """``get_file`` addressed by the modern id streams the same file."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        _, size = await data_layer.subtractions.get_file(
+            await _modern_id(pg, subtraction.id),
+            "subtraction.1.bt2",
+        )
+
+        _, legacy_size = await data_layer.subtractions.get_file(
+            subtraction.id,
+            "subtraction.1.bt2",
+        )
+
+        assert size == legacy_size
+
+    async def test_missing_modern_id(self, data_layer: DataLayer):
+        """A modern id with no matching row raises ``ResourceNotFoundError``."""
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.subtractions.get(999999)
+
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.subtractions.delete(999999)

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -235,6 +235,36 @@ class SubtractionsData(DataLayerDomain):
 
         return await self.get(new_subtraction_id)
 
+    async def _resolve_ids(self, subtraction_id: int | str) -> tuple[int, str]:
+        """Resolve either id form to the subtraction's ``(id, legacy_id)``.
+
+        Accepts the modern integer id (or its stringified form) or the legacy Mongo
+        slug and returns both identifiers. The integer ``id`` keys the
+        ``SQLSubtraction`` mutations; the legacy slug is still needed for the Mongo
+        dual-write, the string-keyed ``SQLSubtractionFile`` rows, and the storage
+        keys. Mirrors :meth:`virtool.analyses.data.AnalysisData._resolve_ids`.
+
+        :param subtraction_id: a modern integer id or legacy string id
+        :return: the integer id and legacy string id
+        :raises ResourceNotFoundError: if no subtraction matches
+        """
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLSubtraction.id, SQLSubtraction.legacy_id).where(
+                        compose_legacy_id_single_expression(
+                            SQLSubtraction,
+                            subtraction_id,
+                        ),
+                    ),
+                )
+            ).one_or_none()
+
+        if row is None:
+            raise ResourceNotFoundError
+
+        return row.id, row.legacy_id
+
     async def get(self, subtraction_id: int | str) -> Subtraction:
         """Get a subtraction by its id."""
         async with AsyncSession(self._pg) as session:
@@ -278,9 +308,11 @@ class SubtractionsData(DataLayerDomain):
     @emits(Operation.UPDATE)
     async def update(
         self,
-        subtraction_id: str,
+        subtraction_id: int | str,
         data: UpdateSubtractionRequest,
     ) -> Subtraction:
+        modern_id, legacy_id = await self._resolve_ids(subtraction_id)
+
         data = data.dict(exclude_unset=True)
 
         values = {}
@@ -292,36 +324,35 @@ class SubtractionsData(DataLayerDomain):
             values["nickname"] = data["nickname"]
 
         if not values:
-            return await self.get(subtraction_id)
+            return await self.get(modern_id)
 
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,
             pg_session,
         ):
-            document = await self._mongo.subtraction.find_one_and_update(
-                {"_id": subtraction_id},
+            await self._mongo.subtraction.update_one(
+                {"_id": legacy_id},
                 {"$set": values},
                 session=mongo_session,
             )
 
-            if document is None:
-                raise ResourceNotFoundError
-
             await pg_session.execute(
                 update(SQLSubtraction)
-                .where(SQLSubtraction.legacy_id == subtraction_id)
+                .where(SQLSubtraction.id == modern_id)
                 .values(**values),
             )
 
-        return await self.get(subtraction_id)
+        return await self.get(modern_id)
 
-    async def delete(self, subtraction_id: str):
+    async def delete(self, subtraction_id: int | str):
+        modern_id, legacy_id = await self._resolve_ids(subtraction_id)
+
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,
             pg_session,
         ):
             update_result = await self._mongo.subtraction.update_one(
-                {"_id": subtraction_id, "deleted": False},
+                {"_id": legacy_id, "deleted": False},
                 {"$set": {"deleted": True}},
                 session=mongo_session,
             )
@@ -331,22 +362,18 @@ class SubtractionsData(DataLayerDomain):
 
             await pg_session.execute(
                 update(SQLSubtraction)
-                .where(SQLSubtraction.legacy_id == subtraction_id)
+                .where(SQLSubtraction.id == modern_id)
                 .values(deleted=True),
             )
 
-            await unlink_default_subtractions(
-                self._mongo, subtraction_id, mongo_session
-            )
+            await unlink_default_subtractions(self._mongo, legacy_id, mongo_session)
 
-        failures = await delete_prefix(
-            self._storage, subtraction_prefix(subtraction_id)
-        )
+        failures = await delete_prefix(self._storage, subtraction_prefix(legacy_id))
 
         for key, exc in failures:
             logger.error(
                 "storage cleanup failed; file orphaned",
-                subtraction_id=subtraction_id,
+                subtraction_id=legacy_id,
                 key=key,
                 error=repr(exc),
             )
@@ -356,7 +383,7 @@ class SubtractionsData(DataLayerDomain):
     @emits(Operation.UPDATE)
     async def finalize(
         self,
-        subtraction_id: str,
+        subtraction_id: int | str,
         data: FinalizeSubtractionRequest,
     ) -> Subtraction:
         """Finalize a subtraction.
@@ -368,7 +395,9 @@ class SubtractionsData(DataLayerDomain):
         :param data:
         :return: finalized subtraction
         """
-        ready = await get_one_field(self._mongo.subtraction, "ready", subtraction_id)
+        modern_id, legacy_id = await self._resolve_ids(subtraction_id)
+
+        ready = await get_one_field(self._mongo.subtraction, "ready", legacy_id)
 
         if ready:
             raise ResourceConflictError("Subtraction has already been finalized")
@@ -377,26 +406,23 @@ class SubtractionsData(DataLayerDomain):
             mongo_session,
             pg_session,
         ):
-            result = await self._mongo.subtraction.update_one(
-                {"_id": subtraction_id},
+            await self._mongo.subtraction.update_one(
+                {"_id": legacy_id},
                 {"$set": {**data.dict(), "ready": True}},
                 session=mongo_session,
             )
 
-            if result.matched_count == 0:
-                raise ResourceNotFoundError
-
             await pg_session.execute(
                 update(SQLSubtraction)
-                .where(SQLSubtraction.legacy_id == subtraction_id)
+                .where(SQLSubtraction.id == modern_id)
                 .values(**data.dict(), ready=True),
             )
 
-        return await self.get(subtraction_id)
+        return await self.get(modern_id)
 
     async def upload_file(
         self,
-        subtraction_id: str,
+        subtraction_id: int | str,
         filename: str,
         chunker: AsyncGenerator[bytearray],
     ) -> SubtractionFile:
@@ -414,10 +440,7 @@ class SubtractionsData(DataLayerDomain):
         :param chunker: the multipart reader containing the file content
         :return: the subtraction file resource model
         """
-        document = await self._mongo.subtraction.find_one(subtraction_id)
-
-        if document is None:
-            raise ResourceNotFoundError
+        _, subtraction_id = await self._resolve_ids(subtraction_id)
 
         if filename not in FILES:
             raise ResourceNotFoundError("Unsupported subtraction file name")
@@ -461,10 +484,10 @@ class SubtractionsData(DataLayerDomain):
             download_url=f"{self._base_url}/subtractions/{subtraction_id}/files/{filename}",
         )
 
-    async def get_file(self, subtraction_id: str, filename: str):
-        document = await self._mongo.subtraction.find_one(subtraction_id)
+    async def get_file(self, subtraction_id: int | str, filename: str):
+        _, subtraction_id = await self._resolve_ids(subtraction_id)
 
-        if document is None or filename not in FILES:
+        if filename not in FILES:
             raise ResourceNotFoundError
 
         async with AsyncSession(self._pg) as session:


### PR DESCRIPTION
## Summary

- Added `_resolve_ids` to `SubtractionsData` that accepts either the Postgres integer id or the legacy Mongo string id and returns both, raising `ResourceNotFoundError` if neither matches
- Updated `update`, `delete`, `finalize`, `upload_file`, and `get_file` to accept `int | str`, using the integer id for Postgres mutations and the legacy string for Mongo dual-writes and storage keys
- The `get` method already supported `int | str` via the existing `compose_legacy_id_single_expression` helper; the other mutating methods now use the same pattern through `_resolve_ids`