### PR TITLE
Switch single history reads to Postgres and re-key the diff table

### DIFF
--- a/assets/alembic/versions/a329dfd5ba23_re_key_history_diffs_to_legacy_history_.py
+++ b/assets/alembic/versions/a329dfd5ba23_re_key_history_diffs_to_legacy_history_.py
@@ -1,0 +1,75 @@
+"""re-key history diffs to legacy_history_diff
+
+Revision ID: a329dfd5ba23
+Revises: 14c5bc110756
+Create Date: 2026-07-02 18:06:34.126679+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a329dfd5ba23"
+down_revision = "14c5bc110756"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Re-key the diff side table from ``change_id`` to an integer ``history_id`` FK.
+
+    The table is renamed ``history_diffs`` -> ``legacy_history_diff`` and gains a
+    nullable ``history_id`` BigInteger foreign key to ``legacy_history.id``. Existing
+    rows are backfilled by joining the old string ``change_id`` to
+    ``legacy_history.legacy_id``. The old ``change_id`` column is intentionally left
+    in place; it is dropped in a later cleanup revision once production stability is
+    confirmed.
+    """
+    op.rename_table("history_diffs", "legacy_history_diff")
+
+    op.add_column(
+        "legacy_history_diff",
+        sa.Column("history_id", sa.BigInteger(), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE legacy_history_diff AS d
+        SET history_id = h.id
+        FROM legacy_history AS h
+        WHERE h.legacy_id = d.change_id
+        """,
+    )
+
+    op.create_foreign_key(
+        "legacy_history_diff_history_id_fkey",
+        "legacy_history_diff",
+        "legacy_history",
+        ["history_id"],
+        ["id"],
+    )
+
+    op.create_unique_constraint(
+        "legacy_history_diff_history_id_key",
+        "legacy_history_diff",
+        ["history_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "legacy_history_diff_history_id_key",
+        "legacy_history_diff",
+        type_="unique",
+    )
+
+    op.drop_constraint(
+        "legacy_history_diff_history_id_fkey",
+        "legacy_history_diff",
+        type_="foreignkey",
+    )
+
+    op.drop_column("legacy_history_diff", "history_id")
+
+    op.rename_table("legacy_history_diff", "history_diffs")

--- a/tests/fixtures/history.py
+++ b/tests/fixtures/history.py
@@ -1,8 +1,10 @@
 import datetime
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from virtool.history.db import bulk_insert_diffs
+from virtool.history.db import bulk_insert_diffs, legacy_history_values
+from virtool.history.sql import SQLLegacyHistory
 
 
 @pytest.fixture
@@ -101,8 +103,10 @@ def test_otu_edit():
 
 
 @pytest.fixture
-def create_mock_history(mongo, pg):
+def create_mock_history(fake, mongo, pg):
     async def func(remove):
+        user = await fake.users.create()
+
         documents = [
             {
                 "_id": "6116cba1.0",
@@ -267,8 +271,19 @@ def create_mock_history(mongo, pg):
 
             await mongo.otus.insert_one(otu)
 
-        # Mirror production: store the real diff in Postgres and only the
-        # "postgres" sentinel in Mongo.
+        # Mirror the production dual-write: one legacy_history row per change, the
+        # real diff in Postgres keyed by history_id, and only the "postgres" sentinel
+        # in Mongo.
+        async with AsyncSession(pg) as session:
+            for document in documents:
+                session.add(
+                    SQLLegacyHistory(
+                        **legacy_history_values({**document, "user": {"id": user.id}}),
+                    ),
+                )
+
+            await session.commit()
+
         await bulk_insert_diffs(
             pg,
             [

--- a/tests/history/__snapshots__/test_api.ambr
+++ b/tests/history/__snapshots__/test_api.ambr
@@ -115,7 +115,7 @@
     'id': '6116cba1.1',
     'index': dict({
       'id': 'unbuilt',
-      'version': 1,
+      'version': 'unbuilt',
     }),
     'method_name': 'edit',
     'otu': dict({

--- a/tests/history/__snapshots__/test_data.ambr
+++ b/tests/history/__snapshots__/test_data.ambr
@@ -14,7 +14,10 @@
       ]),
     ]),
     'id': '6116cba1.1',
-    'index': None,
+    'index': dict({
+      'id': 'unbuilt',
+      'version': 'unbuilt',
+    }),
     'method_name': <HistoryMethod.create: 'create'>,
     'otu': dict({
       'id': '6116cba1',

--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -79,7 +79,7 @@
   })
 # ---
 # name: TestAdd.test_create.2
-  <SQLHistoryDiff(id=1, change_id=6116cba1.0, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
+  <SQLLegacyHistoryDiff(id=1, change_id=6116cba1.0, history_id=1, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
 # ---
 # name: TestAdd.test_create[legacy_history]
   <SQLLegacyHistory(id=1, legacy_id=6116cba1.0, created_at=2015-10-06 20:00:00, description=Created Prunus virus F, method_name=create, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=0, reference=hxn167, index=None, index_version=None)>
@@ -189,7 +189,7 @@
   <SQLLegacyHistory(id=1, legacy_id=6116cba1.1, created_at=2015-10-06 20:00:00, description=This is a description, method_name=edit, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=1, reference=hxn167, index=None, index_version=None)>
 # ---
 # name: TestAdd.test_remove[diff]
-  <SQLHistoryDiff(id=1, change_id=6116cba1.removed, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
+  <SQLLegacyHistoryDiff(id=1, change_id=6116cba1.removed, history_id=1, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
 # ---
 # name: TestAdd.test_remove[document]
   dict({
@@ -308,7 +308,7 @@
       'version': 2,
     }),
     'user': dict({
-      'id': 'test',
+      'id': 1,
     }),
   })
 # ---

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -58,6 +58,18 @@ async def test_get(
     """Test that a specific history change can be retrieved by its change_id."""
     client = await spawn_client(authenticated=True)
 
+    async with AsyncSession(pg) as session:
+        for change in test_changes:
+            session.add(
+                SQLLegacyHistory(
+                    **legacy_history_values(
+                        {**change, "user": {"id": client.user.id}},
+                    ),
+                ),
+            )
+
+        await session.commit()
+
     await bulk_insert_diffs(
         pg,
         [{"change_id": c["_id"], "diff": c["diff"]} for c in test_changes],

--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -1,17 +1,14 @@
-import asyncio
-import datetime
-
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
-from virtool.data.errors import ResourceConflictError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.fake.next import DataFaker
 from virtool.history.data import HistoryData
 from virtool.history.db import bulk_insert_diffs
-from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.mongo.core import Mongo
 
 
@@ -22,7 +19,27 @@ async def test_get(
     snapshot: SnapshotAssertion,
     static_time,
 ):
+    """A change is read from ``legacy_history`` with its diff and reference attached."""
     user = await fake.users.create()
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacyHistory(
+                legacy_id="6116cba1.1",
+                created_at=static_time.datetime,
+                description="test history",
+                method_name="create",
+                user_id=user.id,
+                otu="6116cba1",
+                otu_name="Prunus virus F",
+                otu_version="1",
+                reference="hxn167",
+                index=None,
+                index_version=None,
+            ),
+        )
+
+        await session.commit()
 
     await bulk_insert_diffs(
         pg,
@@ -34,95 +51,25 @@ async def test_get(
         ],
     )
 
-    await asyncio.gather(
-        mongo.references.insert_one(
-            {
-                "_id": "hxn167",
-                "archived": False,
-                "data_type": "genome",
-                "name": "Reference A",
-            },
-        ),
-        mongo.history.insert_one(
-            {
-                "_id": "6116cba1.1",
-                "diff": "postgres",
-                "user": {"id": user.id},
-                "reference": {"id": "hxn167"},
-                "created_at": static_time.datetime,
-                "description": "test history",
-                "method_name": "create",
-                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-            },
-        ),
+    await mongo.references.insert_one(
+        {
+            "_id": "hxn167",
+            "archived": False,
+            "data_type": "genome",
+            "name": "Reference A",
+        },
     )
 
     assert await HistoryData(mongo, pg).get("6116cba1.1") == snapshot
 
 
-async def test_get_inline_diff_raises(
-    fake: DataFaker,
-    mongo: Mongo,
-    pg: AsyncEngine,
-    static_time,
-):
-    """A change holding an unbackfilled inline diff raises instead of returning it."""
-    user = await fake.users.create()
-
-    await asyncio.gather(
-        mongo.references.insert_one(
-            {
-                "_id": "hxn167",
-                "archived": False,
-                "data_type": "genome",
-                "name": "Reference A",
-            },
-        ),
-        mongo.history.insert_one(
-            {
-                "_id": "6116cba1.1",
-                "diff": [["change", "abbreviation", ["PVF", "TST"]]],
-                "user": {"id": user.id},
-                "reference": {"id": "hxn167"},
-                "created_at": static_time.datetime,
-                "description": "test history",
-                "method_name": "create",
-                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-            },
-        ),
-    )
-
-    with pytest.raises(
-        ValueError, match="Unexpected inline diff for change 6116cba1.1"
-    ):
+async def test_get_not_found(mongo: Mongo, pg: AsyncEngine):
+    """A change id with no ``legacy_history`` row raises ``ResourceNotFoundError``."""
+    with pytest.raises(ResourceNotFoundError):
         await HistoryData(mongo, pg).get("6116cba1.1")
 
 
 MOCK_HISTORY_CHANGE_IDS = ["6116cba1.0", "6116cba1.1", "6116cba1.2", "6116cba1.3"]
-
-
-async def seed_legacy_history(pg: AsyncEngine, user_id: int) -> None:
-    """Mirror ``create_mock_history`` into the ``legacy_history`` table."""
-    async with AsyncSession(pg) as session:
-        for change_id in MOCK_HISTORY_CHANGE_IDS:
-            otu_id, otu_version = change_id.split(".")
-            session.add(
-                SQLLegacyHistory(
-                    legacy_id=change_id,
-                    created_at=datetime.datetime(2017, 7, 12, 16, 0, 50),
-                    description="Description",
-                    method_name="update",
-                    user_id=user_id,
-                    otu=otu_id,
-                    otu_name="Prunus virus F",
-                    otu_version=otu_version,
-                    reference="hxn167",
-                    index=None,
-                    index_version=None,
-                ),
-            )
-
-        await session.commit()
 
 
 async def legacy_history_ids(pg: AsyncEngine) -> list[str]:
@@ -145,8 +92,8 @@ async def history_diff_ids(pg: AsyncEngine) -> list[str]:
         return list(
             (
                 await session.execute(
-                    select(SQLHistoryDiff.change_id).order_by(
-                        SQLHistoryDiff.change_id,
+                    select(SQLLegacyHistoryDiff.change_id).order_by(
+                        SQLLegacyHistoryDiff.change_id,
                     ),
                 )
             )
@@ -159,16 +106,13 @@ class TestDelete:
     async def test_dual_write(
         self,
         create_mock_history,
-        fake: DataFaker,
         mongo: Mongo,
         pg: AsyncEngine,
     ):
         """Reverting a change deletes the reverted rows from Mongo, ``legacy_history``
-        and ``history_diffs`` together.
+        and ``legacy_history_diff`` together.
         """
-        user = await fake.users.create()
         await create_mock_history(False)
-        await seed_legacy_history(pg, user.id)
 
         await HistoryData(mongo, pg).delete("6116cba1.2")
 
@@ -183,15 +127,12 @@ class TestDelete:
     async def test_rollback_preserves_postgres(
         self,
         create_mock_history,
-        fake: DataFaker,
         mocker: MockerFixture,
         mongo: Mongo,
         pg: AsyncEngine,
     ):
         """A failure mid-delete rolls back both stores, leaving every row intact."""
-        user = await fake.users.create()
         await create_mock_history(False)
-        await seed_legacy_history(pg, user.id)
 
         mocker.patch(
             "virtool.history.data.delete_history",

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -8,7 +8,7 @@ from syrupy import SnapshotAssertion
 
 import virtool.history.db
 from virtool.fake.next import DataFaker
-from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
@@ -143,8 +143,8 @@ class TestAdd:
 
         async with AsyncSession(pg) as session:
             diff = await session.execute(
-                select(SQLHistoryDiff.diff).where(
-                    SQLHistoryDiff.change_id == change_id,
+                select(SQLLegacyHistoryDiff.diff).where(
+                    SQLLegacyHistoryDiff.change_id == change_id,
                 ),
             )
 
@@ -188,7 +188,7 @@ class TestAdd:
 
         assert change == snapshot
         assert await mongo.history.find_one() == snapshot
-        assert await get_row_by_id(pg, SQLHistoryDiff, 1) == snapshot
+        assert await get_row_by_id(pg, SQLLegacyHistoryDiff, 1) == snapshot
 
         async with AsyncSession(pg) as session:
             legacy = await session.execute(
@@ -229,7 +229,7 @@ class TestAdd:
         assert change == snapshot(name="return_value")
 
         diff, document = await asyncio.gather(
-            get_row_by_id(pg, SQLHistoryDiff, 1),
+            get_row_by_id(pg, SQLLegacyHistoryDiff, 1),
             mongo.history.find_one(),
         )
 
@@ -254,54 +254,57 @@ class TestAdd:
 class TestGetMostRecentChange:
     async def test_ok(
         self,
-        mongo: Mongo,
+        fake: DataFaker,
+        pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         static_time: StaticTime,
     ):
-        """Test that the most recent change document for the given otu is returned."""
+        """The change with the highest ``otu_version`` for the otu is returned."""
+        user = await fake.users.create()
+
         delta = datetime.timedelta(3)
 
-        await mongo.history.insert_many(
-            [
-                {
-                    "_id": "6116cba1.1",
-                    "description": "Description",
-                    "method_name": "update",
-                    "created_at": static_time.datetime - delta,
-                    "user": {"id": "test"},
-                    "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-                    "index": {"id": "unbuilt"},
-                },
-                {
-                    "_id": "6116cba1.2",
-                    "description": "Description number 2",
-                    "method_name": "update",
-                    "created_at": static_time.datetime,
-                    "user": {"id": "test"},
-                    "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 2},
-                    "index": {"id": "unbuilt"},
-                },
-            ],
-            session=None,
-        )
+        async with AsyncSession(pg) as session:
+            session.add_all(
+                [
+                    SQLLegacyHistory(
+                        legacy_id="6116cba1.1",
+                        created_at=static_time.datetime - delta,
+                        description="Description",
+                        method_name="update",
+                        user_id=user.id,
+                        otu="6116cba1",
+                        otu_name="Prunus virus F",
+                        otu_version="1",
+                        reference="hxn167",
+                        index=None,
+                        index_version=None,
+                    ),
+                    SQLLegacyHistory(
+                        legacy_id="6116cba1.2",
+                        created_at=static_time.datetime,
+                        description="Description number 2",
+                        method_name="update",
+                        user_id=user.id,
+                        otu="6116cba1",
+                        otu_name="Prunus virus F",
+                        otu_version="2",
+                        reference="hxn167",
+                        index=None,
+                        index_version=None,
+                    ),
+                ],
+            )
 
-        return_value = await virtool.history.db.get_most_recent_change(
-            mongo,
-            "6116cba1",
-        )
+            await session.commit()
+
+        return_value = await virtool.history.db.get_most_recent_change(pg, "6116cba1")
+
         assert return_value == snapshot
 
-    async def test_does_not_exist(self, mongo: Mongo):
-        """Test that `None` is returned when no change document exists for the given
-        otu.
-        """
-        assert (
-            await virtool.history.db.get_most_recent_change(
-                mongo,
-                "6116cba1",
-            )
-            is None
-        )
+    async def test_does_not_exist(self, pg: AsyncEngine):
+        """``None`` is returned when the otu has no history."""
+        assert await virtool.history.db.get_most_recent_change(pg, "6116cba1") is None
 
 
 @pytest.mark.parametrize("remove", [True, False])
@@ -327,8 +330,8 @@ async def test_patch_to_version(
 
 
 async def test_patch_to_version_missing_diff(mongo: Mongo, pg: AsyncEngine):
-    """A change with the ``"postgres"`` sentinel but no ``SQLHistoryDiff`` row raises a
-    clear error instead of failing later with a ``KeyError``.
+    """A change with the ``"postgres"`` sentinel but no ``SQLLegacyHistoryDiff`` row
+    raises a clear error instead of failing later with a ``KeyError``.
     """
     await mongo.history.insert_one(
         {
@@ -339,7 +342,10 @@ async def test_patch_to_version_missing_diff(mongo: Mongo, pg: AsyncEngine):
         },
     )
 
-    with pytest.raises(ValueError, match="Missing history_diffs rows.*6116cba1.1"):
+    with pytest.raises(
+        ValueError,
+        match="Missing legacy_history_diff rows.*6116cba1.1",
+    ):
         await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)
 
 

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -561,5 +561,12 @@
       'name': 'delete ml model blobs',
       'revision': 't15v503oih88',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 81,
+      'name': 're-key history diffs to legacy_history_diff',
+      'revision': 'a329dfd5ba23',
+    }),
   ])
 # ---

--- a/tests/migration/test_apply.py
+++ b/tests/migration/test_apply.py
@@ -80,6 +80,7 @@ async def test_apply_revisions_with_missing_last_applied(
         assert any(r.revision == revision.id for r in applied)
 
 
+@pytest.mark.timeout(30)
 async def test_apply_fills_in_missed_earlier_revision(
     migration_config: MigrationConfig,
     migration_pg: AsyncEngine,
@@ -90,7 +91,9 @@ async def test_apply_fills_in_missed_earlier_revision(
     Recording only the head revision simulates a history where revisions were
     applied out of order: every earlier revision is unrecorded. The position-based
     scan used to skip all of them because they sort before the recorded head; now
-    each unrecorded revision is filled in.
+    each unrecorded revision is filled in. Because every earlier revision is applied
+    from a fresh database, this exercises the whole migration chain and needs the same
+    generous timeout as :func:`test_apply_revisions`.
     """
     all_revisions = load_all_revisions()
     head = all_revisions[-1]

--- a/tests/otus/__snapshots__/test_api.ambr
+++ b/tests/otus/__snapshots__/test_api.ambr
@@ -2638,12 +2638,12 @@
     'last_indexed_version': 0,
     'most_recent_change': dict({
       'created_at': '2015-10-06T20:00:00Z',
-      'description': 'Edited Prunus virus E',
-      'id': '6116cba1.0',
+      'description': 'Changed name to Prunus virus F and changed abbreviation to PVF2 and modified schema',
+      'id': '6116cba1.1',
       'method_name': 'edit',
       'user': dict({
-        'handle': 'myersmitchell',
-        'id': 2,
+        'handle': 'leeashley',
+        'id': 1,
       }),
     }),
     'name': 'Prunus virus F',
@@ -2686,12 +2686,12 @@
     'last_indexed_version': 0,
     'most_recent_change': dict({
       'created_at': '2015-10-06T20:00:00Z',
-      'description': 'Edited Prunus virus E',
-      'id': '6116cba1.0',
+      'description': 'Changed name to Prunus virus G and changed abbreviation to PVF and modified schema',
+      'id': '6116cba1.1',
       'method_name': 'edit',
       'user': dict({
-        'handle': 'myersmitchell',
-        'id': 2,
+        'handle': 'leeashley',
+        'id': 1,
       }),
     }),
     'name': 'Prunus virus G',

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -2,7 +2,7 @@ import asyncio
 from http import HTTPStatus
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from yarl import URL
 
@@ -11,6 +11,8 @@ from tests.fixtures.response import RespIs
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.history.db import legacy_history_values
+from virtool.history.sql import SQLLegacyHistory
 from virtool.models.enums import HistoryMethod, Molecule
 from virtool.mongo.core import Mongo
 from virtool.otus.models import OTU, OTUIsolate, OTUSegment, OTUSequence
@@ -221,6 +223,7 @@ class TestEdit:
         check_ref_right,
         fake: DataFaker,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         resp_is: RespIs,
         snapshot: SnapshotAssertion,
@@ -233,14 +236,18 @@ class TestEdit:
 
         user = await fake.users.create()
 
+        change = {**test_change, "user": {"id": user.id}, "_id": "6116cba1.0"}
+
         await asyncio.gather(
             mongo.otus.insert_one(test_otu),
             mongo.references.insert_one(test_ref),
             mongo.sequences.insert_one(test_sequence),
-            mongo.history.insert_one(
-                {**test_change, "user": {"id": user.id}, "_id": "6116cba1.0"},
-            ),
+            mongo.history.insert_one(change),
         )
+
+        async with AsyncSession(pg) as session:
+            session.add(SQLLegacyHistory(**legacy_history_values(change)))
+            await session.commit()
 
         resp = await client.patch(f"/otus/{test_otu['_id']}", data)
 

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -8,7 +8,7 @@ from syrupy import SnapshotAssertion
 
 from virtool.api.client import UserClient
 from virtool.fake.next import DataFaker
-from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
@@ -364,8 +364,8 @@ async def test_populate_insert_only_reference_rollback(
     async with AsyncSession(pg) as pg_session:
         diff_count = await pg_session.scalar(
             select(func.count())
-            .select_from(SQLHistoryDiff)
-            .where(SQLHistoryDiff.change_id.in_(["rbotu001.0", "rbotu002.0"])),
+            .select_from(SQLLegacyHistoryDiff)
+            .where(SQLLegacyHistoryDiff.change_id.in_(["rbotu001.0", "rbotu002.0"])),
         )
 
         legacy_count = await pg_session.scalar(

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -13,7 +13,7 @@ from syrupy.matchers import path_type
 
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.sql import SQLLegacyHistoryDiff
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.db import get_manifest
@@ -191,8 +191,8 @@ def assert_reference_created(
             diff_rows = (
                 (
                     await pg_session.execute(
-                        select(SQLHistoryDiff).where(
-                            SQLHistoryDiff.change_id.in_(change_ids),
+                        select(SQLLegacyHistoryDiff).where(
+                            SQLLegacyHistoryDiff.change_id.in_(change_ids),
                         ),
                     )
                 )

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -1,18 +1,23 @@
 from typing import Any
 
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
-from virtool.data.topg import retry_both_transactions
+from virtool.data.topg import (
+    compose_legacy_id_single_expression,
+    retry_both_transactions,
+)
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
-from virtool.history.db import HISTORY_PROJECTION, delete_history, patch_to_version
+from virtool.history.db import delete_history, legacy_history_document, patch_to_version
 from virtool.history.models import History, HistorySearchResult
+from virtool.history.sql import SQLLegacyHistory
 from virtool.history.transforms import AttachDiffTransform
 from virtool.mongo.core import Mongo
 from virtool.references.transforms import AttachReferenceTransform
-from virtool.users.transforms import AttachUserTransform
+from virtool.users.pg import SQLUser
 from virtool.utils import base_processor
 
 
@@ -39,21 +44,35 @@ class HistoryData:
         :param change_id: the ID of the change.
         :return: the change
         """
-        document = await self._mongo.history.find_one(change_id, HISTORY_PROJECTION)
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLLegacyHistory, SQLUser.handle)
+                    .join(SQLUser, SQLLegacyHistory.user_id == SQLUser.id)
+                    .where(
+                        compose_legacy_id_single_expression(
+                            SQLLegacyHistory,
+                            change_id,
+                        ),
+                    ),
+                )
+            ).first()
 
-        if document:
-            document = await apply_transforms(
-                base_processor(document),
-                [
-                    AttachDiffTransform(self._pg),
-                    AttachReferenceTransform(self._mongo),
-                    AttachUserTransform(self._pg),
-                ],
-                self._pg,
-            )
-            return History(**document)
+        if row is None:
+            raise ResourceNotFoundError()
 
-        raise ResourceNotFoundError()
+        legacy_row, handle = row
+
+        document = await apply_transforms(
+            base_processor(legacy_history_document(legacy_row, handle)),
+            [
+                AttachDiffTransform(self._pg),
+                AttachReferenceTransform(self._mongo),
+            ],
+            self._pg,
+        )
+
+        return History(**document)
 
     async def delete(self, change_id: str) -> None:
         """Delete a change given its ID.

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -104,19 +104,18 @@ async def bulk_insert_diffs(pg: AsyncEngine, rows: list[dict]) -> None:
     change_ids = [row["change_id"] for row in rows]
 
     async with AsyncSession(pg) as session:
-        history_ids = {
-            legacy_id: id_
-            for id_, legacy_id in (
-                await session.execute(
-                    select(SQLLegacyHistory.id, SQLLegacyHistory.legacy_id).where(
-                        compose_legacy_id_multi_expression(
-                            SQLLegacyHistory,
-                            change_ids,
-                        ),
-                    ),
-                )
-            ).all()
-        }
+        history_ids: dict[str, int] = {}
+
+        for start in range(0, len(change_ids), _LEGACY_HISTORY_CHUNK_SIZE):
+            chunk = change_ids[start : start + _LEGACY_HISTORY_CHUNK_SIZE]
+            result = await session.execute(
+                select(SQLLegacyHistory.id, SQLLegacyHistory.legacy_id).where(
+                    compose_legacy_id_multi_expression(SQLLegacyHistory, chunk),
+                ),
+            )
+
+            for id_, legacy_id in result.all():
+                history_ids[legacy_id] = id_
 
         missing = [
             change_id for change_id in change_ids if change_id not in history_ids

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -13,9 +13,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.db
 import virtool.utils
-from virtool.data.topg import both_transactions, compose_legacy_id_multi_expression
+from virtool.data.topg import (
+    both_transactions,
+    compose_legacy_id_multi_expression,
+)
 from virtool.data.transforms import apply_transforms
-from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.history.utils import (
     calculate_diff,
     compose_history_description,
@@ -45,11 +48,11 @@ HISTORY_LIST_PROJECTION = [
 HISTORY_PROJECTION = [*HISTORY_LIST_PROJECTION, "diff"]
 """A MongoDB projection for history that includes the ``diff`` field."""
 
-_HISTORY_DIFF_CHUNK_SIZE = 32767 // 2
-"""Max ``history_diffs`` rows per statement.
+_HISTORY_DIFF_CHUNK_SIZE = 32767 // 3
+"""Max ``legacy_history_diff`` rows per statement.
 
-asyncpg caps bind parameters per statement at 32767. Each row binds two
-(``change_id`` and ``diff``).
+asyncpg caps bind parameters per statement at 32767. Each row binds three
+(``change_id``, ``history_id``, and ``diff``).
 """
 
 _LEGACY_HISTORY_CHUNK_SIZE = 32767 // 11
@@ -89,12 +92,47 @@ def legacy_history_values(document: Document) -> dict:
 
 
 async def bulk_insert_diffs(pg: AsyncEngine, rows: list[dict]) -> None:
-    """Insert ``rows`` into ``history_diffs`` in asyncpg-safe chunks."""
+    """Insert ``rows`` into ``legacy_history_diff`` in asyncpg-safe chunks.
+
+    Each row's ``history_id`` foreign key is resolved from the ``legacy_history``
+    row whose ``legacy_id`` matches the row's ``change_id``. A ``change_id`` with no
+    matching ``legacy_history`` row raises, mirroring the foreign key constraint.
+    """
+    if not rows:
+        return
+
+    change_ids = [row["change_id"] for row in rows]
+
     async with AsyncSession(pg) as session:
-        for start in range(0, len(rows), _HISTORY_DIFF_CHUNK_SIZE):
+        history_ids = {
+            legacy_id: id_
+            for id_, legacy_id in (
+                await session.execute(
+                    select(SQLLegacyHistory.id, SQLLegacyHistory.legacy_id).where(
+                        compose_legacy_id_multi_expression(
+                            SQLLegacyHistory,
+                            change_ids,
+                        ),
+                    ),
+                )
+            ).all()
+        }
+
+        missing = [
+            change_id for change_id in change_ids if change_id not in history_ids
+        ]
+
+        if missing:
+            raise ValueError(
+                f"No legacy_history rows for changes: {', '.join(missing)}",
+            )
+
+        values = [{**row, "history_id": history_ids[row["change_id"]]} for row in rows]
+
+        for start in range(0, len(values), _HISTORY_DIFF_CHUNK_SIZE):
             await session.execute(
-                insert(SQLHistoryDiff).values(
-                    rows[start : start + _HISTORY_DIFF_CHUNK_SIZE],
+                insert(SQLLegacyHistoryDiff).values(
+                    values[start : start + _HISTORY_DIFF_CHUNK_SIZE],
                 ),
             )
 
@@ -126,17 +164,26 @@ async def bulk_insert_history(
     legacy_rows = [legacy_history_values(document) for document in documents]
 
     async with AsyncSession(pg) as session:
-        for start in range(0, len(diff_rows), _HISTORY_DIFF_CHUNK_SIZE):
-            await session.execute(
-                insert(SQLHistoryDiff).values(
-                    diff_rows[start : start + _HISTORY_DIFF_CHUNK_SIZE],
-                ),
-            )
+        history_ids: dict[str, int] = {}
 
         for start in range(0, len(legacy_rows), _LEGACY_HISTORY_CHUNK_SIZE):
+            result = await session.execute(
+                insert(SQLLegacyHistory)
+                .values(legacy_rows[start : start + _LEGACY_HISTORY_CHUNK_SIZE])
+                .returning(SQLLegacyHistory.id, SQLLegacyHistory.legacy_id),
+            )
+
+            for id_, legacy_id in result.all():
+                history_ids[legacy_id] = id_
+
+        diff_values = [
+            {**row, "history_id": history_ids[row["change_id"]]} for row in diff_rows
+        ]
+
+        for start in range(0, len(diff_values), _HISTORY_DIFF_CHUNK_SIZE):
             await session.execute(
-                insert(SQLLegacyHistory).values(
-                    legacy_rows[start : start + _LEGACY_HISTORY_CHUNK_SIZE],
+                insert(SQLLegacyHistoryDiff).values(
+                    diff_values[start : start + _HISTORY_DIFF_CHUNK_SIZE],
                 ),
             )
 
@@ -152,7 +199,9 @@ async def bulk_delete_history(pg: AsyncEngine, change_ids: list[str]) -> None:
         for start in range(0, len(change_ids), _HISTORY_DIFF_CHUNK_SIZE):
             chunk = change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE]
             await session.execute(
-                delete(SQLHistoryDiff).where(SQLHistoryDiff.change_id.in_(chunk)),
+                delete(SQLLegacyHistoryDiff).where(
+                    SQLLegacyHistoryDiff.change_id.in_(chunk),
+                ),
             )
             await session.execute(
                 delete(SQLLegacyHistory).where(SQLLegacyHistory.legacy_id.in_(chunk)),
@@ -174,7 +223,9 @@ async def delete_history(pg_session: AsyncSession, change_ids: list[str]) -> Non
     for start in range(0, len(change_ids), _HISTORY_DIFF_CHUNK_SIZE):
         chunk = change_ids[start : start + _HISTORY_DIFF_CHUNK_SIZE]
         await pg_session.execute(
-            delete(SQLHistoryDiff).where(SQLHistoryDiff.change_id.in_(chunk)),
+            delete(SQLLegacyHistoryDiff).where(
+                SQLLegacyHistoryDiff.change_id.in_(chunk),
+            ),
         )
 
     for start in range(0, len(change_ids), _LEGACY_HISTORY_CHUNK_SIZE):
@@ -219,18 +270,22 @@ async def add(
 
     document = prepared.document
 
-    diff_row = SQLHistoryDiff(change_id=document["_id"], diff=prepared.diff)
+    diff_row = SQLLegacyHistoryDiff(change_id=document["_id"], diff=prepared.diff)
     legacy_row = SQLLegacyHistory(**legacy_history_values(document))
 
     if mongo_session is None:
         async with both_transactions(mongo, pg) as (mongo_session, pg_session):
-            pg_session.add(diff_row)
             pg_session.add(legacy_row)
+            await pg_session.flush()
+            diff_row.history_id = legacy_row.id
+            pg_session.add(diff_row)
             await mongo.history.insert_one(document, session=mongo_session)
     else:
         async with AsyncSession(pg) as pg_session:
-            pg_session.add(diff_row)
             pg_session.add(legacy_row)
+            await pg_session.flush()
+            diff_row.history_id = legacy_row.id
+            pg_session.add(diff_row)
             await pg_session.flush()
             await mongo.history.insert_one(document, session=mongo_session)
             await pg_session.commit()
@@ -472,39 +527,58 @@ async def get_contributors(
     ]
 
 
-async def get_most_recent_change(
-    mongo: "Mongo",
-    otu_id: str,
-    session: AsyncIOMotorClientSession | None = None,
-) -> Document:
+async def get_most_recent_change(pg: AsyncEngine, otu_id: str) -> Document | None:
     """Get the most recent change for the otu identified by the passed ``otu_id``.
 
-    :param mongo: the application database client
+    Reads from the ``legacy_history`` table, returning the change with the highest
+    ``otu_version``. A ``NULL`` ``otu_version`` marks a ``"removed"`` change and sorts
+    first, matching the descending Mongo sort it replaces. The returned document
+    mirrors the historical Mongo projection so callers can attach user data and format
+    it unchanged.
+
+    :param pg: the application PostgreSQL database object
     :param otu_id: the target otu_id
-    :param session: a Motor session to use for database operations
-    :return: the most recent change document
+    :return: the most recent change document, or ``None`` if the otu has no history
 
     """
-    return await mongo.history.find_one(
-        {"otu.id": otu_id},
-        [
-            "_id",
-            "description",
-            "method_name",
-            "user",
-            "otu",
-            "created_at",
-        ],
-        sort=[("otu.version", -1)],
-        session=session,
-    )
+    async with AsyncSession(pg) as session:
+        row = (
+            await session.execute(
+                select(SQLLegacyHistory)
+                .where(SQLLegacyHistory.otu == otu_id)
+                .order_by(
+                    cast(SQLLegacyHistory.otu_version, Integer).desc().nulls_first(),
+                    SQLLegacyHistory.id.desc(),
+                )
+                .limit(1),
+            )
+        ).scalar_one_or_none()
+
+    if row is None:
+        return None
+
+    if row.otu_version is None:
+        otu_version: int | str = "removed"
+    else:
+        otu_version = (
+            int(row.otu_version) if row.otu_version.isdigit() else row.otu_version
+        )
+
+    return {
+        "_id": row.legacy_id,
+        "created_at": row.created_at,
+        "description": row.description,
+        "method_name": row.method_name,
+        "user": {"id": row.user_id},
+        "otu": {"id": row.otu, "name": row.otu_name, "version": otu_version},
+    }
 
 
 async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, object]:
     """Resolve the ``diff`` for each change, fetching Postgres-stored diffs in one query.
 
     Every change stores the sentinel string ``"postgres"`` in Mongo and the real diff
-    in ``SQLHistoryDiff``. A change whose ``diff`` is anything else is an unbackfilled
+    in ``SQLLegacyHistoryDiff``. A change whose ``diff`` is anything else is an unbackfilled
     legacy inline diff and raises ``ValueError``.
 
     :param pg: the application PostgreSQL database object
@@ -529,13 +603,21 @@ async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, 
     if postgres_change_ids:
         async with AsyncSession(pg) as session:
             result = await session.execute(
-                select(SQLHistoryDiff.change_id, SQLHistoryDiff.diff).where(
-                    SQLHistoryDiff.change_id.in_(postgres_change_ids),
+                select(SQLLegacyHistory.legacy_id, SQLLegacyHistoryDiff.diff)
+                .join(
+                    SQLLegacyHistoryDiff,
+                    SQLLegacyHistoryDiff.history_id == SQLLegacyHistory.id,
+                )
+                .where(
+                    compose_legacy_id_multi_expression(
+                        SQLLegacyHistory,
+                        postgres_change_ids,
+                    ),
                 ),
             )
 
-            for change_id, diff in result.all():
-                resolved[change_id] = diff
+            for legacy_id, diff in result.all():
+                resolved[legacy_id] = diff
 
         missing = [
             change_id for change_id in postgres_change_ids if change_id not in resolved
@@ -543,7 +625,7 @@ async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, 
 
         if missing:
             raise ValueError(
-                f"Missing history_diffs rows for changes: {', '.join(missing)}",
+                f"Missing legacy_history_diff rows for changes: {', '.join(missing)}",
             )
 
     return resolved

--- a/virtool/history/migration.py
+++ b/virtool/history/migration.py
@@ -8,19 +8,34 @@ sentinel, so the two stores converge and reads can later be served from Postgres
 alone.
 """
 
-from sqlalchemy import select
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import Column, MetaData, String, Table, select
+from sqlalchemy.dialects.postgresql import JSONB, insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from virtool.history.db import legacy_history_values
-from virtool.history.sql import SQLHistoryDiff, SQLLegacyHistory
+from virtool.history.sql import SQLLegacyHistory
 from virtool.migration import MigrationContext
 from virtool.users.pg import SQLUser
 
 logger = get_logger("migration")
 
 POSTGRES_SENTINEL = "postgres"
+
+_history_diffs_at_backfill = Table(
+    "history_diffs",
+    MetaData(),
+    Column("change_id", String),
+    Column("diff", JSONB),
+)
+"""Point-in-time definition of the diff table as it existed when this backfill runs.
+
+The backfill is ordered before the revision that renames ``history_diffs`` to
+``legacy_history_diff`` and adds the ``history_id`` foreign key, so it must target the
+table by its contemporary name rather than the current ORM model. The rename revision
+later carries these rows forward and backfills ``history_id`` by joining ``change_id``
+to ``legacy_history.legacy_id``.
+"""
 
 
 async def backfill_inline_history_diffs(ctx: MigrationContext) -> None:
@@ -84,7 +99,7 @@ async def backfill_inline_history_diffs(ctx: MigrationContext) -> None:
                 continue
 
             await session.execute(
-                insert(SQLHistoryDiff)
+                insert(_history_diffs_at_backfill)
                 .values(change_id=change_id, diff=diff)
                 .on_conflict_do_nothing(index_elements=["change_id"]),
             )

--- a/virtool/history/sql.py
+++ b/virtool/history/sql.py
@@ -17,17 +17,22 @@ from sqlalchemy.orm import Mapped, mapped_column
 from virtool.pg.base import Base
 
 
-class SQLHistoryDiff(Base):
+class SQLLegacyHistoryDiff(Base):
     """A SQL model for storing history diffs.
 
     This is a temporary table and should be removed after history has been completely
     reimplemented in Postgres.
+
+    Diffs are keyed by ``history_id``, an integer foreign key to ``legacy_history.id``.
+    The old string ``change_id`` column is retained during the migration and dropped in
+    a later cleanup revision.
     """
 
-    __tablename__ = "history_diffs"
+    __tablename__ = "legacy_history_diff"
 
     id = Column(Integer, primary_key=True)
     change_id = Column(String, unique=True)
+    history_id = Column(BigInteger, ForeignKey("legacy_history.id"), unique=True)
     diff = Column(JSONB)
 
 

--- a/virtool/history/transforms.py
+++ b/virtool/history/transforms.py
@@ -3,8 +3,9 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.topg import compose_legacy_id_single_expression
 from virtool.data.transforms import AbstractTransform
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.types import Document
 
 
@@ -16,15 +17,14 @@ class AttachDiffTransform(AbstractTransform):
         return {**document, "diff": prepared}
 
     async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
-        if document["diff"] != "postgres":
-            raise ValueError(
-                f"Unexpected inline diff for change {document['id']}; "
-                "expected 'postgres' sentinel",
-            )
-
         result = await session.execute(
-            select(SQLHistoryDiff.diff).where(
-                SQLHistoryDiff.change_id == document["id"],
+            select(SQLLegacyHistoryDiff.diff)
+            .join(
+                SQLLegacyHistory,
+                SQLLegacyHistoryDiff.history_id == SQLLegacyHistory.id,
+            )
+            .where(
+                compose_legacy_id_single_expression(SQLLegacyHistory, document["id"]),
             ),
         )
 

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -164,8 +164,9 @@ class IsolatesView(PydanticView):
 
         """
         mongo = get_mongo_from_req(self.request)
+        pg: AsyncEngine = self.request.app["pg"]
 
-        document = await virtool.otus.db.join_and_format(mongo, otu_id)
+        document = await virtool.otus.db.join_and_format(mongo, pg, otu_id)
 
         if not document:
             raise APINotFound()

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -62,7 +62,7 @@ class OTUData:
         :param otu_id: the ID of the OTU to get
         :return: the OTU
         """
-        document = await virtool.otus.db.join_and_format(self._mongo, otu_id)
+        document = await virtool.otus.db.join_and_format(self._mongo, self._pg, otu_id)
 
         if document is None:
             raise ResourceNotFoundError
@@ -74,7 +74,7 @@ class OTUData:
                 self._pg,
             ),
             virtool.history.db.get_most_recent_change(
-                self._mongo,
+                self._pg,
                 otu_id,
             ),
         )
@@ -548,6 +548,7 @@ class OTUData:
 
         complete = await virtool.otus.db.join_and_format(
             self._mongo,
+            self._pg,
             otu_id,
             joined=new,
         )

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 import virtool.history.db
 import virtool.otus.utils
@@ -219,6 +220,7 @@ async def bulk_join_documents(
 
 async def join_and_format(
     mongo: "Mongo",
+    pg: AsyncEngine,
     otu_id: str,
     joined: dict | None = None,
     issues: dict | bool | None = False,
@@ -229,6 +231,7 @@ async def join_and_format(
     format the joined otu into a format that can be directly returned to API clients.
 
     :param mongo: the application database client
+    :param pg: the application PostgreSQL database object
     :param otu_id: the id of the otu to join
     :param joined:
     :param issues: an object describing issues in the otu
@@ -240,7 +243,7 @@ async def join_and_format(
     if not joined:
         return None
 
-    most_recent_change = await virtool.history.db.get_most_recent_change(mongo, otu_id)
+    most_recent_change = await virtool.history.db.get_most_recent_change(pg, otu_id)
 
     if issues is False:
         issues = await verify(mongo, otu_id)

--- a/virtool/references/bulk.py
+++ b/virtool/references/bulk.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.history.db import prepare_add
-from virtool.history.sql import SQLHistoryDiff
+from virtool.history.sql import SQLLegacyHistoryDiff
 from virtool.mongo.core import Collection, Mongo
 from virtool.mongo.identifier import AbstractIdProvider
 from virtool.otus.db import bulk_join_ids, bulk_join_query
@@ -176,7 +176,7 @@ class OTUDataBuffer(BaseDataBuffer):
         ):
             async with pg_lock:
                 await pg_session.execute(
-                    insert(SQLHistoryDiff).values(
+                    insert(SQLLegacyHistoryDiff).values(
                         [
                             {"change_id": change.data.id, "diff": change.data.diff}
                             for change in change_buffer


### PR DESCRIPTION
## Summary
- Move the two single-record history reads (`HistoryData.get` and `get_most_recent_change`) off Mongo onto the `legacy_history` table, still addressed externally by `legacy_id`.
- Re-key the diff side table from the string `change_id` to an integer `history_id` FK into `legacy_history.id` and rename it `legacy_history_diff` (Alembic revision backfills `history_id`; the old `change_id` column is kept for a later cleanup revision). Writers set `history_id`; readers join on it.
- Part of step 4 of the History → Postgres migration (VIR-2499).