### PR TITLE
Retire job_subtractions link table

### DIFF
--- a/assets/alembic/versions/2b53ffa573a3_drop_job_subtractions_table.py
+++ b/assets/alembic/versions/2b53ffa573a3_drop_job_subtractions_table.py
@@ -10,7 +10,7 @@ stored in a dedicated table.
 repopulate it; the relationship is reconstructable from ``subtractions.job_id``.
 
 Revision ID: 2b53ffa573a3
-Revises: 869aa923399e
+Revises: 90330f98cf4e
 Create Date: 2026-06-09 19:06:46.200229+00:00
 
 """
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "2b53ffa573a3"
-down_revision = "869aa923399e"
+down_revision = "90330f98cf4e"
 branch_labels = None
 depends_on = None
 

--- a/assets/alembic/versions/2b53ffa573a3_drop_job_subtractions_table.py
+++ b/assets/alembic/versions/2b53ffa573a3_drop_job_subtractions_table.py
@@ -1,0 +1,38 @@
+"""drop job_subtractions table
+
+Retires the ``job_subtractions`` link table. Now that subtractions live in
+Postgres with a ``subtractions.job_id`` FK guarded by a ``UNIQUE`` constraint,
+the job->subtraction relationship is derived by inverting that scalar 1:1 edge
+(``LEFT JOIN subtractions ON subtractions.job_id = jobs.id``) instead of being
+stored in a dedicated table.
+
+``downgrade`` re-creates the table with its original schema. It does not
+repopulate it; the relationship is reconstructable from ``subtractions.job_id``.
+
+Revision ID: 2b53ffa573a3
+Revises: 869aa923399e
+Create Date: 2026-06-09 19:06:46.200229+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2b53ffa573a3"
+down_revision = "869aa923399e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_table("job_subtractions")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "job_subtractions",
+        sa.Column("job_id", sa.Integer(), nullable=False),
+        sa.Column("subtraction_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+        sa.PrimaryKeyConstraint("job_id"),
+    )

--- a/assets/revisions/rev_xtwxolun286s_copy_jobs_to_postgres.py
+++ b/assets/revisions/rev_xtwxolun286s_copy_jobs_to_postgres.py
@@ -5,7 +5,7 @@ Date: 2026-01-07 18:03:11.554276
 """
 
 import arrow
-from sqlalchemy import select
+from sqlalchemy import Column, Integer, MetaData, String, Table, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -15,13 +15,23 @@ from virtool.jobs.pg import (
     SQLJobAnalysis,
     SQLJobIndex,
     SQLJobSample,
-    SQLJobSubtraction,
 )
 from virtool.migration import MigrationContext
 from virtool.users.pg import SQLUser
 from virtool.utils import get_safely
 
 logger = get_logger("migration")
+
+# The ``job_subtractions`` link table was retired once subtractions gained a
+# ``subtractions.job_id`` FK. This revision runs earlier in the chain, while the
+# table still exists, so it writes through this frozen table rather than the
+# now-removed ``SQLJobSubtraction`` ORM model.
+_job_subtractions = Table(
+    "job_subtractions",
+    MetaData(),
+    Column("job_id", Integer),
+    Column("subtraction_id", String),
+)
 
 LEGACY_TO_JOB_STATE: dict[str, JobState] = {
     "cancelled": JobState.CANCELLED,
@@ -169,10 +179,14 @@ async def _migrate_job(
     pg_session.add(sql_job)
     await pg_session.flush()
 
-    _add_job_relationship(pg_session, sql_job.id, job)
+    await _add_job_relationship(pg_session, sql_job.id, job)
 
 
-def _add_job_relationship(pg_session: AsyncSession, job_id: int, job: dict) -> None:
+async def _add_job_relationship(
+    pg_session: AsyncSession,
+    job_id: int,
+    job: dict,
+) -> None:
     """Add the appropriate relationship record based on workflow."""
     workflow = job.get("workflow")
     args = job.get("args", {})
@@ -182,8 +196,11 @@ def _add_job_relationship(pg_session: AsyncSession, job_id: int, job: dict) -> N
     elif workflow == "build_index" and "index_id" in args:
         pg_session.add(SQLJobIndex(job_id=job_id, index_id=args["index_id"]))
     elif workflow == "create_subtraction" and "subtraction_id" in args:
-        pg_session.add(
-            SQLJobSubtraction(job_id=job_id, subtraction_id=args["subtraction_id"]),
+        await pg_session.execute(
+            _job_subtractions.insert().values(
+                job_id=job_id,
+                subtraction_id=args["subtraction_id"],
+            ),
         )
     elif workflow in ("aodp", "nuvs", "pathoscope") and "analysis_id" in args:
         pg_session.add(SQLJobAnalysis(job_id=job_id, analysis_id=args["analysis_id"]))

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -25,8 +25,8 @@ from virtool.jobs.pg import (
     SQLJob,
     SQLJobIndex,
     SQLJobSample,
-    SQLJobSubtraction,
 )
+from virtool.subtractions.pg import SQLSubtraction
 from virtool.users.models import User
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
@@ -202,39 +202,32 @@ class TestCreatePostgres:
         assert job_index is not None
         assert job_index.index_id == "index_456"
 
-    async def test_subtraction_join_table(
+    async def test_subtraction_id_resolved_from_subtraction(
         self,
         jobs_data: JobsData,
         fake: DataFaker,
         pg: AsyncEngine,
     ):
-        """Test that create_subtraction jobs write to job_subtractions join table."""
+        """``get`` resolves the subtraction id from the subtraction linked by job_id."""
         user = await fake.users.create()
 
-        job = await jobs_data.create(
-            "create_subtraction",
-            {"subtraction_id": "sub_789"},
-            user.id,
-            0,
-        )
+        job = await jobs_data.create("create_subtraction", {}, user.id, 0)
 
         async with AsyncSession(pg) as session:
-            sql_job = (
-                await session.execute(
-                    select(SQLJob).where(SQLJob.id == job.id),
-                )
-            ).scalar()
+            subtraction = SQLSubtraction(
+                legacy_id="sub_789",
+                name="Subtraction 789",
+                created_at=arrow.utcnow().naive,
+                user_id=user.id,
+                job_id=job.id,
+            )
+            session.add(subtraction)
+            await session.flush()
+            subtraction_id = subtraction.id
+            await session.commit()
 
-            job_subtraction = (
-                await session.execute(
-                    select(SQLJobSubtraction).where(
-                        SQLJobSubtraction.job_id == sql_job.id,
-                    ),
-                )
-            ).scalar()
-
-        assert job_subtraction is not None
-        assert job_subtraction.subtraction_id == "sub_789"
+        fetched_job = await jobs_data.get(job.id)
+        assert fetched_job.args == {"subtraction_id": subtraction_id}
 
     @pytest.mark.parametrize("workflow", ["aodp", "iimi", "nuvs", "pathoscope"])
     async def test_analysis_id_resolved_from_analysis(

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -498,5 +498,12 @@
       'name': 'backfill samples subtractions to integers',
       'revision': '24ysb9cwjiv1',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 72,
+      'name': 'drop job_subtractions table',
+      'revision': '2b53ffa573a3',
+    }),
   ])
 # ---

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -230,7 +230,7 @@ class JobsData:
                     SQLUser,
                     SQLJobSample.sample_id,
                     SQLJobIndex.index_id,
-                    SQLSubtraction.id,
+                    SQLSubtraction.id.label("subtraction_id"),
                     SQLAnalysis.legacy_id,
                 )
                 .join(SQLUser, SQLJob.user_id == SQLUser.id)

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -29,9 +29,9 @@ from virtool.jobs.pg import (
     SQLJob,
     SQLJobIndex,
     SQLJobSample,
-    SQLJobSubtraction,
 )
 from virtool.jobs.utils import compute_progress
+from virtool.subtractions.pg import SQLSubtraction
 from virtool.types import Document
 from virtool.users.models_base import UserNested
 from virtool.users.pg import SQLUser
@@ -212,14 +212,6 @@ class JobsData:
                 session.add(
                     SQLJobIndex(job_id=sql_job.id, index_id=job_args["index_id"]),
                 )
-            elif workflow == "create_subtraction" and "subtraction_id" in job_args:
-                session.add(
-                    SQLJobSubtraction(
-                        job_id=sql_job.id,
-                        subtraction_id=job_args["subtraction_id"],
-                    ),
-                )
-
             new_id = sql_job.id
             await session.commit()
 
@@ -238,13 +230,13 @@ class JobsData:
                     SQLUser,
                     SQLJobSample.sample_id,
                     SQLJobIndex.index_id,
-                    SQLJobSubtraction.subtraction_id,
+                    SQLSubtraction.id,
                     SQLAnalysis.legacy_id,
                 )
                 .join(SQLUser, SQLJob.user_id == SQLUser.id)
                 .outerjoin(SQLJobSample, SQLJob.id == SQLJobSample.job_id)
                 .outerjoin(SQLJobIndex, SQLJob.id == SQLJobIndex.job_id)
-                .outerjoin(SQLJobSubtraction, SQLJob.id == SQLJobSubtraction.job_id)
+                .outerjoin(SQLSubtraction, SQLSubtraction.job_id == SQLJob.id)
                 .outerjoin(SQLAnalysis, SQLAnalysis.job_id == SQLJob.id)
                 .where(SQLJob.id == job_id),
             )

--- a/virtool/jobs/pg.py
+++ b/virtool/jobs/pg.py
@@ -100,13 +100,3 @@ class SQLJobSample(Base):
 
     sample_id: Mapped[str]
     """The sample being created."""
-
-
-class SQLJobSubtraction(Base):
-    __tablename__ = "job_subtractions"
-
-    job_id: Mapped[int] = mapped_column(ForeignKey("jobs.id"), primary_key=True)
-    """The job that is creating the subtraction."""
-
-    subtraction_id: Mapped[str]
-    """The subtraction being created."""


### PR DESCRIPTION
## Summary

- Drops the `job_subtractions` join table now that subtractions have a scalar `job_id` FK on the `subtractions` table — the job→subtraction relationship is derived by inverting that 1:1 edge instead of a separate table.
- Removes the `SQLJobSubtraction` ORM model and updates `JobsData` to join against `SQLSubtraction.job_id` directly.
- Updates the earlier `copy_jobs_to_postgres` migration revision to write through a frozen `Table` definition rather than the now-removed ORM model, keeping the migration chain runnable.