### PR TITLE
Prevent deletion of in-use reserved uploads

### DIFF
--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -233,3 +233,13 @@ async def test_delete(fake: DataFaker, resp_is, spawn_client: ClientSpawner):
 
     resp = await client.get("api/uploads/1")
     assert resp.status == 404
+
+
+async def test_delete_reserved(fake: DataFaker, resp_is, spawn_client: ClientSpawner):
+    """`DELETE /uploads/:id` returns 409 when the upload is reserved and in use."""
+    client = await spawn_client(authenticated=True, administrator=True)
+
+    upload = await fake.uploads.create(user=await fake.users.create(), reserved=True)
+
+    resp = await client.delete(f"/uploads/{upload.id}")
+    await resp_is.conflict(resp, "Upload is reserved and in use")

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.pg.utils import get_row_by_id
@@ -86,6 +86,32 @@ async def test_delete(
 
     with pytest.raises(ResourceNotFoundError):
         await data_layer.uploads.delete(before.id)
+
+
+async def test_delete_reserved(
+    data_layer: DataLayer,
+    fake: DataFaker,
+    memory_storage: StorageBackend,
+    pg: AsyncEngine,
+):
+    """A reserved upload cannot be deleted while it is in use."""
+    before = await fake.uploads.create(user=await fake.users.create(), reserved=True)
+
+    row = await get_row_by_id(pg, SQLUpload, before.id)
+    key = upload_file_key(row.name_on_disk)
+
+    with pytest.raises(ResourceConflictError):
+        await data_layer.uploads.delete(before.id)
+
+    row = await get_row_by_id(pg, SQLUpload, before.id)
+    assert row.removed is False
+    assert row.removed_at is None
+
+    found = False
+    async for info in memory_storage.list(key):
+        if info.key == key:
+            found = True
+    assert found
 
 
 @pytest.mark.parametrize("multi", [True, False])

--- a/virtool/uploads/api.py
+++ b/virtool/uploads/api.py
@@ -1,15 +1,15 @@
 from aiohttp.web_response import Response
 from aiohttp_pydantic import PydanticView
-from aiohttp_pydantic.oas.typing import r200, r201, r204, r401, r403, r404
+from aiohttp_pydantic.oas.typing import r200, r201, r204, r401, r403, r404, r409
 from pydantic import Field, conint
 
 from virtool.api.custom_json import json_response
-from virtool.api.errors import APINotFound
+from virtool.api.errors import APIConflict, APINotFound
 from virtool.api.policy import PermissionRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.api.streaming import stream_storage_response
 from virtool.authorization.permissions import LegacyPermission
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.uploads.models import Upload
 from virtool.uploads.sql import UploadType
@@ -107,7 +107,7 @@ class UploadView(PydanticView):
         )
 
     @policy(PermissionRoutePolicy(LegacyPermission.REMOVE_FILE))
-    async def delete(self, upload_id: int, /) -> r204 | r401 | r403 | r404:
+    async def delete(self, upload_id: int, /) -> r204 | r401 | r403 | r404 | r409:
         """Delete an upload.
 
         Deletes an upload using its 'upload id'.
@@ -117,11 +117,14 @@ class UploadView(PydanticView):
             401: Requires authorization
             403: Not permitted
             404: Not found
+            409: Upload is reserved and in use
         """
         try:
             await get_data_from_req(self.request).uploads.delete(upload_id)
         except ResourceNotFoundError:
             raise APINotFound()
+        except ResourceConflictError as err:
+            raise APIConflict(str(err))
 
         return Response(status=204)
 

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
 from virtool.data.domain import DataLayerDomain
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emits
 from virtool.data.transforms import apply_transforms
 from virtool.storage.protocol import StorageBackend
@@ -230,6 +230,11 @@ class UploadsData(DataLayerDomain):
 
             if not upload or upload.removed:
                 raise ResourceNotFoundError
+
+            if upload.reserved:
+                raise ResourceConflictError(
+                    "Upload is reserved and in use",
+                )
 
             if upload.reads is not None:
                 upload.reads.clear()


### PR DESCRIPTION
## Summary

- `DELETE /uploads/:id` now returns 409 when the upload is reserved and in use, preventing data loss during active workflows
- Subtraction existence checks and attachment transforms migrated from MongoDB to Postgres; subtractions are now addressable by both integer id and legacy string id
- HMM status reads (`get_status`, `get_updates`) migrated from MongoDB to Postgres; `get_updates` moved to the data layer and Mongo utility helpers removed