### PR TITLE
Switch cross-domain history reads to Postgres

### DIFF
--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -54,6 +54,11 @@
     }),
     'modified_otu_count': 0,
     'otus': list([
+      dict({
+        'change_count': 1,
+        'id': 'otu_1',
+        'name': 'Tobacco mosaic virus',
+      }),
     ]),
     'ready': False,
     'reference': dict({

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -18,6 +18,7 @@ from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from tests.fixtures.response import RespIs
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.history.db import legacy_history_values
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import INDEX_FILE_NAMES
 from virtool.indexes.files import create_index_file
@@ -46,6 +47,7 @@ class TestFind:
         fake: DataFaker,
         mocker: MockerFixture,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
@@ -159,6 +161,37 @@ class TestFind:
                 session=None,
             ),
         )
+
+        index_references = {
+            "idx_active_a": "ref_active_a",
+            "idx_active_b": "ref_active_b",
+        }
+
+        async with AsyncSession(pg) as session:
+            session.add_all(
+                SQLLegacyHistory(
+                    legacy_id=legacy_id,
+                    created_at=static_time.datetime,
+                    description="Description",
+                    method_name="edit",
+                    user_id=user.id,
+                    otu=otu_id,
+                    otu_name=otu_id,
+                    otu_version="0",
+                    reference=index_references[index_id],
+                    index=index_id,
+                    index_version="0",
+                )
+                for legacy_id, index_id, otu_id in (
+                    ("0", "idx_active_a", "otu_1"),
+                    ("1", "idx_active_b", "otu_1"),
+                    ("2", "idx_active_a", "otu_2"),
+                    ("3", "idx_active_a", "otu_1"),
+                    ("4", "idx_active_a", "otu_3"),
+                    ("5", "idx_active_b", "otu_4"),
+                )
+            )
+            await session.commit()
 
         mocker.patch(
             "virtool.indexes.db.get_unbuilt_stats",
@@ -543,6 +576,7 @@ async def test_find_history(
     static_time,
     snapshot,
     mongo: Mongo,
+    pg: AsyncEngine,
     spawn_client: ClientSpawner,
     resp_is,
 ):
@@ -554,52 +588,51 @@ async def test_find_history(
     user_1 = await fake.users.create()
     user_2 = await fake.users.create()
 
+    history_documents = [
+        {
+            "_id": "zxbbvngc.0",
+            "created_at": static_time.datetime,
+            "reference": {"id": "foo"},
+            "otu": {"version": 0, "name": "Test", "id": "zxbbvngc"},
+            "user": {"id": user_1.id},
+            "description": "Added Unnamed Isolate as default",
+            "method_name": "add_isolate",
+            "index": {"version": 0, "id": "foobar"},
+        },
+        {
+            "_id": "zxbbvngc.1",
+            "created_at": static_time.datetime,
+            "reference": {"id": "foo"},
+            "otu": {"version": 1, "name": "Test", "id": "zxbbvngc"},
+            "user": {"id": user_1.id},
+            "description": "Added Unnamed Isolate as default",
+            "method_name": "add_isolate",
+            "index": {"version": 0, "id": "foobar"},
+        },
+        {
+            "_id": "zxbbvngc.2",
+            "created_at": static_time.datetime,
+            "reference": {"id": "foo"},
+            "otu": {"version": 2, "name": "Test", "id": "zxbbvngc"},
+            "user": {"id": user_2.id},
+            "description": "Added Unnamed Isolate as default",
+            "method_name": "add_isolate",
+            "index": {"version": 0, "id": "foobar"},
+        },
+        {
+            "_id": "kjs8sa99.3",
+            "created_at": static_time.datetime,
+            "reference": {"id": "foo"},
+            "otu": {"version": 3, "name": "Foo", "id": "kjs8sa99"},
+            "user": {"id": user_1.id},
+            "description": "Edited sequence wrta20tr in Islolate chilli-CR",
+            "method_name": "edit_sequence",
+            "index": {"version": 0, "id": "foobar"},
+        },
+    ]
+
     await asyncio.gather(
-        mongo.history.insert_many(
-            [
-                {
-                    "_id": "zxbbvngc.0",
-                    "created_at": static_time.datetime,
-                    "reference": {"id": "foo"},
-                    "otu": {"version": 0, "name": "Test", "id": "zxbbvngc"},
-                    "user": {"id": user_1.id},
-                    "description": "Added Unnamed Isolate as default",
-                    "method_name": "add_isolate",
-                    "index": {"version": 0, "id": "foobar"},
-                },
-                {
-                    "_id": "zxbbvngc.1",
-                    "created_at": static_time.datetime,
-                    "reference": {"id": "foo"},
-                    "otu": {"version": 1, "name": "Test", "id": "zxbbvngc"},
-                    "user": {"id": user_1.id},
-                    "description": "Added Unnamed Isolate as default",
-                    "method_name": "add_isolate",
-                    "index": {"version": 0, "id": "foobar"},
-                },
-                {
-                    "_id": "zxbbvngc.2",
-                    "created_at": static_time.datetime,
-                    "reference": {"id": "foo"},
-                    "otu": {"version": 2, "name": "Test", "id": "zxbbvngc"},
-                    "user": {"id": user_2.id},
-                    "description": "Added Unnamed Isolate as default",
-                    "method_name": "add_isolate",
-                    "index": {"version": 0, "id": "foobar"},
-                },
-                {
-                    "_id": "kjs8sa99.3",
-                    "created_at": static_time.datetime,
-                    "reference": {"id": "foo"},
-                    "otu": {"version": 3, "name": "Foo", "id": "kjs8sa99"},
-                    "user": {"id": user_1.id},
-                    "description": "Edited sequence wrta20tr in Islolate chilli-CR",
-                    "method_name": "edit_sequence",
-                    "index": {"version": 0, "id": "foobar"},
-                },
-            ],
-            session=None,
-        ),
+        mongo.history.insert_many(history_documents, session=None),
         mongo.references.insert_many(
             [
                 {"_id": "bar", "archived": False, "data_type": "genome", "name": "Bar"},
@@ -608,6 +641,13 @@ async def test_find_history(
             session=None,
         ),
     )
+
+    async with AsyncSession(pg) as session:
+        session.add_all(
+            SQLLegacyHistory(**legacy_history_values(document))
+            for document in history_documents
+        )
+        await session.commit()
 
     resp = await client.get("/indexes/foobar/history")
 

--- a/tests/otus/__snapshots__/test_api.ambr
+++ b/tests/otus/__snapshots__/test_api.ambr
@@ -2805,6 +2805,130 @@
     'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',
   })
 # ---
+# name: TestListHistory.test_ok
+  list([
+    dict({
+      'created_at': 'approximately_now_isoformat',
+      'description': 'Created new sequence NC_772442 in Isolate Important',
+      'id': 'bf1b993c.4',
+      'index': dict({
+        'id': 'unbuilt',
+        'version': 'unbuilt',
+      }),
+      'method_name': 'create_sequence',
+      'otu': dict({
+        'id': 'bf1b993c',
+        'name': 'Pepper bunchy top virus',
+        'version': 4,
+      }),
+      'reference': dict({
+        'data_type': 'genome',
+        'id': 'hxn167',
+        'name': 'Reference A',
+      }),
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+    }),
+    dict({
+      'created_at': 'approximately_now_isoformat',
+      'description': 'Created new sequence NC_688181 in Isolate Important',
+      'id': 'bf1b993c.3',
+      'index': dict({
+        'id': 'unbuilt',
+        'version': 'unbuilt',
+      }),
+      'method_name': 'create_sequence',
+      'otu': dict({
+        'id': 'bf1b993c',
+        'name': 'Pepper bunchy top virus',
+        'version': 3,
+      }),
+      'reference': dict({
+        'data_type': 'genome',
+        'id': 'hxn167',
+        'name': 'Reference A',
+      }),
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+    }),
+    dict({
+      'created_at': 'approximately_now_isoformat',
+      'description': 'Created new sequence VC280715 in Isolate Important',
+      'id': 'bf1b993c.2',
+      'index': dict({
+        'id': 'unbuilt',
+        'version': 'unbuilt',
+      }),
+      'method_name': 'create_sequence',
+      'otu': dict({
+        'id': 'bf1b993c',
+        'name': 'Pepper bunchy top virus',
+        'version': 2,
+      }),
+      'reference': dict({
+        'data_type': 'genome',
+        'id': 'hxn167',
+        'name': 'Reference A',
+      }),
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+    }),
+    dict({
+      'created_at': 'approximately_now_isoformat',
+      'description': 'Added Isolate Important as default',
+      'id': 'bf1b993c.1',
+      'index': dict({
+        'id': 'unbuilt',
+        'version': 'unbuilt',
+      }),
+      'method_name': 'add_isolate',
+      'otu': dict({
+        'id': 'bf1b993c',
+        'name': 'Pepper bunchy top virus',
+        'version': 1,
+      }),
+      'reference': dict({
+        'data_type': 'genome',
+        'id': 'hxn167',
+        'name': 'Reference A',
+      }),
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+    }),
+    dict({
+      'created_at': 'approximately_now_isoformat',
+      'description': 'Created Pepper bunchy top virus (PBTV)',
+      'id': 'bf1b993c.0',
+      'index': dict({
+        'id': 'unbuilt',
+        'version': 'unbuilt',
+      }),
+      'method_name': 'create',
+      'otu': dict({
+        'id': 'bf1b993c',
+        'name': 'Pepper bunchy top virus',
+        'version': 0,
+      }),
+      'reference': dict({
+        'data_type': 'genome',
+        'id': 'hxn167',
+        'name': 'Reference A',
+      }),
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+    }),
+  ])
+# ---
 # name: TestListIsolates.test_ok[json]
   list([
     dict({

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -57,6 +57,42 @@ class TestGet:
         await resp_is.not_found(resp)
 
 
+class TestListHistory:
+    async def test_ok(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        snapshot_recent: SnapshotAssertion,
+        spawn_client: ClientSpawner,
+        test_ref: dict,
+    ):
+        """Test that an OTU's history is listed from Postgres."""
+        client = await spawn_client(authenticated=True)
+
+        await asyncio.gather(
+            fake.users.create(),
+            mongo.references.insert_one({**test_ref}),
+        )
+
+        user = await data_layer.users.get(client.user.id)
+
+        otu = await fake.otus.create(test_ref["_id"], user=user)
+
+        resp = await client.get(f"/otus/{otu.id}/history")
+
+        assert resp.status == HTTPStatus.OK
+        assert await resp.json() == snapshot_recent
+
+    async def test_not_found(self, spawn_client: ClientSpawner, resp_is: RespIs):
+        """Test that listing history for a non-existent OTU results in a ``404``."""
+        client = await spawn_client(authenticated=True)
+
+        resp = await client.get("/otus/foobar/history")
+
+        await resp_is.not_found(resp)
+
+
 class TestEdit:
     @pytest.mark.parametrize(
         ("data", "existing_abbreviation", "description"),

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -1201,6 +1201,11 @@
     }),
     'modified_otu_count': 0,
     'otus': list([
+      dict({
+        'change_count': 1,
+        'id': 'otu_1',
+        'name': 'Tobacco mosaic virus',
+      }),
     ]),
     'ready': False,
     'reference': dict({

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import Integer, cast, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.utils
@@ -12,7 +12,7 @@ from virtool.data.topg import (
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
 from virtool.history.db import delete_history, legacy_history_document, patch_to_version
-from virtool.history.models import History, HistorySearchResult
+from virtool.history.models import History, HistoryMinimal, HistorySearchResult
 from virtool.history.sql import SQLLegacyHistory
 from virtool.history.transforms import AttachDiffTransform
 from virtool.mongo.core import Mongo
@@ -37,6 +37,44 @@ class HistoryData:
         documents = await virtool.history.db.find(self._mongo, self._pg, req_query)
 
         return HistorySearchResult(**documents)
+
+    async def list_by_otu(self, otu_id: str) -> list[HistoryMinimal]:
+        """List all changes affecting a single OTU.
+
+        Changes are read from the ``legacy_history`` table and sorted by OTU version
+        descending with a deterministic ``id`` tiebreaker.
+
+        :param otu_id: the ID of the OTU
+        :return: the OTU's changes
+        """
+        if not await self._mongo.otus.count_documents({"_id": otu_id}, limit=1):
+            raise ResourceNotFoundError()
+
+        async with AsyncSession(self._pg) as session:
+            rows = (
+                await session.execute(
+                    select(SQLLegacyHistory, SQLUser.handle)
+                    .join(SQLUser, SQLLegacyHistory.user_id == SQLUser.id)
+                    .where(SQLLegacyHistory.otu == otu_id)
+                    .order_by(
+                        cast(SQLLegacyHistory.otu_version, Integer)
+                        .desc()
+                        .nulls_first(),
+                        SQLLegacyHistory.id.desc(),
+                    ),
+                )
+            ).all()
+
+        documents = await apply_transforms(
+            [
+                base_processor(legacy_history_document(row, handle))
+                for row, handle in rows
+            ],
+            [AttachReferenceTransform(self._mongo)],
+            self._pg,
+        )
+
+        return [HistoryMinimal(**document) for document in documents]
 
     async def get(self, change_id: str) -> History:
         """Get a change by its ID.

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -468,6 +468,89 @@ async def find(
     }
 
 
+async def find_by_index(
+    mongo: "Mongo",
+    pg: AsyncEngine,
+    index_id: str,
+    req_query,
+    term: str | None = None,
+) -> dict:
+    """List the history changes included in a single index build.
+
+    Changes are read from the ``legacy_history`` table, filtered to ``index_id`` and
+    optionally a search ``term`` matched against the OTU name. They are sorted by OTU
+    name ascending then OTU version descending, mirroring the legacy Mongo query.
+
+    The legacy Mongo query also matched ``term`` against ``user.id``, but that field is
+    now an integer foreign key and never matched the case-insensitive regex, so only the
+    OTU name is searched here.
+
+    ``total_count`` reflects every change in the table, mirroring the unscoped
+    ``base_query`` the previous Mongo implementation passed to ``paginate``.
+
+    :param mongo: the application database client, used to attach reference data
+    :param pg: the application PostgreSQL database object
+    :param index_id: restrict changes to a single index build
+    :param req_query: the raw request query, used to derive ``page`` and ``per_page``
+    :param term: an optional term matched against the OTU name
+    :return: a search result including the matched change documents
+    """
+    try:
+        page = int(req_query["page"])
+    except (KeyError, ValueError):
+        page = 1
+
+    try:
+        per_page = int(req_query["per_page"])
+    except (KeyError, ValueError):
+        per_page = 25
+
+    search_filters = [SQLLegacyHistory.index == index_id]
+
+    if term:
+        search_filters.append(
+            SQLLegacyHistory.otu_name.icontains(term, autoescape=True)
+        )
+
+    async with AsyncSession(pg) as session:
+        total_count = await session.scalar(
+            select(func.count()).select_from(SQLLegacyHistory),
+        )
+
+        found_count = await session.scalar(
+            select(func.count()).select_from(SQLLegacyHistory).where(*search_filters),
+        )
+
+        rows = (
+            await session.execute(
+                select(SQLLegacyHistory, SQLUser.handle)
+                .join(SQLUser, SQLLegacyHistory.user_id == SQLUser.id)
+                .where(*search_filters)
+                .order_by(
+                    SQLLegacyHistory.otu_name.asc(),
+                    cast(SQLLegacyHistory.otu_version, Integer).desc().nulls_last(),
+                )
+                .offset(per_page * (page - 1))
+                .limit(per_page),
+            )
+        ).all()
+
+    documents = await apply_transforms(
+        [base_processor(legacy_history_document(row, handle)) for row, handle in rows],
+        [AttachReferenceTransform(mongo)],
+        pg,
+    )
+
+    return {
+        "documents": documents,
+        "total_count": total_count,
+        "found_count": found_count,
+        "page_count": math.ceil(found_count / per_page),
+        "per_page": per_page,
+        "page": page,
+    }
+
+
 async def get_contributors(
     pg: AsyncEngine,
     reference_id: str | None = None,

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -11,7 +11,6 @@ from structlog import get_logger
 import virtool.history.db
 import virtool.indexes.db
 from virtool.api.custom_json import dump_bytes
-from virtool.api.utils import compose_regex_query, paginate
 from virtool.config import Config
 from virtool.data.errors import (
     ResourceConflictError,
@@ -20,7 +19,6 @@ from virtool.data.errors import (
 )
 from virtool.data.events import Operation, emit, emits
 from virtool.data.transforms import apply_transforms
-from virtool.history.db import HISTORY_LIST_PROJECTION
 from virtool.history.models import HistorySearchResult
 from virtool.indexes.checks import check_fasta_file_uploaded, check_index_files_uploaded
 from virtool.indexes.db import (
@@ -37,7 +35,6 @@ from virtool.mongo.utils import get_one_field
 from virtool.pg.utils import get_rows
 from virtool.references.db import compose_archived_filter, lookup_nested_reference_by_id
 from virtool.references.models import ReferenceNested
-from virtool.references.transforms import AttachReferenceTransform
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
@@ -136,7 +133,7 @@ class IndexData:
 
         contributors, otus = await asyncio.gather(
             virtool.history.db.get_contributors(self._pg, index_id=index_id),
-            virtool.indexes.db.get_otus(self._mongo, index_id),
+            virtool.indexes.db.get_otus(self._pg, index_id),
         )
 
         document.update({"contributors": contributors, "otus": otus})
@@ -344,24 +341,12 @@ class IndexData:
         if not await self._mongo.indexes.count_documents({"_id": index_id}):
             raise ResourceNotFoundError()
 
-        db_query = {"index.id": index_id}
-
-        if term := req_query.get("term"):
-            db_query.update(compose_regex_query(term, ["otu.name", "user.id"]))
-
-        data = await paginate(
-            self._mongo.history,
-            db_query,
-            req_query,
-            sort=[("otu.name", 1), ("otu.version", -1)],
-            projection=HISTORY_LIST_PROJECTION,
-            reverse=True,
-        )
-
-        data["documents"] = await apply_transforms(
-            [base_processor(d) for d in data["documents"]],
-            [AttachReferenceTransform(self._mongo), AttachUserTransform(self._pg)],
+        data = await virtool.history.db.find_by_index(
+            self._mongo,
             self._pg,
+            index_id,
+            req_query,
+            req_query.get("term"),
         )
 
         return HistorySearchResult(**data)

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pymongo
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import update
+from sqlalchemy import Integer, cast, distinct, func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
@@ -73,25 +73,25 @@ class IndexFilesTransform(AbstractTransform):
 
 
 class IndexCountsTransform(AbstractTransform):
-    """Attaches modification counts to index documents based on OTU collection
-    queries.
-    """
-
-    def __init__(self, mongo: "Mongo"):
-        self._mongo = mongo
+    """Attaches modification counts to index documents from the legacy history table."""
 
     async def attach_one(self, document: Document, prepared: Any) -> Document:
         return {**document, **prepared}
 
     async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
-        query = {"index.id": document["id"]}
+        change_count, modified_otu_count = (
+            await session.execute(
+                select(
+                    func.count(),
+                    func.count(distinct(SQLLegacyHistory.otu)),
+                ).where(SQLLegacyHistory.index == document["id"]),
+            )
+        ).one()
 
-        change_count, otu_ids = await asyncio.gather(
-            self._mongo.history.count_documents(query),
-            self._mongo.history.distinct("otu.id", query),
-        )
-
-        return {"change_count": change_count, "modified_otu_count": len(otu_ids)}
+        return {
+            "change_count": change_count,
+            "modified_otu_count": modified_otu_count,
+        }
 
 
 async def create(
@@ -221,7 +221,7 @@ async def find(
         sort="version",
     )
 
-    unbuilt_stats = await get_unbuilt_stats(mongo, ref_id)
+    unbuilt_stats = await get_unbuilt_stats(mongo, pg, ref_id)
 
     return {
         **data,
@@ -232,7 +232,7 @@ async def find(
                 AttachJobTransform(pg),
                 AttachReferenceTransform(mongo),
                 AttachUserTransform(pg),
-                IndexCountsTransform(mongo),
+                IndexCountsTransform(),
             ],
             pg,
         ),
@@ -263,33 +263,46 @@ async def get_current_id_and_version(
     return document["_id"], document["version"]
 
 
-async def get_otus(mongo: "Mongo", index_id: str) -> list[dict]:
+async def get_otus(pg: AsyncEngine, index_id: str) -> list[dict]:
     """Return a list of otus and number of changes for a specific index.
 
-    :param mongo: the application database client
+    The OTU name is taken from the change with the highest ``otu_version``, mirroring
+    the Mongo aggregation's ``$first`` after sorting by version descending. OTUs whose
+    latest change has no name are excluded.
+
+    :param pg: the application PostgreSQL database object
     :param index_id: the id of the index to get otus for
 
     :return: a list of otus modified in the index
 
     """
-    pipeline = [
-        {"$match": {"index.id": index_id}},
-        {"$sort": {"otu.id": 1, "otu.version": -1}},
-        {
-            "$group": {
-                "_id": "$otu.id",
-                "name": {"$first": "$otu.name"},
-                "count": {"$sum": 1},
-            },
-        },
-        {"$match": {"name": {"$ne": None}}},
-        {"$sort": {"name": 1}},
-    ]
+    async with AsyncSession(pg) as session:
+        rows = (
+            await session.execute(
+                select(
+                    SQLLegacyHistory.otu,
+                    SQLLegacyHistory.otu_name,
+                    func.count()
+                    .over(partition_by=SQLLegacyHistory.otu)
+                    .label("change_count"),
+                )
+                .where(SQLLegacyHistory.index == index_id)
+                .distinct(SQLLegacyHistory.otu)
+                .order_by(
+                    SQLLegacyHistory.otu,
+                    cast(SQLLegacyHistory.otu_version, Integer).desc().nulls_last(),
+                ),
+            )
+        ).all()
 
-    return [
-        {"id": otu["_id"], "name": otu["name"], "change_count": otu["count"]}
-        async for otu in mongo.history.aggregate(pipeline)
-    ]
+    return sorted(
+        (
+            {"id": row.otu, "name": row.otu_name, "change_count": row.change_count}
+            for row in rows
+            if row.otu_name is not None
+        ),
+        key=lambda otu: otu["name"],
+    )
 
 
 async def get_next_version(mongo: "Mongo", ref_id: str) -> int:
@@ -304,31 +317,44 @@ async def get_next_version(mongo: "Mongo", ref_id: str) -> int:
     return await mongo.indexes.count_documents({"reference.id": ref_id, "ready": True})
 
 
-async def get_unbuilt_stats(mongo: "Mongo", ref_id: str | None = None) -> dict:
+async def get_unbuilt_stats(
+    mongo: "Mongo",
+    pg: AsyncEngine,
+    ref_id: str | None = None,
+) -> dict:
     """Get the number of unbuilt changes and number of OTUs affected by those changes.
 
-    Used to populate the metadata for an index find request.Can search against a
+    Used to populate the metadata for an index find request. Can search against a
     specific reference or all references.
 
     :param mongo: the application mongodb client
+    :param pg: the application PostgreSQL database object
     :param ref_id: the ref id to search unbuilt changes for
 
     :return: the change count and modified OTU count
 
     """
     ref_query = {}
+    history_filters = [SQLLegacyHistory.index.is_(None)]
 
     if ref_id:
         ref_query["reference.id"] = ref_id
+        history_filters.append(SQLLegacyHistory.reference == ref_id)
 
-    history_query = {**ref_query, "index.id": "unbuilt"}
+    async with AsyncSession(pg) as session:
+        change_count, modified_otu_count = (
+            await session.execute(
+                select(
+                    func.count(),
+                    func.count(distinct(SQLLegacyHistory.otu)),
+                ).where(*history_filters),
+            )
+        ).one()
 
     return {
         "total_otu_count": await mongo.otus.count_documents(ref_query),
-        "change_count": await mongo.history.count_documents(history_query),
-        "modified_otu_count": len(
-            await mongo.history.distinct("otu.id", history_query),
-        ),
+        "change_count": change_count,
+        "modified_otu_count": modified_otu_count,
     }
 
 

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -14,9 +14,7 @@ from virtool.api.errors import (
 )
 from virtool.api.routes import Routes
 from virtool.data.errors import ResourceNotFoundError
-from virtool.data.transforms import apply_transforms
 from virtool.data.utils import get_data_from_req
-from virtool.history.db import HISTORY_LIST_PROJECTION
 from virtool.mongo.utils import get_mongo_from_req, get_one_field
 from virtool.otus.db import SEQUENCE_PROJECTION
 from virtool.otus.models import OTU, OTUIsolate, OTUSequence, Sequence
@@ -28,7 +26,6 @@ from virtool.otus.oas import (
     UpdateSequenceRequest,
 )
 from virtool.otus.utils import evaluate_changes, find_isolate
-from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
 
 routes = Routes()
@@ -592,26 +589,14 @@ async def list_history(req):
 
     Lists an OTU's history.
     """
-    mongo = get_mongo_from_req(req)
-    pg: AsyncEngine = req.app["pg"]
-
     otu_id = req.match_info["otu_id"]
 
-    if not await mongo.otus.count_documents({"_id": otu_id}, limit=1):
+    try:
+        changes = await get_data_from_req(req).history.list_by_otu(otu_id)
+    except ResourceNotFoundError:
         raise APINotFound()
 
-    documents = await mongo.history.find(
-        {"otu.id": otu_id},
-        projection=HISTORY_LIST_PROJECTION,
-    ).to_list(None)
-
-    return json_response(
-        await apply_transforms(
-            [base_processor(d) for d in documents],
-            [AttachUserTransform(pg, ignore_errors=True)],
-            pg,
-        ),
-    )
+    return json_response(changes)
 
 
 @routes.put("/otus/{otu_id}/isolates/{isolate_id}/default")

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -54,7 +54,7 @@ class OTUData:
         self, query: Mapping, term: str | None, verified: bool | None
     ) -> dict[str, Any] | list[dict | None]:
         """Find OTUs matching the given query."""
-        return await virtool.otus.db.find(self._mongo, term, query, verified)
+        return await virtool.otus.db.find(self._mongo, self._pg, term, query, verified)
 
     async def get(self, otu_id: str) -> OTU:
         """Get a single OTU by ID.

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -4,13 +4,15 @@ from collections.abc import Mapping
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy import distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
 import virtool.otus.utils
 from virtool.api.utils import compose_regex_query, paginate
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
+from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.references.transforms import AttachReferenceTransform
@@ -68,6 +70,7 @@ async def check_name_and_abbreviation(
 
 async def find(
     mongo: "Mongo",
+    pg: AsyncEngine,
     term: str | None,
     req_query: Mapping,
     verified: bool | None,
@@ -101,14 +104,17 @@ async def find(
         None,  # pg parameter - not needed for AttachReferenceTransform
     )
 
-    history_query = {"index.id": "unbuilt"}
+    history_filters = [SQLLegacyHistory.index.is_(None)]
 
     if ref_id:
-        history_query["reference.id"] = ref_id
+        history_filters.append(SQLLegacyHistory.reference == ref_id)
 
-    data["modified_count"] = len(
-        await mongo.history.distinct("otu.name", history_query),
-    )
+    async with AsyncSession(pg) as session:
+        data["modified_count"] = await session.scalar(
+            select(func.count(distinct(SQLLegacyHistory.otu_name))).where(
+                *history_filters,
+            ),
+        )
 
     return data
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -34,6 +34,7 @@ from virtool.history.db import (
     patch_to_version,
 )
 from virtool.history.models import HistorySearchResult
+from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.models import IndexMinimal, IndexSearchResult
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
@@ -346,7 +347,7 @@ class ReferencesData(DataLayerDomain):
             get_otu_count(self._mongo, ref_id),
             get_reference_groups(self._pg, document),
             get_reference_users(self._mongo, self._pg, document),
-            get_unbuilt_count(self._mongo, ref_id),
+            get_unbuilt_count(self._pg, ref_id),
         )
 
         document.update(
@@ -548,6 +549,7 @@ class ReferencesData(DataLayerDomain):
         if await virtool.mongo.utils.id_exists(self._mongo.references, ref_id):
             data = await virtool.otus.db.find(
                 self._mongo,
+                self._pg,
                 term,
                 query,
                 verified,
@@ -629,10 +631,19 @@ class ReferencesData(DataLayerDomain):
         ):
             raise ResourceError("There are unverified OTUs")
 
-        if not await self._mongo.history.count_documents(
-            {"reference.id": ref_id, "index.id": "unbuilt"},
-            limit=1,
-        ):
+        async with AsyncSession(self._pg) as session:
+            has_unbuilt = await session.scalar(
+                select(
+                    select(SQLLegacyHistory.id)
+                    .where(
+                        SQLLegacyHistory.reference == ref_id,
+                        SQLLegacyHistory.index.is_(None),
+                    )
+                    .exists(),
+                ),
+            )
+
+        if not has_unbuilt:
             raise ResourceError("There are no unbuilt changes")
 
         index_id = await virtool.mongo.utils.get_new_id(self._mongo.indexes)

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -10,7 +10,7 @@ from aiohttp.web import Request
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pymongo import DeleteMany, DeleteOne, UpdateOne
 from semver import VersionInfo
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
@@ -24,6 +24,7 @@ from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
 from virtool.history.db import bulk_delete_history, bulk_insert_history
+from virtool.history.sql import SQLLegacyHistory
 from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
@@ -73,7 +74,7 @@ async def processor(mongo: "Mongo", pg: AsyncEngine, document: Document) -> Docu
     latest_build, otu_count, unbuilt_count = await asyncio.gather(
         get_latest_build(mongo, pg, ref_id),
         get_otu_count(mongo, ref_id),
-        get_unbuilt_count(mongo, ref_id),
+        get_unbuilt_count(pg, ref_id),
     )
 
     document.update(
@@ -486,17 +487,23 @@ async def get_otu_count(mongo: "Mongo", ref_id: str) -> int:
     return await mongo.otus.count_documents({"reference.id": ref_id})
 
 
-async def get_unbuilt_count(mongo: "Mongo", ref_id: str) -> int:
+async def get_unbuilt_count(pg: AsyncEngine, ref_id: str) -> int:
     """Return a count of unbuilt history changes associated with a given `ref_id`.
 
-    :param mongo: the application database client
+    :param pg: the application PostgreSQL database object
     :param ref_id: the id of the ref to count unbuilt changes for
     :return: the number of unbuilt changes
 
     """
-    return await mongo.history.count_documents(
-        {"reference.id": ref_id, "index.id": "unbuilt"},
-    )
+    async with AsyncSession(pg) as session:
+        return await session.scalar(
+            select(func.count())
+            .select_from(SQLLegacyHistory)
+            .where(
+                SQLLegacyHistory.reference == ref_id,
+                SQLLegacyHistory.index.is_(None),
+            ),
+        )
 
 
 async def create_clone(


### PR DESCRIPTION
## Summary
- Move the history reads embedded in `indexes`, `otus`, and `references` from the Mongo `history` collection to the `legacy_history` Postgres table (VIR-2502, step 4 of the History → Postgres migration).
- Covers the index count/otu/unbuilt-stats reads, the OTU history endpoint and unbuilt distinct, the reference unbuilt guard and count, and the index history endpoint; writes remain dual-write and out of scope.
- The index history endpoint's term search now matches the OTU name only — its former `user.id` regex branch never matched an integer foreign key.