### PR TITLE
Backfill existing history documents to legacy_history

### DIFF
--- a/assets/revisions/rev_iltemfg2gul8_copy_history_to_postgres.py
+++ b/assets/revisions/rev_iltemfg2gul8_copy_history_to_postgres.py
@@ -1,0 +1,38 @@
+"""Copy history to postgres.
+
+Revision ID: iltemfg2gul8
+Date: 2026-07-02 16:12:31.701659
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.history.migration import copy_history_to_postgres
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy history to postgres"
+created_at = arrow.get("2026-07-02 16:12:31.701659")
+revision_id = "iltemfg2gul8"
+
+alembic_down_revision = "edacc4a083f1"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+#
+# ``adea254e2c31`` renames the ``legacy_history`` reference columns to their final
+# names, and depends on ``743a03e550e0`` (create legacy_history table), so requiring
+# it guarantees the destination table exists with the columns this backfill writes.
+required_alembic_revision = "adea254e2c31"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``history`` document into Postgres.
+
+    The implementation lives in :func:`copy_history_to_postgres` so the later
+    re-backfill revision can reuse the same idempotent copy.
+    """
+    await copy_history_to_postgres(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -540,5 +540,12 @@
       'name': 'drop analyses ml_id column',
       'revision': '95ca6fc2a5db',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 78,
+      'name': 'copy history to postgres',
+      'revision': 'iltemfg2gul8',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_history_to_postgres.py
+++ b/tests/migration/test_copy_history_to_postgres.py
@@ -1,0 +1,321 @@
+"""Tests for the copy history to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_iltemfg2gul8_copy_history_to_postgres import upgrade
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+def static_datetime() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
+    """Apply the schema up to the legacy_history table and create a user.
+
+    ``adea254e2c31`` renames the ``legacy_history`` reference columns to their final
+    names; applying it brings up the ``users`` and ``legacy_history`` tables this
+    backfill needs.
+    """
+    await asyncio.to_thread(apply_alembic, "adea254e2c31")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES (
+                    'testuser', 'legacy_user_123', true, '', false,
+                    false, :now, :password, '{}'::jsonb
+                )
+                RETURNING id
+            """),
+            {"now": arrow.utcnow().naive, "password": b"hashed_password"},
+        )
+        user_id = result.scalar_one()
+        await session.commit()
+        return user_id
+
+
+def make_history_document(
+    change_id: str,
+    user_id: str | int,
+    created_at: datetime,
+    *,
+    otu_version: int | str = 3,
+    index_id: str = "index_1",
+    index_version: int | str = 2,
+    method_name: str = "edit",
+) -> dict:
+    """Create a MongoDB history document for testing."""
+    return {
+        "_id": change_id,
+        "created_at": created_at,
+        "description": "Edited Foo Virus",
+        "diff": "postgres",
+        "index": {"id": index_id, "version": index_version},
+        "method_name": method_name,
+        "otu": {"id": "otu_1", "name": "Foo Virus", "version": otu_version},
+        "reference": {"id": "reference_1"},
+        "user": {"id": user_id},
+    }
+
+
+class TestUpgrade:
+    """Tests for the upgrade function."""
+
+    async def test_basic_migration(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A history document is copied with every field mapped correctly."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.3",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text("""
+                        SELECT legacy_id, created_at, description, method_name,
+                               user_id, otu, otu_name, otu_version, reference,
+                               "index", index_version
+                        FROM legacy_history WHERE legacy_id = 'otu_1.3'
+                    """),
+                )
+            ).one()
+
+        assert row.legacy_id == "otu_1.3"
+        assert row.created_at == static_datetime
+        assert row.description == "Edited Foo Virus"
+        assert row.method_name == "edit"
+        assert row.user_id == setup_user
+        assert row.otu == "otu_1"
+        assert row.otu_name == "Foo Virus"
+        assert row.otu_version == "3"
+        assert row.reference == "reference_1"
+        assert row.index == "index_1"
+        assert row.index_version == "2"
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_removed_otu_version_maps_null(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """An ``otu.version`` of ``"removed"`` is stored as NULL."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.removed",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+                otu_version="removed",
+                method_name="remove",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            otu_version = (
+                await session.execute(
+                    text(
+                        "SELECT otu_version FROM legacy_history "
+                        "WHERE legacy_id = 'otu_1.removed'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert otu_version is None
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_unbuilt_index_maps_null(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """An ``unbuilt`` index id and version are both stored as NULL."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.4",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+                index_id="unbuilt",
+                index_version="unbuilt",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        'SELECT "index", index_version FROM legacy_history '
+                        "WHERE legacy_id = 'otu_1.4'",
+                    ),
+                )
+            ).one()
+
+        assert row.index is None
+        assert row.index_version is None
+
+    async def test_integer_user_id_used_directly(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A modern integer ``user.id`` is used directly as the Postgres FK."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.5",
+                user_id=setup_user,
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            user_id = (
+                await session.execute(
+                    text(
+                        "SELECT user_id FROM legacy_history "
+                        "WHERE legacy_id = 'otu_1.5'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert user_id == setup_user
+
+    async def test_skip_existing(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document already present in Postgres is not duplicated."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.6",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+            ),
+        )
+
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text("""
+                    INSERT INTO legacy_history (
+                        legacy_id, created_at, description, method_name, user_id,
+                        otu, otu_name, reference
+                    )
+                    VALUES (
+                        'otu_1.6', :created_at, 'pre-existing', 'edit', :user_id,
+                        'otu_1', 'Foo Virus', 'reference_1'
+                    )
+                """),
+                {"created_at": static_datetime, "user_id": setup_user},
+            )
+            await session.commit()
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) AS count, MAX(description) AS description "
+                        "FROM legacy_history WHERE legacy_id = 'otu_1.6'",
+                    ),
+                )
+            ).one()
+
+        assert row.count == 1
+        assert row.description == "pre-existing"
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_idempotent(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """Running the backfill twice over an unchanged collection is a no-op."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.7",
+                user_id="legacy_user_123",
+                created_at=static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM legacy_history "
+                        "WHERE legacy_id = 'otu_1.7'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert count == 1
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_missing_user_raises(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """A document with no user raises rather than storing a null user_id."""
+        document = make_history_document(
+            change_id="otu_1.8",
+            user_id="legacy_user_123",
+            created_at=static_datetime,
+        )
+        del document["user"]
+        await ctx.mongo.history.insert_one(document)
+
+        with pytest.raises(ValueError, match="has no user"):
+            await upgrade(ctx)
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_unresolvable_user_raises(
+        self,
+        ctx: MigrationContext,
+        static_datetime: datetime,
+    ):
+        """A document whose user cannot be resolved raises."""
+        await ctx.mongo.history.insert_one(
+            make_history_document(
+                change_id="otu_1.9",
+                user_id="nonexistent_user",
+                created_at=static_datetime,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="not found in postgres"):
+            await upgrade(ctx)

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -56,11 +56,11 @@ _LEGACY_HISTORY_CHUNK_SIZE = 32767 // 11
 """Max ``legacy_history`` rows per statement.
 
 asyncpg caps bind parameters per statement at 32767. Each row binds eleven
-columns (see :func:`_legacy_history_values`).
+columns (see :func:`legacy_history_values`).
 """
 
 
-def _legacy_history_values(document: Document) -> dict:
+def legacy_history_values(document: Document) -> dict:
     """Map a Mongo history ``document`` to ``legacy_history`` column values.
 
     Applies the sentinel-to-NULL conventions: an ``otu.version`` of ``"removed"``
@@ -123,7 +123,7 @@ async def bulk_insert_history(
             "diff_rows and documents must describe the same history changes",
         )
 
-    legacy_rows = [_legacy_history_values(document) for document in documents]
+    legacy_rows = [legacy_history_values(document) for document in documents]
 
     async with AsyncSession(pg) as session:
         for start in range(0, len(diff_rows), _HISTORY_DIFF_CHUNK_SIZE):
@@ -220,7 +220,7 @@ async def add(
     document = prepared.document
 
     diff_row = SQLHistoryDiff(change_id=document["_id"], diff=prepared.diff)
-    legacy_row = SQLLegacyHistory(**_legacy_history_values(document))
+    legacy_row = SQLLegacyHistory(**legacy_history_values(document))
 
     if mongo_session is None:
         async with both_transactions(mongo, pg) as (mongo_session, pg_session):

--- a/virtool/history/migration.py
+++ b/virtool/history/migration.py
@@ -8,12 +8,15 @@ sentinel, so the two stores converge and reads can later be served from Postgres
 alone.
 """
 
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.db import legacy_history_values
+from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
 from virtool.migration import MigrationContext
+from virtool.users.pg import SQLUser
 
 logger = get_logger("migration")
 
@@ -99,3 +102,117 @@ async def backfill_inline_history_diffs(ctx: MigrationContext) -> None:
             migrated=migrated_count,
             skipped=skipped_count,
         )
+
+
+async def copy_history_to_postgres(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``history`` document into the ``legacy_history`` table.
+
+    One row is written per Mongo document, so the Postgres row count matches the
+    Mongo document count exactly. The field mapping -- including the sentinel-to-NULL
+    conventions for ``otu.version``, ``index.id``, and ``index.version`` -- is shared
+    with the live dual-write through :func:`legacy_history_values`, so the two paths
+    can never drift.
+
+    The document ``_id`` values are snapshotted up front with a projection-only query,
+    then each document is fetched individually inside the loop, so the run never holds
+    a single cursor open for the whole collection.
+
+    Documents already present in Postgres (by ``legacy_id``) are skipped, and the
+    insert uses ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of defence, so
+    the backfill is safe to re-run after an interruption. Each document is committed
+    individually to bound memory and keep the rows already written on a failure
+    part-way through.
+
+    A history change always has an author, so ``user`` is required: the document's
+    ``user.id`` is resolved to a Postgres ``users.id`` and the migration raises if it
+    cannot be resolved rather than storing ``NULL``. Modern integer ids are used
+    directly (the foreign key enforces their existence); legacy string ids are
+    resolved through a cached ``legacy_id`` map.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_result = await session.execute(
+            select(SQLLegacyHistory.legacy_id).where(
+                SQLLegacyHistory.legacy_id.isnot(None),
+            ),
+        )
+        existing_legacy_ids = {row[0] for row in existing_result}
+
+        logger.info(
+            "found existing legacy history in postgres",
+            count=len(existing_legacy_ids),
+        )
+
+        user_result = await session.execute(
+            select(SQLUser.id, SQLUser.legacy_id).where(SQLUser.legacy_id.isnot(None)),
+        )
+        user_id_map = {row.legacy_id: row.id for row in user_result}
+
+        logger.info("built user ID map", count=len(user_id_map))
+
+        change_ids = [
+            document["_id"]
+            async for document in ctx.mongo.history.find({}, projection=["_id"])
+        ]
+
+        migrated_count = 0
+        skipped_count = 0
+
+        for change_id in change_ids:
+            if change_id in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.history.find_one({"_id": change_id})
+
+            if document is None:
+                skipped_count += 1
+                continue
+
+            user_id = _resolve_user_id(document, user_id_map)
+
+            values = legacy_history_values(document)
+            values["user_id"] = user_id
+
+            await session.execute(
+                insert(SQLLegacyHistory)
+                .values(**values)
+                .on_conflict_do_nothing(index_elements=["legacy_id"]),
+            )
+            await session.commit()
+
+            migrated_count += 1
+
+        logger.info(
+            "legacy history backfill complete",
+            migrated=migrated_count,
+            skipped=skipped_count,
+        )
+
+
+def _resolve_user_id(document: dict, user_id_map: dict[str, int]) -> int:
+    """Resolve a history document's ``user.id`` to a Postgres ``users.id``.
+
+    A modern integer id is used directly; a legacy string id is looked up in
+    ``user_id_map``. Raises if the document has no user or the reference cannot be
+    resolved -- ``legacy_history.user_id`` is required and must never be ``NULL``.
+    """
+    change_id = document["_id"]
+
+    user = document.get("user")
+
+    if user is None or user.get("id") is None:
+        msg = f"History document {change_id} has no user"
+        raise ValueError(msg)
+
+    reference = user["id"]
+
+    if isinstance(reference, int):
+        return reference
+
+    pg_user_id = user_id_map.get(reference)
+
+    if pg_user_id is None:
+        msg = f"User {reference} not found in postgres for history document {change_id}"
+        raise ValueError(msg)
+
+    return pg_user_id


### PR DESCRIPTION
## Summary
- Adds an idempotent Alembic revision (step 3 of the history → Postgres migration) that copies every Mongo `history` document into the `legacy_history` table so both stores converge before reads switch over.
- Puts the copy in a shared `copy_history_to_postgres` helper the later re-backfill revision can reuse, and reuses the dual-write `legacy_history_values` mapping so field mapping (including the sentinel-to-NULL rules) cannot drift between the two paths.
- Resolves each document's `user` to a Postgres `users.id`, raising rather than storing NULL when it can't be resolved; snapshots ids up front and commits per document with `ON CONFLICT (legacy_id) DO NOTHING` for safe re-runs.