### PR TITLE
Update mise test task to use usage field for arg passing

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ description = "Run Python tests in Docker."
 usage = 'arg "[<pytest_args>...]" help="Arguments passed to pytest"'
 run = [
   "docker compose up -d test",
-  "docker compose exec test uv run pytest $@"
+  "docker compose exec test uv run pytest $usage_pytest_args"
 ]
 
 [tasks."test:build"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,9 @@
 [tasks.test]
 description = "Run Python tests in Docker."
+usage = 'arg "[<pytest_args>...]" help="Arguments passed to pytest"'
 run = [
   "docker compose up -d test",
-  'docker compose exec test uv run pytest {{arg(name="pytest_args", var=true, default="")}}'
+  "docker compose exec test uv run pytest $@"
 ]
 
 [tasks."test:build"]


### PR DESCRIPTION
## Summary

- Replace the legacy `{{arg(...)}}` template syntax in the `mise test` task with the `usage` field and `$@`, which is the current idiomatic pattern for passing variadic arguments in mise tasks.