### PR TITLE
feat(migration): add integer sample_id foreign keys to sample files

### DIFF
--- a/assets/alembic/versions/c980043c0c89_add_sample_id_to_sample_files.py
+++ b/assets/alembic/versions/c980043c0c89_add_sample_id_to_sample_files.py
@@ -1,0 +1,75 @@
+"""add sample_id to sample files
+
+Phase 1+2 of keying ``sample_artifacts`` and ``sample_reads`` by an integer FK
+to ``legacy_samples`` instead of the legacy Mongo ``sample`` string. These
+subresource tables predate the migration playbook and never stored their own
+Mongo ``_id``, so only the FK is added (no ``legacy_id`` retrofit).
+
+For each table the migration:
+
+- adds a nullable ``sample_id BIGINT REFERENCES legacy_samples(id)`` column,
+- adds a parallel ``(sample_id, name)`` unique constraint alongside the existing
+  ``(sample, name)`` one (NULLs don't collide, so both coexist),
+- backfills ``sample_id`` with a single set-based UPDATE joining the bare
+  ``sample`` string to ``legacy_samples.legacy_id``.
+
+The backfill is idempotent (guarded by ``sample_id IS NULL``) and safe to
+re-run to catch rows written during the deploy window. The legacy ``sample``
+column, its ``(sample, name)`` constraint, and the ``NOT NULL`` tightening are
+left for a later cleanup revision.
+
+Revision ID: c980043c0c89
+Revises: 1f4e528c2149
+Create Date: 2026-07-06 21:44:40.789411+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c980043c0c89"
+down_revision = "1f4e528c2149"
+branch_labels = None
+depends_on = None
+
+
+TABLES = ("sample_artifacts", "sample_reads")
+
+
+def upgrade() -> None:
+    for table in TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "sample_id",
+                sa.BigInteger(),
+                sa.ForeignKey("legacy_samples.id"),
+                nullable=True,
+            ),
+        )
+        op.create_unique_constraint(
+            f"{table}_sample_id_name_key",
+            table,
+            ["sample_id", "name"],
+        )
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {table}
+                SET sample_id = ls.id
+                FROM legacy_samples ls
+                WHERE {table}.sample_id IS NULL
+                  AND ls.legacy_id = {table}.sample
+                """,  # noqa: S608
+            ),
+        )
+
+
+def downgrade() -> None:
+    for table in TABLES:
+        op.drop_constraint(
+            f"{table}_sample_id_name_key",
+            table,
+            type_="unique",
+        )
+        op.drop_column(table, "sample_id")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -617,5 +617,12 @@
       'name': 'backfill analyses sample ids to integers',
       'revision': 'b4qhmbisvbn3',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 89,
+      'name': 'add sample_id to sample files',
+      'revision': 'c980043c0c89',
+    }),
   ])
 # ---

--- a/tests/migration/test_add_sample_id_to_sample_files.py
+++ b/tests/migration/test_add_sample_id_to_sample_files.py
@@ -1,0 +1,134 @@
+"""Tests for the add-sample-id-to-sample-files (phase 1+2) migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+PREVIOUS_REVISION = "1f4e528c2149"
+REVISION = "c980043c0c89"
+
+
+async def _insert_legacy_sample(ctx: MigrationContext, legacy_id: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO legacy_samples (
+                    legacy_id, name, host, isolate, locale, notes, library_type,
+                    format, created_at, paired, ready, hold, is_legacy, all_read,
+                    all_write, group_read, group_write
+                )
+                VALUES (
+                    :legacy_id, :legacy_id, '', '', '', '', 'normal',
+                    'fastq', :now, false, true, false, false, false,
+                    false, false, false
+                )
+                RETURNING id
+            """),
+            {"legacy_id": legacy_id, "now": arrow.utcnow().naive},
+        )
+        sample_id = result.scalar_one()
+        await session.commit()
+
+    return sample_id
+
+
+async def _insert_artifact(ctx: MigrationContext, sample: str, name: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO sample_artifacts (sample, name, name_on_disk, type)
+                VALUES (:sample, :name, :name, 'fasta')
+                RETURNING id
+            """),
+            {"sample": sample, "name": name},
+        )
+        artifact_id = result.scalar_one()
+        await session.commit()
+
+    return artifact_id
+
+
+async def _insert_reads(ctx: MigrationContext, sample: str, name: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO sample_reads (sample, name, name_on_disk)
+                VALUES (:sample, :name, :name)
+                RETURNING id
+            """),
+            {"sample": sample, "name": name},
+        )
+        reads_id = result.scalar_one()
+        await session.commit()
+
+    return reads_id
+
+
+async def _fetch_sample_id(
+    ctx: MigrationContext,
+    table: str,
+    row_id: int,
+) -> int | None:
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text(f"SELECT sample_id FROM {table} WHERE id = :id"),  # noqa: S608
+            {"id": row_id},
+        )
+        return result.scalar_one()
+
+
+@pytest.fixture
+async def _at_previous_revision(apply_alembic: Callable) -> None:
+    await asyncio.to_thread(apply_alembic, PREVIOUS_REVISION)
+
+
+class TestBackfill:
+    async def test_artifact_sample_id_resolved_from_legacy_id(
+        self,
+        ctx: MigrationContext,
+        _at_previous_revision: None,
+        apply_alembic: Callable,
+    ):
+        sample_id = await _insert_legacy_sample(ctx, "mapped_sample")
+        artifact_id = await _insert_artifact(ctx, "mapped_sample", "reference.fa.gz")
+
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        assert await _fetch_sample_id(ctx, "sample_artifacts", artifact_id) == sample_id
+
+    async def test_reads_sample_id_resolved_from_legacy_id(
+        self,
+        ctx: MigrationContext,
+        _at_previous_revision: None,
+        apply_alembic: Callable,
+    ):
+        sample_id = await _insert_legacy_sample(ctx, "mapped_sample")
+        reads_id = await _insert_reads(ctx, "mapped_sample", "reads_1.fq.gz")
+
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        assert await _fetch_sample_id(ctx, "sample_reads", reads_id) == sample_id
+
+    async def test_unmapped_row_stays_null(
+        self,
+        ctx: MigrationContext,
+        _at_previous_revision: None,
+        apply_alembic: Callable,
+    ):
+        """A file row whose ``sample`` has no matching ``legacy_samples`` row keeps
+        ``sample_id`` NULL rather than raising; the column is nullable during the
+        transition.
+        """
+        artifact_id = await _insert_artifact(ctx, "orphan_sample", "reference.fa.gz")
+        reads_id = await _insert_reads(ctx, "orphan_sample", "reads_1.fq.gz")
+
+        await asyncio.to_thread(apply_alembic, REVISION)
+
+        assert await _fetch_sample_id(ctx, "sample_artifacts", artifact_id) is None
+        assert await _fetch_sample_id(ctx, "sample_reads", reads_id) is None

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -2636,6 +2636,7 @@
     'name': 'small.fq.gz',
     'name_on_disk': 'small.fq.gz',
     'sample': 'test',
+    'sample_id': 1,
     'size': 723988,
     'type': 'fastq',
     'uploaded_at': '2015-10-06T20:00:00Z',

--- a/tests/samples/__snapshots__/test_files.ambr
+++ b/tests/samples/__snapshots__/test_files.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_create_reads_file
-  <SQLSampleReads(id=1, sample=sample_1, name=reads_1.fq.gz, name_on_disk=reads_1.fq.gz, size=123456, upload=None, uploaded_at=2015-10-06 20:00:00)>
+  <SQLSampleReads(id=1, sample=sample_1, sample_id=1, name=reads_1.fq.gz, name_on_disk=reads_1.fq.gz, size=123456, upload=None, uploaded_at=2015-10-06 20:00:00)>
 # ---

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -36,6 +36,32 @@ from virtool.uploads.sql import SQLUpload
 from virtool.users.oas import UpdateUserRequest
 
 
+async def _ensure_legacy_sample_id(session: AsyncSession, legacy_id: str) -> int:
+    """Insert a ``legacy_samples`` row for ``legacy_id`` if absent and return its id.
+
+    Sample file rows are keyed by an integer FK to ``legacy_samples``, so tests that
+    insert artifact/reads rows directly need a parent legacy sample to point at.
+    """
+    sample_id = (
+        await session.execute(
+            select(SQLLegacySample.id).where(SQLLegacySample.legacy_id == legacy_id),
+        )
+    ).scalar()
+
+    if sample_id is None:
+        sample = SQLLegacySample(
+            legacy_id=legacy_id,
+            name=legacy_id,
+            library_type=LibraryType.normal.value,
+            created_at=datetime(2015, 10, 6, 20, 0),
+        )
+        session.add(sample)
+        await session.flush()
+        sample_id = sample.id
+
+    return sample_id
+
+
 class MockJobInterface:
     def __init__(self):
         self.enqueue = make_mocked_coro()
@@ -202,6 +228,7 @@ async def get_sample_data(
                 SQLSampleArtifact(
                     name="reference.fa.gz",
                     sample="test",
+                    sample_id=legacy.id,
                     type="fasta",
                     name_on_disk="reference.fa.gz",
                     size=34879234,
@@ -210,6 +237,7 @@ async def get_sample_data(
                     name="reads_1.fq.gz",
                     name_on_disk="reads_1.fq.gz",
                     sample="test",
+                    sample_id=legacy.id,
                     size=2903109210,
                     uploaded_at=static_time.datetime,
                     upload=None,
@@ -1486,8 +1514,11 @@ class TestUploadArtifact:
     """Test that new artifacts can be uploaded after sample creation using the Jobs API."""
 
     @staticmethod
-    async def _insert_sample(mongo: Mongo) -> None:
+    async def _insert_sample(mongo: Mongo, pg: AsyncEngine) -> None:
         await mongo.samples.insert_one({"_id": "test", "ready": True})
+        async with AsyncSession(pg) as session:
+            await _ensure_legacy_sample_id(session, "test")
+            await session.commit()
 
     @staticmethod
     async def _post(
@@ -1505,12 +1536,13 @@ class TestUploadArtifact:
         example_path: Path,
         memory_storage,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         spawn_job_client: JobClientSpawner,
         static_time,
     ):
         client = await spawn_job_client(authenticated=True)
-        await self._insert_sample(mongo)
+        await self._insert_sample(mongo, pg)
 
         resp = await self._post(
             client, example_path / "sample" / "reads_1.fq.gz", "fastq"
@@ -1526,12 +1558,13 @@ class TestUploadArtifact:
         self,
         example_path: Path,
         mongo: Mongo,
+        pg: AsyncEngine,
         resp_is,
         spawn_job_client: JobClientSpawner,
         static_time,
     ):
         client = await spawn_job_client(authenticated=True)
-        await self._insert_sample(mongo)
+        await self._insert_sample(mongo, pg)
 
         resp = await self._post(
             client, example_path / "sample" / "reads_1.fq.gz", "foo"
@@ -1543,12 +1576,13 @@ class TestUploadArtifact:
         self,
         example_path: Path,
         mongo: Mongo,
+        pg: AsyncEngine,
         resp_is,
         spawn_job_client: JobClientSpawner,
         static_time,
     ):
         client = await spawn_job_client(authenticated=True)
-        await self._insert_sample(mongo)
+        await self._insert_sample(mongo, pg)
 
         path = example_path / "sample" / "reads_1.fq.gz"
 
@@ -1717,6 +1751,7 @@ class TestDownloadReads:
                 SQLSampleReads(
                     id=1,
                     sample="foo",
+                    sample_id=await _ensure_legacy_sample_id(session, "foo"),
                     name=file_name,
                     name_on_disk=file_name,
                     size=size,
@@ -1856,6 +1891,7 @@ class TestDownloadArtifact:
                 SQLSampleArtifact(
                     id=1,
                     sample="foo",
+                    sample_id=await _ensure_legacy_sample_id(session, "foo"),
                     name="fastqc.txt",
                     name_on_disk="fastqc.txt",
                     type="fastq",

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1603,6 +1603,7 @@ class TestUploadReads:
         example_path: Path,
         memory_storage,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         spawn_job_client: JobClientSpawner,
     ):
@@ -1617,6 +1618,10 @@ class TestUploadReads:
                 "ready": True,
             },
         )
+
+        async with AsyncSession(pg) as session:
+            await _ensure_legacy_sample_id(session, "test")
+            await session.commit()
 
         resp_1 = await client.put(
             "/samples/test/reads/reads_1.fq.gz",

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -336,11 +336,18 @@ async def test_finalize(
     )
 
     async with AsyncSession(pg) as session:
+        legacy_sample_id = (
+            await session.execute(
+                select(SQLLegacySample.id).where(SQLLegacySample.legacy_id == "test"),
+            )
+        ).scalar_one()
+
         session.add(
             SQLSampleReads(
                 name="reads.fq.gz",
                 name_on_disk="reads_1.fq.gz",
                 sample="test",
+                sample_id=legacy_sample_id,
                 size=len(b"upload contents"),
                 upload=upload.id,
                 uploaded_at=virtool.utils.timestamp(),

--- a/tests/samples/test_files.py
+++ b/tests/samples/test_files.py
@@ -1,14 +1,28 @@
+from datetime import datetime
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
+from virtool.models.enums import LibraryType
 from virtool.samples.files import create_reads_file
-from virtool.samples.sql import SQLSampleReads
+from virtool.samples.sql import SQLLegacySample, SQLSampleReads
 
 
 async def test_create_reads_file(
     pg: AsyncEngine, snapshot: SnapshotAssertion, static_time
 ):
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacySample(
+                legacy_id="sample_1",
+                name="sample_1",
+                library_type=LibraryType.normal.value,
+                created_at=datetime(2015, 10, 6, 20, 0),
+            ),
+        )
+        await session.commit()
+
     await create_reads_file(
         pg,
         123456,
@@ -18,6 +32,7 @@ async def test_create_reads_file(
     )
 
     async with AsyncSession(pg) as session:
-        assert (
-            await session.execute(select(SQLSampleReads).filter_by(id=1))
-        ).scalar() == snapshot
+        reads = (await session.execute(select(SQLSampleReads).filter_by(id=1))).scalar()
+
+    assert reads == snapshot
+    assert reads.sample_id is not None

--- a/tests/samples/test_files.py
+++ b/tests/samples/test_files.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
@@ -36,3 +37,17 @@ async def test_create_reads_file(
 
     assert reads == snapshot
     assert reads.sample_id is not None
+
+
+async def test_create_reads_file_unknown_sample_raises(pg: AsyncEngine):
+    """Creating a reads file for a sample with no ``legacy_samples`` row is a
+    data-integrity error and must fail loudly rather than store a NULL sample_id.
+    """
+    with pytest.raises(ValueError, match="No legacy_samples row for sample"):
+        await create_reads_file(
+            pg,
+            123456,
+            "reads_1.fq.gz",
+            "reads_1.fq.gz",
+            "missing_sample",
+        )

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -22,6 +22,7 @@ from virtool.data.events import Operation, emits
 from virtool.data.topg import (
     both_transactions,
     compose_legacy_id_multi_expression,
+    compose_legacy_id_subquery,
     retry_both_transactions,
 )
 from virtool.data.transforms import apply_transforms
@@ -523,6 +524,16 @@ class SamplesData(DataLayerDomain):
                 ),
             )
             await pg_session.execute(
+                delete(SQLSampleArtifact).where(
+                    SQLSampleArtifact.sample == sample_id,
+                ),
+            )
+            await pg_session.execute(
+                delete(SQLSampleReads).where(
+                    SQLSampleReads.sample == sample_id,
+                ),
+            )
+            await pg_session.execute(
                 delete(SQLLegacySample).where(
                     SQLLegacySample.legacy_id == sample_id,
                 ),
@@ -934,9 +945,10 @@ class SamplesData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             row = (
                 await session.execute(
-                    select(SQLSampleReads).filter_by(
-                        sample=sample_id,
-                        name=filename,
+                    select(SQLSampleReads).where(
+                        SQLSampleReads.sample_id
+                        == compose_legacy_id_subquery(SQLLegacySample, sample_id),
+                        SQLSampleReads.name == filename,
                     ),
                 )
             ).scalar()
@@ -959,9 +971,10 @@ class SamplesData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             result = (
                 await session.execute(
-                    select(SQLSampleArtifact).filter_by(
-                        sample=sample_id,
-                        name=filename,
+                    select(SQLSampleArtifact).where(
+                        SQLSampleArtifact.sample_id
+                        == compose_legacy_id_subquery(SQLLegacySample, sample_id),
+                        SQLSampleArtifact.name == filename,
                     ),
                 )
             ).scalar()

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -49,16 +49,21 @@ class AttachArtifactsAndReadsTransform(AbstractTransform):
 
     async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
         sample_id = document["id"]
+        sample_subquery = compose_legacy_id_subquery(SQLLegacySample, sample_id)
 
         artifacts = (
             await session.execute(
-                select(SQLSampleArtifact).filter_by(sample=sample_id),
+                select(SQLSampleArtifact).where(
+                    SQLSampleArtifact.sample_id == sample_subquery,
+                ),
             )
         ).scalars()
 
         reads_files = (
             await session.execute(
-                select(SQLSampleReads).filter_by(sample=sample_id),
+                select(SQLSampleReads).where(
+                    SQLSampleReads.sample_id == sample_subquery,
+                ),
             )
         ).scalars()
 

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -83,38 +83,6 @@ async def create_fake_sample(
 
         subtraction_ids = list(result.scalars().all())
 
-    if finalized is True:
-        if paired:
-            for n in (1, 2):
-                file_path = example_path / "sample" / f"reads_{n}.fq.gz"
-
-                await copy_reads_file(
-                    storage,
-                    file_path,
-                    f"reads_{n}.fq.gz",
-                    sample_id,
-                )
-
-                await create_reads_file(
-                    pg,
-                    file_path.stat().st_size,
-                    f"reads_{n}.fq.gz",
-                    f"reads_{n}.fq.gz",
-                    sample_id,
-                )
-        else:
-            file_path = example_path / "sample" / "reads_1.fq.gz"
-
-            await copy_reads_file(storage, file_path, "reads_1.fq.gz", sample_id)
-
-            await create_reads_file(
-                pg,
-                file_path.stat().st_size,
-                "reads_1.fq.gz",
-                "reads_1.fq.gz",
-                sample_id,
-            )
-
     settings = Settings()
     settings.sample_group_read = True
     settings.sample_group_write = True
@@ -154,6 +122,37 @@ async def create_fake_sample(
         await session.commit()
 
     if finalized is True:
+        if paired:
+            for n in (1, 2):
+                file_path = example_path / "sample" / f"reads_{n}.fq.gz"
+
+                await copy_reads_file(
+                    storage,
+                    file_path,
+                    f"reads_{n}.fq.gz",
+                    sample_id,
+                )
+
+                await create_reads_file(
+                    pg,
+                    file_path.stat().st_size,
+                    f"reads_{n}.fq.gz",
+                    f"reads_{n}.fq.gz",
+                    sample_id,
+                )
+        else:
+            file_path = example_path / "sample" / "reads_1.fq.gz"
+
+            await copy_reads_file(storage, file_path, "reads_1.fq.gz", sample_id)
+
+            await create_reads_file(
+                pg,
+                file_path.stat().st_size,
+                "reads_1.fq.gz",
+                "reads_1.fq.gz",
+                sample_id,
+            )
+
         await get_data_from_app(app).samples.finalize(
             sample_id=sample_id,
             quality=await create_fake_quality(fake),

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -7,6 +7,22 @@ from virtool.samples.sql import SQLLegacySample, SQLSampleArtifact, SQLSampleRea
 from virtool.uploads.sql import SQLUpload
 
 
+async def _resolve_sample_id(session: AsyncSession, sample: str) -> int:
+    """Resolve a sample's Mongo id to its ``legacy_samples`` integer primary key.
+
+    A sample file's parent sample is a required relationship, so a sample that
+    has not been backfilled into Postgres is a data-integrity error rather than a
+    row to store with a ``NULL`` ``sample_id``.
+    """
+    sample_id = await resolve_legacy_id(session, SQLLegacySample, sample)
+
+    if sample_id is None:
+        msg = f"No legacy_samples row for sample {sample!r}"
+        raise ValueError(msg)
+
+    return sample_id
+
+
 async def get_existing_reads(pg: AsyncEngine, sample_id: str) -> list[str]:
     """Get read file names for a sample.
 
@@ -46,7 +62,7 @@ async def create_artifact_file(
             name=name,
             name_on_disk=name_on_disk,
             sample=sample,
-            sample_id=await resolve_legacy_id(session, SQLLegacySample, sample),
+            sample_id=await _resolve_sample_id(session, sample),
             type=artifact_type,
             uploaded_at=virtool.utils.timestamp(),
         )
@@ -83,7 +99,7 @@ async def create_reads_file(
     async with AsyncSession(pg) as session:
         reads = SQLSampleReads(
             sample=sample_id,
-            sample_id=await resolve_legacy_id(session, SQLLegacySample, sample_id),
+            sample_id=await _resolve_sample_id(session, sample_id),
             name=name,
             name_on_disk=name_on_disk,
             size=size,

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -2,7 +2,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
-from virtool.samples.sql import SQLSampleArtifact, SQLSampleReads
+from virtool.data.topg import compose_legacy_id_subquery, resolve_legacy_id
+from virtool.samples.sql import SQLLegacySample, SQLSampleArtifact, SQLSampleReads
 from virtool.uploads.sql import SQLUpload
 
 
@@ -15,7 +16,10 @@ async def get_existing_reads(pg: AsyncEngine, sample_id: str) -> list[str]:
     """
     async with AsyncSession(pg) as session:
         result = await session.execute(
-            select(SQLSampleReads).filter_by(sample=sample_id),
+            select(SQLSampleReads).where(
+                SQLSampleReads.sample_id
+                == compose_legacy_id_subquery(SQLLegacySample, sample_id),
+            ),
         )
 
     return [row.name for row in result.scalars().all()]
@@ -42,6 +46,7 @@ async def create_artifact_file(
             name=name,
             name_on_disk=name_on_disk,
             sample=sample,
+            sample_id=await resolve_legacy_id(session, SQLLegacySample, sample),
             type=artifact_type,
             uploaded_at=virtool.utils.timestamp(),
         )
@@ -78,6 +83,7 @@ async def create_reads_file(
     async with AsyncSession(pg) as session:
         reads = SQLSampleReads(
             sample=sample_id,
+            sample_id=await resolve_legacy_id(session, SQLLegacySample, sample_id),
             name=name,
             name_on_disk=name_on_disk,
             size=size,

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -36,10 +36,14 @@ class SQLSampleArtifact(Base):
     """SQL model to store sample artifacts"""
 
     __tablename__ = "sample_artifacts"
-    __table_args__ = (UniqueConstraint("sample", "name"),)
+    __table_args__ = (
+        UniqueConstraint("sample", "name"),
+        UniqueConstraint("sample_id", "name"),
+    )
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)
+    sample_id = Column(BigInteger, ForeignKey("legacy_samples.id"))
     name = Column(String, nullable=False)
     name_on_disk = Column(String)
     size = Column(BigInteger)
@@ -51,10 +55,14 @@ class SQLSampleReads(Base):
     """SQL model to store new sample reads files"""
 
     __tablename__ = "sample_reads"
-    __table_args__ = (UniqueConstraint("sample", "name"),)
+    __table_args__ = (
+        UniqueConstraint("sample", "name"),
+        UniqueConstraint("sample_id", "name"),
+    )
 
     id = Column(Integer, primary_key=True)
     sample = Column(String, nullable=False)
+    sample_id = Column(BigInteger, ForeignKey("legacy_samples.id"))
     name = Column(String(length=13), nullable=False)
     name_on_disk = Column(String, nullable=False)
     size = Column(BigInteger)


### PR DESCRIPTION
## Summary
- Add an integer `sample_id` FK from `sample_artifacts`/`sample_reads` to `legacy_samples`, alongside a parallel `(sample_id, name)` unique constraint
- Backfill the new column from the legacy Mongo sample string and switch readers/writers to the integer FK
- Retain the legacy sample column and constraint for a later cleanup revision