### PR TITLE
feat: keep postgres references consistent through import and clone

### DIFF
--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -14,6 +14,7 @@ from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.db import get_manifest
+from virtool.references.sql import SQLReference
 from virtool.references.tasks import (
     CloneReferenceTask,
     ImportReferenceTask,
@@ -329,3 +330,205 @@ async def test_clone_reference_task(
 
     assert await count_history() == 40
     assert await count_history("foo") == 20
+
+
+async def _reference_row(pg: AsyncEngine, ref_id: str) -> SQLReference | None:
+    async with AsyncSession(pg) as session:
+        return (
+            await session.execute(
+                select(SQLReference).where(SQLReference.legacy_id == ref_id),
+            )
+        ).scalar_one_or_none()
+
+
+class TestImportReferenceDualWrite:
+    """The import population task keeps the Postgres reference row in step."""
+
+    @pytest.fixture
+    async def run_import(
+        self,
+        data_layer: DataLayer,
+        example_path: Path,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        static_time: StaticTime,
+    ):
+        async def setup() -> DataLayer:
+            user = await fake.users.create()
+
+            upload = await data_layer.uploads.create(
+                fake_file_chunker(example_path / "indexes/reference.json.gz"),
+                "import.json.gz",
+                UploadType.reference,
+                user.id,
+            )
+
+            upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
+
+            await memory_storage.write(
+                upload_file_key(upload_row.name_on_disk),
+                fake_file_chunker(example_path / "indexes/reference.json.gz"),
+            )
+
+            await mongo.references.insert_one(
+                {
+                    "_id": "foo",
+                    "archived": False,
+                    "created_at": static_time.datetime,
+                    "data_type": "genome",
+                    "description": "A test reference",
+                    "organism": "",
+                    "user": {"id": user.id},
+                },
+            )
+
+            async with AsyncSession(pg) as session:
+                session.add(
+                    SQLReference(
+                        legacy_id="foo",
+                        name="Test",
+                        description="A test reference",
+                        organism="",
+                        created_at=static_time.datetime,
+                        source_types=[],
+                        user_id=user.id,
+                    ),
+                )
+                session.add(
+                    SQLTask(
+                        id=1,
+                        complete=False,
+                        context={
+                            "name_on_disk": upload_row.name_on_disk,
+                            "ref_id": "foo",
+                            "user_id": user.id,
+                        },
+                        count=0,
+                        progress=0,
+                        step="load_file",
+                        type="import_reference",
+                        created_at=static_time.datetime,
+                    ),
+                )
+                await session.commit()
+
+            return data_layer
+
+        return setup
+
+    @pytest.mark.flaky(reruns=2)
+    async def test_mirrors_organism(self, run_import, mongo: Mongo, pg: AsyncEngine):
+        """The imported organism is written to both Mongo and Postgres."""
+        data_layer = await run_import()
+
+        task = await ImportReferenceTask.from_task_id(data_layer, 1)
+        await task.run()
+
+        document = await mongo.references.find_one("foo")
+        assert document["organism"] == "virus"
+
+        row = await _reference_row(pg, "foo")
+        assert row is not None
+        assert row.organism == "virus"
+
+    async def test_rollback_deletes_postgres_row(
+        self,
+        run_import,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A failed insertion rolls back the Postgres reference row, not just Mongo."""
+        data_layer = await run_import()
+
+        mocker.patch.object(
+            mongo.otus,
+            "insert_many",
+            side_effect=RuntimeError("boom"),
+        )
+
+        task = await ImportReferenceTask.from_task_id(data_layer, 1)
+        await task.run()
+
+        assert await mongo.references.find_one("foo") is None
+        assert await _reference_row(pg, "foo") is None
+
+
+class TestCloneReferenceDualWrite:
+    """The clone population task keeps the Postgres reference row in step."""
+
+    async def test_rollback_deletes_postgres_row(
+        self,
+        create_reference: str,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        static_time: StaticTime,
+    ):
+        """A failed clone insertion rolls back the Postgres reference row."""
+        manifest = await get_manifest(mongo, create_reference)
+
+        user = await fake.users.create()
+
+        await mongo.references.insert_one(
+            {
+                "_id": "foo",
+                "archived": False,
+                "created_at": static_time.datetime,
+                "data_type": "genome",
+                "description": "A test reference",
+                "groups": [],
+                "name": "Test",
+                "organism": "virus",
+                "restrict_source_types": False,
+                "source_types": [],
+                "user": {"id": user.id},
+                "users": [],
+            },
+        )
+
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLReference(
+                    legacy_id="foo",
+                    name="Test",
+                    description="A test reference",
+                    organism="virus",
+                    created_at=static_time.datetime,
+                    source_types=[],
+                    user_id=user.id,
+                ),
+            )
+            session.add(
+                SQLTask(
+                    id=1,
+                    complete=False,
+                    context={
+                        "manifest": manifest,
+                        "ref_id": "foo",
+                        "user_id": user.id,
+                    },
+                    count=0,
+                    progress=0,
+                    step="load_file",
+                    type="import_reference",
+                    created_at=static_time.datetime,
+                ),
+            )
+            await session.commit()
+
+        mocker.patch.object(
+            mongo.otus,
+            "insert_many",
+            side_effect=RuntimeError("boom"),
+        )
+
+        task = await CloneReferenceTask.from_task_id(data_layer, 1)
+        await task.run()
+
+        assert await mongo.references.find_one("foo") is None
+        assert await _reference_row(pg, "foo") is None

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -14,7 +14,7 @@ from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.db import get_manifest
-from virtool.references.sql import SQLReference
+from virtool.references.sql import SQLReference, SQLReferenceUser
 from virtool.references.tasks import (
     CloneReferenceTask,
     ImportReferenceTask,
@@ -385,15 +385,24 @@ class TestImportReferenceDualWrite:
             )
 
             async with AsyncSession(pg) as session:
+                reference = SQLReference(
+                    legacy_id="foo",
+                    name="Test",
+                    description="A test reference",
+                    organism="",
+                    created_at=static_time.datetime,
+                    source_types=[],
+                    user_id=user.id,
+                )
+                session.add(reference)
+                await session.flush()
                 session.add(
-                    SQLReference(
-                        legacy_id="foo",
-                        name="Test",
-                        description="A test reference",
-                        organism="",
-                        created_at=static_time.datetime,
-                        source_types=[],
+                    SQLReferenceUser(
+                        reference_id=reference.id,
                         user_id=user.id,
+                        build=True,
+                        modify=True,
+                        modify_otu=True,
                     ),
                 )
                 session.add(
@@ -492,15 +501,24 @@ class TestCloneReferenceDualWrite:
         )
 
         async with AsyncSession(pg) as session:
+            reference = SQLReference(
+                legacy_id="foo",
+                name="Test",
+                description="A test reference",
+                organism="virus",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=user.id,
+            )
+            session.add(reference)
+            await session.flush()
             session.add(
-                SQLReference(
-                    legacy_id="foo",
-                    name="Test",
-                    description="A test reference",
-                    organism="virus",
-                    created_at=static_time.datetime,
-                    source_types=[],
+                SQLReferenceUser(
+                    reference_id=reference.id,
                     user_id=user.id,
+                    build=True,
+                    modify=True,
+                    modify_otu=True,
                 ),
             )
             session.add(
@@ -515,7 +533,7 @@ class TestCloneReferenceDualWrite:
                     count=0,
                     progress=0,
                     step="load_file",
-                    type="import_reference",
+                    type="clone_reference",
                     created_at=static_time.datetime,
                 ),
             )

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -1137,15 +1137,26 @@ class ReferencesData(DataLayerDomain):
             3,
         )
 
-        await self._mongo.references.update_one(
-            {"_id": ref_id},
-            {
-                "$set": {
-                    "data_type": data.data_type,
-                    "organism": data.organism,
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.references.update_one(
+                {"_id": ref_id},
+                {
+                    "$set": {
+                        "data_type": data.data_type,
+                        "organism": data.organism,
+                    },
                 },
-            },
-        )
+                session=mongo_session,
+            )
+
+            await pg_session.execute(
+                update(SQLReference)
+                .where(SQLReference.legacy_id == ref_id)
+                .values(organism=data.organism),
+            )
 
         await tracker.add(1)
 
@@ -1198,6 +1209,13 @@ class ReferencesData(DataLayerDomain):
             )
 
             await self._mongo.references.delete_one({"_id": ref_id})
+
+            async with AsyncSession(self._pg) as session:
+                await session.execute(
+                    delete(SQLReference).where(SQLReference.legacy_id == ref_id),
+                )
+                await session.commit()
+
             raise
 
         await tracker.add(1)

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -1211,9 +1211,29 @@ class ReferencesData(DataLayerDomain):
             await self._mongo.references.delete_one({"_id": ref_id})
 
             async with AsyncSession(self._pg) as session:
-                await session.execute(
-                    delete(SQLReference).where(SQLReference.legacy_id == ref_id),
-                )
+                reference_id = (
+                    await session.execute(
+                        select(SQLReference.id).where(
+                            SQLReference.legacy_id == ref_id,
+                        ),
+                    )
+                ).scalar_one_or_none()
+
+                if reference_id is not None:
+                    await session.execute(
+                        delete(SQLReferenceUser).where(
+                            SQLReferenceUser.reference_id == reference_id,
+                        ),
+                    )
+                    await session.execute(
+                        delete(SQLReferenceGroup).where(
+                            SQLReferenceGroup.reference_id == reference_id,
+                        ),
+                    )
+                    await session.execute(
+                        delete(SQLReference).where(SQLReference.id == reference_id),
+                    )
+
                 await session.commit()
 
             raise

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -24,7 +24,11 @@ from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
 from virtool.references.alot import prepare_otu_insertion
-from virtool.references.sql import SQLReference
+from virtool.references.sql import (
+    SQLReference,
+    SQLReferenceGroup,
+    SQLReferenceUser,
+)
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
@@ -522,9 +526,29 @@ async def populate_insert_only_reference(
         await mongo.references.delete_one({"_id": reference_id})
 
         async with AsyncSession(pg) as session:
-            await session.execute(
-                delete(SQLReference).where(SQLReference.legacy_id == reference_id),
-            )
+            sql_reference_id = (
+                await session.execute(
+                    select(SQLReference.id).where(
+                        SQLReference.legacy_id == reference_id,
+                    ),
+                )
+            ).scalar_one_or_none()
+
+            if sql_reference_id is not None:
+                await session.execute(
+                    delete(SQLReferenceUser).where(
+                        SQLReferenceUser.reference_id == sql_reference_id,
+                    ),
+                )
+                await session.execute(
+                    delete(SQLReferenceGroup).where(
+                        SQLReferenceGroup.reference_id == sql_reference_id,
+                    ),
+                )
+                await session.execute(
+                    delete(SQLReference).where(SQLReference.id == sql_reference_id),
+                )
+
             await session.commit()
 
         raise

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pymongo
 from aiohttp.web import Request
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
@@ -24,6 +24,7 @@ from virtool.models.enums import HistoryMethod
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.utils import get_mongo_from_req
 from virtool.references.alot import prepare_otu_insertion
+from virtool.references.sql import SQLReference
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
@@ -519,6 +520,13 @@ async def populate_insert_only_reference(
         )
 
         await mongo.references.delete_one({"_id": reference_id})
+
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                delete(SQLReference).where(SQLReference.legacy_id == reference_id),
+            )
+            await session.commit()
+
         raise
 
 


### PR DESCRIPTION
## Summary
- Dual-write the `organism` edit made by the import population task to `SQLReference`, so the Postgres row stays consistent with Mongo while Mongo remains the read authority.
- Roll back the Postgres reference row (not just Mongo) when the import or clone population tasks fail partway through.
- Add tests covering the organism dual-write and both task rollback paths.