### PR TITLE
feat(migration): backfill sample group ids to integers in mongo

### DIFF
--- a/assets/revisions/rev_bfzcj3gxn2dd_backfill_samples_group_ids_to_integers.py
+++ b/assets/revisions/rev_bfzcj3gxn2dd_backfill_samples_group_ids_to_integers.py
@@ -1,0 +1,94 @@
+"""Convert ``samples.group`` to an integer id or ``None``.
+
+Groups are now Postgres-only with an integer ``id`` and a permanent
+``legacy_id`` (the old Mongo string id). The ``samples.group`` field stays in
+Mongo but must hold an integer ``groups.id`` value, or ``None`` when the sample
+has no owner group.
+
+Historically the field also used the string sentinel ``"none"`` to mean "no
+owner group". This revision normalizes that sentinel to ``None``, resolves
+legacy string ids to their integer ``groups.id`` via ``groups.legacy_id``, and
+passes already-integer values through unchanged, so the revision is idempotent
+and safe to re-run.
+
+Unresolved string ids raise loudly rather than being dropped or stored as
+``None`` -- a sample referencing a group that no longer exists in Postgres is a
+data-integrity problem that must surface, not be silently swallowed.
+
+Revision ID: bfzcj3gxn2dd
+Date: 2026-07-03 21:24:58.102815
+
+"""
+
+from typing import TYPE_CHECKING
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill samples group ids to integers"
+created_at = arrow.get("2026-07-03 21:24:58.102815")
+revision_id = "bfzcj3gxn2dd"
+
+alembic_down_revision = "a73a2668403f"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        result = await pg_session.execute(
+            text("SELECT id, legacy_id FROM groups WHERE legacy_id IS NOT NULL"),
+        )
+        group_map: dict[str, int] = {row.legacy_id: row.id for row in result}
+
+    logger.info("built id map", groups=len(group_map))
+
+    await _backfill_sample_groups(ctx.mongo, group_map)
+
+
+def _coerce_group_id(value: int | str, group_map: dict[str, int]) -> int | None:
+    if value == "none":
+        return None
+
+    if value in group_map:
+        return group_map[value]
+
+    msg = f"Group legacy id {value!r} not found in postgres"
+    raise ValueError(msg)
+
+
+async def _backfill_sample_groups(
+    mongo: "AsyncIOMotorDatabase",
+    group_map: dict[str, int],
+) -> None:
+    collection = mongo["samples"]
+
+    migrated = 0
+
+    async for doc in collection.find(
+        {"group": {"$type": "string"}},
+        projection={"group": 1},
+    ):
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"group": _coerce_group_id(doc["group"], group_map)}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled group ids",
+        collection="samples",
+        migrated=migrated,
+    )

--- a/assets/revisions/rev_bfzcj3gxn2dd_backfill_samples_group_ids_to_integers.py
+++ b/assets/revisions/rev_bfzcj3gxn2dd_backfill_samples_group_ids_to_integers.py
@@ -59,6 +59,9 @@ async def upgrade(ctx: MigrationContext) -> None:
 
 
 def _coerce_group_id(value: int | str, group_map: dict[str, int]) -> int | None:
+    if isinstance(value, int):
+        return value
+
     if value == "none":
         return None
 
@@ -75,15 +78,31 @@ async def _backfill_sample_groups(
 ) -> None:
     collection = mongo["samples"]
 
+    sample_ids = [
+        doc["_id"]
+        async for doc in collection.find(
+            {"group": {"$type": "string"}},
+            projection={"_id": 1},
+        )
+    ]
+
     migrated = 0
 
-    async for doc in collection.find(
-        {"group": {"$type": "string"}},
-        projection={"group": 1},
-    ):
+    for sample_id in sample_ids:
+        doc = await collection.find_one({"_id": sample_id}, projection={"group": 1})
+
+        if doc is None:
+            continue
+
+        try:
+            group_id = _coerce_group_id(doc["group"], group_map)
+        except ValueError as exc:
+            msg = f"Failed to coerce group id for sample {sample_id!r}: {exc}"
+            raise ValueError(msg) from exc
+
         await collection.update_one(
-            {"_id": doc["_id"]},
-            {"$set": {"group": _coerce_group_id(doc["group"], group_map)}},
+            {"_id": sample_id},
+            {"$set": {"group": group_id}},
         )
         migrated += 1
 

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -575,5 +575,12 @@
       'name': 'create references table',
       'revision': 'a73a2668403f',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 83,
+      'name': 'backfill samples group ids to integers',
+      'revision': 'bfzcj3gxn2dd',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_samples_group_ids.py
+++ b/tests/migration/test_backfill_samples_group_ids.py
@@ -1,0 +1,119 @@
+"""Tests for the backfill-samples-group-ids-to-integers migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_bfzcj3gxn2dd_backfill_samples_group_ids_to_integers import (
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_groups(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed two groups with legacy ids."""
+    await asyncio.to_thread(apply_alembic, "head")
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO groups (legacy_id, name, permissions)
+                VALUES
+                    ('technicians_legacy', 'Technicians', '{}'),
+                    ('managers_legacy', 'Managers', '{}')
+                RETURNING id, legacy_id
+            """),
+        )
+        group_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return group_ids
+
+
+class TestSamplesGroupIdsBackfill:
+    async def test_legacy_string_converts(
+        self,
+        ctx: MigrationContext,
+        setup_groups: dict[str, int],
+    ):
+        await ctx.mongo.samples.insert_one(
+            {"_id": "sample_legacy", "group": "technicians_legacy"},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_legacy"})
+        assert doc["group"] == setup_groups["technicians_legacy"]
+        assert isinstance(doc["group"], int)
+
+    async def test_none_sentinel_becomes_null(
+        self,
+        ctx: MigrationContext,
+        setup_groups: dict[str, int],
+    ):
+        await ctx.mongo.samples.insert_one({"_id": "sample_sentinel", "group": "none"})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_sentinel"})
+        assert doc["group"] is None
+
+    async def test_null_untouched(
+        self,
+        ctx: MigrationContext,
+        setup_groups: dict[str, int],
+    ):
+        await ctx.mongo.samples.insert_one({"_id": "sample_null", "group": None})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_null"})
+        assert doc["group"] is None
+
+    async def test_already_int_passthrough(
+        self,
+        ctx: MigrationContext,
+        setup_groups: dict[str, int],
+    ):
+        pg_id = setup_groups["managers_legacy"]
+        await ctx.mongo.samples.insert_one({"_id": "sample_int", "group": pg_id})
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_int"})
+        assert doc["group"] == pg_id
+
+    async def test_idempotent_rerun(
+        self,
+        ctx: MigrationContext,
+        setup_groups: dict[str, int],
+    ):
+        await ctx.mongo.samples.insert_one(
+            {"_id": "sample_legacy", "group": "technicians_legacy"},
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.samples.find_one({"_id": "sample_legacy"})
+        assert doc["group"] == setup_groups["technicians_legacy"]
+
+    @pytest.mark.usefixtures("setup_groups")
+    async def test_unmapped_legacy_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        await ctx.mongo.samples.insert_one(
+            {"_id": "sample_orphan", "group": "ghost_group"},
+        )
+
+        with pytest.raises(ValueError, match="ghost_group"):
+            await upgrade(ctx)

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -1088,6 +1088,34 @@ class TestUpdateRights:
         assert legacy.group_read is False
         assert legacy.group_write is False
 
+    async def test_legacy_group_persists_as_integer(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        spawn_client: ClientSpawner,
+    ):
+        """A legacy string group is resolved to an integer id in the Mongo doc."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        group = await fake.groups.create(legacy_id="legacy_owner")
+
+        upload = await fake.uploads.create(user=await fake.users.create())
+        sample = await data_layer.samples.create(
+            CreateSampleRequest(files=[upload.id], name="Rights"),
+            client.user.id,
+            0,
+        )
+
+        await data_layer.samples.update_rights(sample.id, {"group": "legacy_owner"})
+
+        document = await mongo.samples.find_one({"_id": sample.id})
+        assert document["group"] == group.id
+        assert isinstance(document["group"], int)
+
     async def test_missing_group(
         self,
         data_layer: DataLayer,

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -740,6 +740,7 @@ class SamplesData(DataLayerDomain):
 
         if "group" in data:
             scalars["group_id"] = group_id
+            data["group"] = group_id
 
         async def apply(mongo_session, pg_session) -> None:
             result = await self._mongo.samples.update_one(


### PR DESCRIPTION
- Backfill legacy string group ids (and the "none" sentinel) in `samples.group` to integer `groups.id` values, matching the already-migrated `user` and `subtractions` fields.
- Resolve the group to an integer in `update_rights` before writing to Mongo so legacy string ids can't reappear.