### PR TITLE
feat(migration): add integer sample_id fk to analyses

### DIFF
--- a/assets/alembic/versions/1f4e528c2149_add_analyses_sample_id.py
+++ b/assets/alembic/versions/1f4e528c2149_add_analyses_sample_id.py
@@ -1,0 +1,45 @@
+"""add analyses sample_id
+
+Phase 1 of keying ``analyses`` by an integer FK to ``legacy_samples`` instead
+of the legacy Mongo ``sample`` string. Purely additive: adds a nullable
+``sample_id BIGINT REFERENCES legacy_samples(id)`` column and an index on
+``(sample_id, workflow)``, leaving the existing ``sample`` column and its index
+intact.
+
+Backfill and call-site changes are handled by downstream revisions.
+
+Revision ID: 1f4e528c2149
+Revises: fe83de8410d3
+Create Date: 2026-07-06 18:47:01.194974+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1f4e528c2149"
+down_revision = "fe83de8410d3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "analyses",
+        sa.Column(
+            "sample_id",
+            sa.BigInteger(),
+            sa.ForeignKey("legacy_samples.id"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_analyses_sample_id_workflow",
+        "analyses",
+        ["sample_id", "workflow"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_analyses_sample_id_workflow", "analyses")
+    op.drop_column("analyses", "sample_id")

--- a/assets/revisions/rev_b4qhmbisvbn3_backfill_analyses_sample_ids_to_integers.py
+++ b/assets/revisions/rev_b4qhmbisvbn3_backfill_analyses_sample_ids_to_integers.py
@@ -1,0 +1,73 @@
+"""backfill analyses sample ids to integers
+
+Populate ``analyses.sample_id`` from the legacy Mongo ``sample`` string now that
+samples live in Postgres as ``legacy_samples`` with an integer ``id`` and a
+permanent ``legacy_id``.
+
+The update is set-based and idempotent: it only touches rows whose ``sample_id``
+is still ``NULL``, resolving ``analyses.sample`` to ``legacy_samples.id`` via
+``legacy_samples.legacy_id``. Re-running fills only rows created since the last
+run.
+
+An analysis whose ``sample`` string resolves to no ``legacy_samples`` row raises
+loudly rather than being left ``NULL`` -- deleting a sample also deletes its
+analyses, so an unresolved reference is a data-integrity problem that must
+surface.
+
+Revision ID: b4qhmbisvbn3
+Date: 2026-07-06 18:48:50.744545
+
+"""
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill analyses sample ids to integers"
+created_at = arrow.get("2026-07-06 18:48:50.744545")
+revision_id = "b4qhmbisvbn3"
+
+alembic_down_revision = "1f4e528c2149"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        result = await pg_session.execute(
+            text(
+                "UPDATE analyses a "
+                "SET sample_id = s.id "
+                "FROM legacy_samples s "
+                "WHERE a.sample = s.legacy_id AND a.sample_id IS NULL",
+            ),
+        )
+
+        unresolved = (
+            (
+                await pg_session.execute(
+                    text("SELECT sample FROM analyses WHERE sample_id IS NULL"),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        if unresolved:
+            msg = (
+                f"Analyses reference {len(unresolved)} sample(s) not found in "
+                f"postgres: {sorted(set(unresolved))}"
+            )
+            raise ValueError(msg)
+
+        await pg_session.commit()
+
+    logger.info("backfilled analyses sample ids", updated=result.rowcount)

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -404,6 +404,23 @@ class TestCreate:
                 0,
             )
 
+    async def test_unknown_sample_raises(
+        self,
+        data_layer: DataLayer,
+        setup_sample: str,
+        subtraction_ids: dict[str, int],
+    ):
+        """Creating an analysis for a sample with no ``legacy_samples`` row is a
+        conflict.
+        """
+        with pytest.raises(ResourceConflictError, match="Sample does not exist"):
+            await data_layer.analyses.create(
+                _create_request(subtraction_ids),
+                "unknown_sample",
+                setup_sample,
+                0,
+            )
+
     async def test_rolls_back_when_pg_write_fails(
         self,
         data_layer: DataLayer,

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -22,6 +22,7 @@ from virtool.models.enums import AnalysisWorkflow
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
 from virtool.samples.oas import CreateAnalysisRequest
+from virtool.samples.sql import SQLLegacySample
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.utils import timestamp
 
@@ -51,10 +52,25 @@ async def subtraction_ids(fake: DataFaker) -> dict[str, int]:
 @pytest.fixture
 async def setup_sample(
     mongo: "Mongo",
+    pg: AsyncEngine,
     fake: DataFaker,
     subtraction_ids: dict[str, int],
 ) -> str:
     user = await fake.users.create()
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacySample(
+                legacy_id="test_sample",
+                name="Test Sample",
+                library_type="normal",
+                created_at=timestamp(),
+                user_id=user.id,
+                all_read=True,
+                all_write=True,
+            ),
+        )
+        await session.commit()
 
     await asyncio.gather(
         mongo.samples.insert_one(
@@ -116,6 +132,7 @@ async def test_find(
     data_layer: DataLayer,
     snapshot_recent: SnapshotAssertion,
     mongo: Mongo,
+    pg: AsyncEngine,
     setup_sample: str,
     subtraction_ids: dict[str, int],
     mocker,
@@ -126,6 +143,18 @@ async def test_find(
     user_id = setup_sample
 
     await mongo.samples.insert_one({"_id": "test_false", "name": "Test False"})
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacySample(
+                legacy_id="test_false",
+                name="Test False",
+                library_type="normal",
+                created_at=timestamp(),
+                user_id=user_id,
+            ),
+        )
+        await session.commit()
 
     analysis_wrong_sample = await data_layer.analyses.create(
         CreateAnalysisRequest(

--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisSubtraction
 from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.mongo.core import Mongo
+from virtool.samples.sql import SQLLegacySample
 from virtool.subtractions.pg import SQLSubtraction
 
 
@@ -31,7 +32,29 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
 
     await mongo.analyses.insert_one(document)
 
+    sample = document["sample"]
+
     async with AsyncSession(pg) as session:
+        sample_pg_id = (
+            await session.execute(
+                select(SQLLegacySample.id).where(
+                    SQLLegacySample.legacy_id == sample["id"],
+                ),
+            )
+        ).scalar_one_or_none()
+
+        if sample_pg_id is None:
+            legacy_sample = SQLLegacySample(
+                legacy_id=sample["id"],
+                name=sample.get("name", sample["id"]),
+                library_type="normal",
+                created_at=document["created_at"],
+                user_id=document["user"]["id"],
+            )
+            session.add(legacy_sample)
+            await session.flush()
+            sample_pg_id = legacy_sample.id
+
         analysis = SQLAnalysis(
             legacy_id=document["_id"],
             created_at=document["created_at"],
@@ -39,7 +62,8 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
             workflow=document["workflow"],
             ready=document["ready"],
             results=results if isinstance(results, dict) else None,
-            sample=document["sample"]["id"],
+            sample=sample["id"],
+            sample_id=sample_pg_id,
             reference=document["reference"]["id"],
             index=index["id"],
             user_id=document["user"]["id"],

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -603,5 +603,19 @@
       'name': 'require reference user and drop rights created_at',
       'revision': 'fe83de8410d3',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 87,
+      'name': 'add analyses sample_id',
+      'revision': '1f4e528c2149',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 88,
+      'name': 'backfill analyses sample ids to integers',
+      'revision': 'b4qhmbisvbn3',
+    }),
   ])
 # ---

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1187,6 +1187,16 @@ async def test_find_analyses(
     )
 
     async with AsyncSession(pg) as session:
+        legacy_sample = SQLLegacySample(
+            legacy_id="test",
+            name="Test Sample",
+            library_type="normal",
+            created_at=static_time.datetime,
+            user_id=user_1.id,
+        )
+        session.add(legacy_sample)
+        await session.flush()
+
         analyses = [
             SQLAnalysis(
                 legacy_id="test_1",
@@ -1195,6 +1205,7 @@ async def test_find_analyses(
                 workflow="pathoscope",
                 ready=True,
                 sample="test",
+                sample_id=legacy_sample.id,
                 reference="baz",
                 index="foo",
                 user_id=user_1.id,
@@ -1207,6 +1218,7 @@ async def test_find_analyses(
                 workflow="pathoscope",
                 ready=True,
                 sample="test",
+                sample_id=legacy_sample.id,
                 reference="baz",
                 index="foo",
                 user_id=user_1.id,
@@ -1218,6 +1230,7 @@ async def test_find_analyses(
                 workflow="pathoscope",
                 ready=True,
                 sample="test",
+                sample_id=legacy_sample.id,
                 reference="foo",
                 index="foo",
                 user_id=user_2.id,

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -1150,8 +1150,22 @@ class TestUpdateRights:
 class TestDelete:
     """Deleting a sample cascades to its analyses in both Mongo and Postgres."""
 
-    async def _setup(self, fake: DataFaker, mongo: Mongo) -> str:
+    async def _setup(self, fake: DataFaker, mongo: Mongo, pg: AsyncEngine) -> str:
         user = await fake.users.create()
+
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLLegacySample(
+                    legacy_id="test_sample",
+                    name="Test Sample",
+                    library_type=LibraryType.normal.value,
+                    created_at=virtool.utils.timestamp(),
+                    user_id=user.id,
+                    all_read=True,
+                    all_write=True,
+                ),
+            )
+            await session.commit()
 
         await asyncio.gather(
             mongo.samples.insert_one(
@@ -1216,7 +1230,7 @@ class TestDelete:
         pg: AsyncEngine,
     ):
         """Deleting a sample removes its analyses' Postgres rows."""
-        user_id = await self._setup(fake, mongo)
+        user_id = await self._setup(fake, mongo, pg)
 
         analysis = await data_layer.analyses.create(
             CreateAnalysisRequest(
@@ -1249,7 +1263,7 @@ class TestDelete:
         The reservation is keyed on the sample's own ``uploads`` array, so the upload
         is released even when no ``SQLSampleReads`` rows have been written yet.
         """
-        await self._setup(fake, mongo)
+        await self._setup(fake, mongo, pg)
 
         upload = await fake.uploads.create(
             user=await fake.users.create(),

--- a/tests/samples/test_db.py
+++ b/tests/samples/test_db.py
@@ -1,6 +1,7 @@
 import pytest
 from aiohttp.test_utils import make_mocked_request
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -16,6 +17,7 @@ from virtool.samples.db import (
     derive_workflow_state,
     recalculate_workflow_tags,
 )
+from virtool.samples.sql import SQLLegacySample
 from virtool.samples.utils import calculate_workflow_tags
 from virtool.utils import timestamp
 from virtool.workflow.pytest_plugin.utils import StaticTime
@@ -71,27 +73,47 @@ async def test_recalculate_workflow_tags(
 
     await mongo.samples.insert_one({"_id": "test", "pathoscope": False, "nuvs": False})
 
-    def make_row(legacy_id: str, sample: str, workflow: str, *, ready: bool):
-        return SQLAnalysis(
+    def make_legacy_sample(legacy_id: str) -> SQLLegacySample:
+        return SQLLegacySample(
             legacy_id=legacy_id,
+            name=legacy_id,
+            library_type="normal",
             created_at=timestamp(),
-            updated_at=timestamp(),
-            workflow=workflow,
-            ready=ready,
-            sample=sample,
-            reference="ref",
-            index="index",
             user_id=user.id,
         )
 
     async with AsyncSession(pg) as session:
+        session.add_all(
+            [make_legacy_sample("test"), make_legacy_sample("other")],
+        )
+        await session.flush()
+
+        sample_ids = {
+            row.legacy_id: row.id
+            for row in (await session.execute(select(SQLLegacySample))).scalars()
+        }
+
+        def make_row(legacy_id: str, sample: str, workflow: str, *, ready: bool):
+            return SQLAnalysis(
+                legacy_id=legacy_id,
+                created_at=timestamp(),
+                updated_at=timestamp(),
+                workflow=workflow,
+                ready=ready,
+                sample=sample,
+                sample_id=sample_ids[sample],
+                reference="ref",
+                index="index",
+                user_id=user.id,
+            )
+
         session.add_all(
             [
                 make_row("test_1", "test", "pathoscope", ready=False),
                 make_row("test_2", "test", "pathoscope", ready=True),
                 make_row("test_3", "test", "nuvs", ready=True),
                 # Belongs to another sample and must be excluded.
-                make_row("test_4", "foobar", "pathoscope", ready=True),
+                make_row("test_4", "other", "pathoscope", ready=True),
             ],
         )
         await session.commit()

--- a/tests/samples/test_tasks.py
+++ b/tests/samples/test_tasks.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.analyses.sql import SQLAnalysis
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.samples.sql import SQLLegacySample
 from virtool.samples.tasks import (
     SampleWorkflowsUpdateTask,
 )
@@ -39,6 +40,16 @@ async def test_update_workflows_fields(
     )
 
     async with AsyncSession(pg) as session:
+        legacy_sample = SQLLegacySample(
+            legacy_id="test_id",
+            name="Test Sample",
+            library_type="normal",
+            created_at=timestamp(),
+            user_id=user.id,
+        )
+        session.add(legacy_sample)
+        await session.flush()
+
         session.add_all(
             [
                 SQLAnalysis(
@@ -48,6 +59,7 @@ async def test_update_workflows_fields(
                     workflow="pathoscope",
                     ready=ready,
                     sample="test_id",
+                    sample_id=legacy_sample.id,
                     reference="ref",
                     index="index",
                     user_id=user.id,
@@ -59,6 +71,7 @@ async def test_update_workflows_fields(
                     workflow="nuvs",
                     ready=False,
                     sample="test_id",
+                    sample_id=legacy_sample.id,
                     reference="ref",
                     index="index",
                     user_id=user.id,

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -38,6 +38,8 @@ from virtool.data.errors import (
 from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import (
     compose_legacy_id_single_expression,
+    compose_legacy_id_subquery,
+    resolve_legacy_id,
 )
 from virtool.data.transforms import apply_transforms
 from virtool.indexes.db import get_current_id_and_version
@@ -171,13 +173,7 @@ class AnalysisData(DataLayerDomain):
         )
 
         if sample_id is not None:
-            sample_subquery = (
-                select(SQLLegacySample.id)
-                .where(
-                    compose_legacy_id_single_expression(SQLLegacySample, sample_id),
-                )
-                .scalar_subquery()
-            )
+            sample_subquery = compose_legacy_id_subquery(SQLLegacySample, sample_id)
             count_statement = count_statement.where(
                 SQLAnalysis.sample_id == sample_subquery,
             )
@@ -316,16 +312,7 @@ class AnalysisData(DataLayerDomain):
         subtractions = data.subtractions if data.subtractions is not None else []
 
         async with AsyncSession(self._pg) as session:
-            sample_pg_id = (
-                await session.execute(
-                    select(SQLLegacySample.id).where(
-                        compose_legacy_id_single_expression(
-                            SQLLegacySample,
-                            sample_id,
-                        ),
-                    ),
-                )
-            ).scalar_one_or_none()
+            sample_pg_id = await resolve_legacy_id(session, SQLLegacySample, sample_id)
 
             if sample_pg_id is None:
                 raise ResourceConflictError("Sample does not exist")

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -49,6 +49,7 @@ from virtool.pg.utils import delete_row, get_row_by_id
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.samples.db import recalculate_workflow_tags
 from virtool.samples.oas import CreateAnalysisRequest
+from virtool.samples.sql import SQLLegacySample
 from virtool.samples.utils import get_sample_rights
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
@@ -170,8 +171,17 @@ class AnalysisData(DataLayerDomain):
         )
 
         if sample_id is not None:
-            count_statement = count_statement.where(SQLAnalysis.sample == sample_id)
-            statement = statement.where(SQLAnalysis.sample == sample_id)
+            sample_subquery = (
+                select(SQLLegacySample.id)
+                .where(
+                    compose_legacy_id_single_expression(SQLLegacySample, sample_id),
+                )
+                .scalar_subquery()
+            )
+            count_statement = count_statement.where(
+                SQLAnalysis.sample_id == sample_subquery,
+            )
+            statement = statement.where(SQLAnalysis.sample_id == sample_subquery)
 
         async with AsyncSession(self._pg) as session:
             total_count = (await session.execute(count_statement)).scalar_one()
@@ -306,6 +316,20 @@ class AnalysisData(DataLayerDomain):
         subtractions = data.subtractions if data.subtractions is not None else []
 
         async with AsyncSession(self._pg) as session:
+            sample_pg_id = (
+                await session.execute(
+                    select(SQLLegacySample.id).where(
+                        compose_legacy_id_single_expression(
+                            SQLLegacySample,
+                            sample_id,
+                        ),
+                    ),
+                )
+            ).scalar_one_or_none()
+
+            if sample_pg_id is None:
+                raise ResourceConflictError("Sample does not exist")
+
             pg_id = (
                 await session.execute(
                     insert(SQLAnalysis)
@@ -317,6 +341,7 @@ class AnalysisData(DataLayerDomain):
                         ready=False,
                         results=None,
                         sample=sample_id,
+                        sample_id=sample_pg_id,
                         reference=data.ref_id,
                         index=index_id,
                         user_id=user_id,

--- a/virtool/analyses/sql.py
+++ b/virtool/analyses/sql.py
@@ -34,10 +34,13 @@ class SQLAnalysis(Base):
 
     Column naming convention:
 
-    - A bare column (``sample``, ``reference``, ``index``) holds a legacy Mongo
-      string id and has no foreign key, because the referenced collection has
-      not been migrated to Postgres.
+    - A bare column (``reference``, ``index``) holds a legacy Mongo string id
+      and has no foreign key, because the referenced collection has not been
+      migrated to Postgres.
     - An ``{entity}_id`` column is a real foreign key to an existing SQL table.
+    - ``sample`` is mid-migration: the legacy Mongo string is retained
+      alongside the new ``sample_id`` foreign key while readers move over. The
+      bare ``sample`` column is dropped in a later cleanup revision.
 
     The Mongo ``space`` field is intentionally dropped.
     """
@@ -52,6 +55,11 @@ class SQLAnalysis(Base):
     ready: Mapped[bool]
     results: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     sample: Mapped[str] = mapped_column(index=True)
+    sample_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("legacy_samples.id"),
+        nullable=True,
+    )
     reference: Mapped[str]
     index: Mapped[str]
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))

--- a/virtool/data/topg.py
+++ b/virtool/data/topg.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, TypeVar
 
 from pymongo.errors import OperationFailure
-from sqlalchemy import ColumnExpressionArgument, or_
+from sqlalchemy import ColumnExpressionArgument, ScalarSelect, or_, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.pg.base import HasLegacyAndModernIDs
@@ -133,3 +133,46 @@ def compose_legacy_id_single_expression(
         return model.id == int(id_)
 
     return model.legacy_id == id_
+
+
+def compose_legacy_id_subquery(
+    model: HasLegacyAndModernIDs,
+    id_: int | str,
+) -> ScalarSelect:
+    """Build a scalar subquery resolving a legacy (str) or modern (int) resource id to
+    the integer ``id`` of the matching row in ``model``.
+
+    Use this to filter or join on a not-yet-migrated FK column (eg. a legacy Mongo
+    string id) against a table that has already been migrated to Postgres.
+
+    :param model: the SQLAlchemy model to query
+    :param id_: a single legacy or modern id
+    :return: a scalar subquery yielding the matching integer id
+
+    """
+    return (
+        select(model.id)
+        .where(compose_legacy_id_single_expression(model, id_))
+        .scalar_subquery()
+    )
+
+
+async def resolve_legacy_id(
+    session: AsyncSession,
+    model: HasLegacyAndModernIDs,
+    id_: int | str,
+) -> int | None:
+    """Resolve a legacy (str) or modern (int) resource id to the integer ``id`` of the
+    matching row in ``model``.
+
+    :param session: an active Postgres session
+    :param model: the SQLAlchemy model to query
+    :param id_: a single legacy or modern id
+    :return: the matching integer id, or ``None`` if no row matches
+
+    """
+    return (
+        await session.execute(
+            select(model.id).where(compose_legacy_id_single_expression(model, id_)),
+        )
+    ).scalar_one_or_none()

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -493,21 +493,23 @@ class SamplesData(DataLayerDomain):
                     .values(reserved=False),
                 )
 
+            legacy_sample_id = select(SQLLegacySample.id).where(
+                SQLLegacySample.legacy_id == sample_id,
+            )
+
             await pg_session.execute(
                 delete(SQLAnalysisResult).where(
                     SQLAnalysisResult.analysis_id.in_(
                         select(SQLAnalysis.legacy_id).where(
-                            SQLAnalysis.sample == sample_id,
+                            SQLAnalysis.sample_id.in_(legacy_sample_id),
                         ),
                     ),
                 ),
             )
             await pg_session.execute(
-                delete(SQLAnalysis).where(SQLAnalysis.sample == sample_id),
-            )
-
-            legacy_sample_id = select(SQLLegacySample.id).where(
-                SQLLegacySample.legacy_id == sample_id,
+                delete(SQLAnalysis).where(
+                    SQLAnalysis.sample_id.in_(legacy_sample_id),
+                ),
             )
 
             await pg_session.execute(

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -14,13 +14,14 @@ import virtool.samples.utils
 import virtool.utils
 from virtool.analyses.sql import SQLAnalysis
 from virtool.api.errors import APINotFound
+from virtool.data.topg import compose_legacy_id_single_expression
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.samples.models import WorkflowState
-from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
+from virtool.samples.sql import SQLLegacySample, SQLSampleArtifact, SQLSampleReads
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.uploads.data import serialize as serialize_upload
@@ -368,7 +369,10 @@ async def recalculate_workflow_tags(
     async with AsyncSession(pg) as pg_session:
         result = await pg_session.execute(
             select(SQLAnalysis.ready, SQLAnalysis.workflow).where(
-                SQLAnalysis.sample == sample_id,
+                SQLAnalysis.sample_id
+                == select(SQLLegacySample.id)
+                .where(compose_legacy_id_single_expression(SQLLegacySample, sample_id))
+                .scalar_subquery(),
             ),
         )
         analyses = [{"ready": row.ready, "workflow": row.workflow} for row in result]

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -14,7 +14,7 @@ import virtool.samples.utils
 import virtool.utils
 from virtool.analyses.sql import SQLAnalysis
 from virtool.api.errors import APINotFound
-from virtool.data.topg import compose_legacy_id_single_expression
+from virtool.data.topg import compose_legacy_id_subquery
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
@@ -370,9 +370,7 @@ async def recalculate_workflow_tags(
         result = await pg_session.execute(
             select(SQLAnalysis.ready, SQLAnalysis.workflow).where(
                 SQLAnalysis.sample_id
-                == select(SQLLegacySample.id)
-                .where(compose_legacy_id_single_expression(SQLLegacySample, sample_id))
-                .scalar_subquery(),
+                == compose_legacy_id_subquery(SQLLegacySample, sample_id),
             ),
         )
         analyses = [{"ready": row.ready, "workflow": row.workflow} for row in result]

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -9,6 +9,7 @@ from virtool.fake.wrapper import FakerWrapper
 from virtool.mongo.utils import get_mongo_from_app
 from virtool.samples.db import create_sample
 from virtool.samples.files import create_reads_file
+from virtool.samples.sql import SQLLegacySample
 from virtool.samples.utils import sample_file_key
 from virtool.settings.models import Settings
 from virtool.storage.protocol import STORAGE_CHUNK_SIZE, StorageBackend
@@ -120,7 +121,7 @@ async def create_fake_sample(
     settings.sample_all_read = True
     settings.sample_all_write = True
 
-    await create_sample(
+    document = await create_sample(
         _id=sample_id,
         mongo=mongo,
         name=f"Fake {sample_id.upper()}",
@@ -135,6 +136,22 @@ async def create_fake_sample(
         group="none",
         settings=settings,
     )
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacySample(
+                legacy_id=document["id"],
+                name=document["name"],
+                library_type=document["library_type"],
+                created_at=document["created_at"],
+                user_id=user_id,
+                all_read=document["all_read"],
+                all_write=document["all_write"],
+                group_read=document["group_read"],
+                group_write=document["group_write"],
+            ),
+        )
+        await session.commit()
 
     if finalized is True:
         await get_data_from_app(app).samples.finalize(


### PR DESCRIPTION
## Summary
- Adds `analyses.sample_id` as a nullable integer FK to `legacy_samples.id`, indexed with `workflow`, alongside the existing legacy `sample` string column.
- Backfills `sample_id` from the legacy `sample` string via `legacy_samples.legacy_id`, raising loudly on any analysis whose sample can't be resolved in postgres.
- Moves analyses reads and deletes over to the new integer `sample_id` column; the bare `sample` column stays for now and is dropped in a later cleanup revision.