### PR TITLE
fix(migration): delete orphaned analysis_files and nuvs_blast rows

### DIFF
--- a/assets/alembic/versions/f51a03fa6f9a_convert_analysis_files_and_nuvs_blast_.py
+++ b/assets/alembic/versions/f51a03fa6f9a_convert_analysis_files_and_nuvs_blast_.py
@@ -10,9 +10,12 @@ slug to real integer foreign keys against ``analyses.id`` with
   of the same name; its ``(analysis_id, sequence_index)`` unique constraint is
   recreated on the integer column.
 
-Both columns are backfilled by joining ``analyses.legacy_id``. Any row that does
-not resolve to an analysis aborts the migration loudly rather than being dropped
-or left NULL.
+Both columns are backfilled by joining ``analyses.legacy_id``. Rows that do not
+resolve to an analysis are orphans: the analysis they belonged to was deleted,
+but the historical delete path never removed these dependent rows (and the old
+string column carried no foreign key, so nothing cascaded). Their on-disk files
+were already cleaned up at delete time. They are deleted here, matching the
+``ON DELETE CASCADE`` the new foreign keys establish, and the count is logged.
 
 Revision ID: f51a03fa6f9a
 Revises: 997cf9a66f10
@@ -22,6 +25,7 @@ Create Date: 2026-06-05 22:41:04.758568+00:00
 
 import sqlalchemy as sa
 from alembic import op
+from structlog import get_logger
 
 # revision identifiers, used by Alembic.
 revision = "f51a03fa6f9a"
@@ -29,9 +33,38 @@ down_revision = "997cf9a66f10"
 branch_labels = None
 depends_on = None
 
+logger = get_logger("migration")
+
+
+def _delete_orphans(table: str, column: str) -> None:
+    """Delete rows in ``table`` whose ``column`` is still NULL after backfill.
+
+    A NULL means the row referenced an analysis that no longer exists, so the
+    row is an orphan with no on-disk file behind it. Removing it here mirrors the
+    ``ON DELETE CASCADE`` the new foreign key applies going forward.
+    """
+    deleted = (
+        op.get_bind()
+        .execute(sa.text(f"DELETE FROM {table} WHERE {column} IS NULL"))  # noqa: S608
+        .rowcount
+    )
+
+    if deleted:
+        logger.info(
+            "deleted orphaned rows with no matching analysis",
+            table=table,
+            count=deleted,
+        )
+
 
 def _abort_if_unmapped(table: str, column: str) -> None:
-    """Raise if any row in ``table`` has a NULL ``column`` after backfill."""
+    """Raise if any row in ``table`` has a NULL ``column`` after backfill.
+
+    Used by ``downgrade`` only: a NULL slug there means the row points at a
+    Postgres-native analysis that has no ``legacy_id``, so it cannot be
+    represented in the slug-keyed schema. That is live, unrepresentable data, not
+    an orphan, so the downgrade refuses to proceed rather than dropping it.
+    """
     unmapped = (
         op.get_bind()
         .execute(sa.text(f"SELECT COUNT(*) FROM {table} WHERE {column} IS NULL"))  # noqa: S608
@@ -62,7 +95,7 @@ def upgrade() -> None:
         """,
     )
 
-    _abort_if_unmapped("analysis_files", "analysis_id")
+    _delete_orphans("analysis_files", "analysis_id")
 
     op.drop_column("analysis_files", "analysis")
 
@@ -98,7 +131,7 @@ def upgrade() -> None:
         """,
     )
 
-    _abort_if_unmapped("nuvs_blast", "analysis_id_int")
+    _delete_orphans("nuvs_blast", "analysis_id_int")
 
     op.drop_column("nuvs_blast", "analysis_id")
 

--- a/assets/alembic/versions/f51a03fa6f9a_convert_analysis_files_and_nuvs_blast_.py
+++ b/assets/alembic/versions/f51a03fa6f9a_convert_analysis_files_and_nuvs_blast_.py
@@ -220,4 +220,8 @@ def downgrade() -> None:
         """,
     )
 
+    _abort_if_unmapped("analysis_files", "analysis")
+
     op.drop_column("analysis_files", "analysis_id")
+
+    op.alter_column("analysis_files", "analysis", nullable=False)

--- a/tests/alembic/test_f51a03fa6f9a_convert_analysis_files_and_nuvs_blast_to_integer_analysis_fks.py
+++ b/tests/alembic/test_f51a03fa6f9a_convert_analysis_files_and_nuvs_blast_to_integer_analysis_fks.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import alembic.command
 import alembic.config
 import arrow
-import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -126,34 +125,46 @@ async def test_upgrade_backfills_integer_fks(
     assert blast_analysis_id == analysis_id
 
 
-async def test_upgrade_aborts_on_orphan_analysis_file(
+async def test_upgrade_deletes_orphan_analysis_file(
     apply_alembic: Callable,
     migration_pg: AsyncEngine,
 ):
-    """An ``analysis_files`` row whose slug resolves to no analysis aborts the run."""
+    """An ``analysis_files`` row whose slug resolves to no analysis is deleted."""
     await asyncio.to_thread(apply_alembic, DOWN_REVISION)
 
     async with AsyncSession(migration_pg) as session:
         await _insert_analysis_file(session, "orphan")
         await session.commit()
 
-    with pytest.raises(RuntimeError, match="could not be mapped"):
-        await asyncio.to_thread(apply_alembic, REVISION)
+    await asyncio.to_thread(apply_alembic, REVISION)
+
+    async with AsyncSession(migration_pg) as session:
+        file_count = (
+            await session.execute(text("SELECT count(*) FROM analysis_files"))
+        ).scalar_one()
+
+    assert file_count == 0
 
 
-async def test_upgrade_aborts_on_orphan_nuvs_blast(
+async def test_upgrade_deletes_orphan_nuvs_blast(
     apply_alembic: Callable,
     migration_pg: AsyncEngine,
 ):
-    """A ``nuvs_blast`` row whose slug resolves to no analysis aborts the run."""
+    """A ``nuvs_blast`` row whose slug resolves to no analysis is deleted."""
     await asyncio.to_thread(apply_alembic, DOWN_REVISION)
 
     async with AsyncSession(migration_pg) as session:
         await _insert_nuvs_blast(session, "orphan", 1)
         await session.commit()
 
-    with pytest.raises(RuntimeError, match="could not be mapped"):
-        await asyncio.to_thread(apply_alembic, REVISION)
+    await asyncio.to_thread(apply_alembic, REVISION)
+
+    async with AsyncSession(migration_pg) as session:
+        blast_count = (
+            await session.execute(text("SELECT count(*) FROM nuvs_blast"))
+        ).scalar_one()
+
+    assert blast_count == 0
 
 
 async def test_cascade_delete_removes_dependents(


### PR DESCRIPTION
## Summary

- The previous migration revision aborted if any `analysis_files` or `nuvs_blast` rows had a NULL `analysis_id` after the backfill step, which was too strict.
- Those NULLs represent genuine orphans: the parent analysis was deleted via an old code path that never cascaded to dependent rows (the old string column had no FK), but the on-disk files were already cleaned up at delete time.
- This fix replaces the abort-on-NULL check in the `upgrade()` path with a delete-and-log step that removes the orphans, matching the `ON DELETE CASCADE` the new foreign keys establish going forward. The strict check is retained in `downgrade()` where a NULL truly means unrepresentable data.