### PR TITLE
fix: revert removed history changes without 500

### DIFF
--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -124,6 +124,32 @@ class TestDelete:
         assert await legacy_history_ids(pg) == ["6116cba1.0", "6116cba1.1"]
         assert await history_diff_ids(pg) == ["6116cba1.0", "6116cba1.1"]
 
+    async def test_removed(
+        self,
+        create_mock_history,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Reverting a ``.removed`` change deletes only the removal and restores the
+        OTU to the version it held before it was removed.
+        """
+        await create_mock_history(True)
+
+        await HistoryData(mongo, pg).delete("6116cba1.removed")
+
+        remaining = [
+            change["_id"] for change in await mongo.history.find().to_list(None)
+        ]
+        assert sorted(remaining) == MOCK_HISTORY_CHANGE_IDS
+
+        assert await legacy_history_ids(pg) == MOCK_HISTORY_CHANGE_IDS
+        assert await history_diff_ids(pg) == MOCK_HISTORY_CHANGE_IDS
+
+        otu = await mongo.otus.find_one("6116cba1")
+        assert otu is not None
+        assert otu["version"] == 3
+        assert otu["name"] == "Test Virus"
+
     async def test_rollback_preserves_postgres(
         self,
         create_mock_history,

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, cast, select
+from sqlalchemy import Integer, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.utils
@@ -164,14 +164,32 @@ class HistoryData:
 
             otu_id, otu_version = change_id.split(".")
 
-            if otu_version != "removed":
-                otu_version = int(otu_version)
+            if otu_version == "removed":
+                # Reverting a removal restores the OTU to the version it held just
+                # before it was removed, i.e. its highest numbered change. The
+                # removal change itself carries a NULL ``otu_version`` and is always
+                # reverted by ``patch_to_version``.
+                async with AsyncSession(self._pg) as session:
+                    target_version = (
+                        await session.execute(
+                            select(
+                                func.max(
+                                    cast(SQLLegacyHistory.otu_version, Integer),
+                                ),
+                            ).where(
+                                SQLLegacyHistory.otu == otu_id,
+                                SQLLegacyHistory.otu_version.is_not(None),
+                            ),
+                        )
+                    ).scalar_one()
+            else:
+                target_version = int(otu_version) - 1
 
             _, patched, history_to_delete = await patch_to_version(
                 self._mongo,
                 self._pg,
                 otu_id,
-                otu_version - 1,
+                target_version,
             )
         except DatabaseError:
             raise ResourceConflictError()


### PR DESCRIPTION
## Summary
- Deleting a `.removed` history change ran `"removed" - 1`, raising an uncaught `TypeError` (not a `DatabaseError`) and returning a 500.
- `HistoryData.delete()` now computes an explicit target version for removal changes — the OTU's highest numbered `otu_version` — so `patch_to_version` reverts only the removal and restores the OTU to its pre-removal state.
- Adds a regression test for reverting a `.removed` change; the pre-existing `test_revert` parametrized `remove` but always deleted a numbered change, so the path was never exercised.