### PR TITLE
fix(migration): exclude history from embedded reference-id backfill

### DIFF
--- a/assets/revisions/rev_a5hg3lbp6rz1_backfill_embedded_reference_ids_to_integers.py
+++ b/assets/revisions/rev_a5hg3lbp6rz1_backfill_embedded_reference_ids_to_integers.py
@@ -1,10 +1,9 @@
-"""Convert the embedded ``reference.id`` in otus, sequences, and history to integers.
+"""Convert the embedded ``reference.id`` in otus and sequences to integers.
 
 References now live in Postgres as ``legacy_references`` with an integer ``id``
-and a permanent ``legacy_id`` (the old Mongo string id). The Mongo ``otus``,
-``sequences``, and top-level ``history`` documents each embed a ``reference``
-subdocument whose ``id`` must hold the integer ``legacy_references.id`` rather
-than the legacy string.
+and a permanent ``legacy_id`` (the old Mongo string id). The Mongo ``otus`` and
+``sequences`` documents each embed a ``reference`` subdocument whose ``id`` must
+hold the integer ``legacy_references.id`` rather than the legacy string.
 
 This revision rewrites ``reference.id`` on every such document, resolving legacy
 string ids to their integer ``legacy_references.id`` via
@@ -12,10 +11,13 @@ string ids to their integer ``legacy_references.id`` via
 filter skips documents already holding an integer, so the revision is idempotent
 and safe to re-run.
 
-The ``legacy_history_diff`` stored on history documents is intentionally left
-untouched -- ``patch_to_version`` overlays the authoritative reference onto a
-reconstructed OTU at read time, so the reference embedded in the diff is
-irrelevant.
+The Mongo ``history`` collection is intentionally excluded. The orphan-purge
+revision (``0uwpffz8adx0``) leaves ``history`` untouched as an archive of deleted
+history, so it still holds ``reference.id`` values for references that no longer
+exist in Postgres. Nothing reads those embedded ids -- ``patch_to_version``
+overlays the authoritative reference (sourced from ``legacy_history``) onto a
+reconstructed OTU at read time -- so rewriting them would buy nothing while
+forcing the strict resolution below to abort on every orphan.
 
 Unresolved string ids raise loudly rather than being dropped or stored as
 ``NULL`` -- a document referencing a reference that no longer exists in Postgres
@@ -51,7 +53,7 @@ virtool_down_revision = None
 # Change this if an Alembic revision is required to run this migration.
 required_alembic_revision = None
 
-COLLECTIONS = ("otus", "sequences", "history")
+COLLECTIONS = ("otus", "sequences")
 
 
 async def upgrade(ctx: MigrationContext) -> None:

--- a/tests/migration/test_backfill_embedded_reference_ids.py
+++ b/tests/migration/test_backfill_embedded_reference_ids.py
@@ -71,7 +71,7 @@ class TestEmbeddedReferenceIdsBackfill:
         setup_references: dict[str, int],
     ):
         """The embedded ``reference.id`` string resolves to the integer id on
-        otu, sequence, and history documents alike.
+        otu and sequence documents alike.
         """
         ref_a = setup_references["ref_a_legacy"]
 
@@ -81,20 +81,34 @@ class TestEmbeddedReferenceIdsBackfill:
         await ctx.mongo.sequences.insert_one(
             {"_id": "sequence_a", "reference": {"id": "ref_a_legacy"}},
         )
-        await ctx.mongo.history.insert_one(
-            {"_id": "otu_a.0", "reference": {"id": "ref_a_legacy"}},
-        )
 
         await upgrade(ctx)
 
         for collection, doc_id in (
             ("otus", "otu_a"),
             ("sequences", "sequence_a"),
-            ("history", "otu_a.0"),
         ):
             doc = await ctx.mongo[collection].find_one({"_id": doc_id})
             assert doc["reference"]["id"] == ref_a
             assert isinstance(doc["reference"]["id"], int)
+
+    @pytest.mark.usefixtures("setup_references")
+    async def test_leaves_history_untouched(
+        self,
+        ctx: MigrationContext,
+    ):
+        """The ``history`` collection is excluded, so an orphaned embedded
+        ``reference.id`` left there by the orphan purge neither raises nor is
+        rewritten.
+        """
+        await ctx.mongo.history.insert_one(
+            {"_id": "otu_orphan.0", "reference": {"id": "orphaned_reference"}},
+        )
+
+        await upgrade(ctx)
+
+        doc = await ctx.mongo.history.find_one({"_id": "otu_orphan.0"})
+        assert doc["reference"]["id"] == "orphaned_reference"
 
     async def test_leaves_other_reference_fields_intact(
         self,


### PR DESCRIPTION
## Summary
- Stop the embedded-reference-id backfill from aborting when Mongo `history` still holds `reference.id` values for refs the orphan-purge already removed from Postgres.
- Exclude `history` from the backfill's strict-resolution pass since nothing reads its embedded reference id — `patch_to_version` sources it from `legacy_history` at read time instead.