### PR TITLE
feat: read references from postgres

### DIFF
--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -66,9 +66,15 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
         ).scalar_one_or_none()
 
         if reference_pg_id is None:
+            reference_doc = await mongo.references.find_one(reference["id"], ["name"])
+            reference_name = (
+                reference_doc["name"]
+                if reference_doc
+                else reference.get("name", reference["id"])
+            )
             legacy_reference = SQLReference(
                 legacy_id=reference["id"],
-                name=reference.get("name", reference["id"]),
+                name=reference_name,
                 description="",
                 created_at=document["created_at"],
                 source_types=[],

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -170,6 +170,22 @@ class TestFind:
 
         async with AsyncSession(pg) as session:
             session.add_all(
+                SQLReference(
+                    legacy_id=legacy_id,
+                    name=name,
+                    description="",
+                    created_at=static_time.datetime,
+                    archived=archived,
+                    source_types=[],
+                    user_id=user.id,
+                )
+                for legacy_id, name, archived in (
+                    ("ref_active_a", "Active A", False),
+                    ("ref_active_b", "Active B", False),
+                    ("ref_archived", "Archived", True),
+                )
+            )
+            session.add_all(
                 SQLLegacyHistory(
                     legacy_id=legacy_id,
                     created_at=static_time.datetime,
@@ -228,6 +244,7 @@ class TestFind:
         fake: DataFaker,
         snapshot,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         static_time,
     ):
@@ -300,6 +317,25 @@ class TestFind:
             ),
         )
 
+        async with AsyncSession(pg) as session:
+            session.add_all(
+                SQLReference(
+                    legacy_id=legacy_id,
+                    name=name,
+                    description="",
+                    created_at=static_time.datetime,
+                    archived=archived_flag,
+                    source_types=[],
+                    user_id=user.id,
+                )
+                for legacy_id, name, archived_flag in (
+                    ("ref_active_a", "Active A", False),
+                    ("ref_active_b", "Active B", False),
+                    ("ref_archived", "Archived", True),
+                )
+            )
+            await session.commit()
+
         url = "/indexes?ready=True"
         if archived is not None:
             url = f"{url}&archived={archived}"
@@ -347,6 +383,16 @@ async def test_get(
     )
 
     async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id="bar",
+                name="Bar",
+                description="",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=prolific.id,
+            ),
+        )
         session.add_all(
             SQLLegacyHistory(
                 legacy_id=legacy_id,
@@ -681,6 +727,7 @@ async def test_delete_index(
     error,
     fake: DataFaker,
     mongo: Mongo,
+    pg: AsyncEngine,
     spawn_job_client: JobClientSpawner,
     static_time,
 ):
@@ -708,6 +755,19 @@ async def test_delete_index(
                 },
             ),
         )
+
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLReference(
+                    legacy_id="foo",
+                    name="Foo",
+                    description="",
+                    created_at=static_time.datetime,
+                    source_types=[],
+                    user_id=user.id,
+                ),
+            )
+            await session.commit()
 
     response = await client.delete(f"/indexes/{index_id}")
 
@@ -837,6 +897,19 @@ async def test_finalize(
                 "name": "Test A",
             },
         )
+
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLReference(
+                    legacy_id="hxn167",
+                    name="Test A",
+                    description="",
+                    created_at=static_time.datetime,
+                    source_types=[],
+                    user_id=user.id,
+                ),
+            )
+            await session.commit()
 
     await asyncio.gather(
         mongo.indexes.insert_one(

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -8,6 +8,7 @@ from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndexFile
 from virtool.mongo.core import Mongo
+from virtool.references.sql import SQLReference
 
 
 async def test_finalize(
@@ -42,6 +43,14 @@ async def test_finalize(
     async with AsyncSession(pg) as session:
         session.add_all(
             [
+                SQLReference(
+                    legacy_id="bar",
+                    name="Bar",
+                    description="",
+                    created_at=static_time.datetime,
+                    source_types=[],
+                    user_id=user.id,
+                ),
                 SQLIndexFile(
                     id=1,
                     name="reference.1.bt2",
@@ -144,6 +153,14 @@ class TestDelete:
         async with AsyncSession(pg) as session:
             session.add_all(
                 [
+                    SQLReference(
+                        legacy_id="reference",
+                        name="Reference",
+                        description="",
+                        created_at=static_time.datetime,
+                        source_types=[],
+                        user_id=user.id,
+                    ),
                     SQLLegacyHistory(
                         legacy_id="otu_a.0",
                         created_at=static_time.datetime,

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -40,6 +40,7 @@ async def seed_pg_reference(
     user_id: int,
     created_at,
     *,
+    name: str | None = None,
     users: list[tuple[int, dict]] | None = None,
     groups: list[tuple[int, dict]] | None = None,
 ) -> None:
@@ -47,7 +48,7 @@ async def seed_pg_reference(
     async with AsyncSession(pg) as session:
         reference = SQLReference(
             legacy_id=legacy_id,
-            name=legacy_id,
+            name=name or legacy_id,
             description="",
             created_at=created_at,
             source_types=[],
@@ -134,86 +135,6 @@ async def test_find(
     user = await fake.users.create()
     await data_layer.users.update(client.user.id, UpdateUserRequest(groups=[group.id]))
 
-    await mongo.references.insert_many(
-        [
-            {
-                "_id": "owned_active",
-                "archived": False,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [],
-                "name": "Owned Active",
-                "organism": "virus",
-                "restrict_source_types": False,
-                "task": {"id": 1},
-                "user": {"id": client.user.id},
-            },
-            {
-                "_id": "other_active",
-                "archived": False,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [],
-                "name": "Other Active",
-                "organism": "virus",
-                "restrict_source_types": True,
-                "task": {"id": 2},
-                "user": {"id": user.id},
-            },
-            {
-                "_id": "user_member_active",
-                "archived": False,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [],
-                "name": "User Member Active",
-                "organism": "virus",
-                "restrict_source_types": True,
-                "task": {"id": 2},
-                "user": {"id": user.id},
-                "users": [{"id": client.user.id}],
-            },
-            {
-                "_id": "group_member_active",
-                "archived": False,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [{"id": group.id}],
-                "name": "Group Member Active",
-                "organism": "virus",
-                "restrict_source_types": True,
-                "task": {"id": 2},
-                "user": {"id": user.id},
-                "users": [],
-            },
-            {
-                "_id": "owned_archived",
-                "archived": True,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [],
-                "name": "Owned Archived",
-                "organism": "virus",
-                "restrict_source_types": False,
-                "task": {"id": 1},
-                "user": {"id": client.user.id},
-            },
-            {
-                "_id": "other_archived",
-                "archived": True,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [],
-                "name": "Other Archived",
-                "organism": "virus",
-                "restrict_source_types": True,
-                "task": {"id": 2},
-                "user": {"id": user.id},
-            },
-        ],
-        session=None,
-    )
-
     async with AsyncSession(pg) as session:
         session.add_all(
             [
@@ -242,6 +163,90 @@ async def test_find(
             ],
         )
         await session.commit()
+
+    for document in [
+        {
+            "_id": "owned_active",
+            "archived": False,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [],
+            "name": "Owned Active",
+            "organism": "virus",
+            "restrict_source_types": False,
+            "task": {"id": 1},
+            "user": {"id": client.user.id},
+        },
+        {
+            "_id": "other_active",
+            "archived": False,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [],
+            "name": "Other Active",
+            "organism": "virus",
+            "restrict_source_types": True,
+            "task": {"id": 2},
+            "user": {"id": user.id},
+        },
+        {
+            "_id": "user_member_active",
+            "archived": False,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [],
+            "name": "User Member Active",
+            "organism": "virus",
+            "restrict_source_types": True,
+            "task": {"id": 2},
+            "user": {"id": user.id},
+            "users": [{"id": client.user.id}],
+        },
+        {
+            "_id": "group_member_active",
+            "archived": False,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [{"id": group.id}],
+            "name": "Group Member Active",
+            "organism": "virus",
+            "restrict_source_types": True,
+            "task": {"id": 2},
+            "user": {"id": user.id},
+            "users": [],
+        },
+        {
+            "_id": "owned_archived",
+            "archived": True,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [],
+            "name": "Owned Archived",
+            "organism": "virus",
+            "restrict_source_types": False,
+            "task": {"id": 1},
+            "user": {"id": client.user.id},
+        },
+        {
+            "_id": "other_archived",
+            "archived": True,
+            "created_at": static_time.datetime,
+            "data_type": "genome",
+            "description": "",
+            "groups": [],
+            "name": "Other Archived",
+            "organism": "virus",
+            "restrict_source_types": True,
+            "task": {"id": 2},
+            "user": {"id": user.id},
+        },
+    ]:
+        await insert_reference(mongo, pg, document)
 
     url = "/references/v1"
     if archived is not None:
@@ -376,6 +381,7 @@ class TestCreate:
         self,
         fake: DataFaker,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         snapshot: SnapshotAssertion,
         static_time,
@@ -388,12 +394,15 @@ class TestCreate:
         user_1 = await fake.users.create()
         user_2 = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
-                "created_at": virtool.utils.timestamp(),
+                "created_at": static_time.datetime,
                 "data_type": "genome",
+                "description": "",
                 "name": "Foo",
                 "organism": "virus",
                 "restrict_source_types": False,
@@ -439,12 +448,15 @@ class TestEdit:
         user_2 = await fake.users.create()
         user_3 = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
-                "created_at": virtool.utils.timestamp(),
+                "created_at": static_time.datetime,
                 "data_type": "genome",
+                "description": "",
                 "name": "Foo",
                 "organism": "virus",
                 "restrict_source_types": False,
@@ -468,17 +480,6 @@ class TestEdit:
                     },
                 ],
             },
-        )
-
-        await seed_pg_reference(
-            pg,
-            "foo",
-            user_1.id,
-            static_time.datetime,
-            users=[
-                (user_2.id, FULL_RIGHTS),
-                (user_3.id, FULL_RIGHTS),
-            ],
         )
 
     async def test_ok(
@@ -580,13 +581,16 @@ class TestArchive:
         fake: DataFaker,
         mocker,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot_recent: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
         client = await spawn_client(authenticated=True)
         user = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             _archive_reference_doc(user.id, archived=already_archived),
         )
 
@@ -654,13 +658,16 @@ class TestUnarchive:
         fake: DataFaker,
         mocker,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot_recent: SnapshotAssertion,
         spawn_client: ClientSpawner,
     ):
         client = await spawn_client(authenticated=True)
         user = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             _archive_reference_doc(user.id, archived=already_archived),
         )
 
@@ -749,6 +756,7 @@ class TestCreateOTU:
                 "foo",
                 client.user.id,
                 static_time.datetime,
+                name="Foo",
                 users=[] if error == "403" else [(client.user.id, FULL_RIGHTS)],
             )
             await mongo.references.insert_one(
@@ -1389,6 +1397,8 @@ async def test_delete_group(
 async def test_find_otus(
     find: str | None,
     verified: bool | None,
+    fake: DataFaker,
+    pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
     spawn_client: ClientSpawner,
@@ -1397,6 +1407,21 @@ async def test_find_otus(
     filtered.
     """
     client = await spawn_client(authenticated=True)
+
+    user = await fake.users.create()
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id="foo",
+                name="Foo",
+                description="",
+                created_at=virtool.utils.timestamp(),
+                source_types=[],
+                user_id=user.id,
+            ),
+        )
+        await session.commit()
 
     await asyncio.gather(
         mongo.references.insert_one(

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -398,54 +398,6 @@ class TestUpdate:
         assert row.name == "After"
         assert row.organism == "bacteria"
 
-    async def test_skips_postgres_when_row_absent(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-        mongo: Mongo,
-        pg: AsyncEngine,
-        static_time,
-    ):
-        """A Mongo-only reference still updates Mongo without a Postgres row."""
-        user = await fake.users.create()
-
-        await mongo.references.insert_one(
-            {
-                "_id": "mongo_only",
-                "archived": False,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "description": "Mongo only.",
-                "groups": [],
-                "internal_control": None,
-                "name": "Before",
-                "organism": "virus",
-                "restrict_source_types": False,
-                "source_types": [],
-                "user": {"id": user.id},
-                "users": [],
-            },
-        )
-
-        await data_layer.references.update(
-            "mongo_only",
-            UpdateReferenceRequest(name="After"),
-        )
-
-        document = await mongo.references.find_one("mongo_only")
-        assert document["name"] == "After"
-
-        async with AsyncSession(pg) as session:
-            row = (
-                await session.execute(
-                    select(SQLReference).where(
-                        SQLReference.legacy_id == "mongo_only",
-                    ),
-                )
-            ).scalar_one_or_none()
-
-        assert row is None
-
 
 class TestArchive:
     async def test_dual_write(
@@ -616,6 +568,7 @@ class TestUpdateUser:
         data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot,
         static_time,
     ):
@@ -623,7 +576,9 @@ class TestUpdateUser:
         user_1 = await fake.users.create()
         user_2 = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
@@ -715,6 +670,7 @@ class TestDeleteUser:
         data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot,
         static_time,
     ):
@@ -722,7 +678,9 @@ class TestDeleteUser:
         user_1 = await fake.users.create()
         user_2 = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
@@ -911,6 +869,7 @@ class TestUpdateGroup:
         data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot,
         static_time,
     ):
@@ -918,7 +877,9 @@ class TestUpdateGroup:
         user = await fake.users.create()
         group = await fake.groups.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
@@ -1003,6 +964,7 @@ class TestDeleteGroup:
         data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
+        pg: AsyncEngine,
         snapshot,
         static_time,
     ):
@@ -1010,7 +972,9 @@ class TestDeleteGroup:
         user = await fake.users.create()
         group = await fake.groups.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -17,7 +17,6 @@ from virtool.mongo.core import Mongo
 from virtool.references.db import (
     check_right,
     compose_archived_filter,
-    compose_rights_filter,
     create_document,
     get_manifest,
     get_reference_groups,
@@ -410,35 +409,6 @@ class TestComposeArchivedFilter:
         assert compose_archived_filter(archived) == expected
 
 
-class TestComposeRightsFilter:
-    """The user-rights facet of the references find query."""
-
-    def test_administrator(self):
-        """Administrators bypass the rights filter."""
-        assert (
-            compose_rights_filter(
-                user_id=7,
-                administrator=True,
-                groups=["foo"],
-            )
-            == {}
-        )
-
-    def test_non_administrator(self):
-        """Non-administrators get an ``$or`` over their group and user id."""
-        assert compose_rights_filter(
-            user_id=7,
-            administrator=False,
-            groups=["foo"],
-        ) == {
-            "$or": [
-                {"groups.id": {"$in": ["foo"]}},
-                {"users.id": 7},
-                {"user.id": 7},
-            ],
-        }
-
-
 async def test_create_manifest(mongo: Mongo, pg: AsyncEngine, test_otu: dict):
     await mongo.otus.insert_many(
         [
@@ -468,7 +438,7 @@ async def test_get_reference_groups(
     group_1 = await fake.groups.create()
     group_2 = await fake.groups.create(legacy_id="group_2")
 
-    await seed_reference_rights(
+    reference_pk = await seed_reference_rights(
         pg,
         legacy_id="ref_groups",
         owner_id=owner.id,
@@ -480,11 +450,7 @@ async def test_get_reference_groups(
     )
 
     assert (
-        await get_reference_groups(
-            pg,
-            {"_id": "ref_groups", "created_at": static_time.datetime},
-        )
-        == snapshot
+        await get_reference_groups(pg, reference_pk, static_time.datetime) == snapshot
     )
 
 

--- a/tests/references/test_transforms.py
+++ b/tests/references/test_transforms.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.transforms import apply_transforms
 from virtool.fake.next import DataFaker
-from virtool.mongo.core import Mongo
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 
@@ -30,17 +29,16 @@ async def _seed_reference(pg: AsyncEngine, legacy_id: str, user_id: int) -> int:
 class TestAttachReferenceTransform:
     async def test_legacy_string_id(
         self,
-        mongo: Mongo,
+        fake: DataFaker,
         pg: AsyncEngine,
     ):
-        """A document embedding the legacy string id resolves against Mongo."""
-        await mongo.references.insert_one(
-            {"_id": "foo", "name": "Reference A", "data_type": "genome"},
-        )
+        """A document embedding the legacy string id resolves against Postgres."""
+        user = await fake.users.create()
+        await _seed_reference(pg, "foo", user.id)
 
         document = await apply_transforms(
             {"id": "6116cba1", "reference": {"id": "foo"}},
-            [AttachReferenceTransform(mongo)],
+            [AttachReferenceTransform(pg)],
             pg,
         )
 
@@ -53,22 +51,15 @@ class TestAttachReferenceTransform:
     async def test_integer_primary_key(
         self,
         fake: DataFaker,
-        mongo: Mongo,
         pg: AsyncEngine,
     ):
-        """A document embedding the integer primary key is resolved to its Mongo
-        reference via Postgres.
-        """
+        """A document embedding the integer primary key resolves against Postgres."""
         user = await fake.users.create()
         reference_id = await _seed_reference(pg, "foo", user.id)
 
-        await mongo.references.insert_one(
-            {"_id": "foo", "name": "Reference A", "data_type": "genome"},
-        )
-
         document = await apply_transforms(
             {"id": "6116cba1", "reference": {"id": reference_id}},
-            [AttachReferenceTransform(mongo)],
+            [AttachReferenceTransform(pg)],
             pg,
         )
 
@@ -81,23 +72,18 @@ class TestAttachReferenceTransform:
     async def test_many_mixed_ids(
         self,
         fake: DataFaker,
-        mongo: Mongo,
         pg: AsyncEngine,
     ):
         """A batch mixing legacy string and integer ids resolves every document."""
         user = await fake.users.create()
         reference_id = await _seed_reference(pg, "foo", user.id)
 
-        await mongo.references.insert_one(
-            {"_id": "foo", "name": "Reference A", "data_type": "genome"},
-        )
-
         documents = await apply_transforms(
             [
                 {"id": "string_ref", "reference": {"id": "foo"}},
                 {"id": "integer_ref", "reference": {"id": reference_id}},
             ],
-            [AttachReferenceTransform(mongo)],
+            [AttachReferenceTransform(pg)],
             pg,
         )
 

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -23,6 +23,7 @@ from virtool.models.enums import LibraryType, Permission
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.models import Reference
+from virtool.references.sql import SQLReference
 from virtool.samples.fake import create_fake_sample
 from virtool.samples.models import WorkflowState
 from virtool.samples.sql import (
@@ -1401,6 +1402,18 @@ async def test_find_analyses(
     )
 
     async with AsyncSession(pg) as session:
+        session.add_all(
+            SQLReference(
+                legacy_id=legacy_id,
+                name=name,
+                description="",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=user_1.id,
+            )
+            for legacy_id, name in (("foo", "Foo"), ("baz", "Baz"))
+        )
+
         legacy_sample = SQLLegacySample(
             legacy_id="test",
             name="Test Sample",

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -199,7 +199,7 @@ class AnalysisData(DataLayerDomain):
             [
                 AttachIndexTransform(self._mongo),
                 AttachJobTransform(self._pg),
-                AttachReferenceTransform(self._mongo),
+                AttachReferenceTransform(self._pg),
                 AttachAnalysisSubtractionsTransform(self._pg),
                 AttachUserTransform(self._pg),
             ],
@@ -257,7 +257,7 @@ class AnalysisData(DataLayerDomain):
         transforms = [
             AttachIndexTransform(self._mongo),
             AttachJobTransform(self._pg),
-            AttachReferenceTransform(self._mongo),
+            AttachReferenceTransform(self._pg),
             AttachAnalysisSubtractionsTransform(self._pg),
             AttachUserTransform(self._pg),
         ]

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -69,7 +69,7 @@ class HistoryData:
                 base_processor(legacy_history_document(row, handle))
                 for row, handle in rows
             ],
-            [AttachReferenceTransform(self._mongo)],
+            [AttachReferenceTransform(self._pg)],
             self._pg,
         )
 
@@ -104,7 +104,7 @@ class HistoryData:
             base_processor(legacy_history_document(legacy_row, handle)),
             [
                 AttachDiffTransform(self._pg),
-                AttachReferenceTransform(self._mongo),
+                AttachReferenceTransform(self._pg),
             ],
             self._pg,
         )

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -476,7 +476,7 @@ async def find(
 
     documents = await apply_transforms(
         [base_processor(legacy_history_document(row, handle)) for row, handle in rows],
-        [AttachReferenceTransform(mongo)],
+        [AttachReferenceTransform(pg)],
         pg,
     )
 
@@ -551,7 +551,7 @@ async def find_by_index(
 
     documents = await apply_transforms(
         [base_processor(legacy_history_document(row, handle)) for row, handle in rows],
-        [AttachReferenceTransform(mongo)],
+        [AttachReferenceTransform(pg)],
         pg,
     )
 

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -106,7 +106,7 @@ class IndexData:
             items,
             [
                 AttachJobTransform(self._pg),
-                AttachReferenceTransform(self._mongo),
+                AttachReferenceTransform(self._pg),
                 AttachUserTransform(self._pg),
                 IndexCountsTransform(),
             ],
@@ -150,7 +150,7 @@ class IndexData:
             base_processor(document),
             [
                 AttachJobTransform(self._pg),
-                AttachReferenceTransform(self._mongo),
+                AttachReferenceTransform(self._pg),
                 AttachUserTransform(self._pg),
                 IndexCountsTransform(),
             ],

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -265,7 +265,7 @@ async def find(
             [base_processor(d) for d in data["documents"]],
             [
                 AttachJobTransform(pg),
-                AttachReferenceTransform(mongo),
+                AttachReferenceTransform(pg),
                 AttachUserTransform(pg),
                 IndexCountsTransform(),
             ],

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -74,7 +74,7 @@ class OTUData:
         document, most_recent_change = await asyncio.gather(
             apply_transforms(
                 document,
-                [AttachReferenceTransform(self._mongo)],
+                [AttachReferenceTransform(self._pg)],
                 self._pg,
             ),
             virtool.history.db.get_most_recent_change(
@@ -785,7 +785,7 @@ class OTUData:
         ):
             document = await apply_transforms(
                 base_processor(document),
-                [AttachReferenceTransform(self._mongo)],
+                [AttachReferenceTransform(self._pg)],
                 self._pg,
             )
             return Sequence(**document)

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -114,7 +114,7 @@ async def find(
 
     data["documents"] = await apply_transforms(
         [base_processor(d) for d in data["documents"]],
-        [AttachReferenceTransform(mongo)],
+        [AttachReferenceTransform(pg)],
         pg,
     )
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -1,7 +1,8 @@
 import asyncio
+import math
 
 from aiohttp import ClientSession
-from sqlalchemy import delete, select, update
+from sqlalchemy import ColumnExpressionArgument, delete, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -10,7 +11,6 @@ import virtool.indexes.db
 import virtool.otus.db
 import virtool.utils
 from virtool.api.errors import APIInsufficientRights
-from virtool.api.utils import compose_regex_query, paginate
 from virtool.config import Config
 from virtool.data.domain import DataLayerDomain
 from virtool.data.errors import (
@@ -21,6 +21,7 @@ from virtool.data.errors import (
 from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import (
     both_transactions,
+    compose_legacy_id_multi_expression,
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
     resolve_legacy_id,
@@ -44,9 +45,8 @@ from virtool.otus.oas import CreateOTURequest
 from virtool.pg.utils import get_row_by_id
 from virtool.references.alot import prepare_otu_insertion
 from virtool.references.db import (
-    compose_archived_filter,
     compose_reference_id_match,
-    compose_rights_filter,
+    get_cloned_from_lookup,
     get_contributors,
     get_latest_build,
     get_manifest,
@@ -54,6 +54,7 @@ from virtool.references.db import (
     get_reference_groups,
     get_reference_users,
     get_unbuilt_count,
+    map_reference_minimal,
     populate_insert_only_reference,
     processor,
     write_legacy_reference,
@@ -155,6 +156,61 @@ class ReferencesData(DataLayerDomain):
                 "handle": user_row.handle,
             }
 
+    async def _resolve_group_ids(self, groups: list[int | str]) -> list[int]:
+        """Resolve the Postgres primary keys for ``groups``.
+
+        ``groups`` are the requesting client's group memberships, which may be legacy
+        Mongo string ids or integer primary keys during the migration.
+        """
+        if not groups:
+            return []
+
+        async with AsyncSession(self._pg) as session:
+            return list(
+                (
+                    await session.execute(
+                        select(SQLGroup.id).where(
+                            compose_legacy_id_multi_expression(SQLGroup, groups),
+                        ),
+                    )
+                )
+                .scalars()
+                .all(),
+            )
+
+    async def _compose_rights_filter(
+        self,
+        user_id: int,
+        groups: list[int | str],
+    ) -> ColumnExpressionArgument[bool]:
+        """Compose the Postgres predicate scoping references to those the user can read.
+
+        Mirrors the Mongo ``$or`` rights filter: the requesting user owns the
+        reference, is granted direct user rights, or belongs to a group that is
+        granted rights.
+        """
+        clauses = [
+            SQLReference.user_id == user_id,
+            SQLReference.id.in_(
+                select(SQLReferenceUser.reference_id).where(
+                    SQLReferenceUser.user_id == user_id,
+                ),
+            ),
+        ]
+
+        group_ids = await self._resolve_group_ids(groups)
+
+        if group_ids:
+            clauses.append(
+                SQLReference.id.in_(
+                    select(SQLReferenceGroup.reference_id).where(
+                        SQLReferenceGroup.group_id.in_(group_ids),
+                    ),
+                ),
+            )
+
+        return or_(*clauses)
+
     async def find(
         self,
         find: str,
@@ -166,28 +222,55 @@ class ReferencesData(DataLayerDomain):
         archived: bool | None = None,
     ) -> ReferenceSearchResult:
         """Find references."""
-        mongo_query = {**compose_archived_filter(archived)}
+        base_filters: list[ColumnExpressionArgument[bool]] = []
+
+        if not administrator:
+            base_filters.append(await self._compose_rights_filter(user_id, groups))
+
+        search_filters = list(base_filters)
+
+        if archived is not None:
+            search_filters.append(SQLReference.archived.is_(archived))
 
         if find:
-            mongo_query = {
-                **mongo_query,
-                **compose_regex_query(find, ["name", "data_type"]),
-            }
+            escaped = find.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            search_filters.append(
+                SQLReference.name.ilike(f"%{escaped}%", escape="\\"),
+            )
 
-        base_query = compose_rights_filter(user_id, administrator, groups)
+        async with AsyncSession(self._pg) as session:
+            total_count = await session.scalar(
+                select(func.count()).select_from(SQLReference).where(*base_filters),
+            )
 
-        data = await paginate(
-            self._mongo.references,
-            mongo_query,
-            page,
-            per_page,
-            sort="name",
-            base_query=base_query,
-        )
+            found_count = await session.scalar(
+                select(func.count()).select_from(SQLReference).where(*search_filters),
+            )
+
+            rows = (
+                (
+                    await session.execute(
+                        select(SQLReference)
+                        .where(*search_filters)
+                        .order_by(SQLReference.name, SQLReference.id)
+                        .offset(per_page * (page - 1))
+                        .limit(per_page),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            cloned_from_lookup = await get_cloned_from_lookup(session, rows)
 
         documents = [
-            await processor(self._mongo, self._pg, document)
-            for document in data["documents"]
+            await processor(
+                self._mongo,
+                self._pg,
+                row,
+                cloned_from_lookup.get(row.cloned_from_id),
+            )
+            for row in rows
         ]
 
         documents = await apply_transforms(
@@ -201,10 +284,12 @@ class ReferencesData(DataLayerDomain):
         )
 
         return ReferenceSearchResult(
-            **{
-                **data,
-                "documents": documents,
-            },
+            documents=documents,
+            found_count=found_count,
+            total_count=total_count,
+            page=page,
+            page_count=int(math.ceil(found_count / per_page)),
+            per_page=per_page,
         )
 
     @emits(Operation.CREATE)
@@ -346,10 +431,19 @@ class ReferencesData(DataLayerDomain):
 
     async def get(self, ref_id: str) -> Reference:
         """Get a reference."""
-        document = await self._mongo.references.find_one(ref_id)
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLReference).where(
+                        compose_legacy_id_single_expression(SQLReference, ref_id),
+                    ),
+                )
+            ).scalar_one_or_none()
 
-        if not document:
-            raise ResourceNotFoundError
+            if row is None:
+                raise ResourceNotFoundError
+
+            cloned_from_lookup = await get_cloned_from_lookup(session, [row])
 
         (
             contributors,
@@ -359,24 +453,26 @@ class ReferencesData(DataLayerDomain):
             users,
             unbuilt_count,
         ) = await asyncio.gather(
-            get_contributors(self._pg, ref_id),
-            get_latest_build(self._mongo, self._pg, ref_id),
-            get_otu_count(self._mongo, self._pg, ref_id),
-            get_reference_groups(self._pg, document),
-            get_reference_users(self._pg, document),
-            get_unbuilt_count(self._pg, ref_id),
+            get_contributors(self._pg, row.legacy_id),
+            get_latest_build(self._mongo, self._pg, row.legacy_id),
+            get_otu_count(self._mongo, self._pg, row.legacy_id),
+            get_reference_groups(self._pg, row.id, row.created_at),
+            get_reference_users(self._pg, row.id, row.created_at),
+            get_unbuilt_count(self._pg, row.legacy_id),
         )
 
-        document.update(
-            {
-                "contributors": contributors,
-                "groups": groups,
-                "latest_build": latest_build,
-                "otu_count": otu_count,
-                "unbuilt_change_count": unbuilt_count,
-                "users": users,
-            },
-        )
+        document = {
+            **map_reference_minimal(row, cloned_from_lookup.get(row.cloned_from_id)),
+            "description": row.description,
+            "restrict_source_types": row.restrict_source_types,
+            "source_types": row.source_types,
+            "contributors": contributors,
+            "groups": groups,
+            "latest_build": latest_build,
+            "otu_count": otu_count,
+            "unbuilt_change_count": unbuilt_count,
+            "users": users,
+        }
 
         document = await apply_transforms(
             document,

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -147,19 +147,84 @@ async def write_legacy_reference(
         )
 
 
-async def processor(mongo: "Mongo", pg: AsyncEngine, document: Document) -> Document:
-    """Process a reference document to a form that can be expressed in a list.
+def map_reference_minimal(
+    row: SQLReference,
+    cloned_from: Document | None,
+) -> Document:
+    """Shape a ``legacy_references`` row into the base reference document consumed by
+    the ``ReferenceMinimal`` model and the read transforms.
 
-    Used ``attach_computed`` for complete representations of the reference.
+    ``data_type`` is emitted as the constant ``"genome"`` because the column is
+    dropped from Postgres. The integer foreign keys are shaped into the nested
+    ``{"id": ...}`` forms the ``AttachUserTransform``, ``AttachTaskTransform`` and
+    ``AttachImportedFromTransform`` transforms expect. ``cloned_from`` is resolved by
+    the caller via :func:`get_cloned_from_lookup`.
+
+    The public ``id`` remains the legacy Mongo string id for this migration step; the
+    integer primary key cutover happens later.
+
+    :param row: a ``legacy_references`` row
+    :param cloned_from: the resolved nested cloned-from doc, or ``None``
+    :return: the base reference document
+    """
+    return {
+        "id": row.legacy_id,
+        "name": row.name,
+        "organism": row.organism,
+        "created_at": row.created_at,
+        "archived": row.archived,
+        "data_type": "genome",
+        "cloned_from": cloned_from,
+        "imported_from": {"id": row.upload_id} if row.upload_id is not None else None,
+        "task": {"id": row.task_id} if row.task_id is not None else None,
+        "user": row.user_id,
+    }
+
+
+async def get_cloned_from_lookup(
+    session: AsyncSession,
+    rows: list[SQLReference],
+) -> dict[int, Document]:
+    """Map each source ``cloned_from_id`` in ``rows`` to its nested cloned-from doc.
+
+    The denormalized ``cloned_from.name`` snapshot is not stored in Postgres; the
+    source reference's current ``name`` is re-derived here via its primary key. The
+    nested ``id`` remains the source's legacy Mongo string id, matching the
+    pre-migration response shape.
+
+    :param session: an active Postgres session
+    :param rows: the reference rows whose ``cloned_from`` docs are needed
+    :return: a mapping of source primary key to nested cloned-from doc
+    """
+    source_ids = {row.cloned_from_id for row in rows if row.cloned_from_id is not None}
+
+    if not source_ids:
+        return {}
+
+    result = await session.execute(
+        select(SQLReference.id, SQLReference.legacy_id, SQLReference.name).where(
+            SQLReference.id.in_(source_ids),
+        ),
+    )
+
+    return {id_: {"id": legacy_id, "name": name} for id_, legacy_id, name in result}
+
+
+async def processor(
+    mongo: "Mongo",
+    pg: AsyncEngine,
+    row: SQLReference,
+    cloned_from: Document | None,
+) -> Document:
+    """Process a reference row into the ``ReferenceMinimal`` document shape.
 
     :param mongo: the application Mongo client
     :param pg: the application PostgreSQL engine
-    :param document: the document to process
+    :param row: the ``legacy_references`` row to process
+    :param cloned_from: the resolved nested cloned-from doc, or ``None``
     :return: the processed document
     """
-    document = base_processor(document)
-
-    ref_id = document["id"]
+    ref_id = row.legacy_id
 
     latest_build, otu_count, unbuilt_count = await asyncio.gather(
         get_latest_build(mongo, pg, ref_id),
@@ -167,20 +232,19 @@ async def processor(mongo: "Mongo", pg: AsyncEngine, document: Document) -> Docu
         get_unbuilt_count(pg, ref_id),
     )
 
-    document.update(
-        {
-            "latest_build": latest_build,
-            "otu_count": otu_count,
-            "unbuilt_change_count": unbuilt_count,
-        },
-    )
-
-    document["id"] = ref_id
-
-    return document
+    return {
+        **map_reference_minimal(row, cloned_from),
+        "latest_build": latest_build,
+        "otu_count": otu_count,
+        "unbuilt_change_count": unbuilt_count,
+    }
 
 
-async def get_reference_groups(pg: AsyncEngine, document: Document) -> list[Document]:
+async def get_reference_groups(
+    pg: AsyncEngine,
+    reference_pk: int,
+    created_at: datetime.datetime,
+) -> list[Document]:
     """Get a detailed list of groups that have access to the specified reference.
 
     Membership and rights are read from the ``legacy_reference_groups`` child
@@ -189,20 +253,12 @@ async def get_reference_groups(pg: AsyncEngine, document: Document) -> list[Docu
     in Postgres.
 
     :param pg: the application Postgres engine
-    :param document: the reference document
+    :param reference_pk: the reference primary key
+    :param created_at: the reference's creation timestamp
     :return: a list of group data dictionaries
 
     """
     async with AsyncSession(pg) as session:
-        reference_pk = await session.scalar(
-            select(SQLReference.id).where(
-                compose_legacy_id_single_expression(SQLReference, document["_id"]),
-            ),
-        )
-
-        if reference_pk is None:
-            return []
-
         rows = (
             await session.execute(
                 select(
@@ -227,13 +283,17 @@ async def get_reference_groups(pg: AsyncEngine, document: Document) -> list[Docu
             "build": row.build,
             "modify": row.modify,
             "modify_otu": row.modify_otu,
-            "created_at": document["created_at"],
+            "created_at": created_at,
         }
         for row in rows
     ]
 
 
-async def get_reference_users(pg: AsyncEngine, document: Document) -> list[Document]:
+async def get_reference_users(
+    pg: AsyncEngine,
+    reference_pk: int,
+    created_at: datetime.datetime,
+) -> list[Document]:
     """Get a detailed list of users that have access to the specified reference.
 
     Membership and rights are read from the ``legacy_reference_users`` child
@@ -242,22 +302,14 @@ async def get_reference_users(pg: AsyncEngine, document: Document) -> list[Docum
     in Postgres.
 
     :param pg: the application PostgreSQL engine
-    :param document: the reference document
+    :param reference_pk: the reference primary key
+    :param created_at: the reference's creation timestamp
     :return: a list of user data dictionaries
 
     """
     from virtool.users.pg import SQLUser
 
     async with AsyncSession(pg) as session:
-        reference_pk = await session.scalar(
-            select(SQLReference.id).where(
-                compose_legacy_id_single_expression(SQLReference, document["_id"]),
-            ),
-        )
-
-        if reference_pk is None:
-            return []
-
         rows = (
             await session.execute(
                 select(
@@ -280,7 +332,7 @@ async def get_reference_users(pg: AsyncEngine, document: Document) -> list[Docum
             "build": row.build,
             "modify": row.modify,
             "modify_otu": row.modify_otu,
-            "created_at": document["created_at"],
+            "created_at": created_at,
         }
         for row in rows
     ]
@@ -416,38 +468,6 @@ async def compose_reference_ids_match(
     )
 
     return await compose_legacy_id_multi_mongo_match(pg, SQLReference, legacy_ids)
-
-
-def compose_rights_filter(
-    user_id: int,
-    administrator: bool,
-    groups: list[int | str],
-) -> dict:
-    """Compose a Mongo filter restricting reference results to those the
-    requesting user has read rights to.
-
-    Administrators bypass the filter and receive an empty dict.
-
-    :param user_id: the id of the user requesting the search
-    :param administrator: the administrator flag of the user requesting the search
-    :param groups: the id group membership of the user requesting the search
-    :return: a Mongo filter dict; empty for administrators
-
-    """
-    if administrator:
-        return {}
-
-    user_queries = [
-        {"users.id": user_id},
-        {"user.id": user_id},
-    ]
-
-    return {
-        "$or": [
-            {"groups.id": {"$in": groups}},
-            *user_queries,
-        ],
-    }
 
 
 async def get_contributors(pg, ref_id: str) -> list[Document] | None:

--- a/virtool/references/transforms.py
+++ b/virtool/references/transforms.py
@@ -3,6 +3,10 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.topg import (
+    compose_legacy_id_multi_expression,
+    compose_legacy_id_single_expression,
+)
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.pg.utils import get_row_by_id
 from virtool.references.sql import SQLReference
@@ -10,54 +14,31 @@ from virtool.types import Document
 from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
-from virtool.utils import base_processor, get_safely
+from virtool.utils import get_safely
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
 
 
-PROJECTION = ["_id", "name", "data_type"]
+def _shape_nested_reference(legacy_id: str, name: str) -> Document:
+    """Shape a ``legacy_references`` row into a nested reference doc.
 
-
-async def _resolve_legacy_reference_ids(
-    session: AsyncSession,
-    reference_ids: set[int | str],
-) -> dict[int, str]:
-    """Map the integer ``legacy_references`` primary keys in ``reference_ids`` to their
-    legacy Mongo string ids.
-
-    ``references`` are still read from Mongo (keyed by their legacy string ``_id``)
-    while ``otus`` and ``sequences`` may already embed the integer primary key. This
-    resolves those embedded integers back to the Mongo key. Legacy string ids need no
-    resolution and are ignored.
+    ``data_type`` is emitted as the constant ``"genome"`` because the column is
+    dropped from Postgres. The nested ``id`` remains the legacy Mongo string id.
     """
-    integer_ids = {
-        reference_id for reference_id in reference_ids if isinstance(reference_id, int)
-    }
-
-    if not integer_ids:
-        return {}
-
-    result = await session.execute(
-        select(SQLReference.id, SQLReference.legacy_id).where(
-            SQLReference.id.in_(integer_ids),
-        ),
-    )
-
-    return {id_: legacy_id for id_, legacy_id in result if legacy_id is not None}
+    return {"id": legacy_id, "data_type": "genome", "name": name}
 
 
 class AttachReferenceTransform(AbstractTransform):
     """Attach nested references to documents with a ``reference.id`` field.
 
     The embedded ``reference.id`` may be either a legacy Mongo string or the integer
-    ``legacy_references`` primary key during the migration. References are still read
-    from Mongo, so an integer id is resolved to its legacy string key via Postgres
-    before the Mongo lookup.
+    ``legacy_references`` primary key during the migration, so a dual-key lookup keyed
+    on both forms is built when preparing many documents.
     """
 
-    def __init__(self, mongo: "Mongo"):
-        self._mongo = mongo
+    def __init__(self, pg: AsyncEngine):
+        self._pg = pg
 
     async def attach_one(self, document: Document, prepared: Any) -> Document | None:
         return {**document, "reference": prepared}
@@ -70,20 +51,18 @@ class AttachReferenceTransform(AbstractTransform):
         if reference_id is None:
             raise ValueError("Missing reference id")
 
-        if isinstance(reference_id, int):
-            legacy_id_map = await _resolve_legacy_reference_ids(session, {reference_id})
+        row = (
+            await session.execute(
+                select(SQLReference.legacy_id, SQLReference.name).where(
+                    compose_legacy_id_single_expression(SQLReference, reference_id),
+                ),
+            )
+        ).first()
 
-            if reference_id not in legacy_id_map:
-                raise ValueError(f"Reference {reference_id!r} not found in postgres")
+        if row is None:
+            raise ValueError(f"Reference {reference_id!r} not found in postgres")
 
-            reference_id = legacy_id_map[reference_id]
-
-        return base_processor(
-            await self._mongo.references.find_one(
-                {"_id": reference_id},
-                PROJECTION,
-            ),
-        )
+        return _shape_nested_reference(row.legacy_id, row.name)
 
     async def prepare_many(
         self,
@@ -92,38 +71,40 @@ class AttachReferenceTransform(AbstractTransform):
     ) -> dict[str, Document | None]:
         reference_ids = {get_safely(d, "reference", "id") for d in documents}
 
+        if not reference_ids:
+            return {}
+
         if None in reference_ids:
             raise ValueError("Missing reference id")
 
-        legacy_id_map = await _resolve_legacy_reference_ids(session, reference_ids)
-
-        legacy_ids = {
-            legacy_id_map[reference_id]
-            if isinstance(reference_id, int)
-            else reference_id
-            for reference_id in reference_ids
-        }
-
-        reference_lookup = {
-            d["_id"]: base_processor(d)
-            async for d in self._mongo.references.find(
-                {"_id": {"$in": list(legacy_ids)}},
-                PROJECTION,
+        rows = (
+            await session.execute(
+                select(
+                    SQLReference.id,
+                    SQLReference.legacy_id,
+                    SQLReference.name,
+                ).where(
+                    compose_legacy_id_multi_expression(SQLReference, reference_ids),
+                ),
             )
-        }
+        ).all()
+
+        reference_lookup: dict[int | str, Document] = {}
+
+        for row in rows:
+            shaped = _shape_nested_reference(row.legacy_id, row.name)
+            reference_lookup[row.id] = shaped
+
+            if row.legacy_id is not None:
+                reference_lookup[row.legacy_id] = shaped
 
         prepared: dict[str, Document | None] = {}
 
         for document in documents:
             reference_id = get_safely(document, "reference", "id")
 
-            if isinstance(reference_id, int):
-                if reference_id not in legacy_id_map:
-                    raise ValueError(
-                        f"Reference {reference_id!r} not found in postgres",
-                    )
-
-                reference_id = legacy_id_map[reference_id]
+            if reference_id not in reference_lookup:
+                raise ValueError(f"Reference {reference_id!r} not found in postgres")
 
             prepared[document["id"]] = reference_lookup[reference_id]
 


### PR DESCRIPTION
## Summary
- Switch the reference get, find, and serialization paths to Postgres while keeping API responses byte-identical; the public identifier remains the legacy Mongo string id
- `find` now paginates and filters rights in SQL and searches on name only; `data_type` is emitted as the constant "genome", with `cloned_from` name re-derived via join and `imported_from`/`task` shaped from their FK columns
- `AttachReferenceTransform` resolves nested references from Postgres with a dual-key lookup across all consuming domains; Mongo dual-writes are unchanged