### PR TITLE
Replace session_type PostgreSQL enum with text and check constraint

### DIFF
--- a/assets/alembic/versions/90330f98cf4e_convert_session_type_to_text.py
+++ b/assets/alembic/versions/90330f98cf4e_convert_session_type_to_text.py
@@ -1,0 +1,43 @@
+"""convert session_type to text
+
+Revision ID: 90330f98cf4e
+Revises: 869aa923399e
+Create Date: 2026-06-09 19:08:34.001251+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "90330f98cf4e"
+down_revision = "869aa923399e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE sessions ALTER COLUMN session_type TYPE text "
+        "USING session_type::text",
+    )
+
+    op.execute("DROP TYPE session_type_enum")
+
+    op.create_check_constraint(
+        "session_type_valid",
+        "sessions",
+        "session_type IN ('anonymous', 'authenticated', 'reset')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("session_type_valid", "sessions", type_="check")
+
+    op.execute(
+        "CREATE TYPE session_type_enum AS ENUM ('anonymous', 'authenticated', 'reset')",
+    )
+
+    op.execute(
+        "ALTER TABLE sessions ALTER COLUMN session_type TYPE session_type_enum "
+        "USING session_type::session_type_enum",
+    )

--- a/tests/alembic/test_90330f98cf4e_convert_session_type_to_text.py
+++ b/tests/alembic/test_90330f98cf4e_convert_session_type_to_text.py
@@ -1,0 +1,107 @@
+import asyncio
+from pathlib import Path
+
+import alembic.command
+import alembic.config
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+
+def _downgrade(revision: str) -> None:
+    """Downgrade to ``revision`` using the SQLALCHEMY_URL set by ``apply_alembic``."""
+    alembic.command.downgrade(
+        alembic.config.Config(Path(__file__).parent.parent.parent / "alembic.ini"),
+        revision,
+    )
+
+
+async def _insert_session(
+    session: AsyncSession,
+    session_id: str,
+    session_type: str,
+) -> None:
+    await session.execute(
+        text(
+            "INSERT INTO sessions "
+            "(session_id, ip, created_at, expires_at, session_type) "
+            "VALUES (:session_id, '127.0.0.1', now(), now(), :session_type)",
+        ),
+        {"session_id": session_id, "session_type": session_type},
+    )
+
+
+async def test_upgrade(
+    apply_alembic: callable,
+    migration_pg: AsyncEngine,
+):
+    await asyncio.to_thread(apply_alembic, "869aa923399e")
+
+    async with AsyncSession(migration_pg) as session:
+        await _insert_session(session, "anonymous_session", "anonymous")
+        await _insert_session(session, "authenticated_session", "authenticated")
+        await _insert_session(session, "reset_session", "reset")
+        await session.commit()
+
+    await asyncio.to_thread(apply_alembic, "90330f98cf4e")
+
+    await migration_pg.dispose()
+
+    async with AsyncSession(migration_pg) as session:
+        result = await session.execute(
+            text("SELECT session_id, session_type FROM sessions ORDER BY session_id"),
+        )
+        assert result.all() == [
+            ("anonymous_session", "anonymous"),
+            ("authenticated_session", "authenticated"),
+            ("reset_session", "reset"),
+        ]
+
+        column_type = await session.execute(
+            text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = 'sessions' AND column_name = 'session_type'",
+            ),
+        )
+        assert column_type.scalar_one() == "text"
+
+    with pytest.raises(IntegrityError):
+        async with AsyncSession(migration_pg) as session:
+            await _insert_session(session, "invalid_session", "bogus")
+            await session.commit()
+
+
+async def test_downgrade(
+    apply_alembic: callable,
+    migration_pg: AsyncEngine,
+):
+    await asyncio.to_thread(apply_alembic, "90330f98cf4e")
+
+    async with AsyncSession(migration_pg) as session:
+        await _insert_session(session, "anonymous_session", "anonymous")
+        await _insert_session(session, "authenticated_session", "authenticated")
+        await _insert_session(session, "reset_session", "reset")
+        await session.commit()
+
+    await asyncio.to_thread(_downgrade, "869aa923399e")
+
+    await migration_pg.dispose()
+
+    async with AsyncSession(migration_pg) as session:
+        result = await session.execute(
+            text("SELECT session_id, session_type FROM sessions ORDER BY session_id"),
+        )
+        assert result.all() == [
+            ("anonymous_session", "anonymous"),
+            ("authenticated_session", "authenticated"),
+            ("reset_session", "reset"),
+        ]
+
+        column_type = await session.execute(
+            text(
+                "SELECT udt_name FROM information_schema.columns "
+                "WHERE table_name = 'sessions' AND column_name = 'session_type'",
+            ),
+        )
+        assert column_type.scalar_one() == "session_type_enum"

--- a/tests/alembic/test_90330f98cf4e_convert_session_type_to_text.py
+++ b/tests/alembic/test_90330f98cf4e_convert_session_type_to_text.py
@@ -8,6 +8,8 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.utils import timestamp
+
 
 def _downgrade(revision: str) -> None:
     """Downgrade to ``revision`` using the SQLALCHEMY_URL set by ``apply_alembic``."""
@@ -22,13 +24,20 @@ async def _insert_session(
     session_id: str,
     session_type: str,
 ) -> None:
+    now = timestamp()
     await session.execute(
         text(
             "INSERT INTO sessions "
             "(session_id, ip, created_at, expires_at, session_type) "
-            "VALUES (:session_id, '127.0.0.1', now(), now(), :session_type)",
+            "VALUES (:session_id, '127.0.0.1', :created_at, :expires_at, "
+            ":session_type)",
         ),
-        {"session_id": session_id, "session_type": session_type},
+        {
+            "session_id": session_id,
+            "created_at": now,
+            "expires_at": now,
+            "session_type": session_type,
+        },
     )
 
 

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -498,5 +498,12 @@
       'name': 'backfill samples subtractions to integers',
       'revision': '24ysb9cwjiv1',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 72,
+      'name': 'convert session_type to text',
+      'revision': '90330f98cf4e',
+    }),
   ])
 # ---

--- a/virtool/sessions/models.py
+++ b/virtool/sessions/models.py
@@ -34,7 +34,7 @@ class SQLSession(Base):
     token_hash: Mapped[str | None]
     reset_code: Mapped[str | None]
     reset_remember: Mapped[bool | None]
-    session_type: Mapped[SessionType] = mapped_column(String)
+    session_type: Mapped[str] = mapped_column(String)
 
     __table_args__ = (
         CheckConstraint(

--- a/virtool/sessions/models.py
+++ b/virtool/sessions/models.py
@@ -4,8 +4,7 @@ from datetime import datetime
 from enum import Enum
 
 import arrow
-from sqlalchemy import ForeignKey
-from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy import CheckConstraint, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
@@ -35,8 +34,13 @@ class SQLSession(Base):
     token_hash: Mapped[str | None]
     reset_code: Mapped[str | None]
     reset_remember: Mapped[bool | None]
-    session_type: Mapped[SessionType] = mapped_column(
-        ENUM(SessionType, name="session_type_enum")
+    session_type: Mapped[SessionType] = mapped_column(String)
+
+    __table_args__ = (
+        CheckConstraint(
+            "session_type IN ('anonymous', 'authenticated', 'reset')",
+            name="session_type_valid",
+        ),
     )
 
     def is_expired(self) -> bool:


### PR DESCRIPTION
## Summary

- Converts `sessions.session_type` from a PostgreSQL native `ENUM` type (`session_type_enum`) to a plain `text` column with a `CHECK` constraint
- Drops the `session_type_enum` PG type and updates the SQLAlchemy model to use `String` with `CheckConstraint`
- Follows the same pattern used to replace `administrator_role` enum in a prior migration