### PR TITLE
Validate pagination query params at the API boundary

### DIFF
--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -44,6 +44,38 @@ async def test_find(
     assert await resp.json() == snapshot
 
 
+class TestFindValidation:
+    """Out-of-range pagination query params are rejected at the API boundary.
+
+    ``page`` and ``per_page`` are validated by the shared ``Page``/``PerPage``
+    constrained types, so invalid values return ``400`` before reaching the
+    pagination math rather than raising or silently falling back to defaults.
+    """
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "page=0",
+            "page=-1",
+            "page=notanumber",
+            "per_page=0",
+            "per_page=-1",
+            "per_page=101",
+            "per_page=notanumber",
+        ],
+    )
+    async def test_rejects_invalid(
+        self,
+        query: str,
+        spawn_client: ClientSpawner,
+    ):
+        client = await spawn_client(authenticated=True)
+
+        resp = await client.get(f"/history?{query}")
+
+        assert resp.status == HTTPStatus.BAD_REQUEST
+
+
 @pytest.mark.parametrize("error", [None, "404"])
 async def test_get(
     error,

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -2,7 +2,6 @@ import gzip
 import json
 
 import pytest
-from multidict import MultiDict, MultiDictProxy
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -333,10 +332,6 @@ async def _seed_status(pg, **overrides) -> None:
         await session.commit()
 
 
-def _query(**params: str) -> MultiDictProxy:
-    return MultiDictProxy(MultiDict(**params))
-
-
 class TestGet:
     """``get`` reads a single annotation from Postgres by its legacy string id."""
 
@@ -363,7 +358,7 @@ class TestFind:
         await seed_pg_hmm_status({})
         await seed_pg_hmm({**hmm_document, "hidden": False})
 
-        result = await data_layer.hmms.find(_query())
+        result = await data_layer.hmms.find(1, 25)
 
         assert result.found_count == 1
         assert result.total_count == 1
@@ -376,7 +371,7 @@ class TestFind:
         await seed_pg_hmm({**hmm_document, "_id": "visible", "hidden": False})
         await seed_pg_hmm({**hmm_document, "_id": "concealed", "hidden": True})
 
-        result = await data_layer.hmms.find(_query())
+        result = await data_layer.hmms.find(1, 25)
 
         assert result.total_count == 1
         assert [document.id for document in result.documents] == ["visible"]
@@ -392,7 +387,7 @@ class TestFind:
             {**hmm_document, "_id": "capsid", "names": ["capsid protein"]},
         )
 
-        result = await data_layer.hmms.find(_query(find="polymerase"))
+        result = await data_layer.hmms.find(1, 25, "polymerase")
 
         assert result.found_count == 1
         assert result.total_count == 2

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -1,5 +1,4 @@
 import pytest
-from multidict import MultiDict, MultiDictProxy
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -13,10 +12,6 @@ from virtool.subtractions.oas import (
 )
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.uploads.sql import SQLUpload, UploadType
-
-
-def _empty_query() -> MultiDictProxy:
-    return MultiDictProxy(MultiDict())
 
 
 class TestFind:
@@ -46,16 +41,12 @@ class TestFind:
             UpdateSubtractionRequest(name="Malus domestica", nickname="apple"),
         )
 
-        by_name = await data_layer.subtractions.find(
-            "MALUS", False, False, _empty_query()
-        )
+        by_name = await data_layer.subtractions.find("MALUS", False, False, 1, 25)
         assert [d.id for d in by_name.documents] == [malus.id]
         assert by_name.found_count == 1
         assert by_name.total_count == 2
 
-        by_nickname = await data_layer.subtractions.find(
-            "cress", False, False, _empty_query()
-        )
+        by_nickname = await data_layer.subtractions.find("cress", False, False, 1, 25)
         assert [d.id for d in by_nickname.documents] == [arabidopsis.id]
 
     async def test_lists_subtraction_with_removed_upload(
@@ -83,7 +74,7 @@ class TestFind:
             )
             await session.commit()
 
-        result = await data_layer.subtractions.find(None, False, False, _empty_query())
+        result = await data_layer.subtractions.find(None, False, False, 1, 25)
 
         assert [d.id for d in result.documents] == [subtraction.id]
         assert result.documents[0].file.id == upload.id
@@ -99,7 +90,7 @@ class TestFind:
         ready = await fake.subtractions.create(user=user, upload=upload, finalized=True)
         await fake.subtractions.create(user=user, upload=upload, finalized=False)
 
-        result = await data_layer.subtractions.find(None, False, True, _empty_query())
+        result = await data_layer.subtractions.find(None, False, True, 1, 25)
 
         assert [d.id for d in result.documents] == [ready.id]
         assert result.found_count == 1
@@ -118,7 +109,7 @@ class TestFind:
         removed = await fake.subtractions.create(user=user, upload=upload)
         await data_layer.subtractions.delete(removed.id)
 
-        result = await data_layer.subtractions.find(None, False, False, _empty_query())
+        result = await data_layer.subtractions.find(None, False, False, 1, 25)
 
         assert [d.id for d in result.documents] == [kept.id]
         assert result.total_count == 1
@@ -133,7 +124,7 @@ class TestFind:
 
         subtraction = await fake.subtractions.create(user=user, upload=upload)
 
-        result = await data_layer.subtractions.find(None, True, False, _empty_query())
+        result = await data_layer.subtractions.find(None, True, False, 1, 25)
 
         assert result == [{"id": subtraction.id, "name": "foo", "ready": True}]
 
@@ -164,19 +155,13 @@ class TestFind:
         literal_backslash = await named("qux\\end")
         await named("quxend")
 
-        percent = await data_layer.subtractions.find(
-            "foo%bar", False, False, _empty_query()
-        )
+        percent = await data_layer.subtractions.find("foo%bar", False, False, 1, 25)
         assert [d.id for d in percent.documents] == [literal_percent]
 
-        underscore = await data_layer.subtractions.find(
-            "baz_qux", False, False, _empty_query()
-        )
+        underscore = await data_layer.subtractions.find("baz_qux", False, False, 1, 25)
         assert [d.id for d in underscore.documents] == [literal_underscore]
 
-        backslash = await data_layer.subtractions.find(
-            "qux\\end", False, False, _empty_query()
-        )
+        backslash = await data_layer.subtractions.find("qux\\end", False, False, 1, 25)
         assert [d.id for d in backslash.documents] == [literal_backslash]
 
     async def test_ready_filter_with_search_term(
@@ -211,9 +196,7 @@ class TestFind:
 
         await fake.subtractions.create(user=user, upload=upload, finalized=False)
 
-        result = await data_layer.subtractions.find(
-            "arabidopsis", False, True, _empty_query()
-        )
+        result = await data_layer.subtractions.find("arabidopsis", False, True, 1, 25)
 
         assert [d.id for d in result.documents] == [ready_match.id]
         assert result.found_count == 1
@@ -303,7 +286,7 @@ class TestMutations:
 
         await data_layer.subtractions.delete(subtraction.id)
 
-        result = await data_layer.subtractions.find(None, False, False, _empty_query())
+        result = await data_layer.subtractions.find(None, False, False, 1, 25)
         assert subtraction.id not in [d.id for d in result.documents]
 
         async with AsyncSession(pg) as session:

--- a/virtool/administrators/api.py
+++ b/virtool/administrators/api.py
@@ -13,6 +13,7 @@ from virtool.administrators.oas import (
 )
 from virtool.api.custom_json import json_response
 from virtool.api.errors import APIBadRequest, APIForbidden, APINotFound
+from virtool.api.pagination import Page, PerPage
 from virtool.api.policy import AdministratorRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.data.errors import (
@@ -58,26 +59,17 @@ class AdminUsersView(PydanticView):
         active: bool = True,
         administrator: bool | None = None,
         term: str | None = None,
-    ) -> r200[ListAdministratorResponse]:
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[ListAdministratorResponse] | r400:
         """Find users.
 
         Returns a paginated list of users.
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
         """
-        url_query = self.request.query
-
-        try:
-            page = int(url_query["page"])
-        except (KeyError, ValueError):
-            page = 1
-
-        try:
-            per_page = int(url_query["per_page"])
-        except (KeyError, ValueError):
-            per_page = 25
-
         return json_response(
             await get_data_from_req(self.request).users.find(
                 page,

--- a/virtool/api/pagination.py
+++ b/virtool/api/pagination.py
@@ -1,0 +1,20 @@
+"""Reusable constrained types for validating pagination query parameters.
+
+Declare these on ``PydanticView`` list handlers so that ``page`` and ``per_page``
+are validated at the API boundary. Out-of-range values are rejected with a ``400``
+before reaching the pagination math, letting the data layer trust the values it
+receives.
+
+Usage::
+
+    async def get(self, page: Page = 1, per_page: PerPage = 25) -> ...:
+        ...
+"""
+
+from pydantic import conint
+
+Page = conint(ge=1)
+"""The one-indexed page number to return. Must be at least ``1``."""
+
+PerPage = conint(ge=1, le=100)
+"""The number of documents per page. Must be between ``1`` and ``100``."""

--- a/virtool/api/utils.py
+++ b/virtool/api/utils.py
@@ -72,7 +72,8 @@ def compose_regex_query(
 async def paginate(
     collection,
     mongo_query: dict | MultiDictProxy[str],
-    url_query: dict | MultiDictProxy[str],
+    page: int,
+    per_page: int,
     base_query: dict | None = None,
     projection: Projection | None = None,
     reverse: bool = False,
@@ -86,8 +87,9 @@ async def paginate(
     from user input such as search terms and filter options. This documents matching
     query will count toward the returned `found_count`.
 
-    The `url_query` is the raw query from the request URL. This value is used to derive
-    the `page` and `per_page` numbers used in paging the search results.
+    The `page` and `per_page` values control paging of the search results. They are
+    validated at the API boundary, so this function trusts them without bounds
+    checking.
 
     The `base_query` is affects the `total_count` of documents in the collection
     returned to the API client. An example where this is used is only ever returning
@@ -105,7 +107,8 @@ async def paginate(
 
     :param collection: the database collection
     :param mongo_query: a query derived from user supplied - affects found count
-    :param url_query: the raw URL query; used to get the `page` and `page_count` values
+    :param page: the one-indexed page number to return
+    :param per_page: the number of documents to return per page
     :param sort: a field to sort by
     :param projection: the projection to apply to the returned documents
     :param base_query: a query always applied to the search
@@ -113,16 +116,6 @@ async def paginate(
     :return: a search result including a list of matched documents
 
     """
-    try:
-        page = int(url_query["page"])
-    except (KeyError, ValueError):
-        page = 1
-
-    try:
-        per_page = int(url_query["per_page"])
-    except (KeyError, ValueError):
-        per_page = 25
-
     base_query = base_query or {}
 
     if isinstance(sort, str):

--- a/virtool/history/api.py
+++ b/virtool/history/api.py
@@ -1,5 +1,5 @@
 from aiohttp_pydantic import PydanticView
-from aiohttp_pydantic.oas.typing import r200, r204, r403, r404, r409, r422
+from aiohttp_pydantic.oas.typing import r200, r204, r400, r403, r404, r409
 
 import virtool.api.routes
 import virtool.references.db
@@ -10,6 +10,7 @@ from virtool.api.errors import (
     APINoContent,
     APINotFound,
 )
+from virtool.api.pagination import Page, PerPage
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.history.models import History, HistorySearchResult
@@ -20,18 +21,20 @@ routes = virtool.api.routes.Routes()
 
 @routes.view("/history")
 class ChangesView(PydanticView):
-    async def get(self) -> r200[HistorySearchResult] | r422:
+    async def get(
+        self,
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[HistorySearchResult] | r400:
         """List history.
 
         Returns a list of change documents.
 
         Status Codes:
             200: Successful Operation
-            422: Invalid query
+            400: Invalid query
         """
-        data = await get_data_from_req(self.request).history.find(
-            req_query=self.request.query,
-        )
+        data = await get_data_from_req(self.request).history.find(page, per_page)
 
         return json_response(data)
 

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from sqlalchemy import Integer, cast, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -28,13 +26,14 @@ class HistoryData:
         self._mongo = mongo
         self._pg = pg
 
-    async def find(self, req_query: Any) -> HistorySearchResult:
+    async def find(self, page: int, per_page: int) -> HistorySearchResult:
         """List all change documents.
 
-        :param req_query: the request query
+        :param page: the one-indexed page number to return
+        :param per_page: the number of documents to return per page
         :return: a list of all documents
         """
-        documents = await virtool.history.db.find(self._mongo, self._pg, req_query)
+        documents = await virtool.history.db.find(self._mongo, self._pg, page, per_page)
 
         return HistorySearchResult(**documents)
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -389,7 +389,8 @@ def legacy_history_document(row: SQLLegacyHistory, handle: str) -> Document:
 async def find(
     mongo: "Mongo",
     pg: AsyncEngine,
-    req_query,
+    page: int,
+    per_page: int,
     reference_id: str | None = None,
     unbuilt: bool | None = None,
 ) -> dict:
@@ -402,21 +403,12 @@ async def find(
 
     :param mongo: the application database client, used to attach reference data
     :param pg: the application PostgreSQL database object
-    :param req_query: the raw request query, used to derive ``page`` and ``per_page``
+    :param page: the one-indexed page number to return
+    :param per_page: the number of documents to return per page
     :param reference_id: restrict changes to a single reference
     :param unbuilt: ``True`` for unbuilt changes only, ``False`` for built changes only
     :return: a search result including the matched change documents
     """
-    try:
-        page = int(req_query["page"])
-    except (KeyError, ValueError):
-        page = 1
-
-    try:
-        per_page = int(req_query["per_page"])
-    except (KeyError, ValueError):
-        per_page = 25
-
     base_filters = []
 
     if reference_id is not None:
@@ -472,7 +464,8 @@ async def find_by_index(
     mongo: "Mongo",
     pg: AsyncEngine,
     index_id: str,
-    req_query,
+    page: int,
+    per_page: int,
     term: str | None = None,
 ) -> dict:
     """List the history changes included in a single index build.
@@ -491,20 +484,11 @@ async def find_by_index(
     :param mongo: the application database client, used to attach reference data
     :param pg: the application PostgreSQL database object
     :param index_id: restrict changes to a single index build
-    :param req_query: the raw request query, used to derive ``page`` and ``per_page``
+    :param page: the one-indexed page number to return
+    :param per_page: the number of documents to return per page
     :param term: an optional term matched against the OTU name
     :return: a search result including the matched change documents
     """
-    try:
-        page = int(req_query["page"])
-    except (KeyError, ValueError):
-        page = 1
-
-    try:
-        per_page = int(req_query["per_page"])
-    except (KeyError, ValueError):
-        per_page = 25
-
     search_filters = [SQLLegacyHistory.index == index_id]
 
     if term:

--- a/virtool/hmm/api.py
+++ b/virtool/hmm/api.py
@@ -7,6 +7,7 @@ from aiohttp_pydantic.oas.typing import r200, r201, r400, r403, r404, r502
 
 from virtool.api.custom_json import json_response
 from virtool.api.errors import APIBadGateway, APIConflict, APINotFound
+from virtool.api.pagination import Page, PerPage
 from virtool.api.policy import AdministratorRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.data.errors import (
@@ -24,7 +25,12 @@ routes = Routes()
 
 @routes.view("/hmms")
 class HMMsView(PydanticView):
-    async def get(self) -> r200[HMMSearchResult]:
+    async def get(
+        self,
+        find: str | None = None,
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[HMMSearchResult] | r400:
         """Find HMMs.
 
         Lists profile hidden Markov model (HMM) annotations that are used in Virtool for
@@ -39,9 +45,10 @@ class HMMsView(PydanticView):
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
         """
         search_results = await get_data_from_req(self.request).hmms.find(
-            self.request.query,
+            page, per_page, find
         )
 
         return json_response(search_results)

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -4,7 +4,6 @@ import math
 from collections.abc import AsyncIterator
 
 from aiohttp import ClientSession
-from multidict import MultiDictProxy
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -76,22 +75,12 @@ class HmmsData(DataLayerDomain):
         self._pg = pg
         self._storage = storage
 
-    async def find(self, query: MultiDictProxy):
-        try:
-            page = max(1, int(query["page"]))
-        except (KeyError, ValueError):
-            page = 1
-
-        try:
-            per_page = max(1, int(query["per_page"]))
-        except (KeyError, ValueError):
-            per_page = 25
-
+    async def find(self, page: int, per_page: int, term: str | None = None):
         not_hidden = SQLHMM.hidden.is_(False)
 
         filters = [not_hidden]
 
-        if term := query.get("find"):
+        if term:
             filters.append(_compose_hmm_search_filter(term))
 
         data, status = await asyncio.gather(

--- a/virtool/indexes/api.py
+++ b/virtool/indexes/api.py
@@ -10,6 +10,7 @@ from virtool.api.errors import (
     APINoContent,
     APINotFound,
 )
+from virtool.api.pagination import Page, PerPage
 from virtool.api.routes import Routes
 from virtool.api.streaming import stream_storage_response
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
@@ -35,6 +36,8 @@ class IndexesView(PydanticView):
             default=False,
             description="Return only indexes that are ready for use in analysis.",
         ),
+        page: Page = 1,
+        per_page: PerPage = 25,
         archived: bool | None = Field(
             default=None,
             description=(
@@ -54,7 +57,7 @@ class IndexesView(PydanticView):
             400: Invalid query
         """
         data = await get_data_from_req(self.request).index.find(
-            ready, self.request.query, archived=archived
+            ready, page, per_page, archived=archived
         )
 
         if isinstance(data, IndexSearchResult):
@@ -233,19 +236,27 @@ async def finalize(req):
 
 @routes.view("/indexes/{index_id}/history")
 class IndexHistoryView(PydanticView):
-    async def get(self, index_id: str, /) -> r200[HistorySearchResult] | r404:
+    async def get(
+        self,
+        index_id: str,
+        /,
+        term: str | None = None,
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[HistorySearchResult] | r400 | r404:
         """List history.
 
         Lists history changes for a specific index.
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
             404: Not found
 
         """
         try:
             data = await get_data_from_req(self.request).index.find_changes(
-                index_id, self.request.query
+                index_id, page, per_page, term
             )
         except ResourceNotFoundError:
             raise APINotFound()

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -2,7 +2,6 @@ import asyncio
 import gzip
 from collections.abc import AsyncIterator
 
-from multidict import MultiDictProxy
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -59,20 +58,22 @@ class IndexData:
     async def find(
         self,
         ready: bool,
-        query: MultiDictProxy,
+        page: int,
+        per_page: int,
         archived: bool | None = None,
     ) -> list[IndexMinimal] | IndexSearchResult:
         """List all indexes.
 
-        :param ready: the request object
-        :param query: the request query object
+        :param ready: return only indexes that are ready for use in analysis
+        :param page: the one-indexed page number to return
+        :param per_page: the number of documents to return per page
         :param archived: lifecycle filter on the index's reference; see
             :func:`virtool.references.db.compose_archived_filter`
         :return: a list of all index documents
         """
         if not ready:
             data = await virtool.indexes.db.find(
-                self._mongo, self._pg, query, archived=archived
+                self._mongo, self._pg, page, per_page, archived=archived
             )
             return IndexSearchResult(**data)
 
@@ -331,11 +332,16 @@ class IndexData:
     async def find_changes(
         self,
         index_id: str,
-        req_query: MultiDictProxy[str],
+        page: int,
+        per_page: int,
+        term: str | None = None,
     ) -> HistorySearchResult:
         """Find the virus changes that are included in a given index build.
+
         :param index_id: the index ID
-        :param req_query: the request query object
+        :param page: the one-indexed page number to return
+        :param per_page: the number of documents to return per page
+        :param term: an optional term matched against the OTU name
         :return: the changes
         """
         if not await self._mongo.indexes.count_documents({"_id": index_id}):
@@ -345,8 +351,9 @@ class IndexData:
             self._mongo,
             self._pg,
             index_id,
-            req_query,
-            req_query.get("term"),
+            page,
+            per_page,
+            term,
         )
 
         return HistorySearchResult(**data)

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import asyncio.tasks
-from collections.abc import Mapping
 from typing import Any
 
 import pymongo
@@ -157,17 +156,19 @@ async def create(
 async def find(
     mongo: "Mongo",
     pg: AsyncEngine,
-    req_query: Mapping,
+    page: int,
+    per_page: int,
     ref_id: str | None = None,
     archived: bool | None = None,
 ) -> dict:
-    """Find an index document matching the `req_query`
+    """Find index documents.
 
     When ``ref_id`` is given, ``archived`` is ignored — the reference is
     already chosen, so its lifecycle state is fixed.
 
     :param mongo: the application database client
-    :param req_query: the request object
+    :param page: the one-indexed page number to return
+    :param per_page: the number of documents to return per page
     :param ref_id: the id of the reference
     :param archived: lifecycle filter on the index's reference; see
         :func:`virtool.references.db.compose_archived_filter`
@@ -202,7 +203,8 @@ async def find(
     data = await paginate(
         mongo.indexes,
         mongo_query,
-        req_query,
+        page,
+        per_page,
         base_query=base_query,
         projection=[
             "_id",

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -1,7 +1,6 @@
 """The data layer domain for OTUs."""
 
 import asyncio
-from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
 
@@ -51,10 +50,12 @@ class OTUData:
         self._pg = pg
 
     async def find(
-        self, query: Mapping, term: str | None, verified: bool | None
+        self, page: int, per_page: int, term: str | None, verified: bool | None
     ) -> dict[str, Any] | list[dict | None]:
         """Find OTUs matching the given query."""
-        return await virtool.otus.db.find(self._mongo, self._pg, term, query, verified)
+        return await virtool.otus.db.find(
+            self._mongo, self._pg, term, page, per_page, verified
+        )
 
     async def get(self, otu_id: str) -> OTU:
         """Get a single OTU by ID.

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,6 +1,5 @@
 """Work with OTUs in the database."""
 
-from collections.abc import Mapping
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -72,7 +71,8 @@ async def find(
     mongo: "Mongo",
     pg: AsyncEngine,
     term: str | None,
-    req_query: Mapping,
+    page: int,
+    per_page: int,
     verified: bool | None,
     ref_id: str | None = None,
 ) -> dict[str, Any] | list[dict | None]:
@@ -92,7 +92,8 @@ async def find(
     data = await paginate(
         mongo.otus,
         mongo_query,
-        req_query,
+        page,
+        per_page,
         base_query=base_query,
         sort="name",
         projection=["_id", "abbreviation", "name", "reference", "verified", "version"],

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -28,6 +28,7 @@ from virtool.api.errors import (
     APINoContent,
     APINotFound,
 )
+from virtool.api.pagination import Page, PerPage
 from virtool.api.policy import PermissionRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.authorization.permissions import LegacyPermission
@@ -76,6 +77,8 @@ class ReferencesView(PydanticView):
     async def get(
         self,
         find: str | None = None,
+        page: Page = 1,
+        per_page: PerPage = 25,
         archived: bool | None = Field(
             default=None,
             description=(
@@ -98,7 +101,8 @@ class ReferencesView(PydanticView):
             self.request["client"].user_id,
             self.request["client"].administrator_role == AdministratorRole.FULL,
             self.request["client"].groups,
-            self.request.query,
+            page,
+            per_page,
             archived,
         )
 
@@ -372,13 +376,16 @@ class ReferenceOTUsView(PydanticView):
         /,
         find: str | None,
         verified: bool | None,
-    ) -> r200[OTUSearchResult] | r404:
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[OTUSearchResult] | r400 | r404:
         """Find OTUs.
 
         Lists OTUs by name or abbreviation. Results are paginated.
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
             404: Not found
         """
         try:
@@ -386,7 +393,8 @@ class ReferenceOTUsView(PydanticView):
                 find,
                 verified,
                 ref_id,
-                self.request.query,
+                page,
+                per_page,
             )
         except ResourceNotFoundError:
             raise APINotFound()
@@ -438,20 +446,24 @@ class ReferenceHistoryView(PydanticView):
             default=None,
             description="Filter by build status",
         ),
-    ) -> r200[HistorySearchResult] | r404:
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[HistorySearchResult] | r400 | r404:
         """List history.
 
         Lists changes made to OTUs in the reference.
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
             404: Not found
         """
         try:
             data = await get_data_from_req(self.request).references.find_history(
                 ref_id,
                 unbuilt,
-                self.request.query,
+                page,
+                per_page,
             )
         except ResourceNotFoundError:
             raise APINotFound()
@@ -461,19 +473,27 @@ class ReferenceHistoryView(PydanticView):
 
 @routes.view("/references/v1/{ref_id}/indexes")
 class ReferenceIndexesView(PydanticView):
-    async def get(self, ref_id: str, /) -> r200[ListIndexesResponse] | r404:
+    async def get(
+        self,
+        ref_id: str,
+        /,
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[ListIndexesResponse] | r400 | r404:
         """List indexes.
 
         Lists indexes that have been created for the reference.
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
             404: Not found
         """
         try:
             data = await get_data_from_req(self.request).references.find_indexes(
                 ref_id,
-                self.request.query,
+                page,
+                per_page,
             )
         except ResourceNotFoundError:
             raise APINotFound

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 
 import arrow
 from aiohttp import ClientConnectionError, ClientConnectorError, ClientSession
-from multidict import MultiDictProxy
 from semver import VersionInfo
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -154,7 +153,8 @@ class ReferencesData(DataLayerDomain):
         user_id: int,
         administrator: bool,
         groups: list[int | str],
-        query: MultiDictProxy,
+        page: int,
+        per_page: int,
         archived: bool | None = None,
     ) -> ReferenceSearchResult:
         """Find references."""
@@ -171,7 +171,8 @@ class ReferencesData(DataLayerDomain):
         data = await paginate(
             self._mongo.references,
             mongo_query,
-            query,
+            page,
+            per_page,
             sort="name",
             base_query=base_query,
         )
@@ -544,14 +545,16 @@ class ReferencesData(DataLayerDomain):
         term: str | None,
         verified: bool | None,
         ref_id: str | None,
-        query,
+        page: int,
+        per_page: int,
     ) -> OTUSearchResult:
         if await virtool.mongo.utils.id_exists(self._mongo.references, ref_id):
             data = await virtool.otus.db.find(
                 self._mongo,
                 self._pg,
                 term,
-                query,
+                page,
+                per_page,
                 verified,
                 ref_id,
             )
@@ -587,7 +590,8 @@ class ReferencesData(DataLayerDomain):
         self,
         ref_id: str,
         unbuilt: bool | None,
-        query,
+        page: int,
+        per_page: int,
     ) -> HistorySearchResult:
         if not await self._mongo.references.count_documents({"_id": ref_id}):
             raise ResourceNotFoundError()
@@ -595,19 +599,22 @@ class ReferencesData(DataLayerDomain):
         data = await virtool.history.db.find(
             self._mongo,
             self._pg,
-            query,
+            page,
+            per_page,
             reference_id=ref_id,
             unbuilt=unbuilt,
         )
 
         return HistorySearchResult(**data)
 
-    async def find_indexes(self, ref_id: str, query) -> IndexSearchResult:
+    async def find_indexes(
+        self, ref_id: str, page: int, per_page: int
+    ) -> IndexSearchResult:
         if not await virtool.mongo.utils.id_exists(self._mongo.references, ref_id):
             raise ResourceNotFoundError()
 
         data = await virtool.indexes.db.find(
-            self._mongo, self._pg, query, ref_id=ref_id
+            self._mongo, self._pg, page, per_page, ref_id=ref_id
         )
 
         return IndexSearchResult(**data)

--- a/virtool/subtractions/api.py
+++ b/virtool/subtractions/api.py
@@ -5,6 +5,7 @@ from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r403, r404, r409
 
 from virtool.api.custom_json import json_response
 from virtool.api.errors import APIBadRequest, APIConflict, APINoContent, APINotFound
+from virtool.api.pagination import Page, PerPage
 from virtool.api.policy import PermissionRoutePolicy, policy
 from virtool.api.routes import Routes
 from virtool.api.schema import schema
@@ -25,8 +26,13 @@ routes = Routes()
 @routes.view("/subtractions")
 class SubtractionsView(PydanticView):
     async def get(
-        self, find: str | None, short: bool = False, ready: bool = False
-    ) -> r200[SubtractionSearchResult]:
+        self,
+        find: str | None,
+        short: bool = False,
+        ready: bool = False,
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[SubtractionSearchResult] | r400:
         """Find subtractions.
 
         Lists subtractions by their `name` or `nickname` by providing a `term` as a
@@ -38,9 +44,10 @@ class SubtractionsView(PydanticView):
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
         """
         search_result = await get_data_from_req(self.request).subtractions.find(
-            find, short, ready, self.request.query
+            find, short, ready, page, per_page
         )
 
         return json_response(search_result)

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -3,7 +3,6 @@ from asyncio import CancelledError
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
-from multidict import MultiDictProxy
 from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -83,7 +82,7 @@ class SubtractionsData(DataLayerDomain):
         self._pg = pg
         self._storage = storage
 
-    async def find(self, find: str, short: bool, ready: bool, query: MultiDictProxy):
+    async def find(self, find: str, short: bool, ready: bool, page: int, per_page: int):
         not_deleted = SQLSubtraction.deleted.is_(False)
 
         filters = [not_deleted]
@@ -112,9 +111,6 @@ class SubtractionsData(DataLayerDomain):
                 {"id": id_, "name": name, "ready": is_ready}
                 for id_, name, is_ready in rows
             ]
-
-        page = int(query.get("page", 1))
-        per_page = int(query.get("per_page", 25))
 
         async with AsyncSession(self._pg) as session:
             total_count = await session.scalar(

--- a/virtool/users/api.py
+++ b/virtool/users/api.py
@@ -6,6 +6,7 @@ from structlog import get_logger
 import virtool.api.authentication
 from virtool.api.custom_json import json_response
 from virtool.api.errors import APIBadRequest, APIConflict, APINotFound
+from virtool.api.pagination import Page, PerPage
 from virtool.api.policy import (
     AdministratorRoutePolicy,
     PublicRoutePolicy,
@@ -46,7 +47,9 @@ class UsersView(PydanticView):
         find: str | None = Field(
             description="Filter by partial matches to user handles.",
         ),
-    ) -> r200[User]:
+        page: Page = 1,
+        per_page: PerPage = 25,
+    ) -> r200[User] | r400:
         """Find users.
 
         Find all Virtool users.
@@ -59,10 +62,8 @@ class UsersView(PydanticView):
 
         Status Codes:
             200: Successful operation
+            400: Invalid query
         """
-        page = int(self.request.query.get("page", 1))
-        per_page = int(self.request.query.get("per_page", 25))
-
         result = await get_data_from_req(self.request).users.find(
             page=page,
             per_page=per_page,


### PR DESCRIPTION
## Summary
- List handlers read `page`/`per_page` from the raw request query with no bounds checking, causing `ZeroDivisionError` (`per_page=0`), negative offsets, and silent fallback on non-integer input.
- Adds shared `Page`/`PerPage` constrained types and declares them on the list views so aiohttp-pydantic rejects out-of-range values with a `400` before they reach the pagination math.
- Threads validated ints through the `paginate` helper and the history, references, indexes, subtractions, hmm, otus, and users data layers, which now trust the values they receive.

Closes VIR-2575.