### PR TITLE
Hide iimi analyses from find and get endpoints

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -217,6 +217,105 @@ async def test_get(
         await resp_is.not_found(resp)
 
 
+class TestHideIimi:
+    """Iimi analyses are hidden behind a 404 on both the public and jobs get
+    endpoints ahead of the iimi purge migration.
+    """
+
+    async def test_get(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        resp_is: RespIs,
+        spawn_client: ClientSpawner,
+        static_time: StaticTime,
+    ):
+        """The public get endpoint returns 404 for an iimi analysis whose sample is
+        otherwise readable.
+        """
+        client = await spawn_client(authenticated=True)
+
+        user = await fake.users.create()
+
+        await asyncio.gather(
+            mongo.references.insert_one(
+                {"_id": "baz", "archived": False, "data_type": "genome", "name": "Baz"},
+            ),
+            mongo.samples.insert_one(
+                {
+                    "_id": "baz",
+                    "all_read": True,
+                    "all_write": False,
+                    "group": "none",
+                    "group_read": False,
+                    "group_write": False,
+                    "labels": [],
+                    "subtractions": [],
+                    "user": {"id": user.id},
+                },
+            ),
+        )
+
+        analysis_id = await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": "iimi_hidden",
+                "created_at": static_time.datetime,
+                "index": {"id": "bar", "version": 1},
+                "job": None,
+                "ready": True,
+                "reference": {"id": "baz"},
+                "results": {"hits": []},
+                "sample": {"id": "baz"},
+                "subtractions": [],
+                "user": {"id": user.id},
+                "workflow": "iimi",
+            },
+        )
+
+        resp = await client.get(f"/analyses/{analysis_id}")
+
+        await resp_is.not_found(resp)
+
+    async def test_get_for_jobs_api(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        resp_is: RespIs,
+        spawn_job_client: JobClientSpawner,
+        static_time: StaticTime,
+    ):
+        """The jobs get endpoint returns 404 for an iimi analysis."""
+        client = await spawn_job_client(authenticated=True)
+
+        user = await fake.users.create()
+
+        analysis_id = await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": "iimi_hidden",
+                "created_at": static_time.datetime,
+                "index": {"id": "bar", "version": 1},
+                "job": None,
+                "ready": True,
+                "reference": {"id": "baz"},
+                "results": {"hits": []},
+                "sample": {"id": "baz"},
+                "subtractions": [],
+                "user": {"id": user.id},
+                "workflow": "iimi",
+            },
+        )
+
+        resp = await client.get(f"/analyses/{analysis_id}")
+
+        await resp_is.not_found(resp)
+
+
 async def test_get_archived_reference(
     fake: DataFaker,
     mongo: Mongo,

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -8,13 +8,14 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
+from tests.fixtures.analysis import seed_analysis
 from virtool.analyses.sql import (
     SQLAnalysis,
     SQLAnalysisFile,
     SQLAnalysisSubtraction,
 )
 from virtool.api.client import UserClient
-from virtool.data.errors import ResourceConflictError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.models.enums import AnalysisWorkflow
@@ -149,6 +150,81 @@ async def test_find(
     assert analyses_found.dict() == snapshot_recent()
     assert analysis_wrong_sample not in analyses_found
     assert analyses_found.total_count == analyses_found.found_count
+
+
+class TestHideIimi:
+    """Iimi analyses are hidden from the data-layer find and get operations ahead of
+    the iimi purge migration.
+    """
+
+    @staticmethod
+    async def _seed_iimi(mongo: Mongo, pg: AsyncEngine, user_id: str) -> int:
+        return await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": "iimi_hidden",
+                "workflow": "iimi",
+                "created_at": timestamp(),
+                "ready": True,
+                "job": None,
+                "index": {"id": "test_index", "version": 11},
+                "user": {"id": user_id},
+                "sample": {"id": "test_sample"},
+                "reference": {"id": "test_ref"},
+                "results": {"hits": []},
+                "subtractions": [],
+            },
+        )
+
+    async def test_find_excludes_iimi(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+        mocker,
+    ):
+        """An iimi analysis is excluded from both the documents and the counts."""
+        mocker.patch(
+            "virtool.samples.utils.get_sample_rights",
+            return_value=(True, True),
+        )
+        client = mocker.Mock(spec=UserClient)
+        user_id = setup_sample
+
+        visible = await data_layer.analyses.create(
+            CreateAnalysisRequest(
+                ml=None,
+                ref_id="test_ref",
+                subtractions=[],
+                workflow=AnalysisWorkflow.nuvs,
+            ),
+            "test_sample",
+            user_id,
+            0,
+        )
+
+        await self._seed_iimi(mongo, pg, user_id)
+
+        analyses_found = await data_layer.analyses.find(1, 25, client, "test_sample")
+
+        assert [document.id for document in analyses_found.documents] == [visible.id]
+        assert analyses_found.found_count == 1
+        assert analyses_found.total_count == 1
+
+    async def test_get_iimi_not_found(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: str,
+    ):
+        """Getting an iimi analysis by id raises ``ResourceNotFoundError``."""
+        analysis_id = await self._seed_iimi(mongo, pg, setup_sample)
+
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.analyses.get(analysis_id)
 
 
 async def test_create(

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -59,6 +59,9 @@ from virtool.utils import base_processor, wait_for_checks
 
 logger = get_logger("analyses")
 
+IIMI_WORKFLOW = "iimi"
+"""Workflow value for iimi analyses, which are hidden from the API ahead of a purge."""
+
 FIND_COLUMNS = (
     SQLAnalysis.id,
     SQLAnalysis.legacy_id,
@@ -155,10 +158,18 @@ class AnalysisData(DataLayerDomain):
         if page > 1:
             skip_count = (page - 1) * per_page
 
-        count_statement = select(func.count()).select_from(SQLAnalysis)
-        statement = select(*FIND_COLUMNS).order_by(
-            SQLAnalysis.created_at.desc(),
-            SQLAnalysis.id.desc(),
+        count_statement = (
+            select(func.count())
+            .select_from(SQLAnalysis)
+            .where(SQLAnalysis.workflow != IIMI_WORKFLOW)
+        )
+        statement = (
+            select(*FIND_COLUMNS)
+            .where(SQLAnalysis.workflow != IIMI_WORKFLOW)
+            .order_by(
+                SQLAnalysis.created_at.desc(),
+                SQLAnalysis.id.desc(),
+            )
         )
 
         if sample_id is not None:
@@ -223,7 +234,7 @@ class AnalysisData(DataLayerDomain):
                 )
             ).scalar_one_or_none()
 
-        if row is None:
+        if row is None or row.workflow == IIMI_WORKFLOW:
             raise ResourceNotFoundError()
 
         document = _row_to_document(row, include_results=True)


### PR DESCRIPTION
## Summary
- Exclude `workflow="iimi"` rows from the analyses `find()` listing and count queries, so iimi analyses never surface in `GET /analyses` (global or sample-scoped).
- Treat iimi rows as not found in `get()`, returning 404 from both the public `GET /analyses/{id}` and the jobs-API get endpoint (they share the data-layer method).
- Hides half-removed iimi analyses from clients ahead of the iimi purge migration.