### PR TITLE
fix: repair null subtraction upload_ids and migrate reads to postgres

### DIFF
--- a/assets/revisions/rev_n2adlt6ch803_repair_null_subtraction_upload_ids.py
+++ b/assets/revisions/rev_n2adlt6ch803_repair_null_subtraction_upload_ids.py
@@ -1,0 +1,42 @@
+"""Repair subtractions left with a null upload_id by the original backfill.
+
+The Mongo-to-Postgres subtraction backfill wrote ``upload_id = NULL`` whenever a
+subtraction's source upload had been deleted. The read path rebuilds the required
+``file`` field from the joined upload, so those rows raised a validation error
+when listed (VIR-2478).
+
+This revision rebuilds a ``removed`` stand-in upload from the Mongo ``file``
+snapshot for every non-deleted subtraction still carrying a null ``upload_id``
+and links it, restoring the always-present subtraction-to-upload relation. It is
+idempotent: only null ``upload_id`` rows are touched.
+
+Revision ID: n2adlt6ch803
+Date: 2026-06-05 18:49:21.970400
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.subtractions.migration import repair_null_subtraction_uploads
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "repair null subtraction upload ids"
+created_at = arrow.get("2026-06-05 18:49:21.970400")
+revision_id = "n2adlt6ch803"
+
+alembic_down_revision = None
+virtool_down_revision = "ld2t6tbwulbd"
+
+# ``895d6315a838`` adds ``subtraction_files.subtraction_id`` and depends on
+# ``f4624eb353b7`` (create subtractions table). Requiring it guarantees the
+# subtractions, subtraction_files, and uploads tables all exist before this runs.
+required_alembic_revision = "895d6315a838"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Reconstruct removed uploads for subtractions with a null upload_id."""
+    await repair_null_subtraction_uploads(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -400,5 +400,12 @@
       'name': 'copy hmm status to postgres',
       'revision': 'ld2t6tbwulbd',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 58,
+      'name': 'repair null subtraction upload ids',
+      'revision': 'n2adlt6ch803',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_subtractions_to_postgres.py
+++ b/tests/migration/test_copy_subtractions_to_postgres.py
@@ -82,6 +82,39 @@ async def insert_upload(
     return upload_id
 
 
+async def insert_unknown_user(session: AsyncSession) -> int:
+    """Insert the login-disabled ``unknown`` sentinel user and return its id."""
+    result = await session.execute(
+        text("""
+            INSERT INTO users (
+                handle, legacy_id, active, email, force_reset,
+                invalidate_sessions, last_password_change, password, settings
+            )
+            VALUES (
+                'unknown', NULL, false, '', false,
+                false, :now, :password, '{}'::jsonb
+            )
+            RETURNING id
+        """),
+        {"now": timestamp(), "password": b"unusable"},
+    )
+    user_id = result.scalar_one()
+    await session.commit()
+    return user_id
+
+
+async def insert_fasta_file(session: AsyncSession, subtraction_id: str, size: int):
+    """Insert a FASTA subtraction_files row used as the reconstructed upload size."""
+    await session.execute(
+        text("""
+            INSERT INTO subtraction_files (name, subtraction, type, size)
+            VALUES ('subtraction.fa.gz', :subtraction, 'fasta', :size)
+        """),
+        {"subtraction": subtraction_id, "size": size},
+    )
+    await session.commit()
+
+
 def make_subtraction_document(
     subtraction_id: str,
     user_id: int | str,
@@ -124,6 +157,9 @@ class TestUpgrade:
         static_datetime: datetime,
     ):
         """A document's scalar and json fields map correctly."""
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(session, setup_user, "subtraction_1.fa.gz")
+
         await ctx.mongo.subtraction.insert_one(
             make_subtraction_document(
                 subtraction_id="subtraction_1",
@@ -131,6 +167,7 @@ class TestUpgrade:
                 created_at=static_datetime,
                 count=42,
                 gc={"a": 0.3, "t": 0.3, "g": 0.2, "c": 0.2},
+                upload=upload_id,
             ),
         )
 
@@ -158,7 +195,7 @@ class TestUpgrade:
         assert row.ready is True
         assert row.user_id == setup_user
         assert row.job_id is None
-        assert row.upload_id is None
+        assert row.upload_id == upload_id
 
     async def test_user_legacy_id_mapping(
         self,
@@ -255,37 +292,39 @@ class TestUpgrade:
 
         assert stored == upload_id
 
-    async def test_no_job_or_upload(
+    async def test_missing_job_is_null(
         self,
         ctx: MigrationContext,
         setup_user: int,
         static_datetime: datetime,
     ):
-        """job_id and upload_id are null when the document has neither."""
+        """job_id is null when the document has no job."""
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(session, setup_user, "no_job.fa.gz")
+
         await ctx.mongo.subtraction.insert_one(
             make_subtraction_document(
-                subtraction_id="bare_subtraction",
+                subtraction_id="no_job_subtraction",
                 user_id=setup_user,
                 created_at=static_datetime,
                 job_id=None,
-                upload=None,
+                upload=upload_id,
             ),
         )
 
         await upgrade(ctx)
 
         async with AsyncSession(ctx.pg) as session:
-            row = (
+            job_id = (
                 await session.execute(
                     text(
-                        "SELECT job_id, upload_id FROM subtractions "
-                        "WHERE legacy_id = 'bare_subtraction'",
+                        "SELECT job_id FROM subtractions "
+                        "WHERE legacy_id = 'no_job_subtraction'",
                     ),
                 )
-            ).one()
+            ).scalar_one()
 
-        assert row.job_id is None
-        assert row.upload_id is None
+        assert job_id is None
 
     async def test_orphan_user_backfills_null(
         self,
@@ -298,11 +337,15 @@ class TestUpgrade:
         Unlike the analyses backfill, an unresolvable user reference does not abort
         the migration: the row is written with ``user_id = NULL``.
         """
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(session, setup_user, "orphan_user.fa.gz")
+
         await ctx.mongo.subtraction.insert_one(
             make_subtraction_document(
                 subtraction_id="orphan_user_subtraction",
                 user_id=setup_user + 9999,
                 created_at=static_datetime,
+                upload=upload_id,
             ),
         )
 
@@ -350,13 +393,21 @@ class TestUpgrade:
 
         assert row.job_id is None
 
-    async def test_orphan_upload_backfills_null(
+    async def test_orphan_upload_reconstructs_removed_upload(
         self,
         ctx: MigrationContext,
         setup_user: int,
         static_datetime: datetime,
     ):
-        """A document referencing a deleted upload is written with a null upload_id."""
+        """A deleted upload is rebuilt as a removed upload linked to the subtraction.
+
+        The stand-in upload takes its name from the Mongo ``file`` snapshot, its
+        size from the FASTA ``subtraction_files`` row, and is attributed to the
+        subtraction's own user.
+        """
+        async with AsyncSession(ctx.pg) as session:
+            await insert_fasta_file(session, "orphan_upload_subtraction", 4096)
+
         await ctx.mongo.subtraction.insert_one(
             make_subtraction_document(
                 subtraction_id="orphan_upload_subtraction",
@@ -371,14 +422,75 @@ class TestUpgrade:
         async with AsyncSession(ctx.pg) as session:
             row = (
                 await session.execute(
-                    text(
-                        "SELECT upload_id FROM subtractions "
-                        "WHERE legacy_id = 'orphan_upload_subtraction'",
-                    ),
+                    text("""
+                        SELECT u.name, u.size, u.removed, u.ready, u.type, u.user_id
+                        FROM subtractions s
+                        JOIN uploads u ON s.upload_id = u.id
+                        WHERE s.legacy_id = 'orphan_upload_subtraction'
+                    """),
                 )
             ).one()
 
-        assert row.upload_id is None
+        assert row.name == "subtraction.fa.gz"
+        assert row.size == 4096
+        assert row.removed is True
+        assert row.ready is True
+        assert row.type == "subtraction"
+        assert row.user_id == setup_user
+
+    async def test_orphan_upload_and_user_uses_unknown_sentinel(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """When the user is also gone, the rebuilt upload goes to the unknown user."""
+        async with AsyncSession(ctx.pg) as session:
+            unknown_user_id = await insert_unknown_user(session)
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan_both_subtraction",
+                user_id=setup_user + 9999,
+                created_at=static_datetime,
+                upload=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            upload_user_id = (
+                await session.execute(
+                    text("""
+                        SELECT u.user_id
+                        FROM subtractions s
+                        JOIN uploads u ON s.upload_id = u.id
+                        WHERE s.legacy_id = 'orphan_both_subtraction'
+                    """),
+                )
+            ).scalar_one()
+
+        assert upload_user_id == unknown_user_id
+
+    async def test_orphan_upload_and_user_without_sentinel_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A missing ``unknown`` sentinel is a loud failure, not a silent null."""
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan_both_no_sentinel",
+                user_id=setup_user + 9999,
+                created_at=static_datetime,
+                upload=999999,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="unknown"):
+            await upgrade(ctx)
 
     async def test_soft_deleted_is_migrated(
         self,

--- a/tests/migration/test_repair_null_subtraction_uploads.py
+++ b/tests/migration/test_repair_null_subtraction_uploads.py
@@ -1,0 +1,263 @@
+"""Tests for the repair-null-subtraction-uploads migration.
+
+The shared reconstruction logic is exercised through the copy revision in
+``test_copy_subtractions_to_postgres``. These tests cover what this revision
+owns: rebuilding uploads for subtractions that the original backfill already
+wrote to Postgres with a null ``upload_id``.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_n2adlt6ch803_repair_null_subtraction_upload_ids import (
+    upgrade,
+)
+from tests.migration.test_copy_subtractions_to_postgres import (
+    insert_fasta_file,
+    insert_unknown_user,
+    insert_upload,
+    make_subtraction_document,
+    setup_user,
+    static_datetime,
+)
+from virtool.migration.ctx import MigrationContext
+
+__all__ = ["setup_user", "static_datetime"]
+
+
+async def insert_subtraction_row(
+    session: AsyncSession,
+    legacy_id: str,
+    created_at: datetime,
+    *,
+    user_id: int | None,
+    deleted: bool = False,
+) -> int:
+    """Insert a subtraction row with a null upload_id, as the backfill left it."""
+    result = await session.execute(
+        text("""
+            INSERT INTO subtractions (
+                legacy_id, name, nickname, created_at, deleted, ready, user_id
+            )
+            VALUES (
+                :legacy_id, 'Arabidopsis thaliana', '', :created_at, :deleted, true,
+                :user_id
+            )
+            RETURNING id
+        """),
+        {
+            "legacy_id": legacy_id,
+            "created_at": created_at,
+            "deleted": deleted,
+            "user_id": user_id,
+        },
+    )
+    subtraction_pk = result.scalar_one()
+    await session.commit()
+    return subtraction_pk
+
+
+class TestRepair:
+    async def test_reconstructs_removed_upload(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A null upload_id is filled with a removed upload rebuilt from the file."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_subtraction_row(
+                session,
+                "orphan",
+                static_datetime,
+                user_id=setup_user,
+            )
+            await insert_fasta_file(session, "orphan", 8192)
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan",
+                user_id=setup_user,
+                created_at=static_datetime,
+                upload=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text("""
+                        SELECT u.name, u.size, u.removed, u.user_id
+                        FROM subtractions s
+                        JOIN uploads u ON s.upload_id = u.id
+                        WHERE s.legacy_id = 'orphan'
+                    """),
+                )
+            ).one()
+
+        assert row.name == "subtraction.fa.gz"
+        assert row.size == 8192
+        assert row.removed is True
+        assert row.user_id == setup_user
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_orphan_user_uses_unknown_sentinel(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """A subtraction with a null user_id attributes its upload to unknown."""
+        async with AsyncSession(ctx.pg) as session:
+            unknown_user_id = await insert_unknown_user(session)
+            await insert_subtraction_row(
+                session,
+                "orphan_both",
+                static_datetime,
+                user_id=None,
+            )
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="orphan_both",
+                user_id="gone",
+                created_at=static_datetime,
+                upload=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            upload_user_id = (
+                await session.execute(
+                    text("""
+                        SELECT u.user_id
+                        FROM subtractions s
+                        JOIN uploads u ON s.upload_id = u.id
+                        WHERE s.legacy_id = 'orphan_both'
+                    """),
+                )
+            ).scalar_one()
+
+        assert upload_user_id == unknown_user_id
+
+    async def test_relinks_upload_that_reappeared(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """An upload present in Postgres is linked rather than duplicated."""
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(session, setup_user, "live.fa.gz")
+            await insert_subtraction_row(
+                session,
+                "reappeared",
+                static_datetime,
+                user_id=setup_user,
+            )
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="reappeared",
+                user_id=setup_user,
+                created_at=static_datetime,
+                upload=upload_id,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text("""
+                        SELECT s.upload_id, u.removed
+                        FROM subtractions s
+                        JOIN uploads u ON s.upload_id = u.id
+                        WHERE s.legacy_id = 'reappeared'
+                    """),
+                )
+            ).one()
+
+        assert row.upload_id == upload_id
+        assert row.removed is False
+
+    async def test_skips_soft_deleted(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A soft-deleted subtraction with a null upload_id is left untouched."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_subtraction_row(
+                session,
+                "deleted",
+                static_datetime,
+                user_id=setup_user,
+                deleted=True,
+            )
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="deleted",
+                user_id=setup_user,
+                created_at=static_datetime,
+                deleted=True,
+                upload=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = (
+                await session.execute(
+                    text(
+                        "SELECT upload_id FROM subtractions "
+                        "WHERE legacy_id = 'deleted'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert upload_id is None
+
+    async def test_idempotent_rerun(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """Re-running after a full repair does not create a second upload."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_subtraction_row(
+                session,
+                "repeat",
+                static_datetime,
+                user_id=setup_user,
+            )
+
+        await ctx.mongo.subtraction.insert_one(
+            make_subtraction_document(
+                subtraction_id="repeat",
+                user_id=setup_user,
+                created_at=static_datetime,
+                upload=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            upload_count = (
+                await session.execute(text("SELECT COUNT(*) FROM uploads"))
+            ).scalar_one()
+
+        assert upload_count == 1

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -1,6 +1,6 @@
 import pytest
 from multidict import MultiDict, MultiDictProxy
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.errors import ResourceNotFoundError
@@ -13,7 +13,7 @@ from virtool.subtractions.oas import (
     UpdateSubtractionRequest,
 )
 from virtool.subtractions.pg import SQLSubtraction
-from virtool.uploads.sql import UploadType
+from virtool.uploads.sql import SQLUpload, UploadType
 
 
 def _empty_query() -> MultiDictProxy:
@@ -66,6 +66,36 @@ class TestFind:
             "cress", False, False, _empty_query()
         )
         assert [d.id for d in by_nickname.documents] == [arabidopsis.id]
+
+    async def test_lists_subtraction_with_removed_upload(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A subtraction whose source upload is removed still lists with a file.
+
+        Regression for VIR-2478: the read path must not raise when the linked
+        upload is flagged ``removed``, which is how reconstructed uploads for
+        deleted sources are stored.
+        """
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(user=user, upload=upload)
+
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                update(SQLUpload).where(SQLUpload.id == upload.id).values(removed=True),
+            )
+            await session.commit()
+
+        result = await data_layer.subtractions.find(None, False, False, _empty_query())
+
+        assert [d.id for d in result.documents] == [subtraction.id]
+        assert result.documents[0].file.id == upload.id
 
     async def test_ready_filter(self, data_layer: DataLayer, fake: DataFaker):
         """``ready=True`` returns only finalized subtractions but counts both."""

--- a/tests/users/test_api.py
+++ b/tests/users/test_api.py
@@ -185,6 +185,23 @@ class TestCreate:
 
         await resp_is.bad_request(resp, "Reserved user name: virtool")
 
+    async def test_reserved_unknown_handle(
+        self,
+        fake: DataFaker,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+    ):
+        """The ``unknown`` sentinel handle cannot be claimed by a created user."""
+        client = await spawn_client(administrator=True, authenticated=True)
+
+        await fake.users.create()
+
+        data = {"handle": "Unknown", "password": "hello_world", "force_reset": False}
+
+        resp = await client.post("/users", data)
+
+        await resp_is.bad_request(resp, "Reserved user name: Unknown")
+
 
 class TestUpdate:
     async def test_ok(

--- a/virtool/administrators/api.py
+++ b/virtool/administrators/api.py
@@ -27,6 +27,7 @@ from virtool.users.checks import check_password_length
 from virtool.users.models import User
 from virtool.users.oas import CreateUserRequest
 from virtool.users.pg import SQLUser
+from virtool.users.utils import is_reserved_handle
 
 routes = Routes()
 
@@ -99,8 +100,8 @@ class AdminUsersView(PydanticView):
             400: Password does not meet length requirement
             403: Not permitted
         """
-        if data.handle == "virtool":
-            raise APIBadRequest("Reserved user name: virtool")
+        if is_reserved_handle(data.handle):
+            raise APIBadRequest(f"Reserved user name: {data.handle}")
 
         if error := await check_password_length(self.request, password=data.password):
             raise APIBadRequest(error)

--- a/virtool/subtractions/migration.py
+++ b/virtool/subtractions/migration.py
@@ -5,7 +5,7 @@ backfill revision and the later re-backfill revision. Keeping it here lets both
 revisions share a single implementation instead of duplicating ~300 lines.
 """
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -14,11 +14,13 @@ from virtool.data.topg import compose_legacy_id_single_expression
 from virtool.jobs.pg import SQLJob
 from virtool.migration import MigrationContext
 from virtool.pg.base import Base
-from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile
-from virtool.uploads.sql import SQLUpload
+from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile, SubtractionType
+from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.users.pg import SQLUser
 
 logger = get_logger("migration")
+
+UNKNOWN_USER_HANDLE = "unknown"
 
 
 async def copy_subtractions_to_postgres(ctx: MigrationContext) -> None:
@@ -39,10 +41,16 @@ async def copy_subtractions_to_postgres(ctx: MigrationContext) -> None:
     defence, so the backfill is safe to re-run after an interruption.
 
     Unlike the analyses backfill, this never fails on a dangling reference.
-    ``user``, ``job``, and ``upload`` references that no longer resolve to a
-    Postgres row are backfilled as ``NULL`` and logged with a warning. These
-    collections used to be deletable, so legacy subtractions can reference rows
-    that have since been removed, and ``NULL`` is the truthful mapping.
+    ``user`` and ``job`` references that no longer resolve to a Postgres row are
+    backfilled as ``NULL`` and logged with a warning. These collections used to be
+    deletable, so legacy subtractions can reference rows that have since been
+    removed, and ``NULL`` is the truthful mapping.
+
+    A subtraction is always built from a source FASTA upload, so its upload
+    relation must always hold. When the referenced ``upload`` no longer resolves,
+    a stand-in ``removed`` upload is rebuilt from the Mongo ``file`` snapshot
+    rather than backfilled as ``NULL``, so the read path never sees a null
+    ``file``. See :func:`_resolve_upload_id`.
 
     Finally, ``subtraction_files.subtraction_id`` is backfilled with a single
     set-based ``UPDATE`` join on ``legacy_id``. The collection name is
@@ -73,6 +81,7 @@ async def copy_subtractions_to_postgres(ctx: MigrationContext) -> None:
         user_id_cache: dict[int | str, int | None] = {}
         job_id_cache: dict[int | str, int | None] = {}
         upload_id_cache: dict[int | str, int | None] = {}
+        unknown_user_id_cache: dict[str, int] = {}
 
         for subtraction_id in subtraction_ids:
             if subtraction_id in existing_legacy_ids:
@@ -87,7 +96,13 @@ async def copy_subtractions_to_postgres(ctx: MigrationContext) -> None:
 
             user_id = await _resolve_user_id(session, document, user_id_cache)
             job_id = await _resolve_job_id(session, document, job_id_cache)
-            upload_id = await _resolve_upload_id(session, document, upload_id_cache)
+            upload_id = await _resolve_upload_id(
+                session,
+                document,
+                upload_id_cache,
+                user_id,
+                unknown_user_id_cache,
+            )
 
             await session.execute(
                 insert(SQLSubtraction)
@@ -229,30 +244,209 @@ async def _resolve_upload_id(
     session: AsyncSession,
     document: dict,
     cache: dict[int | str, int | None],
-) -> int | None:
-    """Resolve a document's ``upload`` reference to a Postgres ``uploads.id``.
+    user_id: int | None,
+    unknown_user_cache: dict[str, int],
+) -> int:
+    """Resolve a document's upload to a Postgres ``uploads.id``, rebuilding if gone.
 
-    The ``upload`` field holds the integer upload id directly. Returns ``None``
-    when the document has no upload, and also when the upload no longer exists in
-    Postgres, logging a warning in the latter case. Uploads used to be deletable,
-    so legacy subtractions can reference an upload that has since been removed.
+    A subtraction is always built from a source FASTA upload, so the
+    subtraction-to-upload relation must always hold. When the referenced upload
+    still exists its id is returned directly. When it does not -- the upload was
+    deleted, or the document predates the integer ``upload`` field -- a stand-in
+    ``removed`` upload is rebuilt from the Mongo ``file`` snapshot so the relation
+    is preserved and the read path never sees a null ``file``.
+
+    The reconstructed upload is attributed to the subtraction's ``user_id``, or to
+    the ``unknown`` sentinel user when that user was itself deleted.
     """
     reference = document.get("upload")
 
     if reference is None:
-        return None
+        file_id = (document.get("file") or {}).get("id")
+        if isinstance(file_id, int):
+            reference = file_id
 
-    upload_id = await _resolve_id(session, SQLUpload, reference, cache)
+    if reference is not None:
+        upload_id = await _resolve_id(session, SQLUpload, reference, cache)
+        if upload_id is not None:
+            return upload_id
 
-    if upload_id is None:
         logger.warning(
             "subtraction references an upload that no longer exists; "
-            "backfilling null upload_id",
+            "reconstructing a removed upload",
             subtraction_id=document["_id"],
             upload=reference,
         )
 
+    attribution_user_id = (
+        user_id
+        if user_id is not None
+        else await _get_unknown_user_id(session, unknown_user_cache)
+    )
+
+    return await _reconstruct_removed_upload(session, document, attribution_user_id)
+
+
+async def _get_unknown_user_id(
+    session: AsyncSession,
+    cache: dict[str, int],
+) -> int:
+    """Return the id of the ``unknown`` sentinel user, raising if it is absent.
+
+    Orphaned uploads whose owning user was also deleted are attributed to this
+    sentinel so the non-null ``uploads.user_id`` constraint holds. The sentinel is
+    created out of band -- a login-disabled user with handle ``unknown``. A
+    missing one is a loud failure rather than a silent null, because skipping
+    attribution would leave the subtraction without the linked upload the read
+    path requires.
+    """
+    if UNKNOWN_USER_HANDLE in cache:
+        return cache[UNKNOWN_USER_HANDLE]
+
+    user_id = (
+        await session.execute(
+            select(SQLUser.id).where(
+                func.lower(SQLUser.handle) == UNKNOWN_USER_HANDLE,
+            ),
+        )
+    ).scalar_one_or_none()
+
+    if user_id is None:
+        msg = (
+            "the 'unknown' sentinel user is required to attribute orphaned "
+            "subtraction uploads but was not found; create a login-disabled user "
+            "with handle 'unknown' before running this migration"
+        )
+        raise ValueError(msg)
+
+    cache[UNKNOWN_USER_HANDLE] = user_id
+
+    return user_id
+
+
+async def _reconstruct_removed_upload(
+    session: AsyncSession,
+    document: dict,
+    user_id: int,
+) -> int:
+    """Insert a stand-in ``removed`` upload for a subtraction whose upload is gone.
+
+    The blob no longer exists, so the row is flagged ``removed``. The name comes
+    from the Mongo ``file`` snapshot, and the size from the subtraction's FASTA
+    ``subtraction_files`` row when one is present. Timestamps fall back to the
+    subtraction's ``created_at`` because the original upload times are lost.
+    Returns the new upload id.
+    """
+    legacy_id = document["_id"]
+    file = document.get("file") or {}
+    name = file.get("name") or f"{document['name']}.fa.gz"
+    created_at = document["created_at"]
+
+    size = (
+        await session.execute(
+            select(SQLSubtractionFile.size)
+            .where(
+                SQLSubtractionFile.subtraction == legacy_id,
+                SQLSubtractionFile.type == SubtractionType.fasta,
+            )
+            .limit(1),
+        )
+    ).scalar_one_or_none()
+
+    upload_id = (
+        await session.execute(
+            insert(SQLUpload)
+            .values(
+                name=name,
+                name_on_disk=f"reconstructed-upload-{legacy_id}",
+                ready=True,
+                removed=True,
+                removed_at=created_at,
+                reserved=False,
+                size=size,
+                type=UploadType.subtraction,
+                user_id=user_id,
+                created_at=created_at,
+                uploaded_at=created_at,
+            )
+            .returning(SQLUpload.id),
+        )
+    ).scalar_one()
+
+    logger.info(
+        "reconstructed removed upload for subtraction",
+        subtraction_id=legacy_id,
+        upload_id=upload_id,
+    )
+
     return upload_id
+
+
+async def repair_null_subtraction_uploads(ctx: MigrationContext) -> None:
+    """Reconstruct uploads for already-migrated subtractions with a null upload_id.
+
+    The original backfill wrote ``upload_id = NULL`` for subtractions whose source
+    upload had been deleted, which makes the read path raise because ``file`` is a
+    required field. This pass rebuilds a ``removed`` stand-in upload for every
+    non-deleted subtraction still carrying a null ``upload_id`` and links it, so
+    the subtraction-to-upload relation holds and listings stop failing.
+
+    Each subtraction is re-resolved first, so an upload that has since reappeared
+    in Postgres is linked instead of duplicated. Soft-deleted subtractions are
+    skipped because the read path filters them out and they never trigger the bug.
+
+    Idempotent: only rows with a null ``upload_id`` are touched, so a re-run after
+    a complete pass is a no-op.
+    """
+    upload_id_cache: dict[int | str, int | None] = {}
+    unknown_user_cache: dict[str, int] = {}
+    repaired_count = 0
+
+    async with AsyncSession(ctx.pg) as session:
+        rows = (
+            await session.execute(
+                select(
+                    SQLSubtraction.id,
+                    SQLSubtraction.legacy_id,
+                    SQLSubtraction.user_id,
+                ).where(
+                    SQLSubtraction.upload_id.is_(None),
+                    SQLSubtraction.deleted.is_(False),
+                ),
+            )
+        ).all()
+
+        for subtraction_pk, legacy_id, user_id in rows:
+            if legacy_id is None:
+                continue
+
+            document = await ctx.mongo.subtraction.find_one({"_id": legacy_id})
+
+            if document is None:
+                logger.warning(
+                    "subtraction has no mongo document; cannot reconstruct upload",
+                    subtraction_id=legacy_id,
+                )
+                continue
+
+            upload_id = await _resolve_upload_id(
+                session,
+                document,
+                upload_id_cache,
+                user_id,
+                unknown_user_cache,
+            )
+
+            await session.execute(
+                update(SQLSubtraction)
+                .where(SQLSubtraction.id == subtraction_pk)
+                .values(upload_id=upload_id),
+            )
+            await session.commit()
+
+            repaired_count += 1
+
+    logger.info("repaired null subtraction upload ids", repaired=repaired_count)
 
 
 async def _backfill_file_subtraction_ids(session: AsyncSession) -> None:

--- a/virtool/subtractions/migration.py
+++ b/virtool/subtractions/migration.py
@@ -17,10 +17,9 @@ from virtool.pg.base import Base
 from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile, SubtractionType
 from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.users.pg import SQLUser
+from virtool.users.utils import UNKNOWN_USER_HANDLE
 
 logger = get_logger("migration")
-
-UNKNOWN_USER_HANDLE = "unknown"
 
 
 async def copy_subtractions_to_postgres(ctx: MigrationContext) -> None:

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -26,6 +26,7 @@ from virtool.users.oas import (
     CreateUserRequest,
     UpdateUserRequest,
 )
+from virtool.users.utils import is_reserved_handle
 
 routes = Routes()
 
@@ -96,8 +97,8 @@ class UsersView(PydanticView):
             400: Password does not meet length requirement
             403: Not permitted
         """
-        if data.handle == "virtool":
-            raise APIBadRequest("Reserved user name: virtool")
+        if is_reserved_handle(data.handle):
+            raise APIBadRequest(f"Reserved user name: {data.handle}")
 
         if error := await check_password_length(self.request, password=data.password):
             raise APIBadRequest(error)
@@ -144,8 +145,8 @@ class FirstUserView(PydanticView):
             logger.error("attempted to create first user when users already exist")
             raise APIConflict("Virtool already has at least one user")
 
-        if data.handle == "virtool":
-            raise APIBadRequest("Reserved user name: virtool")
+        if is_reserved_handle(data.handle):
+            raise APIBadRequest(f"Reserved user name: {data.handle}")
 
         if error := await check_password_length(self.request, password=data.password):
             raise APIBadRequest(error)

--- a/virtool/users/data.py
+++ b/virtool/users/data.py
@@ -220,8 +220,8 @@ class UsersData(DataLayerDomain):
         if await self.check_users_exist():
             raise ResourceConflictError("Virtool already has at least one user")
 
-        if handle == "virtool":
-            raise ResourceConflictError("Reserved user name: virtool")
+        if virtool.users.utils.is_reserved_handle(handle):
+            raise ResourceConflictError(f"Reserved user name: {handle}")
 
         user = await self.create(handle, password)
 

--- a/virtool/users/utils.py
+++ b/virtool/users/utils.py
@@ -4,13 +4,18 @@ import bcrypt
 
 from virtool.models.enums import Permission
 
-RESERVED_HANDLES = frozenset({"unknown", "virtool"})
-"""Handles that may not be claimed by ordinary users.
+UNKNOWN_USER_HANDLE = "unknown"
+"""Handle of the lost-attribution sentinel user.
 
-``virtool`` is reserved for system-as-actor uses and ``unknown`` for
-lost-attribution sentinels (e.g. uploads whose owning user was deleted).
-Compared case-insensitively.
+Stands in for a real user who has since been deleted (e.g. the owner of an
+upload reconstructed during migration).
 """
+
+VIRTOOL_USER_HANDLE = "virtool"
+"""Handle reserved for system-as-actor uses."""
+
+RESERVED_HANDLES = frozenset({UNKNOWN_USER_HANDLE, VIRTOOL_USER_HANDLE})
+"""Handles that may not be claimed by ordinary users. Compared case-insensitively."""
 
 
 def is_reserved_handle(handle: str) -> bool:

--- a/virtool/users/utils.py
+++ b/virtool/users/utils.py
@@ -4,6 +4,19 @@ import bcrypt
 
 from virtool.models.enums import Permission
 
+RESERVED_HANDLES = frozenset({"unknown", "virtool"})
+"""Handles that may not be claimed by ordinary users.
+
+``virtool`` is reserved for system-as-actor uses and ``unknown`` for
+lost-attribution sentinels (e.g. uploads whose owning user was deleted).
+Compared case-insensitively.
+"""
+
+
+def is_reserved_handle(handle: str) -> bool:
+    """Return whether ``handle`` is reserved for a sentinel user."""
+    return handle.lower() in RESERVED_HANDLES
+
 
 def check_legacy_password(password: str, salt: str, hashed: str) -> bool:
     """Check if a Unicode ``password`` and ``salt`` match a ``hashed`` password from the


### PR DESCRIPTION
## Summary

- Fixes VIR-2478: the original Mongo→Postgres subtraction backfill wrote `upload_id = NULL` when the source upload had already been deleted, causing a validation error when listing subtractions. A new migration revision reconstructs a `removed` stand-in upload for each affected row.
- Routes `GET /hmms/status` and `GET /hmms/status/updates` to read from Postgres instead of Mongo; the `get_updates` method is added to `HmmsData`.
- Makes subtractions addressable by both their legacy string id and their Postgres integer id across `get`, `update`, `delete`, `finalize`, and `get_file`; updates `AttachSubtractionsTransform` and `get_missing_subtraction_ids` to query Postgres.