### PR TITLE
Include subprocess stderr in SubprocessFailedError

### DIFF
--- a/tests/workflow/test_subprocess.py
+++ b/tests/workflow/test_subprocess.py
@@ -75,6 +75,14 @@ async def test_subprocess_failed(run_subprocess: RunSubprocess):
     await run_subprocess(["ls"])
 
 
+async def test_subprocess_failed_includes_stderr(run_subprocess: RunSubprocess):
+    """Test that the raised error message contains the failing command's stderr."""
+    with pytest.raises(SubprocessFailedError) as excinfo:
+        await run_subprocess(["bash", "-c", "echo bowtie2-build failed >&2; exit 1"])
+
+    assert "bowtie2-build failed" in str(excinfo.value)
+
+
 @pytest.mark.timeout(45)
 @pytest.mark.parametrize("cancel", [True, False])
 async def test_terminated_by_cancellation(

--- a/tests/workflow/test_subprocess.py
+++ b/tests/workflow/test_subprocess.py
@@ -76,11 +76,19 @@ async def test_subprocess_failed(run_subprocess: RunSubprocess):
 
 
 async def test_subprocess_failed_includes_stderr(run_subprocess: RunSubprocess):
-    """Test that the raised error message contains the failing command's stderr."""
-    with pytest.raises(SubprocessFailedError) as excinfo:
-        await run_subprocess(["bash", "-c", "echo bowtie2-build failed >&2; exit 1"])
+    """Test that the raised error message folds in the failing command's stderr."""
+    command = ["bash", "-c", "echo bowtie2-build failed >&2; exit 1"]
 
-    assert "bowtie2-build failed" in str(excinfo.value)
+    with pytest.raises(SubprocessFailedError) as excinfo:
+        await run_subprocess(command)
+
+    message = str(excinfo.value)
+
+    assert message.startswith(
+        f"Subprocess failed with exit code 1: {' '.join(command)}"
+    )
+    assert "\nstderr:\n" in message
+    assert message.rstrip().endswith("bowtie2-build failed")
 
 
 @pytest.mark.timeout(45)

--- a/virtool/workflow/errors.py
+++ b/virtool/workflow/errors.py
@@ -66,8 +66,21 @@ class WorkflowStepDescriptionError(Exception):
 class SubprocessFailedError(SubprocessError):
     """Subprocess exited with non-zero status during a workflow."""
 
-    def __init__(self, command: list[str], return_code: int) -> None:
-        """Initialize a SubprocessFailedError with a command and return code."""
-        super().__init__(
-            f"Subprocess failed with exit code {return_code}: {' '.join(command)}"
-        )
+    def __init__(
+        self,
+        command: list[str],
+        return_code: int,
+        stderr: str = "",
+    ) -> None:
+        """Initialize a SubprocessFailedError with a command, return code, and stderr.
+
+        :param command: the command that was run
+        :param return_code: the non-zero exit code
+        :param stderr: a tail of the subprocess' stderr output
+        """
+        message = f"Subprocess failed with exit code {return_code}: {' '.join(command)}"
+
+        if stderr:
+            message = f"{message}\nstderr:\n{stderr}"
+
+        super().__init__(message)

--- a/virtool/workflow/runtime/run_subprocess.py
+++ b/virtool/workflow/runtime/run_subprocess.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from asyncio.subprocess import Process
+from collections import deque
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from pathlib import Path
@@ -97,16 +98,28 @@ async def _run_subprocess(
 
     stdout = asyncio.subprocess.PIPE if stdout_handler else asyncio.subprocess.DEVNULL
 
+    stderr_tail: deque[str] = deque(maxlen=20)
+
+    def _capture_stderr(line: bytes) -> None:
+        line = line.rstrip()
+
+        try:
+            stderr_tail.append(line.decode())
+        except UnicodeDecodeError:
+            stderr_tail.append(str(line))
+
     if stderr_handler:
 
         async def _stderr_handler(line):
             stderr_logger(line)
+            _capture_stderr(line)
             await stderr_handler(line)
 
     else:
 
         async def _stderr_handler(line):
             stderr_logger(line)
+            _capture_stderr(line)
 
     process = await asyncio.create_subprocess_exec(
         *(str(arg) for arg in command),
@@ -153,6 +166,7 @@ async def _run_subprocess(
         raise SubprocessFailedError(
             command=command,
             return_code=process.returncode,
+            stderr="\n".join(stderr_tail),
         )
 
     log.info(

--- a/virtool/workflow/runtime/run_subprocess.py
+++ b/virtool/workflow/runtime/run_subprocess.py
@@ -106,7 +106,7 @@ async def _run_subprocess(
         try:
             stderr_tail.append(line.decode())
         except UnicodeDecodeError:
-            stderr_tail.append(str(line))
+            stderr_tail.append(line.decode(errors="backslashreplace"))
 
     if stderr_handler:
 


### PR DESCRIPTION
## Summary
- Capture a bounded 20-line tail of a workflow subprocess' stderr and fold it into the `SubprocessFailedError` message, so a non-zero exit is diagnosable in Sentry instead of showing only the command and exit code (motivated by the undiagnosable `bowtie2-build` failure in VIR-2569).
- Streaming stderr/stdout handler behaviour is unchanged; capture happens alongside the existing logging and forwarding, with a UTF-8-with-fallback decode so binary output can't crash the handler.

Closes VIR-2570.