### PR TITLE
Convert samples.subtractions to list[int]

### DIFF
--- a/assets/revisions/rev_24ysb9cwjiv1_backfill_samples_subtractions_to_integers.py
+++ b/assets/revisions/rev_24ysb9cwjiv1_backfill_samples_subtractions_to_integers.py
@@ -1,0 +1,98 @@
+"""Convert ``samples.subtractions`` array elements to integer ids.
+
+Subtractions are now Postgres-only with an integer ``id`` and a permanent
+``legacy_id`` (the old Mongo string id). The ``samples.subtractions`` array
+stays in Mongo but must hold integer ``subtractions.id`` values rather than
+legacy string ids.
+
+This revision rewrites each element of every sample's ``subtractions`` array,
+resolving legacy string ids to their integer ``subtractions.id`` via
+``subtractions.legacy_id``. Already-integer elements pass through unchanged, so
+the revision is idempotent and safe to re-run.
+
+Unresolved string ids raise loudly rather than being dropped or stored as
+``NULL`` -- a sample referencing a subtraction that no longer exists in Postgres
+is a data-integrity problem that must surface, not be silently swallowed.
+
+Revision ID: 24ysb9cwjiv1
+Date: 2026-06-09 16:14:05.797921
+
+"""
+
+from typing import TYPE_CHECKING
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill samples subtractions to integers"
+created_at = arrow.get("2026-06-09 16:14:05.797921")
+revision_id = "24ysb9cwjiv1"
+
+alembic_down_revision = "869aa923399e"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        result = await pg_session.execute(
+            text("SELECT id, legacy_id FROM subtractions WHERE legacy_id IS NOT NULL"),
+        )
+        subtraction_map: dict[str, int] = {row.legacy_id: row.id for row in result}
+
+    logger.info("built id map", subtractions=len(subtraction_map))
+
+    await _backfill_sample_subtractions(ctx.mongo, subtraction_map)
+
+
+def _coerce_subtraction_id(value: int | str, subtraction_map: dict[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+
+    if value in subtraction_map:
+        return subtraction_map[value]
+
+    msg = f"Subtraction legacy id {value!r} not found in postgres"
+    raise ValueError(msg)
+
+
+async def _backfill_sample_subtractions(
+    mongo: "AsyncIOMotorDatabase",
+    subtraction_map: dict[str, int],
+) -> None:
+    collection = mongo["samples"]
+
+    migrated = 0
+
+    async for doc in collection.find(
+        {"subtractions": {"$type": "string"}},
+        projection={"subtractions": 1},
+    ):
+        subtractions = [
+            _coerce_subtraction_id(value, subtraction_map)
+            for value in doc["subtractions"]
+        ]
+
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"subtractions": subtractions}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled subtractions",
+        collection="samples",
+        migrated=migrated,
+    )

--- a/tests/fixtures/subtractions.py
+++ b/tests/fixtures/subtractions.py
@@ -54,19 +54,23 @@ async def test_subtraction_files(pg) -> int:
 
 @pytest.fixture
 def insert_subtractions(pg):
-    """Insert Postgres subtractions keyed by legacy id.
+    """Insert Postgres subtractions and return a ``{legacy_id: id}`` map.
 
-    Pass ``(legacy_id, name)`` pairs. The created subtractions resolve through the
-    ``legacy_id`` column the way string-keyed referrers reference them.
+    Pass ``(legacy_id, name)`` pairs. Subtractions are addressed by their integer
+    ``id`` now that ``samples.subtractions`` holds integers, so the returned map
+    lets callers look up the auto-generated id for each seeded subtraction.
 
     ``created_at`` is a fixed naive-UTC literal rather than ``static_time`` because
     that fixture patches the global clock, which would leak into consumers that
     create entities through the data layer. The value is never surfaced.
     """
 
-    async def func(*subtractions: tuple[str, str]) -> None:
+    # Interim: returns the legacy_id -> integer id map only so callers can address
+    # subtractions by integer while the subtraction public id is still a string.
+    # Revert to returning None after the subtraction id cutover (VIR-2535).
+    async def func(*subtractions: tuple[str, str]) -> dict[str, int]:
         async with AsyncSession(pg) as session:
-            session.add_all(
+            rows = [
                 SQLSubtraction(
                     legacy_id=legacy_id,
                     name=name,
@@ -74,8 +78,15 @@ def insert_subtractions(pg):
                     ready=True,
                 )
                 for legacy_id, name in subtractions
-            )
+            ]
+
+            session.add_all(rows)
+            await session.flush()
+
+            id_map = {row.legacy_id: row.id for row in rows}
 
             await session.commit()
+
+        return id_map
 
     return func

--- a/tests/fixtures/subtractions.py
+++ b/tests/fixtures/subtractions.py
@@ -1,9 +1,26 @@
 from datetime import datetime
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile
+
+
+async def resolve_subtraction_pk(pg: AsyncEngine, legacy_id: str) -> int:
+    """Resolve a subtraction's integer id from its legacy string id.
+
+    ``samples.subtractions`` holds integer ids, so linked-sample fixtures must
+    reference the subtraction by its ``subtractions.id`` rather than its legacy id.
+
+    Interim: delete once the subtraction public id is an integer (VIR-2535).
+    """
+    async with AsyncSession(pg) as session:
+        return (
+            await session.execute(
+                select(SQLSubtraction.id).where(SQLSubtraction.legacy_id == legacy_id),
+            )
+        ).scalar_one()
 
 
 @pytest.fixture

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -491,5 +491,12 @@
       'name': 'drop analyses subtractions column',
       'revision': '869aa923399e',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 71,
+      'name': 'backfill samples subtractions to integers',
+      'revision': '24ysb9cwjiv1',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_samples_subtractions.py
+++ b/tests/migration/test_backfill_samples_subtractions.py
@@ -1,0 +1,119 @@
+"""Tests for the backfill-samples-subtractions-to-integers migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_24ysb9cwjiv1_backfill_samples_subtractions_to_integers import (
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_subtractions(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed two subtractions with legacy ids."""
+    await asyncio.to_thread(apply_alembic, "head")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO subtractions (
+                    legacy_id, name, nickname, created_at, deleted, ready
+                )
+                VALUES
+                    ('arabidopsis_legacy', 'Arabidopsis', '', :now, false, true),
+                    ('vitis_legacy', 'Vitis', '', :now, false, true)
+                RETURNING id, legacy_id
+            """),
+            {"now": arrow.utcnow().naive},
+        )
+        subtraction_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return subtraction_ids
+
+
+class TestSamplesSubtractionsBackfill:
+    async def test_legacy_strings_convert(
+        self,
+        ctx: MigrationContext,
+        setup_subtractions: dict[str, int],
+    ):
+        await ctx.mongo.samples.insert_one(
+            {
+                "_id": "sample_both",
+                "subtractions": ["arabidopsis_legacy", "vitis_legacy"],
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_both"})
+        assert doc["subtractions"] == [
+            setup_subtractions["arabidopsis_legacy"],
+            setup_subtractions["vitis_legacy"],
+        ]
+        assert all(isinstance(s, int) for s in doc["subtractions"])
+
+    async def test_already_int_passthrough(
+        self,
+        ctx: MigrationContext,
+        setup_subtractions: dict[str, int],
+    ):
+        pg_id = setup_subtractions["arabidopsis_legacy"]
+        await ctx.mongo.samples.insert_one(
+            {"_id": "sample_int", "subtractions": [pg_id]},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_int"})
+        assert doc["subtractions"] == [pg_id]
+
+    async def test_mixed_array_converts_strings_only(
+        self,
+        ctx: MigrationContext,
+        setup_subtractions: dict[str, int],
+    ):
+        arabidopsis = setup_subtractions["arabidopsis_legacy"]
+        await ctx.mongo.samples.insert_one(
+            {"_id": "sample_mixed", "subtractions": [arabidopsis, "vitis_legacy"]},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_mixed"})
+        assert doc["subtractions"] == [arabidopsis, setup_subtractions["vitis_legacy"]]
+
+    async def test_empty_array_untouched(
+        self,
+        ctx: MigrationContext,
+        setup_subtractions: dict[str, int],
+    ):
+        await ctx.mongo.samples.insert_one({"_id": "sample_empty", "subtractions": []})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_empty"})
+        assert doc["subtractions"] == []
+
+    @pytest.mark.usefixtures("setup_subtractions")
+    async def test_unmapped_legacy_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.samples.insert_one(
+            {"_id": "sample_orphan", "subtractions": ["ghost_subtraction"]},
+        )
+
+        with pytest.raises(ValueError, match="ghost_subtraction"):
+            await upgrade(ctx)

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -80,8 +80,8 @@
     'pathoscope': True,
     'ready': True,
     'subtractions': list([
-      'apple',
-      'pear',
+      1,
+      2,
     ]),
     'user': dict({
       'id': 1,
@@ -140,8 +140,8 @@
     'pathoscope': True,
     'ready': True,
     'subtractions': list([
-      'apple',
-      'pear',
+      1,
+      2,
     ]),
     'user': dict({
       'id': 1,
@@ -200,8 +200,8 @@
     'pathoscope': True,
     'ready': True,
     'subtractions': list([
-      'apple',
-      'pear',
+      1,
+      2,
     ]),
     'user': dict({
       'id': 1,
@@ -260,8 +260,8 @@
     'pathoscope': True,
     'ready': True,
     'subtractions': list([
-      'apple',
-      'pear',
+      1,
+      2,
     ]),
     'user': dict({
       'id': 1,
@@ -320,8 +320,8 @@
     'pathoscope': True,
     'ready': True,
     'subtractions': list([
-      'apple',
-      'pear',
+      1,
+      2,
     ]),
     'user': dict({
       'id': 1,
@@ -403,7 +403,7 @@
     'ready': False,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
     ]),
@@ -484,7 +484,7 @@
     'ready': False,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
     ]),
@@ -569,7 +569,7 @@
     'ready': False,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
     ]),
@@ -672,7 +672,7 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'peach',
+        'id': 3,
         'name': 'Peach',
       }),
     ]),
@@ -691,7 +691,7 @@
 # name: TestEdit.test_subtraction_exists[json]
   dict({
     'id': 'bad_request',
-    'message': 'Subtractions do not exist: bar',
+    'message': 'Subtractions do not exist: 999',
   })
 # ---
 # name: TestFinalize.test_quality
@@ -762,11 +762,11 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
       dict({
-        'id': 'pear',
+        'id': 2,
         'name': 'Pear',
       }),
     ]),
@@ -1981,11 +1981,11 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
       dict({
-        'id': 'pear',
+        'id': 2,
         'name': 'Pear',
       }),
     ]),
@@ -2065,11 +2065,11 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
       dict({
-        'id': 'pear',
+        'id': 2,
         'name': 'Pear',
       }),
     ]),
@@ -2159,11 +2159,11 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
       dict({
-        'id': 'pear',
+        'id': 2,
         'name': 'Pear',
       }),
     ]),
@@ -2243,11 +2243,11 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
       dict({
-        'id': 'pear',
+        'id': 2,
         'name': 'Pear',
       }),
     ]),

--- a/tests/samples/__snapshots__/test_data.ambr
+++ b/tests/samples/__snapshots__/test_data.ambr
@@ -33,7 +33,7 @@
       'id': 0,
     }),
     'subtractions': list([
-      'apple',
+      1,
     ]),
     'uploads': list([
       dict({
@@ -85,7 +85,7 @@
       'id': 0,
     }),
     'subtractions': list([
-      'apple',
+      1,
     ]),
     'uploads': list([
       dict({
@@ -137,7 +137,7 @@
       'id': 0,
     }),
     'subtractions': list([
-      'apple',
+      1,
     ]),
     'uploads': list([
       dict({
@@ -248,11 +248,11 @@
     'ready': True,
     'subtractions': list([
       dict({
-        'id': 'apple',
+        'id': 1,
         'name': 'Apple',
       }),
       dict({
-        'id': 'pear',
+        'id': 2,
         'name': 'Pear',
       }),
     ]),

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -42,7 +42,9 @@ async def get_sample_ready_false(
     user = await fake.users.create()
     job = await fake.jobs.create(user, workflow="create_sample")
 
-    await insert_subtractions(("apple", "Apple"), ("pear", "Pear"), ("peach", "Peach"))
+    subtractions = await insert_subtractions(
+        ("apple", "Apple"), ("pear", "Pear"), ("peach", "Peach")
+    )
 
     await mongo.samples.insert_one(
         {
@@ -74,7 +76,7 @@ async def get_sample_ready_false(
             "nuvs": False,
             "pathoscope": True,
             "ready": False,
-            "subtractions": ["apple", "pear"],
+            "subtractions": [subtractions["apple"], subtractions["pear"]],
             "user": {"id": user.id},
             "workflows": {
                 "aodp": WorkflowState.INCOMPATIBLE.value,
@@ -97,47 +99,48 @@ async def get_sample_data(
     user = await fake.users.create()
     job = await fake.jobs.create(user, workflow="create_sample")
 
-    await asyncio.gather(
-        insert_subtractions(("apple", "Apple"), ("pear", "Pear"), ("peach", "Peach")),
-        mongo.samples.insert_one(
-            {
-                "_id": "test",
-                "all_read": True,
-                "all_write": True,
-                "created_at": static_time.datetime,
-                "files": [
-                    {
-                        "id": "foo",
-                        "name": "Bar.fq.gz",
-                        "download_url": "/download/samples/files/file_1.fq.gz",
-                    },
-                ],
-                "format": "fastq",
-                "group": "none",
-                "group_read": True,
-                "group_write": True,
-                "hold": False,
-                "host": "",
-                "is_legacy": False,
-                "isolate": "",
-                "job": {"id": job.id},
-                "labels": [label.id],
-                "library_type": LibraryType.normal.value,
-                "locale": "",
-                "name": "Test",
-                "notes": "",
-                "nuvs": False,
-                "pathoscope": True,
-                "ready": True,
-                "subtractions": ["apple", "pear"],
-                "user": {"id": user.id},
-                "workflows": {
-                    "aodp": WorkflowState.INCOMPATIBLE.value,
-                    "pathoscope": WorkflowState.COMPLETE.value,
-                    "nuvs": WorkflowState.PENDING.value,
+    subtractions = await insert_subtractions(
+        ("apple", "Apple"), ("pear", "Pear"), ("peach", "Peach")
+    )
+
+    await mongo.samples.insert_one(
+        {
+            "_id": "test",
+            "all_read": True,
+            "all_write": True,
+            "created_at": static_time.datetime,
+            "files": [
+                {
+                    "id": "foo",
+                    "name": "Bar.fq.gz",
+                    "download_url": "/download/samples/files/file_1.fq.gz",
                 },
+            ],
+            "format": "fastq",
+            "group": "none",
+            "group_read": True,
+            "group_write": True,
+            "hold": False,
+            "host": "",
+            "is_legacy": False,
+            "isolate": "",
+            "job": {"id": job.id},
+            "labels": [label.id],
+            "library_type": LibraryType.normal.value,
+            "locale": "",
+            "name": "Test",
+            "notes": "",
+            "nuvs": False,
+            "pathoscope": True,
+            "ready": True,
+            "subtractions": [subtractions["apple"], subtractions["pear"]],
+            "user": {"id": user.id},
+            "workflows": {
+                "aodp": WorkflowState.INCOMPATIBLE.value,
+                "pathoscope": WorkflowState.COMPLETE.value,
+                "nuvs": WorkflowState.PENDING.value,
             },
-        ),
+        },
     )
 
     async with AsyncSession(pg) as session:
@@ -488,13 +491,13 @@ class TestCreate:
         label = await fake.labels.create()
         upload = await fake.uploads.create(user=await fake.users.create())
 
-        await insert_subtractions(("apple", "Apple"))
+        subtractions = await insert_subtractions(("apple", "Apple"))
 
         data = {
             "files": [upload.id],
             "labels": [label.id],
             "name": "Foobar",
-            "subtractions": ["apple"],
+            "subtractions": [subtractions["apple"]],
         }
 
         if group_setting == "force_choice":
@@ -521,7 +524,7 @@ class TestCreate:
 
         upload = await fake.uploads.create(user=await fake.users.create())
 
-        await asyncio.gather(
+        _, subtractions = await asyncio.gather(
             mongo.samples.insert_one(
                 {
                     "_id": "foobar",
@@ -538,7 +541,11 @@ class TestCreate:
 
         resp = await client.post(
             "/samples",
-            {"name": "Foobar", "files": [upload.id], "subtractions": ["apple"]},
+            {
+                "name": "Foobar",
+                "files": [upload.id],
+                "subtractions": [subtractions["apple"]],
+            },
         )
 
         assert resp.status == 400
@@ -567,7 +574,7 @@ class TestCreate:
 
         upload = await fake.uploads.create(user=await fake.users.create())
 
-        await asyncio.gather(
+        _, subtractions = await asyncio.gather(
             get_data_from_app(client.app).settings.update(
                 UpdateSettingsRequest(sample_group="force_choice"),
             ),
@@ -577,7 +584,7 @@ class TestCreate:
         data = {
             "name": "Foobar",
             "files": [upload.id],
-            "subtractions": ["apple"],
+            "subtractions": [subtractions["apple"]],
         }
 
         if error is None:
@@ -606,7 +613,7 @@ class TestCreate:
 
         upload = await fake.uploads.create(user=await fake.users.create())
 
-        await asyncio.gather(
+        _, subtractions = await asyncio.gather(
             get_data_from_app(client.app).settings.update(
                 UpdateSettingsRequest(
                     sample_group="force_choice",
@@ -620,7 +627,7 @@ class TestCreate:
             {
                 "name": "Foobar",
                 "files": [upload.id],
-                "subtractions": ["apple"],
+                "subtractions": [subtractions["apple"]],
                 "group": 5,
             },
         )
@@ -642,10 +649,10 @@ class TestCreate:
 
         resp = await client.post(
             "/samples",
-            {"name": "Foobar", "files": [upload.id], "subtractions": ["apple"]},
+            {"name": "Foobar", "files": [upload.id], "subtractions": [999]},
         )
 
-        await resp_is.bad_request(resp, "Subtractions do not exist: apple")
+        await resp_is.bad_request(resp, "Subtractions do not exist: 999")
 
     @pytest.mark.parametrize("one_exists", [True, False])
     async def test_file_dne(
@@ -665,7 +672,7 @@ class TestCreate:
             permissions=[Permission.create_sample],
         )
 
-        await insert_subtractions(("apple", "Apple"))
+        subtractions = await insert_subtractions(("apple", "Apple"))
 
         if one_exists:
             upload = await fake.uploads.create(user=await fake.users.create())
@@ -675,7 +682,11 @@ class TestCreate:
 
         resp = await client.post(
             "/samples",
-            {"name": "Foobar", "files": files, "subtractions": ["apple"]},
+            {
+                "name": "Foobar",
+                "files": files,
+                "subtractions": [subtractions["apple"]],
+            },
         )
 
         await resp_is.bad_request(resp, "File does not exist")
@@ -702,15 +713,30 @@ class TestCreate:
 
 
 class TestEdit:
-    async def test_ok(self, get_sample_data, snapshot, spawn_client: ClientSpawner):
+    async def test_ok(
+        self,
+        get_sample_data,
+        pg: AsyncEngine,
+        snapshot,
+        spawn_client: ClientSpawner,
+    ):
         """Test that an existing sample can be edited correctly."""
         client = await spawn_client(administrator=True, authenticated=True)
+
+        async with AsyncSession(pg) as session:
+            peach_id = (
+                await session.execute(
+                    select(SQLSubtraction.id).where(
+                        SQLSubtraction.legacy_id == "peach",
+                    ),
+                )
+            ).scalar_one()
 
         resp = await client.patch(
             "/samples/test",
             {
                 "name": "test_sample",
-                "subtractions": ["peach"],
+                "subtractions": [peach_id],
                 "labels": [1],
                 "notes": "This is a test.",
             },
@@ -807,7 +833,7 @@ class TestEdit:
 
         user = await fake.users.create()
 
-        await asyncio.gather(
+        _, subtractions = await asyncio.gather(
             mongo.samples.insert_one(
                 {
                     "_id": "test",
@@ -815,14 +841,17 @@ class TestEdit:
                     "all_read": True,
                     "all_write": True,
                     "ready": True,
-                    "subtractions": ["apple"],
+                    "subtractions": [],
                     "user": {"id": user.id},
                 },
             ),
             insert_subtractions(("foo", "Foo")),
         )
 
-        resp = await client.patch("/samples/test", {"subtractions": ["foo", "bar"]})
+        resp = await client.patch(
+            "/samples/test",
+            {"subtractions": [subtractions["foo"], 999]},
+        )
 
         assert resp.status == 400
         assert await resp.json() == snapshot(name="json")

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -36,7 +36,9 @@ async def get_sample_ready_false(
     user = await fake.users.create()
     job = await fake.jobs.create(user, workflow="create_sample")
 
-    await insert_subtractions(("apple", "Apple"), ("pear", "Pear"), ("peach", "Peach"))
+    subtractions = await insert_subtractions(
+        ("apple", "Apple"), ("pear", "Pear"), ("peach", "Peach")
+    )
 
     await mongo.samples.insert_one(
         {
@@ -68,7 +70,7 @@ async def get_sample_ready_false(
             "nuvs": False,
             "pathoscope": True,
             "ready": False,
-            "subtractions": ["apple", "pear"],
+            "subtractions": [subtractions["apple"], subtractions["pear"]],
             "user": {"id": user.id},
             "workflows": {
                 "aodp": WorkflowState.INCOMPATIBLE.value,
@@ -122,13 +124,13 @@ class TestCreate:
         label = await fake.labels.create()
         upload = await fake.uploads.create(user=await fake.users.create())
 
-        await insert_subtractions(("apple", "Apple"))
+        subtractions = await insert_subtractions(("apple", "Apple"))
 
         data = {
             "files": [upload.id],
             "labels": [label.id],
             "name": "Foobar",
-            "subtractions": ["apple"],
+            "subtractions": [subtractions["apple"]],
         }
 
         if group_setting == "force_choice":

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -14,6 +14,22 @@ from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile
 from virtool.uploads.sql import UploadType
 
 
+async def _subtraction_pk(pg: AsyncEngine, legacy_id: str) -> int:
+    """Resolve a subtraction's integer id from its legacy string id.
+
+    ``samples.subtractions`` holds integer ids, so linked-sample fixtures must
+    reference the subtraction by its ``subtractions.id`` rather than its legacy id.
+
+    Interim: delete once the subtraction public id is an integer (VIR-2535).
+    """
+    async with AsyncSession(pg) as session:
+        return (
+            await session.execute(
+                select(SQLSubtraction.id).where(SQLSubtraction.legacy_id == legacy_id),
+            )
+        ).scalar_one()
+
+
 async def test_find_empty_subtractions(
     snapshot,
     spawn_client: ClientSpawner,
@@ -111,6 +127,7 @@ async def test_edit(
     data: dict,
     fake: DataFaker,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot_recent: SnapshotAssertion,
     spawn_client: ClientSpawner,
 ):
@@ -122,10 +139,12 @@ async def test_edit(
 
     subtraction = await fake.subtractions.create(user=user, upload=upload)
 
+    subtraction_pk = await _subtraction_pk(pg, subtraction.id)
+
     await mongo.samples.insert_many(
         [
-            {"_id": "12", "name": "Sample 12", "subtractions": [subtraction.id]},
-            {"_id": "22", "name": "Sample 22", "subtractions": [subtraction.id]},
+            {"_id": "12", "name": "Sample 12", "subtractions": [subtraction_pk]},
+            {"_id": "22", "name": "Sample 22", "subtractions": [subtraction_pk]},
         ],
         session=None,
     )
@@ -398,6 +417,7 @@ class TestRemoveAsJob:
         fake: DataFaker,
         spawn_job_client: JobClientSpawner,
         mongo: Mongo,
+        pg: AsyncEngine,
         resp_is,
     ):
         """Verifies that a finalized subtraction cannot be deleted."""
@@ -415,7 +435,11 @@ class TestRemoveAsJob:
         client = await spawn_job_client(authenticated=True)
 
         await mongo.samples.insert_one(
-            {"_id": "test", "name": "Test", "subtractions": [subtraction.id]},
+            {
+                "_id": "test",
+                "name": "Test",
+                "subtractions": [await _subtraction_pk(pg, subtraction.id)],
+            },
         )
 
         resp = await client.delete(f"/subtractions/{subtraction.id}")
@@ -427,6 +451,7 @@ class TestRemoveAsJob:
         fake: DataFaker,
         spawn_job_client: JobClientSpawner,
         mongo: Mongo,
+        pg: AsyncEngine,
         resp_is,
     ):
         """Checks successful deletion of an unfinalized subtraction."""
@@ -441,7 +466,11 @@ class TestRemoveAsJob:
             finalized=False,
         )
         await mongo.samples.insert_one(
-            {"_id": "test", "name": "Test", "subtractions": [subtraction.id]},
+            {
+                "_id": "test",
+                "name": "Test",
+                "subtractions": [await _subtraction_pk(pg, subtraction.id)],
+            },
         )
 
         client = await spawn_job_client(authenticated=True)

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -7,27 +7,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy.assertion import SnapshotAssertion
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
+from tests.fixtures.subtractions import resolve_subtraction_pk
 from virtool.fake.next import DataFaker
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile
 from virtool.uploads.sql import UploadType
-
-
-async def _subtraction_pk(pg: AsyncEngine, legacy_id: str) -> int:
-    """Resolve a subtraction's integer id from its legacy string id.
-
-    ``samples.subtractions`` holds integer ids, so linked-sample fixtures must
-    reference the subtraction by its ``subtractions.id`` rather than its legacy id.
-
-    Interim: delete once the subtraction public id is an integer (VIR-2535).
-    """
-    async with AsyncSession(pg) as session:
-        return (
-            await session.execute(
-                select(SQLSubtraction.id).where(SQLSubtraction.legacy_id == legacy_id),
-            )
-        ).scalar_one()
 
 
 async def test_find_empty_subtractions(
@@ -139,7 +124,7 @@ async def test_edit(
 
     subtraction = await fake.subtractions.create(user=user, upload=upload)
 
-    subtraction_pk = await _subtraction_pk(pg, subtraction.id)
+    subtraction_pk = await resolve_subtraction_pk(pg, subtraction.id)
 
     await mongo.samples.insert_many(
         [
@@ -438,7 +423,7 @@ class TestRemoveAsJob:
             {
                 "_id": "test",
                 "name": "Test",
-                "subtractions": [await _subtraction_pk(pg, subtraction.id)],
+                "subtractions": [await resolve_subtraction_pk(pg, subtraction.id)],
             },
         )
 
@@ -469,7 +454,7 @@ class TestRemoveAsJob:
             {
                 "_id": "test",
                 "name": "Test",
-                "subtractions": [await _subtraction_pk(pg, subtraction.id)],
+                "subtractions": [await resolve_subtraction_pk(pg, subtraction.id)],
             },
         )
 

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -2,6 +2,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import virtool.subtractions.db
+from tests.fixtures.subtractions import resolve_subtraction_pk
 from virtool.data.transforms import apply_transforms
 from virtool.fake.next import DataFaker
 from virtool.subtractions.db import (
@@ -118,18 +119,6 @@ class TestGetMissingSubtractionIds:
         )
 
 
-async def _resolve_subtraction_id(pg, legacy_id: str) -> int:
-    # Interim: delete once the subtraction public id is an integer (VIR-2535).
-    async with AsyncSession(pg) as session:
-        return (
-            await session.execute(
-                select(SQLSubtraction.id).where(
-                    SQLSubtraction.legacy_id == legacy_id,
-                ),
-            )
-        ).scalar_one()
-
-
 async def test_get_linked_samples(fake: DataFaker, mongo, pg):
     user = await fake.users.create()
     upload = await fake.uploads.create(
@@ -137,7 +126,7 @@ async def test_get_linked_samples(fake: DataFaker, mongo, pg):
     )
     subtraction = await fake.subtractions.create(user=user, upload=upload)
 
-    target = await _resolve_subtraction_id(pg, subtraction.id)
+    target = await resolve_subtraction_pk(pg, subtraction.id)
 
     # Other integer subtraction ids the samples reference; only ``target`` should
     # match. The offsets simply guarantee distinctness from ``target``.
@@ -145,16 +134,31 @@ async def test_get_linked_samples(fake: DataFaker, mongo, pg):
 
     await mongo.samples.insert_many(
         [
-            {"_id": "foo", "name": "Foo", "subtractions": [other_a, target, other_b]},
-            {"_id": "bar", "name": "Bar", "subtractions": [other_c, target, other_a]},
-            {"_id": "baz", "name": "Baz", "subtractions": [other_a]},
+            {
+                "_id": "sample_with_target",
+                "name": "Sample With Target",
+                "subtractions": [other_a, target, other_b],
+            },
+            {
+                "_id": "another_with_target",
+                "name": "Another With Target",
+                "subtractions": [other_c, target, other_a],
+            },
+            {
+                "_id": "sample_without_target",
+                "name": "Sample Without Target",
+                "subtractions": [other_a],
+            },
         ],
         session=None,
     )
 
     samples = await virtool.subtractions.db.get_linked_samples(mongo, target)
 
-    assert samples == [{"id": "foo", "name": "Foo"}, {"id": "bar", "name": "Bar"}]
+    assert samples == [
+        {"id": "sample_with_target", "name": "Sample With Target"},
+        {"id": "another_with_target", "name": "Another With Target"},
+    ]
 
 
 async def test_unlink_default_subtractions(fake: DataFaker, mongo, pg):
@@ -167,15 +171,15 @@ async def test_unlink_default_subtractions(fake: DataFaker, mongo, pg):
 
     subtraction = await fake.subtractions.create(user=user, upload=upload)
 
-    target = await _resolve_subtraction_id(pg, subtraction.id)
+    target = await resolve_subtraction_pk(pg, subtraction.id)
 
     other_a, other_b, other_c = target + 1, target + 2, target + 3
 
     await mongo.samples.insert_many(
         [
-            {"_id": "foo", "subtractions": [other_a, target, other_b]},
-            {"_id": "bar", "subtractions": [target, other_c, other_b]},
-            {"_id": "baz", "subtractions": [target]},
+            {"_id": "sample_keeps_two", "subtractions": [other_a, target, other_b]},
+            {"_id": "sample_keeps_two_alt", "subtractions": [target, other_c, other_b]},
+            {"_id": "sample_becomes_empty", "subtractions": [target]},
         ],
         session=None,
     )
@@ -184,7 +188,7 @@ async def test_unlink_default_subtractions(fake: DataFaker, mongo, pg):
         await unlink_default_subtractions(mongo, target, session)
 
     assert await mongo.samples.find().to_list(None) == [
-        {"_id": "foo", "subtractions": [other_a, other_b]},
-        {"_id": "bar", "subtractions": [other_c, other_b]},
-        {"_id": "baz", "subtractions": []},
+        {"_id": "sample_keeps_two", "subtractions": [other_a, other_b]},
+        {"_id": "sample_keeps_two_alt", "subtractions": [other_c, other_b]},
+        {"_id": "sample_becomes_empty", "subtractions": []},
     ]

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -118,28 +118,46 @@ class TestGetMissingSubtractionIds:
         )
 
 
-async def test_get_linked_samples(fake: DataFaker, mongo):
+async def _resolve_subtraction_id(pg, legacy_id: str) -> int:
+    # Interim: delete once the subtraction public id is an integer (VIR-2535).
+    async with AsyncSession(pg) as session:
+        return (
+            await session.execute(
+                select(SQLSubtraction.id).where(
+                    SQLSubtraction.legacy_id == legacy_id,
+                ),
+            )
+        ).scalar_one()
+
+
+async def test_get_linked_samples(fake: DataFaker, mongo, pg):
     user = await fake.users.create()
     upload = await fake.uploads.create(
         user=user, upload_type=UploadType.subtraction, name="foobar.fq.gz"
     )
     subtraction = await fake.subtractions.create(user=user, upload=upload)
 
+    target = await _resolve_subtraction_id(pg, subtraction.id)
+
+    # Other integer subtraction ids the samples reference; only ``target`` should
+    # match. The offsets simply guarantee distinctness from ``target``.
+    other_a, other_b, other_c = target + 1, target + 2, target + 3
+
     await mongo.samples.insert_many(
         [
-            {"_id": "foo", "name": "Foo", "subtractions": ["1", subtraction.id, "3"]},
-            {"_id": "bar", "name": "Bar", "subtractions": ["2", subtraction.id, "8"]},
-            {"_id": "baz", "name": "Baz", "subtractions": ["2"]},
+            {"_id": "foo", "name": "Foo", "subtractions": [other_a, target, other_b]},
+            {"_id": "bar", "name": "Bar", "subtractions": [other_c, target, other_a]},
+            {"_id": "baz", "name": "Baz", "subtractions": [other_a]},
         ],
         session=None,
     )
 
-    samples = await virtool.subtractions.db.get_linked_samples(mongo, subtraction.id)
+    samples = await virtool.subtractions.db.get_linked_samples(mongo, target)
 
     assert samples == [{"id": "foo", "name": "Foo"}, {"id": "bar", "name": "Bar"}]
 
 
-async def test_unlink_default_subtractions(fake: DataFaker, mongo):
+async def test_unlink_default_subtractions(fake: DataFaker, mongo, pg):
     user = await fake.users.create()
     upload = await fake.uploads.create(
         user=user,
@@ -149,20 +167,24 @@ async def test_unlink_default_subtractions(fake: DataFaker, mongo):
 
     subtraction = await fake.subtractions.create(user=user, upload=upload)
 
+    target = await _resolve_subtraction_id(pg, subtraction.id)
+
+    other_a, other_b, other_c = target + 1, target + 2, target + 3
+
     await mongo.samples.insert_many(
         [
-            {"_id": "foo", "subtractions": ["1", subtraction.id, "3"]},
-            {"_id": "bar", "subtractions": [subtraction.id, "5", "8"]},
-            {"_id": "baz", "subtractions": [subtraction.id]},
+            {"_id": "foo", "subtractions": [other_a, target, other_b]},
+            {"_id": "bar", "subtractions": [target, other_c, other_b]},
+            {"_id": "baz", "subtractions": [target]},
         ],
         session=None,
     )
 
     async with mongo.create_session() as session:
-        await unlink_default_subtractions(mongo, subtraction.id, session)
+        await unlink_default_subtractions(mongo, target, session)
 
     assert await mongo.samples.find().to_list(None) == [
-        {"_id": "foo", "subtractions": ["1", "3"]},
-        {"_id": "bar", "subtractions": ["5", "8"]},
+        {"_id": "foo", "subtractions": [other_a, other_b]},
+        {"_id": "bar", "subtractions": [other_c, other_b]},
         {"_id": "baz", "subtractions": []},
     ]

--- a/virtool/samples/checks.py
+++ b/virtool/samples/checks.py
@@ -22,7 +22,7 @@ async def check_name_is_in_use(
 
 
 async def check_subtractions_do_not_exist(
-    pg: AsyncEngine, subtractions: list[str]
+    pg: AsyncEngine, subtractions: list[int]
 ) -> None:
     if non_existent_subtractions := await get_missing_subtraction_ids(pg, subtractions):
         raise ResourceConflictError(

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -237,7 +237,7 @@ async def create_sample(
     group: int | str,
     locale: str,
     library_type: str,
-    subtractions: list[str],
+    subtractions: list[int],
     notes: str,
     labels: list[int],
     user_id: int,

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -77,9 +77,7 @@ async def create_fake_sample(
 
     async with AsyncSession(pg) as session:
         result = await session.execute(
-            select(SQLSubtraction.legacy_id)
-            .where(SQLSubtraction.legacy_id.isnot(None))
-            .limit(2),
+            select(SQLSubtraction.id).limit(2),
         )
 
         subtraction_ids = list(result.scalars().all())

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -8,7 +8,6 @@ from virtool.models import BaseModel, SearchResult
 from virtool.models.enums import LibraryType
 from virtool.quality.models import Quality
 from virtool.samples.models_base import SampleNested
-from virtool.subtractions.models import SubtractionNested
 from virtool.uploads.models import UploadMinimal
 from virtool.users.models_base import UserNested
 
@@ -18,6 +17,18 @@ class SampleArtifact(BaseModel):
     download_url: str
     name: str
     size: int
+
+
+class SampleSubtraction(BaseModel):
+    """A subtraction referenced by a sample, identified by its integer id.
+
+    Interim model: exists only because the shared ``SubtractionNested.id`` is still
+    a legacy string. Remove and revert ``Sample.subtractions`` to ``SubtractionNested``
+    after the subtraction id cutover (VIR-2535).
+    """
+
+    id: int
+    name: str
 
 
 class WorkflowState(Enum):
@@ -72,7 +83,7 @@ class SampleMinimal(SampleNested):
                     "nuvs": False,
                     "pathoscope": True,
                     "ready": True,
-                    "subtractions": ["0nhpi36p"],
+                    "subtractions": [21],
                     "user": {
                         "administrator": True,
                         "handle": "mrott",
@@ -113,7 +124,7 @@ class Sample(SampleMinimal):
     paired: bool
     quality: Quality | None
     reads: list[Read]
-    subtractions: list[SubtractionNested]
+    subtractions: list[SampleSubtraction]
 
     class Config:
         schema_extra = {
@@ -191,7 +202,7 @@ class Sample(SampleMinimal):
                     },
                 ],
                 "ready": True,
-                "subtractions": [{"id": "0nhpi36p", "name": "Malus domestica"}],
+                "subtractions": [{"id": 21, "name": "Malus domestica"}],
                 "user": {"administrator": True, "handle": "mrott", "id": "ihvze2u9"},
                 "workflows": {
                     "aodp": "incompatible",

--- a/virtool/samples/oas.py
+++ b/virtool/samples/oas.py
@@ -14,7 +14,7 @@ class CreateSampleRequest(BaseModel):
     group: int | None = None
     locale: constr(strip_whitespace=True) = ""
     library_type: LibraryType = LibraryType.normal
-    subtractions: list = Field(default_factory=list)
+    subtractions: list[int] = Field(default_factory=list)
     files: conlist(item_type=Any, min_items=1, max_items=2)
     notes: str = ""
     labels: list = Field(default_factory=list)
@@ -36,7 +36,7 @@ class UpdateSampleRequest(BaseModel):
     locale: constr(strip_whitespace=True) | None
     notes: constr(strip_whitespace=True) | None
     labels: list | None
-    subtractions: list | None
+    subtractions: list[int] | None
 
     _prevent_none = prevent_none("*")
 

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -367,7 +367,7 @@ class SubtractionsData(DataLayerDomain):
                 .values(deleted=True),
             )
 
-            await unlink_default_subtractions(self._mongo, legacy_id, mongo_session)
+            await unlink_default_subtractions(self._mongo, modern_id, mongo_session)
 
         failures = await delete_prefix(self._storage, subtraction_prefix(legacy_id))
 

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -181,7 +181,7 @@ async def attach_computed(
 
     files, linked_samples = await asyncio.gather(
         get_subtraction_files(pg, subtraction_pk),
-        get_linked_samples(mongo, legacy_id),
+        get_linked_samples(mongo, subtraction_pk),
     )
 
     for file in files:
@@ -193,11 +193,11 @@ async def attach_computed(
     return {**subtraction, "files": files, "linked_samples": linked_samples}
 
 
-async def get_linked_samples(mongo: "Mongo", subtraction_id: str) -> list[dict]:
+async def get_linked_samples(mongo: "Mongo", subtraction_id: int) -> list[dict]:
     """Find all samples containing given 'subtraction_id' in 'subtractions' field.
 
     :param mongo: the application database client
-    :param subtraction_id: the ID of the subtraction
+    :param subtraction_id: the integer ID of the subtraction
     :return: a list of dicts containing linked samples with 'id' and 'name' field.
 
     """
@@ -212,13 +212,13 @@ async def get_linked_samples(mongo: "Mongo", subtraction_id: str) -> list[dict]:
 
 async def unlink_default_subtractions(
     mongo: "Mongo",
-    subtraction_id: str,
+    subtraction_id: int,
     session: AsyncIOMotorClientSession,
 ) -> None:
     """Remove a subtraction as a default subtraction for samples.
 
     :param mongo: the application mongo object
-    :param subtraction_id: the id of the subtraction to remove
+    :param subtraction_id: the integer id of the subtraction to remove
     :param session: a motor session to use
     """
     await mongo.samples.update_many(


### PR DESCRIPTION
## Summary

- Converts `samples.subtractions` in MongoDB from a list of legacy string subtraction IDs to a list of integer PostgreSQL IDs, completing the cross-domain FK upgrade for the subtractions migration.
- Adds a new migration revision (`24ysb9cwjiv1`) that backfills existing sample documents, resolving each string element via `subtractions.legacy_id`; already-integer elements pass through unchanged and unresolved strings raise loudly.
- Updates `samples` API request/response models, data-layer signatures, and `subtractions` DB helpers (`get_linked_samples`, `unlink_default_subtractions`) to operate on integer IDs throughout; adds interim `SampleSubtraction` model (integer `id`) to replace `SubtractionNested` until the subtraction public-ID cutover (VIR-2535).