### PR TITLE
Dual-write samples to Mongo and Postgres

### DIFF
--- a/tests/labels/test_data.py
+++ b/tests/labels/test_data.py
@@ -1,0 +1,88 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from tests.fixtures.client import ClientSpawner
+from virtool.data.errors import ResourceNotFoundError
+from virtool.data.layer import DataLayer
+from virtool.fake.next import DataFaker
+from virtool.labels.sql import SQLLabel
+from virtool.models.enums import Permission
+from virtool.mongo.core import Mongo
+from virtool.samples.oas import CreateSampleRequest
+from virtool.samples.sql import SQLLegacySample, SQLLegacySampleLabel
+
+
+class TestDelete:
+    async def test_missing(self, data_layer: DataLayer):
+        """Deleting a non-existent label raises ``ResourceNotFoundError``."""
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.labels.delete(404)
+
+    async def test_removes_sample_label_join_rows(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """Deleting a label removes its ``legacy_sample_labels`` join rows and pulls
+        the label from sample documents in Mongo.
+        """
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        label = await fake.labels.create()
+        user = await fake.users.create()
+        upload = await fake.uploads.create(user=user)
+
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(
+                files=[upload.id],
+                labels=[label.id],
+                name="Labelled",
+            ),
+            client.user.id,
+            0,
+        )
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one()
+
+            assert (
+                await session.execute(
+                    select(SQLLegacySampleLabel).where(
+                        SQLLegacySampleLabel.label_id == label.id,
+                    ),
+                )
+            ).scalars().all() != []
+
+        await data_layer.labels.delete(label.id)
+
+        async with AsyncSession(pg) as session:
+            assert (
+                await session.execute(
+                    select(SQLLegacySampleLabel).where(
+                        SQLLegacySampleLabel.sample_id == legacy.id,
+                    ),
+                )
+            ).scalars().all() == []
+
+            assert (
+                await session.execute(
+                    select(SQLLabel).where(SQLLabel.id == label.id),
+                )
+            ).scalar_one_or_none() is None
+
+        stored = await mongo.samples.find_one({"_id": sample.id})
+
+        assert label.id not in stored["labels"]

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -96,11 +96,83 @@
   dict({
     'all_read': True,
     'all_write': True,
+    'artifacts': list([
+      dict({
+        'download_url': '/samples/test/artifacts/reference.fa.gz',
+        'id': 1,
+        'name': 'reference.fa.gz',
+        'size': 34879234,
+      }),
+    ]),
+    'created_at': '2015-10-06T20:00:00Z',
+    'format': 'fastq',
     'group': None,
     'group_read': True,
     'group_write': True,
-    'user': dict({
+    'hold': False,
+    'host': '',
+    'id': 'test',
+    'is_legacy': False,
+    'isolate': '',
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
       'id': 1,
+      'progress': 100,
+      'state': 'failed',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'create_sample',
+    }),
+    'labels': list([
+      dict({
+        'color': '#629f70',
+        'description': 'American whole magazine truth stop whose.',
+        'id': 1,
+        'name': 'Three',
+      }),
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': True,
+    'quality': None,
+    'reads': list([
+      dict({
+        'download_url': '/samples/test/reads/reads_1.fq.gz',
+        'id': 1,
+        'name': 'reads_1.fq.gz',
+        'name_on_disk': 'reads_1.fq.gz',
+        'sample': 'test',
+        'size': 2903109210,
+        'upload': None,
+        'uploaded_at': '2015-10-06T20:00:00Z',
+      }),
+    ]),
+    'ready': True,
+    'subtractions': list([
+      dict({
+        'id': 1,
+        'name': 'Apple',
+      }),
+      dict({
+        'id': 2,
+        'name': 'Pear',
+      }),
+    ]),
+    'uploads': None,
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
     }),
   })
 # ---
@@ -156,11 +228,87 @@
   dict({
     'all_read': False,
     'all_write': False,
-    'group': 1,
+    'artifacts': list([
+      dict({
+        'download_url': '/samples/test/artifacts/reference.fa.gz',
+        'id': 1,
+        'name': 'reference.fa.gz',
+        'size': 34879234,
+      }),
+    ]),
+    'created_at': '2015-10-06T20:00:00Z',
+    'format': 'fastq',
+    'group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'arboriculturists',
+    }),
     'group_read': False,
     'group_write': False,
-    'user': dict({
+    'hold': False,
+    'host': '',
+    'id': 'test',
+    'is_legacy': False,
+    'isolate': '',
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
       'id': 1,
+      'progress': 100,
+      'state': 'failed',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'create_sample',
+    }),
+    'labels': list([
+      dict({
+        'color': '#629f70',
+        'description': 'American whole magazine truth stop whose.',
+        'id': 1,
+        'name': 'Three',
+      }),
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': True,
+    'quality': None,
+    'reads': list([
+      dict({
+        'download_url': '/samples/test/reads/reads_1.fq.gz',
+        'id': 1,
+        'name': 'reads_1.fq.gz',
+        'name_on_disk': 'reads_1.fq.gz',
+        'sample': 'test',
+        'size': 2903109210,
+        'upload': None,
+        'uploaded_at': '2015-10-06T20:00:00Z',
+      }),
+    ]),
+    'ready': True,
+    'subtractions': list([
+      dict({
+        'id': 1,
+        'name': 'Apple',
+      }),
+      dict({
+        'id': 2,
+        'name': 'Pear',
+      }),
+    ]),
+    'uploads': None,
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
     }),
   })
 # ---
@@ -216,11 +364,83 @@
   dict({
     'all_read': False,
     'all_write': False,
-    'group': 'none',
+    'artifacts': list([
+      dict({
+        'download_url': '/samples/test/artifacts/reference.fa.gz',
+        'id': 1,
+        'name': 'reference.fa.gz',
+        'size': 34879234,
+      }),
+    ]),
+    'created_at': '2015-10-06T20:00:00Z',
+    'format': 'fastq',
+    'group': None,
     'group_read': True,
     'group_write': True,
-    'user': dict({
+    'hold': False,
+    'host': '',
+    'id': 'test',
+    'is_legacy': False,
+    'isolate': '',
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
       'id': 1,
+      'progress': 100,
+      'state': 'failed',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'create_sample',
+    }),
+    'labels': list([
+      dict({
+        'color': '#629f70',
+        'description': 'American whole magazine truth stop whose.',
+        'id': 1,
+        'name': 'Three',
+      }),
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': True,
+    'quality': None,
+    'reads': list([
+      dict({
+        'download_url': '/samples/test/reads/reads_1.fq.gz',
+        'id': 1,
+        'name': 'reads_1.fq.gz',
+        'name_on_disk': 'reads_1.fq.gz',
+        'sample': 'test',
+        'size': 2903109210,
+        'upload': None,
+        'uploaded_at': '2015-10-06T20:00:00Z',
+      }),
+    ]),
+    'ready': True,
+    'subtractions': list([
+      dict({
+        'id': 1,
+        'name': 'Apple',
+      }),
+      dict({
+        'id': 2,
+        'name': 'Pear',
+      }),
+    ]),
+    'uploads': None,
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
     }),
   })
 # ---
@@ -276,11 +496,87 @@
   dict({
     'all_read': True,
     'all_write': True,
-    'group': 1,
+    'artifacts': list([
+      dict({
+        'download_url': '/samples/test/artifacts/reference.fa.gz',
+        'id': 1,
+        'name': 'reference.fa.gz',
+        'size': 34879234,
+      }),
+    ]),
+    'created_at': '2015-10-06T20:00:00Z',
+    'format': 'fastq',
+    'group': dict({
+      'id': 1,
+      'legacy_id': None,
+      'name': 'arboriculturists',
+    }),
     'group_read': True,
     'group_write': True,
-    'user': dict({
+    'hold': False,
+    'host': '',
+    'id': 'test',
+    'is_legacy': False,
+    'isolate': '',
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
       'id': 1,
+      'progress': 100,
+      'state': 'failed',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'create_sample',
+    }),
+    'labels': list([
+      dict({
+        'color': '#629f70',
+        'description': 'American whole magazine truth stop whose.',
+        'id': 1,
+        'name': 'Three',
+      }),
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': True,
+    'quality': None,
+    'reads': list([
+      dict({
+        'download_url': '/samples/test/reads/reads_1.fq.gz',
+        'id': 1,
+        'name': 'reads_1.fq.gz',
+        'name_on_disk': 'reads_1.fq.gz',
+        'sample': 'test',
+        'size': 2903109210,
+        'upload': None,
+        'uploaded_at': '2015-10-06T20:00:00Z',
+      }),
+    ]),
+    'ready': True,
+    'subtractions': list([
+      dict({
+        'id': 1,
+        'name': 'Apple',
+      }),
+      dict({
+        'id': 2,
+        'name': 'Pear',
+      }),
+    ]),
+    'uploads': None,
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
     }),
   })
 # ---
@@ -336,11 +632,83 @@
   dict({
     'all_read': True,
     'all_write': True,
-    'group': 'none',
+    'artifacts': list([
+      dict({
+        'download_url': '/samples/test/artifacts/reference.fa.gz',
+        'id': 1,
+        'name': 'reference.fa.gz',
+        'size': 34879234,
+      }),
+    ]),
+    'created_at': '2015-10-06T20:00:00Z',
+    'format': 'fastq',
+    'group': None,
     'group_read': False,
     'group_write': False,
-    'user': dict({
+    'hold': False,
+    'host': '',
+    'id': 'test',
+    'is_legacy': False,
+    'isolate': '',
+    'job': dict({
+      'created_at': '2015-10-06T20:00:00Z',
       'id': 1,
+      'progress': 100,
+      'state': 'failed',
+      'user': dict({
+        'handle': 'leeashley',
+        'id': 1,
+      }),
+      'workflow': 'create_sample',
+    }),
+    'labels': list([
+      dict({
+        'color': '#629f70',
+        'description': 'American whole magazine truth stop whose.',
+        'id': 1,
+        'name': 'Three',
+      }),
+    ]),
+    'library_type': 'normal',
+    'locale': '',
+    'name': 'Test',
+    'notes': '',
+    'nuvs': False,
+    'paired': False,
+    'pathoscope': True,
+    'quality': None,
+    'reads': list([
+      dict({
+        'download_url': '/samples/test/reads/reads_1.fq.gz',
+        'id': 1,
+        'name': 'reads_1.fq.gz',
+        'name_on_disk': 'reads_1.fq.gz',
+        'sample': 'test',
+        'size': 2903109210,
+        'upload': None,
+        'uploaded_at': '2015-10-06T20:00:00Z',
+      }),
+    ]),
+    'ready': True,
+    'subtractions': list([
+      dict({
+        'id': 1,
+        'name': 'Apple',
+      }),
+      dict({
+        'id': 2,
+        'name': 'Pear',
+      }),
+    ]),
+    'uploads': None,
+    'user': dict({
+      'handle': 'leeashley',
+      'id': 1,
+    }),
+    'workflows': dict({
+      'aodp': 'incompatible',
+      'nuvs': 'pending',
+      'pathoscope': 'complete',
     }),
   })
 # ---

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -23,7 +23,13 @@ from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.samples.fake import create_fake_sample
 from virtool.samples.models import WorkflowState
-from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
+from virtool.samples.sql import (
+    SQLLegacySample,
+    SQLLegacySampleLabel,
+    SQLLegacySampleSubtraction,
+    SQLSampleArtifact,
+    SQLSampleReads,
+)
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.uploads.sql import SQLUpload
@@ -158,8 +164,41 @@ async def get_sample_data(
     )
 
     async with AsyncSession(pg) as session:
+        legacy = SQLLegacySample(
+            legacy_id="test",
+            name="Test",
+            host="",
+            isolate="",
+            locale="",
+            notes="",
+            library_type=LibraryType.normal.value,
+            format="fastq",
+            quality=None,
+            created_at=static_time.datetime,
+            ready=True,
+            hold=False,
+            is_legacy=False,
+            all_read=True,
+            all_write=True,
+            group_read=True,
+            group_write=True,
+            user_id=user.id,
+            job_id=job.id,
+        )
+        session.add(legacy)
+        await session.flush()
+
         session.add_all(
             [
+                SQLLegacySampleLabel(sample_id=legacy.id, label_id=label.id),
+                SQLLegacySampleSubtraction(
+                    sample_id=legacy.id,
+                    subtraction_id=apple.id,
+                ),
+                SQLLegacySampleSubtraction(
+                    sample_id=legacy.id,
+                    subtraction_id=pear.id,
+                ),
                 SQLSampleArtifact(
                     name="reference.fa.gz",
                     sample="test",

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -1,7 +1,9 @@
 import asyncio
 from collections.abc import AsyncIterator
+from datetime import timedelta
 
 import pytest
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -9,7 +11,7 @@ import virtool.utils
 from tests.fixtures.client import ClientSpawner
 from virtool.analyses.sql import SQLAnalysis
 from virtool.api.client import UserClient
-from virtool.data.errors import ResourceConflictError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.models.enums import AnalysisWorkflow, LibraryType, Permission
@@ -17,8 +19,17 @@ from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
 from virtool.samples.models import WorkflowState
-from virtool.samples.oas import CreateAnalysisRequest, CreateSampleRequest
-from virtool.samples.sql import SQLSampleReads
+from virtool.samples.oas import (
+    CreateAnalysisRequest,
+    CreateSampleRequest,
+    UpdateSampleRequest,
+)
+from virtool.samples.sql import (
+    SQLLegacySample,
+    SQLLegacySampleLabel,
+    SQLLegacySampleSubtraction,
+    SQLSampleReads,
+)
 from virtool.samples.utils import SampleRight
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.storage.errors import StorageKeyNotFoundError
@@ -29,7 +40,12 @@ from virtool.users.oas import UpdateUserRequest
 
 
 @pytest.fixture
-async def get_sample_ready_false(fake: DataFaker, mongo: Mongo, static_time):
+async def get_sample_ready_false(
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    static_time,
+):
     label = await fake.labels.create()
     user = await fake.users.create()
     job = await fake.jobs.create(user, workflow="create_sample")
@@ -81,6 +97,37 @@ async def get_sample_ready_false(fake: DataFaker, mongo: Mongo, static_time):
             },
         },
     )
+
+    async with AsyncSession(pg) as session:
+        legacy = SQLLegacySample(
+            legacy_id="test",
+            name="Test",
+            library_type=LibraryType.normal.value,
+            format="fastq",
+            quality=None,
+            created_at=static_time.datetime,
+            ready=False,
+            hold=False,
+            is_legacy=False,
+            all_read=True,
+            all_write=True,
+            group_read=True,
+            group_write=True,
+            user_id=user.id,
+            job_id=job.id,
+        )
+        session.add(legacy)
+        await session.flush()
+
+        session.add(SQLLegacySampleLabel(sample_id=legacy.id, label_id=label.id))
+        session.add(
+            SQLLegacySampleSubtraction(sample_id=legacy.id, subtraction_id=apple.id),
+        )
+        session.add(
+            SQLLegacySampleSubtraction(sample_id=legacy.id, subtraction_id=pear.id),
+        )
+
+        await session.commit()
 
 
 class TestCreate:
@@ -149,6 +196,60 @@ class TestCreate:
 
         assert sample == snapshot_recent(name="mongo")
         assert upload.reserved is True
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample["_id"],
+                    ),
+                )
+            ).scalar_one()
+
+            label_ids = (
+                (
+                    await session.execute(
+                        select(SQLLegacySampleLabel.label_id).where(
+                            SQLLegacySampleLabel.sample_id == legacy.id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            subtraction_ids = (
+                (
+                    await session.execute(
+                        select(SQLLegacySampleSubtraction.subtraction_id).where(
+                            SQLLegacySampleSubtraction.sample_id == legacy.id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert legacy.name == sample["name"]
+        assert legacy.library_type == sample["library_type"]
+        # Mongo truncates datetimes to millisecond precision while Postgres keeps
+        # microseconds, so the same source timestamp differs sub-millisecond.
+        assert abs(legacy.created_at - sample["created_at"]) < timedelta(
+            milliseconds=1,
+        )
+        assert legacy.user_id == sample["user"]["id"]
+        assert legacy.job_id == sample["job"]["id"]
+        assert legacy.ready is sample["ready"]
+        assert legacy.hold is sample["hold"]
+        assert legacy.all_read is sample["all_read"]
+        assert legacy.all_write is sample["all_write"]
+        assert legacy.group_read is sample["group_read"]
+        assert legacy.group_write is sample["group_write"]
+        assert legacy.group_id == (
+            sample["group"] if isinstance(sample["group"], int) else None
+        )
+        assert set(label_ids) == set(sample["labels"])
+        assert set(subtraction_ids) == set(sample["subtractions"])
 
     async def test_already_reserved(
         self,
@@ -271,6 +372,16 @@ async def test_finalize(
     assert sample.dict() == snapshot_recent()
     assert sample.quality == quality
     assert sample.ready is True
+
+    async with AsyncSession(pg) as session:
+        legacy = (
+            await session.execute(
+                select(SQLLegacySample).where(SQLLegacySample.legacy_id == "test"),
+            )
+        ).scalar_one()
+
+    assert legacy.ready is True
+    assert legacy.quality == quality
 
     with pytest.raises(StorageKeyNotFoundError):
         await memory_storage.size(upload_key)
@@ -638,6 +749,376 @@ class TestHasResourcesForAnalysisJob:
             )
 
 
+class TestUpdate:
+    """Updating a sample reconciles its ``legacy_samples`` row and join rows."""
+
+    @staticmethod
+    async def _create_sample(
+        data_layer: DataLayer,
+        fake: DataFaker,
+        user_id: int,
+        *,
+        labels: list[int] | None = None,
+        subtractions: list[int] | None = None,
+    ):
+        upload = await fake.uploads.create(user=await fake.users.create())
+
+        return await data_layer.samples.create(
+            CreateSampleRequest(
+                files=[upload.id],
+                labels=labels or [],
+                name="Original",
+                subtractions=subtractions or [],
+            ),
+            user_id,
+            0,
+        )
+
+    @staticmethod
+    async def _get_label_ids(pg: AsyncEngine, sample_id: str) -> set[int]:
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample_id,
+                    ),
+                )
+            ).scalar_one()
+
+            return set(
+                (
+                    await session.execute(
+                        select(SQLLegacySampleLabel.label_id).where(
+                            SQLLegacySampleLabel.sample_id == legacy.id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all(),
+            )
+
+    @staticmethod
+    async def _get_subtraction_ids(pg: AsyncEngine, sample_id: str) -> set[int]:
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample_id,
+                    ),
+                )
+            ).scalar_one()
+
+            return set(
+                (
+                    await session.execute(
+                        select(SQLLegacySampleSubtraction.subtraction_id).where(
+                            SQLLegacySampleSubtraction.sample_id == legacy.id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all(),
+            )
+
+    async def test_scalars(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """Scalar fields update both the Mongo doc and the ``legacy_samples`` row."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        sample = await self._create_sample(data_layer, fake, client.user.id)
+
+        await data_layer.samples.update(
+            sample.id,
+            UpdateSampleRequest(name="Renamed", notes="Updated notes"),
+        )
+
+        document = await mongo.samples.find_one({"_id": sample.id})
+        assert document["name"] == "Renamed"
+        assert document["notes"] == "Updated notes"
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one()
+
+        assert legacy.name == "Renamed"
+        assert legacy.notes == "Updated notes"
+
+    async def test_labels_reconciled(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """Replacing labels leaves exactly the new set of ``legacy_sample_labels``."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        keep = await fake.labels.create()
+        drop = await fake.labels.create()
+        add = await fake.labels.create()
+
+        sample = await self._create_sample(
+            data_layer,
+            fake,
+            client.user.id,
+            labels=[keep.id, drop.id],
+        )
+
+        assert await self._get_label_ids(pg, sample.id) == {keep.id, drop.id}
+
+        await data_layer.samples.update(
+            sample.id,
+            UpdateSampleRequest(labels=[keep.id, add.id]),
+        )
+
+        assert await self._get_label_ids(pg, sample.id) == {keep.id, add.id}
+
+    async def test_subtractions_reconciled(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """Replacing subtractions leaves exactly the new set of join rows."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        user = await fake.users.create()
+        upload = await fake.uploads.create(user=user)
+
+        keep = await fake.subtractions.create(
+            user=user,
+            upload=upload,
+            name="Keep",
+            upload_files=False,
+            finalized=False,
+        )
+        drop = await fake.subtractions.create(
+            user=user,
+            upload=upload,
+            name="Drop",
+            upload_files=False,
+            finalized=False,
+        )
+        add = await fake.subtractions.create(
+            user=user,
+            upload=upload,
+            name="Add",
+            upload_files=False,
+            finalized=False,
+        )
+
+        sample = await self._create_sample(
+            data_layer,
+            fake,
+            client.user.id,
+            subtractions=[keep.id, drop.id],
+        )
+
+        assert await self._get_subtraction_ids(pg, sample.id) == {keep.id, drop.id}
+
+        await data_layer.samples.update(
+            sample.id,
+            UpdateSampleRequest(subtractions=[keep.id, add.id]),
+        )
+
+        assert await self._get_subtraction_ids(pg, sample.id) == {keep.id, add.id}
+
+    async def test_labels_without_legacy_row(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """A label update on a sample lacking a ``legacy_samples`` row still succeeds.
+
+        Samples created before the dual-write rollout have no ``legacy_samples`` row
+        until the backfill runs, so join reconciliation must tolerate its absence and
+        still apply the Mongo write.
+        """
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        label = await fake.labels.create()
+        sample = await self._create_sample(data_layer, fake, client.user.id)
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one()
+
+            await session.execute(
+                delete(SQLLegacySampleLabel).where(
+                    SQLLegacySampleLabel.sample_id == legacy.id,
+                ),
+            )
+            await session.execute(
+                delete(SQLLegacySampleSubtraction).where(
+                    SQLLegacySampleSubtraction.sample_id == legacy.id,
+                ),
+            )
+            await session.delete(legacy)
+            await session.commit()
+
+        await data_layer.samples.update(
+            sample.id,
+            UpdateSampleRequest(labels=[label.id]),
+        )
+
+        document = await mongo.samples.find_one({"_id": sample.id})
+        assert document["labels"] == [label.id]
+
+        async with AsyncSession(pg) as session:
+            assert (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one_or_none() is None
+
+
+class TestGetOwnerId:
+    async def test_ok(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        spawn_client: ClientSpawner,
+    ):
+        """The owner user id is returned for an existing sample."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        upload = await fake.uploads.create(user=await fake.users.create())
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(files=[upload.id], name="Owned"),
+            client.user.id,
+            0,
+        )
+
+        assert await data_layer.samples.get_owner_id(sample.id) == client.user.id
+
+    async def test_missing(self, data_layer: DataLayer):
+        """``None`` is returned when the sample does not exist."""
+        assert await data_layer.samples.get_owner_id("nonexistent") is None
+
+
+class TestUpdateRights:
+    async def test_dual_writes_legacy_sample(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """Rights updates hit both the Mongo doc and the ``legacy_samples`` row."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        group = await fake.groups.create()
+
+        upload = await fake.uploads.create(user=await fake.users.create())
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(files=[upload.id], name="Rights"),
+            client.user.id,
+            0,
+        )
+
+        await data_layer.samples.update_rights(
+            sample.id,
+            {
+                "group": group.id,
+                "group_read": False,
+                "group_write": False,
+                "all_read": False,
+                "all_write": False,
+            },
+        )
+
+        document = await mongo.samples.find_one({"_id": sample.id})
+        assert document["group"] == group.id
+        assert document["all_read"] is False
+        assert document["group_read"] is False
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one()
+
+        assert legacy.group_id == group.id
+        assert legacy.all_read is False
+        assert legacy.all_write is False
+        assert legacy.group_read is False
+        assert legacy.group_write is False
+
+    async def test_missing_group(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        spawn_client: ClientSpawner,
+    ):
+        """Assigning a nonexistent group raises ``ResourceConflictError``."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        upload = await fake.uploads.create(user=await fake.users.create())
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(files=[upload.id], name="Rights"),
+            client.user.id,
+            0,
+        )
+
+        with pytest.raises(ResourceConflictError, match=r"Group does not exist"):
+            await data_layer.samples.update_rights(sample.id, {"group": 999999})
+
+    async def test_missing_sample(self, data_layer: DataLayer):
+        """Updating rights on a missing sample raises ``ResourceNotFoundError``."""
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.samples.update_rights(
+                "nonexistent",
+                {"all_read": False},
+            )
+
+
 class TestDelete:
     """Deleting a sample cascades to its analyses in both Mongo and Postgres."""
 
@@ -756,3 +1237,77 @@ class TestDelete:
 
         row = await get_row_by_id(pg, SQLUpload, upload.id)
         assert row.reserved is False
+
+    async def test_removes_legacy_sample_and_join_rows(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """Deleting a sample removes its ``legacy_samples`` row and join rows."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        label = await fake.labels.create()
+        user = await fake.users.create()
+        upload = await fake.uploads.create(user=user)
+        apple = await fake.subtractions.create(
+            user=user,
+            upload=upload,
+            name="Apple",
+            upload_files=False,
+            finalized=False,
+        )
+
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(
+                files=[upload.id],
+                labels=[label.id],
+                name="Foobar",
+                subtractions=[apple.id],
+            ),
+            client.user.id,
+            0,
+        )
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one()
+
+        await data_layer.samples.delete(sample.id)
+
+        async with AsyncSession(pg) as session:
+            assert (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one_or_none() is None
+
+            assert (
+                await session.execute(
+                    select(SQLLegacySampleLabel).where(
+                        SQLLegacySampleLabel.sample_id == legacy.id,
+                    ),
+                )
+            ).scalars().all() == []
+
+            assert (
+                await session.execute(
+                    select(SQLLegacySampleSubtraction).where(
+                        SQLLegacySampleSubtraction.sample_id == legacy.id,
+                    ),
+                )
+            ).scalars().all() == []
+
+        assert await mongo.samples.find_one() is None

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -14,7 +14,6 @@ from virtool.samples.db import (
     create_sample,
     define_initial_workflows,
     derive_workflow_state,
-    get_sample_owner,
     recalculate_workflow_tags,
 )
 from virtool.samples.utils import calculate_workflow_tags
@@ -200,24 +199,6 @@ class TestDeriveWorkflowStates:
                 "pathoscope": "incompatible",
             },
         }
-
-
-class TestGetSampleOwner:
-    async def test(self, mongo):
-        """Test that the correct owner id is returned given a sample id."""
-        await mongo.samples.insert_many(
-            [
-                {"_id": "test", "user": {"id": "foobar"}},
-                {"_id": "baz", "user": {"id": "fred"}},
-            ],
-            session=None,
-        )
-
-        assert await get_sample_owner(mongo, "test") == "foobar"
-
-    async def test_none(self, mongo):
-        """Test that ``None`` is returned if the sample id does not exist."""
-        assert await get_sample_owner(mongo, "foobar") is None
 
 
 async def test_create_sample(

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -3,9 +3,13 @@ from multidict import MultiDict, MultiDictProxy
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from tests.fixtures.client import ClientSpawner
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.models.enums import Permission
+from virtool.samples.oas import CreateSampleRequest
+from virtool.samples.sql import SQLLegacySample, SQLLegacySampleSubtraction
 from virtool.subtractions.oas import (
     FinalizeSubtractionRequest,
     NucleotideComposition,
@@ -313,6 +317,78 @@ class TestMutations:
                 ),
             )
         assert deleted is True
+
+    async def test_delete_unlinks_sample_subtraction_rows(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        spawn_client: ClientSpawner,
+    ):
+        """``delete`` removes the sample's ``legacy_sample_subtractions`` join rows."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        user = await fake.users.create()
+        sample_upload = await fake.uploads.create(user=user)
+        subtraction_upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+        subtraction = await fake.subtractions.create(
+            user=user,
+            upload=subtraction_upload,
+        )
+
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(
+                files=[sample_upload.id],
+                name="With Subtraction",
+                subtractions=[subtraction.id],
+            ),
+            client.user.id,
+            0,
+        )
+
+        async with AsyncSession(pg) as session:
+            legacy = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        SQLLegacySample.legacy_id == sample.id,
+                    ),
+                )
+            ).scalar_one()
+
+            before = (
+                (
+                    await session.execute(
+                        select(SQLLegacySampleSubtraction.subtraction_id).where(
+                            SQLLegacySampleSubtraction.sample_id == legacy.id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert before == [subtraction.id]
+
+        await data_layer.subtractions.delete(subtraction.id)
+
+        async with AsyncSession(pg) as session:
+            after = (
+                (
+                    await session.execute(
+                        select(SQLLegacySampleSubtraction.subtraction_id).where(
+                            SQLLegacySampleSubtraction.sample_id == legacy.id,
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert after == []
 
     async def test_finalize(self, data_layer: DataLayer, fake: DataFaker):
         """``finalize`` marks the subtraction ready."""

--- a/tests/subtractions/test_db.py
+++ b/tests/subtractions/test_db.py
@@ -4,7 +4,6 @@ from virtool.fake.next import DataFaker
 from virtool.subtractions.db import (
     AttachSubtractionsTransform,
     get_missing_subtraction_ids,
-    unlink_default_subtractions,
 )
 from virtool.uploads.sql import UploadType
 
@@ -126,37 +125,4 @@ async def test_get_linked_samples(fake: DataFaker, mongo):
     assert samples == [
         {"id": "sample_with_target", "name": "Sample With Target"},
         {"id": "another_with_target", "name": "Another With Target"},
-    ]
-
-
-async def test_unlink_default_subtractions(fake: DataFaker, mongo):
-    user = await fake.users.create()
-    upload = await fake.uploads.create(
-        user=user,
-        upload_type=UploadType.subtraction,
-        name="foobar.fq.gz",
-    )
-
-    subtraction = await fake.subtractions.create(user=user, upload=upload)
-
-    target = subtraction.id
-
-    other_a, other_b, other_c = target + 1, target + 2, target + 3
-
-    await mongo.samples.insert_many(
-        [
-            {"_id": "sample_keeps_two", "subtractions": [other_a, target, other_b]},
-            {"_id": "sample_keeps_two_alt", "subtractions": [target, other_c, other_b]},
-            {"_id": "sample_becomes_empty", "subtractions": [target]},
-        ],
-        session=None,
-    )
-
-    async with mongo.create_session() as session:
-        await unlink_default_subtractions(mongo, target, session)
-
-    assert await mongo.samples.find().to_list(None) == [
-        {"_id": "sample_keeps_two", "subtractions": [other_a, other_b]},
-        {"_id": "sample_keeps_two_alt", "subtractions": [other_c, other_b]},
-        {"_id": "sample_becomes_empty", "subtractions": []},
     ]

--- a/virtool/labels/data.py
+++ b/virtool/labels/data.py
@@ -1,9 +1,10 @@
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
+from virtool.data.topg import both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.labels.models import Label, LabelMinimal
 from virtool.labels.oas import UpdateLabelRequest
@@ -11,6 +12,7 @@ from virtool.labels.sql import SQLLabel
 from virtool.labels.transforms import AttachSampleCountsTransform
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_generic
+from virtool.samples.sql import SQLLegacySampleLabel
 
 
 class LabelsData:
@@ -137,15 +139,13 @@ class LabelsData:
 
         :param label_id: ID of the label to delete
         """
-        label = await self.get(label_id)
-
-        async with (
-            AsyncSession(
-                self._pg,
-            ) as session,
-            self._mongo.create_session() as mongo_session,
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
         ):
-            result = await session.execute(select(SQLLabel).filter_by(id=label_id))
+            result = await pg_session.execute(
+                select(SQLLabel).filter_by(id=label_id),
+            )
             label = result.scalar()
 
             if label is None:
@@ -157,7 +157,12 @@ class LabelsData:
                 session=mongo_session,
             )
 
-            await session.delete(label)
-            await session.commit()
+            await pg_session.execute(
+                delete(SQLLegacySampleLabel).where(
+                    SQLLegacySampleLabel.label_id == label_id,
+                ),
+            )
+
+            await pg_session.delete(label)
 
         emit(label, "labels", "delete", Operation.DELETE)

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -7,8 +7,7 @@ from aiohttp.web import (
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404, r409
 from pydantic import Field, conint, constr
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine
 from structlog import get_logger
 
 from virtool.analyses.models import AnalysisMinimal
@@ -34,14 +33,11 @@ from virtool.data.errors import (
 )
 from virtool.data.utils import get_data_from_req
 from virtool.errors import DatabaseError
-from virtool.groups.pg import SQLGroup
 from virtool.jobs.models import TERMINAL_JOB_STATES
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
 from virtool.samples.db import (
-    SAMPLE_RIGHTS_PROJECTION,
     check_rights,
-    get_sample_owner,
     recalculate_workflow_tags,
 )
 from virtool.samples.models import Sample, SampleSearchResult
@@ -311,45 +307,32 @@ class RightsView(PydanticView):
             403: Must be administrator or sample owner
             404: Not found
         """
-        mongo = get_mongo_from_req(self.request)
-        pg: AsyncEngine = self.request.app["pg"]
-
-        data = data.dict(exclude_unset=True)
-
-        if not await mongo.samples.count_documents({"_id": sample_id}):
-            raise APINotFound()
-
         client: UserClient = self.request["client"]
+
+        owner_id = await get_data_from_req(self.request).samples.get_owner_id(
+            sample_id,
+        )
+
+        if owner_id is None:
+            raise APINotFound()
 
         if (
             client.administrator_role != AdministratorRole.FULL
-            and client.user_id != await get_sample_owner(mongo, sample_id)
+            and client.user_id != owner_id
         ):
             raise APIInsufficientRights("Must be administrator or sample owner")
 
-        group = data.get("group")
+        try:
+            sample = await get_data_from_req(self.request).samples.update_rights(
+                sample_id,
+                data.dict(exclude_unset=True),
+            )
+        except ResourceConflictError as err:
+            raise APIBadRequest(str(err))
+        except ResourceNotFoundError:
+            raise APINotFound()
 
-        if group is not None and group != "none":
-            async with AsyncSession(pg) as session:
-                result = await session.execute(
-                    select(SQLGroup.id).where(
-                        (SQLGroup.id == group)
-                        if isinstance(group, int)
-                        else (SQLGroup.legacy_id == group),
-                    ),
-                )
-
-                if not result.scalars().one_or_none():
-                    raise APIBadRequest("Group does not exist")
-
-        # Update the sample document with the new rights.
-        document = await mongo.samples.find_one_and_update(
-            {"_id": sample_id},
-            {"$set": data},
-            projection=SAMPLE_RIGHTS_PROJECTION,
-        )
-
-        return json_response(document)
+        return json_response(sample)
 
 
 @routes.jobs_api.delete("/samples/{sample_id}")

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -19,7 +19,11 @@ from virtool.config.cls import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emits
-from virtool.data.topg import both_transactions, compose_legacy_id_multi_expression
+from virtool.data.topg import (
+    both_transactions,
+    compose_legacy_id_multi_expression,
+    retry_both_transactions,
+)
 from virtool.data.transforms import apply_transforms
 from virtool.groups.models import GroupMinimal
 from virtool.groups.pg import SQLGroup
@@ -47,7 +51,14 @@ from virtool.samples.files import (
 )
 from virtool.samples.models import Sample, SampleSearchResult
 from virtool.samples.oas import CreateSampleRequest, UpdateSampleRequest
-from virtool.samples.sql import ArtifactType, SQLSampleArtifact, SQLSampleReads
+from virtool.samples.sql import (
+    ArtifactType,
+    SQLLegacySample,
+    SQLLegacySampleLabel,
+    SQLLegacySampleSubtraction,
+    SQLSampleArtifact,
+    SQLSampleReads,
+)
 from virtool.samples.utils import SampleRight, sample_file_key, sample_prefix
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
@@ -271,6 +282,78 @@ class SamplesData(DataLayerDomain):
             }
         )
 
+    async def _write_legacy_sample(
+        self,
+        pg_session: AsyncSession,
+        document: dict[str, Any],
+    ) -> None:
+        """Write the ``legacy_samples`` row and join rows for a new ``document``.
+
+        The label and subtraction join-row values are already integer ``labels.id``
+        and ``subtractions.id`` values, so they map directly with no legacy-id
+        resolution.
+        """
+        group = document["group"]
+
+        sample = SQLLegacySample(
+            legacy_id=document["_id"],
+            name=document["name"],
+            host=document["host"],
+            isolate=document["isolate"],
+            locale=document["locale"],
+            notes=document["notes"],
+            library_type=document["library_type"],
+            format=document["format"],
+            group_id=group if isinstance(group, int) else None,
+            quality=document["quality"],
+            created_at=document["created_at"],
+            paired=document["paired"],
+            ready=document["ready"],
+            hold=document["hold"],
+            is_legacy=document["is_legacy"],
+            all_read=document["all_read"],
+            all_write=document["all_write"],
+            group_read=document["group_read"],
+            group_write=document["group_write"],
+            user_id=document["user"]["id"],
+            job_id=document["job"]["id"] if document.get("job") else None,
+        )
+
+        pg_session.add(sample)
+        await pg_session.flush()
+
+        self._add_legacy_sample_join_rows(
+            pg_session,
+            sample.id,
+            document["labels"],
+            document["subtractions"],
+        )
+
+    @staticmethod
+    def _add_legacy_sample_join_rows(
+        pg_session: AsyncSession,
+        sample_pk: int,
+        labels: list[int],
+        subtractions: list[int],
+    ) -> None:
+        """Add ``legacy_sample_labels`` and ``legacy_sample_subtractions`` join rows.
+
+        The values are already integer ``labels.id`` and ``subtractions.id`` values,
+        so they map directly with no legacy-id resolution.
+        """
+        for label_id in labels:
+            pg_session.add(
+                SQLLegacySampleLabel(sample_id=sample_pk, label_id=label_id),
+            )
+
+        for subtraction_id in subtractions:
+            pg_session.add(
+                SQLLegacySampleSubtraction(
+                    sample_id=sample_pk,
+                    subtraction_id=subtraction_id,
+                ),
+            )
+
     @emits(Operation.CREATE)
     async def create(
         self,
@@ -375,6 +458,8 @@ class SamplesData(DataLayerDomain):
                 session=mongo_session,
             )
 
+            await self._write_legacy_sample(pg_session, document)
+
         return await self.get(document["_id"])
 
     @emits(Operation.DELETE)
@@ -421,6 +506,26 @@ class SamplesData(DataLayerDomain):
                 delete(SQLAnalysis).where(SQLAnalysis.sample == sample_id),
             )
 
+            legacy_sample_id = select(SQLLegacySample.id).where(
+                SQLLegacySample.legacy_id == sample_id,
+            )
+
+            await pg_session.execute(
+                delete(SQLLegacySampleLabel).where(
+                    SQLLegacySampleLabel.sample_id.in_(legacy_sample_id),
+                ),
+            )
+            await pg_session.execute(
+                delete(SQLLegacySampleSubtraction).where(
+                    SQLLegacySampleSubtraction.sample_id.in_(legacy_sample_id),
+                ),
+            )
+            await pg_session.execute(
+                delete(SQLLegacySample).where(
+                    SQLLegacySample.legacy_id == sample_id,
+                ),
+            )
+
         if result.deleted_count:
             for key, exc in await delete_prefix(
                 self._storage, sample_prefix(sample_id)
@@ -451,13 +556,24 @@ class SamplesData(DataLayerDomain):
         if await get_one_field(self._mongo.samples, "ready", sample_id):
             raise ResourceConflictError("Sample already finalized")
 
-        result: UpdateResult = await self._mongo.samples.update_one(
-            {"_id": sample_id},
-            {"$set": {"quality": quality, "ready": True}},
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            result: UpdateResult = await self._mongo.samples.update_one(
+                {"_id": sample_id},
+                {"$set": {"quality": quality, "ready": True}},
+                session=mongo_session,
+            )
 
-        if not result.modified_count:
-            raise ResourceNotFoundError
+            if not result.modified_count:
+                raise ResourceNotFoundError
+
+            await pg_session.execute(
+                update(SQLLegacySample)
+                .where(SQLLegacySample.legacy_id == sample_id)
+                .values(quality=quality, ready=True),
+            )
 
         uploads = await get_one_field(self._mongo.samples, "uploads", sample_id) or []
         upload_ids = [upload["id"] for upload in uploads]
@@ -518,7 +634,131 @@ class SamplesData(DataLayerDomain):
 
         await wait_for_checks(*aws)
 
-        await self._mongo.samples.update_one({"_id": sample_id}, {"$set": data})
+        scalars = {
+            key: data[key]
+            for key in ("name", "host", "isolate", "locale", "notes")
+            if key in data
+        }
+
+        async def apply(mongo_session, pg_session) -> None:
+            await self._mongo.samples.update_one(
+                {"_id": sample_id},
+                {"$set": data},
+                session=mongo_session,
+            )
+
+            if scalars:
+                await pg_session.execute(
+                    update(SQLLegacySample)
+                    .where(SQLLegacySample.legacy_id == sample_id)
+                    .values(**scalars),
+                )
+
+            if "labels" not in data and "subtractions" not in data:
+                return
+
+            sample_pk = (
+                await pg_session.execute(
+                    select(SQLLegacySample.id).where(
+                        SQLLegacySample.legacy_id == sample_id,
+                    ),
+                )
+            ).scalar_one_or_none()
+
+            if sample_pk is None:
+                return
+
+            if "labels" in data:
+                await pg_session.execute(
+                    delete(SQLLegacySampleLabel).where(
+                        SQLLegacySampleLabel.sample_id == sample_pk,
+                    ),
+                )
+
+            if "subtractions" in data:
+                await pg_session.execute(
+                    delete(SQLLegacySampleSubtraction).where(
+                        SQLLegacySampleSubtraction.sample_id == sample_pk,
+                    ),
+                )
+
+            self._add_legacy_sample_join_rows(
+                pg_session,
+                sample_pk,
+                data.get("labels", []),
+                data.get("subtractions", []),
+            )
+
+        await retry_both_transactions(self._mongo, self._pg, apply)
+
+        return await self.get(sample_id)
+
+    async def get_owner_id(self, sample_id: str) -> int | None:
+        """Return the owner user id of a sample, or ``None`` if it does not exist.
+
+        :param sample_id: the id of the sample
+        :return: the owner user id
+        """
+        document = await self._mongo.samples.find_one(sample_id, ["user"])
+
+        if document:
+            return document["user"]["id"]
+
+        return None
+
+    async def update_rights(self, sample_id: str, data: dict[str, Any]) -> Sample:
+        """Update the rights settings of the sample identified by ``sample_id``.
+
+        :param sample_id: the id of the sample to update
+        :param data: the rights fields to update
+        :return: the updated sample
+        """
+        group_id = None
+
+        if "group" in data and data["group"] is not None:
+            group = data["group"]
+
+            async with AsyncSession(self._pg) as session:
+                group_id = (
+                    await session.execute(
+                        select(SQLGroup.id).where(
+                            SQLGroup.id == group
+                            if isinstance(group, int)
+                            else SQLGroup.legacy_id == group,
+                        ),
+                    )
+                ).scalar_one_or_none()
+
+            if group_id is None:
+                raise ResourceConflictError("Group does not exist")
+
+        scalars = {
+            key: data[key]
+            for key in ("all_read", "all_write", "group_read", "group_write")
+            if key in data
+        }
+
+        if "group" in data:
+            scalars["group_id"] = group_id
+
+        async def apply(mongo_session, pg_session) -> None:
+            result = await self._mongo.samples.update_one(
+                {"_id": sample_id},
+                {"$set": data},
+                session=mongo_session,
+            )
+
+            if not result.matched_count:
+                raise ResourceNotFoundError
+
+            if scalars:
+                await pg_session.execute(
+                    update(SQLLegacySample)
+                    .where(SQLLegacySample.legacy_id == sample_id)
+                    .values(**scalars),
+                )
+
+        await retry_both_transactions(self._mongo, self._pg, apply)
 
         return await self.get(sample_id)
 

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -299,23 +299,6 @@ async def create_sample(
     return base_processor(document)
 
 
-async def get_sample_owner(mongo: "Mongo", sample_id: str) -> str | None:
-    """A Shortcut function for getting the owner user id of a sample given its
-    ``sample_id``.
-
-    :param mongo: the application database client
-    :param sample_id: the id of the sample to get the owner for
-    :return: the id of the owner user
-
-    """
-    document = await mongo.samples.find_one(sample_id, ["user"])
-
-    if document:
-        return document["user"]["id"]
-
-    return None
-
-
 def define_initial_workflows(library_type) -> dict[str, str]:
     """Checks for incompatibility workflow states
 

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
 from multidict import MultiDictProxy
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import delete, func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
@@ -17,12 +17,12 @@ from virtool.data.topg import both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.pg.utils import get_row_by_id
+from virtool.samples.sql import SQLLegacySampleSubtraction
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.db import (
     attach_computed,
     map_subtraction_row,
-    unlink_default_subtractions,
 )
 from virtool.subtractions.models import (
     Subtraction,
@@ -329,10 +329,16 @@ class SubtractionsData(DataLayerDomain):
                 .values(deleted=True),
             )
 
-            await unlink_default_subtractions(
-                self._mongo,
-                subtraction_id,
-                mongo_session,
+            # Unlink this subtraction as a default subtraction on any samples.
+            await self._mongo.samples.update_many(
+                {"subtractions": subtraction_id},
+                {"$pull": {"subtractions": subtraction_id}},
+                session=mongo_session,
+            )
+            await pg_session.execute(
+                delete(SQLLegacySampleSubtraction).where(
+                    SQLLegacySampleSubtraction.subtraction_id == subtraction_id,
+                ),
             )
 
             deleted_count = result.rowcount

--- a/virtool/subtractions/db.py
+++ b/virtool/subtractions/db.py
@@ -3,7 +3,6 @@
 import asyncio
 from typing import Any
 
-from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -180,21 +179,3 @@ async def get_linked_samples(mongo: "Mongo", subtraction_id: int) -> list[dict]:
             ["_id", "name"],
         )
     ]
-
-
-async def unlink_default_subtractions(
-    mongo: "Mongo",
-    subtraction_id: int,
-    session: AsyncIOMotorClientSession,
-) -> None:
-    """Remove a subtraction as a default subtraction for samples.
-
-    :param mongo: the application mongo object
-    :param subtraction_id: the integer id of the subtraction to remove
-    :param session: a motor session to use
-    """
-    await mongo.samples.update_many(
-        {"subtractions": subtraction_id},
-        {"$pull": {"subtractions": subtraction_id}},
-        session=session,
-    )


### PR DESCRIPTION
## Summary
- Step 2 of the samples → Postgres migration: every sample mutation (`create`, `delete`, `finalize`, `update`) now writes a consistent `legacy_samples` row plus label and subtraction join rows in the same transaction as the Mongo write. Mongo remains the read authority; no read paths change.
- Moved the rights update out of the API handler into a dual-writing `update_rights` data-layer method (with a new `get_owner_id`, replacing `get_sample_owner`). The endpoint now returns the full `Sample` it already declared instead of a partial rights projection.
- Cascade label and subtraction deletions to `legacy_sample_labels` / `legacy_sample_subtractions` atomically with their Mongo `$pull`.