### PR TITLE
fix: release reserved uploads on all sample-deletion paths

### DIFF
--- a/tests/samples/__snapshots__/test_data.ambr
+++ b/tests/samples/__snapshots__/test_data.ambr
@@ -256,7 +256,24 @@
         'name': 'Pear',
       }),
     ]),
-    'uploads': None,
+    'uploads': list([
+      dict({
+        'created_at': 'not_approximately_now_datetime',
+        'id': 1,
+        'name': 'test.fq.gz',
+        'ready': True,
+        'removed': True,
+        'removed_at': 'not_approximately_now_datetime',
+        'reserved': False,
+        'size': 723988,
+        'type': 'reads',
+        'uploaded_at': 'not_approximately_now_datetime',
+        'user': dict({
+          'handle': 'zwilliams',
+          'id': 2,
+        }),
+      }),
+    ]),
     'user': dict({
       'handle': 'leeashley',
       'id': 1,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -21,11 +21,13 @@ from virtool.fake.next import DataFaker
 from virtool.jobs.models import JobState
 from virtool.models.enums import LibraryType, Permission
 from virtool.mongo.core import Mongo
+from virtool.pg.utils import get_row_by_id
 from virtool.samples.fake import create_fake_sample
 from virtool.samples.models import WorkflowState
 from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.subtractions.pg import SQLSubtraction
+from virtool.uploads.sql import SQLUpload
 from virtool.users.oas import UpdateUserRequest
 
 
@@ -1005,6 +1007,40 @@ class TestDelete:
         resp = await client.delete("/samples/test")
 
         assert resp.status == 204
+
+    async def test_releases_reserved_uploads(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+        static_time,
+    ):
+        """Deleting a sample through the web API releases its reserved uploads."""
+        client = await self.setup_unfinalized_sample_with_job(
+            JobState.FAILED,
+            fake,
+            mongo,
+            spawn_client,
+            static_time,
+        )
+
+        upload = await fake.uploads.create(
+            user=await fake.users.create(),
+            reserved=True,
+        )
+
+        await mongo.samples.update_one(
+            {"_id": "test"},
+            {"$set": {"uploads": [{"id": upload.id}]}},
+        )
+
+        resp = await client.delete("/samples/test")
+
+        assert resp.status == 204
+
+        row = await get_row_by_id(pg, SQLUpload, upload.id)
+        assert row.reserved is False
 
     async def test_unfinalized_with_running_job(
         self,

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -225,6 +225,11 @@ async def test_finalize(
     upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
     upload_name_on_disk = upload_row.name_on_disk
 
+    await mongo.samples.update_one(
+        {"_id": "test"},
+        {"$set": {"uploads": [{"id": upload.id}]}},
+    )
+
     async with AsyncSession(pg) as session:
         session.add(
             SQLSampleReads(
@@ -265,6 +270,69 @@ async def test_finalize(
 
     with pytest.raises(StorageKeyNotFoundError):
         await memory_storage.size(upload_key)
+
+
+async def test_finalize_cleans_up_uploads_without_reads_link(
+    data_layer: DataLayer,
+    fake: DataFaker,
+    get_sample_ready_false,
+    memory_storage: StorageBackend,
+    mongo: Mongo,
+    pg: AsyncEngine,
+):
+    """Finalizing deletes the sample's uploads from storage using its ``uploads`` array.
+
+    The cleanup keys off the sample's ``uploads`` array rather than ``SQLSampleReads``,
+    so the upload file is removed even when the workflow wrote its reads row without an
+    ``upload_id``.
+    """
+    upload = await fake.uploads.create(user=await fake.users.create())
+
+    upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
+    upload_key = upload_file_key(upload_row.name_on_disk)
+
+    await mongo.samples.update_one(
+        {"_id": "test"},
+        {"$set": {"uploads": [{"id": upload.id}]}},
+    )
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLSampleReads(
+                name="reads.fq.gz",
+                name_on_disk="reads_1.fq.gz",
+                sample="test",
+                size=len(b"upload contents"),
+                upload=None,
+                uploaded_at=virtool.utils.timestamp(),
+            ),
+        )
+
+        await session.commit()
+
+    async def _chunks() -> AsyncIterator[bytes]:
+        yield b"upload contents"
+
+    await memory_storage.write(upload_key, _chunks())
+
+    await data_layer.samples.finalize(
+        "test",
+        {
+            "bases": [[1543]],
+            "composition": [[6372]],
+            "count": 7069,
+            "encoding": "OuBQPPuwYimrxkNpPWUx",
+            "gc": 34222440,
+            "length": [3237],
+            "sequences": [7091],
+        },
+    )
+
+    with pytest.raises(StorageKeyNotFoundError):
+        await memory_storage.size(upload_key)
+
+    refreshed = await get_row_by_id(pg, SQLUpload, upload.id)
+    assert refreshed.removed is True
 
 
 async def test_finalized_already(get_sample_ready_false, data_layer):
@@ -656,3 +724,32 @@ class TestDelete:
         await data_layer.samples.delete("test_sample")
 
         assert await get_row(pg, SQLAnalysis, ("id", analysis.id)) is None
+
+    async def test_releases_reserved_uploads(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Deleting a sample releases the uploads reserved during its creation.
+
+        The reservation is keyed on the sample's own ``uploads`` array, so the upload
+        is released even when no ``SQLSampleReads`` rows have been written yet.
+        """
+        await self._setup(fake, mongo)
+
+        upload = await fake.uploads.create(
+            user=await fake.users.create(),
+            reserved=True,
+        )
+
+        await mongo.samples.update_one(
+            {"_id": "test_sample"},
+            {"$set": {"uploads": [{"id": upload.id}]}},
+        )
+
+        await data_layer.samples.delete("test_sample")
+
+        row = await get_row_by_id(pg, SQLUpload, upload.id)
+        assert row.reserved is False

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -38,7 +38,6 @@ from virtool.groups.pg import SQLGroup
 from virtool.jobs.models import TERMINAL_JOB_STATES
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
-from virtool.pg.utils import get_rows
 from virtool.samples.db import (
     SAMPLE_RIGHTS_PROJECTION,
     check_rights,
@@ -52,7 +51,6 @@ from virtool.samples.oas import (
     UpdateRightsRequest,
     UpdateSampleRequest,
 )
-from virtool.samples.sql import SQLSampleReads
 from virtool.samples.utils import SampleRight
 from virtool.uploads.utils import (
     multipart_file_chunker,
@@ -363,7 +361,6 @@ async def job_remove(req):
     Only usable in the Jobs API and when samples are unfinalized.
 
     """
-    pg = req.app["pg"]
     mongo = get_mongo_from_req(req)
 
     sample_id = req.match_info["sample_id"]
@@ -391,12 +388,6 @@ async def job_remove(req):
             raise APIBadRequest(
                 f"Cannot delete sample with active job (current state: {job.state.value})"
             )
-
-    reads_files = await get_rows(pg, SQLSampleReads, "sample", sample_id)
-    upload_ids = [upload for reads in reads_files if (upload := reads.upload)]
-
-    if upload_ids:
-        await get_data_from_req(req).uploads.release(upload_ids)
 
     try:
         await get_data_from_req(req).samples.delete(sample_id)

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -387,8 +387,7 @@ class SamplesData(DataLayerDomain):
         """
         sample = await self.get(sample_id)
 
-        uploads = await get_one_field(self._mongo.samples, "uploads", sample_id) or []
-        upload_ids = [upload["id"] for upload in uploads]
+        upload_ids = [upload.id for upload in sample.uploads or []]
 
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
 from pymongo.results import UpdateResult
-from sqlalchemy import delete, exc, select
+from sqlalchemy import delete, exc, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
@@ -387,6 +387,9 @@ class SamplesData(DataLayerDomain):
         """
         sample = await self.get(sample_id)
 
+        uploads = await get_one_field(self._mongo.samples, "uploads", sample_id) or []
+        upload_ids = [upload["id"] for upload in uploads]
+
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,
             pg_session,
@@ -398,6 +401,13 @@ class SamplesData(DataLayerDomain):
                 {"sample.id": sample_id},
                 session=mongo_session,
             )
+
+            if upload_ids:
+                await pg_session.execute(
+                    update(SQLUpload)
+                    .where(SQLUpload.id.in_(upload_ids))
+                    .values(reserved=False),
+                )
 
             await pg_session.execute(
                 delete(SQLAnalysisResult).where(
@@ -450,15 +460,16 @@ class SamplesData(DataLayerDomain):
         if not result.modified_count:
             raise ResourceNotFoundError
 
+        uploads = await get_one_field(self._mongo.samples, "uploads", sample_id) or []
+        upload_ids = [upload["id"] for upload in uploads]
+
         names_on_disk = []
 
         async with AsyncSession(self._pg) as session:
             rows = (
                 (
                     await session.execute(
-                        select(SQLUpload)
-                        .where(SQLSampleReads.sample == sample_id)
-                        .join_from(SQLSampleReads, SQLUpload),
+                        select(SQLUpload).where(SQLUpload.id.in_(upload_ids)),
                     )
                 )
                 .unique()


### PR DESCRIPTION
## Summary

- Reserved uploads were only released in the `job_remove` API handler, keyed off `SQLSampleReads` rows — so deletions triggered by other paths (e.g. admin delete) and uploads whose workflow-written reads row lacked an `upload_id` were never released.
- Moved upload-release logic into `SamplesData.delete`, using the sample's `uploads` array directly, so every deletion path releases reserved uploads atomically in the same transaction.
- Similarly fixed `SamplesData.finalize` to key upload cleanup off the `uploads` array instead of joining through `SQLSampleReads`, ensuring cleanup works even when reads rows have no `upload_id`.