### PR TITLE
feat: add sample uploads to postgres

### DIFF
--- a/assets/alembic/versions/1ffbe2dcb108_create_sample_uploads_table.py
+++ b/assets/alembic/versions/1ffbe2dcb108_create_sample_uploads_table.py
@@ -1,0 +1,35 @@
+"""create sample uploads table
+
+Revision ID: 1ffbe2dcb108
+Revises: 48aa4cef7b47
+Create Date: 2026-07-08 22:14:11.548643+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1ffbe2dcb108"
+down_revision = "48aa4cef7b47"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sample_uploads",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("sample", sa.String(), nullable=False),
+        sa.Column("sample_id", sa.BigInteger(), nullable=True),
+        sa.Column("upload_id", sa.Integer(), nullable=False),
+        sa.Column("index", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("upload_id"),
+        sa.ForeignKeyConstraint(["sample_id"], ["legacy_samples.id"]),
+        sa.ForeignKeyConstraint(["upload_id"], ["uploads.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("sample_uploads")

--- a/assets/alembic/versions/1ffbe2dcb108_create_sample_uploads_table.py
+++ b/assets/alembic/versions/1ffbe2dcb108_create_sample_uploads_table.py
@@ -19,7 +19,7 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "sample_uploads",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=True), nullable=False),
         sa.Column("sample", sa.String(), nullable=False),
         sa.Column("sample_id", sa.BigInteger(), nullable=True),
         sa.Column("upload_id", sa.Integer(), nullable=False),

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -694,5 +694,12 @@
       'name': 'compare reference rights',
       'revision': 'td1a0rtqlp32',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 100,
+      'name': 'create sample uploads table',
+      'revision': '1ffbe2dcb108',
+    }),
   ])
 # ---

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -921,6 +921,27 @@ class TestCreate:
 
         await resp_is.bad_request(resp, "File does not exist")
 
+    async def test_duplicate_file(
+        self,
+        fake: DataFaker,
+        spawn_client: ClientSpawner,
+        resp_is,
+    ):
+        """Test that the same upload cannot be passed twice in ``files``."""
+        client = await spawn_client(
+            authenticated=True,
+            permissions=[Permission.create_sample],
+        )
+
+        upload = await fake.uploads.create(user=await fake.users.create())
+
+        resp = await client.post(
+            "/samples",
+            {"name": "Foobar", "files": [upload.id, upload.id]},
+        )
+
+        await resp_is.bad_request(resp, "File is duplicated")
+
     async def test_label_dne(
         self,
         fake: DataFaker,

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -30,6 +30,7 @@ from virtool.samples.sql import (
     SQLLegacySampleLabel,
     SQLLegacySampleSubtraction,
     SQLSampleReads,
+    SQLSampleUpload,
 )
 from virtool.samples.utils import SampleRight
 from virtool.settings.oas import UpdateSettingsRequest
@@ -259,6 +260,22 @@ class TestCreate:
                 .scalars()
                 .all()
             )
+
+            sample_uploads = (
+                (
+                    await session.execute(
+                        select(SQLSampleUpload)
+                        .where(SQLSampleUpload.sample_id == legacy.id)
+                        .order_by(SQLSampleUpload.index),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert [(row.sample, row.upload_id, row.index) for row in sample_uploads] == [
+            (sample["_id"], u["id"], i) for i, u in enumerate(sample["uploads"])
+        ]
 
         assert legacy.name == sample["name"]
         assert legacy.library_type == sample["library_type"]
@@ -1324,6 +1341,14 @@ class TestDelete:
                 )
             ).scalar_one()
 
+            assert (
+                await session.execute(
+                    select(SQLSampleUpload).where(
+                        SQLSampleUpload.sample_id == legacy.id,
+                    ),
+                )
+            ).scalars().all() != []
+
         await data_layer.samples.delete(sample.id)
 
         async with AsyncSession(pg) as session:
@@ -1347,6 +1372,14 @@ class TestDelete:
                 await session.execute(
                     select(SQLLegacySampleSubtraction).where(
                         SQLLegacySampleSubtraction.sample_id == legacy.id,
+                    ),
+                )
+            ).scalars().all() == []
+
+            assert (
+                await session.execute(
+                    select(SQLSampleUpload).where(
+                        SQLSampleUpload.sample_id == legacy.id,
                     ),
                 )
             ).scalars().all() == []

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -537,6 +537,9 @@ class SamplesData(DataLayerDomain):
             check_subtractions_do_not_exist(self._pg, data.subtractions),
         )
 
+        if len(set(data.files)) != len(data.files):
+            raise ResourceConflictError("File is duplicated")
+
         try:
             uploads = [
                 (await self.data.uploads.get(file_)).dict() for file_ in data.files

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -70,6 +70,7 @@ from virtool.samples.sql import (
     SQLLegacySampleSubtraction,
     SQLSampleArtifact,
     SQLSampleReads,
+    SQLSampleUpload,
 )
 from virtool.samples.utils import (
     SampleRight,
@@ -484,6 +485,16 @@ class SamplesData(DataLayerDomain):
             document["subtractions"],
         )
 
+        for index, upload in enumerate(document["uploads"]):
+            pg_session.add(
+                SQLSampleUpload(
+                    sample=document["_id"],
+                    sample_id=sample.id,
+                    upload_id=upload["id"],
+                    index=index,
+                ),
+            )
+
     @staticmethod
     def _add_legacy_sample_join_rows(
         pg_session: AsyncSession,
@@ -690,6 +701,14 @@ class SamplesData(DataLayerDomain):
             await pg_session.execute(
                 delete(SQLLegacySampleSubtraction).where(
                     SQLLegacySampleSubtraction.sample_id == sample_pk,
+                ),
+            )
+            await pg_session.execute(
+                delete(SQLSampleUpload).where(
+                    or_(
+                        SQLSampleUpload.sample_id == sample_pk,
+                        SQLSampleUpload.sample == legacy_id,
+                    ),
                 ),
             )
             await pg_session.execute(

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -76,7 +76,7 @@ class SQLSampleUpload(Base):
     __tablename__ = "sample_uploads"
     __table_args__ = (UniqueConstraint("upload_id"),)
 
-    id = Column(Integer, primary_key=True)
+    id = Column(BigInteger, Identity(always=True), primary_key=True)
     sample = Column(String, nullable=False)
     sample_id = Column(BigInteger, ForeignKey("legacy_samples.id"))
     upload_id = Column(Integer, ForeignKey("uploads.id"), nullable=False)

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -70,6 +70,19 @@ class SQLSampleReads(Base):
     uploaded_at = Column(DateTime)
 
 
+class SQLSampleUpload(Base):
+    """SQL model linking a sample to its input uploads."""
+
+    __tablename__ = "sample_uploads"
+    __table_args__ = (UniqueConstraint("upload_id"),)
+
+    id = Column(Integer, primary_key=True)
+    sample = Column(String, nullable=False)
+    sample_id = Column(BigInteger, ForeignKey("legacy_samples.id"))
+    upload_id = Column(Integer, ForeignKey("uploads.id"), nullable=False)
+    index = Column(Integer, nullable=False)
+
+
 class SQLLegacySample(Base):
     """SQL model for sample metadata.
 


### PR DESCRIPTION
## Summary
- Adds the `sample_uploads` Postgres table linking samples to their input uploads, with a legacy string `sample` column and an integer `sample_id` FK to `legacy_samples`, plus an `index` column preserving upload array order.
- Dual-writes the sample→upload membership on sample creation and cleans it up on deletion, alongside the existing Mongo writes; Mongo stays the read authority for now.
- Backfill and the read cutover (steps 3–4) are deferred to VIR-2619 for a later release, so a single idempotent backfill can run once dual-write is live.