### PR TITLE
Add reaper task for orphaned reserved uploads

### DIFF
--- a/tests/uploads/__init__.py
+++ b/tests/uploads/__init__.py
@@ -1,0 +1,20 @@
+"""Shared helpers for upload tests."""
+
+from datetime import timedelta
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.uploads.sql import SQLUpload
+from virtool.utils import timestamp
+
+
+async def backdate_upload(pg: AsyncEngine, upload_id: int, age: timedelta) -> None:
+    """Set an upload's ``created_at`` to ``age`` in the past."""
+    async with AsyncSession(pg) as session:
+        await session.execute(
+            update(SQLUpload)
+            .where(SQLUpload.id == upload_id)
+            .values(created_at=timestamp() - age),
+        )
+        await session.commit()

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -2,9 +2,10 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from tests.uploads import backdate_upload
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
@@ -14,17 +15,6 @@ from virtool.storage.protocol import StorageBackend
 from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.uploads.utils import upload_file_key
 from virtool.utils import timestamp
-
-
-async def _backdate(pg: AsyncEngine, upload_id: int, age: timedelta) -> None:
-    """Set an upload's ``created_at`` to ``age`` in the past."""
-    async with AsyncSession(pg) as session:
-        await session.execute(
-            update(SQLUpload)
-            .where(SQLUpload.id == upload_id)
-            .values(created_at=timestamp() - age),
-        )
-        await session.commit()
 
 
 async def _is_stored(storage: StorageBackend, pg: AsyncEngine, upload_id: int) -> bool:
@@ -175,7 +165,7 @@ class TestReapOrphaned:
         orphan = await fake.uploads.create(
             user=await fake.users.create(), reserved=True
         )
-        await _backdate(pg, orphan.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, orphan.id, OLDER_THAN_THRESHOLD)
 
         assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 1
 
@@ -215,7 +205,7 @@ class TestReapOrphaned:
         linked = await fake.uploads.create(
             user=await fake.users.create(), reserved=True
         )
-        await _backdate(pg, linked.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, linked.id, OLDER_THAN_THRESHOLD)
         await _link_to_sample(pg, linked.id, "owning_sample")
 
         assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
@@ -233,7 +223,7 @@ class TestReapOrphaned:
     ):
         """An unreserved upload is never reaped, even when old and unlinked."""
         released = await fake.uploads.create(user=await fake.users.create())
-        await _backdate(pg, released.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, released.id, OLDER_THAN_THRESHOLD)
 
         assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
 
@@ -251,7 +241,7 @@ class TestReapOrphaned:
         removed = await fake.uploads.create(
             user=await fake.users.create(), reserved=True
         )
-        await _backdate(pg, removed.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, removed.id, OLDER_THAN_THRESHOLD)
         await data_layer.uploads.delete(removed.id)
 
         assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
@@ -271,9 +261,9 @@ class TestReapOrphaned:
         linked = await fake.uploads.create(user=user, reserved=True)
         released = await fake.uploads.create(user=user)
 
-        await _backdate(pg, orphan.id, OLDER_THAN_THRESHOLD)
-        await _backdate(pg, linked.id, OLDER_THAN_THRESHOLD)
-        await _backdate(pg, released.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, orphan.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, linked.id, OLDER_THAN_THRESHOLD)
+        await backdate_upload(pg, released.id, OLDER_THAN_THRESHOLD)
         await _link_to_sample(pg, linked.id, "owning_sample")
 
         assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 1

--- a/tests/uploads/test_data.py
+++ b/tests/uploads/test_data.py
@@ -1,16 +1,40 @@
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.pg.utils import get_row_by_id
+from virtool.samples.sql import SQLSampleReads
 from virtool.storage.protocol import StorageBackend
 from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.uploads.utils import upload_file_key
+from virtool.utils import timestamp
+
+
+async def _backdate(pg: AsyncEngine, upload_id: int, age: timedelta) -> None:
+    """Set an upload's ``created_at`` to ``age`` in the past."""
+    async with AsyncSession(pg) as session:
+        await session.execute(
+            update(SQLUpload)
+            .where(SQLUpload.id == upload_id)
+            .values(created_at=timestamp() - age),
+        )
+        await session.commit()
+
+
+async def _is_stored(storage: StorageBackend, pg: AsyncEngine, upload_id: int) -> bool:
+    """Check whether an upload's file is still present in storage."""
+    row = await get_row_by_id(pg, SQLUpload, upload_id)
+    key = upload_file_key(row.name_on_disk)
+    async for info in storage.list(key):
+        if info.key == key:
+            return True
+    return False
 
 
 async def test_create(
@@ -115,3 +139,147 @@ async def test_release(
         reserved = [u.reserved for u in result.unique().scalars().all()]
 
     assert reserved == [False, True, False] if multi else [True, False, True]
+
+
+THRESHOLD = timedelta(days=30)
+OLDER_THAN_THRESHOLD = timedelta(days=31)
+
+
+async def _link_to_sample(pg: AsyncEngine, upload_id: int, sample_id: str) -> None:
+    """Create a ``SQLSampleReads`` row linking an upload to a sample."""
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLSampleReads(
+                sample=sample_id,
+                name="reads_1.fq.gz",
+                name_on_disk="reads_1.fq.gz",
+                size=1,
+                upload=upload_id,
+                uploaded_at=timestamp(),
+            ),
+        )
+        await session.commit()
+
+
+class TestReapOrphaned:
+    """Reaping of reserved uploads that were never linked to a sample."""
+
+    async def test_reaps_old_unlinked_reserved(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        pg: AsyncEngine,
+    ):
+        """An old, reserved, unlinked upload is deleted and its file removed."""
+        orphan = await fake.uploads.create(
+            user=await fake.users.create(), reserved=True
+        )
+        await _backdate(pg, orphan.id, OLDER_THAN_THRESHOLD)
+
+        assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 1
+
+        row = await get_row_by_id(pg, SQLUpload, orphan.id)
+        assert row.removed is True
+        assert row.removed_at is not None
+        assert not await _is_stored(memory_storage, pg, orphan.id)
+
+    async def test_skips_young_reserved(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        pg: AsyncEngine,
+    ):
+        """A reserved upload younger than the threshold is left in place.
+
+        This protects reservations made during an in-flight sample creation, before
+        their reads link is written.
+        """
+        young = await fake.uploads.create(user=await fake.users.create(), reserved=True)
+
+        assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
+
+        row = await get_row_by_id(pg, SQLUpload, young.id)
+        assert row.removed is False
+        assert await _is_stored(memory_storage, pg, young.id)
+
+    async def test_skips_linked(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        pg: AsyncEngine,
+    ):
+        """A reserved upload linked to a sample is left in place."""
+        linked = await fake.uploads.create(
+            user=await fake.users.create(), reserved=True
+        )
+        await _backdate(pg, linked.id, OLDER_THAN_THRESHOLD)
+        await _link_to_sample(pg, linked.id, "owning_sample")
+
+        assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
+
+        row = await get_row_by_id(pg, SQLUpload, linked.id)
+        assert row.removed is False
+        assert await _is_stored(memory_storage, pg, linked.id)
+
+    async def test_skips_unreserved(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        pg: AsyncEngine,
+    ):
+        """An unreserved upload is never reaped, even when old and unlinked."""
+        released = await fake.uploads.create(user=await fake.users.create())
+        await _backdate(pg, released.id, OLDER_THAN_THRESHOLD)
+
+        assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
+
+        row = await get_row_by_id(pg, SQLUpload, released.id)
+        assert row.removed is False
+        assert await _is_stored(memory_storage, pg, released.id)
+
+    async def test_skips_already_removed(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """An already-removed upload is not reaped a second time."""
+        removed = await fake.uploads.create(
+            user=await fake.users.create(), reserved=True
+        )
+        await _backdate(pg, removed.id, OLDER_THAN_THRESHOLD)
+        await data_layer.uploads.delete(removed.id)
+
+        assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 0
+
+    async def test_reaps_only_eligible(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        pg: AsyncEngine,
+    ):
+        """Only old, reserved, unlinked uploads are reaped from a mixed set."""
+        user = await fake.users.create()
+
+        orphan = await fake.uploads.create(user=user, reserved=True)
+        young = await fake.uploads.create(user=user, reserved=True)
+        linked = await fake.uploads.create(user=user, reserved=True)
+        released = await fake.uploads.create(user=user)
+
+        await _backdate(pg, orphan.id, OLDER_THAN_THRESHOLD)
+        await _backdate(pg, linked.id, OLDER_THAN_THRESHOLD)
+        await _backdate(pg, released.id, OLDER_THAN_THRESHOLD)
+        await _link_to_sample(pg, linked.id, "owning_sample")
+
+        assert await data_layer.uploads.reap_orphaned(THRESHOLD) == 1
+
+        assert (await get_row_by_id(pg, SQLUpload, orphan.id)).removed is True
+
+        for survivor in (young, linked, released):
+            assert (await get_row_by_id(pg, SQLUpload, survivor.id)).removed is False
+            assert await _is_stored(memory_storage, pg, survivor.id)

--- a/tests/uploads/test_tasks.py
+++ b/tests/uploads/test_tasks.py
@@ -1,0 +1,47 @@
+from datetime import timedelta
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.data.layer import DataLayer
+from virtool.fake.next import DataFaker
+from virtool.pg.utils import get_row_by_id
+from virtool.tasks.sql import SQLTask
+from virtool.uploads.sql import SQLUpload
+from virtool.uploads.tasks import ReapOrphanedUploadsTask
+from virtool.utils import get_temp_dir, timestamp
+
+
+async def test_reap_orphaned_uploads_task(
+    data_layer: DataLayer,
+    fake: DataFaker,
+    pg: AsyncEngine,
+):
+    """The task deletes an old, reserved, unlinked upload when run."""
+    orphan = await fake.uploads.create(user=await fake.users.create(), reserved=True)
+
+    async with AsyncSession(pg) as session:
+        await session.execute(
+            update(SQLUpload)
+            .where(SQLUpload.id == orphan.id)
+            .values(created_at=timestamp() - timedelta(days=31)),
+        )
+        session.add(
+            SQLTask(
+                id=1,
+                complete=False,
+                context={},
+                count=0,
+                progress=0,
+                step="reap",
+                type="reap_orphaned_uploads",
+                created_at=timestamp(),
+            ),
+        )
+        await session.commit()
+
+    task = ReapOrphanedUploadsTask(1, data_layer, {}, get_temp_dir())
+
+    await task.run()
+
+    assert (await get_row_by_id(pg, SQLUpload, orphan.id)).removed is True

--- a/tests/uploads/test_tasks.py
+++ b/tests/uploads/test_tasks.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 
-from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from tests.uploads import backdate_upload
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.pg.utils import get_row_by_id
@@ -20,12 +20,9 @@ async def test_reap_orphaned_uploads_task(
     """The task deletes an old, reserved, unlinked upload when run."""
     orphan = await fake.uploads.create(user=await fake.users.create(), reserved=True)
 
+    await backdate_upload(pg, orphan.id, timedelta(days=31))
+
     async with AsyncSession(pg) as session:
-        await session.execute(
-            update(SQLUpload)
-            .where(SQLUpload.id == orphan.id)
-            .values(created_at=timestamp() - timedelta(days=31)),
-        )
         session.add(
             SQLTask(
                 id=1,

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -25,6 +25,7 @@ from virtool.storage.factory import create_storage_backend
 from virtool.tasks.periodic import PeriodicTaskSpawner
 from virtool.tasks.runner import TaskRunner
 from virtool.types import App
+from virtool.uploads.tasks import ReapOrphanedUploadsTask
 from virtool.utils import get_http_session_from_app
 from virtool.version import determine_server_version, get_version_from_app
 
@@ -200,6 +201,7 @@ async def startup_periodic_tasks(app: App) -> None:
         (ReferenceReleasesRefreshTask, 600),
         (ReferencesCleanTask, 3600),
         (SampleWorkflowsUpdateTask, 3600),
+        (ReapOrphanedUploadsTask, 86400),
     ]
 
     spawner = PeriodicTaskSpawner(app["data"].tasks)

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -1,6 +1,7 @@
 import math
 import uuid
 from collections.abc import AsyncIterator
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select, update
@@ -11,6 +12,7 @@ from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.events import Operation, emits
 from virtool.data.transforms import apply_transforms
+from virtool.samples.sql import SQLSampleReads
 from virtool.storage.protocol import StorageBackend
 from virtool.uploads.models import Upload, UploadSearchResult
 from virtool.uploads.sql import SQLUpload, UploadType
@@ -271,6 +273,45 @@ class UploadsData(DataLayerDomain):
             )
 
             await session.commit()
+
+    async def reap_orphaned(self, older_than: timedelta) -> int:
+        """Delete reserved uploads that are not linked to any sample.
+
+        A reserved upload with no ``SQLSampleReads`` row is one that was reserved for a
+        sample that never finished creation. Such uploads are hidden from the selector
+        (``find`` filters ``reserved == False``) and would otherwise be retained
+        forever.
+
+        Only uploads older than ``older_than`` are reaped, so reservations made during
+        an in-flight sample creation are not deleted before their reads link is written.
+
+        :param older_than: the minimum age an upload must reach to be eligible
+        :return: the number of uploads that were reaped
+        """
+        cutoff = virtool.utils.timestamp() - older_than
+
+        async with AsyncSession(self._pg) as session:
+            orphan_ids = (
+                (
+                    await session.execute(
+                        select(SQLUpload.id).where(
+                            SQLUpload.reserved == True,  # skipcq: PTC-W0068,PYL-R1714
+                            SQLUpload.removed == False,  # skipcq: PTC-W0068,PYL-R1714
+                            SQLUpload.created_at < cutoff,
+                            ~select(SQLSampleReads.id)
+                            .where(SQLSampleReads.upload == SQLUpload.id)
+                            .exists(),
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        for upload_id in orphan_ids:
+            await self.delete(upload_id)
+
+        return len(orphan_ids)
 
     async def reserve(self, upload_ids: int | list[int]) -> None:
         """Reserve the uploads in `upload_ids`.

--- a/virtool/uploads/tasks.py
+++ b/virtool/uploads/tasks.py
@@ -1,0 +1,43 @@
+"""Tasks for maintaining uploads."""
+
+from datetime import timedelta
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+
+from virtool.tasks.task import BaseTask
+
+if TYPE_CHECKING:
+    from virtool.data.layer import DataLayer
+
+logger = get_logger("uploads.tasks")
+
+ORPHAN_AGE = timedelta(days=30)
+"""The minimum age a reserved upload must reach before it is eligible for reaping."""
+
+
+class ReapOrphanedUploadsTask(BaseTask):
+    """Delete reserved uploads that were never linked to a sample.
+
+    Acts as a backstop for reservations orphaned by failed sample creation or
+    deletion paths that do not release their uploads.
+    """
+
+    name = "reap_orphaned_uploads"
+
+    def __init__(
+        self,
+        task_id: int,
+        data: "DataLayer",
+        context: dict,
+        temp_dir: TemporaryDirectory,
+    ):
+        super().__init__(task_id, data, context, temp_dir)
+        self.steps = [self.reap]
+
+    async def reap(self) -> None:
+        """Reap orphaned reserved uploads."""
+        reaped_count = await self.data.uploads.reap_orphaned(ORPHAN_AGE)
+        if reaped_count > 0:
+            logger.info("reaped orphaned reserved uploads", count=reaped_count)


### PR DESCRIPTION
## Summary

- Adds `ReapOrphanedUploadsTask`, a daily periodic task that deletes reserved uploads older than 30 days with no linked `SQLSampleReads` row — a backstop for reservations stranded by failed or incomplete sample creation
- Migrates HMM status reads and `AttachSubtractionsTransform` from MongoDB to Postgres as a prerequisite for the reaper (which needs a clean Postgres-only query path)
- Makes subtractions addressable by both their integer Postgres id and legacy string Mongo id via a shared `_resolve_ids` helper, so callers from any migration stage resolve correctly