### PR TITLE
refactor: collapse history dual-write to postgres only

### DIFF
--- a/tests/history/__snapshots__/test_api.ambr
+++ b/tests/history/__snapshots__/test_api.ambr
@@ -162,54 +162,6 @@
 # name: test_revert[True-False-None].1
   list([
     dict({
-      '_id': '6116cba1.0',
-      'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 495000),
-      'description': 'Description',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'create',
-      'otu': dict({
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'hxn167',
-      }),
-      'user': dict({
-        'id': 'test',
-      }),
-    }),
-    dict({
-      '_id': '6116cba1.1',
-      'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 600000),
-      'description': 'Description',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'update',
-      'otu': dict({
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1,
-      }),
-      'reference': dict({
-        'id': 'hxn167',
-      }),
-      'user': dict({
-        'id': 'test',
-      }),
-    }),
-  ])
-# ---
-# name: test_revert[True-False-None].2
-  list([
-    dict({
       '_id': 'KX269872',
       'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
       'host': 'sweet cherry',
@@ -246,54 +198,6 @@
   })
 # ---
 # name: test_revert[True-True-None].1
-  list([
-    dict({
-      '_id': '6116cba1.0',
-      'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 495000),
-      'description': 'Description',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'create',
-      'otu': dict({
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'hxn167',
-      }),
-      'user': dict({
-        'id': 'test',
-      }),
-    }),
-    dict({
-      '_id': '6116cba1.1',
-      'created_at': datetime.datetime(2017, 7, 12, 16, 0, 50, 600000),
-      'description': 'Description',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'update',
-      'otu': dict({
-        'id': '6116cba1',
-        'name': 'Prunus virus F',
-        'version': 1,
-      }),
-      'reference': dict({
-        'id': 'hxn167',
-      }),
-      'user': dict({
-        'id': 'test',
-      }),
-    }),
-  ])
-# ---
-# name: test_revert[True-True-None].2
   list([
     dict({
       '_id': 'KX269872',

--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -55,30 +55,6 @@
   })
 # ---
 # name: TestAdd.test_create.1
-  dict({
-    '_id': '6116cba1.0',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'description': 'Created Prunus virus F',
-    'diff': 'postgres',
-    'index': dict({
-      'id': 'unbuilt',
-      'version': 'unbuilt',
-    }),
-    'method_name': 'create',
-    'otu': dict({
-      'id': '6116cba1',
-      'name': 'Prunus virus F',
-      'version': 0,
-    }),
-    'reference': dict({
-      'id': 'hxn167',
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
-# name: TestAdd.test_create.2
   <SQLLegacyHistoryDiff(id=1, change_id=6116cba1.0, history_id=1, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
 # ---
 # name: TestAdd.test_create[legacy_history]
@@ -134,30 +110,6 @@
   })
 # ---
 # name: TestAdd.test_edit.1
-  dict({
-    '_id': '6116cba1.1',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'description': 'This is a description',
-    'diff': 'postgres',
-    'index': dict({
-      'id': 'unbuilt',
-      'version': 'unbuilt',
-    }),
-    'method_name': 'edit',
-    'otu': dict({
-      'id': '6116cba1',
-      'name': 'Prunus virus F',
-      'version': 1,
-    }),
-    'reference': dict({
-      'id': 'hxn167',
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
-# name: TestAdd.test_edit.2
   list([
     list([
       'change',
@@ -190,30 +142,6 @@
 # ---
 # name: TestAdd.test_remove[diff]
   <SQLLegacyHistoryDiff(id=1, change_id=6116cba1.removed, history_id=1, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
-# ---
-# name: TestAdd.test_remove[document]
-  dict({
-    '_id': '6116cba1.removed',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'description': 'Removed Prunus virus F',
-    'diff': 'postgres',
-    'index': dict({
-      'id': 'unbuilt',
-      'version': 'unbuilt',
-    }),
-    'method_name': 'remove',
-    'otu': dict({
-      'id': '6116cba1',
-      'name': 'Prunus virus F',
-      'version': 'removed',
-    }),
-    'reference': dict({
-      'id': 'hxn167',
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
 # ---
 # name: TestAdd.test_remove[legacy_history]
   <SQLLegacyHistory(id=1, legacy_id=6116cba1.removed, created_at=2015-10-06 20:00:00, description=Removed Prunus virus F, method_name=remove, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=None, reference=hxn167, index=None, index_version=None)>

--- a/tests/history/test_api.py
+++ b/tests/history/test_api.py
@@ -169,5 +169,4 @@ async def test_revert(
     await resp_is.no_content(resp)
 
     assert await mongo.otus.find_one() == snapshot
-    assert await mongo.history.find().to_list(None) == snapshot
     assert await mongo.sequences.find().to_list(None) == snapshot

--- a/tests/history/test_data.py
+++ b/tests/history/test_data.py
@@ -103,23 +103,18 @@ async def history_diff_ids(pg: AsyncEngine) -> list[str]:
 
 
 class TestDelete:
-    async def test_dual_write(
+    async def test_delete(
         self,
         create_mock_history,
         mongo: Mongo,
         pg: AsyncEngine,
     ):
-        """Reverting a change deletes the reverted rows from Mongo, ``legacy_history``
-        and ``legacy_history_diff`` together.
+        """Reverting a change deletes the reverted ``legacy_history`` and
+        ``legacy_history_diff`` rows together.
         """
         await create_mock_history(False)
 
         await HistoryData(mongo, pg).delete("6116cba1.2")
-
-        remaining = [
-            change["_id"] for change in await mongo.history.find().to_list(None)
-        ]
-        assert sorted(remaining) == ["6116cba1.0", "6116cba1.1"]
 
         assert await legacy_history_ids(pg) == ["6116cba1.0", "6116cba1.1"]
         assert await history_diff_ids(pg) == ["6116cba1.0", "6116cba1.1"]
@@ -136,11 +131,6 @@ class TestDelete:
         await create_mock_history(True)
 
         await HistoryData(mongo, pg).delete("6116cba1.removed")
-
-        remaining = [
-            change["_id"] for change in await mongo.history.find().to_list(None)
-        ]
-        assert sorted(remaining) == MOCK_HISTORY_CHANGE_IDS
 
         assert await legacy_history_ids(pg) == MOCK_HISTORY_CHANGE_IDS
         assert await history_diff_ids(pg) == MOCK_HISTORY_CHANGE_IDS

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 
 import pytest
@@ -112,34 +111,29 @@ class TestGetContributors:
 class TestAdd:
     async def test_edit(
         self,
-        mongo: Mongo,
         pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         static_time,
         fake,
         test_otu_edit,
     ):
-        """A change recorded inside a caller-supplied Mongo session dual-writes."""
+        """An edit writes a normal-version ``legacy_history`` row and its diff."""
         old, new = test_otu_edit
 
         user = await fake.users.create()
 
-        async with mongo.create_session() as session:
-            change = await virtool.history.db.add(
-                mongo,
-                pg,
-                "This is a description",
-                HistoryMethod.edit,
-                old,
-                new,
-                user.id,
-                session,
-            )
+        change = await virtool.history.db.add(
+            pg,
+            "This is a description",
+            HistoryMethod.edit,
+            old,
+            new,
+            user.id,
+        )
 
         change_id = change["_id"]
 
         assert change == snapshot
-        assert await mongo.history.find_one(change_id) == snapshot
 
         async with AsyncSession(pg) as session:
             diff = await session.execute(
@@ -160,14 +154,13 @@ class TestAdd:
 
     async def test_create(
         self,
-        mongo: Mongo,
         pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         static_time,
         fake,
         test_otu_edit,
     ):
-        """A standalone create dual-writes a normal-version ``legacy_history`` row."""
+        """A standalone create writes a normal-version ``legacy_history`` row."""
         # There is no old document because this is a change document for an otu creation
         # operation.
         old = None
@@ -177,7 +170,6 @@ class TestAdd:
         user = await fake.users.create()
 
         change = await virtool.history.db.add(
-            mongo,
             pg,
             f"Created {new['name']}",
             HistoryMethod.create,
@@ -187,7 +179,6 @@ class TestAdd:
         )
 
         assert change == snapshot
-        assert await mongo.history.find_one() == snapshot
         assert await get_row_by_id(pg, SQLLegacyHistoryDiff, 1) == snapshot
 
         async with AsyncSession(pg) as session:
@@ -201,7 +192,6 @@ class TestAdd:
 
     async def test_remove(
         self,
-        mongo: Mongo,
         pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         static_time,
@@ -217,7 +207,6 @@ class TestAdd:
         user = await fake.users.create()
 
         change = await virtool.history.db.add(
-            mongo,
             pg,
             f"Removed {old['name']}",
             HistoryMethod.remove,
@@ -228,13 +217,9 @@ class TestAdd:
 
         assert change == snapshot(name="return_value")
 
-        diff, document = await asyncio.gather(
-            get_row_by_id(pg, SQLLegacyHistoryDiff, 1),
-            mongo.history.find_one(),
-        )
+        diff = await get_row_by_id(pg, SQLLegacyHistoryDiff, 1)
 
         assert diff == snapshot(name="diff")
-        assert document == snapshot(name="document")
 
         async with AsyncSession(pg) as session:
             legacy = (

--- a/tests/indexes/__snapshots__/test_db.ambr
+++ b/tests/indexes/__snapshots__/test_db.ambr
@@ -45,18 +45,6 @@
     'version': 0,
   })
 # ---
-# name: test_create[None].1
-  dict({
-    '_id': 'abc',
-    'index': dict({
-      'id': 'bf1b993c',
-      'version': 0,
-    }),
-    'reference': dict({
-      'id': 'foo',
-    }),
-  })
-# ---
 # name: test_create[abc]
   dict({
     '_id': 'abc',
@@ -75,17 +63,5 @@
       'id': 'test',
     }),
     'version': 0,
-  })
-# ---
-# name: test_create[abc].1
-  dict({
-    '_id': 'abc',
-    'index': dict({
-      'id': 'abc',
-      'version': 0,
-    }),
-    'reference': dict({
-      'id': 'foo',
-    }),
   })
 # ---

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -713,20 +713,6 @@ async def test_delete_index(
                     "version": 4,
                 },
             ),
-            mongo.history.insert_many(
-                [
-                    {
-                        "_id": _id,
-                        "index": {
-                            "id": index_id,
-                            "version": "test_version",
-                        },
-                        "user": {"id": user.id},
-                    }
-                    for _id in ("history1", "history2", "history3")
-                ],
-                session=None,
-            ),
         )
 
     response = await client.delete(f"/indexes/{index_id}")
@@ -735,8 +721,7 @@ async def test_delete_index(
         assert error == response.status
     else:
         assert response.status == 204
-        async for doc in mongo.history.find({"index.id": index_id}):
-            assert doc["index"]["id"] == doc["index"]["version"] == "unbuilt"
+        assert await mongo.indexes.find_one(index_id) is None
 
 
 @pytest.mark.parametrize("error", [None, "409", "404_index", "404_file"])

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -111,8 +111,8 @@ class TestDelete:
         pg: AsyncEngine,
         static_time,
     ):
-        """Deleting an index resets its change records to the unbuilt sentinel in
-        both Mongo and Postgres, leaving changes built into other indexes alone.
+        """Deleting an index resets its ``legacy_history`` change records to the
+        unbuilt sentinel, leaving changes built into other indexes alone.
         """
         user = await fake.users.create()
         job = await fake.jobs.create(user=user)

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -139,26 +139,6 @@ class TestDelete:
                     "manifest": {},
                 },
             ),
-            mongo.history.insert_many(
-                [
-                    {
-                        "_id": "otu_a.0",
-                        "index": {"id": "deleted_index", "version": 4},
-                        "user": {"id": user.id},
-                    },
-                    {
-                        "_id": "otu_b.0",
-                        "index": {"id": "deleted_index", "version": 4},
-                        "user": {"id": user.id},
-                    },
-                    {
-                        "_id": "otu_c.0",
-                        "index": {"id": "other_index", "version": 2},
-                        "user": {"id": user.id},
-                    },
-                ],
-                session=None,
-            ),
         )
 
         async with AsyncSession(pg) as session:
@@ -210,14 +190,6 @@ class TestDelete:
         await data_layer.index.delete("deleted_index")
 
         assert await mongo.indexes.find_one("deleted_index") is None
-
-        async for doc in mongo.history.find({"_id": {"$in": ["otu_a.0", "otu_b.0"]}}):
-            assert doc["index"] == {"id": "unbuilt", "version": "unbuilt"}
-
-        assert (await mongo.history.find_one("otu_c.0"))["index"] == {
-            "id": "other_index",
-            "version": 2,
-        }
 
         async with AsyncSession(pg) as session:
             rows = {

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -30,16 +30,7 @@ async def test_create(
     snapshot: SnapshotAssertion,
     static_time,
 ):
-    await asyncio.gather(
-        mongo.references.insert_one({"_id": "foo"}),
-        mongo.history.insert_one(
-            {
-                "_id": "abc",
-                "index": {"id": "unbuilt", "version": "unbuilt"},
-                "reference": {"id": "foo"},
-            },
-        ),
-    )
+    await mongo.references.insert_one({"_id": "foo"})
 
     mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
 
@@ -54,10 +45,9 @@ async def test_create(
         )
         == snapshot
     )
-    assert await mongo.history.find_one("abc") == snapshot
 
 
-async def test_create_dual_writes_index_assignment(
+async def test_create_assigns_index_in_postgres(
     mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
@@ -65,7 +55,7 @@ async def test_create_dual_writes_index_assignment(
     static_time,
 ):
     """Building an index assigns previously-unbuilt changes for the reference to the
-    new index in both Mongo and Postgres, leaving other references and already-built
+    new index in ``legacy_history``, leaving other references and already-built
     changes untouched.
     """
     user = await fake.users.create()
@@ -79,26 +69,6 @@ async def test_create_dual_writes_index_assignment(
                 "version": 0,
                 "ready": True,
             },
-        ),
-        mongo.history.insert_many(
-            [
-                {
-                    "_id": "ref_unbuilt",
-                    "index": {"id": "unbuilt", "version": "unbuilt"},
-                    "reference": {"id": "built_ref"},
-                },
-                {
-                    "_id": "ref_already_built",
-                    "index": {"id": "prior_index", "version": 0},
-                    "reference": {"id": "built_ref"},
-                },
-                {
-                    "_id": "other_ref_unbuilt",
-                    "index": {"id": "unbuilt", "version": "unbuilt"},
-                    "reference": {"id": "other_ref"},
-                },
-            ],
-            session=None,
         ),
     )
 
@@ -140,19 +110,6 @@ async def test_create_dual_writes_index_assignment(
         index_id="new_index",
     )
 
-    assert (await mongo.history.find_one("ref_unbuilt"))["index"] == {
-        "id": "new_index",
-        "version": 1,
-    }
-    assert (await mongo.history.find_one("ref_already_built"))["index"] == {
-        "id": "prior_index",
-        "version": 0,
-    }
-    assert (await mongo.history.find_one("other_ref_unbuilt"))["index"] == {
-        "id": "unbuilt",
-        "version": "unbuilt",
-    }
-
     async with AsyncSession(pg) as session:
         rows = {
             row.legacy_id: (row.index, row.index_version)
@@ -171,21 +128,12 @@ async def test_create_rolls_back_both_stores_on_failure(
     fake,
     static_time,
 ):
-    """A failure during the dual-write rolls back the Mongo writes already issued
+    """A failure during the index build rolls back the Mongo index insert issued
     inside the transaction, leaving neither store with the index assignment.
     """
     user = await fake.users.create()
 
-    await asyncio.gather(
-        mongo.references.insert_one({"_id": "built_ref"}),
-        mongo.history.insert_one(
-            {
-                "_id": "ref_unbuilt",
-                "index": {"id": "unbuilt", "version": "unbuilt"},
-                "reference": {"id": "built_ref"},
-            },
-        ),
-    )
+    await mongo.references.insert_one({"_id": "built_ref"})
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -222,10 +170,6 @@ async def test_create_rolls_back_both_stores_on_failure(
         )
 
     assert await mongo.indexes.find_one("new_index") is None
-    assert (await mongo.history.find_one("ref_unbuilt"))["index"] == {
-        "id": "unbuilt",
-        "version": "unbuilt",
-    }
 
     async with AsyncSession(pg) as session:
         row = (

--- a/tests/otus/__snapshots__/test_data.ambr
+++ b/tests/otus/__snapshots__/test_data.ambr
@@ -279,30 +279,6 @@
     'version': 1,
   })
 # ---
-# name: test_set_default.2
-  dict({
-    '_id': '6116cba1.1',
-    'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'description': 'Set Isolate A as default',
-    'diff': 'postgres',
-    'index': dict({
-      'id': 'unbuilt',
-      'version': 'unbuilt',
-    }),
-    'method_name': 'set_as_default',
-    'otu': dict({
-      'id': '6116cba1',
-      'name': 'Prunus virus F',
-      'version': 1,
-    }),
-    'reference': dict({
-      'id': 'hxn167',
-    }),
-    'user': dict({
-      'id': 1,
-    }),
-  })
-# ---
 # name: test_update[history]
   dict({
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -2,6 +2,7 @@ import asyncio
 from http import HTTPStatus
 
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from yarl import URL
@@ -278,7 +279,6 @@ class TestEdit:
             mongo.otus.insert_one(test_otu),
             mongo.references.insert_one(test_ref),
             mongo.sequences.insert_one(test_sequence),
-            mongo.history.insert_one(change),
         )
 
         async with AsyncSession(pg) as session:
@@ -289,7 +289,13 @@ class TestEdit:
 
         if check_ref_right:
             assert resp.status == HTTPStatus.OK
-            assert await mongo.history.count_documents({}) == 1 + change_count
+
+            async with AsyncSession(pg) as session:
+                history_count = await session.scalar(
+                    select(func.count()).select_from(SQLLegacyHistory),
+                )
+
+            assert history_count == 1 + change_count
             assert await resp.json() == snapshot(name="json")
         else:
             await resp_is.insufficient_rights(resp)

--- a/tests/otus/test_data.py
+++ b/tests/otus/test_data.py
@@ -136,7 +136,6 @@ async def test_set_default(
     )
 
     assert await mongo.otus.find_one() == snapshot
-    assert await mongo.history.find_one() == snapshot
 
 
 async def test_get_sequence_fasta(mongo, data_layer, test_otu, test_sequence):

--- a/tests/references/__snapshots__/test_db.ambr
+++ b/tests/references/__snapshots__/test_db.ambr
@@ -21,7 +21,7 @@
     }),
   ])
 # ---
-# name: test_populate_insert_only_reference_dual_writes_legacy_history[legacy_history]
+# name: test_populate_insert_only_reference_writes_legacy_history[legacy_history]
   list([
     <SQLLegacyHistory(id=1, legacy_id=lhotu001.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 1 (O1), method_name=remote, user_id=1, otu=lhotu001, otu_name=OTU 1, otu_version=0, reference=ref_legacy_test, index=None, index_version=None)>,
     <SQLLegacyHistory(id=2, legacy_id=lhotu002.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 2 (O2), method_name=remote, user_id=1, otu=lhotu002, otu_name=OTU 2, otu_version=0, reference=ref_legacy_test, index=None, index_version=None)>,

--- a/tests/references/__snapshots__/test_tasks.ambr
+++ b/tests/references/__snapshots__/test_tasks.ambr
@@ -1,448 +1,4 @@
 # serializer version: 1
-# name: test_import_reference_task[history]
-  list([
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Habenaria mosaic virus (HaMV)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Habenaria mosaic virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hardenbergia virus A (HarVA)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hardenbergia virus A',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Helenium virus S',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Helenium virus S',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Helicoverpa zea nudivirus 2 (HzNV-2)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Helicoverpa zea nudivirus 2',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Helleborus net necrosis virus (HeNNV)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Helleborus net necrosis virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hibbertia virus Y (HiVY)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hibbertia virus Y',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hibiscus chlorotic ringspot virus (HCRSV)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hibiscus chlorotic ringspot virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hibiscus golden mosaic virus',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hibiscus golden mosaic virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hibiscus green spot virus (HGSV)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hibiscus green spot virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hibiscus-infecting cilevirus',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hibiscus-infecting cilevirus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hollyhock yellow vein mosaic Islamabad virus',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hollyhock yellow vein mosaic Islamabad virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hollyhock yellow vein virus',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hollyhock yellow vein virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hollyhock yellow vein virus associated symptomless alphasatellite',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hollyhock yellow vein virus associated symptomless alphasatellite',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Honeysuckle yellow vein Japan betasatellite (HYVJB)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Honeysuckle yellow vein Japan betasatellite',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Honeysuckle yellow vein beta-[Japan:Fukui:2001] (HYVB-Japan)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hop latent virus (HpLV)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hop latent virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hosta virus X (HVX)',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hosta virus X',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hot pepper endornavirus',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hot pepper endornavirus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hoya chlorotic spot virus',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hoya chlorotic spot virus',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-    dict({
-      '_id': str,
-      'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-      'description': 'Imported Hypericum japonicum associated circular DNA',
-      'diff': 'postgres',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'import',
-      'otu': dict({
-        'id': str,
-        'name': 'Hypericum japonicum associated circular DNA',
-        'version': 0,
-      }),
-      'reference': dict({
-        'id': 'foo',
-      }),
-      'user': dict({
-        'id': 1,
-      }),
-    }),
-  ])
-# ---
 # name: test_import_reference_task[history_diffs]
   list([
     dict({
@@ -1112,6 +668,49 @@
             None,
             dict({
               '_id': str,
+              'abbreviation': 'HYVB-Japan',
+              'created_at': '2015-10-06T20:00:00Z',
+              'imported': True,
+              'isolates': list([
+                dict({
+                  'default': True,
+                  'id': str,
+                  'source_name': 'Fukui',
+                  'source_type': 'isolate',
+                }),
+              ]),
+              'issues': None,
+              'last_indexed_version': None,
+              'lower_name': 'honeysuckle yellow vein beta-[japan:fukui:2001]',
+              'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
+              'reference': dict({
+                'id': 'foo',
+              }),
+              'remote': dict({
+                'id': '51c5d911',
+              }),
+              'schema': list([
+              ]),
+              'user': dict({
+                'id': 1,
+              }),
+              'verified': True,
+              'version': 0,
+            }),
+          ]),
+        ]),
+      ]),
+    }),
+    dict({
+      'change_id': str,
+      'diff': list([
+        list([
+          'change',
+          '',
+          list([
+            None,
+            dict({
+              '_id': str,
               'abbreviation': 'HYVJB',
               'created_at': '2015-10-06T20:00:00Z',
               'imported': True,
@@ -1141,49 +740,6 @@
                 }),
               ]),
               'taxid': None,
-              'user': dict({
-                'id': 1,
-              }),
-              'verified': True,
-              'version': 0,
-            }),
-          ]),
-        ]),
-      ]),
-    }),
-    dict({
-      'change_id': str,
-      'diff': list([
-        list([
-          'change',
-          '',
-          list([
-            None,
-            dict({
-              '_id': str,
-              'abbreviation': 'HYVB-Japan',
-              'created_at': '2015-10-06T20:00:00Z',
-              'imported': True,
-              'isolates': list([
-                dict({
-                  'default': True,
-                  'id': str,
-                  'source_name': 'Fukui',
-                  'source_type': 'isolate',
-                }),
-              ]),
-              'issues': None,
-              'last_indexed_version': None,
-              'lower_name': 'honeysuckle yellow vein beta-[japan:fukui:2001]',
-              'name': 'Honeysuckle yellow vein beta-[Japan:Fukui:2001]',
-              'reference': dict({
-                'id': 'foo',
-              }),
-              'remote': dict({
-                'id': '51c5d911',
-              }),
-              'schema': list([
-              ]),
               'user': dict({
                 'id': 1,
               }),

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -275,17 +275,9 @@ async def test_populate_insert_only_reference_rollback(
         for i in (1, 2)
     ]
 
-    history_done = asyncio.Event()
     otus_done = asyncio.Event()
 
-    real_history_insert_many = mongo.history.insert_many
     real_otus_insert_many = mongo.otus.insert_many
-
-    async def wrapped_history_insert_many(documents, session):
-        try:
-            return await real_history_insert_many(documents, session)
-        finally:
-            history_done.set()
 
     async def wrapped_otus_insert_many(documents, session):
         try:
@@ -294,16 +286,12 @@ async def test_populate_insert_only_reference_rollback(
             otus_done.set()
 
     async def fail_sequences_insert_many(documents, session):
-        # Wait for the sibling inserts to actually land so the rollback has
+        # Wait for the sibling OTU insert to actually land so the rollback has
         # real Mongo state to clean up — otherwise the test would pass
         # trivially against empty collections.
-        await asyncio.wait_for(
-            asyncio.gather(history_done.wait(), otus_done.wait()),
-            timeout=5.0,
-        )
+        await asyncio.wait_for(otus_done.wait(), timeout=5.0)
         raise RuntimeError("forced mongo failure")
 
-    mocker.patch.object(mongo.history, "insert_many", wrapped_history_insert_many)
     mocker.patch.object(mongo.otus, "insert_many", wrapped_otus_insert_many)
     mocker.patch.object(mongo.sequences, "insert_many", fail_sequences_insert_many)
 
@@ -321,7 +309,6 @@ async def test_populate_insert_only_reference_rollback(
     assert excinfo.group_contains(RuntimeError, match="forced mongo failure")
 
     assert await mongo.otus.count_documents({"reference.id": ref_id}) == 0
-    assert await mongo.history.count_documents({"reference.id": ref_id}) == 0
     assert await mongo.sequences.count_documents({"reference.id": ref_id}) == 0
     assert await mongo.references.find_one({"_id": ref_id}) is None
 
@@ -342,7 +329,7 @@ async def test_populate_insert_only_reference_rollback(
     assert legacy_count == 0
 
 
-async def test_populate_insert_only_reference_dual_writes_legacy_history(
+async def test_populate_insert_only_reference_writes_legacy_history(
     fake: DataFaker,
     mocker: MockerFixture,
     mongo: Mongo,

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -3,14 +3,14 @@ import datetime
 from pathlib import Path
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
-from virtool.history.sql import SQLLegacyHistoryDiff
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.db import get_manifest
@@ -35,11 +35,10 @@ def assert_reference_created(
     async def func(
         query: dict | None = None,
     ):
-        references, otus, sequences, history = await asyncio.gather(
+        references, otus, sequences = await asyncio.gather(
             mongo.references.find_one("foo"),
             mongo.otus.find(query or {}, sort=[("name", 1)]).to_list(None),
             mongo.sequences.find(query or {}, sort=[("accession", 1)]).to_list(None),
-            mongo.history.find(query or {}, sort=[("otu.name", 1)]).to_list(None),
         )
 
         assert references == snapshot(name="ref")
@@ -66,14 +65,20 @@ def assert_reference_created(
             ),
         )
 
-        assert history == snapshot(
-            name="history",
-            matcher=path_type(
-                {".*_id": (str,), r".*\d\.id": (str,), ".*otu.id": (str,)}, regex=True
-            ),
-        )
+        async with AsyncSession(pg) as pg_session:
+            history_rows = (
+                (
+                    await pg_session.execute(
+                        select(SQLLegacyHistory).order_by(SQLLegacyHistory.otu_name),
+                    )
+                )
+                .scalars()
+                .all()
+            )
 
-        change_ids = [doc["_id"] for doc in history]
+        assert len(history_rows) == len(otus)
+
+        change_ids = [row.legacy_id for row in history_rows]
 
         async with AsyncSession(pg) as pg_session:
             diff_rows = (
@@ -299,7 +304,16 @@ async def test_clone_reference_task(
 
         await session.commit()
 
-    assert await mongo.history.count_documents({}) == 20
+    async def count_history(reference: str | None = None) -> int:
+        query = select(func.count()).select_from(SQLLegacyHistory)
+
+        if reference is not None:
+            query = query.where(SQLLegacyHistory.reference == reference)
+
+        async with AsyncSession(pg) as session:
+            return await session.scalar(query)
+
+    assert await count_history() == 20
     assert await mongo.otus.count_documents({}) == 20
 
     task_instance = await CloneReferenceTask.from_task_id(data_layer, 1)
@@ -315,5 +329,5 @@ async def test_clone_reference_task(
     # Make sure OTU count is sum of source and destination references.
     assert len(otus) == 40
 
-    assert await mongo.history.count_documents({}) == 40
-    assert await mongo.history.count_documents({"reference.id": "foo"}) == 20
+    assert await count_history() == 40
+    assert await count_history("foo") == 20

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -224,11 +224,6 @@ class HistoryData:
                     session=mongo_session,
                 )
 
-            await self._mongo.history.delete_many(
-                {"_id": {"$in": history_to_delete}},
-                session=mongo_session,
-            )
-
             await delete_history(pg_session, history_to_delete)
 
         await retry_both_transactions(self._mongo, self._pg, revert)

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -6,17 +6,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import dictdiffer
-from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy import Integer, cast, delete, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.db
 import virtool.utils
-from virtool.data.topg import (
-    both_transactions,
-    compose_legacy_id_multi_expression,
-)
+from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.data.transforms import apply_transforms
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.history.utils import (
@@ -32,21 +28,6 @@ from virtool.utils import base_processor
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
-
-HISTORY_LIST_PROJECTION = [
-    "_id",
-    "description",
-    "method_name",
-    "created_at",
-    "index",
-    "otu",
-    "reference",
-    "user",
-]
-"""A MongoDB projection for history for listing purposes."""
-
-HISTORY_PROJECTION = [*HISTORY_LIST_PROJECTION, "diff"]
-"""A MongoDB projection for history that includes the ``diff`` field."""
 
 _HISTORY_DIFF_CHUNK_SIZE = 32767 // 3
 """Max ``legacy_history_diff`` rows per statement.
@@ -213,7 +194,7 @@ async def delete_history(pg_session: AsyncSession, change_ids: list[str]) -> Non
     """Delete ``history_diffs`` and ``legacy_history`` rows for ``change_ids``.
 
     Operates within an existing ``pg_session`` so the deletes commit atomically with
-    the paired Mongo deletes in a :func:`both_transactions` context. Unlike
+    the paired Mongo writes in the surrounding transaction context. Unlike
     :func:`bulk_delete_history`, it does not open or commit its own session.
     """
     if not change_ids:
@@ -244,18 +225,15 @@ class PreparedChange:
 
 
 async def add(
-    mongo: "Mongo",
     pg: AsyncEngine,
     description: str,
     method_name: HistoryMethod,
     old: dict | None,
     new: dict | None,
     user_id: int,
-    mongo_session: AsyncIOMotorClientSession | None = None,
 ) -> dict:
     """Add a change document to the history collection.
 
-    :param mongo: the application database object
     :param pg: the application PostgreSQL database object
     :param method_name: the name of the handler method that executed the change
     :param old: the otu document prior to the change
@@ -272,22 +250,12 @@ async def add(
     diff_row = SQLLegacyHistoryDiff(change_id=document["_id"], diff=prepared.diff)
     legacy_row = SQLLegacyHistory(**legacy_history_values(document))
 
-    if mongo_session is None:
-        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
-            pg_session.add(legacy_row)
-            await pg_session.flush()
-            diff_row.history_id = legacy_row.id
-            pg_session.add(diff_row)
-            await mongo.history.insert_one(document, session=mongo_session)
-    else:
-        async with AsyncSession(pg) as pg_session:
-            pg_session.add(legacy_row)
-            await pg_session.flush()
-            diff_row.history_id = legacy_row.id
-            pg_session.add(diff_row)
-            await pg_session.flush()
-            await mongo.history.insert_one(document, session=mongo_session)
-            await pg_session.commit()
+    async with AsyncSession(pg) as pg_session:
+        pg_session.add(legacy_row)
+        await pg_session.flush()
+        diff_row.history_id = legacy_row.id
+        pg_session.add(diff_row)
+        await pg_session.commit()
 
     return {**document, "diff": prepared.diff}
 
@@ -360,7 +328,7 @@ def coerce_otu_version(otu_version: str | None) -> int | str:
 
 
 def legacy_history_document(row: SQLLegacyHistory, handle: str) -> Document:
-    """Reconstruct a ``HISTORY_LIST_PROJECTION`` document from a ``legacy_history`` row.
+    """Reconstruct a history list document from a ``legacy_history`` row.
 
     Reverses the sentinel-to-NULL conventions applied by :func:`legacy_history_values`:
     a ``NULL`` ``otu_version`` becomes the ``"removed"`` sentinel and a ``NULL`` ``index``

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -45,7 +45,7 @@ columns (see :func:`legacy_history_values`).
 
 
 def legacy_history_values(document: Document) -> dict:
-    """Map a Mongo history ``document`` to ``legacy_history`` column values.
+    """Map a history change ``document`` to ``legacy_history`` column values.
 
     Applies the sentinel-to-NULL conventions: an ``otu.version`` of ``"removed"``
     and an ``index`` of ``"unbuilt"`` are stored as ``NULL``.
@@ -232,7 +232,7 @@ async def add(
     new: dict | None,
     user_id: int,
 ) -> dict:
-    """Add a change document to the history collection.
+    """Add a change document to ``legacy_history``.
 
     :param pg: the application PostgreSQL database object
     :param method_name: the name of the handler method that executed the change
@@ -267,7 +267,7 @@ def prepare_add(
     user_id: int,
     description: str = "",
 ) -> PreparedChange:
-    """Add a change document to the history collection.
+    """Add a change document to ``legacy_history``.
 
     :param method_name: the name of the method that executed the change
     :param old: the otu document prior to the change
@@ -617,7 +617,7 @@ def _change_to_revert(row: SQLLegacyHistory) -> Document:
     """Build the minimal change document that :func:`patch_to_version` reverts.
 
     The shape mirrors the fields the revert loop and :func:`_resolve_diffs` read from a
-    Mongo history document: ``_id``, the ``"postgres"`` diff sentinel, ``method_name``,
+    history change document: ``_id``, the ``"postgres"`` diff sentinel, ``method_name``,
     and the coerced ``otu.version``. Keeping this construction in one place stops it from
     silently drifting from what :func:`_resolve_diffs` expects.
     """

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -377,12 +377,6 @@ class IndexData:
             if delete_result.deleted_count == 0:
                 raise ResourceNotFoundError
 
-            await self._mongo.history.update_many(
-                {"index.id": index_id},
-                {"$set": {"index": {"id": "unbuilt", "version": "unbuilt"}}},
-                session=mongo_session,
-            )
-
             await pg_session.execute(
                 update(SQLLegacyHistory)
                 .where(SQLLegacyHistory.index == index_id)

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -168,12 +168,6 @@ async def create(
     async with both_transactions(mongo, pg) as (mongo_session, pg_session):
         document = await mongo.indexes.insert_one(document, session=mongo_session)
 
-        await mongo.history.update_many(
-            {"index.id": "unbuilt", "reference.id": ref_id},
-            {"$set": {"index": {"id": document["_id"], "version": index_version}}},
-            session=mongo_session,
-        )
-
         await pg_session.execute(
             update(SQLLegacyHistory)
             .where(

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -252,14 +252,12 @@ class OTUData:
             )
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 compose_create_description(document_),
                 HistoryMethod.create,
                 None,
                 document_,
                 user_id,
-                mongo_session=session,
             )
 
             return document_
@@ -323,7 +321,6 @@ class OTUData:
             await update_otu_verification(self._mongo, new, session=session)
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 compose_edit_description(
                     new["name"],
@@ -335,7 +332,6 @@ class OTUData:
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
         await self._mongo.with_transaction(func)
@@ -375,14 +371,12 @@ class OTUData:
             description = compose_remove_description(joined)
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 description,
                 HistoryMethod.remove,
                 joined,
                 None,
                 user_id,
-                mongo_session=session,
             )
 
             return delete_result
@@ -469,14 +463,12 @@ class OTUData:
                 description += " as default"
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 description,
                 HistoryMethod.add_isolate,
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
             return OTUIsolate(**{**isolate_, "sequences": []})
@@ -533,14 +525,12 @@ class OTUData:
 
             # Use the old and new entry to add a new history document for the change.
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 f"Renamed {old_isolate_name} to {new_isolate_name}",
                 HistoryMethod.edit_isolate,
                 old,
                 new_,
                 user_id,
-                mongo_session=session,
             )
 
             return new_
@@ -617,14 +607,12 @@ class OTUData:
 
             # Use the old and new entry to add a new history document for the change.
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 f"Set {format_isolate_name(isolate)} as default",
                 HistoryMethod.set_as_default,
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
             return find_isolate(new["isolates"], isolate_id)
@@ -699,14 +687,12 @@ class OTUData:
                 description += f" and set {format_isolate_name(new_default)} as default"
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 description,
                 HistoryMethod.remove_isolate,
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
         await self._mongo.with_transaction(func)
@@ -767,14 +753,12 @@ class OTUData:
             )
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 f"Created new sequence {accession} in {isolate_name}",
                 HistoryMethod.create_sequence,
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
             return OTUSequence(**document)
@@ -844,14 +828,12 @@ class OTUData:
             )
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 f"Edited sequence {sequence_id} in {isolate_name}",
                 HistoryMethod.edit_sequence,
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
             return document
@@ -899,14 +881,12 @@ class OTUData:
             )
 
             await virtool.history.db.add(
-                self._mongo,
                 self._pg,
                 f"Removed sequence {sequence_id} from {isolate_name}",
                 HistoryMethod.remove_sequence,
                 old,
                 new,
                 user_id,
-                mongo_session=session,
             )
 
         await self._mongo.with_transaction(func)

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -895,12 +895,6 @@ class ReferencesData(DataLayerDomain):
 
             async with asyncio.TaskGroup() as tg:
                 tg.create_task(
-                    self._mongo.history.insert_many(
-                        [insertion.history.document for insertion in insertions],
-                        None,
-                    ),
-                )
-                tg.create_task(
                     self._mongo.otus.insert_many(
                         [insertion.otu for insertion in insertions],
                         None,
@@ -913,7 +907,6 @@ class ReferencesData(DataLayerDomain):
             await bulk_delete_history(self._pg, [row["change_id"] for row in diff_rows])
 
             await asyncio.gather(
-                self._mongo.history.delete_many({"reference.id": ref_id}),
                 self._mongo.sequences.delete_many({"reference.id": ref_id}),
                 self._mongo.otus.delete_many({"reference.id": ref_id}),
             )

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -534,12 +534,6 @@ async def populate_insert_only_reference(
 
         async with asyncio.TaskGroup() as tg:
             tg.create_task(
-                mongo.history.insert_many(
-                    [insertion.history.document for insertion in insertions],
-                    None,
-                ),
-            )
-            tg.create_task(
                 mongo.otus.insert_many(
                     [insertion.otu for insertion in insertions],
                     None,
@@ -550,7 +544,6 @@ async def populate_insert_only_reference(
         await bulk_delete_history(pg, [row["change_id"] for row in diff_rows])
 
         await asyncio.gather(
-            mongo.history.delete_many({"reference.id": reference_id}),
             mongo.sequences.delete_many({"reference.id": reference_id}),
             mongo.otus.delete_many({"reference.id": reference_id}),
         )


### PR DESCRIPTION
- Removes Mongo access from history create, update, delete, and index-assignment flows — `legacy_history` and `history_diffs` in Postgres are now the sole write target (VIR-2501, migration step 6).
- Keeps `both_transactions` blocks that still coordinate non-migrated Mongo collections (indexes, otus, sequences); only the `mongo.history` writes are dropped from them.
- Leaves `migration.py`'s Mongo reads in applied backfill revisions untouched.