### PR TITLE
Reject iimi at the analysis-creation boundary

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1400,6 +1400,30 @@ class TestAnalyze:
 
         await resp_is.not_found(resp)
 
+    async def test_iimi_rejected(
+        self,
+        analyze_client: VirtoolTestClient,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        await self._insert_reference(mongo)
+        await self._insert_index(mongo)
+        await self._insert_subtraction(pg)
+        await self._insert_sample(analyze_client, fake)
+
+        resp = await analyze_client.post(
+            "/samples/test/analyses",
+            data={
+                "workflow": "iimi",
+                "ref_id": "test_ref",
+                "subtractions": ["subtraction_1"],
+            },
+        )
+
+        assert resp.status == 400
+
 
 class TestUploadArtifact:
     """Test that new artifacts can be uploaded after sample creation using the Jobs API."""

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -396,9 +396,6 @@ async def format_analysis(
     if "pathoscope" in workflow:
         return await format_pathoscope(mongo, pg, results=results)
 
-    if workflow == AnalysisWorkflow.iimi.value:
-        return results
-
     raise ValueError(f"Unknown workflow: {workflow}")
 
 

--- a/virtool/models/enums.py
+++ b/virtool/models/enums.py
@@ -40,7 +40,6 @@ class HistoryMethod(str, Enum):
 
 class AnalysisWorkflow(str, Enum):
     aodp = "aodp"
-    iimi = "iimi"
     nuvs = "nuvs"
     pathoscope = "pathoscope"
 


### PR DESCRIPTION
## Summary
- Remove `iimi` from the `AnalysisWorkflow` enum so `POST /samples/{sample_id}/analyses` with `workflow: "iimi"` is rejected at request validation (4xx).
- Drop the now-dead `iimi` branch in `format_analysis`; unknown workflows fall through to the existing `Unknown workflow` error.
- First issue in the "Dump Iimi" chain (VIR-2546), shipped ahead of the purge migration. Existing iimi analyses will error on the read/format path until VIR-2553 purges them.