### PR TITLE
Remove inline history-diff read fallback; gate server on backfill

### DIFF
--- a/tests/history/__snapshots__/test_data.ambr
+++ b/tests/history/__snapshots__/test_data.ambr
@@ -3,10 +3,17 @@
   dict({
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'description': 'test history',
-    'diff': dict({
-      'foo': 'bar',
-    }),
-    'id': 'baz.2',
+    'diff': list([
+      list([
+        'change',
+        'abbreviation',
+        list([
+          'PVF',
+          'TST',
+        ]),
+      ]),
+    ]),
+    'id': '6116cba1.1',
     'index': None,
     'method_name': <HistoryMethod.create: 'create'>,
     'otu': dict({

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -2,8 +2,10 @@ import asyncio
 from http import HTTPStatus
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from tests.fixtures.client import ClientSpawner
+from virtool.history.db import bulk_insert_diffs
 from virtool.mongo.core import Mongo
 
 
@@ -44,6 +46,7 @@ async def test_get(
     snapshot,
     resp_is,
     mongo: Mongo,
+    pg: AsyncEngine,
     spawn_client: ClientSpawner,
     test_changes,
     static_time,
@@ -51,9 +54,17 @@ async def test_get(
     """Test that a specific history change can be retrieved by its change_id."""
     client = await spawn_client(authenticated=True)
 
+    await bulk_insert_diffs(
+        pg,
+        [{"change_id": c["_id"], "diff": c["diff"]} for c in test_changes],
+    )
+
     await asyncio.gather(
         mongo.history.insert_many(
-            [{**c, "user": {"id": client.user.id}} for c in test_changes],
+            [
+                {**c, "diff": "postgres", "user": {"id": client.user.id}}
+                for c in test_changes
+            ],
             session=None,
         ),
         mongo.references.insert_one(

--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -1,10 +1,12 @@
 import asyncio
 
+import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy import SnapshotAssertion
 
 from virtool.fake.next import DataFaker
 from virtool.history.data import HistoryData
+from virtool.history.db import bulk_insert_diffs
 from virtool.mongo.core import Mongo
 
 
@@ -15,6 +17,51 @@ async def test_get(
     snapshot: SnapshotAssertion,
     static_time,
 ):
+    user = await fake.users.create()
+
+    await bulk_insert_diffs(
+        pg,
+        [
+            {
+                "change_id": "6116cba1.1",
+                "diff": [["change", "abbreviation", ["PVF", "TST"]]],
+            },
+        ],
+    )
+
+    await asyncio.gather(
+        mongo.references.insert_one(
+            {
+                "_id": "hxn167",
+                "archived": False,
+                "data_type": "genome",
+                "name": "Reference A",
+            },
+        ),
+        mongo.history.insert_one(
+            {
+                "_id": "6116cba1.1",
+                "diff": "postgres",
+                "user": {"id": user.id},
+                "reference": {"id": "hxn167"},
+                "created_at": static_time.datetime,
+                "description": "test history",
+                "method_name": "create",
+                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
+            },
+        ),
+    )
+
+    assert await HistoryData(mongo, pg).get("6116cba1.1") == snapshot
+
+
+async def test_get_inline_diff_raises(
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    static_time,
+):
+    """A change holding an unbackfilled inline diff raises instead of returning it."""
     user = await fake.users.create()
 
     await asyncio.gather(
@@ -28,8 +75,8 @@ async def test_get(
         ),
         mongo.history.insert_one(
             {
-                "_id": "baz.2",
-                "diff": {"foo": "bar"},
+                "_id": "6116cba1.1",
+                "diff": [["change", "abbreviation", ["PVF", "TST"]]],
                 "user": {"id": user.id},
                 "reference": {"id": "hxn167"},
                 "created_at": static_time.datetime,
@@ -40,4 +87,7 @@ async def test_get(
         ),
     )
 
-    assert await HistoryData(mongo, pg).get("baz.2") == snapshot
+    with pytest.raises(
+        ValueError, match="Unexpected inline diff for change 6116cba1.1"
+    ):
+        await HistoryData(mongo, pg).get("6116cba1.1")

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -209,3 +209,23 @@ async def test_patch_to_version_missing_diff(mongo: Mongo, pg: AsyncEngine):
 
     with pytest.raises(ValueError, match="Missing history_diffs rows.*6116cba1.1"):
         await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)
+
+
+async def test_patch_to_version_inline_diff(mongo: Mongo, pg: AsyncEngine):
+    """A change holding an unbackfilled inline diff raises instead of being treated as
+    a literal diff.
+    """
+    await mongo.history.insert_one(
+        {
+            "_id": "6116cba1.1",
+            "diff": [["change", "version", [0, 1]]],
+            "method_name": "update",
+            "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Unexpected inline diff for change 6116cba1.1",
+    ):
+        await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -281,23 +281,28 @@ async def get_most_recent_change(
 async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, object]:
     """Resolve the ``diff`` for each change, fetching Postgres-stored diffs in one query.
 
-    Changes created since OTU diffs moved to Postgres store the sentinel string
-    ``"postgres"`` in Mongo and the real diff in ``SQLHistoryDiff``. Older inline diffs
-    are returned as-is.
+    Every change stores the sentinel string ``"postgres"`` in Mongo and the real diff
+    in ``SQLHistoryDiff``. A change whose ``diff`` is anything else is an unbackfilled
+    legacy inline diff and raises ``ValueError``.
 
     :param pg: the application PostgreSQL database object
     :param changes: the change documents to resolve diffs for
     :return: a mapping of change id to resolved diff
+    :raises ValueError: if a change holds an inline diff instead of the ``"postgres"``
+        sentinel
 
     """
     resolved: dict[str, object] = {}
     postgres_change_ids = []
 
     for change in changes:
-        if change["diff"] == "postgres":
-            postgres_change_ids.append(change["_id"])
-        else:
-            resolved[change["_id"]] = change["diff"]
+        if change["diff"] != "postgres":
+            raise ValueError(
+                f"Unexpected inline diff for change {change['_id']}; "
+                "expected 'postgres' sentinel",
+            )
+
+        postgres_change_ids.append(change["_id"])
 
     if postgres_change_ids:
         async with AsyncSession(pg) as session:

--- a/virtool/history/transforms.py
+++ b/virtool/history/transforms.py
@@ -16,13 +16,16 @@ class AttachDiffTransform(AbstractTransform):
         return {**document, "diff": prepared}
 
     async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
-        if document["diff"] == "postgres":
-            result = await session.execute(
-                select(SQLHistoryDiff.diff).where(
-                    SQLHistoryDiff.change_id == document["id"],
-                ),
+        if document["diff"] != "postgres":
+            raise ValueError(
+                f"Unexpected inline diff for change {document['id']}; "
+                "expected 'postgres' sentinel",
             )
 
-            return result.scalar_one()
+        result = await session.execute(
+            select(SQLHistoryDiff.diff).where(
+                SQLHistoryDiff.change_id == document["id"],
+            ),
+        )
 
-        return document["diff"]
+        return result.scalar_one()

--- a/virtool/migration/required.py
+++ b/virtool/migration/required.py
@@ -1,6 +1,6 @@
 """Required migration constants."""
 
-REQUIRED_VIRTOOL_REVISION = "g2cecswiq3r2"
+REQUIRED_VIRTOOL_REVISION = "an1no64kah8t"
 """The revision that Virtool requires to be applied before it can run.
 
 This constant can be updated automatically using `virtool migrate depend`.


### PR DESCRIPTION
## Summary

- Removes the inline-diff fallback in `_resolve_diffs` and `AttachDiffTransform`; any change document whose `diff` field is not the `"postgres"` sentinel now raises `ValueError` instead of silently returning the raw value
- Bumps `REQUIRED_VIRTOOL_REVISION` to the inline-history-diff backfill revision so the server will not start until the backfill has been applied