### PR TITLE
Create legacy_samples table for the samples Postgres migration

### DIFF
--- a/assets/alembic/versions/edacc4a083f1_create_legacy_samples_table.py
+++ b/assets/alembic/versions/edacc4a083f1_create_legacy_samples_table.py
@@ -1,0 +1,95 @@
+"""create legacy_samples table
+
+Revision ID: edacc4a083f1
+Revises: ed265b939a84
+Create Date: 2026-06-30 20:08:49.120626+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "edacc4a083f1"
+down_revision = "ed265b939a84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "legacy_samples",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=True), nullable=False),
+        sa.Column("legacy_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("host", sa.String(), nullable=False),
+        sa.Column("isolate", sa.String(), nullable=False),
+        sa.Column("locale", sa.String(), nullable=False),
+        sa.Column("notes", sa.String(), nullable=False),
+        sa.Column("library_type", sa.String(), nullable=False),
+        sa.Column("format", sa.String(), nullable=False),
+        sa.Column("group", sa.String(), nullable=True),
+        sa.Column("quality", JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("paired", sa.Boolean(), nullable=False),
+        sa.Column("ready", sa.Boolean(), nullable=False),
+        sa.Column("hold", sa.Boolean(), nullable=False),
+        sa.Column("is_legacy", sa.Boolean(), nullable=False),
+        sa.Column("all_read", sa.Boolean(), nullable=False),
+        sa.Column("all_write", sa.Boolean(), nullable=False),
+        sa.Column("group_read", sa.Boolean(), nullable=False),
+        sa.Column("group_write", sa.Boolean(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("job_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("legacy_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+    )
+    op.create_index(
+        "ix_legacy_samples_user_id_created_at",
+        "legacy_samples",
+        ["user_id", sa.text("created_at DESC")],
+    )
+    op.create_index(
+        "ix_legacy_samples_all_read",
+        "legacy_samples",
+        ["all_read"],
+        postgresql_where=sa.text("all_read = true"),
+    )
+    op.create_index(
+        "ix_legacy_samples_group_read",
+        "legacy_samples",
+        ["group_read"],
+        postgresql_where=sa.text("group_read = true"),
+    )
+    op.create_index("ix_legacy_samples_group", "legacy_samples", ["group"])
+
+    op.create_table(
+        "legacy_sample_labels",
+        sa.Column("sample_id", sa.BigInteger(), nullable=False),
+        sa.Column("label_id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("sample_id", "label_id"),
+        sa.ForeignKeyConstraint(["sample_id"], ["legacy_samples.id"]),
+        sa.ForeignKeyConstraint(["label_id"], ["labels.id"]),
+    )
+
+    op.create_table(
+        "legacy_sample_subtractions",
+        sa.Column("sample_id", sa.BigInteger(), nullable=False),
+        sa.Column("subtraction_id", sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint("sample_id", "subtraction_id"),
+        sa.ForeignKeyConstraint(["sample_id"], ["legacy_samples.id"]),
+        sa.ForeignKeyConstraint(["subtraction_id"], ["subtractions.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("legacy_sample_subtractions")
+    op.drop_table("legacy_sample_labels")
+    op.drop_index("ix_legacy_samples_group", table_name="legacy_samples")
+    op.drop_index("ix_legacy_samples_group_read", table_name="legacy_samples")
+    op.drop_index("ix_legacy_samples_all_read", table_name="legacy_samples")
+    op.drop_index("ix_legacy_samples_user_id_created_at", table_name="legacy_samples")
+    op.drop_table("legacy_samples")

--- a/assets/alembic/versions/edacc4a083f1_create_legacy_samples_table.py
+++ b/assets/alembic/versions/edacc4a083f1_create_legacy_samples_table.py
@@ -29,7 +29,7 @@ def upgrade() -> None:
         sa.Column("notes", sa.String(), nullable=False),
         sa.Column("library_type", sa.String(), nullable=False),
         sa.Column("format", sa.String(), nullable=False),
-        sa.Column("group", sa.String(), nullable=True),
+        sa.Column("group_id", sa.Integer(), nullable=True),
         sa.Column("quality", JSONB(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("paired", sa.Boolean(), nullable=False),
@@ -46,6 +46,7 @@ def upgrade() -> None:
         sa.UniqueConstraint("legacy_id"),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
         sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+        sa.ForeignKeyConstraint(["group_id"], ["groups.id"]),
     )
     op.create_index(
         "ix_legacy_samples_user_id_created_at",
@@ -64,7 +65,7 @@ def upgrade() -> None:
         ["group_read"],
         postgresql_where=sa.text("group_read = true"),
     )
-    op.create_index("ix_legacy_samples_group", "legacy_samples", ["group"])
+    op.create_index("ix_legacy_samples_group_id", "legacy_samples", ["group_id"])
 
     op.create_table(
         "legacy_sample_labels",
@@ -88,7 +89,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("legacy_sample_subtractions")
     op.drop_table("legacy_sample_labels")
-    op.drop_index("ix_legacy_samples_group", table_name="legacy_samples")
+    op.drop_index("ix_legacy_samples_group_id", table_name="legacy_samples")
     op.drop_index("ix_legacy_samples_group_read", table_name="legacy_samples")
     op.drop_index("ix_legacy_samples_all_read", table_name="legacy_samples")
     op.drop_index("ix_legacy_samples_user_id_created_at", table_name="legacy_samples")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -526,5 +526,12 @@
       'name': 'purge iimi analyses',
       'revision': 'icp41e0o5dwn',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 76,
+      'name': 'create legacy_samples table',
+      'revision': 'edacc4a083f1',
+    }),
   ])
 # ---

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -131,7 +131,7 @@ class SQLLegacySampleLabel(Base):
     __tablename__ = "legacy_sample_labels"
 
     sample_id: Mapped[int] = mapped_column(
-        ForeignKey("legacy_samples.id"), primary_key=True
+        BigInteger, ForeignKey("legacy_samples.id"), primary_key=True
     )
     label_id: Mapped[int] = mapped_column(ForeignKey("labels.id"), primary_key=True)
 
@@ -142,8 +142,8 @@ class SQLLegacySampleSubtraction(Base):
     __tablename__ = "legacy_sample_subtractions"
 
     sample_id: Mapped[int] = mapped_column(
-        ForeignKey("legacy_samples.id"), primary_key=True
+        BigInteger, ForeignKey("legacy_samples.id"), primary_key=True
     )
     subtraction_id: Mapped[int] = mapped_column(
-        ForeignKey("subtractions.id"), primary_key=True
+        BigInteger, ForeignKey("subtractions.id"), primary_key=True
     )

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -1,4 +1,19 @@
-from sqlalchemy import BigInteger, Column, DateTime, Enum, Integer, String
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Enum,
+    Identity,
+    Index,
+    Integer,
+    String,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql.schema import ForeignKey, UniqueConstraint
 
 from virtool.pg.base import Base
@@ -45,3 +60,90 @@ class SQLSampleReads(Base):
     size = Column(BigInteger)
     upload = Column(Integer, ForeignKey("uploads.id"))
     uploaded_at = Column(DateTime)
+
+
+class SQLLegacySample(Base):
+    """SQL model for sample metadata.
+
+    Follows the new convention modeled on :class:`virtool.subtractions.pg.SQLSubtraction`:
+
+    - ``BigInteger`` primary key with ``Identity(always=True)``.
+    - ``legacy_id`` holds the Mongo ``_id`` and is nullable so samples created
+      natively in Postgres can omit it.
+    - ``user_id`` and ``job_id`` are real integer foreign keys because ``users``
+      and ``jobs`` are already migrated. ``group`` is kept as a nullable string
+      because groups are not yet normalized into this schema.
+
+    The Mongo ``workflows``, ``nuvs``, and ``pathoscope`` fields are intentionally
+    omitted; workflow state is derived on read. ``labels`` and ``subtractions``
+    become the ``legacy_sample_labels`` and ``legacy_sample_subtractions`` join
+    tables rather than array columns. ``quality`` is stored as JSONB and never
+    queried.
+    """
+
+    __tablename__ = "legacy_samples"
+    __table_args__ = (
+        Index(
+            "ix_legacy_samples_user_id_created_at",
+            "user_id",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_legacy_samples_all_read",
+            "all_read",
+            postgresql_where=text("all_read = true"),
+        ),
+        Index(
+            "ix_legacy_samples_group_read",
+            "group_read",
+            postgresql_where=text("group_read = true"),
+        ),
+        Index("ix_legacy_samples_group", "group"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
+    legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    name: Mapped[str]
+    host: Mapped[str] = mapped_column(default="")
+    isolate: Mapped[str] = mapped_column(default="")
+    locale: Mapped[str] = mapped_column(default="")
+    notes: Mapped[str] = mapped_column(default="")
+    library_type: Mapped[str]
+    format: Mapped[str] = mapped_column(default="fastq")
+    group: Mapped[str | None]
+    quality: Mapped[dict | None] = mapped_column(JSONB)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    paired: Mapped[bool] = mapped_column(Boolean, default=False)
+    ready: Mapped[bool] = mapped_column(Boolean, default=False)
+    hold: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_legacy: Mapped[bool] = mapped_column(Boolean, default=False)
+    all_read: Mapped[bool] = mapped_column(Boolean, default=False)
+    all_write: Mapped[bool] = mapped_column(Boolean, default=False)
+    group_read: Mapped[bool] = mapped_column(Boolean, default=False)
+    group_write: Mapped[bool] = mapped_column(Boolean, default=False)
+    user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
+    job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"))
+
+
+class SQLLegacySampleLabel(Base):
+    """Join table linking a sample to its labels."""
+
+    __tablename__ = "legacy_sample_labels"
+
+    sample_id: Mapped[int] = mapped_column(
+        ForeignKey("legacy_samples.id"), primary_key=True
+    )
+    label_id: Mapped[int] = mapped_column(ForeignKey("labels.id"), primary_key=True)
+
+
+class SQLLegacySampleSubtraction(Base):
+    """Join table linking a sample to its default subtractions."""
+
+    __tablename__ = "legacy_sample_subtractions"
+
+    sample_id: Mapped[int] = mapped_column(
+        ForeignKey("legacy_samples.id"), primary_key=True
+    )
+    subtraction_id: Mapped[int] = mapped_column(
+        ForeignKey("subtractions.id"), primary_key=True
+    )

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -70,9 +70,9 @@ class SQLLegacySample(Base):
     - ``BigInteger`` primary key with ``Identity(always=True)``.
     - ``legacy_id`` holds the Mongo ``_id`` and is nullable so samples created
       natively in Postgres can omit it.
-    - ``user_id`` and ``job_id`` are real integer foreign keys because ``users``
-      and ``jobs`` are already migrated. ``group`` is kept as a nullable string
-      because groups are not yet normalized into this schema.
+    - ``user_id``, ``job_id``, and ``group_id`` are real integer foreign keys
+      because ``users``, ``jobs``, and ``groups`` are already migrated. All three
+      are nullable.
 
     The Mongo ``workflows``, ``nuvs``, and ``pathoscope`` fields are intentionally
     omitted; workflow state is derived on read. ``labels`` and ``subtractions``
@@ -98,7 +98,7 @@ class SQLLegacySample(Base):
             "group_read",
             postgresql_where=text("group_read = true"),
         ),
-        Index("ix_legacy_samples_group", "group"),
+        Index("ix_legacy_samples_group_id", "group_id"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
@@ -110,7 +110,7 @@ class SQLLegacySample(Base):
     notes: Mapped[str] = mapped_column(default="")
     library_type: Mapped[str]
     format: Mapped[str] = mapped_column(default="fastq")
-    group: Mapped[str | None]
+    group_id: Mapped[int | None] = mapped_column(ForeignKey("groups.id"))
     quality: Mapped[dict | None] = mapped_column(JSONB)
     created_at: Mapped[datetime] = mapped_column(DateTime)
     paired: Mapped[bool] = mapped_column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- Add the `legacy_samples` table plus `legacy_sample_labels` and `legacy_sample_subtractions` join tables in a single reversible Alembic revision, with matching SQLAlchemy 2.0 models in `virtool/samples/sql.py` (new `BigInteger`/`Identity(always=True)` convention).
- Real integer FKs for `user_id`, `job_id`, and `subtraction_id` (those collections are already migrated); `group` stays a nullable string and `quality` is JSONB. Mongo `workflows`/`nuvs`/`pathoscope` are dropped and derived on read later.
- Indexes cover sample listing (`(user_id, created_at DESC)`) and rights filtering (partial on `all_read`/`group_read`, btree on `group`). No code reads or writes the new tables yet — this is the schema-only first step (VIR-2527) that unblocks dual-write (VIR-2524).