### PR TITLE
Dual-write legacy_history in remote reference update flow

### DIFF
--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -3,12 +3,16 @@ import datetime
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.history.db import legacy_history_values
+from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
 from virtool.references.bulk import BulkOTUUpdater
 from virtool.references.models import ReferenceDataType
@@ -1431,6 +1435,84 @@ class TestUpdateRemoteReference:
         )
 
         await self._assert(ref_id, mongo, snapshot)
+
+    async def test_dual_writes_legacy_history(
+        self,
+        populated_reference: tuple,
+        data_layer: DataLayer,
+        mocker: MockerFixture,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Every history document written by a remote reference update is dual-written
+        to the ``legacy_history`` table, one Postgres row per Mongo document with the
+        canonical column mapping.
+
+        The update exercises create (otu_r4), update (otu_r1), and remove (otu_r3, whose
+        ``otu_version`` sentinel maps to ``NULL``) so the mapping is covered across every
+        history method.
+        """
+        ref_id, user_id, update_release = populated_reference
+
+        await self._run_update(
+            data_layer,
+            mocker,
+            ref_id,
+            user_id,
+            update_release,
+            otus=[
+                _make_otu_r1(name="OTU One Renamed", abbreviation="OOR"),
+                _make_otu_r2(),
+                # otu_r3 omitted -> removed
+                ReferenceSourceOTU(
+                    _id="otu_r4",
+                    name="OTU Four",
+                    abbreviation="OF",
+                    isolates=[
+                        ReferenceSourceIsolate(
+                            id="iso_r4",
+                            default=True,
+                            source_type="strain",
+                            source_name="New",
+                            sequences=[
+                                ReferenceSourceSequence(
+                                    _id="seq_r4",
+                                    accession="NC_000006",
+                                    definition="Sequence 4",
+                                    sequence="GGGGGGGGGGGGGGGG",
+                                    host="None",
+                                )
+                            ],
+                        )
+                    ],
+                ),
+            ],
+        )
+
+        documents = await mongo.history.find({"reference.id": ref_id}).to_list(None)
+
+        async with AsyncSession(pg) as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(SQLLegacyHistory).where(
+                            SQLLegacyHistory.reference == ref_id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        rows_by_legacy_id = {row.legacy_id: row for row in rows}
+
+        assert rows_by_legacy_id.keys() == {document["_id"] for document in documents}
+
+        for document in documents:
+            expected = legacy_history_values(document)
+            row = rows_by_legacy_id[document["_id"]]
+
+            assert {column: getattr(row, column) for column in expected} == expected
 
     async def test_update_fails(
         self,

--- a/virtool/references/bulk.py
+++ b/virtool/references/bulk.py
@@ -7,8 +7,8 @@ from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from virtool.history.db import prepare_add
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.db import legacy_history_values, prepare_add
+from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
 from virtool.mongo.core import Collection, Mongo
 from virtool.mongo.identifier import AbstractIdProvider
 from virtool.otus.db import bulk_join_ids, bulk_join_query
@@ -179,6 +179,14 @@ class OTUDataBuffer(BaseDataBuffer):
                     insert(SQLHistoryDiff).values(
                         [
                             {"change_id": change.data.id, "diff": change.data.diff}
+                            for change in change_buffer
+                        ],
+                    ),
+                )
+                await pg_session.execute(
+                    insert(SQLLegacyHistory).values(
+                        [
+                            legacy_history_values(change.data.document)
                             for change in change_buffer
                         ],
                     ),


### PR DESCRIPTION
## Summary
- The bulk OTU history insert buffer wrote `history_diffs` and Mongo documents but never inserted the paired `legacy_history` rows, breaking the step-2 dual-write invariant — history from remote reference updates went missing once list/contributor reads switched to `legacy_history`.
- Insert `legacy_history` rows in the same locked block using the canonical `legacy_history_values` mapper, atomic with the diff and Mongo writes under the surrounding `both_transactions`.
- Add a regression test asserting every history document from a remote update (covering create/update/remove) has a matching `legacy_history` row with the correct column mapping.