### PR TITLE
feat(migration): backfill references and rights to postgres

### DIFF
--- a/assets/revisions/rev_t4u44jre75a0_copy_references_to_postgres.py
+++ b/assets/revisions/rev_t4u44jre75a0_copy_references_to_postgres.py
@@ -1,0 +1,39 @@
+"""Copy references to postgres.
+
+Revision ID: t4u44jre75a0
+Date: 2026-07-06 21:57:50.570636
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.references.migration import copy_references_to_postgres
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "copy references to postgres"
+created_at = arrow.get("2026-07-06 21:57:50.570636")
+revision_id = "t4u44jre75a0"
+
+alembic_down_revision = None
+virtool_down_revision = "b4qhmbisvbn3"
+
+# Change this if an Alembic revision is required to run this migration.
+#
+# ``fe83de8410d3`` is the head of the reference schema chain: it makes
+# ``legacy_references.user_id`` not-null and drops ``created_at`` from the rights
+# tables, on top of ``a73a2668403f`` (create the three tables) and
+# ``425ac8573f1c`` (drop ``remove`` from the rights tables). Requiring it
+# guarantees every destination table exists in its final shape before this runs.
+required_alembic_revision = "fe83de8410d3"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``references`` document into Postgres.
+
+    The implementation lives in :func:`copy_references_to_postgres`.
+    """
+    await copy_references_to_postgres(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -617,5 +617,12 @@
       'name': 'backfill analyses sample ids to integers',
       'revision': 'b4qhmbisvbn3',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 89,
+      'name': 'copy references to postgres',
+      'revision': 't4u44jre75a0',
+    }),
   ])
 # ---

--- a/tests/migration/test_copy_references_to_postgres.py
+++ b/tests/migration/test_copy_references_to_postgres.py
@@ -1,0 +1,606 @@
+"""Tests for the copy references to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_t4u44jre75a0_copy_references_to_postgres import (
+    required_alembic_revision,
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+from virtool.utils import timestamp
+
+
+@pytest.fixture
+def static_datetime() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def setup_user(ctx: MigrationContext, apply_alembic: Callable) -> int:
+    """Apply alembic to the required revision and seed a user with a legacy id."""
+    await asyncio.to_thread(apply_alembic, required_alembic_revision)
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(
+            text("""
+                INSERT INTO users (
+                    handle, legacy_id, active, email, force_reset,
+                    invalidate_sessions, last_password_change, password, settings
+                )
+                VALUES (
+                    'testuser', 'legacy_user_123', true, '', false,
+                    false, :now, :password, '{}'::jsonb
+                )
+                RETURNING id
+            """),
+            {"now": timestamp(), "password": b"hashed_password"},
+        )
+        user_id = result.scalar_one()
+        await session.commit()
+        return user_id
+
+
+async def insert_group(session: AsyncSession, name: str) -> int:
+    """Insert a group and return its integer primary key."""
+    result = await session.execute(
+        text(
+            "INSERT INTO groups (name, permissions) VALUES (:name, '{}') RETURNING id",
+        ),
+        {"name": name},
+    )
+    group_id = result.scalar_one()
+    await session.commit()
+    return group_id
+
+
+async def insert_upload(session: AsyncSession, user_id: int, name: str) -> int:
+    """Insert an upload and return its integer primary key."""
+    result = await session.execute(
+        text("""
+            INSERT INTO uploads (
+                name, name_on_disk, ready, removed, reserved, type, user_id
+            )
+            VALUES (:name, :name, true, false, false, 'reference', :user_id)
+            RETURNING id
+        """),
+        {"name": name, "user_id": user_id},
+    )
+    upload_id = result.scalar_one()
+    await session.commit()
+    return upload_id
+
+
+async def insert_task(session: AsyncSession, created_at: datetime) -> int:
+    """Insert a task and return its integer primary key."""
+    result = await session.execute(
+        text(
+            "INSERT INTO tasks (created_at, type, complete) "
+            "VALUES (:now, 'clone_reference', false) RETURNING id",
+        ),
+        {"now": created_at},
+    )
+    task_id = result.scalar_one()
+    await session.commit()
+    return task_id
+
+
+def make_rights_member(
+    member_id: int | str,
+    created_at: datetime,
+    *,
+    build: bool = False,
+    modify: bool = False,
+    modify_otu: bool = False,
+) -> dict:
+    """Create an embedded rights member, mirroring the Mongo shape."""
+    return {
+        "id": member_id,
+        "build": build,
+        "modify": modify,
+        "modify_otu": modify_otu,
+        "created_at": created_at,
+    }
+
+
+def make_reference_document(
+    reference_id: str,
+    user_id: int | str,
+    created_at: datetime,
+    *,
+    name: str = "Plant Viruses",
+    description: str = "A reference of plant viruses.",
+    organism: str = "virus",
+    archived: bool = False,
+    restrict_source_types: bool = False,
+    source_types: list[str] | None = None,
+    users: list[dict] | None = None,
+    groups: list[dict] | None = None,
+    imported_from: int | None = None,
+    task_id: int | None = None,
+    cloned_from: str | None = None,
+) -> dict:
+    """Create a MongoDB reference document in the post-conversion shape.
+
+    ``data_type``, ``space`` and ``internal_control`` are included to prove the
+    migration ignores the fields it intentionally drops.
+    """
+    return {
+        "_id": reference_id,
+        "name": name,
+        "description": description,
+        "organism": organism,
+        "created_at": created_at,
+        "archived": archived,
+        "restrict_source_types": restrict_source_types,
+        "source_types": source_types if source_types is not None else ["isolate"],
+        "data_type": "genome",
+        "space": {"id": 0},
+        "internal_control": None,
+        "user": {"id": user_id},
+        "users": users if users is not None else [],
+        "groups": groups if groups is not None else [],
+        "imported_from": {"id": imported_from} if imported_from is not None else None,
+        "task": {"id": task_id} if task_id is not None else None,
+        "cloned_from": (
+            {"id": cloned_from, "name": "Source"} if cloned_from is not None else None
+        ),
+    }
+
+
+async def get_reference_pk(session: AsyncSession, legacy_id: str) -> int:
+    """Return the integer primary key of a backfilled reference by legacy id."""
+    return (
+        await session.execute(
+            text("SELECT id FROM legacy_references WHERE legacy_id = :legacy_id"),
+            {"legacy_id": legacy_id},
+        )
+    ).scalar_one()
+
+
+class TestUpgrade:
+    """Tests for the upgrade function."""
+
+    async def test_field_fidelity(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A document's scalar and json fields map correctly."""
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(session, setup_user, "plant.fa.gz")
+            task_id = await insert_task(session, static_datetime)
+
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "reference_1",
+                setup_user,
+                static_datetime,
+                archived=True,
+                restrict_source_types=True,
+                source_types=["isolate", "strain"],
+                imported_from=upload_id,
+                task_id=task_id,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    text("""
+                        SELECT id, legacy_id, name, description, organism, created_at,
+                               archived, restrict_source_types, source_types, user_id,
+                               upload_id, cloned_from_id, task_id
+                        FROM legacy_references WHERE legacy_id = 'reference_1'
+                    """),
+                )
+            ).one()
+
+        assert isinstance(row.id, int)
+        assert row.legacy_id == "reference_1"
+        assert row.name == "Plant Viruses"
+        assert row.description == "A reference of plant viruses."
+        assert row.organism == "virus"
+        assert row.created_at == static_datetime
+        assert row.archived is True
+        assert row.restrict_source_types is True
+        assert row.source_types == ["isolate", "strain"]
+        assert row.user_id == setup_user
+        assert row.upload_id == upload_id
+        assert row.cloned_from_id is None
+        assert row.task_id == task_id
+
+    async def test_user_legacy_id_mapping(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A legacy string user id resolves to the user's integer primary key."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "legacy_user_reference",
+                "legacy_user_123",
+                static_datetime,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            stored = (
+                await session.execute(
+                    text(
+                        "SELECT user_id FROM legacy_references "
+                        "WHERE legacy_id = 'legacy_user_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert stored == setup_user
+
+    async def test_missing_user_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A reference whose owner is missing from postgres aborts the migration."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "orphan_user_reference",
+                setup_user + 9999,
+                static_datetime,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="does not exist in postgres"):
+            await upgrade(ctx)
+
+    async def test_rights_rows(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """Each embedded rights member becomes a join row with its rights booleans."""
+        async with AsyncSession(ctx.pg) as session:
+            group_id = await insert_group(session, "Technicians")
+
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "rights_reference",
+                setup_user,
+                static_datetime,
+                users=[
+                    make_rights_member(
+                        setup_user,
+                        static_datetime,
+                        build=True,
+                        modify=True,
+                        modify_otu=True,
+                    ),
+                ],
+                groups=[
+                    make_rights_member(
+                        group_id,
+                        static_datetime,
+                        build=True,
+                        modify_otu=True,
+                    ),
+                ],
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            reference_pk = await get_reference_pk(session, "rights_reference")
+
+            user_row = (
+                await session.execute(
+                    text("""
+                        SELECT user_id, build, modify, modify_otu
+                        FROM legacy_reference_users WHERE reference_id = :reference_id
+                    """),
+                    {"reference_id": reference_pk},
+                )
+            ).one()
+
+            group_row = (
+                await session.execute(
+                    text("""
+                        SELECT group_id, build, modify, modify_otu
+                        FROM legacy_reference_groups WHERE reference_id = :reference_id
+                    """),
+                    {"reference_id": reference_pk},
+                )
+            ).one()
+
+        assert user_row.user_id == setup_user
+        assert (user_row.build, user_row.modify, user_row.modify_otu) == (
+            True,
+            True,
+            True,
+        )
+        assert group_row.group_id == group_id
+        assert (group_row.build, group_row.modify, group_row.modify_otu) == (
+            True,
+            False,
+            True,
+        )
+
+    async def test_missing_rights_user_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A rights member user missing from postgres aborts the migration."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "orphan_rights_user",
+                setup_user,
+                static_datetime,
+                users=[make_rights_member(setup_user + 9999, static_datetime)],
+            ),
+        )
+
+        with pytest.raises(ValueError, match="does not exist in postgres"):
+            await upgrade(ctx)
+
+    async def test_missing_rights_group_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A rights member group missing from postgres aborts the migration."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "orphan_rights_group",
+                setup_user,
+                static_datetime,
+                groups=[make_rights_member(999999, static_datetime)],
+            ),
+        )
+
+        with pytest.raises(ValueError, match="does not exist in postgres"):
+            await upgrade(ctx)
+
+    async def test_cloned_from_resolved(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A clone's cloned_from_id resolves to its source, even when copied first.
+
+        The clone is inserted into Mongo before its source so the first pass writes
+        it with a null ``cloned_from_id``; the second pass links it once the source
+        row exists.
+        """
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "clone_reference",
+                setup_user,
+                static_datetime,
+                name="Clone",
+                cloned_from="source_reference",
+            ),
+        )
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "source_reference",
+                setup_user,
+                static_datetime,
+                name="Source",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            source_pk = await get_reference_pk(session, "source_reference")
+            cloned_from_id = (
+                await session.execute(
+                    text(
+                        "SELECT cloned_from_id FROM legacy_references "
+                        "WHERE legacy_id = 'clone_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert cloned_from_id == source_pk
+
+    async def test_orphan_cloned_from_is_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A clone whose source no longer exists keeps a null cloned_from_id."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "orphan_clone_reference",
+                setup_user,
+                static_datetime,
+                cloned_from="deleted_source",
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            cloned_from_id = (
+                await session.execute(
+                    text(
+                        "SELECT cloned_from_id FROM legacy_references "
+                        "WHERE legacy_id = 'orphan_clone_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert cloned_from_id is None
+
+    async def test_missing_upload_is_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """upload_id is null when the imported upload no longer exists."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "orphan_upload_reference",
+                setup_user,
+                static_datetime,
+                imported_from=999999,
+            ),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = (
+                await session.execute(
+                    text(
+                        "SELECT upload_id FROM legacy_references "
+                        "WHERE legacy_id = 'orphan_upload_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert upload_id is None
+
+    async def test_missing_task_is_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """task_id is null when the referenced task no longer exists."""
+        await ctx.mongo.references.insert_one(
+            {
+                **make_reference_document(
+                    "orphan_task_reference",
+                    setup_user,
+                    static_datetime,
+                ),
+                "task": {"id": 999999},
+            },
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            task_id = (
+                await session.execute(
+                    text(
+                        "SELECT task_id FROM legacy_references "
+                        "WHERE legacy_id = 'orphan_task_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert task_id is None
+
+    async def test_idempotent_rerun(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A re-run leaves a single reference row and a single set of rights rows."""
+        async with AsyncSession(ctx.pg) as session:
+            group_id = await insert_group(session, "Technicians")
+
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "repeat_reference",
+                setup_user,
+                static_datetime,
+                users=[make_rights_member(setup_user, static_datetime, build=True)],
+                groups=[make_rights_member(group_id, static_datetime, modify=True)],
+            ),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            reference_count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM legacy_references "
+                        "WHERE legacy_id = 'repeat_reference'",
+                    ),
+                )
+            ).scalar_one()
+            reference_pk = await get_reference_pk(session, "repeat_reference")
+            user_count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM legacy_reference_users "
+                        "WHERE reference_id = :reference_id",
+                    ),
+                    {"reference_id": reference_pk},
+                )
+            ).scalar_one()
+            group_count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM legacy_reference_groups "
+                        "WHERE reference_id = :reference_id",
+                    ),
+                    {"reference_id": reference_pk},
+                )
+            ).scalar_one()
+
+        assert reference_count == 1
+        assert user_count == 1
+        assert group_count == 1
+
+    async def test_row_count_parity(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """The Postgres row count matches the Mongo document count."""
+        for i in range(4):
+            await ctx.mongo.references.insert_one(
+                make_reference_document(f"reference_{i}", setup_user, static_datetime),
+            )
+
+        await upgrade(ctx)
+
+        mongo_count = await ctx.mongo.references.count_documents({})
+
+        async with AsyncSession(ctx.pg) as session:
+            pg_count = (
+                await session.execute(text("SELECT COUNT(*) FROM legacy_references"))
+            ).scalar_one()
+
+        assert pg_count == mongo_count == 4
+
+    @pytest.mark.usefixtures("setup_user")
+    async def test_empty_collection(self, ctx: MigrationContext):
+        """An empty references collection is a no-op."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM legacy_references"))
+            ).scalar_one()
+
+        assert count == 0

--- a/tests/migration/test_copy_references_to_postgres.py
+++ b/tests/migration/test_copy_references_to_postgres.py
@@ -358,13 +358,18 @@ class TestUpgrade:
         with pytest.raises(ValueError, match="does not exist in postgres"):
             await upgrade(ctx)
 
-    async def test_missing_rights_group_raises(
+    async def test_missing_rights_group_skipped(
         self,
         ctx: MigrationContext,
         setup_user: int,
         static_datetime: datetime,
     ):
-        """A rights member group missing from postgres aborts the migration."""
+        """A rights member group deleted from postgres is skipped, not fatal.
+
+        Groups can be deleted without scrubbing the grant from the reference
+        document, so a stale grant must not abort the whole backfill. The reference
+        is still written, just without the dangling group row.
+        """
         await ctx.mongo.references.insert_one(
             make_reference_document(
                 "orphan_rights_group",
@@ -374,8 +379,21 @@ class TestUpgrade:
             ),
         )
 
-        with pytest.raises(ValueError, match="does not exist in postgres"):
-            await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            reference_pk = await get_reference_pk(session, "orphan_rights_group")
+            group_count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM legacy_reference_groups "
+                        "WHERE reference_id = :reference_id",
+                    ),
+                    {"reference_id": reference_pk},
+                )
+            ).scalar_one()
+
+        assert group_count == 0
 
     async def test_cloned_from_resolved(
         self,
@@ -508,6 +526,76 @@ class TestUpgrade:
                     text(
                         "SELECT task_id FROM legacy_references "
                         "WHERE legacy_id = 'orphan_task_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert task_id is None
+
+    async def test_absent_cloned_from_field_is_safe(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A non-clone reference with no cloned_from field survives the second pass.
+
+        Documents created by ``create_document`` carry no ``cloned_from`` key at
+        all, so the second pass must not assume the field is present.
+        """
+        document = make_reference_document(
+            "plain_reference",
+            setup_user,
+            static_datetime,
+        )
+        del document["cloned_from"]
+
+        await ctx.mongo.references.insert_one(document)
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            cloned_from_id = (
+                await session.execute(
+                    text(
+                        "SELECT cloned_from_id FROM legacy_references "
+                        "WHERE legacy_id = 'plain_reference'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert cloned_from_id is None
+
+    async def test_non_numeric_task_id_is_null(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A non-integer task id is nulled rather than aborting the backfill.
+
+        ``tasks`` has no legacy_id column, so resolving a non-numeric string id
+        would raise; it is treated as a dangling reference instead.
+        """
+        await ctx.mongo.references.insert_one(
+            {
+                **make_reference_document(
+                    "legacy_task_reference",
+                    setup_user,
+                    static_datetime,
+                ),
+                "task": {"id": "legacy_task_abc"},
+            },
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            task_id = (
+                await session.execute(
+                    text(
+                        "SELECT task_id FROM legacy_references "
+                        "WHERE legacy_id = 'legacy_task_reference'",
                     ),
                 )
             ).scalar_one()

--- a/virtool/references/migration.py
+++ b/virtool/references/migration.py
@@ -52,11 +52,13 @@ async def copy_references_to_postgres(ctx: MigrationContext) -> None:
     ``compose_legacy_id_single_expression`` tolerates both legacy string ids and
     the integer ids written since those collections were migrated:
 
-    - ``user`` is required. A reference that references a user missing from
-      Postgres raises, rather than being backfilled with a null owner.
-    - Every ``users`` and ``groups`` rights member is required. A member that no
-      longer resolves to a Postgres row raises, matching the not-null foreign key
-      on the join tables.
+    - ``user`` is required, both as the reference owner and as a ``users`` rights
+      member, because users are never hard-deleted (only deactivated). A reference
+      that references a user missing from Postgres raises, rather than being
+      backfilled with a null owner or a dropped grant.
+    - ``groups`` rights members are best-effort. Groups can be deleted without
+      scrubbing the grant from the reference document, so a member that no longer
+      resolves is logged and skipped rather than aborting the migration.
     - ``upload`` (``imported_from``) and ``task`` are optional. A dangling
       reference is backfilled as ``NULL`` and logged with a warning.
 
@@ -160,10 +162,12 @@ async def _insert_rights_rows(
 ) -> None:
     """Insert the user and group rights rows for a reference.
 
-    Each member's id is resolved to a Postgres primary key. The rights join tables
-    have a not-null foreign key, so a member that no longer resolves raises rather
-    than being skipped. Each insert uses ``ON CONFLICT DO NOTHING`` so a re-run
-    over an interrupted document adds only the rows that are missing.
+    User grants are required: users are never hard-deleted, so a ``users`` member
+    that does not resolve raises. Group grants are best-effort: a group can be
+    deleted without scrubbing the grant from the reference document, so a
+    ``groups`` member that does not resolve is logged and skipped. Each insert uses
+    ``ON CONFLICT DO NOTHING`` so a re-run over an interrupted document adds only
+    the rows that are missing.
     """
     for member in document.get("users") or []:
         user_id = await _resolve_rights_member_id(
@@ -188,14 +192,16 @@ async def _insert_rights_rows(
         )
 
     for member in document.get("groups") or []:
-        group_id = await _resolve_rights_member_id(
-            session,
-            SQLGroup,
-            member["id"],
-            group_id_cache,
-            document["_id"],
-            "group",
-        )
+        group_id = await _resolve_id(session, SQLGroup, member["id"], group_id_cache)
+
+        if group_id is None:
+            logger.warning(
+                "reference grants rights to a group that no longer exists; "
+                "skipping grant",
+                reference_id=document["_id"],
+                group=member["id"],
+            )
+            continue
 
         await session.execute(
             insert(SQLReferenceGroup)
@@ -228,7 +234,10 @@ async def _backfill_cloned_from_ids(
         {"cloned_from": {"$ne": None}},
         projection=["_id", "cloned_from"],
     ):
-        cloned_from = document["cloned_from"]
+        cloned_from = document.get("cloned_from")
+
+        if not cloned_from:
+            continue
 
         cloned_from_id = (
             await session.execute(
@@ -366,6 +375,11 @@ async def _resolve_task_id(
     Returns ``None`` when the reference has no task, and also when a task is
     referenced but no longer exists in Postgres. Dangling references are logged so
     the migration leaves an audit trail, distinct from the legitimate no-task case.
+
+    ``tasks`` was born in Postgres with integer ids and has no ``legacy_id``
+    column, so a non-integer task reference can never resolve and would make
+    ``compose_legacy_id_single_expression`` raise. Such a value is treated as a
+    dangling reference and nulled rather than aborting the backfill.
     """
     task = document.get("task")
 
@@ -373,6 +387,17 @@ async def _resolve_task_id(
         return None
 
     reference = task["id"]
+
+    if not isinstance(reference, int) and not (
+        isinstance(reference, str) and reference.isdigit()
+    ):
+        logger.warning(
+            "reference references a task with a non-integer id; "
+            "backfilling null task_id",
+            reference_id=document["_id"],
+            task=reference,
+        )
+        return None
 
     task_id = await _resolve_id(session, SQLTask, reference, cache)
 
@@ -395,11 +420,11 @@ async def _resolve_rights_member_id(
     reference_id: str,
     kind: str,
 ) -> int:
-    """Resolve a rights member's id to a Postgres primary key, raising if missing.
+    """Resolve a required rights member's id to a Postgres primary key.
 
-    The rights join tables have a not-null foreign key, so a ``users`` or
-    ``groups`` member that no longer resolves to a Postgres row raises rather than
-    being skipped or backfilled as ``NULL``.
+    Used for ``users`` grants, which must always resolve because users are never
+    hard-deleted. A member that does not resolve raises rather than being skipped
+    or backfilled as ``NULL``, matching the not-null foreign key on the join table.
     """
     resolved = await _resolve_id(session, model, reference, cache)
 

--- a/virtool/references/migration.py
+++ b/virtool/references/migration.py
@@ -1,0 +1,413 @@
+"""Backfill logic for copying Mongo references into Postgres.
+
+This module holds the idempotent copy used by the reference backfill revision. It
+is kept here rather than inline in the revision so it can be unit tested and
+reused.
+"""
+
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.data.topg import compose_legacy_id_single_expression
+from virtool.groups.pg import SQLGroup
+from virtool.migration import MigrationContext
+from virtool.pg.base import Base
+from virtool.references.sql import (
+    SQLReference,
+    SQLReferenceGroup,
+    SQLReferenceUser,
+)
+from virtool.references.utils import reference_values
+from virtool.tasks.sql import SQLTask
+from virtool.uploads.sql import SQLUpload
+from virtool.users.pg import SQLUser
+
+logger = get_logger("migration")
+
+
+async def copy_references_to_postgres(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``references`` document into Postgres.
+
+    One row is written per Mongo document into ``legacy_references``, plus one row
+    per member of the embedded ``users`` and ``groups`` rights arrays into the
+    ``legacy_reference_users`` and ``legacy_reference_groups`` join tables.
+    Documents are processed one at a time and committed individually, so memory
+    stays bounded and a failure part-way through keeps the rows already written
+    rather than rolling back the whole collection.
+
+    The document ``_id`` values are snapshotted up front so the rest of the run
+    fetches one document at a time by id, rather than holding a single Mongo cursor
+    open for the entire migration.
+
+    The parent row and its rights rows are inserted in a single transaction and
+    committed together, so a committed reference always carries its complete set of
+    rights rows. Documents already present in Postgres (by ``legacy_id``) are
+    therefore skipped wholesale, and every insert uses ``ON CONFLICT DO NOTHING``
+    as a second line of defence, so the backfill is safe to re-run after an
+    interruption.
+
+    Foreign keys are resolved from their Mongo references to Postgres primary keys.
+    ``compose_legacy_id_single_expression`` tolerates both legacy string ids and
+    the integer ids written since those collections were migrated:
+
+    - ``user`` is required. A reference that references a user missing from
+      Postgres raises, rather than being backfilled with a null owner.
+    - Every ``users`` and ``groups`` rights member is required. A member that no
+      longer resolves to a Postgres row raises, matching the not-null foreign key
+      on the join tables.
+    - ``upload`` (``imported_from``) and ``task`` are optional. A dangling
+      reference is backfilled as ``NULL`` and logged with a warning.
+
+    The ``cloned_from_id`` self-foreign key is resolved in a second pass, once
+    every reference row exists, so a clone written before its source can still be
+    linked. See :func:`_backfill_cloned_from_ids`.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_result = await session.execute(
+            select(SQLReference.legacy_id).where(
+                SQLReference.legacy_id.isnot(None),
+            ),
+        )
+        existing_legacy_ids = {row[0] for row in existing_result}
+
+        logger.info(
+            "found existing references in postgres",
+            count=len(existing_legacy_ids),
+        )
+
+        reference_ids = [
+            document["_id"]
+            async for document in ctx.mongo.references.find({}, projection=["_id"])
+        ]
+
+        migrated_count = 0
+        skipped_count = 0
+
+        user_id_cache: dict[int | str, int | None] = {}
+        group_id_cache: dict[int | str, int | None] = {}
+        upload_id_cache: dict[int | str, int | None] = {}
+        task_id_cache: dict[int | str, int | None] = {}
+
+        for reference_id in reference_ids:
+            if reference_id in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.references.find_one({"_id": reference_id})
+
+            if document is None:
+                skipped_count += 1
+                continue
+
+            user_id = await _resolve_user_id(session, document, user_id_cache)
+            upload_id = await _resolve_upload_id(session, document, upload_id_cache)
+            task_id = await _resolve_task_id(session, document, task_id_cache)
+
+            reference_pk = (
+                await session.execute(
+                    insert(SQLReference)
+                    .values(
+                        **reference_values(
+                            document,
+                            user_id=user_id,
+                            upload_id=upload_id,
+                            cloned_from_id=None,
+                            task_id=task_id,
+                        ),
+                    )
+                    .on_conflict_do_nothing(index_elements=["legacy_id"])
+                    .returning(SQLReference.id),
+                )
+            ).scalar_one_or_none()
+
+            if reference_pk is None:
+                reference_pk = (
+                    await session.execute(
+                        select(SQLReference.id).where(
+                            SQLReference.legacy_id == reference_id,
+                        ),
+                    )
+                ).scalar_one()
+
+            await _insert_rights_rows(
+                session,
+                reference_pk,
+                document,
+                user_id_cache,
+                group_id_cache,
+            )
+            await session.commit()
+
+            migrated_count += 1
+
+        logger.info(
+            "reference migration complete",
+            migrated=migrated_count,
+            skipped=skipped_count,
+        )
+
+        await _backfill_cloned_from_ids(ctx, session)
+
+
+async def _insert_rights_rows(
+    session: AsyncSession,
+    reference_pk: int,
+    document: dict,
+    user_id_cache: dict[int | str, int | None],
+    group_id_cache: dict[int | str, int | None],
+) -> None:
+    """Insert the user and group rights rows for a reference.
+
+    Each member's id is resolved to a Postgres primary key. The rights join tables
+    have a not-null foreign key, so a member that no longer resolves raises rather
+    than being skipped. Each insert uses ``ON CONFLICT DO NOTHING`` so a re-run
+    over an interrupted document adds only the rows that are missing.
+    """
+    for member in document.get("users") or []:
+        user_id = await _resolve_rights_member_id(
+            session,
+            SQLUser,
+            member["id"],
+            user_id_cache,
+            document["_id"],
+            "user",
+        )
+
+        await session.execute(
+            insert(SQLReferenceUser)
+            .values(
+                reference_id=reference_pk,
+                user_id=user_id,
+                build=member.get("build", False),
+                modify=member.get("modify", False),
+                modify_otu=member.get("modify_otu", False),
+            )
+            .on_conflict_do_nothing(),
+        )
+
+    for member in document.get("groups") or []:
+        group_id = await _resolve_rights_member_id(
+            session,
+            SQLGroup,
+            member["id"],
+            group_id_cache,
+            document["_id"],
+            "group",
+        )
+
+        await session.execute(
+            insert(SQLReferenceGroup)
+            .values(
+                reference_id=reference_pk,
+                group_id=group_id,
+                build=member.get("build", False),
+                modify=member.get("modify", False),
+                modify_otu=member.get("modify_otu", False),
+            )
+            .on_conflict_do_nothing(),
+        )
+
+
+async def _backfill_cloned_from_ids(
+    ctx: MigrationContext,
+    session: AsyncSession,
+) -> None:
+    """Resolve the ``cloned_from_id`` self-foreign key for cloned references.
+
+    This runs after every reference row exists, so a clone written before its
+    source can still be linked. Each ``UPDATE`` is guarded by
+    ``cloned_from_id IS NULL`` so a re-run only touches rows not already linked,
+    and a source that no longer resolves is logged and left ``NULL`` rather than
+    failing the migration.
+    """
+    linked_count = 0
+
+    async for document in ctx.mongo.references.find(
+        {"cloned_from": {"$ne": None}},
+        projection=["_id", "cloned_from"],
+    ):
+        cloned_from = document["cloned_from"]
+
+        cloned_from_id = (
+            await session.execute(
+                select(SQLReference.id).where(
+                    compose_legacy_id_single_expression(
+                        SQLReference,
+                        cloned_from["id"],
+                    ),
+                ),
+            )
+        ).scalar_one_or_none()
+
+        if cloned_from_id is None:
+            logger.warning(
+                "reference was cloned from a source missing in postgres; "
+                "leaving cloned_from_id null",
+                reference_id=document["_id"],
+                cloned_from=cloned_from["id"],
+            )
+            continue
+
+        result = await session.execute(
+            update(SQLReference)
+            .where(
+                SQLReference.legacy_id == document["_id"],
+                SQLReference.cloned_from_id.is_(None),
+            )
+            .values(cloned_from_id=cloned_from_id),
+        )
+        await session.commit()
+
+        linked_count += result.rowcount
+
+    logger.info("backfilled reference cloned_from_id", linked=linked_count)
+
+
+async def _resolve_id(
+    session: AsyncSession,
+    model: type[Base],
+    reference: int | str,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a Mongo reference to a Postgres primary key, memoising results.
+
+    The reference may be a legacy string id or a modern integer id. The resolved
+    id (or ``None`` if no row matches) is cached by reference so that references
+    sharing the same user do not each issue a query.
+    """
+    if reference in cache:
+        return cache[reference]
+
+    resolved = (
+        await session.execute(
+            select(model.id).where(
+                compose_legacy_id_single_expression(model, reference),
+            ),
+        )
+    ).scalar_one_or_none()
+
+    cache[reference] = resolved
+
+    return resolved
+
+
+async def _resolve_user_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int:
+    """Resolve a document's ``user`` reference to a Postgres ``users.id``.
+
+    A reference always has an owner, so a missing ``user`` reference or one that no
+    longer resolves to a Postgres row raises rather than being backfilled as
+    ``NULL``.
+    """
+    user = document.get("user")
+
+    if not user or "id" not in user:
+        msg = f"reference {document['_id']!r} has no user reference"
+        raise ValueError(msg)
+
+    reference = user["id"]
+
+    user_id = await _resolve_id(session, SQLUser, reference, cache)
+
+    if user_id is None:
+        msg = (
+            f"reference {document['_id']!r} references user {reference!r} "
+            "which does not exist in postgres"
+        )
+        raise ValueError(msg)
+
+    return user_id
+
+
+async def _resolve_upload_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a document's ``imported_from`` upload to a Postgres ``uploads.id``.
+
+    Returns ``None`` when the reference was not imported, and also when an upload
+    is referenced but no longer exists in Postgres. Dangling references are logged
+    so the migration leaves an audit trail, distinct from the legitimate
+    not-imported case.
+    """
+    imported_from = document.get("imported_from")
+
+    if not imported_from or "id" not in imported_from:
+        return None
+
+    reference = imported_from["id"]
+
+    upload_id = await _resolve_id(session, SQLUpload, reference, cache)
+
+    if upload_id is None:
+        logger.warning(
+            "reference references an upload that no longer exists; "
+            "backfilling null upload_id",
+            reference_id=document["_id"],
+            upload=reference,
+        )
+
+    return upload_id
+
+
+async def _resolve_task_id(
+    session: AsyncSession,
+    document: dict,
+    cache: dict[int | str, int | None],
+) -> int | None:
+    """Resolve a document's ``task`` reference to a Postgres ``tasks.id``.
+
+    Returns ``None`` when the reference has no task, and also when a task is
+    referenced but no longer exists in Postgres. Dangling references are logged so
+    the migration leaves an audit trail, distinct from the legitimate no-task case.
+    """
+    task = document.get("task")
+
+    if not task or "id" not in task:
+        return None
+
+    reference = task["id"]
+
+    task_id = await _resolve_id(session, SQLTask, reference, cache)
+
+    if task_id is None:
+        logger.warning(
+            "reference references a task that no longer exists; "
+            "backfilling null task_id",
+            reference_id=document["_id"],
+            task=reference,
+        )
+
+    return task_id
+
+
+async def _resolve_rights_member_id(
+    session: AsyncSession,
+    model: type[Base],
+    reference: int | str,
+    cache: dict[int | str, int | None],
+    reference_id: str,
+    kind: str,
+) -> int:
+    """Resolve a rights member's id to a Postgres primary key, raising if missing.
+
+    The rights join tables have a not-null foreign key, so a ``users`` or
+    ``groups`` member that no longer resolves to a Postgres row raises rather than
+    being skipped or backfilled as ``NULL``.
+    """
+    resolved = await _resolve_id(session, model, reference, cache)
+
+    if resolved is None:
+        msg = (
+            f"reference {reference_id!r} grants rights to {kind} {reference!r} "
+            "which does not exist in postgres"
+        )
+        raise ValueError(msg)
+
+    return resolved


### PR DESCRIPTION
## Summary
- Adds an idempotent migration that copies every Mongo `references` document into `legacy_references`, along with their embedded `users`/`groups` rights arrays into the new join tables.
- Resolves owner, rights, upload, and task foreign keys against Postgres — raising on unresolved required references (user, rights members) and nulling optional ones (upload, task) with a warning.
- Backfills `cloned_from_id` in a second pass so clones written before their source reference still link up correctly.