### PR TITLE
Read patch_to_version change list from Postgres

### DIFF
--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -419,3 +419,58 @@
     '6116cba1.2',
   ])
 # ---
+# name: test_patch_to_version_intermediate[current]
+  dict({
+    '_id': '6116cba1',
+    'abbreviation': 'TST',
+    'imported': True,
+    'isolates': list([
+    ]),
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Test Virus',
+    'reference': dict({
+      'id': 'hxn167',
+    }),
+    'schema': list([
+    ]),
+    'verified': False,
+    'version': 3,
+  })
+# ---
+# name: test_patch_to_version_intermediate[patched]
+  dict({
+    '_id': '6116cba1',
+    'abbreviation': 'TST',
+    'imported': True,
+    'isolates': list([
+      dict({
+        'default': True,
+        'id': 'cab8b360',
+        'sequences': list([
+          dict({
+            '_id': 'KX269872',
+            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
+            'host': 'sweet cherry',
+            'isolate_id': 'cab8b360',
+            'otu_id': '6116cba1',
+            'segment': None,
+            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
+          }),
+        ]),
+        'source_name': '8816-v2',
+        'source_type': 'isolate',
+      }),
+    ]),
+    'last_indexed_version': 0,
+    'lower_name': 'prunus virus f',
+    'name': 'Test Virus',
+    'reference': dict({
+      'id': 'hxn167',
+    }),
+    'schema': list([
+    ]),
+    'verified': False,
+    'version': 2,
+  })
+# ---

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -329,18 +329,40 @@ async def test_patch_to_version(
     assert reverted_change_ids == snapshot(name="reverted_change_ids")
 
 
-async def test_patch_to_version_missing_diff(mongo: Mongo, pg: AsyncEngine):
-    """A change with the ``"postgres"`` sentinel but no ``SQLLegacyHistoryDiff`` row
-    raises a clear error instead of failing later with a ``KeyError``.
+async def test_patch_to_version_intermediate(
+    create_mock_history,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    snapshot: SnapshotAssertion,
+):
+    """Patching to an intermediate version reverts only the changes above it, stopping
+    at the first change at or below the target version.
     """
-    await mongo.history.insert_one(
-        {
-            "_id": "6116cba1.1",
-            "diff": "postgres",
-            "method_name": "update",
-            "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-        },
+    await create_mock_history(remove=False)
+
+    current, patched, reverted_change_ids = await virtool.history.db.patch_to_version(
+        mongo,
+        pg,
+        "6116cba1",
+        2,
     )
+
+    assert reverted_change_ids == ["6116cba1.3"]
+    assert current == snapshot(name="current")
+    assert patched == snapshot(name="patched")
+
+
+async def test_patch_to_version_missing_diff(
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+):
+    """A ``legacy_history`` change with no matching ``SQLLegacyHistoryDiff`` row raises
+    a clear error instead of failing later with a ``KeyError``.
+    """
+    user = await fake.users.create()
+
+    await add_contribution(pg, "6116cba1.1", user.id, "hxn167")
 
     with pytest.raises(
         ValueError,
@@ -349,21 +371,15 @@ async def test_patch_to_version_missing_diff(mongo: Mongo, pg: AsyncEngine):
         await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)
 
 
-async def test_patch_to_version_inline_diff(mongo: Mongo, pg: AsyncEngine):
+async def test_resolve_diffs_inline_diff(pg: AsyncEngine):
     """A change holding an unbackfilled inline diff raises instead of being treated as
     a literal diff.
     """
-    await mongo.history.insert_one(
-        {
-            "_id": "6116cba1.1",
-            "diff": [["change", "version", [0, 1]]],
-            "method_name": "update",
-            "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-        },
-    )
-
     with pytest.raises(
         ValueError,
         match="Unexpected inline diff for change 6116cba1.1",
     ):
-        await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)
+        await virtool.history.db._resolve_diffs(
+            pg,
+            [{"_id": "6116cba1.1", "diff": [["change", "version", [0, 1]]]}],
+        )

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -661,6 +661,22 @@ async def get_most_recent_change(pg: AsyncEngine, otu_id: str) -> Document | Non
     }
 
 
+def _change_to_revert(row: SQLLegacyHistory) -> Document:
+    """Build the minimal change document that :func:`patch_to_version` reverts.
+
+    The shape mirrors the fields the revert loop and :func:`_resolve_diffs` read from a
+    Mongo history document: ``_id``, the ``"postgres"`` diff sentinel, ``method_name``,
+    and the coerced ``otu.version``. Keeping this construction in one place stops it from
+    silently drifting from what :func:`_resolve_diffs` expects.
+    """
+    return {
+        "_id": row.legacy_id,
+        "diff": "postgres",
+        "method_name": row.method_name,
+        "otu": {"version": coerce_otu_version(row.otu_version)},
+    }
+
+
 async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, object]:
     """Resolve the ``diff`` for each change, fetching Postgres-stored diffs in one query.
 
@@ -744,43 +760,29 @@ async def patch_to_version(
 
     patched = deepcopy(current)
 
-    async with AsyncSession(pg) as session:
-        rows = (
-            (
-                await session.execute(
-                    select(SQLLegacyHistory)
-                    .where(SQLLegacyHistory.otu == otu_id)
-                    .order_by(
-                        cast(SQLLegacyHistory.otu_version, Integer)
-                        .desc()
-                        .nulls_first(),
-                        SQLLegacyHistory.id.desc(),
-                    ),
-                )
-            )
-            .scalars()
-            .all()
-        )
-
-    # Collect the changes to revert, sorted by descending version. Iterate the
-    # ordered rows and stop at the first change at or below the target version,
-    # preserving the terminating break of the legacy Mongo cursor.
+    # Collect the changes to revert, sorted by descending version. Stream the ordered
+    # rows and stop at the first change at or below the target version, preserving the
+    # early break of the legacy Mongo cursor so a heavily-edited otu never loads its
+    # whole history.
     changes_to_revert = []
 
-    for row in rows:
-        otu_version = coerce_otu_version(row.otu_version)
+    async with AsyncSession(pg) as session:
+        result = await session.stream_scalars(
+            select(SQLLegacyHistory)
+            .where(SQLLegacyHistory.otu == otu_id)
+            .order_by(
+                cast(SQLLegacyHistory.otu_version, Integer).desc().nulls_first(),
+                SQLLegacyHistory.id.desc(),
+            ),
+        )
 
-        if otu_version == "removed" or otu_version > version:
-            changes_to_revert.append(
-                {
-                    "_id": row.legacy_id,
-                    "diff": "postgres",
-                    "method_name": row.method_name,
-                    "otu": {"version": otu_version},
-                },
-            )
-        else:
-            break
+        async for row in result:
+            otu_version = coerce_otu_version(row.otu_version)
+
+            if otu_version == "removed" or otu_version > version:
+                changes_to_revert.append(_change_to_revert(row))
+            else:
+                break
 
     diffs = await _resolve_diffs(pg, changes_to_revert)
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -346,6 +346,19 @@ def prepare_add(
     )
 
 
+def coerce_otu_version(otu_version: str | None) -> int | str:
+    """Reverse the ``legacy_history.otu_version`` sentinel-to-NULL convention.
+
+    A ``NULL`` ``otu_version`` becomes the ``"removed"`` sentinel and a stringified
+    numeric version is coerced back to an ``int`` so the reconstructed value matches
+    the historical Mongo representation.
+    """
+    if otu_version is None:
+        return "removed"
+
+    return int(otu_version) if otu_version.isdigit() else otu_version
+
+
 def legacy_history_document(row: SQLLegacyHistory, handle: str) -> Document:
     """Reconstruct a ``HISTORY_LIST_PROJECTION`` document from a ``legacy_history`` row.
 
@@ -357,12 +370,7 @@ def legacy_history_document(row: SQLLegacyHistory, handle: str) -> Document:
     The ``handle`` comes from a join on ``users`` so the nested user is fully populated
     without a follow-up transform.
     """
-    if row.otu_version is None:
-        otu_version: int | str = "removed"
-    else:
-        otu_version = (
-            int(row.otu_version) if row.otu_version.isdigit() else row.otu_version
-        )
+    otu_version = coerce_otu_version(row.otu_version)
 
     if row.index is None:
         index = {"id": "unbuilt", "version": "unbuilt"}
@@ -639,20 +647,17 @@ async def get_most_recent_change(pg: AsyncEngine, otu_id: str) -> Document | Non
     if row is None:
         return None
 
-    if row.otu_version is None:
-        otu_version: int | str = "removed"
-    else:
-        otu_version = (
-            int(row.otu_version) if row.otu_version.isdigit() else row.otu_version
-        )
-
     return {
         "_id": row.legacy_id,
         "created_at": row.created_at,
         "description": row.description,
         "method_name": row.method_name,
         "user": {"id": row.user_id},
-        "otu": {"id": row.otu, "name": row.otu_name, "version": otu_version},
+        "otu": {
+            "id": row.otu,
+            "name": row.otu_name,
+            "version": coerce_otu_version(row.otu_version),
+        },
     }
 
 
@@ -739,15 +744,41 @@ async def patch_to_version(
 
     patched = deepcopy(current)
 
-    # Collect the changes to revert, sorted by descending version.
+    async with AsyncSession(pg) as session:
+        rows = (
+            (
+                await session.execute(
+                    select(SQLLegacyHistory)
+                    .where(SQLLegacyHistory.otu == otu_id)
+                    .order_by(
+                        cast(SQLLegacyHistory.otu_version, Integer)
+                        .desc()
+                        .nulls_first(),
+                        SQLLegacyHistory.id.desc(),
+                    ),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    # Collect the changes to revert, sorted by descending version. Iterate the
+    # ordered rows and stop at the first change at or below the target version,
+    # preserving the terminating break of the legacy Mongo cursor.
     changes_to_revert = []
 
-    async for change in mongo.history.find(
-        {"otu.id": otu_id},
-        sort=[("otu.version", -1)],
-    ):
-        if change["otu"]["version"] == "removed" or change["otu"]["version"] > version:
-            changes_to_revert.append(change)
+    for row in rows:
+        otu_version = coerce_otu_version(row.otu_version)
+
+        if otu_version == "removed" or otu_version > version:
+            changes_to_revert.append(
+                {
+                    "_id": row.legacy_id,
+                    "diff": "postgres",
+                    "method_name": row.method_name,
+                    "otu": {"version": otu_version},
+                },
+            )
         else:
             break
 


### PR DESCRIPTION
## Summary
- Switch `patch_to_version`'s change-list read from the Mongo `history` collection to the `legacy_history` table (ordered by `otu_version` descending), completing the step-4 read switch for the History → Postgres migration.
- Iterate the ordered rows with the original append/break loop so the `"removed"` sentinel, the `version > target` check, and the terminating break are preserved exactly; diff resolution stays on Postgres via `_resolve_diffs`. The function signature is unchanged, so no call sites needed edits.
- Extract a shared `coerce_otu_version` helper (reused in `legacy_history_document` and `get_most_recent_change`), and update tests: add an intermediate-version case, reseed the missing-diff test against `legacy_history`, and move the inline-diff guard test to `_resolve_diffs` where that path is now reachable.