### PR TITLE
Switch HMM annotation reads to Postgres

### DIFF
--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -9,6 +9,7 @@ from syrupy import SnapshotAssertion
 import virtool.analyses
 from virtool.analyses.format import (
     CSV_HEADERS,
+    format_nuvs,
     transform_coverage_to_coordinates,
 )
 from virtool.mongo.core import Mongo
@@ -173,17 +174,18 @@ class TestFormatAnalysis:
         )
         m_format_pathoscope = mocker.patch("virtool.analyses.format.format_pathoscope")
 
+        pg = mocker.Mock()
         results = {"hits": []}
 
         formatted = await virtool.analyses.format.format_analysis(
             mongo,
-            mocker.Mock(),
+            pg,
             workflow="nuvs",
             results=results,
         )
 
         assert formatted == {"is_nuvs": True, "is_pathoscope": False}
-        m_format_nuvs.assert_called_with(mongo, results=results)
+        m_format_nuvs.assert_called_with(pg, results=results)
         assert not m_format_pathoscope.called
 
     async def test_pathoscope(self, mocker: MockerFixture, mongo: Mongo):
@@ -207,6 +209,33 @@ class TestFormatAnalysis:
         assert formatted == {"is_nuvs": False, "is_pathoscope": True}
         m_format_pathoscope.assert_called_with(mongo, pg, results=results)
         assert not m_format_nuvs.called
+
+
+class TestFormatNuvs:
+    """``format_nuvs`` enriches hits with HMM annotation data read from Postgres."""
+
+    async def test_enriches_hits_from_postgres(self, pg, seed_pg_hmm, hmm_document):
+        await seed_pg_hmm(hmm_document)
+
+        results = {
+            "hits": [
+                {"orfs": [{"hits": [{"hit": "f8666902", "score": 1.0}]}]},
+            ],
+        }
+
+        formatted = await format_nuvs(pg, results=results)
+
+        hit = formatted["hits"][0]["orfs"][0]["hits"][0]
+
+        assert hit["cluster"] == hmm_document["cluster"]
+        assert hit["families"] == hmm_document["families"]
+        assert hit["names"] == hmm_document["names"]
+        assert hit["score"] == 1.0
+
+    async def test_no_hits_skips_query(self, pg):
+        results = {"hits": []}
+
+        assert await format_nuvs(pg, results=results) == {"hits": []}
 
 
 class TestDownloadResults:

--- a/tests/fixtures/hmm.py
+++ b/tests/fixtures/hmm.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from virtool.hmm.sql import SQLHMMStatus
+from virtool.hmm.sql import SQLHMM, SQLHMMStatus
 
 
 @pytest.fixture
@@ -20,6 +20,36 @@ def seed_pg_hmm_status(pg):
                     release=document.get("release"),
                     task_id=task["id"] if task else None,
                     updates=document.get("updates", []),
+                ),
+            )
+            await session.commit()
+
+    return func
+
+
+@pytest.fixture
+def seed_pg_hmm(pg):
+    """Return a function that mirrors a Mongo HMM annotation document into Postgres.
+
+    The Mongo ``_id`` is stored in ``legacy_id``, matching the dual-write done by
+    ``HmmsData.install``.
+    """
+
+    async def func(document: dict) -> None:
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLHMM(
+                    legacy_id=document["_id"],
+                    cluster=document["cluster"],
+                    count=document["count"],
+                    length=document["length"],
+                    mean_entropy=document["mean_entropy"],
+                    total_entropy=document["total_entropy"],
+                    hidden=document.get("hidden", False),
+                    names=document["names"],
+                    families=document["families"],
+                    genera=document["genera"],
+                    entries=document["entries"],
                 ),
             )
             await session.commit()

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -5,8 +5,6 @@ import pytest
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from virtool.fake.next import DataFaker
-from virtool.mongo.core import Mongo
-from virtool.mongo.utils import get_mongo_from_app
 
 
 @pytest.fixture
@@ -70,16 +68,16 @@ async def fake_hmm_status(mongo, seed_pg_hmm_status, fake: DataFaker, static_tim
 async def test_find(
     fake_hmm_status,
     snapshot,
-    mongo: Mongo,
+    seed_pg_hmm,
     spawn_client: ClientSpawner,
     hmm_document,
 ):
-    """Check that a request with no URL parameters returns a list of HMM annotation documents."""
+    """Check that a request with no URL parameters returns a list of HMM annotation documents read from Postgres."""
     client = await spawn_client(authenticated=True)
 
     hmm_document["hidden"] = False
 
-    await mongo.hmm.insert_one(hmm_document)
+    await seed_pg_hmm(hmm_document)
 
     resp = await client.get("/hmms")
 
@@ -122,13 +120,13 @@ async def test_list_updates(fake_hmm_status, spawn_client, snapshot):
 async def test_get(
     error,
     snapshot,
-    mongo: Mongo,
+    seed_pg_hmm,
     spawn_client: ClientSpawner,
     hmm_document,
     resp_is,
 ):
     """Check that a ``GET`` request for a valid annotation document results in a response containing that complete
-    document.
+    document read from Postgres.
 
     Check that a `404` is returned if the HMM does not exist.
 
@@ -136,7 +134,7 @@ async def test_get(
     client = await spawn_client(authenticated=True)
 
     if not error:
-        await mongo.hmm.insert_one(hmm_document)
+        await seed_pg_hmm(hmm_document)
 
     resp = await client.get("/hmms/f8666902")
 
@@ -148,12 +146,15 @@ async def test_get(
     assert await resp.json() == snapshot(name="json")
 
 
-async def test_get_hmm_annotations(spawn_job_client: JobClientSpawner):
+async def test_get_hmm_annotations(
+    seed_pg_hmm,
+    spawn_job_client: JobClientSpawner,
+    hmm_document,
+):
+    """The annotations file is regenerated from the Postgres ``hmms`` table."""
     client = await spawn_job_client(authenticated=True)
-    mongo = get_mongo_from_app(client.app)
 
-    await mongo.hmm.insert_one({"_id": "foo"})
-    await mongo.hmm.insert_one({"_id": "bar"})
+    await seed_pg_hmm({**hmm_document, "hidden": False})
 
     async with client.get("/hmms/files/annotations.json.gz") as response:
         assert response.status == HTTPStatus.OK
@@ -165,7 +166,21 @@ async def test_get_hmm_annotations(spawn_job_client: JobClientSpawner):
     decompressed = gzip.decompress(compressed_bytes)
     hmms = json.loads(decompressed)
 
-    assert hmms == [{"id": "foo"}, {"id": "bar"}]
+    assert hmms == [
+        {
+            "id": "f8666902",
+            "cluster": 3463,
+            "count": 4,
+            "length": 199,
+            "mean_entropy": 0.51,
+            "total_entropy": 101.49,
+            "hidden": False,
+            "names": ["ORF-63", "ORF67", "hypothetical protein"],
+            "families": {"Baculoviridae": 3},
+            "genera": {"Alphabaculovirus": 3},
+            "entries": hmm_document["entries"],
+        },
+    ]
 
 
 @pytest.mark.parametrize("file_exists", [True, False])

--- a/tests/hmm/test_api.py
+++ b/tests/hmm/test_api.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 from http import HTTPStatus
 
@@ -75,9 +76,7 @@ async def test_find(
     """Check that a request with no URL parameters returns a list of HMM annotation documents read from Postgres."""
     client = await spawn_client(authenticated=True)
 
-    hmm_document["hidden"] = False
-
-    await seed_pg_hmm(hmm_document)
+    await seed_pg_hmm({**hmm_document, "hidden": False})
 
     resp = await client.get("/hmms")
 
@@ -160,8 +159,6 @@ async def test_get_hmm_annotations(
         assert response.status == HTTPStatus.OK
 
         compressed_bytes = await response.read()
-
-    import gzip
 
     decompressed = gzip.decompress(compressed_bytes)
     hmms = json.loads(decompressed)

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -2,6 +2,7 @@ import gzip
 import json
 
 import pytest
+from multidict import MultiDict, MultiDictProxy
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -224,19 +225,14 @@ class TestDownloadAnnotations:
         assert size == len(b"STORED-ANNOTATIONS")
         assert await _drain(stream) == b"STORED-ANNOTATIONS"
 
-    async def test_regenerates_and_stores_when_missing(self, mongo):
-        """When no object exists, annotations are regenerated from Mongo and stored."""
+    async def test_regenerates_and_stores_when_missing(self, pg, seed_pg_hmm):
+        """When no object exists, annotations are regenerated from Postgres and stored."""
         storage = ObjectProvider.for_memory()
 
-        await mongo.hmm.insert_many(
-            [
-                {"_id": "annotation_alpha", "cluster": 1, "hidden": False},
-                {"_id": "annotation_beta", "cluster": 2, "hidden": False},
-            ],
-            session=None,
-        )
+        await seed_pg_hmm({**ANNOTATION, "_id": "annotation_alpha", "cluster": 1})
+        await seed_pg_hmm({**ANNOTATION, "_id": "annotation_beta", "cluster": 2})
 
-        hmms = HmmsData(None, mongo, None, storage)
+        hmms = HmmsData(None, None, pg, storage)
 
         stream, size = await hmms.download_annotations()
 
@@ -339,6 +335,72 @@ async def _seed_status(mongo, pg, **overrides) -> None:
             ),
         )
         await session.commit()
+
+
+def _query(**params: str) -> MultiDictProxy:
+    return MultiDictProxy(MultiDict(**params))
+
+
+class TestGet:
+    """``get`` reads a single annotation from Postgres by its legacy string id."""
+
+    async def test_reads_from_postgres(self, data_layer, seed_pg_hmm, hmm_document):
+        await seed_pg_hmm(hmm_document)
+
+        hmm = await data_layer.hmms.get("f8666902")
+
+        assert hmm.id == "f8666902"
+        assert hmm.cluster == hmm_document["cluster"]
+        assert hmm.entries == hmm_document["entries"]
+
+    async def test_missing_raises_not_found(self, data_layer, seed_pg_hmm):
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.hmms.get("does_not_exist")
+
+
+class TestFind:
+    """``find`` lists annotations from Postgres, excluding hidden ones."""
+
+    async def test_reads_from_postgres(
+        self, data_layer, seed_pg_hmm_status, seed_pg_hmm, hmm_document
+    ):
+        await seed_pg_hmm_status({})
+        await seed_pg_hmm({**hmm_document, "hidden": False})
+
+        result = await data_layer.hmms.find(_query())
+
+        assert result.found_count == 1
+        assert result.total_count == 1
+        assert [document.id for document in result.documents] == ["f8666902"]
+
+    async def test_excludes_hidden(
+        self, data_layer, seed_pg_hmm_status, seed_pg_hmm, hmm_document
+    ):
+        await seed_pg_hmm_status({})
+        await seed_pg_hmm({**hmm_document, "_id": "visible", "hidden": False})
+        await seed_pg_hmm({**hmm_document, "_id": "concealed", "hidden": True})
+
+        result = await data_layer.hmms.find(_query())
+
+        assert result.total_count == 1
+        assert [document.id for document in result.documents] == ["visible"]
+
+    async def test_search_filters_by_name(
+        self, data_layer, seed_pg_hmm_status, seed_pg_hmm, hmm_document
+    ):
+        await seed_pg_hmm_status({})
+        await seed_pg_hmm(
+            {**hmm_document, "_id": "polymerase", "names": ["RNA polymerase"]},
+        )
+        await seed_pg_hmm(
+            {**hmm_document, "_id": "capsid", "names": ["capsid protein"]},
+        )
+
+        result = await data_layer.hmms.find(_query(find="polymerase"))
+
+        assert result.found_count == 1
+        assert result.total_count == 2
+        assert [document.id for document in result.documents] == ["polymerase"]
 
 
 class TestInstall:

--- a/tests/hmm/test_db.py
+++ b/tests/hmm/test_db.py
@@ -1,14 +1,14 @@
 import json
 
 from virtool.hmm.db import generate_annotations
-from virtool.mongo.core import Mongo
 
 
-async def test_generate_annotations(mongo: Mongo):
-    await mongo.hmm.insert_one({"_id": "foo"})
-    await mongo.hmm.insert_one({"_id": "bar"})
+async def test_generate_annotations(pg, seed_pg_hmm, hmm_document):
+    """Annotations are generated from the Postgres ``hmms`` table."""
+    await seed_pg_hmm({**hmm_document, "_id": "foo", "hidden": False})
+    await seed_pg_hmm({**hmm_document, "_id": "bar", "hidden": False})
 
-    result = await generate_annotations(mongo)
+    result = await generate_annotations(pg)
 
     hmms = json.loads(result)
 

--- a/tests/hmm/test_fake.py
+++ b/tests/hmm/test_fake.py
@@ -2,6 +2,6 @@ from virtool.fake.next import DataFaker
 
 
 async def test_create_fake_hmm(fake: DataFaker, snapshot):
-    hmm = await fake.hmm.create(fake.mongo)
+    hmm = await fake.hmm.create()
 
     assert hmm == snapshot

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -13,9 +13,12 @@ from typing import TYPE_CHECKING, Any
 
 import openpyxl.styles
 import visvalingamwyatt as vw
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.history.db import patch_to_version
+from virtool.hmm.sql import SQLHMM
 from virtool.models.enums import AnalysisWorkflow
 from virtool.otus.utils import format_isolate_name
 
@@ -199,13 +202,13 @@ def format_pathoscope_sequences(
 
 
 async def format_nuvs(
-    mongo: "Mongo",
+    pg: AsyncEngine,
     *,
     results: dict[str, Any],
 ) -> dict[str, Any]:
     """Format NuVs analysis results by attaching the HMM annotation data to the hits.
 
-    :param mongo: the database object
+    :param pg: the application PostgreSQL database object
     :param results: the results to format
     :return: the formatted results
 
@@ -214,9 +217,27 @@ async def format_nuvs(
 
     hit_ids = list({h["hit"] for s in hits for o in s["orfs"] for h in o["hits"]})
 
-    cursor = mongo.hmm.find({"_id": {"$in": hit_ids}}, ["cluster", "families", "names"])
+    hmms = {}
 
-    hmms = {d.pop("_id"): d async for d in cursor}
+    if hit_ids:
+        async with AsyncSession(pg) as session:
+            rows = (
+                await session.execute(
+                    select(SQLHMM).where(
+                        compose_legacy_id_multi_expression(SQLHMM, hit_ids),
+                    ),
+                )
+            ).scalars()
+
+        for row in rows:
+            annotation = {
+                "cluster": row.cluster,
+                "families": row.families,
+                "names": row.names,
+            }
+
+            hmms[row.legacy_id] = annotation
+            hmms[str(row.id)] = annotation
 
     for sequence in hits:
         for orf in sequence["orfs"]:
@@ -365,7 +386,7 @@ async def format_analysis(
         raise ValueError("Analysis has no workflow field")
 
     if workflow == AnalysisWorkflow.nuvs.value:
-        return await format_nuvs(mongo, results=results)
+        return await format_nuvs(pg, results=results)
 
     if workflow == AnalysisWorkflow.aodp.value:
         return await format_aodp(mongo, pg, results=results)

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -236,8 +236,10 @@ async def format_nuvs(
                 "names": row.names,
             }
 
-            hmms[row.legacy_id] = annotation
             hmms[str(row.id)] = annotation
+
+            if row.legacy_id is not None:
+                hmms[row.legacy_id] = annotation
 
     for sequence in hits:
         for orf in sequence["orfs"]:

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -267,13 +267,11 @@ class GroupsFakerDomain(DataFakerDomain):
 class HMMFakerDomain(DataFakerDomain):
     model = HMM
 
-    async def create(self, mongo: Mongo) -> HMM:
+    async def create(self) -> HMM:
         """Create a new fake hmm.
 
         The annotation is dual-written to Mongo and Postgres so it is visible
         to read paths that have been switched to Postgres.
-
-        :param mongo: the mongo DB connection
 
         :return: a new fake hmm
         """
@@ -300,8 +298,11 @@ class HMMFakerDomain(DataFakerDomain):
             "names": [faker.pystr()],
         }
 
-        async with both_transactions(mongo, self._pg) as (mongo_session, pg_session):
-            await mongo.hmm.insert_one(
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.hmm.insert_one(
                 {**document, "hidden": False},
                 session=mongo_session,
             )

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -23,12 +23,14 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
 from virtool.data.layer import DataLayer
+from virtool.data.topg import both_transactions
 from virtool.example import example_path
 from virtool.fake.providers import OrganismProvider, SegmentProvider, SequenceProvider
 from virtool.groups.models import Group
 from virtool.groups.oas import PermissionsUpdate, UpdateGroupRequest
 from virtool.groups.pg import SQLGroup
 from virtool.hmm.models import HMM
+from virtool.hmm.sql import SQLHMM
 from virtool.jobs.models import TERMINAL_JOB_STATES, Job, JobState
 from virtool.jobs.pg import SQLJob
 from virtool.jobs.utils import WORKFLOW_NAMES
@@ -268,6 +270,9 @@ class HMMFakerDomain(DataFakerDomain):
     async def create(self, mongo: Mongo) -> HMM:
         """Create a new fake hmm.
 
+        The annotation is dual-written to Mongo and Postgres so it is visible
+        to read paths that have been switched to Postgres.
+
         :param mongo: the mongo DB connection
 
         :return: a new fake hmm
@@ -275,27 +280,47 @@ class HMMFakerDomain(DataFakerDomain):
         hmm_id = "".join(self._faker.mongo_id())
         faker = self._faker
 
-        document = await mongo.hmm.insert_one(
-            {
-                "entries": [
-                    {
-                        "accession": faker.pystr(),
-                        "gi": faker.pystr(),
-                        "name": faker.pystr(),
-                        "organism": faker.pystr(),
-                    },
-                ],
-                "genera": {faker.pystr(): faker.pyint()},
-                "length": faker.pyint(),
-                "mean_entropy": faker.pyfloat(),
-                "total_entropy": faker.pyfloat(),
-                "_id": hmm_id,
-                "cluster": faker.pyint(),
-                "count": faker.pyint(),
-                "families": {faker.pystr(): faker.pyint()},
-                "names": [faker.pystr()],
-            },
-        )
+        document = {
+            "entries": [
+                {
+                    "accession": faker.pystr(),
+                    "gi": faker.pystr(),
+                    "name": faker.pystr(),
+                    "organism": faker.pystr(),
+                },
+            ],
+            "genera": {faker.pystr(): faker.pyint()},
+            "length": faker.pyint(),
+            "mean_entropy": faker.pyfloat(),
+            "total_entropy": faker.pyfloat(),
+            "_id": hmm_id,
+            "cluster": faker.pyint(),
+            "count": faker.pyint(),
+            "families": {faker.pystr(): faker.pyint()},
+            "names": [faker.pystr()],
+        }
+
+        async with both_transactions(mongo, self._pg) as (mongo_session, pg_session):
+            await mongo.hmm.insert_one(
+                {**document, "hidden": False},
+                session=mongo_session,
+            )
+
+            pg_session.add(
+                SQLHMM(
+                    legacy_id=hmm_id,
+                    cluster=document["cluster"],
+                    count=document["count"],
+                    length=document["length"],
+                    mean_entropy=document["mean_entropy"],
+                    total_entropy=document["total_entropy"],
+                    hidden=False,
+                    names=document["names"],
+                    families=document["families"],
+                    genera=document["genera"],
+                    entries=document["entries"],
+                ),
+            )
 
         return HMM(**document)
 

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -1,25 +1,27 @@
 import asyncio
 import gzip
+import math
 from collections.abc import AsyncIterator
 
 from aiohttp import ClientSession
 from multidict import MultiDictProxy
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.api.utils import compose_regex_query, paginate
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import (
     ResourceConflictError,
     ResourceError,
     ResourceNotFoundError,
 )
-from virtool.data.topg import both_transactions
+from virtool.data.topg import (
+    both_transactions,
+    compose_legacy_id_single_expression,
+)
 from virtool.data.transforms import apply_transforms
 from virtool.github import create_update_subdocument
 from virtool.hmm.db import (
     HMM_REPO_SLUG,
-    HMMS_PROJECTION,
     fetch_and_update_release,
     generate_annotations,
 )
@@ -43,6 +45,28 @@ HMM_ANNOTATIONS_KEY = "hmm/annotations.json.gz"
 """The storage key for the gzipped HMM annotations file."""
 
 
+def _compose_hmm_search_filter(term: str):
+    """Compose a case-insensitive substring match against any of an HMM's names.
+
+    Mirrors the Mongo ``compose_regex_query(term, ["names"])`` behaviour the find
+    endpoint used before reading from Postgres: ``names`` is an array, so the
+    match succeeds when any element contains the term. The term is matched
+    literally, so SQL ``LIKE`` wildcards in it are escaped rather than
+    interpreted.
+    """
+    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped}%"
+
+    elements = func.jsonb_array_elements_text(SQLHMM.names).table_valued("value")
+
+    return (
+        select(1)
+        .select_from(elements)
+        .where(elements.c.value.ilike(pattern, escape="\\"))
+        .exists()
+    )
+
+
 class HmmsData(DataLayerDomain):
     name = "hmms"
 
@@ -59,32 +83,92 @@ class HmmsData(DataLayerDomain):
         self._storage = storage
 
     async def find(self, query: MultiDictProxy):
-        db_query = {}
+        try:
+            page = int(query["page"])
+        except (KeyError, ValueError):
+            page = 1
+
+        try:
+            per_page = int(query["per_page"])
+        except (KeyError, ValueError):
+            per_page = 25
+
+        not_hidden = SQLHMM.hidden.is_(False)
+
+        filters = [not_hidden]
 
         if term := query.get("find"):
-            db_query.update(compose_regex_query(term, ["names"]))
+            filters.append(_compose_hmm_search_filter(term))
 
         data, status = await asyncio.gather(
-            paginate(
-                self._mongo.hmm,
-                db_query,
-                query,
-                sort="cluster",
-                projection=HMMS_PROJECTION,
-                base_query={"hidden": False},
-            ),
+            self._find(page, per_page, filters, not_hidden),
             self.get_status(),
         )
 
         return HMMSearchResult(**data, status=status)
 
+    async def _find(self, page: int, per_page: int, filters: list, not_hidden) -> dict:
+        async with AsyncSession(self._pg) as session:
+            total_count = await session.scalar(
+                select(func.count()).select_from(SQLHMM).where(not_hidden),
+            )
+            found_count = await session.scalar(
+                select(func.count()).select_from(SQLHMM).where(*filters),
+            )
+
+            rows = (
+                await session.execute(
+                    select(SQLHMM)
+                    .where(*filters)
+                    .order_by(SQLHMM.cluster, SQLHMM.id)
+                    .offset(per_page * (page - 1))
+                    .limit(per_page),
+                )
+            ).scalars()
+
+        return {
+            "documents": [
+                {
+                    "id": row.legacy_id,
+                    "cluster": row.cluster,
+                    "count": row.count,
+                    "families": row.families,
+                    "names": row.names,
+                }
+                for row in rows
+            ],
+            "total_count": total_count,
+            "found_count": found_count,
+            "page_count": math.ceil(found_count / per_page),
+            "per_page": per_page,
+            "page": page,
+        }
+
     async def get(self, hmm_id: str) -> HMM:
-        document = await self._mongo.hmm.find_one({"_id": hmm_id})
+        async with AsyncSession(self._pg) as session:
+            hmm = (
+                await session.execute(
+                    select(SQLHMM).where(
+                        compose_legacy_id_single_expression(SQLHMM, hmm_id),
+                    ),
+                )
+            ).scalar_one_or_none()
 
-        if document:
-            return HMM(**document)
+        if hmm is None:
+            raise ResourceNotFoundError()
 
-        raise ResourceNotFoundError()
+        return HMM(
+            id=hmm.legacy_id,
+            cluster=hmm.cluster,
+            count=hmm.count,
+            length=hmm.length,
+            mean_entropy=hmm.mean_entropy,
+            total_entropy=hmm.total_entropy,
+            names=hmm.names,
+            families=hmm.families,
+            genera=hmm.genera,
+            entries=hmm.entries,
+        )
 
     async def get_status(self):
         async with AsyncSession(self._pg) as session:
@@ -310,7 +394,7 @@ class HmmsData(DataLayerDomain):
         else:
             return self._storage.read(HMM_ANNOTATIONS_KEY), size
 
-        annotations_bytes = await generate_annotations(self._mongo)
+        annotations_bytes = await generate_annotations(self._pg)
         compressed = await asyncio.to_thread(
             gzip.compress,
             annotations_bytes,

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -84,12 +84,12 @@ class HmmsData(DataLayerDomain):
 
     async def find(self, query: MultiDictProxy):
         try:
-            page = int(query["page"])
+            page = max(1, int(query["page"]))
         except (KeyError, ValueError):
             page = 1
 
         try:
-            per_page = int(query["per_page"])
+            per_page = max(1, int(query["per_page"]))
         except (KeyError, ValueError):
             per_page = 25
 

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -4,19 +4,18 @@ import json
 
 import aiohttp.client_exceptions
 from aiohttp import ClientSession
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
 import virtool.utils
 from virtool.data.topg import both_transactions
 from virtool.errors import GitHubError
 from virtool.github import get_etag, get_release
-from virtool.hmm.sql import HMM_STATUS_ID, SQLHMMStatus
+from virtool.hmm.sql import HMM_STATUS_ID, SQLHMM, SQLHMMStatus
 from virtool.hmm.utils import format_hmm_release
-from virtool.mongo.core import Mongo
 from virtool.types import Document
-from virtool.utils import base_processor
 
 logger = get_logger("hmms")
 
@@ -29,9 +28,6 @@ HMMS_REFRESH_INTERVAL = 600
 There is currently only one version of HMM data and refreshes after the initial install
 of the data do nothing.
 """
-
-HMMS_PROJECTION = ["_id", "cluster", "names", "count", "families"]
-"""A MongoDB projection for HMM document lists."""
 
 
 async def fetch_and_update_release(
@@ -140,12 +136,36 @@ async def fetch_and_update_release(
     return release
 
 
-async def generate_annotations(mongo: Mongo) -> bytes:
+def annotation_from_row(row: SQLHMM) -> Document:
+    """Reconstruct the stored HMM annotation document from a Postgres row.
+
+    The Mongo ``_id`` is exposed as ``id`` so the output matches the document
+    shape that was previously generated from Mongo.
+    """
+    return {
+        "id": row.legacy_id,
+        "cluster": row.cluster,
+        "count": row.count,
+        "length": row.length,
+        "mean_entropy": row.mean_entropy,
+        "total_entropy": row.total_entropy,
+        "hidden": row.hidden,
+        "names": row.names,
+        "families": row.families,
+        "genera": row.genera,
+        "entries": row.entries,
+    }
+
+
+async def generate_annotations(pg: AsyncEngine) -> bytes:
     """Generate the HMM annotations as JSON bytes.
 
-    :param mongo: the app mongo client
+    :param pg: the application Postgres client
     :return: the annotations as JSON bytes
     """
-    annotations = [base_processor(document) async for document in mongo.hmm.find({})]
+    async with AsyncSession(pg) as session:
+        rows = (await session.execute(select(SQLHMM))).scalars().all()
+
+    annotations = [annotation_from_row(row) for row in rows]
 
     return json.dumps(annotations).encode()

--- a/virtool/hmm/db.py
+++ b/virtool/hmm/db.py
@@ -164,7 +164,9 @@ async def generate_annotations(pg: AsyncEngine) -> bytes:
     :return: the annotations as JSON bytes
     """
     async with AsyncSession(pg) as session:
-        rows = (await session.execute(select(SQLHMM))).scalars().all()
+        rows = (
+            (await session.execute(select(SQLHMM).order_by(SQLHMM.id))).scalars().all()
+        )
 
     annotations = [annotation_from_row(row) for row in rows]
 


### PR DESCRIPTION
## Summary

- Moves `find`, `get`, and `generate_annotations` in `HmmsData` from MongoDB to PostgreSQL (step 4 of the HMM migration)
- Switches `format_nuvs` in `analyses/format.py` to look up HMM annotation hits from Postgres instead of Mongo
- Updates `HMMFakerDomain.create` to dual-write to both stores so fake data is visible to the new Postgres read paths