### PR TITLE
Harden upload reservation during sample creation

### DIFF
--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -148,6 +148,69 @@ class TestCreate:
         )
 
         assert sample == snapshot_recent(name="mongo")
+        assert upload.reserved is True
+
+    async def test_already_reserved(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """A reserved file cannot be used to create a sample."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        upload = await fake.uploads.create(
+            user=await fake.users.create(),
+            reserved=True,
+        )
+
+        with pytest.raises(ResourceConflictError, match=r"File is already reserved"):
+            await data_layer.samples.create(
+                CreateSampleRequest(files=[upload.id], name="Foobar"),
+                client.user.id,
+                0,
+            )
+
+        assert await mongo.samples.find_one() is None
+
+    async def test_reservation_rolled_back_on_failure(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """A failed sample insert leaves no reserved upload and no sample behind."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        upload = await fake.uploads.create(user=await fake.users.create())
+
+        mocker.patch.object(
+            mongo.samples,
+            "insert_one",
+            side_effect=RuntimeError("boom"),
+        )
+
+        with pytest.raises(RuntimeError, match=r"boom"):
+            await data_layer.samples.create(
+                CreateSampleRequest(files=[upload.id], name="Foobar"),
+                client.user.id,
+                0,
+            )
+
+        row = await get_row_by_id(pg, SQLUpload, upload.id)
+        assert row.reserved is False
+        assert await mongo.samples.find_one() is None
 
 
 async def test_finalize(

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -168,7 +168,10 @@ class TestReserve:
         free = await fake.uploads.create(user=user)
         reserved = await fake.uploads.create(user=user, reserved=True)
 
-        with pytest.raises(ResourceConflictError):
+        with pytest.raises(
+            ResourceConflictError,
+            match=r"One or more files are already reserved",
+        ):
             async with AsyncSession(pg) as session:
                 await data_layer.uploads.reserve([free.id, reserved.id], session)
                 await session.commit()
@@ -184,7 +187,10 @@ class TestReserve:
         user = await fake.users.create()
         free = await fake.uploads.create(user=user)
 
-        with pytest.raises(ResourceConflictError):
+        with pytest.raises(
+            ResourceConflictError,
+            match=r"One or more files do not exist",
+        ):
             async with AsyncSession(pg) as session:
                 await data_layer.uploads.reserve([free.id, 999999], session)
                 await session.commit()

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.pg.utils import get_row_by_id
@@ -115,3 +115,78 @@ async def test_release(
         reserved = [u.reserved for u in result.unique().scalars().all()]
 
     assert reserved == [False, True, False] if multi else [True, False, True]
+
+
+async def _reserved_states(pg: AsyncEngine) -> list[bool]:
+    async with AsyncSession(pg) as session:
+        result = await session.execute(select(SQLUpload).order_by(SQLUpload.id))
+        return [u.reserved for u in result.unique().scalars().all()]
+
+
+class TestReserve:
+    async def test_single(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        user = await fake.users.create()
+        upload = await fake.uploads.create(user=user)
+
+        async with AsyncSession(pg) as session:
+            await data_layer.uploads.reserve(upload.id, session)
+            await session.commit()
+
+        assert await _reserved_states(pg) == [True]
+
+    async def test_multiple(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        user = await fake.users.create()
+        first = await fake.uploads.create(user=user)
+        second = await fake.uploads.create(user=user)
+        untouched = await fake.uploads.create(user=user)
+
+        async with AsyncSession(pg) as session:
+            await data_layer.uploads.reserve([first.id, second.id], session)
+            await session.commit()
+
+        assert await _reserved_states(pg) == [True, True, False]
+        assert untouched.id
+
+    async def test_already_reserved(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A conflict is raised and no upload is reserved when one is already taken."""
+        user = await fake.users.create()
+        free = await fake.uploads.create(user=user)
+        reserved = await fake.uploads.create(user=user, reserved=True)
+
+        with pytest.raises(ResourceConflictError):
+            async with AsyncSession(pg) as session:
+                await data_layer.uploads.reserve([free.id, reserved.id], session)
+                await session.commit()
+
+        assert await _reserved_states(pg) == [False, True]
+
+    async def test_missing(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        user = await fake.users.create()
+        free = await fake.uploads.create(user=user)
+
+        with pytest.raises(ResourceConflictError):
+            async with AsyncSession(pg) as session:
+                await data_layer.uploads.reserve([free.id, 999999], session)
+                await session.commit()
+
+        assert await _reserved_states(pg) == [False]

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -472,7 +472,9 @@ class UploadsFakerDomain(DataFakerDomain):
         )
 
         if reserved:
-            await self._layer.uploads.reserve(upload.id)
+            async with AsyncSession(self._pg) as session:
+                await self._layer.uploads.reserve(upload.id, session)
+                await session.commit()
 
         return await self._layer.uploads.get(upload.id)
 

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -1,6 +1,5 @@
 """The sample data layer domain."""
 
-import asyncio
 import math
 from asyncio import CancelledError, gather
 from collections.abc import AsyncGenerator, AsyncIterator
@@ -295,6 +294,9 @@ class SamplesData(DataLayerDomain):
         except ResourceNotFoundError:
             raise ResourceConflictError("File does not exist")
 
+        if any(upload["reserved"] for upload in uploads):
+            raise ResourceConflictError("File is already reserved")
+
         group = None
 
         # Require a valid ``group`` field if the ``sample_group`` setting is
@@ -321,8 +323,15 @@ class SamplesData(DataLayerDomain):
             if user is not None and user.primary_group is not None:
                 group = user.primary_group.id
 
-        async with self._mongo.create_session() as session:
-            sample_id = _id or await get_new_id(self._mongo.samples, session=session)
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            sample_id = _id or await get_new_id(
+                self._mongo.samples, session=mongo_session
+            )
+
+            await self.data.uploads.reserve(data.files, pg_session)
 
             job = await self.data.jobs.create(
                 "create_sample",
@@ -330,42 +339,39 @@ class SamplesData(DataLayerDomain):
                 user_id,
             )
 
-            document, _ = await asyncio.gather(
-                self._mongo.samples.insert_one(
-                    {
-                        "_id": sample_id,
-                        "all_read": settings.sample_all_read,
-                        "all_write": settings.sample_all_write,
-                        "created_at": virtool.utils.timestamp(),
-                        "format": "fastq",
-                        "group": group,
-                        "group_read": settings.sample_group_read,
-                        "group_write": settings.sample_group_write,
-                        "hold": True,
-                        "host": data.host,
-                        "is_legacy": False,
-                        "isolate": data.isolate,
-                        "job": {"id": job.id},
-                        "labels": data.labels,
-                        "library_type": data.library_type,
-                        "locale": data.locale,
-                        "name": data.name,
-                        "notes": data.notes,
-                        "nuvs": False,
-                        "paired": len(uploads) == 2,
-                        "pathoscope": False,
-                        "quality": None,
-                        "ready": False,
-                        "results": None,
-                        "space": {"id": space_id},
-                        "subtractions": data.subtractions,
-                        "uploads": [{"id": upload["id"]} for upload in uploads],
-                        "user": {"id": user_id},
-                        "workflows": define_initial_workflows(data.library_type),
-                    },
-                    session=session,
-                ),
-                self.data.uploads.reserve(data.files),
+            document = await self._mongo.samples.insert_one(
+                {
+                    "_id": sample_id,
+                    "all_read": settings.sample_all_read,
+                    "all_write": settings.sample_all_write,
+                    "created_at": virtool.utils.timestamp(),
+                    "format": "fastq",
+                    "group": group,
+                    "group_read": settings.sample_group_read,
+                    "group_write": settings.sample_group_write,
+                    "hold": True,
+                    "host": data.host,
+                    "is_legacy": False,
+                    "isolate": data.isolate,
+                    "job": {"id": job.id},
+                    "labels": data.labels,
+                    "library_type": data.library_type,
+                    "locale": data.locale,
+                    "name": data.name,
+                    "notes": data.notes,
+                    "nuvs": False,
+                    "paired": len(uploads) == 2,
+                    "pathoscope": False,
+                    "quality": None,
+                    "ready": False,
+                    "results": None,
+                    "space": {"id": space_id},
+                    "subtractions": data.subtractions,
+                    "uploads": [{"id": upload["id"]} for upload in uploads],
+                    "user": {"id": user_id},
+                    "workflows": define_initial_workflows(data.library_type),
+                },
+                session=mongo_session,
             )
 
         return await self.get(document["_id"])

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -280,13 +280,12 @@ class UploadsData(DataLayerDomain):
         """Reserve the uploads in `upload_ids` within the given session.
 
         The `reserved` field is set to `True`, preventing the uploads from being used
-        for sample creation. Only uploads that are not already reserved are updated.
+        for sample creation.
 
-        The reservation participates in the caller's transaction: it is the caller's
-        responsibility to commit ``session``.
-
-        If any requested upload is missing or already reserved, no upload is reserved
-        and a :class:`ResourceConflictError` is raised.
+        The requested uploads are validated before any are reserved: if any upload is
+        missing or already reserved, a :class:`ResourceConflictError` is raised and no
+        upload is reserved. The reservation participates in the caller's transaction;
+        it is the caller's responsibility to commit ``session``.
 
         :param upload_ids: an upload id or list of upload ids
         :param session: the PostgreSQL session to reserve within
@@ -294,6 +293,20 @@ class UploadsData(DataLayerDomain):
         """
         ids = {upload_ids} if isinstance(upload_ids, int) else set(upload_ids)
 
+        existing = (
+            await session.execute(
+                select(SQLUpload.id, SQLUpload.reserved).where(SQLUpload.id.in_(ids)),
+            )
+        ).all()
+
+        if ids - {row.id for row in existing}:
+            raise ResourceConflictError("One or more files do not exist")
+
+        if any(row.reserved for row in existing):
+            raise ResourceConflictError("One or more files are already reserved")
+
+        # The conditional update and row-count check guard against a concurrent
+        # request reserving one of these uploads between the check above and here.
         result = await session.execute(
             update(SQLUpload)
             .where(

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
 from virtool.data.domain import DataLayerDomain
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emits
 from virtool.data.transforms import apply_transforms
 from virtool.storage.protocol import StorageBackend
@@ -272,24 +272,37 @@ class UploadsData(DataLayerDomain):
 
             await session.commit()
 
-    async def reserve(self, upload_ids: int | list[int]) -> None:
-        """Reserve the uploads in `upload_ids`.
+    async def reserve(
+        self,
+        upload_ids: int | list[int],
+        session: AsyncSession,
+    ) -> None:
+        """Reserve the uploads in `upload_ids` within the given session.
 
         The `reserved` field is set to `True`, preventing the uploads from being used
-        for sample creation.
+        for sample creation. Only uploads that are not already reserved are updated.
 
-        :param upload_ids: List of upload ids
+        The reservation participates in the caller's transaction: it is the caller's
+        responsibility to commit ``session``.
+
+        If any requested upload is missing or already reserved, no upload is reserved
+        and a :class:`ResourceConflictError` is raised.
+
+        :param upload_ids: an upload id or list of upload ids
+        :param session: the PostgreSQL session to reserve within
+        :raises ResourceConflictError: if any upload is missing or already reserved
         """
-        if isinstance(upload_ids, int):
-            query = SQLUpload.id == upload_ids
-        else:
-            query = SQLUpload.id.in_(upload_ids)
+        ids = {upload_ids} if isinstance(upload_ids, int) else set(upload_ids)
 
-        async with AsyncSession(self._pg) as session:
-            await session.execute(
-                update(SQLUpload)
-                .where(query)
-                .values(reserved=True)
-                .execution_options(synchronize_session="fetch"),
+        result = await session.execute(
+            update(SQLUpload)
+            .where(
+                SQLUpload.id.in_(ids),
+                SQLUpload.reserved == False,  # skipcq: PTC-W0068,PYL-R1714
             )
-            await session.commit()
+            .values(reserved=True)
+            .execution_options(synchronize_session=False),
+        )
+
+        if result.rowcount != len(ids):
+            raise ResourceConflictError("One or more files are already reserved")


### PR DESCRIPTION
## Summary

- The `reserve` method now accepts an `AsyncSession` so the reservation participates in the caller's transaction, making it atomic with the sample insert
- A `ResourceConflictError` is raised if any requested upload is already reserved or missing; an early pre-check surfaces this before the transaction begins
- If the sample insert fails for any reason, the upload reservation is rolled back automatically, preventing orphaned reservations