### PR TITLE
Replace uploadtype enum with text and check constraint

### DIFF
--- a/assets/alembic/versions/ed265b939a84_replace_uploadtype_enum_with_text_check.py
+++ b/assets/alembic/versions/ed265b939a84_replace_uploadtype_enum_with_text_check.py
@@ -1,0 +1,52 @@
+"""replace uploadtype enum with text check
+
+Revision ID: ed265b939a84
+Revises: 2b53ffa573a3
+Create Date: 2026-06-30 01:19:24.545633+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ed265b939a84"
+down_revision = "2b53ffa573a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM uploads WHERE type = 'hmm'")
+
+    op.execute(
+        "ALTER TABLE uploads ALTER COLUMN type TYPE text USING type::text",
+    )
+
+    op.execute("DROP TYPE uploadtype")
+
+    op.create_check_constraint(
+        "ck_uploads_type",
+        "uploads",
+        "type IN ('reference', 'reads', 'subtraction')",
+    )
+
+
+def downgrade() -> None:
+    # The upgrade deletes rows with type 'hmm'. That deletion is not reversible:
+    # the rows are gone and cannot be restored on downgrade.
+    op.drop_constraint("ck_uploads_type", "uploads", type_="check")
+
+    op.execute(
+        "CREATE TYPE uploadtype AS ENUM ('hmm', 'reference', 'reads', 'subtraction')",
+    )
+
+    # Coerce any value outside the recreated enum to NULL so the cast cannot fail
+    # on rows written while the column was free-form text.
+    op.execute(
+        "UPDATE uploads SET type = NULL "
+        "WHERE type NOT IN ('hmm', 'reference', 'reads', 'subtraction')",
+    )
+
+    op.execute(
+        "ALTER TABLE uploads ALTER COLUMN type TYPE uploadtype USING type::uploadtype",
+    )

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -512,5 +512,12 @@
       'name': 'drop job_subtractions table',
       'revision': '2b53ffa573a3',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 74,
+      'name': 'replace uploadtype enum with text check',
+      'revision': 'ed265b939a84',
+    }),
   ])
 # ---

--- a/tests/uploads/test_api.py
+++ b/tests/uploads/test_api.py
@@ -86,12 +86,12 @@ class TestUpload:
         assert await resp.json() == [
             {
                 "ctx": {
-                    "enum_values": ["hmm", "reference", "reads", "subtraction"],
+                    "enum_values": ["reference", "reads", "subtraction"],
                 },
                 "in": "query string",
                 "loc": ["type"],
                 "msg": (
-                    "value is not a valid enumeration member; permitted: 'hmm', "
+                    "value is not a valid enumeration member; permitted: "
                     "'reference', 'reads', 'subtraction'"
                 ),
                 "type": "type_error.enum",

--- a/virtool/subtractions/migration.py
+++ b/virtool/subtractions/migration.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     String,
     Table,
     func,
+    literal_column,
     select,
     update,
 )
@@ -25,7 +26,7 @@ from virtool.jobs.pg import SQLJob
 from virtool.migration import MigrationContext
 from virtool.pg.base import Base
 from virtool.subtractions.pg import SQLSubtraction, SubtractionType
-from virtool.uploads.sql import SQLUpload, UploadType
+from virtool.uploads.sql import SQLUpload
 from virtool.users.pg import SQLUser
 from virtool.users.utils import UNKNOWN_USER_HANDLE
 
@@ -387,7 +388,11 @@ async def _reconstruct_removed_upload(
                 removed_at=created_at,
                 reserved=False,
                 size=size,
-                type=UploadType.subtraction,
+                # This revision runs before the enum-to-text migration, so
+                # ``uploads.type`` is still the legacy ``uploadtype`` enum.
+                # An untyped SQL literal lets Postgres coerce it to whichever
+                # column type is present (enum here, text after migration).
+                type=literal_column("'subtraction'"),
                 user_id=user_id,
                 created_at=created_at,
                 uploaded_at=created_at,

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -35,7 +35,7 @@ def serialize(upload: SQLUpload) -> dict:
         "reserved": upload.reserved,
         "size": upload.size,
         "space": upload.space,
-        "type": upload.type.value if upload.type is not None else None,
+        "type": upload.type,
         "uploaded_at": upload.uploaded_at,
         "user": {"id": upload.user_id},
     }

--- a/virtool/uploads/sql.py
+++ b/virtool/uploads/sql.py
@@ -22,13 +22,16 @@ class UploadType(str, SQLEnum):
     subtraction = "subtraction"
 
 
+_ALLOWED_UPLOAD_TYPES = ", ".join(repr(value) for value in UploadType.to_list())
+
+
 class SQLUpload(Base):
     """SQL table to store all new uploads"""
 
     __tablename__ = "uploads"
     __table_args__ = (
         CheckConstraint(
-            "type IN ('reference', 'reads', 'subtraction')",
+            f"type IN ({_ALLOWED_UPLOAD_TYPES})",
             name="ck_uploads_type",
         ),
     )

--- a/virtool/uploads/sql.py
+++ b/virtool/uploads/sql.py
@@ -1,9 +1,9 @@
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
-    Enum,
     ForeignKey,
     Integer,
     String,
@@ -17,7 +17,6 @@ from virtool.pg.utils import SQLEnum
 class UploadType(str, SQLEnum):
     """Enumerated type for possible upload types"""
 
-    hmm = "hmm"
     reference = "reference"
     reads = "reads"
     subtraction = "subtraction"
@@ -27,6 +26,12 @@ class SQLUpload(Base):
     """SQL table to store all new uploads"""
 
     __tablename__ = "uploads"
+    __table_args__ = (
+        CheckConstraint(
+            "type IN ('reference', 'reads', 'subtraction')",
+            name="ck_uploads_type",
+        ),
+    )
 
     id: Column = Column(Integer, primary_key=True)
     created_at: Column = Column(DateTime)
@@ -39,6 +44,6 @@ class SQLUpload(Base):
     reserved: Column = Column(Boolean, default=False, nullable=False)
     size: Column = Column(BigInteger)
     space: Mapped[int] = Column(Integer, ForeignKey("spaces.id"), nullable=True)
-    type: Column = Column(Enum(UploadType))
+    type: Column = Column(String)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     uploaded_at: Column = Column(DateTime)


### PR DESCRIPTION
## Summary
- Drop the dead `hmm` value from `UploadType` — HMM profiles are installed by a background task, never user-uploaded.
- Convert `uploads.type` from a Postgres enum to `text` + a `CHECK (type IN ('reference', 'reads', 'subtraction'))` constraint, since enums are painful to evolve. The `UploadType` definition stays the API validation source of truth.
- Migration deletes any existing `hmm` rows, converts the column, drops the `uploadtype` enum, and adds the check constraint (with a reversible downgrade).