### PR TITLE
Throttle Sentry traces for probe and count-polling endpoints

### DIFF
--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 
 from virtool.sentry import (
     DEFAULT_TRACES_SAMPLE_RATE,
-    UNTRACED_PATHS,
+    PATH_TRACES_SAMPLE_RATES,
     configure_sentry,
     traces_sampler,
 )
@@ -50,20 +50,26 @@ class TestConfigureSentry:
 
 
 class TestTracesSampler:
-    """Test the traces_sampler trace-suppression logic."""
+    """Test the traces_sampler trace-throttling logic."""
 
-    def test_untraced_path_is_suppressed(self) -> None:
-        """A high-frequency probe or polling path is never traced."""
+    def test_probe_path_is_suppressed(self) -> None:
+        """A health probe path is never traced."""
         request = MagicMock(path="/health/ready")
 
         assert traces_sampler({"aiohttp_request": request}) == 0.0
 
-    def test_all_untraced_paths_are_suppressed(self) -> None:
-        """Every configured untraced path is suppressed."""
-        for path in UNTRACED_PATHS:
+    def test_count_path_uses_small_rate(self) -> None:
+        """A count-polling path keeps a small sample rate."""
+        request = MagicMock(path="/jobs/counts")
+
+        assert traces_sampler({"aiohttp_request": request}) == 0.01
+
+    def test_throttled_paths_use_configured_rate(self) -> None:
+        """Every configured path is sampled at its rate."""
+        for path, rate in PATH_TRACES_SAMPLE_RATES.items():
             request = MagicMock(path=path)
 
-            assert traces_sampler({"aiohttp_request": request}) == 0.0
+            assert traces_sampler({"aiohttp_request": request}) == rate
 
     def test_other_path_uses_default_rate(self) -> None:
         """A normal request path is sampled at the default rate."""
@@ -78,7 +84,7 @@ class TestTracesSampler:
         assert traces_sampler({}) == DEFAULT_TRACES_SAMPLE_RATE
 
     def test_parent_sampling_decision_is_honoured(self) -> None:
-        """An upstream sampling decision is inherited for traced paths."""
+        """An upstream sampling decision is inherited for non-throttled paths."""
         request = MagicMock(path="/samples")
 
         assert (
@@ -88,8 +94,8 @@ class TestTracesSampler:
             traces_sampler({"aiohttp_request": request, "parent_sampled": True}) == 1.0
         )
 
-    def test_untraced_path_overrides_parent_sampling(self) -> None:
-        """An untraced path is suppressed even when the parent was sampled."""
+    def test_throttled_path_overrides_parent_sampling(self) -> None:
+        """A throttled path uses its rate even when the parent was sampled."""
         request = MagicMock(path="/health/live")
 
         assert (

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock
 
 from pytest_mock import MockerFixture
 
-from virtool.sentry import configure_sentry
+from virtool.sentry import (
+    DEFAULT_TRACES_SAMPLE_RATE,
+    UNTRACED_PATHS,
+    configure_sentry,
+    traces_sampler,
+)
 
 
 class TestConfigureSentry:
@@ -24,7 +29,7 @@ class TestConfigureSentry:
 
         assert init_args["dsn"] == dsn
         assert init_args["release"] == release
-        assert init_args["traces_sample_rate"] == 0.6
+        assert init_args["traces_sampler"] is traces_sampler
         assert "_experiments" in init_args
         assert init_args["_experiments"]["enable_logs"] is True
 
@@ -42,3 +47,51 @@ class TestConfigureSentry:
 
         configure_sentry(None, "9.1.0")
         mock_sentry_sdk.init.assert_not_called()
+
+
+class TestTracesSampler:
+    """Test the traces_sampler trace-suppression logic."""
+
+    def test_untraced_path_is_suppressed(self) -> None:
+        """A high-frequency probe or polling path is never traced."""
+        request = MagicMock(path="/health/ready")
+
+        assert traces_sampler({"aiohttp_request": request}) == 0.0
+
+    def test_all_untraced_paths_are_suppressed(self) -> None:
+        """Every configured untraced path is suppressed."""
+        for path in UNTRACED_PATHS:
+            request = MagicMock(path=path)
+
+            assert traces_sampler({"aiohttp_request": request}) == 0.0
+
+    def test_other_path_uses_default_rate(self) -> None:
+        """A normal request path is sampled at the default rate."""
+        request = MagicMock(path="/samples")
+
+        assert (
+            traces_sampler({"aiohttp_request": request}) == DEFAULT_TRACES_SAMPLE_RATE
+        )
+
+    def test_missing_request_uses_default_rate(self) -> None:
+        """A non-aiohttp transaction falls back to the default rate."""
+        assert traces_sampler({}) == DEFAULT_TRACES_SAMPLE_RATE
+
+    def test_parent_sampling_decision_is_honoured(self) -> None:
+        """An upstream sampling decision is inherited for traced paths."""
+        request = MagicMock(path="/samples")
+
+        assert (
+            traces_sampler({"aiohttp_request": request, "parent_sampled": False}) == 0.0
+        )
+        assert (
+            traces_sampler({"aiohttp_request": request, "parent_sampled": True}) == 1.0
+        )
+
+    def test_untraced_path_overrides_parent_sampling(self) -> None:
+        """An untraced path is suppressed even when the parent was sampled."""
+        request = MagicMock(path="/health/live")
+
+        assert (
+            traces_sampler({"aiohttp_request": request, "parent_sampled": True}) == 0.0
+        )

--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -11,34 +11,33 @@ from structlog import get_logger
 logger = get_logger("sentry")
 
 DEFAULT_TRACES_SAMPLE_RATE = 0.6
-"""The sample rate applied to transactions that are not explicitly suppressed."""
+"""The sample rate applied to transactions that are not explicitly throttled."""
 
-UNTRACED_PATHS = frozenset(
-    {
-        "/health/live",
-        "/health/ready",
-        "/jobs/counts",
-        "/tasks/counts",
-    },
-)
-"""Request paths that are never traced.
+PATH_TRACES_SAMPLE_RATES = {
+    "/health/live": 0.0,
+    "/health/ready": 0.0,
+    "/jobs/counts": 0.01,
+    "/tasks/counts": 0.01,
+}
+"""Per-path trace sample rates for high-frequency, low-value endpoints.
 
-These are high-frequency, low-value endpoints: orchestrator liveness and readiness
-probes and frontend count polling. Tracing them at the default rate exhausts the
-trace budget without yielding useful performance data.
+These were exhausting the trace budget at the default rate. Orchestrator liveness
+and readiness probes carry no useful performance data and are dropped entirely.
+The count-polling endpoints keep a small rate so occasional slowdowns are still
+visible.
 """
 
 
 def traces_sampler(sampling_context: dict[str, Any]) -> float:
     """Decide the trace sample rate for a transaction.
 
-    Suppress tracing entirely for high-frequency probe and polling endpoints while
-    honouring an upstream sampling decision for everything else.
+    Throttle high-frequency probe and polling endpoints to their configured rate
+    while honouring an upstream sampling decision for everything else.
     """
     request = sampling_context.get("aiohttp_request")
 
-    if request is not None and request.path in UNTRACED_PATHS:
-        return 0.0
+    if request is not None and request.path in PATH_TRACES_SAMPLE_RATES:
+        return PATH_TRACES_SAMPLE_RATES[request.path]
 
     parent_sampled = sampling_context.get("parent_sampled")
 

--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -1,6 +1,7 @@
 """Sentry integration for error tracking, performance monitoring, and log capture."""
 
 import logging
+from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -8,6 +9,43 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from structlog import get_logger
 
 logger = get_logger("sentry")
+
+DEFAULT_TRACES_SAMPLE_RATE = 0.6
+"""The sample rate applied to transactions that are not explicitly suppressed."""
+
+UNTRACED_PATHS = frozenset(
+    {
+        "/health/live",
+        "/health/ready",
+        "/jobs/counts",
+        "/tasks/counts",
+    },
+)
+"""Request paths that are never traced.
+
+These are high-frequency, low-value endpoints: orchestrator liveness and readiness
+probes and frontend count polling. Tracing them at the default rate exhausts the
+trace budget without yielding useful performance data.
+"""
+
+
+def traces_sampler(sampling_context: dict[str, Any]) -> float:
+    """Decide the trace sample rate for a transaction.
+
+    Suppress tracing entirely for high-frequency probe and polling endpoints while
+    honouring an upstream sampling decision for everything else.
+    """
+    request = sampling_context.get("aiohttp_request")
+
+    if request is not None and request.path in UNTRACED_PATHS:
+        return 0.0
+
+    parent_sampled = sampling_context.get("parent_sampled")
+
+    if parent_sampled is not None:
+        return float(parent_sampled)
+
+    return DEFAULT_TRACES_SAMPLE_RATE
 
 
 def configure_sentry(dsn: str, release: str) -> None:
@@ -29,7 +67,7 @@ def configure_sentry(dsn: str, release: str) -> None:
                 LoggingIntegration(event_level=logging.WARNING, level=logging.INFO),
             ],
             release=release,
-            traces_sample_rate=0.6,
+            traces_sampler=traces_sampler,
         )
 
     else:


### PR DESCRIPTION
## Summary

- Health probe paths (`/health/live`, `/health/ready`) were generating a constant stream of Sentry traces with no useful performance data, exhausting the trace budget.
- Count-polling endpoints (`/jobs/counts`, `/tasks/counts`) are also high-frequency and low-value, but kept at a small sample rate (1%) so occasional slowdowns remain visible.
- Replaces the flat `traces_sample_rate=0.6` with a `traces_sampler` function that applies per-path rates and honours upstream parent-sampling decisions for everything else.