### PR TITLE
feat(migration): compare reference rights before read cutover

### DIFF
--- a/assets/revisions/rev_td1a0rtqlp32_compare_reference_rights.py
+++ b/assets/revisions/rev_td1a0rtqlp32_compare_reference_rights.py
@@ -1,0 +1,42 @@
+"""Compare Mongo and Postgres reference rights before the read cutover.
+
+A read-only gating check run after the reference backfill and before authorization
+and reference reads switch to Postgres. It verifies that every reference's embedded
+Mongo ``groups``/``users`` rights arrays match the backfilled
+``legacy_reference_groups``/``legacy_reference_users`` tables, and raises on any
+drift so the cutover cannot proceed against inconsistent data.
+
+The implementation lives in :func:`compare_reference_rights`.
+
+Revision ID: td1a0rtqlp32
+Date: 2026-07-08 19:41:57.222957
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.references.migration import compare_reference_rights
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "compare reference rights"
+created_at = arrow.get("2026-07-08 19:41:57.222957")
+revision_id = "td1a0rtqlp32"
+
+alembic_down_revision = None
+virtool_down_revision = "tr3p2obxndjm"
+
+# ``fe83de8410d3`` leaves the reference rights tables in their final shape (no
+# ``remove``, no ``created_at``), the same guard the reference backfill uses.
+required_alembic_revision = "fe83de8410d3"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Fail loudly if Mongo and Postgres reference rights disagree.
+
+    The implementation lives in :func:`compare_reference_rights`.
+    """
+    await compare_reference_rights(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -687,5 +687,12 @@
       'name': 'backfill embedded index reference ids to integers',
       'revision': 'tr3p2obxndjm',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 99,
+      'name': 'compare reference rights',
+      'revision': 'td1a0rtqlp32',
+    }),
   ])
 # ---

--- a/tests/migration/test_compare_reference_rights.py
+++ b/tests/migration/test_compare_reference_rights.py
@@ -1,0 +1,251 @@
+"""Tests for the compare reference rights drift check.
+
+The compare pass is read-only: it reports drift between Mongo's embedded rights
+arrays and the backfilled Postgres join tables and raises on any disagreement. The
+backfill itself is exercised in ``test_copy_references_to_postgres``; these tests
+cover only what the compare owns -- matching a clean backfill, detecting rights
+that were changed out from under it, canonicalising legacy string group ids the
+way the read path does, and not mistaking a skipped deleted-group grant for drift.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_t4u44jre75a0_copy_references_to_postgres import (
+    upgrade as backfill,
+)
+from assets.revisions.rev_td1a0rtqlp32_compare_reference_rights import (
+    upgrade as compare,
+)
+from tests.migration.test_copy_references_to_postgres import (
+    get_reference_pk,
+    insert_group,
+    make_reference_document,
+    make_rights_member,
+    setup_user,
+    static_datetime,
+)
+from virtool.migration.ctx import MigrationContext
+
+__all__ = ["setup_user", "static_datetime"]
+
+
+async def insert_legacy_group(
+    session: AsyncSession,
+    name: str,
+    legacy_id: str,
+) -> int:
+    """Insert a group carrying a legacy id and return its integer primary key."""
+    result = await session.execute(
+        text(
+            "INSERT INTO groups (name, legacy_id, permissions) "
+            "VALUES (:name, :legacy_id, '{}') RETURNING id",
+        ),
+        {"name": name, "legacy_id": legacy_id},
+    )
+    group_id = result.scalar_one()
+    await session.commit()
+    return group_id
+
+
+class TestCompareReferenceRights:
+    async def test_clean_backfill_passes(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A reference whose rights were faithfully backfilled reports no drift."""
+        async with AsyncSession(ctx.pg) as session:
+            group_id = await insert_group(session, "Technicians")
+
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "clean_reference",
+                setup_user,
+                static_datetime,
+                users=[
+                    make_rights_member(
+                        setup_user,
+                        static_datetime,
+                        build=True,
+                        modify=True,
+                    ),
+                ],
+                groups=[
+                    make_rights_member(group_id, static_datetime, modify_otu=True),
+                ],
+            ),
+        )
+
+        await backfill(ctx)
+
+        await compare(ctx)
+
+    async def test_group_rights_drift_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A group grant changed in Postgres after backfill is flagged as drift."""
+        async with AsyncSession(ctx.pg) as session:
+            group_id = await insert_group(session, "Technicians")
+
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "group_drift_reference",
+                setup_user,
+                static_datetime,
+                groups=[
+                    make_rights_member(group_id, static_datetime, modify_otu=True),
+                ],
+            ),
+        )
+
+        await backfill(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            reference_pk = await get_reference_pk(session, "group_drift_reference")
+            await session.execute(
+                text(
+                    "UPDATE legacy_reference_groups SET modify_otu = false "
+                    "WHERE reference_id = :reference_id AND group_id = :group_id",
+                ),
+                {"reference_id": reference_pk, "group_id": group_id},
+            )
+            await session.commit()
+
+        with pytest.raises(ValueError, match="drift detected in 1 references"):
+            await compare(ctx)
+
+    async def test_user_rights_drift_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A user grant changed in Postgres after backfill is flagged as drift."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "user_drift_reference",
+                setup_user,
+                static_datetime,
+                users=[
+                    make_rights_member(setup_user, static_datetime, build=True),
+                ],
+            ),
+        )
+
+        await backfill(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            reference_pk = await get_reference_pk(session, "user_drift_reference")
+            await session.execute(
+                text(
+                    "UPDATE legacy_reference_users SET build = false "
+                    "WHERE reference_id = :reference_id AND user_id = :user_id",
+                ),
+                {"reference_id": reference_pk, "user_id": setup_user},
+            )
+            await session.commit()
+
+        with pytest.raises(ValueError, match="drift detected in 1 references"):
+            await compare(ctx)
+
+    async def test_missing_grant_in_postgres_raises(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A grant present in Mongo but deleted from Postgres is flagged as drift."""
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "deleted_grant_reference",
+                setup_user,
+                static_datetime,
+                users=[
+                    make_rights_member(setup_user, static_datetime, build=True),
+                ],
+            ),
+        )
+
+        await backfill(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            reference_pk = await get_reference_pk(session, "deleted_grant_reference")
+            await session.execute(
+                text(
+                    "DELETE FROM legacy_reference_users "
+                    "WHERE reference_id = :reference_id",
+                ),
+                {"reference_id": reference_pk},
+            )
+            await session.commit()
+
+        with pytest.raises(ValueError, match="drift detected in 1 references"):
+            await compare(ctx)
+
+    async def test_legacy_string_group_id_is_not_drift(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A grant addressing a group by its legacy string id matches the backfill.
+
+        The read path canonicalises the legacy id to the group's integer primary
+        key, and so must the compare, or every reference migrated before groups
+        moved to integer ids would report false drift.
+        """
+        async with AsyncSession(ctx.pg) as session:
+            await insert_legacy_group(session, "Technicians", "legacy_group_1")
+
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "legacy_group_reference",
+                setup_user,
+                static_datetime,
+                groups=[
+                    make_rights_member(
+                        "legacy_group_1",
+                        static_datetime,
+                        modify_otu=True,
+                    ),
+                ],
+            ),
+        )
+
+        await backfill(ctx)
+
+        await compare(ctx)
+
+    async def test_deleted_group_grant_is_not_drift(
+        self,
+        ctx: MigrationContext,
+        setup_user: int,
+        static_datetime: datetime,
+    ):
+        """A grant to a group missing from Postgres is dropped, not flagged.
+
+        The backfill skips grants to deleted groups, so Postgres legitimately holds
+        no row for them and the compare must not treat the absence as drift.
+        """
+        await ctx.mongo.references.insert_one(
+            make_reference_document(
+                "deleted_group_reference",
+                setup_user,
+                static_datetime,
+                groups=[
+                    make_rights_member(999999, static_datetime, modify_otu=True),
+                ],
+            ),
+        )
+
+        await backfill(ctx)
+
+        await compare(ctx)

--- a/virtool/references/migration.py
+++ b/virtool/references/migration.py
@@ -575,6 +575,186 @@ async def _archive_and_delete(
     return result.deleted_count
 
 
+async def compare_reference_rights(ctx: MigrationContext) -> None:
+    """Verify Mongo's embedded reference rights match the Postgres join tables.
+
+    A gating drift check run after the reference backfill and before authorization
+    and reference reads switch to Postgres. It changes nothing: it reads every
+    production reference (no sampling), builds the set of rights grants recorded in
+    Mongo and the set recorded in Postgres, and raises if they disagree.
+
+    For each reference two comparisons run independently:
+
+    - **Groups.** The embedded ``groups`` member ids are canonicalised through
+      :class:`SQLGroup` exactly as the read path :func:`get_reference_groups` does,
+      so an int id and the legacy string id of the same group collapse to one
+      canonical integer. A member whose group no longer resolves is dropped rather
+      than counted as drift: the backfill deliberately skips grants to deleted
+      groups (see :func:`_insert_rights_rows`), so Postgres is expected not to hold
+      them. The number dropped is logged so the omission is not silent.
+    - **Users.** User grants must always resolve, because users are never
+      hard-deleted and the backfill raises on an unresolvable ``users`` member. A
+      member that fails to resolve here is therefore recorded as drift rather than
+      silently dropped.
+
+    Only the authorization-relevant booleans ``build``, ``modify`` and
+    ``modify_otu`` take part in the comparison. There is no ``remove`` right, and
+    the join tables carry no ``created_at``, so neither can contribute drift.
+
+    The check is exhaustive before it fails: mismatches are accumulated across
+    every reference, the full per-reference report is logged, and a single
+    :class:`ValueError` is raised at the end. A clean run logs zero drift.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        reference_ids = [
+            document["_id"]
+            async for document in ctx.mongo.references.find({}, projection=["_id"])
+        ]
+
+        group_id_cache: dict[int | str, int | None] = {}
+        user_id_cache: dict[int | str, int | None] = {}
+
+        drifted: list[dict] = []
+        dropped_group_grants = 0
+
+        for reference_id in reference_ids:
+            document = await ctx.mongo.references.find_one({"_id": reference_id})
+
+            if document is None:
+                continue
+
+            reference_pk = (
+                await session.execute(
+                    select(SQLReference.id).where(
+                        SQLReference.legacy_id == reference_id,
+                    ),
+                )
+            ).scalar_one_or_none()
+
+            if reference_pk is None:
+                msg = (
+                    f"reference {reference_id!r} exists in mongo but is missing "
+                    "from postgres"
+                )
+                raise ValueError(msg)
+
+            expected_groups: set[tuple[int, bool, bool, bool]] = set()
+
+            for member in document.get("groups") or []:
+                group_id = await _resolve_id(
+                    session,
+                    SQLGroup,
+                    member["id"],
+                    group_id_cache,
+                )
+
+                if group_id is None:
+                    dropped_group_grants += 1
+                    continue
+
+                expected_groups.add(_rights_tuple(group_id, member))
+
+            unresolvable_users: list[int | str] = []
+            expected_users: set[tuple[int, bool, bool, bool]] = set()
+
+            for member in document.get("users") or []:
+                user_id = await _resolve_id(
+                    session,
+                    SQLUser,
+                    member["id"],
+                    user_id_cache,
+                )
+
+                if user_id is None:
+                    unresolvable_users.append(member["id"])
+                    continue
+
+                expected_users.add(_rights_tuple(user_id, member))
+
+            actual_groups = {
+                (row.group_id, row.build, row.modify, row.modify_otu)
+                for row in (
+                    await session.execute(
+                        select(
+                            SQLReferenceGroup.group_id,
+                            SQLReferenceGroup.build,
+                            SQLReferenceGroup.modify,
+                            SQLReferenceGroup.modify_otu,
+                        ).where(SQLReferenceGroup.reference_id == reference_pk),
+                    )
+                ).all()
+            }
+
+            actual_users = {
+                (row.user_id, row.build, row.modify, row.modify_otu)
+                for row in (
+                    await session.execute(
+                        select(
+                            SQLReferenceUser.user_id,
+                            SQLReferenceUser.build,
+                            SQLReferenceUser.modify,
+                            SQLReferenceUser.modify_otu,
+                        ).where(SQLReferenceUser.reference_id == reference_pk),
+                    )
+                ).all()
+            }
+
+            if (
+                expected_groups != actual_groups
+                or expected_users != actual_users
+                or unresolvable_users
+            ):
+                drifted.append(
+                    {
+                        "reference_id": reference_id,
+                        "groups_only_in_mongo": sorted(
+                            expected_groups - actual_groups,
+                        ),
+                        "groups_only_in_postgres": sorted(
+                            actual_groups - expected_groups,
+                        ),
+                        "users_only_in_mongo": sorted(expected_users - actual_users),
+                        "users_only_in_postgres": sorted(
+                            actual_users - expected_users,
+                        ),
+                        "unresolvable_users": unresolvable_users,
+                    },
+                )
+
+    if dropped_group_grants:
+        logger.info(
+            "dropped grants to deleted groups when building expected rights",
+            dropped=dropped_group_grants,
+        )
+
+    if drifted:
+        for report in drifted:
+            logger.error("reference rights drift", **report)
+
+        msg = f"reference rights drift detected in {len(drifted)} references"
+        raise ValueError(msg)
+
+    logger.info(
+        "reference rights match; no drift",
+        references=len(reference_ids),
+    )
+
+
+def _rights_tuple(canonical_id: int, member: dict) -> tuple[int, bool, bool, bool]:
+    """Build a hashable rights grant keyed by a canonical integer id.
+
+    ``created_at`` and the retired ``remove`` right are intentionally excluded: the
+    join tables store neither, so only the three live authorization booleans take
+    part in the comparison.
+    """
+    return (
+        canonical_id,
+        member.get("build", False),
+        member.get("modify", False),
+        member.get("modify_otu", False),
+    )
+
+
 async def _resolve_rights_member_id(
     session: AsyncSession,
     model: type[Base],


### PR DESCRIPTION
## Summary

- Add a gating drift check that compares Mongo's embedded reference `users`/`groups` rights against the Postgres `legacy_reference_users`/`legacy_reference_groups` join tables, raising on any mismatch before reads cut over to Postgres.
- Treat unresolvable group grants as an expected, logged drop (matching backfill behaviour) while unresolvable user grants are always flagged as drift, since users are never hard-deleted.
- Report every drifted reference in one exhaustive pass rather than failing on the first mismatch, so a single run surfaces the full scope of any drift.