### PR TITLE
feat: read samples from postgres

### DIFF
--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import arrow
 import pytest
 from aiohttp.test_utils import make_mocked_coro
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -36,13 +36,93 @@ from virtool.uploads.sql import SQLUpload
 from virtool.users.oas import UpdateUserRequest
 
 
+async def insert_pg_sample(
+    session: AsyncSession,
+    document: dict,
+    group_id: int | None = None,
+) -> SQLLegacySample:
+    """Insert the ``legacy_samples`` row and label join rows mirroring a Mongo sample.
+
+    Sample reads are served from Postgres, so tests that seed Mongo directly must seed
+    the matching Postgres rows too.
+    """
+    created_at = document["created_at"]
+
+    if created_at.tzinfo is not None:
+        created_at = created_at.replace(tzinfo=None)
+
+    sample = SQLLegacySample(
+        legacy_id=document["_id"],
+        name=document["name"],
+        host=document.get("host", ""),
+        isolate=document.get("isolate", ""),
+        locale=document.get("locale", ""),
+        notes=document.get("notes", ""),
+        library_type=document["library_type"],
+        format=document.get("format", "fastq"),
+        group_id=group_id,
+        quality=document.get("quality"),
+        created_at=created_at,
+        paired=document.get("paired", False),
+        ready=document.get("ready", False),
+        hold=document.get("hold", True),
+        is_legacy=document.get("is_legacy", False),
+        all_read=document.get("all_read", False),
+        all_write=document.get("all_write", False),
+        group_read=document.get("group_read", False),
+        group_write=document.get("group_write", False),
+        user_id=document["user"]["id"],
+        job_id=document["job"]["id"] if document.get("job") else None,
+    )
+
+    session.add(sample)
+    await session.flush()
+
+    for label_id in document.get("labels", []):
+        session.add(SQLLegacySampleLabel(sample_id=sample.id, label_id=label_id))
+
+    for subtraction_id in document.get("subtractions", []):
+        session.add(
+            SQLLegacySampleSubtraction(
+                sample_id=sample.id,
+                subtraction_id=subtraction_id,
+            ),
+        )
+
+    return sample
+
+
+async def update_pg_sample_rights(
+    pg: AsyncEngine,
+    legacy_id: str,
+    **values,
+) -> None:
+    """Apply a rights change to the Postgres ``legacy_samples`` row for a test.
+
+    Read paths resolve rights from Postgres, so tests that mutate rights in Mongo must
+    mirror the change here.
+    """
+    async with AsyncSession(pg) as session:
+        await session.execute(
+            update(SQLLegacySample)
+            .where(SQLLegacySample.legacy_id == legacy_id)
+            .values(**values),
+        )
+        await session.commit()
+
+
 class MockJobInterface:
     def __init__(self):
         self.enqueue = make_mocked_coro()
 
 
 @pytest.fixture
-async def get_sample_ready_false(fake: DataFaker, mongo: Mongo, static_time):
+async def get_sample_ready_false(
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    static_time,
+):
     label = await fake.labels.create()
     user = await fake.users.create()
     job = await fake.jobs.create(user, workflow="create_sample")
@@ -55,45 +135,49 @@ async def get_sample_ready_false(fake: DataFaker, mongo: Mongo, static_time):
         user=user, upload=upload, name="Pear", upload_files=False, finalized=False
     )
 
-    await mongo.samples.insert_one(
-        {
-            "_id": "test",
-            "all_read": True,
-            "all_write": True,
-            "created_at": static_time.datetime,
-            "files": [
-                {
-                    "id": "foo",
-                    "name": "Bar.fq.gz",
-                    "download_url": "/download/samples/files/file_1.fq.gz",
-                },
-            ],
-            "format": "fastq",
-            "group": "none",
-            "group_read": True,
-            "group_write": True,
-            "hold": False,
-            "host": "",
-            "is_legacy": False,
-            "isolate": "",
-            "job": {"id": job.id},
-            "labels": [label.id],
-            "library_type": LibraryType.normal.value,
-            "locale": "",
-            "name": "Test",
-            "notes": "",
-            "nuvs": False,
-            "pathoscope": True,
-            "ready": False,
-            "subtractions": [apple.id, pear.id],
-            "user": {"id": user.id},
-            "workflows": {
-                "aodp": WorkflowState.INCOMPATIBLE.value,
-                "pathoscope": WorkflowState.COMPLETE.value,
-                "nuvs": WorkflowState.PENDING.value,
+    document = {
+        "_id": "test",
+        "all_read": True,
+        "all_write": True,
+        "created_at": static_time.datetime,
+        "files": [
+            {
+                "id": "foo",
+                "name": "Bar.fq.gz",
+                "download_url": "/download/samples/files/file_1.fq.gz",
             },
+        ],
+        "format": "fastq",
+        "group": "none",
+        "group_read": True,
+        "group_write": True,
+        "hold": False,
+        "host": "",
+        "is_legacy": False,
+        "isolate": "",
+        "job": {"id": job.id},
+        "labels": [label.id],
+        "library_type": LibraryType.normal.value,
+        "locale": "",
+        "name": "Test",
+        "notes": "",
+        "nuvs": False,
+        "pathoscope": True,
+        "ready": False,
+        "subtractions": [apple.id, pear.id],
+        "user": {"id": user.id},
+        "workflows": {
+            "aodp": WorkflowState.INCOMPATIBLE.value,
+            "pathoscope": WorkflowState.COMPLETE.value,
+            "nuvs": WorkflowState.PENDING.value,
         },
-    )
+    }
+
+    await mongo.samples.insert_one(document)
+
+    async with AsyncSession(pg) as session:
+        await insert_pg_sample(session, document)
+        await session.commit()
 
 
 @pytest.fixture
@@ -225,6 +309,7 @@ async def get_sample_data(
 async def find_samples_client(
     fake: DataFaker,
     mongo: Mongo,
+    pg: AsyncEngine,
     spawn_client: ClientSpawner,
     static_time,
 ):
@@ -239,65 +324,70 @@ async def find_samples_client(
 
     client = await spawn_client(authenticated=True)
 
-    await mongo.samples.insert_many(
-        [
-            {
-                "_id": "beb1eb10",
-                "all_read": True,
-                "created_at": arrow.get(static_time.datetime).shift(hours=1).datetime,
-                "foobar": True,
-                "host": "",
-                "isolate": "Thing",
-                "job": {"id": job.id},
-                "labels": [label_1.id, label_2.id],
-                "library_type": "normal",
-                "name": "16GVP042",
-                "notes": "",
-                "nuvs": True,
-                "pathoscope": True,
-                "ready": True,
-                "user": {"id": user_1.id},
-                "workflows": {"aodp": "none", "nuvs": "none", "pathoscope": "none"},
-            },
-            {
-                "user": {"id": user_2.id},
-                "nuvs": False,
-                "host": "",
-                "foobar": True,
-                "isolate": "Test",
-                "library_type": "srna",
-                "created_at": arrow.get(static_time.datetime).datetime,
-                "_id": "72bb8b31",
-                "job": None,
-                "name": "16GVP043",
-                "pathoscope": False,
-                "all_read": True,
-                "ready": True,
-                "labels": [label_1.id],
-                "notes": "This is a good sample.",
-                "workflows": {"aodp": "none", "nuvs": "none", "pathoscope": "none"},
-            },
-            {
-                "user": {"id": user_2.id},
-                "nuvs": False,
-                "host": "",
-                "library_type": "amplicon",
-                "notes": "",
-                "foobar": True,
-                "ready": True,
-                "isolate": "",
-                "created_at": arrow.get(static_time.datetime).shift(hours=2).datetime,
-                "_id": "cb400e6d",
-                "job": None,
-                "name": "16SPP044",
-                "pathoscope": False,
-                "all_read": True,
-                "labels": [label_3.id],
-                "workflows": {"aodp": "none", "nuvs": "none", "pathoscope": "none"},
-            },
-        ],
-        session=None,
-    )
+    documents = [
+        {
+            "_id": "beb1eb10",
+            "all_read": True,
+            "created_at": arrow.get(static_time.datetime).shift(hours=1).datetime,
+            "foobar": True,
+            "host": "",
+            "isolate": "Thing",
+            "job": {"id": job.id},
+            "labels": [label_1.id, label_2.id],
+            "library_type": "normal",
+            "name": "16GVP042",
+            "notes": "",
+            "nuvs": True,
+            "pathoscope": True,
+            "ready": True,
+            "user": {"id": user_1.id},
+            "workflows": {"aodp": "none", "nuvs": "none", "pathoscope": "none"},
+        },
+        {
+            "user": {"id": user_2.id},
+            "nuvs": False,
+            "host": "",
+            "foobar": True,
+            "isolate": "Test",
+            "library_type": "srna",
+            "created_at": arrow.get(static_time.datetime).datetime,
+            "_id": "72bb8b31",
+            "job": None,
+            "name": "16GVP043",
+            "pathoscope": False,
+            "all_read": True,
+            "ready": True,
+            "labels": [label_1.id],
+            "notes": "This is a good sample.",
+            "workflows": {"aodp": "none", "nuvs": "none", "pathoscope": "none"},
+        },
+        {
+            "user": {"id": user_2.id},
+            "nuvs": False,
+            "host": "",
+            "library_type": "amplicon",
+            "notes": "",
+            "foobar": True,
+            "ready": True,
+            "isolate": "",
+            "created_at": arrow.get(static_time.datetime).shift(hours=2).datetime,
+            "_id": "cb400e6d",
+            "job": None,
+            "name": "16SPP044",
+            "pathoscope": False,
+            "all_read": True,
+            "labels": [label_3.id],
+            "workflows": {"aodp": "none", "nuvs": "none", "pathoscope": "none"},
+        },
+    ]
+
+    await mongo.samples.insert_many(documents, session=None)
+
+    async with AsyncSession(pg) as session:
+        for document in documents:
+            await insert_pg_sample(session, document)
+
+        await session.commit()
 
     return client
 
@@ -405,6 +495,7 @@ class TestGet:
         get_sample_data,
         snapshot: SnapshotAssertion,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
     ):
         """Test that a sample can be retrieved by its owner."""
@@ -421,6 +512,14 @@ class TestGet:
                 },
             },
         )
+        await update_pg_sample_rights(
+            pg,
+            "test",
+            all_read=False,
+            group_read=False,
+            group_id=None,
+            user_id=client.user.id,
+        )
 
         resp = await client.get("/samples/test")
 
@@ -433,6 +532,7 @@ class TestGet:
         get_sample_data,
         snapshot: SnapshotAssertion,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
     ):
         """Test that a sample can be retrieved any user when ``all_read`` is ``True`` on
@@ -453,6 +553,14 @@ class TestGet:
                 },
             },
         )
+        await update_pg_sample_rights(
+            pg,
+            "test",
+            all_read=True,
+            group_read=False,
+            group_id=None,
+            user_id=user.id,
+        )
 
         resp = await client.get("/samples/test")
 
@@ -466,6 +574,7 @@ class TestGet:
         fake: DataFaker,
         get_sample_data,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
@@ -494,6 +603,15 @@ class TestGet:
                     "user": {"id": user.id},
                 },
             },
+        )
+        await update_pg_sample_rights(
+            pg,
+            "test",
+            all_read=False,
+            all_write=False,
+            group_read=True,
+            group_id=group.id,
+            user_id=user.id,
         )
 
         resp = await client.get("/samples/test")

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncIterator
 from datetime import timedelta
 
 import pytest
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -37,6 +37,35 @@ from virtool.storage.protocol import StorageBackend
 from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.uploads.utils import upload_file_key
 from virtool.users.oas import UpdateUserRequest
+
+
+async def insert_rights_sample(
+    pg: AsyncEngine,
+    legacy_id: str,
+    user_id: int,
+    all_read: bool = False,
+    all_write: bool = False,
+    group_read: bool = False,
+    group_write: bool = False,
+    group_id: int | None = None,
+) -> None:
+    """Insert a minimal ``legacy_samples`` row for exercising ``has_right``."""
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacySample(
+                legacy_id=legacy_id,
+                name=legacy_id,
+                library_type=LibraryType.normal.value,
+                created_at=virtool.utils.timestamp(),
+                user_id=user_id,
+                all_read=all_read,
+                all_write=all_write,
+                group_read=group_read,
+                group_write=group_write,
+                group_id=group_id,
+            ),
+        )
+        await session.commit()
 
 
 @pytest.fixture
@@ -472,7 +501,7 @@ class TestHasRight:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
+        pg: AsyncEngine,
     ):
         """Test group member can write when group_write is True."""
         group = await fake.groups.create()
@@ -488,16 +517,13 @@ class TestHasRight:
             user_id=user.id,
         )
 
-        await mongo.samples.insert_one(
-            {
-                "_id": "sample_1",
-                "all_read": False,
-                "all_write": False,
-                "group": group.id,
-                "group_read": True,
-                "group_write": True,
-                "user": {"id": sample_owner.id},
-            }
+        await insert_rights_sample(
+            pg,
+            "sample_1",
+            user_id=sample_owner.id,
+            group_id=group.id,
+            group_read=True,
+            group_write=True,
         )
 
         assert await data_layer.samples.has_right("sample_1", client, SampleRight.write)
@@ -506,7 +532,7 @@ class TestHasRight:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
+        pg: AsyncEngine,
     ):
         """Test group member can read when group_read is True."""
         group = await fake.groups.create()
@@ -522,16 +548,12 @@ class TestHasRight:
             user_id=user.id,
         )
 
-        await mongo.samples.insert_one(
-            {
-                "_id": "sample_2",
-                "all_read": False,
-                "all_write": False,
-                "group": group.id,
-                "group_read": True,
-                "group_write": False,
-                "user": {"id": sample_owner.id},
-            }
+        await insert_rights_sample(
+            pg,
+            "sample_2",
+            user_id=sample_owner.id,
+            group_id=group.id,
+            group_read=True,
         )
 
         assert await data_layer.samples.has_right("sample_2", client, SampleRight.read)
@@ -563,7 +585,7 @@ class TestHasRight:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
+        pg: AsyncEngine,
     ):
         """Test full administrator has access regardless of permissions."""
         user = await fake.users.create(administrator_role=AdministratorRole.FULL)
@@ -578,17 +600,7 @@ class TestHasRight:
             user_id=user.id,
         )
 
-        await mongo.samples.insert_one(
-            {
-                "_id": "sample_3",
-                "all_read": False,
-                "all_write": False,
-                "group": "none",
-                "group_read": False,
-                "group_write": False,
-                "user": {"id": sample_owner.id},
-            }
-        )
+        await insert_rights_sample(pg, "sample_3", user_id=sample_owner.id)
 
         assert await data_layer.samples.has_right("sample_3", client, SampleRight.write)
 
@@ -596,7 +608,7 @@ class TestHasRight:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
+        pg: AsyncEngine,
     ):
         """Test sample owner has full access."""
         user = await fake.users.create()
@@ -610,17 +622,7 @@ class TestHasRight:
             user_id=user.id,
         )
 
-        await mongo.samples.insert_one(
-            {
-                "_id": "sample_4",
-                "all_read": False,
-                "all_write": False,
-                "group": "none",
-                "group_read": False,
-                "group_write": False,
-                "user": {"id": user.id},
-            }
-        )
+        await insert_rights_sample(pg, "sample_4", user_id=user.id)
 
         assert await data_layer.samples.has_right("sample_4", client, SampleRight.write)
 
@@ -628,7 +630,7 @@ class TestHasRight:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
+        pg: AsyncEngine,
     ):
         """Test non-group member is denied when all_write is False."""
         group = await fake.groups.create()
@@ -644,16 +646,12 @@ class TestHasRight:
             user_id=user.id,
         )
 
-        await mongo.samples.insert_one(
-            {
-                "_id": "sample_5",
-                "all_read": False,
-                "all_write": False,
-                "group": group.id,
-                "group_read": False,
-                "group_write": True,
-                "user": {"id": sample_owner.id},
-            }
+        await insert_rights_sample(
+            pg,
+            "sample_5",
+            user_id=sample_owner.id,
+            group_id=group.id,
+            group_write=True,
         )
 
         assert not await data_layer.samples.has_right(
@@ -943,67 +941,6 @@ class TestUpdate:
         )
 
         assert await self._get_subtraction_ids(pg, sample.id) == {keep.id, add.id}
-
-    async def test_labels_without_legacy_row(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mongo: Mongo,
-        pg: AsyncEngine,
-        spawn_client: ClientSpawner,
-    ):
-        """A label update on a sample lacking a ``legacy_samples`` row still succeeds.
-
-        Samples created before the dual-write rollout have no ``legacy_samples`` row
-        until the backfill runs, so join reconciliation must tolerate its absence and
-        still apply the Mongo write.
-        """
-        client = await spawn_client(
-            authenticated=True,
-            permissions=[Permission.create_sample],
-        )
-
-        label = await fake.labels.create()
-        sample = await self._create_sample(data_layer, fake, client.user.id)
-
-        async with AsyncSession(pg) as session:
-            legacy = (
-                await session.execute(
-                    select(SQLLegacySample).where(
-                        SQLLegacySample.legacy_id == sample.id,
-                    ),
-                )
-            ).scalar_one()
-
-            await session.execute(
-                delete(SQLLegacySampleLabel).where(
-                    SQLLegacySampleLabel.sample_id == legacy.id,
-                ),
-            )
-            await session.execute(
-                delete(SQLLegacySampleSubtraction).where(
-                    SQLLegacySampleSubtraction.sample_id == legacy.id,
-                ),
-            )
-            await session.delete(legacy)
-            await session.commit()
-
-        await data_layer.samples.update(
-            sample.id,
-            UpdateSampleRequest(labels=[label.id]),
-        )
-
-        document = await mongo.samples.find_one({"_id": sample.id})
-        assert document["labels"] == [label.id]
-
-        async with AsyncSession(pg) as session:
-            assert (
-                await session.execute(
-                    select(SQLLegacySample).where(
-                        SQLLegacySample.legacy_id == sample.id,
-                    ),
-                )
-            ).scalar_one_or_none() is None
 
 
 class TestGetOwnerId:

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -2,11 +2,21 @@
 
 import math
 from asyncio import CancelledError, gather
+from collections import defaultdict
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
 from pymongo.results import UpdateResult
-from sqlalchemy import delete, exc, select, update
+from sqlalchemy import (
+    ColumnExpressionArgument,
+    and_,
+    delete,
+    exc,
+    func,
+    or_,
+    select,
+    update,
+)
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
@@ -14,7 +24,6 @@ import virtool.uploads.db
 import virtool.utils
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
 from virtool.api.client import UserClient
-from virtool.api.utils import compose_regex_query
 from virtool.config.cls import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
@@ -22,6 +31,7 @@ from virtool.data.events import Operation, emits
 from virtool.data.topg import (
     both_transactions,
     compose_legacy_id_multi_expression,
+    compose_legacy_id_single_expression,
     retry_both_transactions,
 )
 from virtool.data.transforms import apply_transforms
@@ -40,6 +50,7 @@ from virtool.samples.checks import (
 )
 from virtool.samples.db import (
     AttachArtifactsAndReadsTransform,
+    AttachMongoSampleFieldsTransform,
     AttachUploadsTransform,
     compose_sample_workflow_query,
     define_initial_workflows,
@@ -70,9 +81,96 @@ from virtool.uploads.sql import SQLUpload
 from virtool.uploads.utils import is_gzip_compressed, upload_file_key
 from virtool.users.pg import SQLUser
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import base_processor, chunk_list, wait_for_checks
+from virtool.utils import chunk_list, wait_for_checks
 
 logger = get_logger("samples")
+
+
+def _compose_sample_search_filter(term: str) -> ColumnExpressionArgument[bool]:
+    """Compose a case-insensitive substring match on ``name`` and the owner id.
+
+    Mirrors the Mongo ``compose_regex_query(term, ["name", "user.id"])`` the find
+    endpoint used before reading from Postgres: the term is matched literally, so SQL
+    ``LIKE`` wildcards in the term are escaped rather than interpreted. The historical
+    ``user.id`` value is the owner's legacy Mongo id, now ``SQLUser.legacy_id``.
+    """
+    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped}%"
+
+    return or_(
+        SQLLegacySample.name.ilike(pattern, escape="\\"),
+        SQLLegacySample.user_id.in_(
+            select(SQLUser.id).where(SQLUser.legacy_id.ilike(pattern, escape="\\")),
+        ),
+    )
+
+
+def _map_sample_minimal_row(
+    row: SQLLegacySample,
+    label_ids: list[int],
+) -> dict[str, Any]:
+    """Shape a ``SQLLegacySample`` row into the ``SampleMinimal`` transform input.
+
+    The public id stays the legacy Mongo string until the integer PK flip (VIR-2529).
+    """
+    return {
+        "id": row.legacy_id,
+        "name": row.name,
+        "created_at": row.created_at,
+        "host": row.host,
+        "isolate": row.isolate,
+        "job": {"id": row.job_id} if row.job_id is not None else None,
+        "labels": label_ids,
+        "library_type": row.library_type,
+        "notes": row.notes,
+        "ready": row.ready,
+        "user": row.user_id,
+    }
+
+
+def _map_sample_row(
+    row: SQLLegacySample,
+    label_ids: list[int],
+    subtraction_ids: list[int],
+) -> dict[str, Any]:
+    """Shape a ``SQLLegacySample`` row into the full ``Sample`` transform input."""
+    return {
+        **_map_sample_minimal_row(row, label_ids),
+        "all_read": row.all_read,
+        "all_write": row.all_write,
+        "format": row.format,
+        "group_read": row.group_read,
+        "group_write": row.group_write,
+        "hold": row.hold,
+        "is_legacy": row.is_legacy,
+        "locale": row.locale,
+        "quality": row.quality,
+        "subtractions": subtraction_ids,
+    }
+
+
+async def _get_labels_by_sample(
+    session: AsyncSession,
+    sample_ids: list[int],
+) -> dict[int, list[int]]:
+    """Map each sample's integer PK to its ordered list of label ids."""
+    if not sample_ids:
+        return {}
+
+    rows = (
+        await session.execute(
+            select(SQLLegacySampleLabel.sample_id, SQLLegacySampleLabel.label_id)
+            .where(SQLLegacySampleLabel.sample_id.in_(sample_ids))
+            .order_by(SQLLegacySampleLabel.label_id),
+        )
+    ).all()
+
+    labels_by_sample: dict[int, list[int]] = defaultdict(list)
+
+    for sample_id, label_id in rows:
+        labels_by_sample[sample_id].append(label_id)
+
+    return labels_by_sample
 
 
 class SamplesData(DataLayerDomain):
@@ -100,114 +198,70 @@ class SamplesData(DataLayerDomain):
         client,
     ) -> SampleSearchResult:
         """Find and filter samples."""
-        queries = []
+        filters = [await self._compose_rights_filter(client)]
 
         if term:
-            queries.append(compose_regex_query(term, ["name", "user.id"]))
+            filters.append(_compose_sample_search_filter(term))
 
         if labels:
-            queries.append({"labels": {"$in": labels}})
+            filters.append(
+                SQLLegacySample.id.in_(
+                    select(SQLLegacySampleLabel.sample_id).where(
+                        SQLLegacySampleLabel.label_id.in_(labels),
+                    ),
+                ),
+            )
 
         if workflows:
-            queries.append(compose_sample_workflow_query(workflows))
+            # The workflow tags are not yet stored in Postgres. Resolve the matching
+            # sample ids from Mongo and constrain the Postgres query by them. Moving
+            # this filter into SQL is tracked in VIR-2525.
+            workflow_query = compose_sample_workflow_query(workflows)
 
-        query = {}
-
-        if queries:
-            query["$and"] = queries
-
-        rights_filter = [
-            {"all_read": True},
-            {"user.id": client.user_id},
-        ]
-
-        if client.groups:
-            async with AsyncSession(self._pg) as session:
-                result = await session.execute(
-                    select(SQLGroup).where(
-                        compose_legacy_id_multi_expression(SQLGroup, client.groups),
-                    ),
+            if workflow_query is not None:
+                matching_ids = await self._mongo.samples.distinct(
+                    "_id",
+                    workflow_query,
                 )
+                filters.append(SQLLegacySample.legacy_id.in_(matching_ids))
 
-                group_ids = []
+        async with AsyncSession(self._pg) as session:
+            total_count = await session.scalar(
+                select(func.count()).select_from(SQLLegacySample),
+            )
+            found_count = await session.scalar(
+                select(func.count()).select_from(SQLLegacySample).where(*filters),
+            )
 
-                for group in result.scalars().all():
-                    group_ids.append(group.id)
+            rows = (
+                (
+                    await session.execute(
+                        select(SQLLegacySample)
+                        .where(*filters)
+                        .order_by(
+                            SQLLegacySample.created_at.desc(),
+                            SQLLegacySample.id,
+                        )
+                        .offset(per_page * (page - 1))
+                        .limit(per_page),
+                    )
+                )
+                .scalars()
+                .all()
+            )
 
-                    if group.legacy_id is not None:
-                        group_ids.append(group.legacy_id)
-
-            # The sample rights allow owner group members to view the sample and the
-            # requesting user is a member of the owner group.
-            rights_filter.append({"group_read": True, "group": {"$in": group_ids}})
-
-        search_query = {"$and": [{"$or": rights_filter}, query]}
-
-        skip_count = 0
-
-        if page > 1:
-            skip_count = (page - 1) * per_page
-
-        found_count = 0
-        total_count = 0
-
-        async for paginate_dict in self._mongo.samples.aggregate(
-            [
-                {
-                    "$facet": {
-                        "total_count": [{"$count": "total_count"}],
-                        "found_count": [
-                            {"$match": search_query},
-                            {"$count": "found_count"},
-                        ],
-                        "data": [
-                            {"$match": search_query},
-                            {"$sort": {"created_at": -1}},
-                            {"$skip": skip_count},
-                            {"$limit": per_page},
-                        ],
-                    },
-                },
-                {
-                    "$project": {
-                        "data": dict.fromkeys(
-                            (
-                                "_id",
-                                "created_at",
-                                "host",
-                                "isolate",
-                                "job",
-                                "library_type",
-                                "pathoscope",
-                                "name",
-                                "notes",
-                                "nuvs",
-                                "ready",
-                                "subtractions",
-                                "uploads",
-                                "user",
-                                "workflows",
-                                "labels",
-                            ),
-                            True,
-                        ),
-                        "total_count": {
-                            "$arrayElemAt": ["$total_count.total_count", 0],
-                        },
-                        "found_count": {
-                            "$arrayElemAt": ["$found_count.found_count", 0],
-                        },
-                    },
-                },
-            ],
-        ):
-            data = paginate_dict["data"]
-            found_count = paginate_dict.get("found_count", 0)
-            total_count = paginate_dict.get("total_count", 0)
+            labels_by_sample = await _get_labels_by_sample(
+                session,
+                [row.id for row in rows],
+            )
 
         documents = await apply_transforms(
-            [base_processor(d) for d in data],
             [
+                _map_sample_minimal_row(row, labels_by_sample.get(row.id, []))
+                for row in rows
+            ],
+            [
+                AttachMongoSampleFieldsTransform(self._mongo),
                 AttachJobTransform(self._pg),
                 AttachLabelsTransform(self._pg),
                 AttachUploadsTransform(self._pg),
@@ -225,6 +279,48 @@ class SamplesData(DataLayerDomain):
             per_page=per_page,
         )
 
+    async def _compose_rights_filter(
+        self,
+        client,
+    ) -> ColumnExpressionArgument[bool]:
+        """Compose the Postgres predicate scoping samples to those ``client`` can read.
+
+        Mirrors the Mongo ``$or`` rights filter: the requesting user owns the sample,
+        the sample is world-readable, or the sample is readable by a group the user
+        belongs to.
+        """
+        rights_filter = [
+            SQLLegacySample.all_read.is_(True),
+            SQLLegacySample.user_id == client.user_id,
+        ]
+
+        if client.groups:
+            async with AsyncSession(self._pg) as session:
+                group_ids = (
+                    (
+                        await session.execute(
+                            select(SQLGroup.id).where(
+                                compose_legacy_id_multi_expression(
+                                    SQLGroup,
+                                    client.groups,
+                                ),
+                            ),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+
+            if group_ids:
+                rights_filter.append(
+                    and_(
+                        SQLLegacySample.group_read.is_(True),
+                        SQLLegacySample.group_id.in_(group_ids),
+                    ),
+                )
+
+        return or_(*rights_filter)
+
     async def get(self, sample_id: str) -> Sample:
         """Get a sample by its id.
 
@@ -232,14 +328,65 @@ class SamplesData(DataLayerDomain):
         :return: the sample
         :raises ResourceNotFoundError: when the sample does not exist
         """
-        document = await self._mongo.samples.find_one({"_id": sample_id})
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLLegacySample).where(
+                        compose_legacy_id_single_expression(
+                            SQLLegacySample,
+                            sample_id,
+                        ),
+                    ),
+                )
+            ).scalar_one_or_none()
 
-        if document is None:
-            raise ResourceNotFoundError
+            if row is None:
+                raise ResourceNotFoundError
+
+            label_ids = list(
+                (
+                    await session.execute(
+                        select(SQLLegacySampleLabel.label_id)
+                        .where(SQLLegacySampleLabel.sample_id == row.id)
+                        .order_by(SQLLegacySampleLabel.label_id),
+                    )
+                )
+                .scalars()
+                .all(),
+            )
+
+            subtraction_ids = list(
+                (
+                    await session.execute(
+                        select(SQLLegacySampleSubtraction.subtraction_id)
+                        .where(SQLLegacySampleSubtraction.sample_id == row.id)
+                        .order_by(SQLLegacySampleSubtraction.subtraction_id),
+                    )
+                )
+                .scalars()
+                .all(),
+            )
+
+            group = None
+
+            if row.group_id is not None:
+                group_row = (
+                    await session.execute(
+                        select(SQLGroup).where(SQLGroup.id == row.group_id),
+                    )
+                ).scalar_one_or_none()
+
+                if group_row is not None:
+                    group = GroupMinimal(
+                        id=group_row.id,
+                        name=group_row.name,
+                        legacy_id=group_row.legacy_id,
+                    )
 
         document = await apply_transforms(
-            base_processor(document),
+            _map_sample_row(row, label_ids, subtraction_ids),
             [
+                AttachMongoSampleFieldsTransform(self._mongo),
                 AttachArtifactsAndReadsTransform(self._pg),
                 AttachJobTransform(self._pg),
                 AttachLabelsTransform(self._pg),
@@ -250,36 +397,12 @@ class SamplesData(DataLayerDomain):
             self._pg,
         )
 
-        group = None
-
-        if document["group"] == "none":
-            document["group"] = None
-
-        if document["group"] is not None:
-            async with AsyncSession(self._pg) as session:
-                result = await session.execute(
-                    select(SQLGroup).where(
-                        compose_legacy_id_multi_expression(
-                            SQLGroup, [document["group"]]
-                        ),
-                    ),
-                )
-
-                row = result.scalar_one_or_none()
-
-            if row:
-                group = GroupMinimal(
-                    id=row.id,
-                    name=row.name,
-                    legacy_id=row.legacy_id,
-                )
-
         return Sample(
             **{
                 **document,
                 "group": group,
                 "paired": len(document["reads"]) == 2,
-            }
+            },
         )
 
     async def _write_legacy_sample(
@@ -771,34 +894,60 @@ class SamplesData(DataLayerDomain):
         client: UserClient,
         right: SampleRight,
     ) -> bool:
-        document = await self._mongo.samples.find_one(
-            {"_id": sample_id},
-            ["all_read", "all_write", "group", "group_read", "group_write", "user"],
-        )
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(
+                        SQLLegacySample.all_read,
+                        SQLLegacySample.all_write,
+                        SQLLegacySample.group_read,
+                        SQLLegacySample.group_write,
+                        SQLLegacySample.group_id,
+                        SQLLegacySample.user_id,
+                    ).where(
+                        compose_legacy_id_single_expression(
+                            SQLLegacySample,
+                            sample_id,
+                        ),
+                    ),
+                )
+            ).first()
 
-        if document is None:
+        if row is None:
             return True
 
         if (
             client.administrator_role == AdministratorRole.FULL
-            or client.user_id == document["user"]["id"]
+            or client.user_id == row.user_id
         ):
             return True
 
-        # Handle both None and "none" during the transition period
-        group = document["group"]
-        if group == "none":
-            group = None
+        is_group_member = False
 
-        is_group_member = bool(group and group in client.groups)
+        if row.group_id is not None and client.groups:
+            async with AsyncSession(self._pg) as session:
+                member_group_ids = (
+                    (
+                        await session.execute(
+                            select(SQLGroup.id).where(
+                                compose_legacy_id_multi_expression(
+                                    SQLGroup,
+                                    client.groups,
+                                ),
+                            ),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+
+            is_group_member = row.group_id in member_group_ids
 
         if right == SampleRight.read:
-            return document["all_read"] or (is_group_member and document["group_read"])
+            return row.all_read or (is_group_member and row.group_read)
 
         if right == SampleRight.write:
-            return document["all_write"] or (
-                is_group_member and document["group_write"]
-            )
+            return row.all_write or (is_group_member and row.group_write)
 
         raise ValueError(f"Invalid sample right: {right}")
 

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -280,6 +280,31 @@ class SamplesData(DataLayerDomain):
             per_page=per_page,
         )
 
+    async def _resolve_client_group_ids(self, client) -> list[int]:
+        """Resolve the Postgres group ids for the groups ``client`` belongs to.
+
+        Shared by ``_compose_rights_filter`` and ``has_right`` so the two rights
+        paths resolve group membership the same way.
+        """
+        if not client.groups:
+            return []
+
+        async with AsyncSession(self._pg) as session:
+            return list(
+                (
+                    await session.execute(
+                        select(SQLGroup.id).where(
+                            compose_legacy_id_multi_expression(
+                                SQLGroup,
+                                client.groups,
+                            ),
+                        ),
+                    )
+                )
+                .scalars()
+                .all(),
+            )
+
     async def _compose_rights_filter(
         self,
         client,
@@ -295,30 +320,15 @@ class SamplesData(DataLayerDomain):
             SQLLegacySample.user_id == client.user_id,
         ]
 
-        if client.groups:
-            async with AsyncSession(self._pg) as session:
-                group_ids = (
-                    (
-                        await session.execute(
-                            select(SQLGroup.id).where(
-                                compose_legacy_id_multi_expression(
-                                    SQLGroup,
-                                    client.groups,
-                                ),
-                            ),
-                        )
-                    )
-                    .scalars()
-                    .all()
-                )
+        group_ids = await self._resolve_client_group_ids(client)
 
-            if group_ids:
-                rights_filter.append(
-                    and_(
-                        SQLLegacySample.group_read.is_(True),
-                        SQLLegacySample.group_id.in_(group_ids),
-                    ),
-                )
+        if group_ids:
+            rights_filter.append(
+                and_(
+                    SQLLegacySample.group_read.is_(True),
+                    SQLLegacySample.group_id.in_(group_ids),
+                ),
+            )
 
         return or_(*rights_filter)
 
@@ -935,23 +945,8 @@ class SamplesData(DataLayerDomain):
 
         is_group_member = False
 
-        if row.group_id is not None and client.groups:
-            async with AsyncSession(self._pg) as session:
-                member_group_ids = (
-                    (
-                        await session.execute(
-                            select(SQLGroup.id).where(
-                                compose_legacy_id_multi_expression(
-                                    SQLGroup,
-                                    client.groups,
-                                ),
-                            ),
-                        )
-                    )
-                    .scalars()
-                    .all()
-                )
-
+        if row.group_id is not None:
+            member_group_ids = await self._resolve_client_group_ids(client)
             is_group_member = row.group_id in member_group_ids
 
         if right == SampleRight.read:

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -168,6 +168,76 @@ class AttachUploadsTransform(AbstractTransform):
         }
 
 
+MONGO_SAMPLE_FIELDS = ["nuvs", "pathoscope", "uploads", "workflows"]
+
+
+def _mongo_sample_fields(document: Document) -> dict[str, Any]:
+    return {
+        "nuvs": document["nuvs"],
+        "pathoscope": document["pathoscope"],
+        "uploads": document.get("uploads"),
+        "workflows": document["workflows"],
+    }
+
+
+class AttachMongoSampleFieldsTransform(AbstractTransform):
+    """Attach the sample fields still sourced from MongoDB.
+
+    Sample metadata is now read from Postgres, but the workflow tags (``nuvs``,
+    ``pathoscope``, ``workflows``) and the reserved ``uploads`` array are not stored
+    there. This transform bridges them from Mongo so read responses are unchanged.
+
+    It must run before :class:`~virtool.samples.db.AttachUploadsTransform`, which
+    enriches the bridged ``uploads`` array with upload details from Postgres.
+
+    Temporary: deriving the workflow fields from analyses on read, moving the
+    ``?workflows=`` filter into SQL, and migrating ``uploads`` are tracked in
+    VIR-2525, which removes this transform and its Mongo read.
+    """
+
+    def __init__(self, mongo: Mongo):
+        self._mongo = mongo
+
+    async def attach_one(self, document: Document, prepared: Any) -> Document:
+        return {**document, **prepared}
+
+    async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
+        mongo_document = await self._mongo.samples.find_one(
+            {"_id": document["id"]},
+            MONGO_SAMPLE_FIELDS,
+        )
+
+        if mongo_document is None:
+            raise KeyError(f"Sample missing from Mongo: {document['id']}")
+
+        return _mongo_sample_fields(mongo_document)
+
+    async def prepare_many(
+        self,
+        documents: list[Document],
+        session: AsyncSession,
+    ) -> dict[str, dict[str, Any]]:
+        sample_ids = [document["id"] for document in documents]
+
+        mongo_documents = {
+            mongo_document["_id"]: mongo_document
+            async for mongo_document in self._mongo.samples.find(
+                {"_id": {"$in": sample_ids}},
+                MONGO_SAMPLE_FIELDS,
+            )
+        }
+
+        missing = set(sample_ids) - mongo_documents.keys()
+
+        if missing:
+            raise KeyError(f"Samples missing from Mongo: {missing}")
+
+        return {
+            document["id"]: _mongo_sample_fields(mongo_documents[document["id"]])
+            for document in documents
+        }
+
+
 async def check_rights_error_check(
     db,
     sample_id: str | None,

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -9,7 +9,7 @@ from virtool.fake.wrapper import FakerWrapper
 from virtool.mongo.utils import get_mongo_from_app
 from virtool.samples.db import create_sample
 from virtool.samples.files import create_reads_file
-from virtool.samples.sql import SQLLegacySample
+from virtool.samples.sql import SQLLegacySample, SQLLegacySampleSubtraction
 from virtool.samples.utils import sample_file_key
 from virtool.settings.models import Settings
 from virtool.storage.protocol import STORAGE_CHUNK_SIZE, StorageBackend
@@ -138,19 +138,38 @@ async def create_fake_sample(
     )
 
     async with AsyncSession(pg) as session:
-        session.add(
-            SQLLegacySample(
-                legacy_id=document["id"],
-                name=document["name"],
-                library_type=document["library_type"],
-                created_at=document["created_at"],
-                user_id=user_id,
-                all_read=document["all_read"],
-                all_write=document["all_write"],
-                group_read=document["group_read"],
-                group_write=document["group_write"],
-            ),
+        sample = SQLLegacySample(
+            legacy_id=document["id"],
+            name=document["name"],
+            host=document["host"],
+            isolate=document["isolate"],
+            locale=document["locale"],
+            notes=document["notes"],
+            library_type=document["library_type"],
+            format=document["format"],
+            quality=document["quality"],
+            created_at=document["created_at"],
+            paired=document["paired"],
+            ready=document["ready"],
+            hold=document["hold"],
+            is_legacy=document["is_legacy"],
+            all_read=document["all_read"],
+            all_write=document["all_write"],
+            group_read=document["group_read"],
+            group_write=document["group_write"],
+            user_id=user_id,
         )
+        session.add(sample)
+        await session.flush()
+
+        for subtraction_id in document["subtractions"]:
+            session.add(
+                SQLLegacySampleSubtraction(
+                    sample_id=sample.id,
+                    subtraction_id=subtraction_id,
+                ),
+            )
+
         await session.commit()
 
     if finalized is True:


### PR DESCRIPTION
## Summary
- Switch the sample list, get, and rights-check read paths from MongoDB to PostgreSQL, serving metadata from `legacy_samples` and its join tables.
- Bridge workflow tags (`nuvs`/`pathoscope`/`workflows`) and the reserved `uploads` array from Mongo temporarily, until they move to Postgres in VIR-2525.
- Keep the legacy Mongo string as the public sample identifier.