### PR TITLE
Dual-write history deletes to Postgres

### DIFF
--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -1,12 +1,17 @@
 import asyncio
+import datetime
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
+from virtool.data.errors import ResourceConflictError
 from virtool.fake.next import DataFaker
 from virtool.history.data import HistoryData
 from virtool.history.db import bulk_insert_diffs
+from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
 from virtool.mongo.core import Mongo
 
 
@@ -91,3 +96,137 @@ async def test_get_inline_diff_raises(
         ValueError, match="Unexpected inline diff for change 6116cba1.1"
     ):
         await HistoryData(mongo, pg).get("6116cba1.1")
+
+
+MOCK_HISTORY_CHANGE_IDS = ["6116cba1.0", "6116cba1.1", "6116cba1.2", "6116cba1.3"]
+
+
+async def seed_legacy_history(pg: AsyncEngine, user_id: int) -> None:
+    """Mirror ``create_mock_history`` into the ``legacy_history`` table."""
+    async with AsyncSession(pg) as session:
+        for change_id in MOCK_HISTORY_CHANGE_IDS:
+            otu_id, otu_version = change_id.split(".")
+            session.add(
+                SQLLegacyHistory(
+                    legacy_id=change_id,
+                    created_at=datetime.datetime(2017, 7, 12, 16, 0, 50),
+                    description="Description",
+                    method_name="update",
+                    user_id=user_id,
+                    otu=otu_id,
+                    otu_name="Prunus virus F",
+                    otu_version=otu_version,
+                    reference="hxn167",
+                    index="unbuilt",
+                    index_version="unbuilt",
+                ),
+            )
+
+        await session.commit()
+
+
+async def legacy_history_ids(pg: AsyncEngine) -> list[str]:
+    async with AsyncSession(pg) as session:
+        return list(
+            (
+                await session.execute(
+                    select(SQLLegacyHistory.legacy_id).order_by(
+                        SQLLegacyHistory.legacy_id,
+                    ),
+                )
+            )
+            .scalars()
+            .all(),
+        )
+
+
+async def history_diff_ids(pg: AsyncEngine) -> list[str]:
+    async with AsyncSession(pg) as session:
+        return list(
+            (
+                await session.execute(
+                    select(SQLHistoryDiff.change_id).order_by(
+                        SQLHistoryDiff.change_id,
+                    ),
+                )
+            )
+            .scalars()
+            .all(),
+        )
+
+
+class TestDelete:
+    async def test_dual_write(
+        self,
+        create_mock_history,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Reverting a change deletes the reverted rows from Mongo, ``legacy_history``
+        and ``history_diffs`` together.
+        """
+        user = await fake.users.create()
+        await create_mock_history(False)
+        await seed_legacy_history(pg, user.id)
+
+        await HistoryData(mongo, pg).delete("6116cba1.2")
+
+        remaining = [
+            change["_id"] for change in await mongo.history.find().to_list(None)
+        ]
+        assert sorted(remaining) == ["6116cba1.0", "6116cba1.1"]
+
+        assert await legacy_history_ids(pg) == ["6116cba1.0", "6116cba1.1"]
+        assert await history_diff_ids(pg) == ["6116cba1.0", "6116cba1.1"]
+
+    async def test_rollback_preserves_postgres(
+        self,
+        create_mock_history,
+        fake: DataFaker,
+        mocker: MockerFixture,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A failure mid-delete rolls back both stores, leaving every row intact."""
+        user = await fake.users.create()
+        await create_mock_history(False)
+        await seed_legacy_history(pg, user.id)
+
+        mocker.patch(
+            "virtool.history.data.delete_history",
+            side_effect=RuntimeError("boom"),
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await HistoryData(mongo, pg).delete("6116cba1.2")
+
+        remaining = [
+            change["_id"] for change in await mongo.history.find().to_list(None)
+        ]
+        assert sorted(remaining) == MOCK_HISTORY_CHANGE_IDS
+
+        assert await legacy_history_ids(pg) == MOCK_HISTORY_CHANGE_IDS
+        assert await history_diff_ids(pg) == MOCK_HISTORY_CHANGE_IDS
+
+    async def test_conflict_when_built(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A change included in a build is not revertible."""
+        user = await fake.users.create()
+
+        await mongo.history.insert_one(
+            {
+                "_id": "6116cba1.1",
+                "index": {"id": "index_1", "version": 2},
+                "reference": {"id": "hxn167"},
+                "user": {"id": user.id},
+                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
+            },
+        )
+
+        with pytest.raises(ResourceConflictError):
+            await HistoryData(mongo, pg).delete("6116cba1.1")

--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -117,8 +117,8 @@ async def seed_legacy_history(pg: AsyncEngine, user_id: int) -> None:
                     otu_name="Prunus virus F",
                     otu_version=otu_version,
                     reference="hxn167",
-                    index="unbuilt",
-                    index_version="unbuilt",
+                    index=None,
+                    index_version=None,
                 ),
             )
 

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -4,9 +4,10 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 import virtool.otus.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
+from virtool.data.topg import retry_both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
-from virtool.history.db import HISTORY_PROJECTION, patch_to_version
+from virtool.history.db import HISTORY_PROJECTION, delete_history, patch_to_version
 from virtool.history.models import History, HistorySearchResult
 from virtool.history.transforms import AttachDiffTransform
 from virtool.mongo.core import Mongo
@@ -88,26 +89,44 @@ class HistoryData:
                 otu_id,
                 otu_version - 1,
             )
+        except DatabaseError:
+            raise ResourceConflictError()
 
+        async def revert(mongo_session, pg_session) -> None:
             # Remove the old sequences from the collection.
-            await self._mongo.sequences.delete_many({"otu_id": otu_id})
+            await self._mongo.sequences.delete_many(
+                {"otu_id": otu_id},
+                session=mongo_session,
+            )
 
             if patched is None:
-                await self._mongo.otus.delete_one({"_id": otu_id})
+                await self._mongo.otus.delete_one(
+                    {"_id": otu_id},
+                    session=mongo_session,
+                )
             else:
                 patched_otu, sequences = virtool.otus.utils.split(patched)
 
                 # Add the reverted sequences to the collection.
                 for sequence in sequences:
-                    await self._mongo.sequences.insert_one(sequence)
+                    await self._mongo.sequences.insert_one(
+                        sequence,
+                        session=mongo_session,
+                    )
 
                 # Replace existing otu with patched one. If it doesn't exist, insert it.
                 await self._mongo.otus.replace_one(
                     {"_id": otu_id},
                     patched_otu,
                     upsert=True,
+                    session=mongo_session,
                 )
 
-            await self._mongo.history.delete_many({"_id": {"$in": history_to_delete}})
-        except DatabaseError:
-            raise ResourceConflictError()
+            await self._mongo.history.delete_many(
+                {"_id": {"$in": history_to_delete}},
+                session=mongo_session,
+            )
+
+            await delete_history(pg_session, history_to_delete)
+
+        await retry_both_transactions(self._mongo, self._pg, revert)

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 import virtool.otus.db
 import virtool.utils
 from virtool.api.utils import paginate
-from virtool.data.topg import both_transactions
+from virtool.data.topg import both_transactions, compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
 from virtool.history.utils import (
@@ -159,6 +159,31 @@ async def bulk_delete_history(pg: AsyncEngine, change_ids: list[str]) -> None:
             )
 
         await session.commit()
+
+
+async def delete_history(pg_session: AsyncSession, change_ids: list[str]) -> None:
+    """Delete ``history_diffs`` and ``legacy_history`` rows for ``change_ids``.
+
+    Operates within an existing ``pg_session`` so the deletes commit atomically with
+    the paired Mongo deletes in a :func:`both_transactions` context. Unlike
+    :func:`bulk_delete_history`, it does not open or commit its own session.
+    """
+    if not change_ids:
+        return
+
+    for start in range(0, len(change_ids), _HISTORY_DIFF_CHUNK_SIZE):
+        chunk = change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE]
+        await pg_session.execute(
+            delete(SQLHistoryDiff).where(SQLHistoryDiff.change_id.in_(chunk)),
+        )
+
+    for start in range(0, len(change_ids), _LEGACY_HISTORY_CHUNK_SIZE):
+        chunk = change_ids[start : start + _LEGACY_HISTORY_CHUNK_SIZE]
+        await pg_session.execute(
+            delete(SQLLegacyHistory).where(
+                compose_legacy_id_multi_expression(SQLLegacyHistory, chunk),
+            ),
+        )
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Wrap `HistoryData.delete` in `retry_both_transactions` so reverting a change deletes the reverted rows from Mongo, `legacy_history`, and `history_diffs` atomically — both stores roll back together on failure.
- Add `delete_history` to issue the Postgres deletes (via `compose_legacy_id_multi_expression`) within the shared session, leaving Mongo the read authority.
- The build-revertibility guard and `patch_to_version` stay outside the transaction, preserving the existing `ResourceConflictError` behavior.