### PR TITLE
Correct WFIndex reference file path

### DIFF
--- a/tests/workflow/data/test_indexes.py
+++ b/tests/workflow/data/test_indexes.py
@@ -27,7 +27,9 @@ class TestIndex:
         index: WFIndex = await scope.instantiate_by_key("index")
 
         assert index.path == work_path / "indexes" / workflow_data.analysis.index.id
+        assert index.fasta_path == index.path / "reference.fa"
         assert index.json_path == index.path / "otus.json"
+        assert index.fasta_path.exists()
 
         assert {p.name for p in index.path.iterdir()} == {
             "otus.json",

--- a/virtool/workflow/data/indexes.py
+++ b/virtool/workflow/data/indexes.py
@@ -51,7 +51,7 @@ class WFIndex:
         work directory.
 
         """
-        return self.path / "ref.fa"
+        return self.path / "reference.fa"
 
     @property
     def json_path(self) -> Path:


### PR DESCRIPTION
Changes:

  - Corrects that path of index.fasta_path from `ref.fa` to `reference.fa` to match the real name of the de-compressed file