### PR TITLE
feat(migration): purge orphaned reference data before backfill

### DIFF
--- a/assets/revisions/rev_0uwpffz8adx0_purge_orphaned_references.py
+++ b/assets/revisions/rev_0uwpffz8adx0_purge_orphaned_references.py
@@ -1,0 +1,44 @@
+"""Purge orphaned references.
+
+Remove the OTU, sequence, index, and history data belonging to references whose
+Mongo document was deleted without cascading to its children. These orphans were
+never copied to Postgres, so the reference-id backfill (``xgqo66avrcdh``) cannot
+resolve them; running this first lets that backfill stay a strict correctness
+guard.
+
+The implementation lives in :func:`purge_orphaned_references`.
+
+Revision ID: 0uwpffz8adx0
+Date: 2026-07-07 18:05:23.934964
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.references.migration import purge_orphaned_references
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "purge orphaned references"
+created_at = arrow.get("2026-07-07 18:05:23.934964")
+revision_id = "0uwpffz8adx0"
+
+alembic_down_revision = "91b32f49a8b2"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+#
+# ``91b32f49a8b2`` adds the ``reference_id`` columns; this purge runs immediately
+# after it and immediately before the ``xgqo66avrcdh`` backfill that fills them.
+required_alembic_revision = "91b32f49a8b2"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Purge OTU, sequence, index, and history data for deleted references.
+
+    The implementation lives in :func:`purge_orphaned_references`.
+    """
+    await purge_orphaned_references(ctx)

--- a/assets/revisions/rev_xgqo66avrcdh_backfill_reference_ids_to_integers.py
+++ b/assets/revisions/rev_xgqo66avrcdh_backfill_reference_ids_to_integers.py
@@ -33,8 +33,8 @@ name = "backfill reference ids to integers"
 created_at = arrow.get("2026-07-06 23:05:46.057817")
 revision_id = "xgqo66avrcdh"
 
-alembic_down_revision = "91b32f49a8b2"
-virtool_down_revision = None
+alembic_down_revision = None
+virtool_down_revision = "0uwpffz8adx0"
 
 # Change this if an Alembic revision is required to run this migration.
 required_alembic_revision = None

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -642,6 +642,13 @@
       'applied_at': datetime,
       'created_at': datetime,
       'id': 92,
+      'name': 'purge orphaned references',
+      'revision': '0uwpffz8adx0',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 93,
       'name': 'backfill reference ids to integers',
       'revision': 'xgqo66avrcdh',
     }),

--- a/tests/migration/test_purge_orphaned_references.py
+++ b/tests/migration/test_purge_orphaned_references.py
@@ -1,0 +1,358 @@
+"""Tests for the purge orphaned references migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_0uwpffz8adx0_purge_orphaned_references import upgrade
+from virtool.migration.ctx import MigrationContext
+
+# ``91b32f49a8b2`` (add reference_id columns) is the alembic revision the purge
+# runs immediately after, and brings up every table it touches.
+PIN = "91b32f49a8b2"
+
+
+@pytest.fixture
+def now() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def user_id(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+    now: datetime,
+) -> int:
+    """Bring up the schema the purge touches and create a history/analysis author."""
+    await asyncio.to_thread(apply_alembic, PIN)
+
+    async with AsyncSession(ctx.pg) as session:
+        uid = (
+            await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES (
+                        'author', 'legacy_author', true, '', false,
+                        false, :now, :password, '{}'::jsonb
+                    )
+                    RETURNING id
+                """),
+                {"now": now, "password": b"hashed"},
+            )
+        ).scalar_one()
+        await session.commit()
+
+    return uid
+
+
+def history_doc(reference: str, change_id: str) -> dict:
+    """Build a minimal Mongo history document keyed to a reference."""
+    return {"_id": change_id, "reference": {"id": reference}}
+
+
+def otu_doc(reference: str, otu_id: str) -> dict:
+    """Build a minimal Mongo otu document keyed to a reference."""
+    return {"_id": otu_id, "reference": {"id": reference}, "name": "OTU"}
+
+
+def sequence_doc(reference: str, sequence_id: str) -> dict:
+    """Build a minimal Mongo sequence document keyed to a reference."""
+    return {"_id": sequence_id, "reference": {"id": reference}, "sequence": "ATGC"}
+
+
+def index_doc(reference: str, index_id: str) -> dict:
+    """Build a minimal Mongo index document keyed to a reference."""
+    return {"_id": index_id, "reference": {"id": reference}, "version": 1}
+
+
+async def insert_history(
+    session: AsyncSession,
+    *,
+    legacy_id: str,
+    reference: str,
+    user_id: int,
+    now: datetime,
+) -> None:
+    """Insert a legacy_history row and its diff, mirroring the copied Mongo doc."""
+    history_id = (
+        await session.execute(
+            text("""
+                INSERT INTO legacy_history (
+                    legacy_id, created_at, description, method_name, user_id,
+                    otu, otu_name, reference
+                )
+                VALUES (
+                    :legacy_id, :now, 'desc', 'edit', :user_id,
+                    'otu', 'OTU', :reference
+                )
+                RETURNING id
+            """),
+            {
+                "legacy_id": legacy_id,
+                "now": now,
+                "user_id": user_id,
+                "reference": reference,
+            },
+        )
+    ).scalar_one()
+
+    await session.execute(
+        text("""
+            INSERT INTO legacy_history_diff (change_id, history_id, diff)
+            VALUES (:change_id, :history_id, '{}'::jsonb)
+        """),
+        {"change_id": legacy_id, "history_id": history_id},
+    )
+
+
+async def insert_analysis(
+    session: AsyncSession,
+    *,
+    legacy_id: str,
+    reference: str,
+    user_id: int,
+    now: datetime,
+) -> None:
+    """Insert an analysis row recording the reference it ran against."""
+    await session.execute(
+        text("""
+            INSERT INTO analyses (
+                legacy_id, created_at, updated_at, workflow, ready,
+                sample, reference, "index", user_id
+            )
+            VALUES (
+                :legacy_id, :now, :now, 'pathoscope', true,
+                'sample', :reference, 'index', :user_id
+            )
+        """),
+        {
+            "legacy_id": legacy_id,
+            "now": now,
+            "reference": reference,
+            "user_id": user_id,
+        },
+    )
+
+
+@pytest.fixture
+async def seeded(ctx: MigrationContext, user_id: int, now: datetime) -> int:
+    """Seed one orphaned reference (``gone``) and one live reference (``live``).
+
+    ``gone`` has no ``references`` document but retains history, otus, and
+    sequences; ``live`` is intact. Returns the author ``user_id``.
+    """
+    await ctx.mongo.references.insert_one({"_id": "live"})
+
+    await ctx.mongo.history.insert_many(
+        [
+            history_doc("gone", "gone.1"),
+            history_doc("gone", "gone.2"),
+            history_doc("live", "live.1"),
+        ],
+    )
+    await ctx.mongo.otus.insert_many(
+        [
+            otu_doc("gone", "otu_gone_1"),
+            otu_doc("gone", "otu_gone_2"),
+            otu_doc("live", "otu_live"),
+        ],
+    )
+    await ctx.mongo.sequences.insert_many(
+        [
+            sequence_doc("gone", "seq_gone_1"),
+            sequence_doc("gone", "seq_gone_2"),
+            sequence_doc("live", "seq_live"),
+        ],
+    )
+    await ctx.mongo.indexes.insert_many(
+        [
+            index_doc("gone", "index_gone"),
+            index_doc("live", "index_live"),
+        ],
+    )
+
+    async with AsyncSession(ctx.pg) as session:
+        for legacy_id, reference in (
+            ("gone.1", "gone"),
+            ("gone.2", "gone"),
+            ("live.1", "live"),
+        ):
+            await insert_history(
+                session,
+                legacy_id=legacy_id,
+                reference=reference,
+                user_id=user_id,
+                now=now,
+            )
+        await session.commit()
+
+    return user_id
+
+
+class TestPurgeOrphanedReferences:
+    """Tests for the purge_orphaned_references upgrade."""
+
+    @pytest.mark.usefixtures("seeded")
+    async def test_archives_and_deletes_orphaned_otus_sequences_and_indexes(
+        self,
+        ctx: MigrationContext,
+    ):
+        """Orphaned otus/sequences/indexes move to the deleted_* collections."""
+        await upgrade(ctx)
+
+        assert await ctx.mongo.otus.distinct("_id") == ["otu_live"]
+        assert sorted(await ctx.mongo.deleted_otus.distinct("_id")) == [
+            "otu_gone_1",
+            "otu_gone_2",
+        ]
+        assert await ctx.mongo.sequences.distinct("_id") == ["seq_live"]
+        assert sorted(await ctx.mongo.deleted_sequences.distinct("_id")) == [
+            "seq_gone_1",
+            "seq_gone_2",
+        ]
+        assert await ctx.mongo.indexes.distinct("_id") == ["index_live"]
+        assert await ctx.mongo.deleted_indexes.distinct("_id") == ["index_gone"]
+
+    @pytest.mark.usefixtures("seeded")
+    async def test_deletes_orphaned_legacy_history_rows_and_diffs(
+        self,
+        ctx: MigrationContext,
+    ):
+        """Orphaned legacy_history rows and their diffs are deleted from Postgres."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            references = (
+                (await session.execute(text("SELECT reference FROM legacy_history")))
+                .scalars()
+                .all()
+            )
+            diffs = (
+                (
+                    await session.execute(
+                        text("SELECT change_id FROM legacy_history_diff"),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert references == ["live"]
+        assert diffs == ["live.1"]
+
+    @pytest.mark.usefixtures("seeded")
+    async def test_leaves_mongo_history_intact(self, ctx: MigrationContext):
+        """The Mongo history collection is untouched; it doubles as the archive."""
+        await upgrade(ctx)
+
+        assert sorted(await ctx.mongo.history.distinct("_id")) == [
+            "gone.1",
+            "gone.2",
+            "live.1",
+        ]
+
+    async def test_aborts_when_analysis_depends_on_orphan(
+        self,
+        ctx: MigrationContext,
+        seeded: int,
+        now: datetime,
+    ):
+        """An analysis referencing an orphan aborts the purge before any deletion."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_analysis(
+                session,
+                legacy_id="analysis_1",
+                reference="gone",
+                user_id=seeded,
+                now=now,
+            )
+            await session.commit()
+
+        with pytest.raises(ValueError, match="analysis dependents"):
+            await upgrade(ctx)
+
+        assert sorted(await ctx.mongo.otus.distinct("_id")) == [
+            "otu_gone_1",
+            "otu_gone_2",
+            "otu_live",
+        ]
+
+        async with AsyncSession(ctx.pg) as session:
+            surviving = (
+                (
+                    await session.execute(
+                        text(
+                            "SELECT legacy_id FROM legacy_history "
+                            "WHERE reference = 'gone' ORDER BY legacy_id",
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert surviving == ["gone.1", "gone.2"]
+
+    async def test_no_orphans_is_noop(
+        self,
+        ctx: MigrationContext,
+        now: datetime,
+        user_id: int,
+    ):
+        """With every reference intact, nothing is archived or deleted."""
+        await ctx.mongo.references.insert_one({"_id": "live"})
+        await ctx.mongo.history.insert_one(history_doc("live", "live.1"))
+        await ctx.mongo.otus.insert_one(otu_doc("live", "otu_live"))
+
+        async with AsyncSession(ctx.pg) as session:
+            await insert_history(
+                session,
+                legacy_id="live.1",
+                reference="live",
+                user_id=user_id,
+                now=now,
+            )
+            await session.commit()
+
+        await upgrade(ctx)
+
+        assert await ctx.mongo.otus.distinct("_id") == ["otu_live"]
+        assert await ctx.mongo.deleted_otus.distinct("_id") == []
+
+        async with AsyncSession(ctx.pg) as session:
+            references = (
+                (await session.execute(text("SELECT reference FROM legacy_history")))
+                .scalars()
+                .all()
+            )
+
+        assert references == ["live"]
+
+    @pytest.mark.usefixtures("seeded")
+    async def test_idempotent(self, ctx: MigrationContext):
+        """Re-running the purge leaves the same state and raises no error."""
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        assert await ctx.mongo.otus.distinct("_id") == ["otu_live"]
+        assert sorted(await ctx.mongo.deleted_otus.distinct("_id")) == [
+            "otu_gone_1",
+            "otu_gone_2",
+        ]
+
+        async with AsyncSession(ctx.pg) as session:
+            references = (
+                (await session.execute(text("SELECT reference FROM legacy_history")))
+                .scalars()
+                .all()
+            )
+
+        assert references == ["live"]

--- a/tests/migration/test_purge_orphaned_references.py
+++ b/tests/migration/test_purge_orphaned_references.py
@@ -301,6 +301,30 @@ class TestPurgeOrphanedReferences:
 
         assert surviving == ["gone.1", "gone.2"]
 
+    @pytest.mark.usefixtures("user_id")
+    async def test_ignores_documents_without_reference_id(
+        self,
+        ctx: MigrationContext,
+    ):
+        """A null or missing reference.id is never treated as an orphan."""
+        await ctx.mongo.references.insert_one({"_id": "live"})
+        await ctx.mongo.otus.insert_many(
+            [
+                otu_doc("live", "otu_live"),
+                {"_id": "otu_null_ref", "reference": {"id": None}},
+                {"_id": "otu_no_ref"},
+            ],
+        )
+
+        await upgrade(ctx)
+
+        assert sorted(await ctx.mongo.otus.distinct("_id")) == [
+            "otu_live",
+            "otu_no_ref",
+            "otu_null_ref",
+        ]
+        assert await ctx.mongo.deleted_otus.distinct("_id") == []
+
     async def test_no_orphans_is_noop(
         self,
         ctx: MigrationContext,

--- a/virtool/references/migration.py
+++ b/virtool/references/migration.py
@@ -5,13 +5,15 @@ is kept here rather than inline in the revision so it can be unit tested and
 reused.
 """
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
+from virtool.analyses.sql import SQLAnalysis
 from virtool.data.topg import compose_legacy_id_single_expression
 from virtool.groups.pg import SQLGroup
+from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.migration import MigrationContext
 from virtool.pg.base import Base
 from virtool.references.sql import (
@@ -410,6 +412,162 @@ async def _resolve_task_id(
         )
 
     return task_id
+
+
+async def purge_orphaned_references(ctx: MigrationContext) -> None:
+    """Purge data belonging to references whose Mongo document was deleted.
+
+    A handful of reference documents were deleted from Mongo without cascading to
+    their OTU, sequence, index, and history data. Those orphaned children were
+    never copied to Postgres -- :func:`copy_references_to_postgres` only copies
+    references still present in Mongo -- so the reference-id backfill cannot
+    resolve them and aborts. This removes the orphaned data at the root.
+
+    OTUs, sequences, and indexes are moved out of the live
+    ``otus``/``sequences``/``indexes`` collections into
+    ``deleted_otus``/``deleted_sequences``/``deleted_indexes`` and then deleted, so
+    they are recoverable but no longer visible to the application or to the pending
+    OTU/sequence/index migrations. The orphaned ``legacy_history`` rows (and their
+    diffs) are deleted from Postgres so the strict backfill resolves cleanly. The
+    Mongo ``history`` collection is left untouched: nothing reads it any more, and
+    it doubles as an untouched archive of the deleted history.
+
+    Before deleting anything, the function verifies that no analysis depends on an
+    orphaned reference. An analysis records the one reference it ran against in the
+    non-null ``reference`` column and its results are reference-scoped, so a
+    non-empty result here means real dependents and the purge aborts rather than
+    destroying data an analysis needs.
+
+    The function is idempotent. The orphan set is computed from the surviving Mongo
+    ``history``/``otus`` reference ids minus the ``references`` collection (both
+    left intact by this purge), and the archival ``$merge`` and every delete are
+    safe to re-run after an interruption.
+    """
+    orphaned = await _find_orphaned_reference_ids(ctx)
+
+    if not orphaned:
+        logger.info("no orphaned references found")
+        return
+
+    logger.info("found orphaned references", orphaned=orphaned)
+
+    async with AsyncSession(ctx.pg) as session:
+        dependents = (
+            await session.execute(
+                select(SQLAnalysis.reference, func.count())
+                .where(SQLAnalysis.reference.in_(orphaned))
+                .group_by(SQLAnalysis.reference),
+            )
+        ).all()
+
+        if dependents:
+            counts = dict(dependents)
+            msg = (
+                "refusing to purge orphaned references with analysis dependents: "
+                f"{counts}"
+            )
+            raise ValueError(msg)
+
+        history_ids = (
+            (
+                await session.execute(
+                    select(SQLLegacyHistory.id).where(
+                        SQLLegacyHistory.reference.in_(orphaned),
+                    ),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        if history_ids:
+            await session.execute(
+                delete(SQLLegacyHistoryDiff).where(
+                    SQLLegacyHistoryDiff.history_id.in_(history_ids),
+                ),
+            )
+            await session.execute(
+                delete(SQLLegacyHistory).where(SQLLegacyHistory.id.in_(history_ids)),
+            )
+
+        await session.commit()
+
+    otus_moved = await _archive_and_delete(ctx, "otus", "deleted_otus", orphaned)
+    sequences_moved = await _archive_and_delete(
+        ctx,
+        "sequences",
+        "deleted_sequences",
+        orphaned,
+    )
+    indexes_moved = await _archive_and_delete(
+        ctx,
+        "indexes",
+        "deleted_indexes",
+        orphaned,
+    )
+
+    logger.info(
+        "purged orphaned reference data",
+        references=len(orphaned),
+        legacy_history_rows=len(history_ids),
+        otus=otus_moved,
+        sequences=sequences_moved,
+        indexes=indexes_moved,
+    )
+
+
+async def _find_orphaned_reference_ids(ctx: MigrationContext) -> list[str]:
+    """Return reference ids used by Mongo history/otus/indexes but since deleted.
+
+    The reference document is gone from the ``references`` collection, but its
+    ``reference.id`` still appears on surviving ``history``, ``otus``, and
+    ``indexes`` documents.
+    """
+    existing = set(await ctx.mongo.references.distinct("_id"))
+    history_refs = set(await ctx.mongo.history.distinct("reference.id"))
+    otu_refs = set(await ctx.mongo.otus.distinct("reference.id"))
+    index_refs = set(await ctx.mongo.indexes.distinct("reference.id"))
+
+    return sorted((history_refs | otu_refs | index_refs) - existing)
+
+
+async def _archive_and_delete(
+    ctx: MigrationContext,
+    collection: str,
+    archive: str,
+    orphaned: list[str],
+) -> int:
+    """Move a collection's orphaned documents into an archive, then delete them.
+
+    The archival ``$merge`` copies matching documents into ``archive`` keyed by
+    ``_id`` (replacing any already-archived copy), then the originals are deleted
+    from the live collection. Both steps run server-side, so memory stays bounded
+    regardless of how many documents match, and both are safe to re-run: a re-run
+    re-copies any documents a prior interrupted run archived but failed to delete.
+    """
+    query = {"reference.id": {"$in": orphaned}}
+
+    await (
+        ctx.mongo[collection]
+        .aggregate(
+            [
+                {"$match": query},
+                {
+                    "$merge": {
+                        "into": archive,
+                        "on": "_id",
+                        "whenMatched": "replace",
+                        "whenNotMatched": "insert",
+                    },
+                },
+            ],
+        )
+        .to_list(length=None)
+    )
+
+    result = await ctx.mongo[collection].delete_many(query)
+
+    return result.deleted_count
 
 
 async def _resolve_rights_member_id(

--- a/virtool/references/migration.py
+++ b/virtool/references/migration.py
@@ -528,7 +528,12 @@ async def _find_orphaned_reference_ids(ctx: MigrationContext) -> list[str]:
     otu_refs = set(await ctx.mongo.otus.distinct("reference.id"))
     index_refs = set(await ctx.mongo.indexes.distinct("reference.id"))
 
-    return sorted((history_refs | otu_refs | index_refs) - existing)
+    orphaned = (history_refs | otu_refs | index_refs) - existing
+
+    # Drop null/empty ids: a ``{"$in": [None]}`` archive query would otherwise
+    # match every document with a null or missing ``reference.id`` and sweep them
+    # into the deleted collections.
+    return sorted(reference for reference in orphaned if reference)
 
 
 async def _archive_and_delete(


### PR DESCRIPTION
## Summary
- Add a revision that runs before the reference-id backfill to clean up references that were deleted from Mongo without cascading, which previously made the backfill abort
- Archive orphaned OTUs, sequences, and indexes into `deleted_*` collections and drop their `legacy_history` rows, after verifying no analysis still depends on them
- Leave the backfill as a strict correctness guard once orphans are cleared