### PR TITLE
feat: dual-write bulk history inserts for reference import/clone

### DIFF
--- a/tests/references/__snapshots__/test_db.ambr
+++ b/tests/references/__snapshots__/test_db.ambr
@@ -41,3 +41,9 @@
     }),
   ])
 # ---
+# name: test_populate_insert_only_reference_dual_writes_legacy_history[legacy_history]
+  list([
+    <SQLLegacyHistory(id=1, legacy_id=lhotu001.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 1 (O1), method_name=remote, user_id=1, otu=lhotu001, otu_name=OTU 1, otu_version=0, reference=ref_legacy_test, index=None, index_version=None)>,
+    <SQLLegacyHistory(id=2, legacy_id=lhotu002.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 2 (O2), method_name=remote, user_id=1, otu=lhotu002, otu_name=OTU 2, otu_version=0, reference=ref_legacy_test, index=None, index_version=None)>,
+  ])
+# ---

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -442,7 +442,9 @@ async def test_populate_insert_only_reference_dual_writes_legacy_history(
         rows = (
             (
                 await pg_session.execute(
-                    select(SQLLegacyHistory).order_by(SQLLegacyHistory.legacy_id),
+                    select(SQLLegacyHistory)
+                    .where(SQLLegacyHistory.reference == ref_id)
+                    .order_by(SQLLegacyHistory.legacy_id),
                 )
             )
             .scalars()

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -8,7 +8,7 @@ from syrupy import SnapshotAssertion
 
 from virtool.api.client import UserClient
 from virtool.fake.next import DataFaker
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
 from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
@@ -362,10 +362,96 @@ async def test_populate_insert_only_reference_rollback(
     assert await mongo.references.find_one({"_id": ref_id}) is None
 
     async with AsyncSession(pg) as pg_session:
-        count = await pg_session.scalar(
+        diff_count = await pg_session.scalar(
             select(func.count())
             .select_from(SQLHistoryDiff)
             .where(SQLHistoryDiff.change_id.in_(["rbotu001.0", "rbotu002.0"])),
         )
 
-    assert count == 0
+        legacy_count = await pg_session.scalar(
+            select(func.count())
+            .select_from(SQLLegacyHistory)
+            .where(SQLLegacyHistory.legacy_id.in_(["rbotu001.0", "rbotu002.0"])),
+        )
+
+    assert diff_count == 0
+    assert legacy_count == 0
+
+
+async def test_populate_insert_only_reference_dual_writes_legacy_history(
+    fake: DataFaker,
+    mocker: MockerFixture,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    snapshot: SnapshotAssertion,
+    static_time,
+):
+    """A successful bulk insert writes one ``legacy_history`` row per OTU."""
+    user = await fake.users.create()
+    ref_id = "ref_legacy_test"
+
+    mocker.patch(
+        "virtool.references.alot.random_alphanumeric",
+        side_effect=[
+            "lhotu001",
+            "lhiso001",
+            "lhseq001",
+            "lhotu002",
+            "lhiso002",
+            "lhseq002",
+        ],
+    )
+
+    otus = [
+        {
+            "_id": f"remote_{i}",
+            "name": f"OTU {i}",
+            "abbreviation": f"O{i}",
+            "isolates": [
+                {
+                    "id": f"remote_iso_{i}",
+                    "default": True,
+                    "source_type": "isolate",
+                    "source_name": "a",
+                    "sequences": [
+                        {
+                            "_id": f"remote_seq_{i}",
+                            "accession": f"ACC{i}",
+                            "sequence": "ATCG",
+                            "definition": "test",
+                            "host": "h",
+                        },
+                    ],
+                },
+            ],
+        }
+        for i in (1, 2)
+    ]
+
+    await populate_insert_only_reference(
+        static_time.datetime,
+        HistoryMethod.remote,
+        mongo,
+        pg,
+        otus,
+        ref_id,
+        user.id,
+    )
+
+    async with AsyncSession(pg) as pg_session:
+        rows = (
+            (
+                await pg_session.execute(
+                    select(SQLLegacyHistory).order_by(SQLLegacyHistory.legacy_id),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert [row.legacy_id for row in rows] == ["lhotu001.0", "lhotu002.0"]
+    assert all(row.user_id == user.id for row in rows)
+    assert all(row.reference == ref_id for row in rows)
+    assert all(row.otu_version == "0" for row in rows)
+    assert all(row.index is None and row.index_version is None for row in rows)
+    assert rows == snapshot(name="legacy_history")

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -421,7 +421,7 @@ async def create_reference(
                 context={
                     "name_on_disk": upload_row.name_on_disk,
                     "ref_id": "bar",
-                    "user_id": "test",
+                    "user_id": user.id,
                 },
                 count=0,
                 created_at=static_time.datetime,

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -101,21 +101,6 @@ async def bulk_insert_diffs(pg: AsyncEngine, rows: list[dict]) -> None:
         await session.commit()
 
 
-async def bulk_delete_diffs(pg: AsyncEngine, change_ids: list[str]) -> None:
-    """Delete ``history_diffs`` rows for the given ``change_ids`` in chunks."""
-    async with AsyncSession(pg) as session:
-        for start in range(0, len(change_ids), _HISTORY_DIFF_CHUNK_SIZE):
-            await session.execute(
-                delete(SQLHistoryDiff).where(
-                    SQLHistoryDiff.change_id.in_(
-                        change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE],
-                    ),
-                ),
-            )
-
-        await session.commit()
-
-
 async def bulk_insert_history(
     pg: AsyncEngine,
     diff_rows: list[dict],

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -123,9 +123,21 @@ async def bulk_insert_history(
 ) -> None:
     """Insert ``history_diffs`` and ``legacy_history`` rows in one transaction.
 
+    ``diff_rows`` and ``documents`` are parallel: ``diff_rows[i]`` must describe
+    the same change as ``documents[i]``. They are validated to be aligned by
+    ``change_id`` before any write, so a misaligned caller fails loudly rather
+    than corrupting history.
+
     Both tables are written in asyncpg-safe chunks within a single Postgres
     transaction so they commit or roll back together.
     """
+    if {row["change_id"] for row in diff_rows} != {
+        document["_id"] for document in documents
+    }:
+        raise ValueError(
+            "diff_rows and documents must describe the same history changes",
+        )
+
     legacy_rows = [_legacy_history_values(document) for document in documents]
 
     async with AsyncSession(pg) as session:

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -52,6 +52,41 @@ asyncpg caps bind parameters per statement at 32767. Each row binds two
 (``change_id`` and ``diff``).
 """
 
+_LEGACY_HISTORY_CHUNK_SIZE = 32767 // 11
+"""Max ``legacy_history`` rows per statement.
+
+asyncpg caps bind parameters per statement at 32767. Each row binds eleven
+columns (see :func:`_legacy_history_values`).
+"""
+
+
+def _legacy_history_values(document: Document) -> dict:
+    """Map a Mongo history ``document`` to ``legacy_history`` column values.
+
+    Applies the sentinel-to-NULL conventions: an ``otu.version`` of ``"removed"``
+    and an ``index`` of ``"unbuilt"`` are stored as ``NULL``.
+    """
+    otu_version = document["otu"]["version"]
+    index_document = document["index"]
+
+    return {
+        "legacy_id": document["_id"],
+        "created_at": document["created_at"],
+        "description": document["description"],
+        "method_name": document["method_name"],
+        "user_id": document["user"]["id"],
+        "otu": document["otu"]["id"],
+        "otu_name": document["otu"]["name"],
+        "otu_version": None if otu_version == "removed" else str(otu_version),
+        "reference": document["reference"]["id"],
+        "index": None if index_document["id"] == "unbuilt" else index_document["id"],
+        "index_version": (
+            None
+            if index_document["version"] == "unbuilt"
+            else str(index_document["version"])
+        ),
+    }
+
 
 async def bulk_insert_diffs(pg: AsyncEngine, rows: list[dict]) -> None:
     """Insert ``rows`` into ``history_diffs`` in asyncpg-safe chunks."""
@@ -76,6 +111,54 @@ async def bulk_delete_diffs(pg: AsyncEngine, change_ids: list[str]) -> None:
                         change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE],
                     ),
                 ),
+            )
+
+        await session.commit()
+
+
+async def bulk_insert_history(
+    pg: AsyncEngine,
+    diff_rows: list[dict],
+    documents: list[Document],
+) -> None:
+    """Insert ``history_diffs`` and ``legacy_history`` rows in one transaction.
+
+    Both tables are written in asyncpg-safe chunks within a single Postgres
+    transaction so they commit or roll back together.
+    """
+    legacy_rows = [_legacy_history_values(document) for document in documents]
+
+    async with AsyncSession(pg) as session:
+        for start in range(0, len(diff_rows), _HISTORY_DIFF_CHUNK_SIZE):
+            await session.execute(
+                insert(SQLHistoryDiff).values(
+                    diff_rows[start : start + _HISTORY_DIFF_CHUNK_SIZE],
+                ),
+            )
+
+        for start in range(0, len(legacy_rows), _LEGACY_HISTORY_CHUNK_SIZE):
+            await session.execute(
+                insert(SQLLegacyHistory).values(
+                    legacy_rows[start : start + _LEGACY_HISTORY_CHUNK_SIZE],
+                ),
+            )
+
+        await session.commit()
+
+
+async def bulk_delete_history(pg: AsyncEngine, change_ids: list[str]) -> None:
+    """Delete ``history_diffs`` and ``legacy_history`` rows for ``change_ids``.
+
+    Used to compensate the Postgres writes when a paired Mongo bulk insert fails.
+    """
+    async with AsyncSession(pg) as session:
+        for start in range(0, len(change_ids), _HISTORY_DIFF_CHUNK_SIZE):
+            chunk = change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE]
+            await session.execute(
+                delete(SQLHistoryDiff).where(SQLHistoryDiff.change_id.in_(chunk)),
+            )
+            await session.execute(
+                delete(SQLLegacyHistory).where(SQLLegacyHistory.legacy_id.in_(chunk)),
             )
 
         await session.commit()
@@ -113,27 +196,9 @@ async def add(
     prepared = prepare_add(method_name, old, new, user_id, description=description)
 
     document = prepared.document
-    otu_version = document["otu"]["version"]
-    index_document = document["index"]
 
     diff_row = SQLHistoryDiff(change_id=document["_id"], diff=prepared.diff)
-    legacy_row = SQLLegacyHistory(
-        legacy_id=document["_id"],
-        created_at=document["created_at"],
-        description=document["description"],
-        method_name=document["method_name"],
-        user_id=user_id,
-        otu=document["otu"]["id"],
-        otu_name=document["otu"]["name"],
-        otu_version=None if otu_version == "removed" else str(otu_version),
-        reference=document["reference"]["id"],
-        index=None if index_document["id"] == "unbuilt" else index_document["id"],
-        index_version=(
-            None
-            if index_document["version"] == "unbuilt"
-            else str(index_document["version"])
-        ),
-    )
+    legacy_row = SQLLegacyHistory(**_legacy_history_values(document))
 
     if mongo_session is None:
         async with both_transactions(mongo, pg) as (mongo_session, pg_session):

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -28,7 +28,11 @@ from virtool.data.transforms import apply_transforms
 from virtool.errors import GitHubError
 from virtool.github import create_update_subdocument, format_release
 from virtool.groups.pg import SQLGroup
-from virtool.history.db import bulk_delete_diffs, bulk_insert_diffs, patch_to_version
+from virtool.history.db import (
+    bulk_delete_history,
+    bulk_insert_history,
+    patch_to_version,
+)
 from virtool.history.models import HistorySearchResult
 from virtool.indexes.models import IndexMinimal, IndexSearchResult
 from virtool.models.enums import HistoryMethod
@@ -1023,7 +1027,11 @@ class ReferencesData(DataLayerDomain):
             for insertion in insertions
         ]
 
-        await bulk_insert_diffs(self._pg, diff_rows)
+        await bulk_insert_history(
+            self._pg,
+            diff_rows,
+            [insertion.history.document for insertion in insertions],
+        )
 
         await tracker.add(1)
 
@@ -1050,7 +1058,7 @@ class ReferencesData(DataLayerDomain):
                     self._mongo.sequences.insert_many(sequences, None),
                 )
         except Exception:
-            await bulk_delete_diffs(self._pg, [row["change_id"] for row in diff_rows])
+            await bulk_delete_history(self._pg, [row["change_id"] for row in diff_rows])
 
             await asyncio.gather(
                 self._mongo.history.delete_many({"reference.id": ref_id}),

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -23,7 +23,7 @@ from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
-from virtool.history.db import bulk_delete_diffs, bulk_insert_diffs
+from virtool.history.db import bulk_delete_history, bulk_insert_history
 from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
@@ -811,7 +811,11 @@ async def populate_insert_only_reference(
         for insertion in insertions
     ]
 
-    await bulk_insert_diffs(pg, diff_rows)
+    await bulk_insert_history(
+        pg,
+        diff_rows,
+        [insertion.history.document for insertion in insertions],
+    )
 
     try:
         sequences = []
@@ -834,7 +838,7 @@ async def populate_insert_only_reference(
             )
             tg.create_task(mongo.sequences.insert_many(sequences, None))
     except Exception:
-        await bulk_delete_diffs(pg, [row["change_id"] for row in diff_rows])
+        await bulk_delete_history(pg, [row["change_id"] for row in diff_rows])
 
         await asyncio.gather(
             mongo.history.delete_many({"reference.id": reference_id}),


### PR DESCRIPTION
## Summary

- Extends the dual-write pattern to bulk history inserts that occur during reference import and clone operations, writing to both `history_diffs` and `legacy_history` in a single Postgres transaction.
- Adds `bulk_insert_history` and `bulk_delete_history` to replace the diff-only `bulk_insert_diffs`/`bulk_delete_diffs` in the bulk insert paths; extracts `_legacy_history_values()` to share mapping logic with the single-record `add()` path.
- Adds a test asserting that `legacy_history` rows are created on successful bulk insert and absent after a rolled-back insert.