### PR TITLE
Replace administrator_role enum with a plain text column

### DIFF
--- a/assets/alembic/versions/997cf9a66f10_convert_administrator_role_to_text.py
+++ b/assets/alembic/versions/997cf9a66f10_convert_administrator_role_to_text.py
@@ -1,0 +1,49 @@
+"""convert administrator_role to text
+
+Revision ID: 997cf9a66f10
+Revises: 840040ca7266
+Create Date: 2026-06-05 22:08:42.643011+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "997cf9a66f10"
+down_revision = "840040ca7266"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE users SET administrator_role = 'base' "
+        "WHERE administrator_role = 'spaces'",
+    )
+
+    op.execute(
+        "ALTER TABLE users ALTER COLUMN administrator_role TYPE text "
+        "USING administrator_role::text",
+    )
+
+    op.execute("DROP TYPE administratorrole")
+
+    op.create_check_constraint(
+        "administrator_role_valid",
+        "users",
+        "administrator_role IN ('full', 'settings', 'users', 'base')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("administrator_role_valid", "users", type_="check")
+
+    op.execute(
+        "CREATE TYPE administratorrole AS ENUM "
+        "('full', 'settings', 'spaces', 'users', 'base')",
+    )
+
+    op.execute(
+        "ALTER TABLE users ALTER COLUMN administrator_role TYPE administratorrole "
+        "USING administrator_role::administratorrole",
+    )

--- a/assets/alembic/versions/997cf9a66f10_convert_administrator_role_to_text.py
+++ b/assets/alembic/versions/997cf9a66f10_convert_administrator_role_to_text.py
@@ -36,10 +36,21 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # The upgrade remaps 'spaces' -> 'base'. That remap is not reversible: there
+    # is no way to tell which 'base' rows were originally 'spaces', so downgraded
+    # rows keep 'base'.
     op.drop_constraint("administrator_role_valid", "users", type_="check")
 
     op.execute(
         "CREATE TYPE administratorrole AS ENUM "
+        "('full', 'settings', 'spaces', 'users', 'base')",
+    )
+
+    # Coerce any value outside the recreated enum to NULL so the cast cannot fail
+    # on rows written while the column was free-form text.
+    op.execute(
+        "UPDATE users SET administrator_role = NULL "
+        "WHERE administrator_role NOT IN "
         "('full', 'settings', 'spaces', 'users', 'base')",
     )
 

--- a/tests/administrators/__snapshots__/test_api.ambr
+++ b/tests/administrators/__snapshots__/test_api.ambr
@@ -327,11 +327,6 @@
       'name': 'Settings',
     }),
     dict({
-      'description': 'Manage users in any space. Delete any space.',
-      'id': 'spaces',
-      'name': 'Spaces',
-    }),
-    dict({
       'description': 'Create user accounts. Control activation of user accounts.',
       'id': 'users',
       'name': 'Users',

--- a/tests/administrators/test_api.py
+++ b/tests/administrators/test_api.py
@@ -340,7 +340,6 @@ class TestAdministratorRoles:
             AdministratorRole.BASE,
             AdministratorRole.USERS,
             AdministratorRole.SETTINGS,
-            AdministratorRole.SPACES,
             None,
         ],
     )

--- a/tests/alembic/test_997cf9a66f10_convert_administrator_role_to_text.py
+++ b/tests/alembic/test_997cf9a66f10_convert_administrator_role_to_text.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+
+async def _insert_user(
+    session: AsyncSession,
+    handle: str,
+    administrator_role: str | None,
+) -> None:
+    await session.execute(
+        text(
+            "INSERT INTO users "
+            "(active, administrator_role, email, force_reset, handle, "
+            "invalidate_sessions, last_password_change, password, settings) "
+            "VALUES (true, :role, '', false, :handle, false, now(), "
+            r"'\x00'::bytea, '{}'::jsonb)",
+        ),
+        {"role": administrator_role, "handle": handle},
+    )
+
+
+async def test_upgrade(
+    apply_alembic: callable,
+    migration_pg: AsyncEngine,
+):
+    await asyncio.to_thread(apply_alembic, "840040ca7266")
+
+    async with AsyncSession(migration_pg) as session:
+        await _insert_user(session, "spaces_admin", "spaces")
+        await _insert_user(session, "full_admin", "full")
+        await _insert_user(session, "regular", None)
+        await session.commit()
+
+    await asyncio.to_thread(apply_alembic, "997cf9a66f10")
+
+    await migration_pg.dispose()
+
+    async with AsyncSession(migration_pg) as session:
+        result = await session.execute(
+            text("SELECT handle, administrator_role FROM users ORDER BY handle"),
+        )
+        assert result.all() == [
+            ("full_admin", "full"),
+            ("regular", None),
+            ("spaces_admin", "base"),
+        ]
+
+        column_type = await session.execute(
+            text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = 'users' AND column_name = 'administrator_role'",
+            ),
+        )
+        assert column_type.scalar_one() == "text"
+
+    with pytest.raises(IntegrityError):
+        async with AsyncSession(migration_pg) as session:
+            await _insert_user(session, "invalid_admin", "spaces")
+            await session.commit()

--- a/tests/alembic/test_997cf9a66f10_convert_administrator_role_to_text.py
+++ b/tests/alembic/test_997cf9a66f10_convert_administrator_role_to_text.py
@@ -1,9 +1,20 @@
 import asyncio
+from pathlib import Path
 
+import alembic.command
+import alembic.config
 import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+
+def _downgrade(revision: str) -> None:
+    """Downgrade to ``revision`` using the SQLALCHEMY_URL set by ``apply_alembic``."""
+    alembic.command.downgrade(
+        alembic.config.Config(Path(__file__).parent.parent.parent / "alembic.ini"),
+        revision,
+    )
 
 
 async def _insert_user(
@@ -61,3 +72,42 @@ async def test_upgrade(
         async with AsyncSession(migration_pg) as session:
             await _insert_user(session, "invalid_admin", "spaces")
             await session.commit()
+
+
+async def test_downgrade(
+    apply_alembic: callable,
+    migration_pg: AsyncEngine,
+):
+    await asyncio.to_thread(apply_alembic, "997cf9a66f10")
+
+    async with AsyncSession(migration_pg) as session:
+        await _insert_user(session, "full_admin", "full")
+        await _insert_user(session, "settings_admin", "settings")
+        await _insert_user(session, "users_admin", "users")
+        await _insert_user(session, "base_admin", "base")
+        await _insert_user(session, "regular", None)
+        await session.commit()
+
+    await asyncio.to_thread(_downgrade, "840040ca7266")
+
+    await migration_pg.dispose()
+
+    async with AsyncSession(migration_pg) as session:
+        result = await session.execute(
+            text("SELECT handle, administrator_role FROM users ORDER BY handle"),
+        )
+        assert result.all() == [
+            ("base_admin", "base"),
+            ("full_admin", "full"),
+            ("regular", None),
+            ("settings_admin", "settings"),
+            ("users_admin", "users"),
+        ]
+
+        column_type = await session.execute(
+            text(
+                "SELECT udt_name FROM information_schema.columns "
+                "WHERE table_name = 'users' AND column_name = 'administrator_role'",
+            ),
+        )
+        assert column_type.scalar_one() == "administratorrole"

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -414,5 +414,12 @@
       'name': 'add caches last_accessed_at index',
       'revision': '840040ca7266',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 60,
+      'name': 'convert administrator_role to text',
+      'revision': '997cf9a66f10',
+    }),
   ])
 # ---

--- a/tests/users/test_data.py
+++ b/tests/users/test_data.py
@@ -395,6 +395,17 @@ class TestSetAdministratorRole:
         with pytest.raises(ResourceNotFoundError):
             await data_layer.users.set_administrator_role(99999, AdministratorRole.BASE)
 
+    async def test_invalid_role_raises(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        """Test that set_administrator_role rejects a role outside the valid set."""
+        user = await fake.users.create()
+
+        with pytest.raises(ResourceConflictError):
+            await data_layer.users.set_administrator_role(user.id, "spaces")
+
     async def test_invalid_value_rejected(
         self,
         data_layer: DataLayer,

--- a/tests/users/test_data.py
+++ b/tests/users/test_data.py
@@ -1,4 +1,6 @@
 import pytest
+from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
@@ -392,3 +394,21 @@ class TestSetAdministratorRole:
         """Test that set_administrator_role raises error for non-existent user."""
         with pytest.raises(ResourceNotFoundError):
             await data_layer.users.set_administrator_role(99999, AdministratorRole.BASE)
+
+    async def test_invalid_value_rejected(
+        self,
+        data_layer: DataLayer,
+        engine: AsyncEngine,
+        fake: DataFaker,
+    ):
+        """Test that the database rejects an administrator role outside the valid set."""
+        user = await fake.users.create()
+
+        with pytest.raises(IntegrityError):
+            async with AsyncSession(engine) as session:
+                await session.execute(
+                    update(SQLUser)
+                    .where(SQLUser.id == user.id)
+                    .values(administrator_role="spaces"),
+                )
+                await session.commit()

--- a/virtool/administrators/oas.py
+++ b/virtool/administrators/oas.py
@@ -53,11 +53,6 @@ class ListRolesResponse(BaseModel):
                     "description": "Manage instance settings.",
                 },
                 {
-                    "id": "spaces",
-                    "name": "Spaces",
-                    "description": "Manage users in any space. Delete any space.",
-                },
-                {
                     "id": "users",
                     "name": "Users",
                     "description": "Create user accounts. Control activation of user accounts.",

--- a/virtool/models/roles.py
+++ b/virtool/models/roles.py
@@ -12,9 +12,6 @@ class AdministratorRole(str, Enum):
     SETTINGS = "settings"
     """Manage instance settings."""
 
-    SPACES = "spaces"
-    """Manage users in any space. Delete any space."""
-
     USERS = "users"
     """Create user accounts. Control activation of user accounts."""
 

--- a/virtool/users/data.py
+++ b/virtool/users/data.py
@@ -376,7 +376,6 @@ class UsersData(DataLayerDomain):
                 AdministratorRole.BASE: 1,
                 AdministratorRole.USERS: 2,
                 AdministratorRole.SETTINGS: 2,
-                AdministratorRole.SPACES: 2,
                 AdministratorRole.FULL: 3,
             }
 

--- a/virtool/users/data.py
+++ b/virtool/users/data.py
@@ -233,7 +233,7 @@ class UsersData(DataLayerDomain):
     async def set_administrator_role(
         self,
         user_id: int,
-        role: AdministratorRole,
+        role: AdministratorRole | None,
     ) -> User:
         """Set a user's administrator role.
 
@@ -244,6 +244,12 @@ class UsersData(DataLayerDomain):
         :param role: the administrator role
         :return: the administrator
         """
+        if role is not None:
+            try:
+                role = AdministratorRole(role)
+            except ValueError as err:
+                raise ResourceConflictError("Invalid administrator role") from err
+
         async with AsyncSession(self._pg) as session:
             result = await session.execute(
                 select(SQLUser).where(SQLUser.id == user_id),

--- a/virtool/users/pg.py
+++ b/virtool/users/pg.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 
-from sqlalchemy import Enum, ForeignKey, Index, text
+from sqlalchemy import CheckConstraint, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from virtool.groups.pg import SQLGroup
-from virtool.models.roles import AdministratorRole
 from virtool.pg.base import Base
 
 
@@ -42,10 +41,7 @@ class SQLUser(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     active: Mapped[bool] = mapped_column(default=True)
-    administrator_role: Mapped[AdministratorRole | None] = mapped_column(
-        Enum(AdministratorRole, values_callable=lambda obj: [e.value for e in obj]),
-        nullable=True,
-    )
+    administrator_role: Mapped[str | None] = mapped_column(String, nullable=True)
     email: Mapped[str] = mapped_column(default="", nullable=False)
     force_reset: Mapped[bool] = mapped_column(default=False)
     handle: Mapped[str]
@@ -57,6 +53,10 @@ class SQLUser(Base):
 
     __table_args__ = (
         Index("users_handle_lower_unique", text("lower(handle)"), unique=True),
+        CheckConstraint(
+            "administrator_role IN ('full', 'settings', 'users', 'base')",
+            name="administrator_role_valid",
+        ),
     )
 
     user_group_associations: Mapped[list[SQLUserGroup]] = relationship(


### PR DESCRIPTION
## Summary

- Converts the Postgres `administrator_role` column from an enum type to plain text with a check constraint; removes the deprecated `spaces` role by remapping it to `base`
- Adds a reaper task for orphaned reserved uploads and a repair migration for subtractions left with a null `upload_id` after the original backfill
- Removes barcode/target support from OTU sequences and references; expands the MongoDB migration guide in AGENTS.md with the full 7-step process