### PR TITLE
feat(migration): reference indexes by integer id

### DIFF
--- a/assets/revisions/rev_tr3p2obxndjm_backfill_embedded_index_reference_ids_to_integers.py
+++ b/assets/revisions/rev_tr3p2obxndjm_backfill_embedded_index_reference_ids_to_integers.py
@@ -78,16 +78,29 @@ async def _backfill_embedded_reference(
 ) -> None:
     collection = mongo["indexes"]
 
+    index_ids = [
+        doc["_id"]
+        async for doc in collection.find(
+            {"reference.id": {"$type": "string"}},
+            projection={"_id": 1},
+        )
+    ]
+
     migrated = 0
 
-    async for doc in collection.find(
-        {"reference.id": {"$type": "string"}},
-        projection={"reference": 1},
-    ):
+    for index_id in index_ids:
+        doc = await collection.find_one(
+            {"_id": index_id},
+            projection={"reference": 1},
+        )
+
+        if doc is None or not isinstance(doc["reference"]["id"], str):
+            continue
+
         reference_id = _coerce_reference_id(doc["reference"]["id"], reference_map)
 
         await collection.update_one(
-            {"_id": doc["_id"]},
+            {"_id": index_id},
             {"$set": {"reference.id": reference_id}},
         )
         migrated += 1

--- a/assets/revisions/rev_tr3p2obxndjm_backfill_embedded_index_reference_ids_to_integers.py
+++ b/assets/revisions/rev_tr3p2obxndjm_backfill_embedded_index_reference_ids_to_integers.py
@@ -1,0 +1,99 @@
+"""Convert the embedded ``reference.id`` in indexes to integers.
+
+References now live in Postgres as ``legacy_references`` with an integer ``id``
+and a permanent ``legacy_id`` (the old Mongo string id). The Mongo ``indexes``
+documents each embed a ``reference`` subdocument whose ``id`` must hold the
+integer ``legacy_references.id`` rather than the legacy string.
+
+This revision rewrites ``reference.id`` on every index document, resolving legacy
+string ids to their integer ``legacy_references.id`` via
+``legacy_references.legacy_id``. The ``{"reference.id": {"$type": "string"}}``
+filter skips documents already holding an integer, so the revision is idempotent
+and safe to re-run.
+
+Unresolved string ids raise loudly rather than being dropped or stored as
+``NULL`` -- an index referencing a reference that no longer exists in Postgres is
+a data-integrity problem that must surface, not be silently swallowed.
+
+Revision ID: tr3p2obxndjm
+Date: 2026-07-08 16:46:09.542355
+
+"""
+
+from typing import TYPE_CHECKING
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorDatabase
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill embedded index reference ids to integers"
+created_at = arrow.get("2026-07-08 16:46:09.542355")
+revision_id = "tr3p2obxndjm"
+
+alembic_down_revision = None
+virtool_down_revision = "a5hg3lbp6rz1"
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as pg_session:
+        result = await pg_session.execute(
+            text(
+                "SELECT id, legacy_id FROM legacy_references "
+                "WHERE legacy_id IS NOT NULL",
+            ),
+        )
+        reference_map: dict[str, int] = {row.legacy_id: row.id for row in result}
+
+    logger.info("built id map", references=len(reference_map))
+
+    await _backfill_embedded_reference(ctx.mongo, reference_map)
+
+
+def _coerce_reference_id(value: int | str, reference_map: dict[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+
+    if value in reference_map:
+        return reference_map[value]
+
+    msg = f"Reference legacy id {value!r} not found in postgres"
+    raise ValueError(msg)
+
+
+async def _backfill_embedded_reference(
+    mongo: "AsyncIOMotorDatabase",
+    reference_map: dict[str, int],
+) -> None:
+    collection = mongo["indexes"]
+
+    migrated = 0
+
+    async for doc in collection.find(
+        {"reference.id": {"$type": "string"}},
+        projection={"reference": 1},
+    ):
+        reference_id = _coerce_reference_id(doc["reference"]["id"], reference_map)
+
+        await collection.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"reference.id": reference_id}},
+        )
+        migrated += 1
+
+    logger.info(
+        "backfilled embedded references",
+        collection="indexes",
+        migrated=migrated,
+    )

--- a/tests/data/test_topg.py
+++ b/tests/data/test_topg.py
@@ -1,11 +1,77 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.data.topg import both_transactions
+from virtool.data.topg import both_transactions, compose_legacy_id_multi_mongo_match
 from virtool.groups.pg import SQLGroup
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.users.utils import generate_base_permissions
+
+
+class TestComposeLegacyIdMultiMongoMatch:
+    @pytest.fixture
+    async def groups(self, pg: AsyncEngine) -> dict[str, int]:
+        async with AsyncSession(pg) as session:
+            rows = [
+                SQLGroup(
+                    legacy_id="group_a_legacy",
+                    name="A",
+                    permissions=generate_base_permissions(),
+                ),
+                SQLGroup(
+                    legacy_id="group_b_legacy",
+                    name="B",
+                    permissions=generate_base_permissions(),
+                ),
+            ]
+            session.add_all(rows)
+            await session.flush()
+            ids = {row.legacy_id: row.id for row in rows}
+            await session.commit()
+
+        return ids
+
+    async def test_covers_both_forms(self, pg: AsyncEngine, groups: dict[str, int]):
+        """Each matched row contributes both its legacy string and integer id."""
+        match = await compose_legacy_id_multi_mongo_match(
+            pg, SQLGroup, ["group_a_legacy", "group_b_legacy"]
+        )
+
+        assert set(match["$in"]) == {
+            "group_a_legacy",
+            "group_b_legacy",
+            groups["group_a_legacy"],
+            groups["group_b_legacy"],
+        }
+
+    async def test_integer_input_resolves_legacy(
+        self, pg: AsyncEngine, groups: dict[str, int]
+    ):
+        """An integer input resolves to its legacy string so mixed-form documents
+        still match.
+        """
+        match = await compose_legacy_id_multi_mongo_match(
+            pg, SQLGroup, [groups["group_a_legacy"]]
+        )
+
+        assert set(match["$in"]) == {groups["group_a_legacy"], "group_a_legacy"}
+
+    async def test_unresolved_id_passes_through(
+        self, pg: AsyncEngine, groups: dict[str, int]
+    ):
+        """An id with no matching row is kept so nothing is silently dropped."""
+        match = await compose_legacy_id_multi_mongo_match(
+            pg, SQLGroup, ["group_a_legacy", "ghost"]
+        )
+
+        assert "ghost" in match["$in"]
+        assert groups["group_a_legacy"] in match["$in"]
+
+    async def test_empty_matches_nothing(self, pg: AsyncEngine):
+        """An empty id list yields an empty ``$in`` without querying Postgres."""
+        assert await compose_legacy_id_multi_mongo_match(pg, SQLGroup, []) == {
+            "$in": []
+        }
 
 
 class TestBothTransactions:

--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -14,7 +14,7 @@
     }),
     'ready': False,
     'reference': dict({
-      'id': 'foo',
+      'id': 1,
     }),
     'user': dict({
       'id': 1,

--- a/tests/indexes/__snapshots__/test_db.ambr
+++ b/tests/indexes/__snapshots__/test_db.ambr
@@ -37,7 +37,7 @@
     'manifest': 'manifest',
     'ready': False,
     'reference': dict({
-      'id': 'foo',
+      'id': 1,
     }),
     'user': dict({
       'id': 'test',
@@ -57,7 +57,7 @@
     'manifest': 'manifest',
     'ready': False,
     'reference': dict({
-      'id': 'foo',
+      'id': 1,
     }),
     'user': dict({
       'id': 'test',

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -22,16 +22,37 @@ from virtool.mongo.core import Mongo
 from virtool.references.sql import SQLReference
 
 
+async def _add_reference(pg: AsyncEngine, legacy_id: str, user_id: int, static_time):
+    async with AsyncSession(pg) as session:
+        reference = SQLReference(
+            legacy_id=legacy_id,
+            name=legacy_id,
+            description="",
+            created_at=static_time.datetime,
+            source_types=[],
+            user_id=user_id,
+        )
+        session.add(reference)
+        await session.commit()
+
+
 @pytest.mark.parametrize("index_id", [None, "abc"])
 async def test_create(
     index_id: str | None,
     mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
+    fake,
     snapshot: SnapshotAssertion,
     static_time,
 ):
+    """The new index embeds the integer ``legacy_references`` primary key of its
+    reference rather than the legacy Mongo string id.
+    """
+    user = await fake.users.create()
+
     await mongo.references.insert_one({"_id": "foo"})
+    await _add_reference(pg, "foo", user.id, static_time)
 
     mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
 
@@ -154,6 +175,7 @@ async def test_create_rolls_back_both_stores_on_failure(
     user = await fake.users.create()
 
     await mongo.references.insert_one({"_id": "built_ref"})
+    await _add_reference(pg, "built_ref", user.id, static_time)
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -206,7 +228,9 @@ async def test_create_rolls_back_both_stores_on_failure(
 
 @pytest.mark.parametrize("exists", [True, False])
 @pytest.mark.parametrize("has_ref", [True, False])
-async def test_get_current_id_and_version(exists, has_ref, test_indexes, mongo):
+async def test_get_current_id_and_version(
+    exists, has_ref, test_indexes, mongo, pg: AsyncEngine
+):
     if not exists:
         test_indexes = [dict(i, ready=False, has_files=False) for i in test_indexes]
 
@@ -214,7 +238,7 @@ async def test_get_current_id_and_version(exists, has_ref, test_indexes, mongo):
 
     ref_id = "hxn167" if has_ref else "foobar"
 
-    index_id, index_version = await get_current_id_and_version(mongo, ref_id)
+    index_id, index_version = await get_current_id_and_version(mongo, pg, ref_id)
 
     if has_ref and exists:
         assert index_id == "ptlrcefm"
@@ -227,7 +251,7 @@ async def test_get_current_id_and_version(exists, has_ref, test_indexes, mongo):
 
 @pytest.mark.parametrize("empty", [False, True])
 @pytest.mark.parametrize("has_ref", [True, False])
-async def test_get_next_version(empty, has_ref, test_indexes, mongo):
+async def test_get_next_version(empty, has_ref, test_indexes, mongo, pg: AsyncEngine):
     if not empty:
         await mongo.indexes.insert_many(test_indexes, session=None)
 
@@ -236,7 +260,47 @@ async def test_get_next_version(empty, has_ref, test_indexes, mongo):
     if empty or not has_ref:
         expected = 0
 
-    assert await get_next_version(mongo, "hxn167" if has_ref else "foobar") == expected
+    assert (
+        await get_next_version(mongo, pg, "hxn167" if has_ref else "foobar") == expected
+    )
+
+
+async def test_reads_tolerate_integer_embedded_reference_id(
+    mongo: Mongo,
+    pg: AsyncEngine,
+    fake,
+    static_time,
+):
+    """``get_current_id_and_version`` and ``get_next_version`` resolve the legacy
+    string ref id and match an index whose embedded ``reference.id`` is the integer
+    ``legacy_references`` primary key.
+    """
+    user = await fake.users.create()
+
+    await mongo.references.insert_one({"_id": "legacy_ref"})
+    await _add_reference(pg, "legacy_ref", user.id, static_time)
+
+    async with AsyncSession(pg) as session:
+        reference_pk = (
+            await session.execute(
+                select(SQLReference.id).where(SQLReference.legacy_id == "legacy_ref"),
+            )
+        ).scalar_one()
+
+    await mongo.indexes.insert_one(
+        {
+            "_id": "built_index",
+            "reference": {"id": reference_pk},
+            "version": 0,
+            "ready": True,
+        },
+    )
+
+    index_id, index_version = await get_current_id_and_version(mongo, pg, "legacy_ref")
+
+    assert index_id == "built_index"
+    assert index_version == 0
+    assert await get_next_version(mongo, pg, "legacy_ref") == 1
 
 
 async def test_get_patched_otus(mocker: MockerFixture, mongo: Mongo):

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -680,5 +680,12 @@
       'name': 'backfill embedded reference ids to integers',
       'revision': 'a5hg3lbp6rz1',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 98,
+      'name': 'backfill embedded index reference ids to integers',
+      'revision': 'tr3p2obxndjm',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_embedded_index_reference_ids.py
+++ b/tests/migration/test_backfill_embedded_index_reference_ids.py
@@ -1,0 +1,157 @@
+"""Tests for the backfill-embedded-index-reference-ids-to-integers migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import arrow
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_tr3p2obxndjm_backfill_embedded_index_reference_ids_to_integers import (
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+
+
+@pytest.fixture
+async def setup_references(
+    ctx: MigrationContext,
+    apply_alembic: Callable,
+) -> dict[str, int]:
+    """Apply alembic head and seed a user and two references with legacy ids."""
+    await asyncio.to_thread(apply_alembic, "head")
+
+    now = arrow.utcnow().naive
+
+    async with AsyncSession(ctx.pg) as session:
+        user_id = (
+            await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES (
+                        'alice', 'alice_legacy', true, '',
+                        false, false, :now, :pw, '{}'::jsonb
+                    )
+                    RETURNING id
+                """),
+                {"now": now, "pw": b"hashed"},
+            )
+        ).scalar_one()
+
+        result = await session.execute(
+            text("""
+                INSERT INTO legacy_references (
+                    legacy_id, name, description, organism, created_at,
+                    archived, restrict_source_types, source_types, user_id
+                )
+                VALUES
+                    ('ref_a_legacy', 'Reference A', '', '', :now,
+                     false, false, '[]'::jsonb, :user_id),
+                    ('ref_b_legacy', 'Reference B', '', '', :now,
+                     false, false, '[]'::jsonb, :user_id)
+                RETURNING id, legacy_id
+            """),
+            {"now": now, "user_id": user_id},
+        )
+        reference_ids = {row.legacy_id: row.id for row in result}
+
+        await session.commit()
+
+    return reference_ids
+
+
+class TestEmbeddedIndexReferenceIdsBackfill:
+    async def test_backfills_indexes(
+        self,
+        ctx: MigrationContext,
+        setup_references: dict[str, int],
+    ):
+        """The embedded ``reference.id`` string resolves to the integer id on
+        index documents.
+        """
+        ref_a = setup_references["ref_a_legacy"]
+
+        await ctx.mongo.indexes.insert_one(
+            {"_id": "index_a", "reference": {"id": "ref_a_legacy"}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.indexes.find_one({"_id": "index_a"})
+        assert doc["reference"]["id"] == ref_a
+        assert isinstance(doc["reference"]["id"], int)
+
+    async def test_leaves_other_reference_fields_intact(
+        self,
+        ctx: MigrationContext,
+        setup_references: dict[str, int],
+    ):
+        """Only ``reference.id`` is rewritten; sibling reference fields survive."""
+        await ctx.mongo.indexes.insert_one(
+            {
+                "_id": "index_a",
+                "reference": {"id": "ref_a_legacy", "data_type": "genome"},
+            },
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.indexes.find_one({"_id": "index_a"})
+        assert doc["reference"] == {
+            "id": setup_references["ref_a_legacy"],
+            "data_type": "genome",
+        }
+
+    async def test_already_int_passthrough(
+        self,
+        ctx: MigrationContext,
+        setup_references: dict[str, int],
+    ):
+        """An index already holding an integer id is left untouched and does not
+        need a matching ``legacy_references`` row.
+        """
+        ref_b = setup_references["ref_b_legacy"]
+
+        await ctx.mongo.indexes.insert_one(
+            {"_id": "index_int", "reference": {"id": ref_b}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.indexes.find_one({"_id": "index_int"})
+        assert doc["reference"]["id"] == ref_b
+
+    async def test_idempotent(
+        self,
+        ctx: MigrationContext,
+        setup_references: dict[str, int],
+    ):
+        """Re-running the backfill leaves already-resolved documents unchanged."""
+        await ctx.mongo.indexes.insert_one(
+            {"_id": "index_a", "reference": {"id": "ref_a_legacy"}},
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.indexes.find_one({"_id": "index_a"})
+        assert doc["reference"]["id"] == setup_references["ref_a_legacy"]
+
+    @pytest.mark.usefixtures("setup_references")
+    async def test_unresolved_reference_raises(
+        self,
+        ctx: MigrationContext,
+    ):
+        """An index whose embedded ``reference.id`` matches no reference row raises
+        rather than being silently dropped.
+        """
+        await ctx.mongo.indexes.insert_one(
+            {"_id": "index_orphan", "reference": {"id": "ghost_reference"}},
+        )
+
+        with pytest.raises(ValueError, match="ghost_reference"):
+            await upgrade(ctx)

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -1079,7 +1079,7 @@
     }),
     'ready': False,
     'reference': dict({
-      'id': 'foo',
+      'id': 1,
     }),
     'user': dict({
       'id': 1,

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -18,6 +18,7 @@ from virtool.models.enums import AnalysisWorkflow, LibraryType, Permission
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
+from virtool.references.sql import SQLReference
 from virtool.samples.models import WorkflowState
 from virtool.samples.oas import (
     CreateAnalysisRequest,
@@ -711,6 +712,62 @@ class TestHasResourcesForAnalysisJob:
             await data_layer.samples.has_resources_for_analysis_job(
                 "test_ref",
                 [subtraction_id],
+            )
+            is None
+        )
+
+    async def test_ok_migrated_reference(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A ready index embedding the integer reference id is still matched."""
+        user = await fake.users.create()
+        upload = await fake.uploads.create(
+            user=user,
+            upload_type=UploadType.subtraction,
+        )
+
+        async with AsyncSession(pg) as session:
+            reference = SQLReference(
+                legacy_id="test_ref",
+                name="Test Reference",
+                description="",
+                created_at=virtool.utils.timestamp(),
+                source_types=[],
+                user_id=user.id,
+            )
+            session.add(reference)
+            await session.flush()
+            reference_pk = reference.id
+            await session.commit()
+
+        _, _, subtraction = await asyncio.gather(
+            mongo.references.insert_one(
+                {
+                    "_id": "test_ref",
+                    "archived": False,
+                    "data_type": "genome",
+                    "name": "Test Reference",
+                },
+            ),
+            mongo.indexes.insert_one(
+                {
+                    "_id": "test_index",
+                    "reference": {"id": reference_pk},
+                    "ready": True,
+                    "version": 1,
+                },
+            ),
+            fake.subtractions.create(user=user, upload=upload),
+        )
+
+        assert (
+            await data_layer.samples.has_resources_for_analysis_job(
+                "test_ref",
+                [subtraction.id],
             )
             is None
         )

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -297,6 +297,7 @@ class AnalysisData(DataLayerDomain):
 
         index_id, _ = await get_current_id_and_version(
             self._mongo,
+            self._pg,
             data.ref_id,
         )
 

--- a/virtool/data/topg.py
+++ b/virtool/data/topg.py
@@ -213,3 +213,40 @@ async def compose_legacy_id_mongo_match(
                 values.append(value)
 
     return {"$in": values}
+
+
+async def compose_legacy_id_multi_mongo_match(
+    pg: AsyncEngine,
+    model: HasLegacyAndModernIDs,
+    id_list: list[int | str] | set[int | str] | tuple[int | str],
+) -> dict:
+    """Build a Mongo match value for an embedded reference that may hold either the
+    legacy string id or the integer primary key of ``model``, for any id in ``id_list``.
+
+    The multi-id counterpart of :func:`compose_legacy_id_mongo_match`. Each input id
+    may itself be in either form, so both the integer primary key and the legacy string
+    of every matching row are included, letting a mid-migration collection with mixed
+    id forms be matched in full. An empty ``id_list`` yields an empty ``$in`` that
+    matches nothing.
+
+    :param pg: the application PostgreSQL engine
+    :param model: the SQLAlchemy model the embedded id points at
+    :param id_list: legacy or modern ids
+    :return: a Mongo ``$in`` match value covering both id forms
+    """
+    values: list[int | str] = list(dict.fromkeys(id_list))
+
+    if id_list:
+        async with AsyncSession(pg) as session:
+            rows = await session.execute(
+                select(model.id, model.legacy_id).where(
+                    compose_legacy_id_multi_expression(model, id_list),
+                ),
+            )
+
+        for row in rows:
+            for value in row:
+                if value is not None and value not in values:
+                    values.append(value)
+
+    return {"$in": values}

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -35,7 +35,7 @@ from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.pg.utils import get_rows
 from virtool.references.db import (
-    compose_reference_ids_in_match,
+    compose_reference_ids_match,
     resolve_reference_legacy_id,
 )
 from virtool.references.models import ReferenceNested
@@ -90,13 +90,11 @@ class IndexData:
                     {
                         "$match": {
                             "ready": True,
-                            "reference.id": {
-                                "$in": await compose_reference_ids_in_match(
-                                    self._pg,
-                                    self._mongo,
-                                    archived,
-                                ),
-                            },
+                            "reference.id": await compose_reference_ids_match(
+                                self._pg,
+                                self._mongo,
+                                archived,
+                            ),
                         },
                     },
                     {"$sort": {"created_at": 1}},

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -34,8 +34,12 @@ from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.pg.utils import get_rows
-from virtool.references.db import compose_archived_filter, lookup_nested_reference_by_id
+from virtool.references.db import (
+    compose_reference_ids_in_match,
+    resolve_reference_legacy_id,
+)
 from virtool.references.models import ReferenceNested
+from virtool.references.transforms import AttachReferenceTransform
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
@@ -87,14 +91,14 @@ class IndexData:
                         "$match": {
                             "ready": True,
                             "reference.id": {
-                                "$in": await self._mongo.references.distinct(
-                                    "_id",
-                                    compose_archived_filter(archived),
+                                "$in": await compose_reference_ids_in_match(
+                                    self._pg,
+                                    self._mongo,
+                                    archived,
                                 ),
                             },
                         },
                     },
-                    *lookup_nested_reference_by_id(local_field="reference.id"),
                     {"$sort": {"created_at": 1}},
                 ],
             )
@@ -104,6 +108,7 @@ class IndexData:
             items,
             [
                 AttachJobTransform(self._pg),
+                AttachReferenceTransform(self._mongo),
                 AttachUserTransform(self._pg),
                 IndexCountsTransform(),
             ],
@@ -121,7 +126,6 @@ class IndexData:
         result = await self._mongo.indexes.aggregate(
             [
                 {"$match": {"_id": index_id}},
-                *lookup_nested_reference_by_id(local_field="reference.id"),
                 {"$sort": {"created_at": 1}},
             ],
         ).to_list(length=1)
@@ -148,6 +152,7 @@ class IndexData:
             base_processor(document),
             [
                 AttachJobTransform(self._pg),
+                AttachReferenceTransform(self._mongo),
                 AttachUserTransform(self._pg),
                 IndexCountsTransform(),
             ],
@@ -170,7 +175,12 @@ class IndexData:
 
         if reference_field and (
             reference := await self._mongo.references.find_one(
-                {"_id": reference_field["id"]},
+                {
+                    "_id": await resolve_reference_legacy_id(
+                        self._pg,
+                        reference_field["id"],
+                    ),
+                },
                 ["data_type", "name"],
             )
         ):
@@ -299,7 +309,11 @@ class IndexData:
         except KeyError:
             raise ResourceError("Could not find index reference id")
 
-        data_type = await get_one_field(self._mongo.references, "data_type", ref_id)
+        data_type = await get_one_field(
+            self._mongo.references,
+            "data_type",
+            await resolve_reference_legacy_id(self._pg, ref_id),
+        )
 
         if data_type is None:
             raise ResourceNotFoundError

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -26,7 +26,7 @@ from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
 from virtool.references.db import (
     compose_reference_id_match,
-    compose_reference_ids_in_match,
+    compose_reference_ids_match,
 )
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
@@ -226,17 +226,11 @@ async def find(
         # filter goes into mongo_query so total_count reflects all indexes whose
         # reference exists, while found_count narrows to the requested
         # lifecycle.
-        base_query = {
-            "reference.id": {
-                "$in": await compose_reference_ids_in_match(pg, mongo),
-            },
-        }
+        base_query = {"reference.id": await compose_reference_ids_match(pg, mongo)}
 
         if archived is not None:
             mongo_query = {
-                "reference.id": {
-                    "$in": await compose_reference_ids_in_match(pg, mongo, archived),
-                },
+                "reference.id": await compose_reference_ids_match(pg, mongo, archived),
             }
 
     data = await paginate(

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -14,13 +14,20 @@ import virtool.pg.utils
 import virtool.references.db
 import virtool.utils
 from virtool.api.utils import paginate
-from virtool.data.topg import both_transactions, compose_legacy_id_subquery
+from virtool.data.topg import (
+    both_transactions,
+    compose_legacy_id_subquery,
+    resolve_legacy_id,
+)
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndexFile
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
-from virtool.references.db import compose_archived_filter, compose_reference_id_match
+from virtool.references.db import (
+    compose_reference_id_match,
+    compose_reference_ids_in_match,
+)
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
@@ -147,7 +154,7 @@ async def create(
     :return: the new index document
     """
     index_version, manifest = await asyncio.gather(
-        get_next_version(mongo, ref_id),
+        get_next_version(mongo, pg, ref_id),
         virtool.references.db.get_manifest(mongo, pg, ref_id),
     )
 
@@ -158,7 +165,6 @@ async def create(
         "ready": False,
         "has_files": True,
         "has_json": False,
-        "reference": {"id": ref_id},
         "job": {"id": job_id},
         "user": {"id": user_id},
     }
@@ -167,6 +173,13 @@ async def create(
         document["_id"] = index_id
 
     async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+        reference_pk = await resolve_legacy_id(pg_session, SQLReference, ref_id)
+
+        if reference_pk is None:
+            raise ValueError(f"Reference {ref_id!r} not found in postgres")
+
+        document["reference"] = {"id": reference_pk}
+
         document = await mongo.indexes.insert_one(document, session=mongo_session)
 
         await pg_session.execute(
@@ -207,25 +220,22 @@ async def find(
     mongo_query: dict = {}
 
     if ref_id:
-        base_query = {"reference.id": ref_id}
+        base_query = {"reference.id": await compose_reference_id_match(pg, ref_id)}
     else:
         # base_query is the orphan filter only (visibility scope). The lifecycle
         # filter goes into mongo_query so total_count reflects all indexes whose
         # reference exists, while found_count narrows to the requested
         # lifecycle.
         base_query = {
-            "reference.id": {"$in": await mongo.references.distinct("_id")},
+            "reference.id": {
+                "$in": await compose_reference_ids_in_match(pg, mongo),
+            },
         }
 
-        archived_filter = compose_archived_filter(archived)
-
-        if archived_filter:
+        if archived is not None:
             mongo_query = {
                 "reference.id": {
-                    "$in": await mongo.references.distinct(
-                        "_id",
-                        archived_filter,
-                    ),
+                    "$in": await compose_reference_ids_in_match(pg, mongo, archived),
                 },
             }
 
@@ -272,18 +282,23 @@ async def find(
 
 async def get_current_id_and_version(
     mongo: "Mongo",
+    pg: AsyncEngine,
     ref_id: str,
 ) -> tuple[str | None, int]:
     """Return the current index id and version number.
 
     :param mongo: the application database client
+    :param pg: the application Postgres client
     :param ref_id: the id of the reference to get the current index for
 
     :return: the index and version of the current index
 
     """
     document = await mongo.indexes.find_one(
-        {"reference.id": ref_id, "ready": True},
+        {
+            "reference.id": await compose_reference_id_match(pg, ref_id),
+            "ready": True,
+        },
         sort=[("version", pymongo.DESCENDING)],
         projection=["_id", "version"],
     )
@@ -336,16 +351,22 @@ async def get_otus(pg: AsyncEngine, index_id: str) -> list[dict]:
     )
 
 
-async def get_next_version(mongo: "Mongo", ref_id: str) -> int:
+async def get_next_version(mongo: "Mongo", pg: AsyncEngine, ref_id: str) -> int:
     """Get the version number that should be used for the next index build.
 
     :param mongo: the application mongodb client
+    :param pg: the application Postgres client
     :param ref_id: the id of the reference to get the next version for
 
     :return: the next version number
 
     """
-    return await mongo.indexes.count_documents({"reference.id": ref_id, "ready": True})
+    return await mongo.indexes.count_documents(
+        {
+            "reference.id": await compose_reference_id_match(pg, ref_id),
+            "ready": True,
+        },
+    )
 
 
 async def get_unbuilt_stats(

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -565,7 +565,10 @@ class ReferencesData(DataLayerDomain):
         await self._require_not_archived(ref_id)
 
         if await self._mongo.indexes.count_documents(
-            {"reference.id": ref_id, "ready": False},
+            {
+                "reference.id": await compose_reference_id_match(self._pg, ref_id),
+                "ready": False,
+            },
             limit=1,
         ):
             raise ResourceConflictError("Index build already in progress")

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -17,6 +17,7 @@ from virtool.data.errors import ResourceNotFoundError
 from virtool.data.topg import (
     compose_legacy_id_mongo_match,
     compose_legacy_id_multi_expression,
+    compose_legacy_id_multi_mongo_match,
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
     resolve_legacy_id,
@@ -350,13 +351,12 @@ def compose_archived_filter(archived: bool | None) -> dict:
     return {"archived": archived}
 
 
-async def compose_reference_ids_in_match(
+async def compose_reference_ids_match(
     pg: AsyncEngine,
     mongo: "Mongo",
     archived: bool | None = None,
-) -> list[int | str]:
-    """Build a Mongo ``$in`` list of embedded reference ids for the references
-    matching ``archived``.
+) -> dict:
+    """Build a Mongo ``reference.id`` match for the references matching ``archived``.
 
     ``indexes`` documents embed either the legacy Mongo string reference id or the
     integer ``legacy_references`` primary key during the migration, so both forms
@@ -366,27 +366,14 @@ async def compose_reference_ids_in_match(
     :param pg: the application PostgreSQL engine
     :param mongo: the application database client
     :param archived: lifecycle filter mode; see :func:`compose_archived_filter`
-    :return: a list of both id forms for use as a Mongo ``$in`` value
+    :return: a Mongo ``$in`` match value covering both id forms
     """
-    legacy_ids: list[str] = await mongo.references.distinct(
+    legacy_ids = await mongo.references.distinct(
         "_id",
         compose_archived_filter(archived),
     )
 
-    async with AsyncSession(pg) as session:
-        integer_ids = (
-            (
-                await session.execute(
-                    select(SQLReference.id).where(
-                        SQLReference.legacy_id.in_(legacy_ids),
-                    ),
-                )
-            )
-            .scalars()
-            .all()
-        )
-
-    return [*legacy_ids, *integer_ids]
+    return await compose_legacy_id_multi_mongo_match(pg, SQLReference, legacy_ids)
 
 
 def compose_rights_filter(

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -350,6 +350,45 @@ def compose_archived_filter(archived: bool | None) -> dict:
     return {"archived": archived}
 
 
+async def compose_reference_ids_in_match(
+    pg: AsyncEngine,
+    mongo: "Mongo",
+    archived: bool | None = None,
+) -> list[int | str]:
+    """Build a Mongo ``$in`` list of embedded reference ids for the references
+    matching ``archived``.
+
+    ``indexes`` documents embed either the legacy Mongo string reference id or the
+    integer ``legacy_references`` primary key during the migration, so both forms
+    are included for every matching reference. This backs the orphan and lifecycle
+    filters on the index list, which scope indexes to references that still exist.
+
+    :param pg: the application PostgreSQL engine
+    :param mongo: the application database client
+    :param archived: lifecycle filter mode; see :func:`compose_archived_filter`
+    :return: a list of both id forms for use as a Mongo ``$in`` value
+    """
+    legacy_ids: list[str] = await mongo.references.distinct(
+        "_id",
+        compose_archived_filter(archived),
+    )
+
+    async with AsyncSession(pg) as session:
+        integer_ids = (
+            (
+                await session.execute(
+                    select(SQLReference.id).where(
+                        SQLReference.legacy_id.in_(legacy_ids),
+                    ),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    return [*legacy_ids, *integer_ids]
+
+
 def compose_rights_filter(
     user_id: int,
     administrator: bool,
@@ -405,7 +444,10 @@ async def get_latest_build(
 
     """
     latest_build = await mongo.indexes.find_one(
-        {"reference.id": ref_id, "ready": True},
+        {
+            "reference.id": await compose_reference_id_match(pg, ref_id),
+            "ready": True,
+        },
         projection=["created_at", "version", "user", "has_json"],
         sort=[("version", pymongo.DESCENDING)],
     )
@@ -684,29 +726,3 @@ async def populate_insert_only_reference(
             await session.commit()
 
         raise
-
-
-def lookup_nested_reference_by_id(
-    local_field: str = "reference.id",
-    set_as: str = "reference",
-) -> list[dict]:
-    """Create a mongoDB aggregation pipeline step to look up nested reference by id.
-
-    :param local_field: reference field to look up
-    :param set_as: desired name of the returned record
-    :return: mongoDB aggregation steps for use in an aggregation pipeline
-    """
-    return [
-        {
-            "$lookup": {
-                "from": "references",
-                "let": {"reference_id": f"${local_field}"},
-                "pipeline": [
-                    {"$match": {"$expr": {"$eq": ["$_id", "$$reference_id"]}}},
-                    {"$project": {"_id": True, "name": True, "data_type": True}},
-                ],
-                "as": set_as,
-            },
-        },
-        {"$set": {set_as: {"$first": f"${set_as}"}}},
-    ]

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -44,6 +44,7 @@ from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id, get_one_field
 from virtool.pg.utils import delete_row
+from virtool.references.db import compose_reference_id_match
 from virtool.samples.checks import (
     check_labels_do_not_exist,
     check_name_is_in_use,
@@ -985,7 +986,10 @@ class SamplesData(DataLayerDomain):
             raise ResourceConflictError("Reference is archived")
 
         if not await self._mongo.indexes.count_documents(
-            {"reference.id": ref_id, "ready": True},
+            {
+                "reference.id": await compose_reference_id_match(self._pg, ref_id),
+                "ready": True,
+            },
         ):
             raise ResourceConflictError("No ready index")
 


### PR DESCRIPTION
## Summary
- Rewrite the embedded `reference.id` in Mongo index documents from the legacy Mongo string to the integer `legacy_references` id, with a data revision that backfills existing indexes and raises loudly on any reference not resolvable in Postgres.
- Make index reads tolerate either id form: single-id lookups and the orphan/archived list filters resolve both the legacy string and integer primary key, with the nested reference now attached via `AttachReferenceTransform` instead of a Mongo `$lookup` that couldn't join an integer to the string-keyed `references` collection.
- Keep the public-facing reference id as the legacy string until VIR-2591.