### PR TITLE
feat(migration): reference analyses and history by integer foreign key

### DIFF
--- a/assets/alembic/versions/91b32f49a8b2_add_reference_id_to_analyses_and_legacy_.py
+++ b/assets/alembic/versions/91b32f49a8b2_add_reference_id_to_analyses_and_legacy_.py
@@ -1,0 +1,55 @@
+"""add reference_id to analyses and legacy_history
+
+Phase 1 of keying ``analyses`` and ``legacy_history`` by an integer FK to
+``legacy_references`` instead of the legacy Mongo ``reference`` string. Purely
+additive: adds a nullable ``reference_id BIGINT REFERENCES legacy_references(id)``
+column to each table (indexed on ``legacy_history`` where reads filter by
+reference), leaving the existing ``reference`` columns intact.
+
+Backfill and call-site changes are handled by downstream revisions.
+
+Revision ID: 91b32f49a8b2
+Revises: c980043c0c89
+Create Date: 2026-07-06 23:05:12.307733+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "91b32f49a8b2"
+down_revision = "c980043c0c89"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "analyses",
+        sa.Column(
+            "reference_id",
+            sa.BigInteger(),
+            sa.ForeignKey("legacy_references.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "legacy_history",
+        sa.Column(
+            "reference_id",
+            sa.BigInteger(),
+            sa.ForeignKey("legacy_references.id"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_legacy_history_reference_id",
+        "legacy_history",
+        ["reference_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_legacy_history_reference_id", "legacy_history")
+    op.drop_column("legacy_history", "reference_id")
+    op.drop_column("analyses", "reference_id")

--- a/assets/revisions/rev_xgqo66avrcdh_backfill_reference_ids_to_integers.py
+++ b/assets/revisions/rev_xgqo66avrcdh_backfill_reference_ids_to_integers.py
@@ -1,0 +1,90 @@
+"""backfill reference ids to integers
+
+Populate ``analyses.reference_id`` and ``legacy_history.reference_id`` from the
+legacy Mongo ``reference`` string now that references live in Postgres as
+``legacy_references`` with an integer ``id`` and a permanent ``legacy_id``.
+
+Each update is set-based and idempotent: it only touches rows whose
+``reference_id`` is still ``NULL``, resolving the legacy ``reference`` string to
+``legacy_references.id`` via ``legacy_references.legacy_id``. Re-running fills
+only rows created since the last run.
+
+A row whose ``reference`` string resolves to no ``legacy_references`` row raises
+loudly rather than being left ``NULL`` -- a reference is a required relationship
+for both analyses and history, so an unresolved reference is a data-integrity
+problem that must surface.
+
+Revision ID: xgqo66avrcdh
+Date: 2026-07-06 23:05:46.057817
+
+"""
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill reference ids to integers"
+created_at = arrow.get("2026-07-06 23:05:46.057817")
+revision_id = "xgqo66avrcdh"
+
+alembic_down_revision = "91b32f49a8b2"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        analyses_result = await pg_session.execute(
+            text(
+                "UPDATE analyses a "
+                "SET reference_id = r.id "
+                "FROM legacy_references r "
+                "WHERE a.reference = r.legacy_id AND a.reference_id IS NULL",
+            ),
+        )
+
+        history_result = await pg_session.execute(
+            text(
+                "UPDATE legacy_history h "
+                "SET reference_id = r.id "
+                "FROM legacy_references r "
+                "WHERE h.reference = r.legacy_id AND h.reference_id IS NULL",
+            ),
+        )
+
+        for table in ("analyses", "legacy_history"):
+            unresolved = (
+                (
+                    await pg_session.execute(
+                        text(
+                            f"SELECT reference FROM {table} "  # noqa: S608
+                            "WHERE reference_id IS NULL",
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            if unresolved:
+                msg = (
+                    f"{table} references {len(unresolved)} reference(s) not found "
+                    f"in postgres: {sorted(set(unresolved))}"
+                )
+                raise ValueError(msg)
+
+        await pg_session.commit()
+
+    logger.info(
+        "backfilled reference ids",
+        analyses_updated=analyses_result.rowcount,
+        legacy_history_updated=history_result.rowcount,
+    )

--- a/tests/analyses/__snapshots__/test_data.ambr
+++ b/tests/analyses/__snapshots__/test_data.ambr
@@ -21,7 +21,7 @@
     'ready': False,
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'test_ref',
+      'id': 'bf1b993c',
       'name': 'Test Reference',
     }),
     'results': None,
@@ -80,7 +80,7 @@
         'ready': False,
         'reference': dict({
           'data_type': <ReferenceDataType.genome: 'genome'>,
-          'id': 'test_ref',
+          'id': 'bf1b993c',
           'name': 'Test Reference',
         }),
         'sample': dict({
@@ -135,7 +135,7 @@
         'ready': False,
         'reference': dict({
           'data_type': <ReferenceDataType.genome: 'genome'>,
-          'id': 'test_ref',
+          'id': 'bf1b993c',
           'name': 'Test Reference',
         }),
         'sample': dict({
@@ -179,7 +179,7 @@
         'ready': False,
         'reference': dict({
           'data_type': <ReferenceDataType.genome: 'genome'>,
-          'id': 'test_ref',
+          'id': 'bf1b993c',
           'name': 'Test Reference',
         }),
         'sample': dict({

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+from typing import NamedTuple
 from unittest.mock import ANY
 
 import pytest
@@ -49,14 +50,22 @@ async def subtraction_ids(fake: DataFaker) -> dict[str, int]:
     return {"subtraction_1": first.id, "subtraction_2": second.id}
 
 
+class SampleSetup(NamedTuple):
+    """Identifiers for the sample and reference seeded by ``setup_sample``."""
+
+    user_id: str
+    reference_id: str
+
+
 @pytest.fixture
 async def setup_sample(
     mongo: "Mongo",
     pg: AsyncEngine,
     fake: DataFaker,
     subtraction_ids: dict[str, int],
-) -> str:
+) -> SampleSetup:
     user = await fake.users.create()
+    reference = await fake.references.create(user=user, name="Test Reference")
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -111,19 +120,11 @@ async def setup_sample(
                 "_id": "test_index",
                 "version": 11,
                 "ready": True,
-                "reference": {"id": "test_ref"},
-            },
-        ),
-        mongo.references.insert_one(
-            {
-                "_id": "test_ref",
-                "archived": False,
-                "data_type": "genome",
-                "name": "Test Reference",
+                "reference": {"id": reference.id},
             },
         ),
     )
-    return user.id
+    return SampleSetup(user_id=user.id, reference_id=reference.id)
 
 
 @pytest.mark.parametrize("number_of_analyses", [0, 1, 2])
@@ -133,14 +134,14 @@ async def test_find(
     snapshot_recent: SnapshotAssertion,
     mongo: Mongo,
     pg: AsyncEngine,
-    setup_sample: str,
+    setup_sample: SampleSetup,
     subtraction_ids: dict[str, int],
     mocker,
 ):
     """Tests that all analysis are listed."""
     mocker.patch("virtool.samples.utils.get_sample_rights", return_value=(True, True))
     client = mocker.Mock(spec=UserClient)
-    user_id = setup_sample
+    user_id = setup_sample.user_id
 
     await mongo.samples.insert_one({"_id": "test_false", "name": "Test False"})
 
@@ -158,7 +159,7 @@ async def test_find(
 
     analysis_wrong_sample = await data_layer.analyses.create(
         CreateAnalysisRequest(
-            ref_id="test_ref",
+            ref_id=setup_sample.reference_id,
             subtractions=[
                 subtraction_ids["subtraction_1"],
                 subtraction_ids["subtraction_2"],
@@ -173,7 +174,7 @@ async def test_find(
     for _ in range(number_of_analyses):
         await data_layer.analyses.create(
             CreateAnalysisRequest(
-                ref_id="test_ref",
+                ref_id=setup_sample.reference_id,
                 subtractions=[
                     subtraction_ids["subtraction_1"],
                     subtraction_ids["subtraction_2"],
@@ -198,7 +199,7 @@ class TestHideIimi:
     """
 
     @staticmethod
-    async def _seed_iimi(mongo: Mongo, pg: AsyncEngine, user_id: str) -> int:
+    async def _seed_iimi(mongo: Mongo, pg: AsyncEngine, setup: SampleSetup) -> int:
         return await seed_analysis(
             mongo,
             pg,
@@ -209,9 +210,9 @@ class TestHideIimi:
                 "ready": True,
                 "job": None,
                 "index": {"id": "test_index", "version": 11},
-                "user": {"id": user_id},
+                "user": {"id": setup.user_id},
                 "sample": {"id": "test_sample"},
-                "reference": {"id": "test_ref"},
+                "reference": {"id": setup.reference_id},
                 "results": {"hits": []},
                 "subtractions": [],
             },
@@ -222,7 +223,7 @@ class TestHideIimi:
         data_layer: DataLayer,
         mongo: Mongo,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         mocker,
     ):
         """An iimi analysis is excluded from both the documents and the counts."""
@@ -231,11 +232,11 @@ class TestHideIimi:
             return_value=(True, True),
         )
         client = mocker.Mock(spec=UserClient)
-        user_id = setup_sample
+        user_id = setup_sample.user_id
 
         visible = await data_layer.analyses.create(
             CreateAnalysisRequest(
-                ref_id="test_ref",
+                ref_id=setup_sample.reference_id,
                 subtractions=[],
                 workflow=AnalysisWorkflow.nuvs,
             ),
@@ -244,7 +245,7 @@ class TestHideIimi:
             0,
         )
 
-        await self._seed_iimi(mongo, pg, user_id)
+        await self._seed_iimi(mongo, pg, setup_sample)
 
         analyses_found = await data_layer.analyses.find(1, 25, client, "test_sample")
 
@@ -257,7 +258,7 @@ class TestHideIimi:
         data_layer: DataLayer,
         mongo: Mongo,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
     ):
         """Getting an iimi analysis by id raises ``ResourceNotFoundError``."""
         analysis_id = await self._seed_iimi(mongo, pg, setup_sample)
@@ -269,15 +270,15 @@ class TestHideIimi:
 async def test_create(
     data_layer: DataLayer,
     snapshot: SnapshotAssertion,
-    setup_sample: str,
+    setup_sample: SampleSetup,
     subtraction_ids: dict[str, int],
 ):
     """Tests that an analysis is created with the expected fields."""
-    user_id: str = setup_sample
+    user_id: str = setup_sample.user_id
 
     analysis = await data_layer.analyses.create(
         CreateAnalysisRequest(
-            ref_id="test_ref",
+            ref_id=setup_sample.reference_id,
             subtractions=[
                 subtraction_ids["subtraction_1"],
                 subtraction_ids["subtraction_2"],
@@ -292,9 +293,12 @@ async def test_create(
     assert analysis == snapshot(name="obj", exclude=props("created_at", "updated_at"))
 
 
-def _create_request(subtraction_ids: dict[str, int]) -> CreateAnalysisRequest:
+def _create_request(
+    subtraction_ids: dict[str, int],
+    ref_id: str,
+) -> CreateAnalysisRequest:
     return CreateAnalysisRequest(
-        ref_id="test_ref",
+        ref_id=ref_id,
         subtractions=[
             subtraction_ids["subtraction_1"],
             subtraction_ids["subtraction_2"],
@@ -310,14 +314,14 @@ class TestCreate:
         self,
         data_layer: DataLayer,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
     ):
         """The Postgres row reflects the creation request."""
         analysis = await data_layer.analyses.create(
-            _create_request(subtraction_ids),
+            _create_request(subtraction_ids, setup_sample.reference_id),
             "test_sample",
-            setup_sample,
+            setup_sample.user_id,
             0,
         )
 
@@ -329,7 +333,7 @@ class TestCreate:
         assert row.ready is False
         assert row.results is None
         assert row.sample == "test_sample"
-        assert row.reference == "test_ref"
+        assert row.reference == setup_sample.reference_id
         assert row.created_at == row.updated_at
         assert isinstance(row.user_id, int)
 
@@ -357,16 +361,16 @@ class TestCreate:
         self,
         data_layer: DataLayer,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
     ):
         """An analysis created without subtractions links no subtraction rows."""
         analysis = await data_layer.analyses.create(
             CreateAnalysisRequest(
-                ref_id="test_ref",
+                ref_id=setup_sample.reference_id,
                 workflow=AnalysisWorkflow.nuvs,
             ),
             "test_sample",
-            setup_sample,
+            setup_sample.user_id,
             0,
         )
 
@@ -388,26 +392,26 @@ class TestCreate:
     async def test_unknown_subtraction_raises(
         self,
         data_layer: DataLayer,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
     ):
         """Creating an analysis with an unresolvable subtraction is a conflict."""
         with pytest.raises(ResourceConflictError, match="905"):
             await data_layer.analyses.create(
                 CreateAnalysisRequest(
-                    ref_id="test_ref",
+                    ref_id=setup_sample.reference_id,
                     subtractions=[subtraction_ids["subtraction_1"], 905],
                     workflow=AnalysisWorkflow.nuvs,
                 ),
                 "test_sample",
-                setup_sample,
+                setup_sample.user_id,
                 0,
             )
 
     async def test_unknown_sample_raises(
         self,
         data_layer: DataLayer,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
     ):
         """Creating an analysis for a sample with no ``legacy_samples`` row is a
@@ -415,9 +419,33 @@ class TestCreate:
         """
         with pytest.raises(ResourceConflictError, match="Sample does not exist"):
             await data_layer.analyses.create(
-                _create_request(subtraction_ids),
+                _create_request(subtraction_ids, setup_sample.reference_id),
                 "unknown_sample",
-                setup_sample,
+                setup_sample.user_id,
+                0,
+            )
+
+    async def test_unknown_reference_raises(
+        self,
+        data_layer: DataLayer,
+        setup_sample: SampleSetup,
+        subtraction_ids: dict[str, int],
+    ):
+        """Creating an analysis for a reference with no ``legacy_references`` row is a
+        conflict.
+        """
+        with pytest.raises(ResourceConflictError, match="Reference does not exist"):
+            await data_layer.analyses.create(
+                CreateAnalysisRequest(
+                    ref_id="unknown_ref",
+                    subtractions=[
+                        subtraction_ids["subtraction_1"],
+                        subtraction_ids["subtraction_2"],
+                    ],
+                    workflow=AnalysisWorkflow.nuvs,
+                ),
+                "test_sample",
+                setup_sample.user_id,
                 0,
             )
 
@@ -425,7 +453,7 @@ class TestCreate:
         self,
         data_layer: DataLayer,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
         mocker,
     ):
@@ -437,9 +465,9 @@ class TestCreate:
 
         with pytest.raises(RuntimeError):
             await data_layer.analyses.create(
-                _create_request(subtraction_ids),
+                _create_request(subtraction_ids, setup_sample.reference_id),
                 "test_sample",
-                setup_sample,
+                setup_sample.user_id,
                 0,
             )
 
@@ -456,7 +484,7 @@ class TestFinalize:
         data_layer: DataLayer,
         mongo: Mongo,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
         mocker,
     ):
@@ -467,9 +495,9 @@ class TestFinalize:
         )
 
         analysis = await data_layer.analyses.create(
-            _create_request(subtraction_ids),
+            _create_request(subtraction_ids, setup_sample.reference_id),
             "test_sample",
-            setup_sample,
+            setup_sample.user_id,
             0,
         )
 
@@ -502,14 +530,14 @@ class TestDelete:
         self,
         data_layer: DataLayer,
         pg: AsyncEngine,
-        setup_sample: str,
+        setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
     ):
         """Delete removes the Postgres row."""
         analysis = await data_layer.analyses.create(
-            _create_request(subtraction_ids),
+            _create_request(subtraction_ids, setup_sample.reference_id),
             "test_sample",
-            setup_sample,
+            setup_sample.user_id,
             0,
         )
 
@@ -520,13 +548,13 @@ class TestDelete:
 
 async def test_get_without_if_modified_since(
     data_layer: DataLayer,
-    setup_sample: str,
+    setup_sample: SampleSetup,
     subtraction_ids: dict[str, int],
 ):
     """Test that an analysis can be fetched without an HTTP cache validator."""
     analysis = await data_layer.analyses.create(
         CreateAnalysisRequest(
-            ref_id="test_ref",
+            ref_id=setup_sample.reference_id,
             subtractions=[
                 subtraction_ids["subtraction_1"],
                 subtraction_ids["subtraction_2"],
@@ -534,7 +562,7 @@ async def test_get_without_if_modified_since(
             workflow=AnalysisWorkflow.nuvs,
         ),
         "test_sample",
-        setup_sample,
+        setup_sample.user_id,
         0,
     )
 
@@ -546,7 +574,7 @@ async def test_get_without_if_modified_since(
 async def test_upload_file(
     data_layer: DataLayer,
     example_path: Path,
-    setup_sample: str,
+    setup_sample: SampleSetup,
     subtraction_ids: dict[str, int],
     snapshot_recent: SnapshotAssertion,
     spawn_job_client,
@@ -555,11 +583,11 @@ async def test_upload_file(
     """Test that an analysis result file is properly uploaded and a row is inserted into
     the `analysis_files` SQL table.
     """
-    user_id = setup_sample
+    user_id = setup_sample.user_id
 
     analysis = await data_layer.analyses.create(
         CreateAnalysisRequest(
-            ref_id="test_ref",
+            ref_id=setup_sample.reference_id,
             subtractions=[
                 subtraction_ids["subtraction_1"],
                 subtraction_ids["subtraction_2"],

--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisSubtraction
 from virtool.data.topg import compose_legacy_id_multi_expression
 from virtool.mongo.core import Mongo
+from virtool.references.sql import SQLReference
 from virtool.samples.sql import SQLLegacySample
 from virtool.subtractions.pg import SQLSubtraction
 
@@ -33,6 +34,7 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
     await mongo.analyses.insert_one(document)
 
     sample = document["sample"]
+    reference = document["reference"]
 
     async with AsyncSession(pg) as session:
         sample_pg_id = (
@@ -55,6 +57,27 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
             await session.flush()
             sample_pg_id = legacy_sample.id
 
+        reference_pg_id = (
+            await session.execute(
+                select(SQLReference.id).where(
+                    SQLReference.legacy_id == reference["id"],
+                ),
+            )
+        ).scalar_one_or_none()
+
+        if reference_pg_id is None:
+            legacy_reference = SQLReference(
+                legacy_id=reference["id"],
+                name=reference.get("name", reference["id"]),
+                description="",
+                created_at=document["created_at"],
+                source_types=[],
+                user_id=document["user"]["id"],
+            )
+            session.add(legacy_reference)
+            await session.flush()
+            reference_pg_id = legacy_reference.id
+
         analysis = SQLAnalysis(
             legacy_id=document["_id"],
             created_at=document["created_at"],
@@ -64,7 +87,8 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
             results=results if isinstance(results, dict) else None,
             sample=sample["id"],
             sample_id=sample_pg_id,
-            reference=document["reference"]["id"],
+            reference=reference["id"],
+            reference_id=reference_pg_id,
             index=index["id"],
             user_id=document["user"]["id"],
             job_id=job["id"] if job and isinstance(job["id"], int) else None,

--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -58,7 +58,7 @@
   <SQLLegacyHistoryDiff(id=1, change_id=6116cba1.0, history_id=1, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
 # ---
 # name: TestAdd.test_create[legacy_history]
-  <SQLLegacyHistory(id=1, legacy_id=6116cba1.0, created_at=2015-10-06 20:00:00, description=Created Prunus virus F, method_name=create, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=0, reference=hxn167, index=None, index_version=None)>
+  <SQLLegacyHistory(id=1, legacy_id=6116cba1.0, created_at=2015-10-06 20:00:00, description=Created Prunus virus F, method_name=create, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=0, reference=hxn167, reference_id=1, index=None, index_version=None)>
 # ---
 # name: TestAdd.test_edit
   dict({
@@ -138,13 +138,13 @@
   ])
 # ---
 # name: TestAdd.test_edit[legacy_history]
-  <SQLLegacyHistory(id=1, legacy_id=6116cba1.1, created_at=2015-10-06 20:00:00, description=This is a description, method_name=edit, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=1, reference=hxn167, index=None, index_version=None)>
+  <SQLLegacyHistory(id=1, legacy_id=6116cba1.1, created_at=2015-10-06 20:00:00, description=This is a description, method_name=edit, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=1, reference=hxn167, reference_id=1, index=None, index_version=None)>
 # ---
 # name: TestAdd.test_remove[diff]
   <SQLLegacyHistoryDiff(id=1, change_id=6116cba1.removed, history_id=1, diff={'_id': '6116cba1', 'name': 'Prunus virus F', 'schema': [], 'version': 0, 'imported': True, 'isolates': [{'default': True, 'sequences': [{'_id': 'KX269872', 'host': 'sweet cherry', 'segment': None, 'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC', 'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.', 'isolate_id': 'cab8b360'}], 'isolate_id': 'cab8b360', 'source_name': '8816-v2', 'source_type': 'isolate'}], 'reference': {'id': 'hxn167'}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': 0})>
 # ---
 # name: TestAdd.test_remove[legacy_history]
-  <SQLLegacyHistory(id=1, legacy_id=6116cba1.removed, created_at=2015-10-06 20:00:00, description=Removed Prunus virus F, method_name=remove, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=None, reference=hxn167, index=None, index_version=None)>
+  <SQLLegacyHistory(id=1, legacy_id=6116cba1.removed, created_at=2015-10-06 20:00:00, description=Removed Prunus virus F, method_name=remove, user_id=1, otu=6116cba1, otu_name=Prunus virus F, otu_version=None, reference=hxn167, reference_id=1, index=None, index_version=None)>
 # ---
 # name: TestAdd.test_remove[return_value]
   dict({

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -11,7 +11,38 @@ from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
+from virtool.references.sql import SQLReference
 from virtool.workflow.pytest_plugin.utils import StaticTime
+
+
+async def ensure_reference(
+    session: AsyncSession,
+    legacy_id: str,
+    user_id: int,
+) -> int:
+    """Return the integer id of the ``legacy_references`` row for ``legacy_id``,
+    creating it if it does not yet exist.
+    """
+    reference_id = (
+        await session.execute(
+            select(SQLReference.id).where(SQLReference.legacy_id == legacy_id),
+        )
+    ).scalar_one_or_none()
+
+    if reference_id is None:
+        reference = SQLReference(
+            legacy_id=legacy_id,
+            name=legacy_id,
+            description="",
+            created_at=datetime.datetime(2017, 7, 12, 16, 0, 50),
+            source_types=[],
+            user_id=user_id,
+        )
+        session.add(reference)
+        await session.flush()
+        reference_id = reference.id
+
+    return reference_id
 
 
 async def add_contribution(
@@ -35,6 +66,7 @@ async def add_contribution(
                 otu_name="Prunus virus F",
                 otu_version=otu_version,
                 reference=reference,
+                reference_id=await ensure_reference(session, reference, user_id),
                 index=index,
                 index_version=None if index is None else "1",
             ),
@@ -122,6 +154,10 @@ class TestAdd:
 
         user = await fake.users.create()
 
+        async with AsyncSession(pg) as session:
+            await ensure_reference(session, "hxn167", user.id)
+            await session.commit()
+
         change = await virtool.history.db.add(
             pg,
             "This is a description",
@@ -169,6 +205,10 @@ class TestAdd:
 
         user = await fake.users.create()
 
+        async with AsyncSession(pg) as session:
+            await ensure_reference(session, "hxn167", user.id)
+            await session.commit()
+
         change = await virtool.history.db.add(
             pg,
             f"Created {new['name']}",
@@ -205,6 +245,10 @@ class TestAdd:
         old, _ = test_otu_edit
 
         user = await fake.users.create()
+
+        async with AsyncSession(pg) as session:
+            await ensure_reference(session, "hxn167", user.id)
+            await session.commit()
 
         change = await virtool.history.db.add(
             pg,

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -631,5 +631,19 @@
       'name': 'add sample_id to sample files',
       'revision': 'c980043c0c89',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 91,
+      'name': 'add reference_id to analyses and legacy_history',
+      'revision': '91b32f49a8b2',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 92,
+      'name': 'backfill reference ids to integers',
+      'revision': 'xgqo66avrcdh',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_reference_ids.py
+++ b/tests/migration/test_backfill_reference_ids.py
@@ -1,0 +1,182 @@
+"""Tests for the backfill-reference-ids-to-integers migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_xgqo66avrcdh_backfill_reference_ids_to_integers import (
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_references(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed a user and two references with legacy ids."""
+    await asyncio.to_thread(apply_alembic, "head")
+
+    now = arrow.utcnow().naive
+
+    async with AsyncSession(ctx.pg) as session:
+        user_id = (
+            await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES (
+                        'alice', 'alice_legacy', true, '',
+                        false, false, :now, :pw, '{}'::jsonb
+                    )
+                    RETURNING id
+                """),
+                {"now": now, "pw": b"hashed"},
+            )
+        ).scalar_one()
+
+        result = await session.execute(
+            text("""
+                INSERT INTO legacy_references (
+                    legacy_id, name, description, organism, created_at,
+                    archived, restrict_source_types, source_types, user_id
+                )
+                VALUES
+                    ('ref_a_legacy', 'Reference A', '', '', :now,
+                     false, false, '[]'::jsonb, :user_id),
+                    ('ref_b_legacy', 'Reference B', '', '', :now,
+                     false, false, '[]'::jsonb, :user_id)
+                RETURNING id, legacy_id
+            """),
+            {"now": now, "user_id": user_id},
+        )
+        reference_ids = {row.legacy_id: row.id for row in result}
+
+        await session.execute(
+            text("""
+                INSERT INTO analyses (
+                    legacy_id, created_at, updated_at, workflow, ready,
+                    sample, reference, index, user_id
+                )
+                VALUES (
+                    'analysis_a', :now, :now, 'pathoscope_bowtie', true,
+                    'sample_a', 'ref_a_legacy', 'index_a', :user_id
+                )
+            """),
+            {"now": now, "user_id": user_id},
+        )
+
+        await session.execute(
+            text("""
+                INSERT INTO legacy_history (
+                    legacy_id, created_at, description, method_name,
+                    user_id, otu, otu_name, reference
+                )
+                VALUES (
+                    'otu_b.0', :now, 'Description', 'create',
+                    :user_id, 'otu_b', 'OTU B', 'ref_b_legacy'
+                )
+            """),
+            {"now": now, "user_id": user_id},
+        )
+
+        await session.commit()
+
+    return reference_ids
+
+
+class TestReferenceIdsBackfill:
+    async def test_backfills_both_tables(
+        self,
+        ctx: MigrationContext,
+        setup_references: dict[str, int],
+    ):
+        """The legacy ``reference`` string resolves to the integer FK on both the
+        ``analyses`` and ``legacy_history`` tables.
+        """
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            analysis_reference_id = (
+                await session.execute(
+                    text(
+                        "SELECT reference_id FROM analyses "
+                        "WHERE legacy_id = 'analysis_a'",
+                    ),
+                )
+            ).scalar_one()
+
+            history_reference_id = (
+                await session.execute(
+                    text(
+                        "SELECT reference_id FROM legacy_history "
+                        "WHERE legacy_id = 'otu_b.0'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert analysis_reference_id == setup_references["ref_a_legacy"]
+        assert history_reference_id == setup_references["ref_b_legacy"]
+
+    async def test_idempotent(
+        self,
+        ctx: MigrationContext,
+        setup_references: dict[str, int],
+    ):
+        """Re-running the backfill leaves already-resolved rows unchanged."""
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            analysis_reference_id = (
+                await session.execute(
+                    text(
+                        "SELECT reference_id FROM analyses "
+                        "WHERE legacy_id = 'analysis_a'",
+                    ),
+                )
+            ).scalar_one()
+
+        assert analysis_reference_id == setup_references["ref_a_legacy"]
+
+    @pytest.mark.usefixtures("setup_references")
+    async def test_unresolved_reference_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        """An analysis whose ``reference`` string matches no reference row raises
+        rather than being left ``NULL``.
+        """
+        now = arrow.utcnow().naive
+
+        async with AsyncSession(ctx.pg) as session:
+            user_id = (
+                await session.execute(
+                    text("SELECT id FROM users WHERE legacy_id = 'alice_legacy'"),
+                )
+            ).scalar_one()
+
+            await session.execute(
+                text("""
+                    INSERT INTO analyses (
+                        legacy_id, created_at, updated_at, workflow, ready,
+                        sample, reference, index, user_id
+                    )
+                    VALUES (
+                        'analysis_orphan', :now, :now, 'pathoscope_bowtie', true,
+                        'sample_orphan', 'ghost_reference', 'index_orphan', :user_id
+                    )
+                """),
+                {"now": now, "user_id": user_id},
+            )
+            await session.commit()
+
+        with pytest.raises(ValueError, match="ghost_reference"):
+            await upgrade(ctx)

--- a/tests/otus/__snapshots__/test_api.ambr
+++ b/tests/otus/__snapshots__/test_api.ambr
@@ -172,7 +172,7 @@
             0,
             dict({
               'default': True,
-              'id': 'fb085f7f',
+              'id': '7cf872dc',
               'sequences': list([
               ]),
               'source_name': 'b',
@@ -190,21 +190,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.1',
+    'id': 'fb085f7f.1',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.add_isolate: 'add_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Prunus virus F',
       'version': 1,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -215,7 +215,7 @@
 # name: TestAddIsolate.test_first[True][json]
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
     ]),
     'source_name': 'b',
@@ -223,16 +223,16 @@
   })
 # ---
 # name: TestAddIsolate.test_first[True][location]
-  'https://virtool.example.com/otus/bf1b993c/isolates/fb085f7f'
+  'https://virtool.example.com/otus/fb085f7f/isolates/7cf872dc'
 # ---
 # name: TestAddIsolate.test_first[True][otu]
   dict({
     'abbreviation': 'PVF',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
         ]),
         'source_name': 'b',
@@ -241,7 +241,7 @@
     ]),
     'issues': dict({
       'empty_isolate': list([
-        'fb085f7f',
+        '7cf872dc',
       ]),
       'empty_otu': False,
       'empty_sequence': False,
@@ -251,7 +251,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Added Isolate b as default',
-      'id': 'bf1b993c.1',
+      'id': 'fb085f7f.1',
       'method_name': <HistoryMethod.add_isolate: 'add_isolate'>,
       'user': dict({
         'handle': 'leeashley',
@@ -268,8 +268,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -289,7 +289,7 @@
             0,
             dict({
               'default': True,
-              'id': 'fb085f7f',
+              'id': '7cf872dc',
               'sequences': list([
               ]),
               'source_name': 'Beta',
@@ -307,21 +307,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.1',
+    'id': 'fb085f7f.1',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.add_isolate: 'add_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Prunus virus F',
       'version': 1,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -332,7 +332,7 @@
 # name: TestAddIsolate.test_force_case[True][json]
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
     ]),
     'source_name': 'Beta',
@@ -340,16 +340,16 @@
   })
 # ---
 # name: TestAddIsolate.test_force_case[True][location]
-  'https://virtool.example.com/otus/bf1b993c/isolates/fb085f7f'
+  'https://virtool.example.com/otus/fb085f7f/isolates/7cf872dc'
 # ---
 # name: TestAddIsolate.test_force_case[True][otu]
   dict({
     'abbreviation': 'PVF',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
         ]),
         'source_name': 'Beta',
@@ -358,7 +358,7 @@
     ]),
     'issues': dict({
       'empty_isolate': list([
-        'fb085f7f',
+        '7cf872dc',
       ]),
       'empty_otu': False,
       'empty_sequence': False,
@@ -368,7 +368,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Added Isolate Beta as default',
-      'id': 'bf1b993c.1',
+      'id': 'fb085f7f.1',
       'method_name': <HistoryMethod.add_isolate: 'add_isolate'>,
       'user': dict({
         'handle': 'leeashley',
@@ -385,8 +385,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -413,10 +413,10 @@
               'accession': 'foobar',
               'definition': 'A made up sequence',
               'host': 'Plant',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': None,
               'sequence': 'ATGCGTGTACTG',
@@ -433,21 +433,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.5',
+    'id': 'fb085f7f.5',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.create_sequence: 'create_sequence'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper leafroll virus',
       'version': 5,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'aanderson',
@@ -467,22 +467,22 @@
   })
 # ---
 # name: TestCreateSequence.test_ok[True][location]
-  '/otus/bf1b993c/isolates/fb085f7f/sequences/bf1b993c'
+  '/otus/fb085f7f/isolates/7cf872dc/sequences/bf1b993c'
 # ---
 # name: TestCreateSequence.test_ok[True][otu]
   dict({
     'abbreviation': 'PLV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
           dict({
             'accession': 'NC_795330',
             'definition': 'Bring determine some forward staff.',
             'host': 'prunus',
-            'id': '7cf872dc',
+            'id': '3cbb22cc',
             'remote': None,
             'segment': 'RNA_C',
             'sequence': 'GGAGCSCAAAGAAGACADGCGAGCCGAATTACCGTTRCRCGAGGAACAKCAGRGKCTCAGCAGCAGCCCCGGATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMT',
@@ -491,7 +491,7 @@
             'accession': 'NC_076279',
             'definition': 'Purpose character would in.',
             'host': 'rice',
-            'id': '3cbb22cc',
+            'id': 'da42dca3',
             'remote': None,
             'segment': 'RNA-U3',
             'sequence': 'CCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAAHTTCCGCCTACATACGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAG',
@@ -500,7 +500,7 @@
             'accession': 'QX375248',
             'definition': 'Bar standard final.',
             'host': 'apple',
-            'id': 'da42dca3',
+            'id': '09d01419',
             'remote': None,
             'segment': 'RNA L',
             'sequence': 'ACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATGCTAKGGGGAGGGCGAGTGCCCAAAGAATHGTGATCVATKACTCGTGBVAGGASAABGCTTTACAGAATGGCSATGTACATTTCCATTTCTAACGCAAATCCCCTCGTGGRCTGATHTCTAATCCCAATSATCYWACTCGGGGGAAGCNATTGCYGNCHATCHCGCCTTTABCGGSTTCTAGCCGAKCGCCGACATCTTGABCACACGTTCMGTGAAVGCCTGGCAGGNGAVGCTGCACAGGGACTAGSKCGATYCTATCTGTAGCHAGACCAGTGGGGGGAAACAACATAATGTCGGATTCDACATBYAGGKCTGCGAATTCTGGTAGCAACCCTCTACACGAATCTGCCAAKAAACCTTCTGCCATGACHTCAATCCGTTGCGGAACCCTAKTATCCGACTGTGANCTGTATTCCGCAACTASAYCSGTCATMATAGGCCTCGGACGCGCBCCAACGACAGGCATTCGCNGAHATCTATTGCAGATGGTCHGGCVKTTCTCRTTCTCAGTCTCCCA',
@@ -524,7 +524,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Created new sequence foobar in Isolate Position',
-      'id': 'bf1b993c.5',
+      'id': 'fb085f7f.5',
       'method_name': <HistoryMethod.create_sequence: 'create_sequence'>,
       'user': dict({
         'handle': 'aanderson',
@@ -551,8 +551,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': True,
@@ -565,11 +565,11 @@
     'definition': 'A made up sequence',
     'host': 'Plant',
     'id': 'bf1b993c',
-    'otu_id': 'bf1b993c',
+    'otu_id': 'fb085f7f',
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'segment': None,
@@ -581,48 +581,48 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'description': 'Removed Pepper bunchy top virus (PBTV)',
     'diff': dict({
-      '_id': 'bf1b993c',
+      '_id': 'fb085f7f',
       'abbreviation': 'PBTV',
       'isolates': list([
         dict({
           'default': True,
-          'id': 'fb085f7f',
+          'id': '7cf872dc',
           'sequences': list([
             dict({
-              '_id': '7cf872dc',
+              '_id': '3cbb22cc',
               'accession': 'VC280715',
               'definition': 'Exactly drive well good explain grow water.',
               'host': 'prunus',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'DNA M',
               'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',
             }),
             dict({
-              '_id': '3cbb22cc',
+              '_id': 'da42dca3',
               'accession': 'NC_688181',
               'definition': 'Buy throw like lawyer fund indicate help.',
               'host': 'lettuce',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'RNA_R',
               'sequence': 'CGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAGGHCACTACGACTGGTAAGATACGACGACCTTCCTAAGAHTHCTGTGCTATTTWYCGGTAAGCAAAAATGTTCCTTGMAGCAAGGAVCAGGKGAGAGGGCGGGGACRATTTTCAGCRGAGTTCVHCTAGCGGGAGGTGGCCGTCTTGTCTAGMGCTTAGSGTGCTTGTGCTTTAACGCYGCYTTRCGATGACGHSGAGCRCCTGCAYAGBTGGGATAAACTGGTTGCACTCYTATCCCAATCCGAADTHGCCYTCCGGCCTTCCTACSGCAADTGGTTATGGACHWGTGCACAGCGTAYRAGAGTTHGCGTCCRCCAACTAGGGCGGCAAGANWAGGTGAACGCCATGCCCRATGTGAACAATTSGCCTCCCTCGGTGACCTGTACHCATTCGGTGGCCGTGGGKGCCMGGGCAACCGCCTTTGGATTTTTTCMTCCCATGTAGCGTAATTGCRTTAGTAAAGGCTTCGGGGGAYGTATGTCTYTWAAHCCACCBGNRTAAMTGGGGCMCBGTAAWAGTGACAAGTWACTCGGGAGCGTCAGGGGTACCWCCCTSCTGACTCTTTAACCCAGYATGAGGTHTAGTGCGGCCTTGVAAVATCCCATATAGAACAGCCCCCCGYCCCGTHGGAAAGGACATCTGSGTCCGTCAGTGGCAGTGATGARGATGCGTAACAACTCGTGAATGTAAGCGCACCAGGAGGTCTTAGWGACMTTGGGGDGGCAAACCTTAAGCTTTRVCAAGTCCHATCCATCCTAACTGTGAAADTCGCGCGGAGTGGAGTTCTGGATGGCTTGATMBATGCAGTTTAAGAAGGTCTGTGTATACTDATTGTGCTACAATACCTACTAKAAACRGTGATBAAGAGTCCGACATWTTTCGCGRTGAACCTCSTTVCCRATGTACGGGTAACAACCCCATCGTYATGGGTCTVATTGGCTCTATTCTGKTKGGDGTCTGCGTTBTGVTATAGGGACTVACYGGATTCAAGCCGGTTCTGAGGTMCTMTAAGAATACACACCAGAAGCCAACACGVGAAGGTACBGCAGTTYCCTTCACGDGSCAATGAR',
             }),
             dict({
-              '_id': 'da42dca3',
+              '_id': '09d01419',
               'accession': 'NC_772442',
               'definition': 'Common prevent spend.',
               'host': 'sweet potato',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'RNA_L',
               'sequence': 'ACCCCTCCGTTATMTTCTAGCGATGTATTGTCHGGATWCACGCATGAAGAATCGYACGAGCCBDTAGTAGTGGGGGRTCCMCCGAGTTBGGTGACTVANTTCCTGCACTGTCCCWATCTAACWTGAGTCCCCGRCGGCATAACCVCGGVCBTTCGAAKTGCCTAAATACACACATTKGYAAAGTTCAAGTCAGSTCTTATGTGCTGCTCATAACCGACAMCNATTTGACTAGABACTGAGTCAAKAATGTCAGRGTACTTAGTGYGACGGGCRGTTGTGAATTAGTTATACTCTHGRVGGAGYTCGATACVCCGTTCTNNAGGHCAAGGGATTAAATAGBVWCVGAGCAATAAACAYGGGGCCCGCTGTCMNGMAGGGTGGMGKAANCKAMCCCACCTDASCGNGGGCAATATACCCGCCATNGAGAGTGAVTAAAATTTTAACTTGTAATCGCAACCGCGATHCAGGCAGTTAGATAGTACGAGCCGCGRGTGCVAATAVGGSAGTTTYGWTTYAGGAGGNGGADTGAGADAGAGGCATCRAATAGTATCCCAAGGCABGAAACCAGATGCAGGAVTTCTTCTTTGGTAAACYTTGCTAGCAGCGATAACAATTGATTACTTACHAGTGCAATTGGAGTWGACGKATAGACGGTACTCCCAAGTTADNCATAGACGCTTSATTTAGCGATATYTHAGAVCDTTGCCGTGCGGAHCTAAGGGARTYKCTCATMMNGAGTAMCGTCCTTGCAGGTCTCCTCAA',
@@ -636,7 +636,7 @@
       'lower_name': 'pepper bunchy top virus',
       'name': 'Pepper bunchy top virus',
       'reference': dict({
-        'id': 'hxn167',
+        'id': 'bf1b993c',
       }),
       'schema': list([
         dict({
@@ -658,21 +658,21 @@
       'verified': True,
       'version': 4,
     }),
-    'id': 'bf1b993c.removed',
+    'id': 'fb085f7f.removed',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.remove: 'remove'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper bunchy top virus',
       'version': 'removed',
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -693,8 +693,8 @@
           'id',
         ]),
         list([
-          'fb085f7f',
-          '09d01419',
+          '7cf872dc',
+          'f60bae36',
         ]),
       ]),
       list([
@@ -720,14 +720,14 @@
           list([
             2,
             dict({
-              '_id': 'da42dca3',
+              '_id': '09d01419',
               'accession': 'NC_772442',
               'definition': 'Common prevent spend.',
               'host': 'sweet potato',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'RNA_L',
               'sequence': 'ACCCCTCCGTTATMTTCTAGCGATGTATTGTCHGGATWCACGCATGAAGAATCGYACGAGCCBDTAGTAGTGGGGGRTCCMCCGAGTTBGGTGACTVANTTCCTGCACTGTCCCWATCTAACWTGAGTCCCCGRCGGCATAACCVCGGVCBTTCGAAKTGCCTAAATACACACATTKGYAAAGTTCAAGTCAGSTCTTATGTGCTGCTCATAACCGACAMCNATTTGACTAGABACTGAGTCAAKAATGTCAGRGTACTTAGTGYGACGGGCRGTTGTGAATTAGTTATACTCTHGRVGGAGYTCGATACVCCGTTCTNNAGGHCAAGGGATTAAATAGBVWCVGAGCAATAAACAYGGGGCCCGCTGTCMNGMAGGGTGGMGKAANCKAMCCCACCTDASCGNGGGCAATATACCCGCCATNGAGAGTGAVTAAAATTTTAACTTGTAATCGCAACCGCGATHCAGGCAGTTAGATAGTACGAGCCGCGRGTGCVAATAVGGSAGTTTYGWTTYAGGAGGNGGADTGAGADAGAGGCATCRAATAGTATCCCAAGGCABGAAACCAGATGCAGGAVTTCTTCTTTGGTAAACYTTGCTAGCAGCGATAACAATTGATTACTTACHAGTGCAATTGGAGTWGACGKATAGACGGTACTCCCAAGTTADNCATAGACGCTTSATTTAGCGATATYTHAGAVCDTTGCCGTGCGGAHCTAAGGGARTYKCTCATMMNGAGTAMCGTCCTTGCAGGTCTCCTCAA',
@@ -736,14 +736,14 @@
           list([
             1,
             dict({
-              '_id': '3cbb22cc',
+              '_id': 'da42dca3',
               'accession': 'NC_688181',
               'definition': 'Buy throw like lawyer fund indicate help.',
               'host': 'lettuce',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'RNA_R',
               'sequence': 'CGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAGGHCACTACGACTGGTAAGATACGACGACCTTCCTAAGAHTHCTGTGCTATTTWYCGGTAAGCAAAAATGTTCCTTGMAGCAAGGAVCAGGKGAGAGGGCGGGGACRATTTTCAGCRGAGTTCVHCTAGCGGGAGGTGGCCGTCTTGTCTAGMGCTTAGSGTGCTTGTGCTTTAACGCYGCYTTRCGATGACGHSGAGCRCCTGCAYAGBTGGGATAAACTGGTTGCACTCYTATCCCAATCCGAADTHGCCYTCCGGCCTTCCTACSGCAADTGGTTATGGACHWGTGCACAGCGTAYRAGAGTTHGCGTCCRCCAACTAGGGCGGCAAGANWAGGTGAACGCCATGCCCRATGTGAACAATTSGCCTCCCTCGGTGACCTGTACHCATTCGGTGGCCGTGGGKGCCMGGGCAACCGCCTTTGGATTTTTTCMTCCCATGTAGCGTAATTGCRTTAGTAAAGGCTTCGGGGGAYGTATGTCTYTWAAHCCACCBGNRTAAMTGGGGCMCBGTAAWAGTGACAAGTWACTCGGGAGCGTCAGGGGTACCWCCCTSCTGACTCTTTAACCCAGYATGAGGTHTAGTGCGGCCTTGVAAVATCCCATATAGAACAGCCCCCCGYCCCGTHGGAAAGGACATCTGSGTCCGTCAGTGGCAGTGATGARGATGCGTAACAACTCGTGAATGTAAGCGCACCAGGAGGTCTTAGWGACMTTGGGGDGGCAAACCTTAAGCTTTRVCAAGTCCHATCCATCCTAACTGTGAAADTCGCGCGGAGTGGAGTTCTGGATGGCTTGATMBATGCAGTTTAAGAAGGTCTGTGTATACTDATTGTGCTACAATACCTACTAKAAACRGTGATBAAGAGTCCGACATWTTTCGCGRTGAACCTCSTTVCCRATGTACGGGTAACAACCCCATCGTYATGGGTCTVATTGGCTCTATTCTGKTKGGDGTCTGCGTTBTGVTATAGGGACTVACYGGATTCAAGCCGGTTCTGAGGTMCTMTAAGAATACACACCAGAAGCCAACACGVGAAGGTACBGCAGTTYCCTTCACGDGSCAATGAR',
@@ -752,14 +752,14 @@
           list([
             0,
             dict({
-              '_id': '7cf872dc',
+              '_id': '3cbb22cc',
               'accession': 'VC280715',
               'definition': 'Exactly drive well good explain grow water.',
               'host': 'prunus',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'DNA M',
               'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',
@@ -775,7 +775,7 @@
             1,
             dict({
               'default': False,
-              'id': '09d01419',
+              'id': 'f60bae36',
               'sequences': list([
               ]),
               'source_name': 'b',
@@ -793,21 +793,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.6',
+    'id': 'fb085f7f.6',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.remove_isolate: 'remove_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper bunchy top virus',
       'version': 6,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -818,11 +818,11 @@
 # name: TestDeleteIsolate.test_default[True][otu]
   dict({
     'abbreviation': 'PBTV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': '09d01419',
+        'id': 'f60bae36',
         'sequences': list([
         ]),
         'source_name': 'b',
@@ -831,7 +831,7 @@
     ]),
     'issues': dict({
       'empty_isolate': list([
-        '09d01419',
+        'f60bae36',
       ]),
       'empty_otu': False,
       'empty_sequence': False,
@@ -841,7 +841,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Removed Isolate Important and set Isolate b as default',
-      'id': 'bf1b993c.6',
+      'id': 'fb085f7f.6',
       'method_name': <HistoryMethod.remove_isolate: 'remove_isolate'>,
       'user': dict({
         'handle': 'leeashley',
@@ -868,8 +868,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -897,56 +897,56 @@
             0,
             dict({
               'default': True,
-              'id': 'fb085f7f',
+              'id': '7cf872dc',
               'sequences': list([
                 dict({
-                  '_id': '7cf872dc',
+                  '_id': '3cbb22cc',
                   'accession': 'VC280715',
                   'definition': 'Exactly drive well good explain grow water.',
                   'host': 'prunus',
-                  'isolate_id': 'fb085f7f',
-                  'otu_id': 'bf1b993c',
+                  'isolate_id': '7cf872dc',
+                  'otu_id': 'fb085f7f',
                   'reference': dict({
-                    'id': 'hxn167',
+                    'id': 'bf1b993c',
                   }),
                   'segment': 'DNA M',
                   'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',
                 }),
                 dict({
-                  '_id': '3cbb22cc',
+                  '_id': 'da42dca3',
                   'accession': 'NC_688181',
                   'definition': 'Buy throw like lawyer fund indicate help.',
                   'host': 'lettuce',
-                  'isolate_id': 'fb085f7f',
-                  'otu_id': 'bf1b993c',
+                  'isolate_id': '7cf872dc',
+                  'otu_id': 'fb085f7f',
                   'reference': dict({
-                    'id': 'hxn167',
+                    'id': 'bf1b993c',
                   }),
                   'segment': 'RNA_R',
                   'sequence': 'CGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAGGHCACTACGACTGGTAAGATACGACGACCTTCCTAAGAHTHCTGTGCTATTTWYCGGTAAGCAAAAATGTTCCTTGMAGCAAGGAVCAGGKGAGAGGGCGGGGACRATTTTCAGCRGAGTTCVHCTAGCGGGAGGTGGCCGTCTTGTCTAGMGCTTAGSGTGCTTGTGCTTTAACGCYGCYTTRCGATGACGHSGAGCRCCTGCAYAGBTGGGATAAACTGGTTGCACTCYTATCCCAATCCGAADTHGCCYTCCGGCCTTCCTACSGCAADTGGTTATGGACHWGTGCACAGCGTAYRAGAGTTHGCGTCCRCCAACTAGGGCGGCAAGANWAGGTGAACGCCATGCCCRATGTGAACAATTSGCCTCCCTCGGTGACCTGTACHCATTCGGTGGCCGTGGGKGCCMGGGCAACCGCCTTTGGATTTTTTCMTCCCATGTAGCGTAATTGCRTTAGTAAAGGCTTCGGGGGAYGTATGTCTYTWAAHCCACCBGNRTAAMTGGGGCMCBGTAAWAGTGACAAGTWACTCGGGAGCGTCAGGGGTACCWCCCTSCTGACTCTTTAACCCAGYATGAGGTHTAGTGCGGCCTTGVAAVATCCCATATAGAACAGCCCCCCGYCCCGTHGGAAAGGACATCTGSGTCCGTCAGTGGCAGTGATGARGATGCGTAACAACTCGTGAATGTAAGCGCACCAGGAGGTCTTAGWGACMTTGGGGDGGCAAACCTTAAGCTTTRVCAAGTCCHATCCATCCTAACTGTGAAADTCGCGCGGAGTGGAGTTCTGGATGGCTTGATMBATGCAGTTTAAGAAGGTCTGTGTATACTDATTGTGCTACAATACCTACTAKAAACRGTGATBAAGAGTCCGACATWTTTCGCGRTGAACCTCSTTVCCRATGTACGGGTAACAACCCCATCGTYATGGGTCTVATTGGCTCTATTCTGKTKGGDGTCTGCGTTBTGVTATAGGGACTVACYGGATTCAAGCCGGTTCTGAGGTMCTMTAAGAATACACACCAGAAGCCAACACGVGAAGGTACBGCAGTTYCCTTCACGDGSCAATGAR',
                 }),
                 dict({
-                  '_id': 'da42dca3',
+                  '_id': '09d01419',
                   'accession': 'NC_772442',
                   'definition': 'Common prevent spend.',
                   'host': 'sweet potato',
-                  'isolate_id': 'fb085f7f',
-                  'otu_id': 'bf1b993c',
+                  'isolate_id': '7cf872dc',
+                  'otu_id': 'fb085f7f',
                   'reference': dict({
-                    'id': 'hxn167',
+                    'id': 'bf1b993c',
                   }),
                   'segment': 'RNA_L',
                   'sequence': 'ACCCCTCCGTTATMTTCTAGCGATGTATTGTCHGGATWCACGCATGAAGAATCGYACGAGCCBDTAGTAGTGGGGGRTCCMCCGAGTTBGGTGACTVANTTCCTGCACTGTCCCWATCTAACWTGAGTCCCCGRCGGCATAACCVCGGVCBTTCGAAKTGCCTAAATACACACATTKGYAAAGTTCAAGTCAGSTCTTATGTGCTGCTCATAACCGACAMCNATTTGACTAGABACTGAGTCAAKAATGTCAGRGTACTTAGTGYGACGGGCRGTTGTGAATTAGTTATACTCTHGRVGGAGYTCGATACVCCGTTCTNNAGGHCAAGGGATTAAATAGBVWCVGAGCAATAAACAYGGGGCCCGCTGTCMNGMAGGGTGGMGKAANCKAMCCCACCTDASCGNGGGCAATATACCCGCCATNGAGAGTGAVTAAAATTTTAACTTGTAATCGCAACCGCGATHCAGGCAGTTAGATAGTACGAGCCGCGRGTGCVAATAVGGSAGTTTYGWTTYAGGAGGNGGADTGAGADAGAGGCATCRAATAGTATCCCAAGGCABGAAACCAGATGCAGGAVTTCTTCTTTGGTAAACYTTGCTAGCAGCGATAACAATTGATTACTTACHAGTGCAATTGGAGTWGACGKATAGACGGTACTCCCAAGTTADNCATAGACGCTTSATTTAGCGATATYTHAGAVCDTTGCCGTGCGGAHCTAAGGGARTYKCTCATMMNGAGTAMCGTCCTTGCAGGTCTCCTCAA',
                 }),
                 dict({
-                  '_id': '09d01419',
+                  '_id': 'f60bae36',
                   'accession': 'OR596737.1',
                   'definition': 'Prunus virus F isolate PCEG segment RNA2',
                   'host': 'Prunus cerasus',
-                  'isolate_id': 'fb085f7f',
-                  'otu_id': 'bf1b993c',
+                  'isolate_id': '7cf872dc',
+                  'otu_id': 'fb085f7f',
                   'reference': dict({
-                    'id': 'hxn167',
+                    'id': 'bf1b993c',
                   }),
                   'segment': 2,
                   'sequence': 'TAAGAGATTAAACAACCGCTTTCGTTACCAGAAACTGCTTTCTTTGAACGTTTCTGTTTGCTT',
@@ -967,21 +967,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.6',
+    'id': 'fb085f7f.6',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.remove_isolate: 'remove_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper bunchy top virus',
       'version': 6,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -992,7 +992,7 @@
 # name: TestDeleteSequence.test_ok[history]
   dict({
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'description': 'Removed sequence 7cf872dc from Isolate Important',
+    'description': 'Removed sequence 3cbb22cc from Isolate Important',
     'diff': list([
       list([
         'change',
@@ -1004,8 +1004,8 @@
           '_id',
         ]),
         list([
-          '7cf872dc',
           '3cbb22cc',
+          'da42dca3',
         ]),
       ]),
       list([
@@ -1088,8 +1088,8 @@
           '_id',
         ]),
         list([
-          '3cbb22cc',
           'da42dca3',
+          '09d01419',
         ]),
       ]),
       list([
@@ -1173,14 +1173,14 @@
           list([
             2,
             dict({
-              '_id': 'da42dca3',
+              '_id': '09d01419',
               'accession': 'NC_772442',
               'definition': 'Common prevent spend.',
               'host': 'sweet potato',
-              'isolate_id': 'fb085f7f',
-              'otu_id': 'bf1b993c',
+              'isolate_id': '7cf872dc',
+              'otu_id': 'fb085f7f',
               'reference': dict({
-                'id': 'hxn167',
+                'id': 'bf1b993c',
               }),
               'segment': 'RNA_L',
               'sequence': 'ACCCCTCCGTTATMTTCTAGCGATGTATTGTCHGGATWCACGCATGAAGAATCGYACGAGCCBDTAGTAGTGGGGGRTCCMCCGAGTTBGGTGACTVANTTCCTGCACTGTCCCWATCTAACWTGAGTCCCCGRCGGCATAACCVCGGVCBTTCGAAKTGCCTAAATACACACATTKGYAAAGTTCAAGTCAGSTCTTATGTGCTGCTCATAACCGACAMCNATTTGACTAGABACTGAGTCAAKAATGTCAGRGTACTTAGTGYGACGGGCRGTTGTGAATTAGTTATACTCTHGRVGGAGYTCGATACVCCGTTCTNNAGGHCAAGGGATTAAATAGBVWCVGAGCAATAAACAYGGGGCCCGCTGTCMNGMAGGGTGGMGKAANCKAMCCCACCTDASCGNGGGCAATATACCCGCCATNGAGAGTGAVTAAAATTTTAACTTGTAATCGCAACCGCGATHCAGGCAGTTAGATAGTACGAGCCGCGRGTGCVAATAVGGSAGTTTYGWTTYAGGAGGNGGADTGAGADAGAGGCATCRAATAGTATCCCAAGGCABGAAACCAGATGCAGGAVTTCTTCTTTGGTAAACYTTGCTAGCAGCGATAACAATTGATTACTTACHAGTGCAATTGGAGTWGACGKATAGACGGTACTCCCAAGTTADNCATAGACGCTTSATTTAGCGATATYTHAGAVCDTTGCCGTGCGGAHCTAAGGGARTYKCTCATMMNGAGTAMCGTCCTTGCAGGTCTCCTCAA',
@@ -1197,21 +1197,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.5',
+    'id': 'fb085f7f.5',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.remove_sequence: 'remove_sequence'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper bunchy top virus',
       'version': 5,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -1262,8 +1262,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -1307,8 +1307,8 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -1355,8 +1355,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -1414,8 +1414,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -1459,8 +1459,8 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -1507,8 +1507,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -1550,8 +1550,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -1595,8 +1595,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -1643,8 +1643,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -1702,8 +1702,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -1747,8 +1747,8 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -1795,8 +1795,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -1854,8 +1854,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -1899,8 +1899,8 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -1947,8 +1947,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -2006,8 +2006,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -2051,8 +2051,8 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2099,8 +2099,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -2142,8 +2142,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -2187,8 +2187,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2235,8 +2235,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -2278,8 +2278,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -2323,8 +2323,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2371,8 +2371,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -2414,8 +2414,8 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -2459,8 +2459,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2507,8 +2507,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -2553,8 +2553,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2601,8 +2601,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2649,8 +2649,8 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2697,8 +2697,8 @@
     'name': 'Prunus virus G',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
@@ -2709,42 +2709,33 @@
 # ---
 # name: TestGet.test_ok
   dict({
-    'abbreviation': 'PBTV',
-    'id': 'bf1b993c',
+    'abbreviation': 'SBSV',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
           dict({
-            'accession': 'VC280715',
-            'definition': 'Exactly drive well good explain grow water.',
-            'host': 'prunus',
-            'id': '7cf872dc',
-            'remote': None,
-            'segment': 'DNA M',
-            'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',
-          }),
-          dict({
-            'accession': 'NC_688181',
-            'definition': 'Buy throw like lawyer fund indicate help.',
-            'host': 'lettuce',
+            'accession': 'NC_112201',
+            'definition': 'Raise study modern miss dog Democrat quickly.',
+            'host': 'okra',
             'id': '3cbb22cc',
             'remote': None,
-            'segment': 'RNA_R',
-            'sequence': 'CGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAGGHCACTACGACTGGTAAGATACGACGACCTTCCTAAGAHTHCTGTGCTATTTWYCGGTAAGCAAAAATGTTCCTTGMAGCAAGGAVCAGGKGAGAGGGCGGGGACRATTTTCAGCRGAGTTCVHCTAGCGGGAGGTGGCCGTCTTGTCTAGMGCTTAGSGTGCTTGTGCTTTAACGCYGCYTTRCGATGACGHSGAGCRCCTGCAYAGBTGGGATAAACTGGTTGCACTCYTATCCCAATCCGAADTHGCCYTCCGGCCTTCCTACSGCAADTGGTTATGGACHWGTGCACAGCGTAYRAGAGTTHGCGTCCRCCAACTAGGGCGGCAAGANWAGGTGAACGCCATGCCCRATGTGAACAATTSGCCTCCCTCGGTGACCTGTACHCATTCGGTGGCCGTGGGKGCCMGGGCAACCGCCTTTGGATTTTTTCMTCCCATGTAGCGTAATTGCRTTAGTAAAGGCTTCGGGGGAYGTATGTCTYTWAAHCCACCBGNRTAAMTGGGGCMCBGTAAWAGTGACAAGTWACTCGGGAGCGTCAGGGGTACCWCCCTSCTGACTCTTTAACCCAGYATGAGGTHTAGTGCGGCCTTGVAAVATCCCATATAGAACAGCCCCCCGYCCCGTHGGAAAGGACATCTGSGTCCGTCAGTGGCAGTGATGARGATGCGTAACAACTCGTGAATGTAAGCGCACCAGGAGGTCTTAGWGACMTTGGGGDGGCAAACCTTAAGCTTTRVCAAGTCCHATCCATCCTAACTGTGAAADTCGCGCGGAGTGGAGTTCTGGATGGCTTGATMBATGCAGTTTAAGAAGGTCTGTGTATACTDATTGTGCTACAATACCTACTAKAAACRGTGATBAAGAGTCCGACATWTTTCGCGRTGAACCTCSTTVCCRATGTACGGGTAACAACCCCATCGTYATGGGTCTVATTGGCTCTATTCTGKTKGGDGTCTGCGTTBTGVTATAGGGACTVACYGGATTCAAGCCGGTTCTGAGGTMCTMTAAGAATACACACCAGAAGCCAACACGVGAAGGTACBGCAGTTYCCTTCACGDGSCAATGAR',
+            'segment': 'DNA A',
+            'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
           }),
           dict({
-            'accession': 'NC_772442',
-            'definition': 'Common prevent spend.',
-            'host': 'sweet potato',
+            'accession': 'PV426197',
+            'definition': 'Tell time special beyond could key assume.',
+            'host': 'tobacco',
             'id': 'da42dca3',
             'remote': None,
-            'segment': 'RNA_L',
-            'sequence': 'ACCCCTCCGTTATMTTCTAGCGATGTATTGTCHGGATWCACGCATGAAGAATCGYACGAGCCBDTAGTAGTGGGGGRTCCMCCGAGTTBGGTGACTVANTTCCTGCACTGTCCCWATCTAACWTGAGTCCCCGRCGGCATAACCVCGGVCBTTCGAAKTGCCTAAATACACACATTKGYAAAGTTCAAGTCAGSTCTTATGTGCTGCTCATAACCGACAMCNATTTGACTAGABACTGAGTCAAKAATGTCAGRGTACTTAGTGYGACGGGCRGTTGTGAATTAGTTATACTCTHGRVGGAGYTCGATACVCCGTTCTNNAGGHCAAGGGATTAAATAGBVWCVGAGCAATAAACAYGGGGCCCGCTGTCMNGMAGGGTGGMGKAANCKAMCCCACCTDASCGNGGGCAATATACCCGCCATNGAGAGTGAVTAAAATTTTAACTTGTAATCGCAACCGCGATHCAGGCAGTTAGATAGTACGAGCCGCGRGTGCVAATAVGGSAGTTTYGWTTYAGGAGGNGGADTGAGADAGAGGCATCRAATAGTATCCCAAGGCABGAAACCAGATGCAGGAVTTCTTCTTTGGTAAACYTTGCTAGCAGCGATAACAATTGATTACTTACHAGTGCAATTGGAGTWGACGKATAGACGGTACTCCCAAGTTADNCATAGACGCTTSATTTAGCGATATYTHAGAVCDTTGCCGTGCGGAHCTAAGGGARTYKCTCATMMNGAGTAMCGTCCTTGCAGGTCTCCTCAA',
+            'segment': 'DNA_U3',
+            'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
           }),
         ]),
-        'source_name': 'Important',
+        'source_name': 'Ever',
         'source_type': 'isolate',
       }),
     ]),
@@ -2752,40 +2743,35 @@
     'last_indexed_version': None,
     'most_recent_change': dict({
       'created_at': 'approximately_now_isoformat',
-      'description': 'Created new sequence NC_772442 in Isolate Important',
-      'id': 'bf1b993c.4',
+      'description': 'Created new sequence PV426197 in Isolate Ever',
+      'id': 'fb085f7f.3',
       'method_name': 'create_sequence',
       'user': dict({
         'handle': 'leeashley',
         'id': 1,
       }),
     }),
-    'name': 'Pepper bunchy top virus',
+    'name': 'Squash browning spot virus',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'schema': list([
       dict({
         'molecule': 'ssRNA',
-        'name': 'DNA M',
+        'name': 'DNA A',
         'required': True,
       }),
       dict({
         'molecule': 'ssRNA',
-        'name': 'RNA_R',
-        'required': True,
-      }),
-      dict({
-        'molecule': 'ssRNA',
-        'name': 'RNA_L',
+        'name': 'DNA_U3',
         'required': True,
       }),
     ]),
     'verified': True,
-    'version': 4,
+    'version': 3,
   })
 # ---
 # name: TestGetSequence.test_ok
@@ -2793,12 +2779,12 @@
     'accession': 'VC280715',
     'definition': 'Exactly drive well good explain grow water.',
     'host': 'prunus',
-    'id': '7cf872dc',
-    'otu_id': 'bf1b993c',
+    'id': '3cbb22cc',
+    'otu_id': 'fb085f7f',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'segment': 'DNA M',
@@ -2809,46 +2795,22 @@
   list([
     dict({
       'created_at': 'approximately_now_isoformat',
-      'description': 'Created new sequence NC_772442 in Isolate Important',
-      'id': 'bf1b993c.4',
+      'description': 'Created new sequence PV426197 in Isolate Ever',
+      'id': 'fb085f7f.3',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
       }),
       'method_name': 'create_sequence',
       'otu': dict({
-        'id': 'bf1b993c',
-        'name': 'Pepper bunchy top virus',
-        'version': 4,
-      }),
-      'reference': dict({
-        'data_type': 'genome',
-        'id': 'hxn167',
-        'name': 'Reference A',
-      }),
-      'user': dict({
-        'handle': 'leeashley',
-        'id': 1,
-      }),
-    }),
-    dict({
-      'created_at': 'approximately_now_isoformat',
-      'description': 'Created new sequence NC_688181 in Isolate Important',
-      'id': 'bf1b993c.3',
-      'index': dict({
-        'id': 'unbuilt',
-        'version': 'unbuilt',
-      }),
-      'method_name': 'create_sequence',
-      'otu': dict({
-        'id': 'bf1b993c',
-        'name': 'Pepper bunchy top virus',
+        'id': 'fb085f7f',
+        'name': 'Squash browning spot virus',
         'version': 3,
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'hxn167',
-        'name': 'Reference A',
+        'id': 'bf1b993c',
+        'name': 'Reference',
       }),
       'user': dict({
         'handle': 'leeashley',
@@ -2857,22 +2819,22 @@
     }),
     dict({
       'created_at': 'approximately_now_isoformat',
-      'description': 'Created new sequence VC280715 in Isolate Important',
-      'id': 'bf1b993c.2',
+      'description': 'Created new sequence NC_112201 in Isolate Ever',
+      'id': 'fb085f7f.2',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
       }),
       'method_name': 'create_sequence',
       'otu': dict({
-        'id': 'bf1b993c',
-        'name': 'Pepper bunchy top virus',
+        'id': 'fb085f7f',
+        'name': 'Squash browning spot virus',
         'version': 2,
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'hxn167',
-        'name': 'Reference A',
+        'id': 'bf1b993c',
+        'name': 'Reference',
       }),
       'user': dict({
         'handle': 'leeashley',
@@ -2881,22 +2843,22 @@
     }),
     dict({
       'created_at': 'approximately_now_isoformat',
-      'description': 'Added Isolate Important as default',
-      'id': 'bf1b993c.1',
+      'description': 'Added Isolate Ever as default',
+      'id': 'fb085f7f.1',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
       }),
       'method_name': 'add_isolate',
       'otu': dict({
-        'id': 'bf1b993c',
-        'name': 'Pepper bunchy top virus',
+        'id': 'fb085f7f',
+        'name': 'Squash browning spot virus',
         'version': 1,
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'hxn167',
-        'name': 'Reference A',
+        'id': 'bf1b993c',
+        'name': 'Reference',
       }),
       'user': dict({
         'handle': 'leeashley',
@@ -2905,22 +2867,22 @@
     }),
     dict({
       'created_at': 'approximately_now_isoformat',
-      'description': 'Created Pepper bunchy top virus (PBTV)',
-      'id': 'bf1b993c.0',
+      'description': 'Created Squash browning spot virus (SBSV)',
+      'id': 'fb085f7f.0',
       'index': dict({
         'id': 'unbuilt',
         'version': 'unbuilt',
       }),
       'method_name': 'create',
       'otu': dict({
-        'id': 'bf1b993c',
-        'name': 'Pepper bunchy top virus',
+        'id': 'fb085f7f',
+        'name': 'Squash browning spot virus',
         'version': 0,
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'hxn167',
-        'name': 'Reference A',
+        'id': 'bf1b993c',
+        'name': 'Reference',
       }),
       'user': dict({
         'handle': 'leeashley',
@@ -2955,7 +2917,7 @@
       'accession': 'VC280715',
       'definition': 'Exactly drive well good explain grow water.',
       'host': 'prunus',
-      'id': '7cf872dc',
+      'id': '3cbb22cc',
       'remote': None,
       'segment': 'DNA M',
       'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',
@@ -2964,7 +2926,7 @@
       'accession': 'NC_688181',
       'definition': 'Buy throw like lawyer fund indicate help.',
       'host': 'lettuce',
-      'id': '3cbb22cc',
+      'id': 'da42dca3',
       'remote': None,
       'segment': 'RNA_R',
       'sequence': 'CGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAGGHCACTACGACTGGTAAGATACGACGACCTTCCTAAGAHTHCTGTGCTATTTWYCGGTAAGCAAAAATGTTCCTTGMAGCAAGGAVCAGGKGAGAGGGCGGGGACRATTTTCAGCRGAGTTCVHCTAGCGGGAGGTGGCCGTCTTGTCTAGMGCTTAGSGTGCTTGTGCTTTAACGCYGCYTTRCGATGACGHSGAGCRCCTGCAYAGBTGGGATAAACTGGTTGCACTCYTATCCCAATCCGAADTHGCCYTCCGGCCTTCCTACSGCAADTGGTTATGGACHWGTGCACAGCGTAYRAGAGTTHGCGTCCRCCAACTAGGGCGGCAAGANWAGGTGAACGCCATGCCCRATGTGAACAATTSGCCTCCCTCGGTGACCTGTACHCATTCGGTGGCCGTGGGKGCCMGGGCAACCGCCTTTGGATTTTTTCMTCCCATGTAGCGTAATTGCRTTAGTAAAGGCTTCGGGGGAYGTATGTCTYTWAAHCCACCBGNRTAAMTGGGGCMCBGTAAWAGTGACAAGTWACTCGGGAGCGTCAGGGGTACCWCCCTSCTGACTCTTTAACCCAGYATGAGGTHTAGTGCGGCCTTGVAAVATCCCATATAGAACAGCCCCCCGYCCCGTHGGAAAGGACATCTGSGTCCGTCAGTGGCAGTGATGARGATGCGTAACAACTCGTGAATGTAAGCGCACCAGGAGGTCTTAGWGACMTTGGGGDGGCAAACCTTAAGCTTTRVCAAGTCCHATCCATCCTAACTGTGAAADTCGCGCGGAGTGGAGTTCTGGATGGCTTGATMBATGCAGTTTAAGAAGGTCTGTGTATACTDATTGTGCTACAATACCTACTAKAAACRGTGATBAAGAGTCCGACATWTTTCGCGRTGAACCTCSTTVCCRATGTACGGGTAACAACCCCATCGTYATGGGTCTVATTGGCTCTATTCTGKTKGGDGTCTGCGTTBTGVTATAGGGACTVACYGGATTCAAGCCGGTTCTGAGGTMCTMTAAGAATACACACCAGAAGCCAACACGVGAAGGTACBGCAGTTYCCTTCACGDGSCAATGAR',
@@ -2973,7 +2935,7 @@
       'accession': 'NC_772442',
       'definition': 'Common prevent spend.',
       'host': 'sweet potato',
-      'id': 'da42dca3',
+      'id': '09d01419',
       'remote': None,
       'segment': 'RNA_L',
       'sequence': 'ACCCCTCCGTTATMTTCTAGCGATGTATTGTCHGGATWCACGCATGAAGAATCGYACGAGCCBDTAGTAGTGGGGGRTCCMCCGAGTTBGGTGACTVANTTCCTGCACTGTCCCWATCTAACWTGAGTCCCCGRCGGCATAACCVCGGVCBTTCGAAKTGCCTAAATACACACATTKGYAAAGTTCAAGTCAGSTCTTATGTGCTGCTCATAACCGACAMCNATTTGACTAGABACTGAGTCAAKAATGTCAGRGTACTTAGTGYGACGGGCRGTTGTGAATTAGTTATACTCTHGRVGGAGYTCGATACVCCGTTCTNNAGGHCAAGGGATTAAATAGBVWCVGAGCAATAAACAYGGGGCCCGCTGTCMNGMAGGGTGGMGKAANCKAMCCCACCTDASCGNGGGCAATATACCCGCCATNGAGAGTGAVTAAAATTTTAACTTGTAATCGCAACCGCGATHCAGGCAGTTAGATAGTACGAGCCGCGRGTGCVAATAVGGSAGTTTYGWTTYAGGAGGNGGADTGAGADAGAGGCATCRAATAGTATCCCAAGGCABGAAACCAGATGCAGGAVTTCTTCTTTGGTAAACYTTGCTAGCAGCGATAACAATTGATTACTTACHAGTGCAATTGGAGTWGACGKATAGACGGTACTCCCAAGTTADNCATAGACGCTTSATTTAGCGATATYTHAGAVCDTTGCCGTGCGGAHCTAAGGGARTYKCTCATMMNGAGTAMCGTCCTTGCAGGTCTCCTCAA',
@@ -3018,21 +2980,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.5',
+    'id': 'fb085f7f.5',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.set_as_default: 'set_as_default'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Squash browning spot virus',
       'version': 5,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -3043,7 +3005,7 @@
 # name: TestSetAsDefault.test[json]
   dict({
     'default': True,
-    'id': 'da42dca3',
+    'id': '09d01419',
     'sequences': list([
     ]),
     'source_name': 'b',
@@ -3053,30 +3015,30 @@
 # name: TestSetAsDefault.test_no_change[json]
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
       dict({
-        '_id': '7cf872dc',
+        '_id': '3cbb22cc',
         'accession': 'NC_112201',
         'definition': 'Raise study modern miss dog Democrat quickly.',
         'host': 'okra',
-        'isolate_id': 'fb085f7f',
-        'otu_id': 'bf1b993c',
+        'isolate_id': '7cf872dc',
+        'otu_id': 'fb085f7f',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA A',
         'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
       }),
       dict({
-        '_id': '3cbb22cc',
+        '_id': 'da42dca3',
         'accession': 'PV426197',
         'definition': 'Tell time special beyond could key assume.',
         'host': 'tobacco',
-        'isolate_id': 'fb085f7f',
-        'otu_id': 'bf1b993c',
+        'isolate_id': '7cf872dc',
+        'otu_id': 'fb085f7f',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA_U3',
         'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3089,15 +3051,15 @@
 # name: TestUpdateIsolate.test_force_case
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
       dict({
         'accession': 'NC_112201',
         'definition': 'Raise study modern miss dog Democrat quickly.',
         'host': 'okra',
-        'id': '7cf872dc',
+        'id': '3cbb22cc',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA A',
         'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3106,9 +3068,9 @@
         'accession': 'PV426197',
         'definition': 'Tell time special beyond could key assume.',
         'host': 'tobacco',
-        'id': '3cbb22cc',
+        'id': 'da42dca3',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA_U3',
         'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3156,21 +3118,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.4',
+    'id': 'fb085f7f.4',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.edit_isolate: 'edit_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Squash browning spot virus',
       'version': 4,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -3181,15 +3143,15 @@
 # name: TestUpdateIsolate.test_ok[both][json]
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
       dict({
         'accession': 'NC_112201',
         'definition': 'Raise study modern miss dog Democrat quickly.',
         'host': 'okra',
-        'id': '7cf872dc',
+        'id': '3cbb22cc',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA A',
         'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3198,9 +3160,9 @@
         'accession': 'PV426197',
         'definition': 'Tell time special beyond could key assume.',
         'host': 'tobacco',
-        'id': '3cbb22cc',
+        'id': 'da42dca3',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA_U3',
         'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3213,17 +3175,17 @@
 # name: TestUpdateIsolate.test_ok[both][otu]
   dict({
     'abbreviation': 'SBSV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
           dict({
             'accession': 'NC_112201',
             'definition': 'Raise study modern miss dog Democrat quickly.',
             'host': 'okra',
-            'id': '7cf872dc',
+            'id': '3cbb22cc',
             'remote': None,
             'segment': 'DNA A',
             'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3232,7 +3194,7 @@
             'accession': 'PV426197',
             'definition': 'Tell time special beyond could key assume.',
             'host': 'tobacco',
-            'id': '3cbb22cc',
+            'id': 'da42dca3',
             'remote': None,
             'segment': 'DNA_U3',
             'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3247,7 +3209,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Renamed Isolate Ever to Variant A',
-      'id': 'bf1b993c.4',
+      'id': 'fb085f7f.4',
       'method_name': <HistoryMethod.edit_isolate: 'edit_isolate'>,
       'user': dict({
         'handle': 'leeashley',
@@ -3269,8 +3231,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': True,
@@ -3303,21 +3265,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.4',
+    'id': 'fb085f7f.4',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.edit_isolate: 'edit_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Squash browning spot virus',
       'version': 4,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -3328,15 +3290,15 @@
 # name: TestUpdateIsolate.test_ok[source_name][json]
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
       dict({
         'accession': 'NC_112201',
         'definition': 'Raise study modern miss dog Democrat quickly.',
         'host': 'okra',
-        'id': '7cf872dc',
+        'id': '3cbb22cc',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA A',
         'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3345,9 +3307,9 @@
         'accession': 'PV426197',
         'definition': 'Tell time special beyond could key assume.',
         'host': 'tobacco',
-        'id': '3cbb22cc',
+        'id': 'da42dca3',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA_U3',
         'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3360,17 +3322,17 @@
 # name: TestUpdateIsolate.test_ok[source_name][otu]
   dict({
     'abbreviation': 'SBSV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
           dict({
             'accession': 'NC_112201',
             'definition': 'Raise study modern miss dog Democrat quickly.',
             'host': 'okra',
-            'id': '7cf872dc',
+            'id': '3cbb22cc',
             'remote': None,
             'segment': 'DNA A',
             'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3379,7 +3341,7 @@
             'accession': 'PV426197',
             'definition': 'Tell time special beyond could key assume.',
             'host': 'tobacco',
-            'id': '3cbb22cc',
+            'id': 'da42dca3',
             'remote': None,
             'segment': 'DNA_U3',
             'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3394,7 +3356,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Renamed Isolate Ever to Isolate A',
-      'id': 'bf1b993c.4',
+      'id': 'fb085f7f.4',
       'method_name': <HistoryMethod.edit_isolate: 'edit_isolate'>,
       'user': dict({
         'handle': 'leeashley',
@@ -3416,8 +3378,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': True,
@@ -3450,21 +3412,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.4',
+    'id': 'fb085f7f.4',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.edit_isolate: 'edit_isolate'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Squash browning spot virus',
       'version': 4,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -3475,15 +3437,15 @@
 # name: TestUpdateIsolate.test_ok[source_type][json]
   dict({
     'default': True,
-    'id': 'fb085f7f',
+    'id': '7cf872dc',
     'sequences': list([
       dict({
         'accession': 'NC_112201',
         'definition': 'Raise study modern miss dog Democrat quickly.',
         'host': 'okra',
-        'id': '7cf872dc',
+        'id': '3cbb22cc',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA A',
         'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3492,9 +3454,9 @@
         'accession': 'PV426197',
         'definition': 'Tell time special beyond could key assume.',
         'host': 'tobacco',
-        'id': '3cbb22cc',
+        'id': 'da42dca3',
         'reference': dict({
-          'id': 'hxn167',
+          'id': 'bf1b993c',
         }),
         'segment': 'DNA_U3',
         'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3507,17 +3469,17 @@
 # name: TestUpdateIsolate.test_ok[source_type][otu]
   dict({
     'abbreviation': 'SBSV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
           dict({
             'accession': 'NC_112201',
             'definition': 'Raise study modern miss dog Democrat quickly.',
             'host': 'okra',
-            'id': '7cf872dc',
+            'id': '3cbb22cc',
             'remote': None,
             'segment': 'DNA A',
             'sequence': 'CCCNYGACCCGTGAAGTGAAGACYCGACCCTTHAABAAAGSATATACTACAAVATGGKACDAGGTTCTACTCCTTGTCAGTATTWTTTWCCGTTCAATTCTGCTTGTCATTACCCGGCTCGGGANCAGVTGTAGAGCAACGTHAGTATCGGACCTGTAAGCWSYAGGCGRCTCACAATGGTCAAVTTCTCTAACATTTAYCGHTCGTTGGKCTHCAAGAATCTCCGTTVTGTTAGGRCGATAAWAAATCAVVATGGCYTCCCACATBGGAATGGCGGAAGATAAGTAACDCRCCGGGVGRACCGCGTCGGCAACTAGSTTGACATGAATCGGCAVTCTACAACCACTTGCGCCCTAGCGAYGYGGGCGAGTGCGAAMCRSCCAAGGGGTTATCKMTAGGATGAKBGAATATAHGAGAACSAATACGAATBADTCTSBCANACAGWGTTGTTAAAAATCGATCATTWATTGTATCWGTCGGTTGTTCSACCCAAGCATGCCAGCGGTGTVAGATCCTATTGYCAGTTCTKATTCCCCTCTGGTTCAGTCACTCTCGTCATGACACGACAGGGCAACNGGGTGTACTATGTTGCAYTGTGTAASCATTAAACACCGCTGTCCCBBMMCCGATAAACAGGDTKCTAGGTCTAATACAACGTGTTGAMACGAGHCAAAGTKTATGGAACAGMTTCTCATTCCTTAGAGTTGCGCGACAGTGGCAGTCGTCTAGCTCAATHCAGGGCGAGGGTCCRAGCTCAACCCWCTGTCGGGTAAGBTTGCTCTTCGAACAATCAADTGATTATVGTTTCGGCAKTTAAGCGATGGTAGAGGAAMCCCACTGGAMAATATTGTTCTTRCHGCTGCGTCAGAGCGTGACTHDACTDKCGGTYRTGAGCWTCTGCVAAAAMWCWGGGACTWAACAACGCGTTTNGWCCVAGGGGACKCTWCTCGTACSGCCC',
@@ -3526,7 +3488,7 @@
             'accession': 'PV426197',
             'definition': 'Tell time special beyond could key assume.',
             'host': 'tobacco',
-            'id': '3cbb22cc',
+            'id': 'da42dca3',
             'remote': None,
             'segment': 'DNA_U3',
             'sequence': 'CSTGGCAAATGTGCTGACGAGTACCACTAAACAMGWTRVGTCCTTAAACCGAGACGCWTCACGATGTTMNARCACCAGGACCTCATCCCCGTGATTCGCVGATAGAGATATTAGGTGAATRGCCGTAGATTATACCACCGCAAGGGTCAGTBCAYCTATACAAKCTGCWCGGATTATTGCGACAMATGNAGCAGACGCTATYTTACCATCDTTCTTCTCGNGTACCTATGDAGAGATGTKGCATTCNTCMTCGCGABACTCTTGTGTACATTAGGGCCAATCGTGGGTABGTGRTCTGYVGTGNTWCDNGGAACGMCGCACVAGCTGAGGCACCTCGKCGAGKAGGGCCAGTAATGCYMACTCCCAGCCCACAGGAAATWCTTAAGAGGACAGCGCGMCGTAATGTACWCTACTTTGTSGCGTTAGTCCCTYTTTGNGCTTTTABCATTCHHCCGCCTGATGTDVCAAATAGTTATAACMAGAAGGAATMTGTTGCTCGGGCCAWGTGCCTCCACAAYAGCCTTTCTGTTCMAGATGTTTCTTCCMDCATCCWAAGGGCGTATGGBGGCGAKGCTCCGCATTRGCAAATCAGGGTCVGTGACTTTCGCAGGWTCCGGAAGCGTAANACCTCADCATGTGGTDAGCATCTGATCTGTAACCANCTGATCBGGATATTTTGAGCTCACAGTTNCTGACCGCCCGTCGNGBTCGTTHTNGAGVTCGAGTGWACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATG',
@@ -3541,7 +3503,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Renamed Isolate Ever to Variant Ever',
-      'id': 'bf1b993c.4',
+      'id': 'fb085f7f.4',
       'method_name': <HistoryMethod.edit_isolate: 'edit_isolate'>,
       'user': dict({
         'handle': 'leeashley',
@@ -3563,8 +3525,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': True,
@@ -3574,7 +3536,7 @@
 # name: TestUpdateSequence.test_ok[True][history]
   dict({
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
-    'description': 'Edited sequence 7cf872dc in Isolate Important',
+    'description': 'Edited sequence 3cbb22cc in Isolate Important',
     'diff': list([
       list([
         'change',
@@ -3627,21 +3589,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.5',
+    'id': 'fb085f7f.5',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.edit_sequence: 'edit_sequence'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper bunchy top virus',
       'version': 5,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -3654,11 +3616,11 @@
     'accession': 'VC280715',
     'definition': 'A made up sequence',
     'host': 'Grapevine',
-    'id': '7cf872dc',
-    'isolate_id': 'fb085f7f',
-    'otu_id': 'bf1b993c',
+    'id': '3cbb22cc',
+    'isolate_id': '7cf872dc',
+    'otu_id': 'fb085f7f',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 'bf1b993c',
     }),
     'segment': 'DNA M',
     'sequence': 'ATGCGTGTACTG',
@@ -3669,12 +3631,12 @@
     'accession': 'VC280715',
     'definition': 'A made up sequence',
     'host': 'Grapevine',
-    'id': '7cf872dc',
-    'otu_id': 'bf1b993c',
+    'id': '3cbb22cc',
+    'otu_id': 'fb085f7f',
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'segment': 'DNA M',
@@ -3686,11 +3648,11 @@
     'accession': 'VC280715',
     'definition': 'Exactly drive well good explain grow water.',
     'host': 'prunus',
-    'id': '7cf872dc',
-    'isolate_id': 'fb085f7f',
-    'otu_id': 'bf1b993c',
+    'id': '3cbb22cc',
+    'isolate_id': '7cf872dc',
+    'otu_id': 'fb085f7f',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 'bf1b993c',
     }),
     'segment': None,
     'sequence': 'GATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMTGTSCAGCAGGTACCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAA',

--- a/tests/otus/__snapshots__/test_data.ambr
+++ b/tests/otus/__snapshots__/test_data.ambr
@@ -4,7 +4,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'description': 'Created Tobacco mosaic virus (TMV)',
     'diff': dict({
-      '_id': 'bf1b993c',
+      '_id': 'fb085f7f',
       'abbreviation': 'TMV',
       'isolates': list([
       ]),
@@ -12,28 +12,28 @@
       'lower_name': 'tobacco mosaic virus',
       'name': 'Tobacco mosaic virus',
       'reference': dict({
-        'id': 'hxn167',
+        'id': 'bf1b993c',
       }),
       'schema': list([
       ]),
       'verified': False,
       'version': 0,
     }),
-    'id': 'bf1b993c.0',
+    'id': 'fb085f7f.0',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.create: 'create'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Tobacco mosaic virus',
       'version': 0,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -44,7 +44,7 @@
 # name: test_create[full][otu]
   dict({
     'abbreviation': 'TMV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
     ]),
     'issues': dict({
@@ -57,7 +57,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Created Tobacco mosaic virus (TMV)',
-      'id': 'bf1b993c.0',
+      'id': 'fb085f7f.0',
       'method_name': <HistoryMethod.create: 'create'>,
       'user': dict({
         'handle': 'leeashley',
@@ -69,8 +69,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -80,7 +80,7 @@
 # name: test_create[full][return_value]
   dict({
     'abbreviation': 'TMV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
     ]),
     'issues': dict({
@@ -93,7 +93,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Created Tobacco mosaic virus (TMV)',
-      'id': 'bf1b993c.0',
+      'id': 'fb085f7f.0',
       'method_name': <HistoryMethod.create: 'create'>,
       'user': dict({
         'handle': 'leeashley',
@@ -105,8 +105,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -118,7 +118,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'description': 'Created Prunus virus A',
     'diff': dict({
-      '_id': 'bf1b993c',
+      '_id': 'fb085f7f',
       'abbreviation': '',
       'isolates': list([
       ]),
@@ -126,28 +126,28 @@
       'lower_name': 'prunus virus a',
       'name': 'Prunus virus A',
       'reference': dict({
-        'id': 'hxn167',
+        'id': 'bf1b993c',
       }),
       'schema': list([
       ]),
       'verified': False,
       'version': 0,
     }),
-    'id': 'bf1b993c.0',
+    'id': 'fb085f7f.0',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.create: 'create'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Prunus virus A',
       'version': 0,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -158,7 +158,7 @@
 # name: test_create[no_abbreviation][otu]
   dict({
     'abbreviation': '',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
     ]),
     'issues': dict({
@@ -171,7 +171,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Created Prunus virus A',
-      'id': 'bf1b993c.0',
+      'id': 'fb085f7f.0',
       'method_name': <HistoryMethod.create: 'create'>,
       'user': dict({
         'handle': 'leeashley',
@@ -183,8 +183,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -194,7 +194,7 @@
 # name: test_create[no_abbreviation][return_value]
   dict({
     'abbreviation': '',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
     ]),
     'issues': dict({
@@ -207,7 +207,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Created Prunus virus A',
-      'id': 'bf1b993c.0',
+      'id': 'fb085f7f.0',
       'method_name': <HistoryMethod.create: 'create'>,
       'user': dict({
         'handle': 'leeashley',
@@ -219,8 +219,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': False,
@@ -270,7 +270,7 @@
     'lower_name': 'prunus virus f',
     'name': 'Prunus virus F',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 'bf1b993c',
     }),
     'remote_id': None,
     'schema': list([
@@ -317,21 +317,21 @@
         ]),
       ]),
     ]),
-    'id': 'bf1b993c.5',
+    'id': 'fb085f7f.5',
     'index': dict({
       'id': 'unbuilt',
       'version': 'unbuilt',
     }),
     'method_name': <HistoryMethod.edit: 'edit'>,
     'otu': dict({
-      'id': 'bf1b993c',
+      'id': 'fb085f7f',
       'name': 'Pepper leafroll virus',
       'version': 5,
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'user': dict({
       'handle': 'leeashley',
@@ -342,17 +342,17 @@
 # name: test_update[return_value]
   dict({
     'abbreviation': 'TMV',
-    'id': 'bf1b993c',
+    'id': 'fb085f7f',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'fb085f7f',
+        'id': '7cf872dc',
         'sequences': list([
           dict({
             'accession': 'NC_795330',
             'definition': 'Bring determine some forward staff.',
             'host': 'prunus',
-            'id': '7cf872dc',
+            'id': '3cbb22cc',
             'remote': None,
             'segment': 'RNA_C',
             'sequence': 'GGAGCSCAAAGAAGACADGCGAGCCGAATTACCGTTRCRCGAGGAACAKCAGRGKCTCAGCAGCAGCCCCGGATGGACGAATGCGAGCGGAAGTGRCAATGAGHTCBHGAAWTAAGHGCACATGACKCAYGATCGCAAGAATTTCGGBCCCCTGATTATTTAGATACTVAAGMTGGTGTACCTGGAACATGAACGNAGAATACTKGGAAANCAAAGGACGACTCNGCACTGACCCCTCGGGNCGCMAGGTTCGCATTGCGCYAATGTGGGCTTCAAGCCATGTRTHGDCTGAGGTCTCTGGTTAMT',
@@ -361,7 +361,7 @@
             'accession': 'NC_076279',
             'definition': 'Purpose character would in.',
             'host': 'rice',
-            'id': '3cbb22cc',
+            'id': 'da42dca3',
             'remote': None,
             'segment': 'RNA-U3',
             'sequence': 'CCAGACATGCAGGAAGCMCDGTGBTTGBVAGNATTATCBRATACCGTGGCCCCWAGTAAATABGTTCGTTTAGTAGTTCAACGRGTGMTACCGTAATBTGCTCACTTAAACTATCGCTGATTKCTTTCCCTABRTTWAAAACAGMATABTCTCAGTGTCAAHTCTGACBCTCATCATGGTGTGCAAATCAGGGAGTACAABCGRTTCAAATCCTCGACCCBTACGATTNGHGAWKTTAATCTRACATGTTCGAMATAATVTCGGTAGRACGTGGTTAGGGGTAGCCCGTCTCTAATTAATACCAACCATCGTCAAGTGTGTCTCGTTCACTYTCTATGAGACGCGTBTAGTTNARCGGGCCCTACGATAGNACTATTDCTGCTGRATTTCCAACTCGGAANAAYCGDTATTCACKCACCTBCAGGGCGAATATTSATGTGCCTTAACACTCATAWTGTCAKTATCGGTAGCGHGGCAWACCCGGATGAWBGGGCGTGACGCATGTCGCTCCCAGTGSACTCACCMATATATNTGGMNGGCTGTAVGSTCCGAGAGGCAATTTCTTAGCTTAGYCCTCASTGCACCSCCTTTAGGTTCTTGTAACGGGTCAYCGGRTHAATGAGCTAGTCTGGGGAATATTTTGTTTCGATTCCGGCTCCTGTKAAGTAGCCTGBATANCTAAGCAGYGGGGCGGGTAGGAATGTGGCCYGTACACGTWAGCGCGYAGAACAGACCTTTGCAKAATCACGGYCGAKMTTCCTTGCACTWAAAATGGTGGGCGCTGKACGATADACGBATSGAGAGSMTABCTTCTDTATTCTGACGGAAATAAKCAAGGTCGGKTATACTAGTTYTCKATTCCCGGTCGTCCGATGGHTACCACAKGGATATCCAGTGTTACATTAAATACCCGATGAAAAACRCTGGGYGGTACDCATGCTYTTCTTTAHACCHGAGGCCCTGAAAATGTGTGCGTACGGCGACANTCTGTCKATATGCTTGACTCCTTTTTCYCBCCTACGTTACACCAATGCGACTGGGTCVTATBKATTGDGATAGCGTCGATGTGCTTHGGTARAAMGMTTGHCCMNGATTTCACTWGTAGTTGAAGAWACAGCYACGCCTCKTTCAAHABATTTCACTAAAAGAAHTTCCGCCTACATACGGCTGTTGCBGATCATTCMAGGAMCAATTCARTACAAWGTGGATCCGCAGCCMCACCTGAATGCCADCKCTGCATGGTVTNAAAASWGATATATCGCCBCCRTCACGGACTAAGCGCBTCATGHTGMTCMATCCBCTTGACMAAAGTCTATCCGCACARGCTANACBGTAANAAGAAGAACTAGTAG',
@@ -370,7 +370,7 @@
             'accession': 'QX375248',
             'definition': 'Bar standard final.',
             'host': 'apple',
-            'id': 'da42dca3',
+            'id': '09d01419',
             'remote': None,
             'segment': 'RNA L',
             'sequence': 'ACTAGHCTTTCTAHNATTGAGCTGCTCHAGGGACGTCTTGCTATCTGTTTGRBAGCATTTCSAGGTTATACTATGTGSTCGCATVTGGGGGGAACACCAAAGABVGCTTTTGGATAAGCATCGGACCAACTDCGACGGATCTCTGYTCTCGCGGGAACCGCRGCGCTTCCAGDCAAATGAGSAADTGAVACMGTGTCTTCGGGACTAKAAACCCCSGRAGACMCTTYKCGTAHCTHCTGAGAATGCTAKGGGGAGGGCGAGTGCCCAAAGAATHGTGATCVATKACTCGTGBVAGGASAABGCTTTACAGAATGGCSATGTACATTTCCATTTCTAACGCAAATCCCCTCGTGGRCTGATHTCTAATCCCAATSATCYWACTCGGGGGAAGCNATTGCYGNCHATCHCGCCTTTABCGGSTTCTAGCCGAKCGCCGACATCTTGABCACACGTTCMGTGAAVGCCTGGCAGGNGAVGCTGCACAGGGACTAGSKCGATYCTATCTGTAGCHAGACCAGTGGGGGGAAACAACATAATGTCGGATTCDACATBYAGGKCTGCGAATTCTGGTAGCAACCCTCTACACGAATCTGCCAAKAAACCTTCTGCCATGACHTCAATCCGTTGCGGAACCCTAKTATCCGACTGTGANCTGTATTCCGCAACTASAYCSGTCATMATAGGCCTCGGACGCGCBCCAACGACAGGCATTCGCNGAHATCTATTGCAGATGGTCHGGCVKTTCTCRTTCTCAGTCTCCCA',
@@ -385,7 +385,7 @@
     'most_recent_change': dict({
       'created_at': datetime.datetime(2015, 10, 6, 20, 0),
       'description': 'Changed name to Tobacco mosaic virus and changed abbreviation to TMV and modified schema',
-      'id': 'bf1b993c.5',
+      'id': 'fb085f7f.5',
       'method_name': <HistoryMethod.edit: 'edit'>,
       'user': dict({
         'handle': 'leeashley',
@@ -412,8 +412,8 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'hxn167',
-      'name': 'Reference A',
+      'id': 'bf1b993c',
+      'name': 'Reference',
     }),
     'remote': None,
     'verified': True,

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -27,22 +27,17 @@ class TestGet:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
         snapshot_recent: SnapshotAssertion,
         spawn_client: ClientSpawner,
-        test_ref: dict,
     ):
         """Test that a valid request returns the expected history item."""
         client = await spawn_client(authenticated=True)
 
-        await asyncio.gather(
-            fake.users.create(),
-            mongo.references.insert_one({**test_ref}),
-        )
-
         user = await data_layer.users.get(client.user.id)
 
-        otu = await fake.otus.create(test_ref["_id"], user=user)
+        reference = await fake.references.create(user=user)
+
+        otu = await fake.otus.create(reference.id, user=user)
 
         response = await client.get(f"/otus/{otu.id}")
 
@@ -63,22 +58,17 @@ class TestListHistory:
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mongo: Mongo,
         snapshot_recent: SnapshotAssertion,
         spawn_client: ClientSpawner,
-        test_ref: dict,
     ):
         """Test that an OTU's history is listed from Postgres."""
         client = await spawn_client(authenticated=True)
 
-        await asyncio.gather(
-            fake.users.create(),
-            mongo.references.insert_one({**test_ref}),
-        )
-
         user = await data_layer.users.get(client.user.id)
 
-        otu = await fake.otus.create(test_ref["_id"], user=user)
+        reference = await fake.references.create(user=user)
+
+        otu = await fake.otus.create(reference.id, user=user)
 
         resp = await client.get(f"/otus/{otu.id}/history")
 
@@ -149,13 +139,13 @@ class TestEdit:
         existing_abbreviation: str,
         description: str,
         check_ref_right,
+        fake: DataFaker,
         mongo: Mongo,
         pg: AsyncEngine,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         resp_is: RespIs,
         test_otu,
-        test_ref,
     ):
         """Test that changing the name and abbreviation results:
 
@@ -165,11 +155,14 @@ class TestEdit:
         """
         client = await spawn_client(authenticated=True)
 
-        await asyncio.gather(
-            mongo.otus.insert_one(
-                {**test_otu, "existing_abbreviation": existing_abbreviation},
-            ),
-            mongo.references.insert_one(test_ref),
+        reference = await fake.references.create(user=client.user)
+
+        await mongo.otus.insert_one(
+            {
+                **test_otu,
+                "existing_abbreviation": existing_abbreviation,
+                "reference": {"id": reference.id},
+            },
         )
 
         resp = await client.patch("/otus/6116cba1", data)
@@ -266,7 +259,6 @@ class TestEdit:
         snapshot: SnapshotAssertion,
         test_change,
         test_otu,
-        test_ref,
         test_sequence,
     ):
         client = await spawn_client(authenticated=True)
@@ -275,9 +267,10 @@ class TestEdit:
 
         change = {**test_change, "user": {"id": user.id}, "_id": "6116cba1.0"}
 
+        reference = await fake.references.create(user=user)
+
         await asyncio.gather(
-            mongo.otus.insert_one(test_otu),
-            mongo.references.insert_one(test_ref),
+            mongo.otus.insert_one({**test_otu, "reference": {"id": reference.id}}),
             mongo.sequences.insert_one(test_sequence),
         )
 
@@ -324,7 +317,6 @@ class TestDelete:
         resp_is: RespIs,
         test_change,
         test_otu,
-        test_ref,
         test_sequence,
     ):
         """Test that an OTU can be deleted.
@@ -339,9 +331,9 @@ class TestDelete:
 
         user = await fake.users.create()
 
-        await mongo.references.insert_one(test_ref)
+        reference = await fake.references.create(user=user)
 
-        otu = await fake.otus.create(test_ref["_id"], user)
+        otu = await fake.otus.create(reference.id, user)
 
         resp = await client.delete(f"/otus/{otu.id}")
 
@@ -520,7 +512,6 @@ class TestAddIsolate:
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         """Test that the first isolate for an OTu is set as the ``default`` otu even if
         ``default`` is set to ``False`` in the POST input.
@@ -532,10 +523,10 @@ class TestAddIsolate:
 
         user = await fake.users.create()
 
-        await mongo.references.insert_one(test_ref)
+        reference = await fake.references.create(user=user)
 
         otu = await data_layer.otus.create(
-            "hxn167",
+            reference.id,
             CreateOTURequest(
                 abbreviation="PVF",
                 name="Prunus virus F",
@@ -581,7 +572,6 @@ class TestAddIsolate:
         spawn_client: ClientSpawner,
         static_time: StaticTime,
         resp_is: RespIs,
-        test_ref: dict,
     ):
         """Test that the ``source_type`` value is forced to lower case."""
         client = await spawn_client(
@@ -589,12 +579,12 @@ class TestAddIsolate:
             base_url="https://virtool.example.com",
         )
 
-        await mongo.references.insert_one(test_ref)
-
         user = await fake.users.create()
 
+        reference = await fake.references.create(user=user)
+
         otu = await data_layer.otus.create(
-            "hxn167",
+            reference.id,
             CreateOTURequest(
                 abbreviation="PVF",
                 name="Prunus virus F",
@@ -652,26 +642,12 @@ class TestUpdateIsolate:
         mongo: Mongo,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         self.client = await spawn_client(authenticated=True)
 
-        await mongo.references.insert_one(
-            {
-                **test_ref,
-                "users": [
-                    {
-                        "id": self.client.user.id,
-                        "build": True,
-                        "modify": True,
-                        "modify_otu": True,
-                        "remove": True,
-                    },
-                ],
-            },
-        )
+        reference = await fake.references.create(user=self.client.user)
 
-        self.otu = await fake.otus.create("hxn167", self.client.user)
+        self.otu = await fake.otus.create(reference.id, self.client.user)
         self.isolate = self.otu.isolates[0]
 
     @pytest.mark.parametrize(
@@ -776,26 +752,12 @@ class TestSetAsDefault:
         mongo: Mongo,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         self.client = await spawn_client(authenticated=True)
 
-        await mongo.references.insert_one(
-            {
-                **test_ref,
-                "users": [
-                    {
-                        "id": self.client.user.id,
-                        "build": True,
-                        "modify": True,
-                        "modify_otu": True,
-                        "remove": True,
-                    },
-                ],
-            },
-        )
+        reference = await fake.references.create(user=self.client.user)
 
-        self.otu = await fake.otus.create("hxn167", self.client.user)
+        self.otu = await fake.otus.create(reference.id, self.client.user)
         self.isolate = self.otu.isolates[0]
 
     async def test(
@@ -883,7 +845,6 @@ class TestDeleteIsolate:
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         """Test that a valid request results in a ``204`` response and the isolate and
         associated sequence data is removed.
@@ -892,9 +853,9 @@ class TestDeleteIsolate:
 
         user = await fake.users.create()
 
-        await mongo.references.insert_one(test_ref)
+        reference = await fake.references.create(user=user)
 
-        otu = await fake.otus.create("hxn167", user)
+        otu = await fake.otus.create(reference.id, user)
 
         isolate = otu.isolates[0]
 
@@ -943,7 +904,6 @@ class TestDeleteIsolate:
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         """Test that a valid request results in a ``204`` response and ``default``
         status is reassigned correctly.
@@ -952,9 +912,9 @@ class TestDeleteIsolate:
 
         user = await fake.users.create()
 
-        await mongo.references.insert_one(test_ref)
+        reference = await fake.references.create(user=user)
 
-        otu = await fake.otus.create("hxn167", user)
+        otu = await fake.otus.create(reference.id, user)
 
         first_isolate = otu.isolates[0]
 
@@ -1021,16 +981,15 @@ class TestListSequences:
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
-        test_ref,
     ):
         """Test that sequences can be listed for an isolate."""
         client = await spawn_client(authenticated=True)
 
-        await mongo.references.insert_one(test_ref)
-
         user = await fake.users.create()
 
-        otu = await fake.otus.create(test_ref["_id"], user)
+        reference = await fake.references.create(user=user)
+
+        otu = await fake.otus.create(reference.id, user)
 
         resp = await client.get(
             f"/otus/{otu.id}/isolates/{otu.isolates[0].id}/sequences",
@@ -1059,15 +1018,14 @@ class TestGetSequence:
         mongo: Mongo,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
-        test_ref: dict,
     ):
         client = await spawn_client(authenticated=True)
 
-        await mongo.references.insert_one(test_ref)
-
         user = await fake.users.create()
 
-        otu = await fake.otus.create(test_ref["_id"], user)
+        reference = await fake.references.create(user=user)
+
+        otu = await fake.otus.create(reference.id, user)
         isolate = otu.isolates[0]
         sequence = isolate.sequences[0]
 
@@ -1089,13 +1047,12 @@ class TestCreateSequence:
         fake: DataFaker,
         mongo: Mongo,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         user = await fake.users.create()
 
-        await mongo.references.insert_one(test_ref)
+        reference = await fake.references.create(user=user)
 
-        self.otu = await fake.otus.create(test_ref["_id"], user)
+        self.otu = await fake.otus.create(reference.id, user)
         self.isolate = self.otu.isolates[0]
 
     async def test_ok(
@@ -1178,15 +1135,14 @@ class TestUpdateSequence:
         fake: DataFaker,
         mongo: Mongo,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         self.client = await spawn_client(authenticated=True)
 
         user = await fake.users.create()
 
-        await mongo.references.insert_one(test_ref)
+        reference = await fake.references.create(user=user)
 
-        self.otu = await fake.otus.create(test_ref["_id"], user)
+        self.otu = await fake.otus.create(reference.id, user)
         self.isolate = self.otu.isolates[0]
         self.sequence = self.isolate.sequences[0]
 
@@ -1344,29 +1300,14 @@ class TestDeleteSequence:
         fake: DataFaker,
         mongo: Mongo,
         static_time: StaticTime,
-        test_ref: dict,
     ):
         self.client = await spawn_client(authenticated=True)
 
         user = await fake.users.create()
 
-        await mongo.references.insert_one(
-            {
-                **test_ref,
-                "users": [
-                    {
-                        "id": self.client.user.id,
-                        "build": True,
-                        "modify": True,
-                        "remove": True,
-                        "modify_otu": True,
-                        "remove_otu": True,
-                    },
-                ],
-            },
-        )
+        reference = await fake.references.create(user=self.client.user)
 
-        self.otu = await fake.otus.create(test_ref["_id"], user)
+        self.otu = await fake.otus.create(reference.id, user)
         self.isolate = self.otu.isolates[0]
         self.sequence = self.isolate.sequences[0]
 

--- a/tests/otus/test_data.py
+++ b/tests/otus/test_data.py
@@ -6,7 +6,6 @@ TODO: Use `fake` fixture.
 
 """
 
-import asyncio
 from asyncio import gather
 
 import pytest
@@ -14,7 +13,6 @@ from syrupy import SnapshotAssertion
 
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
-from virtool.mongo.core import Mongo
 from virtool.otus.oas import CreateOTURequest, UpdateOTURequest
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
@@ -31,15 +29,13 @@ async def test_create(
     data: CreateOTURequest,
     data_layer: DataLayer,
     fake: DataFaker,
-    mongo: Mongo,
     snapshot: SnapshotAssertion,
     static_time: StaticTime,
-    test_ref: dict,
 ):
     user = await fake.users.create()
-    await mongo.references.insert_one(test_ref)
+    reference = await fake.references.create(user=user)
 
-    otu = await data_layer.otus.create(test_ref["_id"], data, user.id)
+    otu = await data_layer.otus.create(reference.id, data, user.id)
 
     assert otu == snapshot(name="return_value")
 
@@ -82,17 +78,13 @@ async def test_get_fasta(mongo, snapshot, test_otu, test_sequence, data_layer):
 async def test_update(
     data_layer: DataLayer,
     fake: DataFaker,
-    mongo: Mongo,
     snapshot: SnapshotAssertion,
     static_time: StaticTime,
-    test_ref: dict,
 ):
-    user, _ = await asyncio.gather(
-        fake.users.create(),
-        mongo.references.insert_one(test_ref),
-    )
+    user = await fake.users.create()
+    reference = await fake.references.create(user=user)
 
-    otu = await fake.otus.create(test_ref["_id"], user)
+    otu = await fake.otus.create(reference.id, user)
 
     updated_otu = await data_layer.otus.update(
         otu.id,
@@ -123,7 +115,9 @@ async def test_set_default(
     data_layer,
 ):
     user = await fake.users.create()
+    reference = await fake.references.create(user=user)
 
+    test_otu["reference"] = {"id": reference.id}
     test_otu["isolates"].append(
         {"default": False, "id": "bar", "source_type": "isolate", "source_name": "A"},
     )

--- a/tests/references/__snapshots__/test_db.ambr
+++ b/tests/references/__snapshots__/test_db.ambr
@@ -21,7 +21,7 @@
 # ---
 # name: test_populate_insert_only_reference_writes_legacy_history[legacy_history]
   list([
-    <SQLLegacyHistory(id=1, legacy_id=lhotu001.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 1 (O1), method_name=remote, user_id=1, otu=lhotu001, otu_name=OTU 1, otu_version=0, reference=ref_legacy_test, index=None, index_version=None)>,
-    <SQLLegacyHistory(id=2, legacy_id=lhotu002.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 2 (O2), method_name=remote, user_id=1, otu=lhotu002, otu_name=OTU 2, otu_version=0, reference=ref_legacy_test, index=None, index_version=None)>,
+    <SQLLegacyHistory(id=1, legacy_id=lhotu001.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 1 (O1), method_name=remote, user_id=1, otu=lhotu001, otu_name=OTU 1, otu_version=0, reference=ref_legacy_test, reference_id=1, index=None, index_version=None)>,
+    <SQLLegacyHistory(id=2, legacy_id=lhotu002.0, created_at=2015-10-06 20:00:00, description=Remoted OTU 2 (O2), method_name=remote, user_id=1, otu=lhotu002, otu_name=OTU 2, otu_version=0, reference=ref_legacy_test, reference_id=1, index=None, index_version=None)>,
   ])
 # ---

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -23,10 +23,32 @@ from virtool.otus.oas import (
 )
 from virtool.references.models import ReferenceDataType
 from virtool.references.oas import CreateReferenceRequest, CreateReferenceUserRequest
+from virtool.references.sql import SQLReference
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.tasks.sql import SQLTask
 from virtool.users.oas import UpdateUserRequest
 from virtool.workflow.pytest_plugin.utils import StaticTime
+
+
+async def seed_pg_reference(
+    pg: AsyncEngine,
+    legacy_id: str,
+    user_id: int,
+    created_at,
+) -> None:
+    """Insert a ``legacy_references`` row so OTU history writes can resolve its FK."""
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id=legacy_id,
+                name=legacy_id,
+                description="",
+                created_at=created_at,
+                source_types=[],
+                user_id=user_id,
+            ),
+        )
+        await session.commit()
 
 
 @pytest.mark.parametrize(
@@ -654,6 +676,7 @@ class TestCreateOTU:
         error: str | None,
         data_layer: DataLayer,
         mongo: Mongo,
+        pg: AsyncEngine,
         resp_is: RespIs,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
@@ -668,6 +691,7 @@ class TestCreateOTU:
         )
 
         if error != "404":
+            await seed_pg_reference(pg, "foo", client.user.id, static_time.datetime)
             await mongo.references.insert_one(
                 {
                     "_id": "foo",
@@ -734,6 +758,7 @@ class TestCreateOTU:
         mocker,
         resp_is,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         static_time,
     ):
@@ -749,6 +774,7 @@ class TestCreateOTU:
         client = await spawn_client(authenticated=True)
 
         if error != "404":
+            await seed_pg_reference(pg, "foo", client.user.id, static_time.datetime)
             await mongo.references.insert_one(
                 {
                     "_id": "foo",

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -22,6 +22,28 @@ from virtool.references.db import (
     populate_insert_only_reference,
 )
 from virtool.references.models import ReferenceRights
+from virtool.references.sql import SQLReference
+
+
+async def seed_reference(
+    pg: AsyncEngine,
+    legacy_id: str,
+    user_id: int,
+    created_at,
+) -> None:
+    """Insert a ``legacy_references`` row so history writes can resolve its FK."""
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id=legacy_id,
+                name=legacy_id,
+                description="",
+                created_at=created_at,
+                source_types=[],
+                user_id=user_id,
+            ),
+        )
+        await session.commit()
 
 
 @pytest.mark.parametrize("is_administrator", [True, False])
@@ -223,6 +245,8 @@ async def test_populate_insert_only_reference_rollback(
     user = await fake.users.create()
     ref_id = "ref_rollback_test"
 
+    await seed_reference(pg, ref_id, user.id, static_time.datetime)
+
     await mongo.references.insert_one(
         {
             "_id": ref_id,
@@ -336,6 +360,8 @@ async def test_populate_insert_only_reference_writes_legacy_history(
     """A successful bulk insert writes one ``legacy_history`` row per OTU."""
     user = await fake.users.create()
     ref_id = "ref_legacy_test"
+
+    await seed_reference(pg, ref_id, user.id, static_time.datetime)
 
     mocker.patch(
         "virtool.references.alot.random_alphanumeric",

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -155,6 +155,16 @@ async def test_import_reference_task(
 
     async with AsyncSession(pg) as session:
         session.add(
+            SQLReference(
+                legacy_id="foo",
+                name="foo",
+                description="",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=user.id,
+            ),
+        )
+        session.add(
             SQLTask(
                 id=1,
                 complete=False,
@@ -206,6 +216,16 @@ async def create_reference(
     )
 
     async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id="bar",
+                name="bar",
+                description="",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=user.id,
+            ),
+        )
         session.add(
             SQLTask(
                 id=2,
@@ -284,6 +304,16 @@ async def test_clone_reference_task(
     )
 
     async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id="foo",
+                name="foo",
+                description="",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=user.id,
+            ),
+        )
         session.add(
             SQLTask(
                 id=1,

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -23,7 +23,7 @@
     'ready': False,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'test_ref',
+      'id': 'bf1b993c',
       'name': 'Test Reference',
     }),
     'results': None,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -21,6 +21,7 @@ from virtool.jobs.models import JobState
 from virtool.models.enums import LibraryType, Permission
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
+from virtool.references.models import Reference
 from virtool.samples.fake import create_fake_sample
 from virtool.samples.models import WorkflowState
 from virtool.samples.sql import (
@@ -1314,22 +1315,16 @@ class TestAnalyze:
         return client
 
     @staticmethod
-    async def _insert_reference(mongo: Mongo, *, archived: bool = False) -> None:
-        await mongo.references.insert_one(
-            {
-                "_id": "test_ref",
-                "archived": archived,
-                "data_type": "genome",
-                "name": "Test Reference",
-            },
-        )
+    async def _insert_reference(fake: DataFaker) -> Reference:
+        user = await fake.users.create()
+        return await fake.references.create(user=user, name="Test Reference")
 
     @staticmethod
-    async def _insert_index(mongo: Mongo, *, ready: bool = True) -> None:
+    async def _insert_index(mongo: Mongo, ref_id: str, *, ready: bool = True) -> None:
         await mongo.indexes.insert_one(
             {
                 "_id": "test",
-                "reference": {"id": "test_ref"},
+                "reference": {"id": ref_id},
                 "ready": ready,
                 "version": 4,
             },
@@ -1355,12 +1350,12 @@ class TestAnalyze:
         await create_fake_sample(client.app, "test", user.id, finalized=True)
 
     @staticmethod
-    async def _post(client: VirtoolTestClient):
+    async def _post(client: VirtoolTestClient, ref_id: str):
         return await client.post(
             "/samples/test/analyses",
             data={
                 "workflow": "pathoscope",
-                "ref_id": "test_ref",
+                "ref_id": ref_id,
                 "subtractions": [1],
             },
         )
@@ -1374,12 +1369,12 @@ class TestAnalyze:
         snapshot: SnapshotAssertion,
         static_time,
     ):
-        await self._insert_reference(mongo)
-        await self._insert_index(mongo)
+        reference = await self._insert_reference(fake)
+        await self._insert_index(mongo, reference.id)
         await self._insert_subtraction(pg)
         await self._insert_sample(analyze_client, fake)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, reference.id)
 
         assert resp.status == 201
         assert resp.headers["Location"] == "/analyses/1"
@@ -1396,25 +1391,27 @@ class TestAnalyze:
         await self._insert_subtraction(pg)
         await self._insert_sample(analyze_client, fake)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, "does_not_exist")
 
         await resp_is.conflict(resp, "Reference does not exist")
 
     async def test_archived_reference(
         self,
         analyze_client: VirtoolTestClient,
+        data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
         pg: AsyncEngine,
         resp_is,
         static_time,
     ):
-        await self._insert_reference(mongo, archived=True)
-        await self._insert_index(mongo)
+        reference = await self._insert_reference(fake)
+        await data_layer.references.archive(reference.id)
+        await self._insert_index(mongo, reference.id)
         await self._insert_subtraction(pg)
         await self._insert_sample(analyze_client, fake)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, reference.id)
 
         await resp_is.conflict(resp, "Reference is archived")
 
@@ -1427,11 +1424,11 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._insert_reference(mongo)
+        reference = await self._insert_reference(fake)
         await self._insert_subtraction(pg)
         await self._insert_sample(analyze_client, fake)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, reference.id)
 
         await resp_is.conflict(resp, "No ready index")
 
@@ -1444,12 +1441,12 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._insert_reference(mongo)
-        await self._insert_index(mongo, ready=False)
+        reference = await self._insert_reference(fake)
+        await self._insert_index(mongo, reference.id, ready=False)
         await self._insert_subtraction(pg)
         await self._insert_sample(analyze_client, fake)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, reference.id)
 
         await resp_is.conflict(resp, "No ready index")
 
@@ -1461,27 +1458,28 @@ class TestAnalyze:
         resp_is,
         static_time,
     ):
-        await self._insert_reference(mongo)
-        await self._insert_index(mongo)
+        reference = await self._insert_reference(fake)
+        await self._insert_index(mongo, reference.id)
         await self._insert_sample(analyze_client, fake)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, reference.id)
 
         await resp_is.conflict(resp, "Subtractions do not exist: 1")
 
     async def test_missing_sample(
         self,
         analyze_client: VirtoolTestClient,
+        fake: DataFaker,
         mongo: Mongo,
         pg: AsyncEngine,
         resp_is,
         static_time,
     ):
-        await self._insert_reference(mongo)
-        await self._insert_index(mongo)
+        reference = await self._insert_reference(fake)
+        await self._insert_index(mongo, reference.id)
         await self._insert_subtraction(pg)
 
-        resp = await self._post(analyze_client)
+        resp = await self._post(analyze_client, reference.id)
 
         await resp_is.not_found(resp)
 
@@ -1493,8 +1491,8 @@ class TestAnalyze:
         pg: AsyncEngine,
         static_time,
     ):
-        await self._insert_reference(mongo)
-        await self._insert_index(mongo)
+        reference = await self._insert_reference(fake)
+        await self._insert_index(mongo, reference.id)
         await self._insert_subtraction(pg)
         await self._insert_sample(analyze_client, fake)
 
@@ -1502,7 +1500,7 @@ class TestAnalyze:
             "/samples/test/analyses",
             data={
                 "workflow": "iimi",
-                "ref_id": "test_ref",
+                "ref_id": reference.id,
                 "subtractions": ["subtraction_1"],
             },
         )

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -1157,8 +1157,14 @@ class TestUpdateRights:
 class TestDelete:
     """Deleting a sample cascades to its analyses in both Mongo and Postgres."""
 
-    async def _setup(self, fake: DataFaker, mongo: Mongo, pg: AsyncEngine) -> str:
+    async def _setup(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ) -> tuple[str, str]:
         user = await fake.users.create()
+        reference = await fake.references.create(user=user, name="Test Reference")
 
         async with AsyncSession(pg) as session:
             session.add(
@@ -1213,20 +1219,12 @@ class TestDelete:
                     "_id": "test_index",
                     "version": 11,
                     "ready": True,
-                    "reference": {"id": "test_ref"},
-                },
-            ),
-            mongo.references.insert_one(
-                {
-                    "_id": "test_ref",
-                    "archived": False,
-                    "data_type": "genome",
-                    "name": "Test Reference",
+                    "reference": {"id": reference.id},
                 },
             ),
         )
 
-        return user.id
+        return user.id, reference.id
 
     async def test_deletes_analysis_pg_rows(
         self,
@@ -1237,11 +1235,11 @@ class TestDelete:
         pg: AsyncEngine,
     ):
         """Deleting a sample removes its analyses' Postgres rows."""
-        user_id = await self._setup(fake, mongo, pg)
+        user_id, ref_id = await self._setup(fake, mongo, pg)
 
         analysis = await data_layer.analyses.create(
             CreateAnalysisRequest(
-                ref_id="test_ref",
+                ref_id=ref_id,
                 subtractions=[],
                 workflow=AnalysisWorkflow.nuvs,
             ),

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -48,6 +48,7 @@ from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id
 from virtool.pg.utils import delete_row, get_row_by_id
+from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.samples.db import recalculate_workflow_tags
 from virtool.samples.oas import CreateAnalysisRequest
@@ -317,6 +318,15 @@ class AnalysisData(DataLayerDomain):
             if sample_pg_id is None:
                 raise ResourceConflictError("Sample does not exist")
 
+            reference_pg_id = await resolve_legacy_id(
+                session,
+                SQLReference,
+                data.ref_id,
+            )
+
+            if reference_pg_id is None:
+                raise ResourceConflictError("Reference does not exist")
+
             pg_id = (
                 await session.execute(
                     insert(SQLAnalysis)
@@ -330,6 +340,7 @@ class AnalysisData(DataLayerDomain):
                         sample=sample_id,
                         sample_id=sample_pg_id,
                         reference=data.ref_id,
+                        reference_id=reference_pg_id,
                         index=index_id,
                         user_id=user_id,
                         job_id=job.id,

--- a/virtool/analyses/sql.py
+++ b/virtool/analyses/sql.py
@@ -34,13 +34,14 @@ class SQLAnalysis(Base):
 
     Column naming convention:
 
-    - A bare column (``reference``, ``index``) holds a legacy Mongo string id
-      and has no foreign key, because the referenced collection has not been
-      migrated to Postgres.
+    - A bare column (``index``) holds a legacy Mongo string id and has no
+      foreign key, because the referenced collection has not been migrated to
+      Postgres.
     - An ``{entity}_id`` column is a real foreign key to an existing SQL table.
-    - ``sample`` is mid-migration: the legacy Mongo string is retained
-      alongside the new ``sample_id`` foreign key while readers move over. The
-      bare ``sample`` column is dropped in a later cleanup revision.
+    - ``sample`` and ``reference`` are mid-migration: the legacy Mongo string is
+      retained alongside the new ``sample_id``/``reference_id`` foreign key while
+      readers move over. The bare columns are dropped in a later cleanup
+      revision.
 
     The Mongo ``space`` field is intentionally dropped.
     """
@@ -61,6 +62,11 @@ class SQLAnalysis(Base):
         nullable=True,
     )
     reference: Mapped[str]
+    reference_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("legacy_references.id"),
+        nullable=True,
+    )
     index: Mapped[str]
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"), nullable=True)

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
 from virtool.data.layer import DataLayer
+from virtool.data.topg import both_transactions
 from virtool.example import example_path
 from virtool.fake.providers import OrganismProvider, SegmentProvider, SequenceProvider
 from virtool.groups.models import Group
@@ -39,6 +40,8 @@ from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.otus.models import OTU, OTUSegment
 from virtool.otus.oas import CreateOTURequest
+from virtool.references.db import create_document, write_legacy_reference
+from virtool.references.models import Reference, ReferenceDataType
 from virtool.references.tasks import CloneReferenceTask
 from virtool.subtractions.models import Subtraction
 from virtool.subtractions.oas import (
@@ -128,6 +131,7 @@ class DataFaker:
         self.jobs = JobsFakerDomain(self)
         self.labels = LabelsFakerDomain(self)
         self.otus = OTUsFakerDomain(self)
+        self.references = ReferencesFakerDomain(self)
         self.subtractions = SubtractionFakerDomain(self)
         self.tasks = TasksFakerDomain(self)
         self.users = UsersFakerDomain(self)
@@ -320,6 +324,48 @@ class LabelsFakerDomain(DataFakerDomain):
             self._faker.hex_color(),
             self._faker.sentence(),
         )
+
+
+class ReferencesFakerDomain(DataFakerDomain):
+    model = Reference
+
+    async def create(
+        self,
+        user: User,
+        id_: str | None = None,
+        name: str = "Reference",
+        data_type: ReferenceDataType = ReferenceDataType.genome,
+        organism: str = "",
+        description: str = "",
+    ) -> Reference:
+        """Create a fake reference in both Mongo and Postgres.
+
+        Pass ``id_`` to force the Mongo ``_id`` (and Postgres ``legacy_id``); omit it
+        for a generated id. The reference is dual-written so its integer primary key
+        exists for holders (analyses, history) to resolve.
+        """
+        settings = await self._layer.settings.get_all()
+
+        document = await create_document(
+            self._mongo,
+            settings,
+            name,
+            organism,
+            description,
+            data_type.value,
+            created_at=virtool.utils.timestamp(),
+            ref_id=id_,
+            user_id=user.id,
+        )
+
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            await self._mongo.references.insert_one(document, session=mongo_session)
+            await write_legacy_reference(pg_session, document)
+
+        return await self._layer.references.get(document["_id"])
 
 
 class OTUsFakerDomain(DataFakerDomain):

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.otus.db
 import virtool.utils
-from virtool.data.topg import compose_legacy_id_multi_expression
+from virtool.data.topg import (
+    compose_legacy_id_multi_expression,
+    compose_legacy_id_subquery,
+    resolve_legacy_id,
+)
 from virtool.data.transforms import apply_transforms
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.history.utils import (
@@ -21,6 +25,7 @@ from virtool.history.utils import (
     derive_otu_information,
 )
 from virtool.models.enums import HistoryMethod
+from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
 from virtool.users.pg import SQLUser
@@ -36,11 +41,12 @@ asyncpg caps bind parameters per statement at 32767. Each row binds three
 (``change_id``, ``history_id``, and ``diff``).
 """
 
-_LEGACY_HISTORY_CHUNK_SIZE = 32767 // 11
+_LEGACY_HISTORY_CHUNK_SIZE = 32767 // 12
 """Max ``legacy_history`` rows per statement.
 
-asyncpg caps bind parameters per statement at 32767. Each row binds eleven
-columns (see :func:`legacy_history_values`).
+asyncpg caps bind parameters per statement at 32767. Each row binds twelve
+columns: the eleven from :func:`legacy_history_values` plus the resolved
+``reference_id``.
 """
 
 
@@ -141,9 +147,38 @@ async def bulk_insert_history(
             "diff_rows and documents must describe the same history changes",
         )
 
+    if not documents:
+        return
+
     legacy_rows = [legacy_history_values(document) for document in documents]
 
     async with AsyncSession(pg) as session:
+        reference_legacy_ids = {row["reference"] for row in legacy_rows}
+
+        reference_id_map = {
+            legacy_id: id_
+            for id_, legacy_id in (
+                await session.execute(
+                    select(SQLReference.id, SQLReference.legacy_id).where(
+                        compose_legacy_id_multi_expression(
+                            SQLReference,
+                            reference_legacy_ids,
+                        ),
+                    ),
+                )
+            ).all()
+        }
+
+        unresolved = reference_legacy_ids - reference_id_map.keys()
+
+        if unresolved:
+            raise ValueError(
+                f"References not found in postgres: {sorted(unresolved)}",
+            )
+
+        for row in legacy_rows:
+            row["reference_id"] = reference_id_map[row["reference"]]
+
         history_ids: dict[str, int] = {}
 
         for start in range(0, len(legacy_rows), _LEGACY_HISTORY_CHUNK_SIZE):
@@ -251,6 +286,17 @@ async def add(
     legacy_row = SQLLegacyHistory(**legacy_history_values(document))
 
     async with AsyncSession(pg) as pg_session:
+        reference_id = document["reference"]["id"]
+
+        legacy_row.reference_id = await resolve_legacy_id(
+            pg_session,
+            SQLReference,
+            reference_id,
+        )
+
+        if legacy_row.reference_id is None:
+            raise ValueError(f"Reference {reference_id!r} not found in postgres")
+
         pg_session.add(legacy_row)
         await pg_session.flush()
         diff_row.history_id = legacy_row.id
@@ -388,7 +434,10 @@ async def find(
     base_filters = []
 
     if reference_id is not None:
-        base_filters.append(SQLLegacyHistory.reference == reference_id)
+        base_filters.append(
+            SQLLegacyHistory.reference_id
+            == compose_legacy_id_subquery(SQLReference, reference_id),
+        )
 
     search_filters = list(base_filters)
 
@@ -534,7 +583,10 @@ async def get_contributors(
     filters = []
 
     if reference_id is not None:
-        filters.append(SQLLegacyHistory.reference == reference_id)
+        filters.append(
+            SQLLegacyHistory.reference_id
+            == compose_legacy_id_subquery(SQLReference, reference_id),
+        )
 
     if index_id is not None:
         filters.append(SQLLegacyHistory.index == index_id)

--- a/virtool/history/sql.py
+++ b/virtool/history/sql.py
@@ -42,8 +42,11 @@ class SQLLegacyHistory(Base):
     This is a faithful 1:1 lift of the Mongo document into Postgres. Nested Mongo
     fields are flattened into columns:
 
-    - ``otu``/``reference``/``index`` ids are bare string columns with no foreign
-      key, because those collections have not been migrated to Postgres yet.
+    - ``otu``/``index`` ids are bare string columns with no foreign key, because
+      those collections have not been migrated to Postgres yet.
+    - ``reference`` is mid-migration: the legacy Mongo string is retained
+      alongside the new ``reference_id`` foreign key while readers move over. The
+      bare ``reference`` column is dropped in a later cleanup revision.
     - ``user.id`` becomes a real foreign key to ``users.id``.
     - ``otu_version`` and ``index_version`` are strings because Mongo stores both
       integer versions and sentinel values such as ``"removed"`` and ``"unbuilt"``.
@@ -64,5 +67,11 @@ class SQLLegacyHistory(Base):
     otu_name: Mapped[str]
     otu_version: Mapped[str | None]
     reference: Mapped[str] = mapped_column(index=True)
+    reference_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("legacy_references.id"),
+        nullable=True,
+        index=True,
+    )
     index: Mapped[str | None] = mapped_column(index=True)
     index_version: Mapped[str | None]

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -53,6 +53,7 @@ from virtool.references.db import (
     get_unbuilt_count,
     populate_insert_only_reference,
     processor,
+    write_legacy_reference,
 )
 from virtool.references.models import (
     Reference,
@@ -77,7 +78,7 @@ from virtool.references.tasks import (
     ImportReferenceTask,
 )
 from virtool.references.transforms import AttachImportedFromTransform
-from virtool.references.utils import RIGHTS, ReferenceSourceData, reference_values
+from virtool.references.utils import RIGHTS, ReferenceSourceData
 from virtool.storage.protocol import StorageBackend
 from virtool.tasks.progress import (
     AccumulatingProgressHandlerWrapper,
@@ -277,79 +278,11 @@ class ReferencesData(DataLayerDomain):
 
         async def persist(mongo_session, pg_session) -> None:
             await self._mongo.references.insert_one(document, session=mongo_session)
-            await self._write_legacy_reference(pg_session, document)
+            await write_legacy_reference(pg_session, document)
 
         await retry_both_transactions(self._mongo, self._pg, persist)
 
         return await self.get(document["_id"])
-
-    async def _write_legacy_reference(
-        self,
-        pg_session: AsyncSession,
-        document: Document,
-    ) -> None:
-        """Insert a ``legacy_references`` row and its seeded rights from a Mongo
-        reference ``document`` into the open Postgres session.
-
-        ``cloned_from`` holds the source reference's legacy id, which is resolved
-        to its Postgres primary key. If the source has no Postgres row yet, the
-        foreign key is left ``NULL`` for the backfill to fill in later.
-        """
-        cloned_from = document.get("cloned_from")
-
-        cloned_from_id = None
-
-        if cloned_from is not None:
-            cloned_from_id = (
-                await pg_session.execute(
-                    select(SQLReference.id).where(
-                        compose_legacy_id_single_expression(
-                            SQLReference,
-                            cloned_from["id"],
-                        ),
-                    ),
-                )
-            ).scalar_one_or_none()
-
-        user = document.get("user")
-        imported_from = document.get("imported_from")
-        task = document.get("task")
-
-        reference = SQLReference(
-            **reference_values(
-                document,
-                user_id=user["id"] if user else None,
-                upload_id=imported_from["id"] if imported_from else None,
-                cloned_from_id=cloned_from_id,
-                task_id=task["id"] if task else None,
-            ),
-        )
-
-        pg_session.add(reference)
-
-        await pg_session.flush()
-
-        for member in document.get("users", []):
-            pg_session.add(
-                SQLReferenceUser(
-                    reference_id=reference.id,
-                    user_id=member["id"],
-                    build=member.get("build", False),
-                    modify=member.get("modify", False),
-                    modify_otu=member.get("modify_otu", False),
-                ),
-            )
-
-        for member in document.get("groups", []):
-            pg_session.add(
-                SQLReferenceGroup(
-                    reference_id=reference.id,
-                    group_id=member["id"],
-                    build=member.get("build", False),
-                    modify=member.get("modify", False),
-                    modify_otu=member.get("modify_otu", False),
-                ),
-            )
 
     async def _resolve_reference_pk(
         self,

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -14,7 +14,10 @@ import virtool.history.db
 import virtool.mongo.utils
 import virtool.utils
 from virtool.data.errors import ResourceNotFoundError
-from virtool.data.topg import compose_legacy_id_multi_expression
+from virtool.data.topg import (
+    compose_legacy_id_multi_expression,
+    compose_legacy_id_single_expression,
+)
 from virtool.data.transforms import apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
@@ -29,6 +32,7 @@ from virtool.references.sql import (
     SQLReferenceGroup,
     SQLReferenceUser,
 )
+from virtool.references.utils import reference_values
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
@@ -37,6 +41,74 @@ from virtool.utils import base_processor
 if TYPE_CHECKING:
     from virtool.api.client import UserClient
     from virtool.mongo.core import Mongo
+
+
+async def write_legacy_reference(
+    pg_session: AsyncSession,
+    document: Document,
+) -> None:
+    """Insert a ``legacy_references`` row and its seeded rights from a Mongo reference
+    ``document`` into the open Postgres session.
+
+    ``cloned_from`` holds the source reference's legacy id, which is resolved to its
+    Postgres primary key. If the source has no Postgres row yet, the foreign key is left
+    ``NULL`` for the backfill to fill in later.
+    """
+    cloned_from = document.get("cloned_from")
+
+    cloned_from_id = None
+
+    if cloned_from is not None:
+        cloned_from_id = (
+            await pg_session.execute(
+                select(SQLReference.id).where(
+                    compose_legacy_id_single_expression(
+                        SQLReference,
+                        cloned_from["id"],
+                    ),
+                ),
+            )
+        ).scalar_one_or_none()
+
+    user = document.get("user")
+    imported_from = document.get("imported_from")
+    task = document.get("task")
+
+    reference = SQLReference(
+        **reference_values(
+            document,
+            user_id=user["id"] if user else None,
+            upload_id=imported_from["id"] if imported_from else None,
+            cloned_from_id=cloned_from_id,
+            task_id=task["id"] if task else None,
+        ),
+    )
+
+    pg_session.add(reference)
+
+    await pg_session.flush()
+
+    for member in document.get("users", []):
+        pg_session.add(
+            SQLReferenceUser(
+                reference_id=reference.id,
+                user_id=member["id"],
+                build=member.get("build", False),
+                modify=member.get("modify", False),
+                modify_otu=member.get("modify_otu", False),
+            ),
+        )
+
+    for member in document.get("groups", []):
+        pg_session.add(
+            SQLReferenceGroup(
+                reference_id=reference.id,
+                group_id=member["id"],
+                build=member.get("build", False),
+                modify=member.get("modify", False),
+                modify_otu=member.get("modify_otu", False),
+            ),
+        )
 
 
 async def processor(mongo: "Mongo", pg: AsyncEngine, document: Document) -> Document:


### PR DESCRIPTION
## Summary
- Add nullable integer `reference_id` foreign keys to the analyses and `legacy_history` Postgres tables, backfilling existing string references to their integer primary keys
- Populate `reference_id` on the write path and switch reads to the integer foreign key
- Add `fake.references.create()` to dual-write references to Mongo and Postgres for test seeding