### PR TITLE
Purge iimi analyses and their files

### DIFF
--- a/assets/revisions/rev_icp41e0o5dwn_purge_iimi_analyses.py
+++ b/assets/revisions/rev_icp41e0o5dwn_purge_iimi_analyses.py
@@ -1,0 +1,115 @@
+"""purge iimi analyses
+
+Permanently delete every ``workflow = "iimi"`` analysis and its on-disk result
+files. The ``iimi`` workflow has been removed from Virtool; these analyses are
+already hidden from the API and are now purged outright.
+
+Analyses are mid-migration from Mongo to Postgres, so an iimi analysis may exist
+in the Postgres ``analyses`` table, the Mongo ``analyses`` collection, or both.
+Storage prefixes are gathered from both stores before any rows are deleted, then
+the files are removed, then the rows are deleted from each store. Doing the file
+deletion before the row deletion means an interrupted run still has the rows
+needed to recompute the prefixes on a re-run.
+
+Idempotent: a re-run finds no iimi rows, recomputes no prefixes, and deletes
+nothing. ``delete_prefix`` is a no-op against already-removed keys.
+
+Revision ID: icp41e0o5dwn
+Date: 2026-06-30 19:38:26.167797
+
+"""
+
+import arrow
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.analyses.sql import SQLAnalysis
+from virtool.migration import MigrationContext
+from virtool.storage.cleanup import delete_prefix
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "purge iimi analyses"
+created_at = arrow.get("2026-06-30 19:38:26.167797")
+revision_id = "icp41e0o5dwn"
+
+alembic_down_revision = "ed265b939a84"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+IIMI_WORKFLOW = "iimi"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Purge every iimi analysis and its on-disk files from both stores."""
+    prefixes = await _collect_storage_prefixes(ctx)
+
+    logger.info("found iimi analysis files to purge", count=len(prefixes))
+
+    for prefix in prefixes:
+        for key, exc in await delete_prefix(ctx.storage, prefix):
+            logger.error(
+                "storage cleanup failed; file orphaned",
+                prefix=prefix,
+                key=key,
+                error=repr(exc),
+            )
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            delete(SQLAnalysis).where(SQLAnalysis.workflow == IIMI_WORKFLOW),
+        )
+        await session.commit()
+
+        postgres_deleted = result.rowcount
+
+    mongo_result = await ctx.mongo.analyses.delete_many({"workflow": IIMI_WORKFLOW})
+
+    logger.info(
+        "purged iimi analyses",
+        postgres=postgres_deleted,
+        mongo=mongo_result.deleted_count,
+    )
+
+
+async def _collect_storage_prefixes(ctx: MigrationContext) -> set[str]:
+    """Collect the storage prefix of every iimi analysis across both stores.
+
+    Files live under ``samples/{sample}/analysis/{legacy_id}/``, where
+    ``legacy_id`` is the analysis' Mongo ``_id``. Postgres and Mongo are
+    snapshotted up front so the slow per-prefix storage deletes don't hold a
+    Mongo cursor open. The same analysis copied into both stores yields the same
+    prefix, so collecting into a set deduplicates it.
+    """
+    prefixes: set[str] = set()
+
+    async with AsyncSession(ctx.pg) as session:
+        rows = await session.execute(
+            select(SQLAnalysis.sample, SQLAnalysis.legacy_id).where(
+                SQLAnalysis.workflow == IIMI_WORKFLOW,
+            ),
+        )
+
+        for sample, legacy_id in rows:
+            if legacy_id is None:
+                logger.warning(
+                    "iimi analysis has no legacy id; cannot locate its files",
+                    sample=sample,
+                )
+                continue
+
+            prefixes.add(f"samples/{sample}/analysis/{legacy_id}/")
+
+    async for document in ctx.mongo.analyses.find(
+        {"workflow": IIMI_WORKFLOW},
+        projection=["sample"],
+    ):
+        prefixes.add(
+            f"samples/{document['sample']['id']}/analysis/{document['_id']}/",
+        )
+
+    return prefixes

--- a/tests/fixtures/migration.py
+++ b/tests/fixtures/migration.py
@@ -28,6 +28,7 @@ from virtool.pg.utils import (
     PgOptions,
     get_sqlalchemy_url,
 )
+from virtool.storage.protocol import StorageBackend
 
 
 @pytest.fixture
@@ -119,15 +120,24 @@ def migration_config(
     return MigrationConfig(
         mongodb_connection_string=f"{mongo_connection_string}/{migration_mongo_name}?authSource=admin",
         postgres_connection_string=migration_pg_connection_string,
+        storage_backend="s3",
+        storage_s3_bucket="test",
     )
 
 
 @pytest.fixture
 async def ctx(
-    migration_config: MigrationConfig, migration_mongo_name: str
+    migration_config: MigrationConfig,
+    migration_mongo_name: str,
+    memory_storage: StorageBackend,
 ) -> MigrationContext:
-    """A migration context for testing backed by test instances of backing services."""
+    """A migration context for testing backed by test instances of backing services.
+
+    The object-storage backend is replaced with an in-memory provider so
+    revisions that delete on-disk files can be exercised without a real bucket.
+    """
     ctx = await create_migration_context(migration_config)
+    ctx.storage = memory_storage
     yield ctx
     await ctx.mongo.client.drop_database(
         ctx.mongo.client.get_database(migration_mongo_name)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -519,5 +519,12 @@
       'name': 'replace uploadtype enum with text check',
       'revision': 'ed265b939a84',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 75,
+      'name': 'purge iimi analyses',
+      'revision': 'icp41e0o5dwn',
+    }),
   ])
 # ---

--- a/tests/migration/test_purge_iimi_analyses.py
+++ b/tests/migration/test_purge_iimi_analyses.py
@@ -1,0 +1,186 @@
+"""Tests for the purge-iimi-analyses migration."""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+
+import arrow
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_icp41e0o5dwn_purge_iimi_analyses import upgrade
+from virtool.analyses.sql import SQLAnalysis
+from virtool.migration.ctx import MigrationContext
+from virtool.storage.protocol import StorageBackend
+
+
+async def _one_chunk(content: bytes) -> AsyncIterator[bytes]:
+    yield content
+
+
+def _analysis_document(analysis_id: str, sample_id: str, workflow: str) -> dict:
+    return {
+        "_id": analysis_id,
+        "created_at": arrow.utcnow().naive,
+        "updated_at": arrow.utcnow().naive,
+        "index": {"id": "index_1"},
+        "reference": {"id": "reference_1"},
+        "ready": True,
+        "results": None,
+        "sample": {"id": sample_id},
+        "subtractions": [],
+        "user": {"id": "user_1"},
+        "workflow": workflow,
+    }
+
+
+class TestUpgrade:
+    async def _setup_user(self, ctx: MigrationContext, apply_alembic: Callable) -> int:
+        await asyncio.to_thread(apply_alembic, "head")
+
+        async with AsyncSession(ctx.pg) as session:
+            result = await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES (
+                        'testuser', 'legacy_user_1', true, '', false,
+                        false, :now, :password, '{}'::jsonb
+                    )
+                    RETURNING id
+                """),
+                {"now": arrow.utcnow().naive, "password": b"hashed_password"},
+            )
+            user_id = result.scalar_one()
+            await session.commit()
+
+        return user_id
+
+    async def _add_pg_analysis(
+        self,
+        ctx: MigrationContext,
+        user_id: int,
+        *,
+        legacy_id: str,
+        sample: str,
+        workflow: str,
+    ) -> None:
+        async with AsyncSession(ctx.pg) as session:
+            session.add(
+                SQLAnalysis(
+                    legacy_id=legacy_id,
+                    created_at=arrow.utcnow().naive,
+                    updated_at=arrow.utcnow().naive,
+                    workflow=workflow,
+                    ready=True,
+                    sample=sample,
+                    reference="reference_1",
+                    index="index_1",
+                    user_id=user_id,
+                ),
+            )
+            await session.commit()
+
+    async def test_purges_iimi_from_both_stores_and_storage(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+        memory_storage: StorageBackend,
+    ):
+        user_id = await self._setup_user(ctx, apply_alembic)
+
+        await self._add_pg_analysis(
+            ctx,
+            user_id,
+            legacy_id="iimi_pg",
+            sample="sample_pg",
+            workflow="iimi",
+        )
+        await self._add_pg_analysis(
+            ctx,
+            user_id,
+            legacy_id="keep_pg",
+            sample="sample_pg",
+            workflow="pathoscope",
+        )
+
+        await ctx.mongo.analyses.insert_one(
+            _analysis_document("iimi_mongo", "sample_mongo", "iimi"),
+        )
+        await ctx.mongo.analyses.insert_one(
+            _analysis_document("keep_mongo", "sample_mongo", "pathoscope"),
+        )
+
+        purged_keys = (
+            "samples/sample_pg/analysis/iimi_pg/results.json",
+            "samples/sample_mongo/analysis/iimi_mongo/results.json",
+        )
+        retained_keys = (
+            "samples/sample_pg/analysis/keep_pg/results.json",
+            "samples/sample_mongo/analysis/keep_mongo/results.json",
+        )
+
+        for key in (*purged_keys, *retained_keys):
+            await memory_storage.write(key, _one_chunk(b"content"))
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            remaining_pg = (
+                (await session.execute(select(SQLAnalysis.legacy_id))).scalars().all()
+            )
+
+        assert set(remaining_pg) == {"keep_pg"}
+
+        remaining_mongo = await ctx.mongo.analyses.distinct("_id")
+        assert set(remaining_mongo) == {"keep_mongo"}
+
+        for key in purged_keys:
+            assert not await _exists(memory_storage, key)
+
+        for key in retained_keys:
+            assert await _exists(memory_storage, key)
+
+    async def test_is_idempotent(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+        memory_storage: StorageBackend,
+    ):
+        user_id = await self._setup_user(ctx, apply_alembic)
+
+        await self._add_pg_analysis(
+            ctx,
+            user_id,
+            legacy_id="iimi_pg",
+            sample="sample_pg",
+            workflow="iimi",
+        )
+        await self._add_pg_analysis(
+            ctx,
+            user_id,
+            legacy_id="keep_pg",
+            sample="sample_pg",
+            workflow="pathoscope",
+        )
+        await ctx.mongo.analyses.insert_one(
+            _analysis_document("keep_mongo", "sample_mongo", "pathoscope"),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            remaining_pg = (
+                (await session.execute(select(SQLAnalysis.legacy_id))).scalars().all()
+            )
+
+        assert set(remaining_pg) == {"keep_pg"}
+        assert set(await ctx.mongo.analyses.distinct("_id")) == {"keep_mongo"}
+
+
+async def _exists(storage: StorageBackend, key: str) -> bool:
+    async for _ in storage.list(key):
+        return True
+    return False

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -124,6 +124,7 @@ def migration() -> None:
 @migration.command("apply")
 @mongodb_connection_string_option
 @postgres_connection_string_option
+@storage_options
 def migration_apply(**kwargs) -> None:
     """Apply all pending migrations."""
     configure_logging(False)

--- a/virtool/config/cls.py
+++ b/virtool/config/cls.py
@@ -58,12 +58,49 @@ def _validate_cache_storage_budget(cache_storage_budget: int) -> None:
         raise ValueError("cache_storage_budget must be greater than 0")
 
 
+def _validate_storage_backend(
+    config: "MigrationConfig | ServerConfig | TaskRunnerConfig",
+) -> None:
+    """Validate the ``storage_*`` fields shared by every service config.
+
+    Mirrors the requirements ``build_primary_backend`` relies on: an S3 backend
+    needs a bucket and complete (or absent) credentials; an Azure backend needs
+    an account and container.
+    """
+    if config.storage_backend == "s3":
+        if not config.storage_s3_bucket:
+            raise ValueError("storage_backend=s3 requires --storage-s3-bucket")
+
+        _validate_s3_credentials(
+            config.storage_s3_access_key_id,
+            config.storage_s3_secret_access_key,
+        )
+
+    if config.storage_backend == "azure":
+        if not config.storage_azure_account:
+            raise ValueError("storage_backend=azure requires --storage-azure-account")
+        if not config.storage_azure_container:
+            raise ValueError(
+                "storage_backend=azure requires --storage-azure-container",
+            )
+
+
 @dataclass
 class MigrationConfig:
     """Configuration for the migration service."""
 
     mongodb_connection_string: str
     postgres_connection_string: str
+    storage_backend: StorageBackendName
+    storage_s3_bucket: str = ""
+    storage_s3_region: str = ""
+    storage_s3_endpoint: str = ""
+    storage_s3_access_key_id: str = ""
+    storage_s3_secret_access_key: str = ""
+    storage_azure_account: str = ""
+    storage_azure_container: str = ""
+    storage_azure_access_key: str = ""
+    storage_azure_endpoint: str = ""
 
     @property
     def mongodb_name(self) -> str:
@@ -77,6 +114,9 @@ class MigrationConfig:
     @property
     def pg_options(self):
         return PgOptions.from_connection_string(self.postgres_connection_string)
+
+    def __post_init__(self):
+        _validate_storage_backend(self)
 
 
 @dataclass
@@ -122,26 +162,7 @@ class ServerConfig:
 
         _validate_cache_storage_budget(self.cache_storage_budget)
 
-        if self.storage_backend == "s3" and not self.storage_s3_bucket:
-            raise ValueError(
-                "storage_backend=s3 requires --storage-s3-bucket",
-            )
-
-        if self.storage_backend == "s3":
-            _validate_s3_credentials(
-                self.storage_s3_access_key_id,
-                self.storage_s3_secret_access_key,
-            )
-
-        if self.storage_backend == "azure":
-            if not self.storage_azure_account:
-                raise ValueError(
-                    "storage_backend=azure requires --storage-azure-account",
-                )
-            if not self.storage_azure_container:
-                raise ValueError(
-                    "storage_backend=azure requires --storage-azure-container",
-                )
+        _validate_storage_backend(self)
 
 
 @dataclass
@@ -184,26 +205,7 @@ class TaskRunnerConfig:
 
         _validate_cache_storage_budget(self.cache_storage_budget)
 
-        if self.storage_backend == "s3" and not self.storage_s3_bucket:
-            raise ValueError(
-                "storage_backend=s3 requires --storage-s3-bucket",
-            )
-
-        if self.storage_backend == "s3":
-            _validate_s3_credentials(
-                self.storage_s3_access_key_id,
-                self.storage_s3_secret_access_key,
-            )
-
-        if self.storage_backend == "azure":
-            if not self.storage_azure_account:
-                raise ValueError(
-                    "storage_backend=azure requires --storage-azure-account",
-                )
-            if not self.storage_azure_container:
-                raise ValueError(
-                    "storage_backend=azure requires --storage-azure-container",
-                )
+        _validate_storage_backend(self)
 
 
 class WorkflowConfig(BaseModel):

--- a/virtool/migration/ctx.py
+++ b/virtool/migration/ctx.py
@@ -16,6 +16,8 @@ import virtool.mongo.connect
 from virtool.api.custom_json import dump_string
 from virtool.config.cls import MigrationConfig
 from virtool.pg.utils import get_sqlalchemy_url
+from virtool.storage.factory import build_primary_backend
+from virtool.storage.protocol import StorageBackend
 
 logger = get_logger("migration")
 
@@ -49,6 +51,8 @@ class RevisionContext:
 class MigrationContext:
     mongo: AsyncIOMotorDatabase
     pg: AsyncEngine
+    storage: StorageBackend
+    """The object-storage backend, for revisions that delete on-disk files."""
 
 
 async def create_migration_context(config: MigrationConfig) -> MigrationContext:
@@ -82,4 +86,5 @@ async def create_migration_context(config: MigrationConfig) -> MigrationContext:
     return MigrationContext(
         mongo=mongo_database,
         pg=pg,
+        storage=build_primary_backend(config),
     )


### PR DESCRIPTION
## Summary
- Add an idempotent migration that permanently deletes every `workflow="iimi"` analysis and its on-disk result files, gathering storage prefixes from both the Postgres `analyses` table and the Mongo `analyses` collection (analyses are mid-migration, so iimi rows may live in either) before deleting files and then rows from each store.
- Wire object storage into the migration framework: `MigrationConfig` gains the `storage_*` fields, `migration apply` accepts `--storage-*`, and `MigrationContext` now carries a `StorageBackend`. Shared S3/Azure validation is extracted into one helper used by every service config.

## Deployment notes
- The migration deploy job now needs storage credentials injected (`--storage-backend` plus bucket/keys).
- This revision must not ship to production before VIR-2546 (reject iimi at the analysis-creation boundary) is live, to avoid racing newly created iimi rows.