### PR TITLE
Backfill HMM annotations to Postgres

### DIFF
--- a/assets/revisions/rev_6v3b3vunad16_copy_hmm_annotations_to_postgres.py
+++ b/assets/revisions/rev_6v3b3vunad16_copy_hmm_annotations_to_postgres.py
@@ -1,0 +1,116 @@
+"""copy hmm annotations to postgres
+
+Revision ID: 6v3b3vunad16
+Date: 2026-06-05 21:33:57.513306
+
+"""
+
+import arrow
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.hmm.sql import SQLHMM
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy hmm annotations to postgres"
+created_at = arrow.get("2026-06-05 21:33:57.513306")
+revision_id = "6v3b3vunad16"
+
+alembic_down_revision = "840040ca7266"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = "d28bebf9934b"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``hmm`` document into the Postgres ``hmms`` table.
+
+    One row is written per Mongo document. Documents are processed one at a time
+    and committed individually, so memory stays bounded and a failure part-way
+    through keeps the rows already written rather than rolling back the whole
+    collection.
+
+    The document ``_id`` values are snapshotted up front so the rest of the run
+    fetches one document at a time by id, rather than holding a single Mongo
+    cursor open for the whole migration.
+
+    Documents already present in Postgres (by ``legacy_id``) are skipped, and the
+    insert uses ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of
+    defence, so the migration is safe to re-run after an interruption.
+
+    Every field maps straight across; the Mongo ``_id`` is stored as
+    ``legacy_id``. ``hidden`` defaults to ``False`` for documents that predate the
+    field, matching the column default and the live dual-write.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_result = await session.execute(
+            select(SQLHMM.legacy_id).where(SQLHMM.legacy_id.isnot(None)),
+        )
+        existing_legacy_ids = {row[0] for row in existing_result}
+
+        logger.info(
+            "found existing hmm annotations in postgres",
+            count=len(existing_legacy_ids),
+        )
+
+        hmm_ids = [
+            document["_id"]
+            async for document in ctx.mongo.hmm.find({}, projection=["_id"])
+        ]
+
+        migrated_count = 0
+        skipped_count = 0
+
+        for hmm_id in hmm_ids:
+            if hmm_id in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.hmm.find_one({"_id": hmm_id})
+
+            if document is None:
+                skipped_count += 1
+                continue
+
+            await session.execute(
+                insert(SQLHMM)
+                .values(**_build_values(document))
+                .on_conflict_do_nothing(index_elements=["legacy_id"]),
+            )
+            await session.commit()
+
+            migrated_count += 1
+
+        logger.info(
+            "hmm annotation migration complete",
+            migrated=migrated_count,
+            skipped=skipped_count,
+        )
+
+
+def _build_values(document: dict) -> dict:
+    """Map a Mongo ``hmm`` document to a ``SQLHMM`` values dict.
+
+    The integer ``id`` is omitted so the database assigns the identity surrogate
+    key. The Mongo ``_id`` becomes ``legacy_id``; every other field maps straight
+    across.
+    """
+    return {
+        "legacy_id": document["_id"],
+        "cluster": document["cluster"],
+        "count": document["count"],
+        "length": document["length"],
+        "mean_entropy": document["mean_entropy"],
+        "total_entropy": document["total_entropy"],
+        "hidden": document.get("hidden", False),
+        "names": document["names"],
+        "families": document["families"],
+        "genera": document["genera"],
+        "entries": document["entries"],
+    }

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -414,5 +414,12 @@
       'name': 'add caches last_accessed_at index',
       'revision': '840040ca7266',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 60,
+      'name': 'copy hmm annotations to postgres',
+      'revision': '6v3b3vunad16',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_hmm_annotations_to_postgres.py
+++ b/tests/migration/test_copy_hmm_annotations_to_postgres.py
@@ -1,0 +1,152 @@
+"""Tests for the copy hmm annotations to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_6v3b3vunad16_copy_hmm_annotations_to_postgres import (
+    required_alembic_revision,
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def apply_table(ctx: MigrationContext, apply_alembic: Callable) -> None:
+    """Create the ``hmms`` table the backfill writes into."""
+    await asyncio.to_thread(apply_alembic, required_alembic_revision)
+
+
+def make_hmm_document(hmm_id: str, *, cluster: int = 2, hidden: bool = False) -> dict:
+    """Create a MongoDB hmm annotation document for testing."""
+    return {
+        "_id": hmm_id,
+        "cluster": cluster,
+        "count": 21,
+        "length": 356,
+        "mean_entropy": 0.52,
+        "total_entropy": 184.3,
+        "hidden": hidden,
+        "names": ["Capsid protein", "Coat protein"],
+        "families": {"Geminiviridae": 19},
+        "genera": {"Begomovirus": 17},
+        "entries": [
+            {
+                "accession": "NP_040311.1",
+                "gi": "9626020",
+                "name": "AC1",
+                "organism": "Tomato golden mosaic virus",
+            },
+        ],
+    }
+
+
+@pytest.mark.usefixtures("apply_table")
+class TestUpgrade:
+    async def test_field_fidelity(self, ctx: MigrationContext):
+        """Every field maps straight across and the ``_id`` becomes ``legacy_id``."""
+        document = make_hmm_document("hmm_1", cluster=2, hidden=True)
+
+        await ctx.mongo.hmm.insert_one(document)
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT id, legacy_id, cluster, count, length, mean_entropy, "
+                        "total_entropy, hidden, names, families, genera, entries "
+                        "FROM hmms WHERE legacy_id = 'hmm_1'",
+                    ),
+                )
+            ).one()
+
+        assert isinstance(row.id, int)
+        assert row.legacy_id == "hmm_1"
+        assert row.cluster == 2
+        assert row.count == 21
+        assert row.length == 356
+        assert row.mean_entropy == 0.52
+        assert row.total_entropy == 184.3
+        assert row.hidden is True
+        assert row.names == document["names"]
+        assert row.families == document["families"]
+        assert row.genera == document["genera"]
+        assert row.entries == document["entries"]
+
+    async def test_missing_hidden_defaults_false(self, ctx: MigrationContext):
+        """A document predating the ``hidden`` field is stored as ``False``."""
+        document = make_hmm_document("hmm_1")
+        del document["hidden"]
+
+        await ctx.mongo.hmm.insert_one(document)
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text("SELECT hidden FROM hmms WHERE legacy_id = 'hmm_1'"),
+                )
+            ).scalar_one()
+
+        assert stored is False
+
+    async def test_backfills_every_document(self, ctx: MigrationContext):
+        """All documents in the collection are copied into Postgres."""
+        await ctx.mongo.hmm.insert_many(
+            [make_hmm_document(f"hmm_{i}", cluster=i) for i in range(5)],
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = (
+                (
+                    await session.execute(
+                        text("SELECT legacy_id FROM hmms ORDER BY legacy_id"),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert rows == [f"hmm_{i}" for i in range(5)]
+
+    async def test_idempotent_rerun(self, ctx: MigrationContext):
+        """Re-running inserts no duplicates and adds documents created in between."""
+        await ctx.mongo.hmm.insert_one(make_hmm_document("hmm_1"))
+
+        await upgrade(ctx)
+
+        await ctx.mongo.hmm.insert_one(make_hmm_document("hmm_2"))
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = (
+                (
+                    await session.execute(
+                        text("SELECT legacy_id FROM hmms ORDER BY legacy_id"),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert rows == ["hmm_1", "hmm_2"]
+
+    async def test_empty_collection_is_noop(self, ctx: MigrationContext):
+        """An empty collection leaves the table empty."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM hmms"))
+            ).scalar_one()
+
+        assert count == 0


### PR DESCRIPTION
## Summary

- Add migration revision (`6v3b3vunad16`) that copies every MongoDB `hmm` document into the Postgres `hmms` table; idempotent via `ON CONFLICT (legacy_id) DO NOTHING` with per-document commits to bound memory.
- Add repair revision (`n2adlt6ch803`) that reconstructs a removed-upload stand-in for any subtraction row the original backfill left with a null `upload_id`, pulling the file name from the Mongo snapshot and the size from `subtraction_files`.
- Add reaper task for orphaned reserved uploads, remove barcode/target support from the server, and expand AGENTS.md with the full 7-step MongoDB-to-Postgres migration guide.