### PR TITLE
feat(migration): add legacy_history postgres table

### DIFF
--- a/assets/alembic/versions/743a03e550e0_create_legacy_history_table.py
+++ b/assets/alembic/versions/743a03e550e0_create_legacy_history_table.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("description", sa.String(), nullable=False),
         sa.Column("method_name", sa.String(), nullable=False),
-        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
         sa.Column("otu_id", sa.String(), nullable=False),
         sa.Column("otu_name", sa.String(), nullable=False),
         sa.Column("otu_version", sa.String(), nullable=True),

--- a/assets/alembic/versions/743a03e550e0_create_legacy_history_table.py
+++ b/assets/alembic/versions/743a03e550e0_create_legacy_history_table.py
@@ -1,0 +1,65 @@
+"""create legacy_history table
+
+Revision ID: 743a03e550e0
+Revises: 997cf9a66f10
+Create Date: 2026-06-06 00:13:19.076687+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "743a03e550e0"
+down_revision = "997cf9a66f10"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "legacy_history",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=True), nullable=False),
+        sa.Column("legacy_id", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("method_name", sa.String(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("otu_id", sa.String(), nullable=False),
+        sa.Column("otu_name", sa.String(), nullable=False),
+        sa.Column("otu_version", sa.String(), nullable=True),
+        sa.Column("reference_id", sa.String(), nullable=False),
+        sa.Column("index_id", sa.String(), nullable=True),
+        sa.Column("index_version", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("legacy_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+    )
+    op.create_index(
+        "ix_legacy_history_otu_id_otu_version",
+        "legacy_history",
+        ["otu_id", sa.text("otu_version DESC")],
+    )
+    op.create_index(
+        "ix_legacy_history_reference_id",
+        "legacy_history",
+        ["reference_id"],
+    )
+    op.create_index(
+        "ix_legacy_history_index_id",
+        "legacy_history",
+        ["index_id"],
+    )
+    op.create_index(
+        "ix_legacy_history_user_id",
+        "legacy_history",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_legacy_history_user_id", table_name="legacy_history")
+    op.drop_index("ix_legacy_history_index_id", table_name="legacy_history")
+    op.drop_index("ix_legacy_history_reference_id", table_name="legacy_history")
+    op.drop_index("ix_legacy_history_otu_id_otu_version", table_name="legacy_history")
+    op.drop_table("legacy_history")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -428,5 +428,12 @@
       'name': 'convert administrator_role to text',
       'revision': '997cf9a66f10',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 62,
+      'name': 'create legacy_history table',
+      'revision': '743a03e550e0',
+    }),
   ])
 # ---

--- a/tests/migration/test_create_legacy_history_table.py
+++ b/tests/migration/test_create_legacy_history_table.py
@@ -1,0 +1,126 @@
+"""Tests for the create-legacy-history-table migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+from virtool.utils import timestamp
+
+REVISION = "743a03e550e0"
+
+
+async def insert_user(session: AsyncSession) -> int:
+    result = await session.execute(
+        text("""
+            INSERT INTO users (
+                handle, legacy_id, active, email, force_reset,
+                invalidate_sessions, last_password_change, password, settings
+            )
+            VALUES (
+                'testuser', 'legacy_user_123', true, '', false,
+                false, :now, :password, '{}'::jsonb
+            )
+            RETURNING id
+        """),
+        {"now": timestamp(), "password": b"hashed_password"},
+    )
+    return result.scalar_one()
+
+
+INSERT_HISTORY = text("""
+    INSERT INTO legacy_history (
+        legacy_id, created_at, description, method_name, user_id,
+        otu_id, otu_name, otu_version, reference_id, index_id, index_version
+    )
+    VALUES (
+        :legacy_id, :now, 'Created Foobar', 'create', :user_id,
+        'otu_1', 'Foobar', '0', 'ref_1', 'unbuilt', 'unbuilt'
+    )
+""")
+
+
+class TestCreateLegacyHistoryTable:
+    async def test_creates_empty_table(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = (
+                (await session.execute(text("SELECT * FROM legacy_history")))
+                .mappings()
+                .all()
+            )
+
+        assert rows == []
+
+    async def test_accepts_row_with_valid_user(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            user_id = await insert_user(session)
+            await session.execute(
+                INSERT_HISTORY,
+                {"legacy_id": "otu_1.0", "now": timestamp(), "user_id": user_id},
+            )
+            await session.commit()
+
+            rows = (
+                (
+                    await session.execute(
+                        text("SELECT legacy_id, user_id FROM legacy_history"),
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        assert [dict(row) for row in rows] == [
+            {"legacy_id": "otu_1.0", "user_id": user_id},
+        ]
+
+    async def test_rejects_duplicate_legacy_id(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            user_id = await insert_user(session)
+            await session.execute(
+                INSERT_HISTORY,
+                {"legacy_id": "otu_1.0", "now": timestamp(), "user_id": user_id},
+            )
+            await session.commit()
+
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    INSERT_HISTORY,
+                    {"legacy_id": "otu_1.0", "now": timestamp(), "user_id": user_id},
+                )
+
+    async def test_rejects_unknown_user_id(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        async with AsyncSession(ctx.pg) as session:
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    INSERT_HISTORY,
+                    {"legacy_id": "otu_1.0", "now": timestamp(), "user_id": 999},
+                )

--- a/virtool/history/sql.py
+++ b/virtool/history/sql.py
@@ -54,7 +54,7 @@ class SQLLegacyHistory(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime)
     description: Mapped[str]
     method_name: Mapped[str]
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"), index=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
     otu_id: Mapped[str]
     otu_name: Mapped[str]
     otu_version: Mapped[str | None]

--- a/virtool/history/sql.py
+++ b/virtool/history/sql.py
@@ -1,5 +1,18 @@
-from sqlalchemy import Column, Integer, String
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Identity,
+    Index,
+    Integer,
+    String,
+    desc,
+)
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
 
@@ -16,3 +29,35 @@ class SQLHistoryDiff(Base):
     id = Column(Integer, primary_key=True)
     change_id = Column(String, unique=True)
     diff = Column(JSONB)
+
+
+class SQLLegacyHistory(Base):
+    """SQL model for the legacy Mongo ``history`` collection.
+
+    This is a faithful 1:1 lift of the Mongo document into Postgres. Nested Mongo
+    fields are flattened into columns:
+
+    - ``otu``/``reference``/``index`` ids are bare string columns with no foreign
+      key, because those collections have not been migrated to Postgres yet.
+    - ``user.id`` becomes a real foreign key to ``users.id``.
+    - ``otu_version`` and ``index_version`` are strings because Mongo stores both
+      integer versions and sentinel values such as ``"removed"`` and ``"unbuilt"``.
+    """
+
+    __tablename__ = "legacy_history"
+    __table_args__ = (
+        Index("ix_legacy_history_otu_id_otu_version", "otu_id", desc("otu_version")),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
+    legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    description: Mapped[str]
+    method_name: Mapped[str]
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"), index=True)
+    otu_id: Mapped[str]
+    otu_name: Mapped[str]
+    otu_version: Mapped[str | None]
+    reference_id: Mapped[str] = mapped_column(index=True)
+    index_id: Mapped[str | None] = mapped_column(index=True)
+    index_version: Mapped[str | None]


### PR DESCRIPTION
## Summary

- Creates the `legacy_history` Postgres table as step 1 of migrating the history collection from MongoDB to Postgres
- Adds the `SQLLegacyHistory` SQLAlchemy model with flattened columns for nested Mongo fields; `otu_id`, `reference_id`, and `index_id` are bare strings (no FK) because those collections haven't been migrated yet
- Adds indexes on `(otu_id, otu_version DESC)`, `reference_id`, `index_id`, and `user_id`; `user_id` carries a real FK to `users.id`