### PR TITLE
refactor: remove dead index file uploaded_at and ready assignments

### DIFF
--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -247,8 +247,6 @@ class IndexData:
             )
 
             index_file.size = size
-            index_file.uploaded_at = virtool.utils.timestamp()
-            index_file.ready = True
 
             index_file_dict = index_file.to_dict()
 


### PR DESCRIPTION
## Summary
- Drop the `uploaded_at` and `ready` assignments in `IndexData.upload_file` — `SQLIndexFile` has no such columns, so they were set as orphan Python attributes that were never persisted or serialized.
- No behaviour or response change; `to_dict()` already ignored them.