### PR TITLE
Switch history list and contributors reads to Postgres

### DIFF
--- a/tests/history/__snapshots__/test_api.ambr
+++ b/tests/history/__snapshots__/test_api.ambr
@@ -5,10 +5,10 @@
       dict({
         'created_at': '2015-10-06T20:00:00Z',
         'description': 'Edited Prunus virus E',
-        'id': '6116cba1.1',
+        'id': 'foobar.2',
         'index': dict({
           'id': 'unbuilt',
-          'version': 1,
+          'version': 'unbuilt',
         }),
         'method_name': 'edit',
         'otu': dict({
@@ -32,7 +32,7 @@
         'id': 'foobar.1',
         'index': dict({
           'id': 'unbuilt',
-          'version': 1,
+          'version': 'unbuilt',
         }),
         'method_name': 'edit',
         'otu': dict({
@@ -53,10 +53,10 @@
       dict({
         'created_at': '2015-10-06T20:00:00Z',
         'description': 'Edited Prunus virus E',
-        'id': 'foobar.2',
+        'id': '6116cba1.1',
         'index': dict({
           'id': 'unbuilt',
-          'version': 1,
+          'version': 'unbuilt',
         }),
         'method_name': 'edit',
         'otu': dict({

--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -273,6 +273,29 @@
     }),
   })
 # ---
+# name: TestGetContributors.test_by_index
+  list([
+    dict({
+      'count': 2,
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+  ])
+# ---
+# name: TestGetContributors.test_by_reference
+  list([
+    dict({
+      'count': 2,
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    dict({
+      'count': 1,
+      'handle': 'zclark',
+      'id': 2,
+    }),
+  ])
+# ---
 # name: TestGetMostRecentChange.test_ok
   dict({
     '_id': '6116cba1.2',

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -2,16 +2,18 @@ import asyncio
 from http import HTTPStatus
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from tests.fixtures.client import ClientSpawner
-from virtool.history.db import bulk_insert_diffs
+from virtool.history.db import bulk_insert_diffs, legacy_history_values
+from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
 
 
 async def test_find(
     snapshot,
     mongo: Mongo,
+    pg: AsyncEngine,
     spawn_client: ClientSpawner,
     test_changes,
     static_time,
@@ -19,20 +21,22 @@ async def test_find(
     """Test that a list of processed change documents are returned with a ``200`` status."""
     client = await spawn_client(authenticated=True)
 
-    await asyncio.gather(
-        mongo.references.insert_one(
-            {
-                "_id": "hxn167",
-                "archived": False,
-                "data_type": "genome",
-                "name": "Reference A",
-            },
-        ),
-        mongo.history.insert_many(
-            [{**c, "user": {"id": client.user.id}} for c in test_changes],
-            session=None,
-        ),
+    changes = [{**c, "user": {"id": client.user.id}} for c in test_changes]
+
+    await mongo.references.insert_one(
+        {
+            "_id": "hxn167",
+            "archived": False,
+            "data_type": "genome",
+            "name": "Reference A",
+        },
     )
+
+    async with AsyncSession(pg) as session:
+        for change in changes:
+            session.add(SQLLegacyHistory(**legacy_history_values(change)))
+
+        await session.commit()
 
     resp = await client.get("/history")
 

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -100,6 +100,14 @@ class TestGetContributors:
             == []
         )
 
+    async def test_requires_scope(self, pg: AsyncEngine):
+        """An unscoped call raises instead of aggregating the whole table."""
+        with pytest.raises(
+            ValueError,
+            match="get_contributors requires a reference_id or index_id",
+        ):
+            await virtool.history.db.get_contributors(pg)
+
 
 class TestAdd:
     async def test_edit(

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -7,11 +7,98 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 import virtool.history.db
+from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.workflow.pytest_plugin.utils import StaticTime
+
+
+async def add_contribution(
+    pg: AsyncEngine,
+    change_id: str,
+    user_id: int,
+    reference: str,
+    index: str | None = None,
+) -> None:
+    """Insert a single ``legacy_history`` row for contributor-counting tests."""
+    async with AsyncSession(pg) as session:
+        otu_id, otu_version = change_id.split(".")
+        session.add(
+            SQLLegacyHistory(
+                legacy_id=change_id,
+                created_at=datetime.datetime(2017, 7, 12, 16, 0, 50),
+                description="Description",
+                method_name="update",
+                user_id=user_id,
+                otu=otu_id,
+                otu_name="Prunus virus F",
+                otu_version=otu_version,
+                reference=reference,
+                index=index,
+                index_version=None if index is None else "1",
+            ),
+        )
+        await session.commit()
+
+
+class TestGetContributors:
+    async def test_by_reference(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        snapshot: SnapshotAssertion,
+    ):
+        """Contributions are grouped and counted per user, scoped to the reference."""
+        prolific = await fake.users.create()
+        occasional = await fake.users.create()
+        other_reference_only = await fake.users.create()
+
+        await add_contribution(pg, "otu_a.0", prolific.id, "reference_a")
+        await add_contribution(pg, "otu_a.1", prolific.id, "reference_a")
+        await add_contribution(pg, "otu_b.0", occasional.id, "reference_a")
+        await add_contribution(pg, "otu_c.0", other_reference_only.id, "reference_b")
+
+        contributors = await virtool.history.db.get_contributors(
+            pg,
+            reference_id="reference_a",
+        )
+
+        assert contributors == snapshot
+
+    async def test_by_index(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        snapshot: SnapshotAssertion,
+    ):
+        """Only changes included in the requested built index are counted."""
+        builder = await fake.users.create()
+
+        await add_contribution(
+            pg, "otu_a.0", builder.id, "reference_a", index="index_1"
+        )
+        await add_contribution(
+            pg, "otu_a.1", builder.id, "reference_a", index="index_1"
+        )
+        await add_contribution(
+            pg, "otu_b.0", builder.id, "reference_a", index="index_2"
+        )
+
+        contributors = await virtool.history.db.get_contributors(
+            pg,
+            index_id="index_1",
+        )
+
+        assert contributors == snapshot
+
+    async def test_empty(self, pg: AsyncEngine):
+        """A reference with no history yields no contributors."""
+        assert (
+            await virtool.history.db.get_contributors(pg, reference_id="reference_a")
+            == []
+        )
 
 
 class TestAdd:

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -18,6 +18,7 @@ from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from tests.fixtures.response import RespIs
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import INDEX_FILE_NAMES
 from virtool.indexes.files import create_index_file
 from virtool.indexes.sql import SQLIndexFile
@@ -361,10 +362,9 @@ async def test_get(
         assert await resp.json() == snapshot
 
         # Check that get_contributors was called with correct parameter types
-        call_args = m_get_contributors.call_args[0]
-        assert isinstance(call_args[0], Mongo)
-        assert isinstance(call_args[1], AsyncEngine)
-        assert call_args[2] == {"index.id": "foobar"}
+        call_args = m_get_contributors.call_args
+        assert isinstance(call_args.args[0], AsyncEngine)
+        assert call_args.kwargs == {"index_id": "foobar"}
         m_get_otus.assert_called_with(ANY, "foobar")
     else:
         await resp_is.not_found(resp)
@@ -428,6 +428,7 @@ class TestCreate:
         fake: DataFaker,
         mocker: MockerFixture,
         mongo: Mongo,
+        pg: AsyncEngine,
         resp_is: RespIs,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
@@ -454,6 +455,24 @@ class TestCreate:
                 },
             ),
         )
+
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLLegacyHistory(
+                    legacy_id="history_1",
+                    created_at=static_time.datetime,
+                    description="Description",
+                    method_name="create",
+                    user_id=user.id,
+                    otu="otu_1",
+                    otu_name="Tobacco mosaic virus",
+                    otu_version="0",
+                    reference="foo",
+                    index=None,
+                    index_version=None,
+                ),
+            )
+            await session.commit()
 
         m_create_manifest = mocker.patch(
             "virtool.references.db.get_manifest",

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -864,16 +864,16 @@
       }),
       dict({
         'created_at': 'approximately_now_isoformat',
-        'description': 'Created Tobacco mosaic virus (TMV)',
-        'id': 'fb085f7f.0',
+        'description': 'Created Cucumber mosaic virus',
+        'id': '3cbb22cc.0',
         'index': dict({
           'id': 'unbuilt',
           'version': 'unbuilt',
         }),
         'method_name': 'create',
         'otu': dict({
-          'id': 'fb085f7f',
-          'name': 'Tobacco mosaic virus',
+          'id': '3cbb22cc',
+          'name': 'Cucumber mosaic virus',
           'version': 0,
         }),
         'reference': dict({
@@ -912,16 +912,16 @@
       }),
       dict({
         'created_at': 'approximately_now_isoformat',
-        'description': 'Created Cucumber mosaic virus',
-        'id': '3cbb22cc.0',
+        'description': 'Created Tobacco mosaic virus (TMV)',
+        'id': 'fb085f7f.0',
         'index': dict({
           'id': 'unbuilt',
           'version': 'unbuilt',
         }),
         'method_name': 'create',
         'otu': dict({
-          'id': '3cbb22cc',
-          'name': 'Cucumber mosaic virus',
+          'id': 'fb085f7f',
+          'name': 'Tobacco mosaic virus',
           'version': 0,
         }),
         'reference': dict({

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -14,6 +14,7 @@ from tests.fixtures.client import ClientSpawner, VirtoolTestClient
 from tests.fixtures.response import RespIs
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.history.sql import SQLLegacyHistory
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app, get_one_field
@@ -1130,6 +1131,7 @@ async def test_create_index(
     mocker,
     resp_is,
     mongo: Mongo,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     spawn_client: ClientSpawner,
     static_time,
@@ -1156,6 +1158,24 @@ async def test_create_index(
             },
         ),
     )
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacyHistory(
+                legacy_id="history_1",
+                created_at=static_time.datetime,
+                description="Description",
+                method_name="create",
+                user_id=user.id,
+                otu="otu_1",
+                otu_name="Tobacco mosaic virus",
+                otu_version="0",
+                reference="foo",
+                index=None,
+                index_version=None,
+            ),
+        )
+        await session.commit()
 
     m_create_manifest = mocker.patch(
         "virtool.references.db.get_manifest",

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -29,7 +29,7 @@ class HistoryData:
         :param req_query: the request query
         :return: a list of all documents
         """
-        documents = await virtool.history.db.find(self._mongo, self._pg, {}, req_query)
+        documents = await virtool.history.db.find(self._mongo, self._pg, req_query)
 
         return HistorySearchResult(**documents)
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -1,18 +1,18 @@
 """Work with OTU history in the database."""
 
+import math
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import dictdiffer
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import delete, select
+from sqlalchemy import Integer, cast, delete, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.db
 import virtool.utils
-from virtool.api.utils import paginate
 from virtool.data.topg import both_transactions, compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
@@ -24,7 +24,7 @@ from virtool.history.utils import (
 from virtool.models.enums import HistoryMethod
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
-from virtool.users.transforms import AttachUserTransform
+from virtool.users.pg import SQLUser
 from virtool.utils import base_processor
 
 if TYPE_CHECKING:
@@ -292,73 +292,179 @@ def prepare_add(
     )
 
 
-async def find(
-    mongo: "Mongo",
-    pg: "AsyncEngine",
-    mongo_query: Document,
-    req_query,
-    base_query: Document | None = None,
-):
-    data = await paginate(
-        mongo.history,
-        mongo_query,
-        req_query,
-        base_query=base_query,
-        sort="otu.version",
-        projection=HISTORY_LIST_PROJECTION,
-        reverse=True,
-    )
+def legacy_history_document(row: SQLLegacyHistory, handle: str) -> Document:
+    """Reconstruct a ``HISTORY_LIST_PROJECTION`` document from a ``legacy_history`` row.
+
+    Reverses the sentinel-to-NULL conventions applied by :func:`legacy_history_values`:
+    a ``NULL`` ``otu_version`` becomes the ``"removed"`` sentinel and a ``NULL`` ``index``
+    becomes the ``"unbuilt"`` sentinel. Stringified numeric versions are coerced back to
+    integers so the resource shape matches the historical Mongo representation.
+
+    The ``handle`` comes from a join on ``users`` so the nested user is fully populated
+    without a follow-up transform.
+    """
+    if row.otu_version is None:
+        otu_version: int | str = "removed"
+    else:
+        otu_version = (
+            int(row.otu_version) if row.otu_version.isdigit() else row.otu_version
+        )
+
+    if row.index is None:
+        index = {"id": "unbuilt", "version": "unbuilt"}
+    else:
+        index_version = row.index_version
+
+        if index_version is not None and index_version.isdigit():
+            index_version = int(index_version)
+
+        index = {"id": row.index, "version": index_version}
 
     return {
-        **data,
-        "documents": await apply_transforms(
-            [base_processor(d) for d in data["documents"]],
-            [AttachReferenceTransform(mongo), AttachUserTransform(pg)],
-            pg,
-        ),
+        "_id": row.legacy_id,
+        "created_at": row.created_at,
+        "description": row.description,
+        "method_name": row.method_name,
+        "otu": {"id": row.otu, "name": row.otu_name, "version": otu_version},
+        "reference": {"id": row.reference},
+        "index": index,
+        "user": {"id": row.user_id, "handle": handle},
     }
 
 
-async def get_contributors(mongo: "Mongo", pg: AsyncEngine, query: dict) -> list[dict]:
-    """Return list of contributors and their contribution count for a specific set of
-    history.
+async def find(
+    mongo: "Mongo",
+    pg: AsyncEngine,
+    req_query,
+    reference_id: str | None = None,
+    unbuilt: bool | None = None,
+) -> dict:
+    """List history changes from the ``legacy_history`` table.
 
-    :param mongo: the application database client
-    :param pg: the PostgreSQL engine for user lookups
-    :param query: a query to filter scanned history by
-    :return: a list of contributors to the scanned history changes
+    Changes are sorted by ``otu_version`` descending with a deterministic ``id``
+    tiebreaker so pagination is stable. ``reference_id`` scopes both the returned page
+    and the ``total_count``; ``unbuilt`` is a tri-state search filter on whether the
+    change is included in a built index (``index`` is ``NULL`` when unbuilt).
 
+    :param mongo: the application database client, used to attach reference data
+    :param pg: the application PostgreSQL database object
+    :param req_query: the raw request query, used to derive ``page`` and ``per_page``
+    :param reference_id: restrict changes to a single reference
+    :param unbuilt: ``True`` for unbuilt changes only, ``False`` for built changes only
+    :return: a search result including the matched change documents
     """
-    from sqlalchemy import select
+    try:
+        page = int(req_query["page"])
+    except (KeyError, ValueError):
+        page = 1
 
-    from virtool.users.pg import SQLUser
+    try:
+        per_page = int(req_query["per_page"])
+    except (KeyError, ValueError):
+        per_page = 25
 
-    cursor = mongo.history.aggregate(
-        [{"$match": query}, {"$group": {"_id": "$user.id", "count": {"$sum": 1}}}],
-    )
+    base_filters = []
 
-    contributors = [{"id": c["_id"], "count": c["count"]} async for c in cursor]
+    if reference_id is not None:
+        base_filters.append(SQLLegacyHistory.reference == reference_id)
 
-    if not contributors:
-        return []
+    search_filters = list(base_filters)
 
-    user_ids = [c["id"] for c in contributors]
+    if unbuilt is True:
+        search_filters.append(SQLLegacyHistory.index.is_(None))
+    elif unbuilt is False:
+        search_filters.append(SQLLegacyHistory.index.isnot(None))
 
     async with AsyncSession(pg) as session:
-        result = await session.execute(
-            select(SQLUser.id, SQLUser.handle).where(SQLUser.id.in_(user_ids)),
+        total_count = await session.scalar(
+            select(func.count()).select_from(SQLLegacyHistory).where(*base_filters),
         )
 
-        user_rows = result.all()
+        found_count = await session.scalar(
+            select(func.count()).select_from(SQLLegacyHistory).where(*search_filters),
+        )
 
-    users = {row.id: {"id": row.id, "handle": row.handle} for row in user_rows}
+        rows = (
+            await session.execute(
+                select(SQLLegacyHistory, SQLUser.handle)
+                .join(SQLUser, SQLLegacyHistory.user_id == SQLUser.id)
+                .where(*search_filters)
+                .order_by(
+                    cast(SQLLegacyHistory.otu_version, Integer).desc().nulls_first(),
+                    SQLLegacyHistory.id.desc(),
+                )
+                .offset(per_page * (page - 1))
+                .limit(per_page),
+            )
+        ).all()
+
+    documents = await apply_transforms(
+        [base_processor(legacy_history_document(row, handle)) for row, handle in rows],
+        [AttachReferenceTransform(mongo)],
+        pg,
+    )
+
+    return {
+        "documents": documents,
+        "total_count": total_count,
+        "found_count": found_count,
+        "page_count": math.ceil(found_count / per_page),
+        "per_page": per_page,
+        "page": page,
+    }
+
+
+async def get_contributors(
+    pg: AsyncEngine,
+    reference_id: str | None = None,
+    index_id: str | None = None,
+) -> list[dict]:
+    """Return a list of contributors and their contribution count for a set of history.
+
+    The set is scoped by ``reference_id`` or ``index_id``. Contribution counts are
+    aggregated in Postgres by ``user_id`` and joined to user handles. A change whose
+    user cannot be resolved is reported as the ``"Unknown User"`` fallback.
+
+    :param pg: the application PostgreSQL database object
+    :param reference_id: restrict contributions to a single reference
+    :param index_id: restrict contributions to a single built index
+    :return: a list of contributors to the scanned history changes
+    """
+    filters = []
+
+    if reference_id is not None:
+        filters.append(SQLLegacyHistory.reference == reference_id)
+
+    if index_id is not None:
+        filters.append(SQLLegacyHistory.index == index_id)
+
+    async with AsyncSession(pg) as session:
+        counts = (
+            await session.execute(
+                select(SQLLegacyHistory.user_id, func.count())
+                .where(*filters)
+                .group_by(SQLLegacyHistory.user_id)
+                .order_by(SQLLegacyHistory.user_id),
+            )
+        ).all()
+
+        if not counts:
+            return []
+
+        users = {
+            row.id: {"id": row.id, "handle": row.handle}
+            for row in (
+                await session.execute(
+                    select(SQLUser.id, SQLUser.handle).where(
+                        SQLUser.id.in_([user_id for user_id, _ in counts]),
+                    ),
+                )
+            ).all()
+        }
 
     return [
-        {
-            **users.get(c["id"], {"id": -1, "handle": "Unknown User"}),
-            "count": c["count"],
-        }
-        for c in contributors
+        {**users.get(user_id, {"id": -1, "handle": "Unknown User"}), "count": count}
+        for user_id, count in counts
     ]
 
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -429,7 +429,11 @@ async def get_contributors(
     :param reference_id: restrict contributions to a single reference
     :param index_id: restrict contributions to a single built index
     :return: a list of contributors to the scanned history changes
+    :raises ValueError: if neither ``reference_id`` nor ``index_id`` is provided
     """
+    if reference_id is None and index_id is None:
+        raise ValueError("get_contributors requires a reference_id or index_id")
+
     filters = []
 
     if reference_id is not None:

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -135,9 +135,7 @@ class IndexData:
         document = result[0]
 
         contributors, otus = await asyncio.gather(
-            virtool.history.db.get_contributors(
-                self._mongo, self._pg, {"index.id": index_id}
-            ),
+            virtool.history.db.get_contributors(self._pg, index_id=index_id),
             virtool.indexes.db.get_otus(self._mongo, index_id),
         )
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -340,7 +340,7 @@ class ReferencesData(DataLayerDomain):
             users,
             unbuilt_count,
         ) = await asyncio.gather(
-            get_contributors(self._mongo, self._pg, ref_id),
+            get_contributors(self._pg, ref_id),
             get_internal_control(self._mongo, internal_control_id, ref_id),
             get_latest_build(self._mongo, self._pg, ref_id),
             get_otu_count(self._mongo, ref_id),
@@ -590,16 +590,12 @@ class ReferencesData(DataLayerDomain):
         if not await self._mongo.references.count_documents({"_id": ref_id}):
             raise ResourceNotFoundError()
 
-        base_query = {"reference.id": ref_id}
-
-        search_query = {}
-        if unbuilt is True:
-            search_query["index.id"] = "unbuilt"
-        elif unbuilt is False:
-            search_query["index.id"] = {"$ne": "unbuilt"}
-
         data = await virtool.history.db.find(
-            self._mongo, self._pg, search_query, query, base_query
+            self._mongo,
+            self._pg,
+            query,
+            reference_id=ref_id,
+            unbuilt=unbuilt,
         )
 
         return HistorySearchResult(**data)

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -376,18 +376,15 @@ async def fetch_and_update_release(
     return release
 
 
-async def get_contributors(mongo: "Mongo", pg, ref_id: str) -> list[Document] | None:
+async def get_contributors(pg, ref_id: str) -> list[Document] | None:
     """Return a list of contributors and their contribution count for a specific ref.
 
-    :param mongo: the application database client
     :param pg: the PostgreSQL engine
     :param ref_id: the id of the ref to get contributors for
     :return: a list of contributors to the ref
 
     """
-    return await virtool.history.db.get_contributors(
-        mongo, pg, {"reference.id": ref_id}
-    )
+    return await virtool.history.db.get_contributors(pg, reference_id=ref_id)
 
 
 async def get_internal_control(


### PR DESCRIPTION
## Summary
- Reimplement `history.db.find` over the `legacy_history` table instead of `mongo.history`, sorting by `otu_version` descending with a deterministic `id` tiebreaker and joining `users` for handles; `AttachReferenceTransform` stays since references are not yet migrated.
- Reimplement `get_contributors` as a SQL `GROUP BY user_id` scoped by `reference_id` or `index_id`, resolving handles via `SQLUser`.
- Update the reference/index callers to the new signatures and refresh the affected snapshots.