### PR TITLE
Count OTU list modified_count by OTU id, not name

### DIFF
--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -1,9 +1,13 @@
 import pytest
 from aiohttp.test_utils import make_mocked_coro
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.history.sql import SQLLegacyHistory
+from virtool.mongo.core import Mongo
 from virtool.otus.db import (
     check_name_and_abbreviation,
     check_sequence_segment,
+    find,
     increment_otu_version,
     join,
 )
@@ -85,3 +89,86 @@ class TestCheckSequenceSegment:
         await mongo.otus.insert_one({"_id": "foo", "schema": [{"name": "RNA1"}]})
 
         assert await check_sequence_segment(mongo, "foo", {}) is None
+
+
+class TestFindModifiedCount:
+    """``modified_count`` counts distinct modified OTU ids, not names.
+
+    Counting by name (the legacy behaviour) disagreed with the index metadata's
+    ``modified_otu_count`` whenever OTUs shared a name or were renamed across
+    versions.
+    """
+
+    async def _add_history(
+        self,
+        pg: AsyncEngine,
+        user_id: int,
+        created_at,
+        rows: list[tuple[str, str, str]],
+    ) -> None:
+        async with AsyncSession(pg) as session:
+            session.add_all(
+                SQLLegacyHistory(
+                    legacy_id=f"{otu}.{otu_version}",
+                    created_at=created_at,
+                    description="",
+                    method_name="edit",
+                    user_id=user_id,
+                    otu=otu,
+                    otu_name=otu_name,
+                    otu_version=otu_version,
+                    reference="reference",
+                    index=None,
+                    index_version=None,
+                )
+                for otu, otu_name, otu_version in rows
+            )
+            await session.commit()
+
+    async def test_shared_name_counted_separately(
+        self,
+        fake,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        """Two OTUs that share a name count as two modifications, not one."""
+        user = await fake.users.create()
+
+        await self._add_history(
+            pg,
+            user.id,
+            static_time.datetime,
+            [
+                ("first_otu", "Shared Name", "0"),
+                ("second_otu", "Shared Name", "0"),
+            ],
+        )
+
+        data = await find(mongo, pg, None, {}, None)
+
+        assert data["modified_count"] == 2
+
+    async def test_renamed_otu_counted_once(
+        self,
+        fake,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        """One OTU renamed across versions counts as a single modification."""
+        user = await fake.users.create()
+
+        await self._add_history(
+            pg,
+            user.id,
+            static_time.datetime,
+            [
+                ("renamed_otu", "Old Name", "0"),
+                ("renamed_otu", "New Name", "1"),
+            ],
+        )
+
+        data = await find(mongo, pg, None, {}, None)
+
+        assert data["modified_count"] == 1

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -111,7 +111,7 @@ async def find(
 
     async with AsyncSession(pg) as session:
         data["modified_count"] = await session.scalar(
-            select(func.count(distinct(SQLLegacyHistory.otu_name))).where(
+            select(func.count(distinct(SQLLegacyHistory.otu))).where(
                 *history_filters,
             ),
         )


### PR DESCRIPTION
## Summary
- Count the OTU list's `modified_count` by distinct OTU id rather than distinct OTU name, so it agrees with the index metadata's `modified_otu_count` (which already counts by id). The two previously diverged when OTUs shared a name or were renamed across versions.
- Add regression tests covering both divergence modes: OTUs sharing a name are counted separately, and an OTU renamed across versions is counted once.

Deferred from #3607 (VIR-2502), where changing count semantics was out of scope for a read migration meant to preserve identical results.