### PR TITLE
Dual-write index-assignment history update to Postgres

### DIFF
--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -3,11 +3,13 @@ import asyncio
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 import virtool.indexes.db
 from tests.fixtures.client import ClientSpawner
+from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import (
     attach_files,
     get_current_id_and_version,
@@ -24,6 +26,7 @@ async def test_create(
     index_id: str | None,
     mocker: MockerFixture,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     static_time,
 ):
@@ -43,6 +46,7 @@ async def test_create(
     assert (
         await virtool.indexes.db.create(
             mongo,
+            pg,
             "foo",
             "test",
             "bar",
@@ -51,6 +55,113 @@ async def test_create(
         == snapshot
     )
     assert await mongo.history.find_one("abc") == snapshot
+
+
+async def test_create_dual_writes_index_assignment(
+    mocker: MockerFixture,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    fake,
+    static_time,
+):
+    """Building an index assigns previously-unbuilt changes for the reference to the
+    new index in both Mongo and Postgres, leaving other references and already-built
+    changes untouched.
+    """
+    user = await fake.users.create()
+
+    await asyncio.gather(
+        mongo.references.insert_one({"_id": "built_ref"}),
+        mongo.indexes.insert_one(
+            {
+                "_id": "prior_index",
+                "reference": {"id": "built_ref"},
+                "version": 0,
+                "ready": True,
+            },
+        ),
+        mongo.history.insert_many(
+            [
+                {
+                    "_id": "ref_unbuilt",
+                    "index": {"id": "unbuilt", "version": "unbuilt"},
+                    "reference": {"id": "built_ref"},
+                },
+                {
+                    "_id": "ref_already_built",
+                    "index": {"id": "prior_index", "version": 0},
+                    "reference": {"id": "built_ref"},
+                },
+                {
+                    "_id": "other_ref_unbuilt",
+                    "index": {"id": "unbuilt", "version": "unbuilt"},
+                    "reference": {"id": "other_ref"},
+                },
+            ],
+            session=None,
+        ),
+    )
+
+    def legacy_row(
+        legacy_id: str, reference: str, index: str | None
+    ) -> SQLLegacyHistory:
+        return SQLLegacyHistory(
+            legacy_id=legacy_id,
+            created_at=static_time.datetime,
+            description="",
+            method_name="create_otu",
+            user_id=user.id,
+            otu=legacy_id,
+            otu_name=legacy_id,
+            otu_version="0",
+            reference=reference,
+            index=index,
+            index_version="0" if index else None,
+        )
+
+    async with AsyncSession(pg) as session:
+        session.add_all(
+            [
+                legacy_row("ref_unbuilt", "built_ref", None),
+                legacy_row("ref_already_built", "built_ref", "prior_index"),
+                legacy_row("other_ref_unbuilt", "other_ref", None),
+            ],
+        )
+        await session.commit()
+
+    mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
+
+    await virtool.indexes.db.create(
+        mongo,
+        pg,
+        "built_ref",
+        user.id,
+        1,
+        index_id="new_index",
+    )
+
+    assert (await mongo.history.find_one("ref_unbuilt"))["index"] == {
+        "id": "new_index",
+        "version": 1,
+    }
+    assert (await mongo.history.find_one("ref_already_built"))["index"] == {
+        "id": "prior_index",
+        "version": 0,
+    }
+    assert (await mongo.history.find_one("other_ref_unbuilt"))["index"] == {
+        "id": "unbuilt",
+        "version": "unbuilt",
+    }
+
+    async with AsyncSession(pg) as session:
+        rows = {
+            row.legacy_id: (row.index, row.index_version)
+            for row in (await session.execute(select(SQLLegacyHistory))).scalars()
+        }
+
+    assert rows["ref_unbuilt"] == ("new_index", "1")
+    assert rows["ref_already_built"] == ("prior_index", "0")
+    assert rows["other_ref_unbuilt"] == (None, None)
 
 
 @pytest.mark.parametrize("exists", [True, False])

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -164,6 +164,82 @@ async def test_create_dual_writes_index_assignment(
     assert rows["other_ref_unbuilt"] == (None, None)
 
 
+async def test_create_rolls_back_both_stores_on_failure(
+    mocker: MockerFixture,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    fake,
+    static_time,
+):
+    """A failure during the dual-write rolls back the Mongo writes already issued
+    inside the transaction, leaving neither store with the index assignment.
+    """
+    user = await fake.users.create()
+
+    await asyncio.gather(
+        mongo.references.insert_one({"_id": "built_ref"}),
+        mongo.history.insert_one(
+            {
+                "_id": "ref_unbuilt",
+                "index": {"id": "unbuilt", "version": "unbuilt"},
+                "reference": {"id": "built_ref"},
+            },
+        ),
+    )
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacyHistory(
+                legacy_id="ref_unbuilt",
+                created_at=static_time.datetime,
+                description="",
+                method_name="create_otu",
+                user_id=user.id,
+                otu="ref_unbuilt",
+                otu_name="ref_unbuilt",
+                otu_version="0",
+                reference="built_ref",
+                index=None,
+                index_version=None,
+            ),
+        )
+        await session.commit()
+
+    mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
+    mocker.patch(
+        "virtool.indexes.db.update",
+        side_effect=RuntimeError("postgres write failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="postgres write failed"):
+        await virtool.indexes.db.create(
+            mongo,
+            pg,
+            "built_ref",
+            user.id,
+            1,
+            index_id="new_index",
+        )
+
+    assert await mongo.indexes.find_one("new_index") is None
+    assert (await mongo.history.find_one("ref_unbuilt"))["index"] == {
+        "id": "unbuilt",
+        "version": "unbuilt",
+    }
+
+    async with AsyncSession(pg) as session:
+        row = (
+            await session.execute(
+                select(SQLLegacyHistory).where(
+                    SQLLegacyHistory.legacy_id == "ref_unbuilt",
+                ),
+            )
+        ).scalar_one()
+
+    assert row.index is None
+    assert row.index_version is None
+
+
 @pytest.mark.parametrize("exists", [True, False])
 @pytest.mark.parametrize("has_ref", [True, False])
 async def test_get_current_id_and_version(exists, has_ref, test_indexes, mongo):

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pymongo
 from motor.motor_asyncio import AsyncIOMotorClientSession
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
@@ -14,7 +15,9 @@ import virtool.pg.utils
 import virtool.references.db
 import virtool.utils
 from virtool.api.utils import paginate
+from virtool.data.topg import both_transactions
 from virtool.data.transforms import AbstractTransform, apply_transforms
+from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndexFile
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
@@ -92,7 +95,8 @@ class IndexCountsTransform(AbstractTransform):
 
 
 async def create(
-    mongo,
+    mongo: "Mongo",
+    pg: AsyncEngine,
     ref_id: str,
     user_id: int,
     job_id: int,
@@ -102,6 +106,7 @@ async def create(
     index.
 
     :param mongo: the application database client
+    :param pg: the application Postgres client
     :param ref_id: the ID of the reference to create index for
     :param user_id: the ID of the current user
     :param job_id: the ID of the job
@@ -128,13 +133,22 @@ async def create(
     if index_id:
         document["_id"] = index_id
 
-    async with mongo.create_session() as mongo_session:
+    async with both_transactions(mongo, pg) as (mongo_session, pg_session):
         document = await mongo.indexes.insert_one(document, session=mongo_session)
 
         await mongo.history.update_many(
             {"index.id": "unbuilt", "reference.id": ref_id},
             {"$set": {"index": {"id": document["_id"], "version": index_version}}},
             session=mongo_session,
+        )
+
+        await pg_session.execute(
+            update(SQLLegacyHistory)
+            .where(
+                SQLLegacyHistory.reference == ref_id,
+                SQLLegacyHistory.index.is_(None),
+            )
+            .values(index=document["_id"], index_version=str(index_version)),
         )
 
     return document

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -650,6 +650,7 @@ class ReferencesData(DataLayerDomain):
 
         document = await virtool.indexes.db.create(
             self._mongo,
+            self._pg,
             ref_id,
             user_id,
             job.id,


### PR DESCRIPTION
## Summary
- When an index is built, the path that flips previously-unbuilt history changes onto the new index now dual-writes: the existing Mongo `update_many` is wrapped in `both_transactions`, with a parallel set-based `UPDATE` on `legacy_history` setting `index`/`index_version` for the reference's unbuilt rows. Reads still come from Mongo.
- Threaded the Postgres engine through the `indexes.db.create` build-index call site.
- Added a test covering the unbuilt → built assignment across both stores, asserting other-reference and already-built rows are left untouched.