### PR TITLE
refactor: source index reference filter from postgres

### DIFF
--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -448,13 +448,12 @@ class TestComposeReferenceIdsMatch:
         return reference_ids
 
     async def test_unfiltered(self, pg: AsyncEngine, references: dict[str, int]):
-        """Both id forms of every reference are matched when ``archived`` is None."""
+        """Both id forms of every legacy reference are matched when ``archived`` is None."""
         match = await compose_reference_ids_match(pg)
 
         assert set(match["$in"]) == {
             references["active"],
             references["archived"],
-            references["native_active"],
             "ref_active",
             "ref_archived",
         }
@@ -465,14 +464,24 @@ class TestComposeReferenceIdsMatch:
         assert set(match["$in"]) == {references["archived"], "ref_archived"}
 
     async def test_active(self, pg: AsyncEngine, references: dict[str, int]):
-        """A Postgres-native reference contributes its integer id and no legacy id."""
         match = await compose_reference_ids_match(pg, False)
 
-        assert set(match["$in"]) == {
-            references["active"],
-            references["native_active"],
-            "ref_active",
-        }
+        assert set(match["$in"]) == {references["active"], "ref_active"}
+
+    async def test_native_reference_excluded(
+        self,
+        pg: AsyncEngine,
+        references: dict[str, int],
+    ):
+        """A reference with no ``legacy_id`` never enters the match.
+
+        It cannot be shaped into a ``ReferenceNested``, whose ``id`` is a required
+        string, so matching its indexes would fail response validation.
+        """
+        match = await compose_reference_ids_match(pg)
+
+        assert references["native_active"] not in match["$in"]
+        assert None not in match["$in"]
 
 
 async def test_create_manifest(mongo: Mongo, pg: AsyncEngine, test_otu: dict):

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -16,7 +16,7 @@ from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.references.db import (
     check_right,
-    compose_archived_filter,
+    compose_reference_ids_match,
     create_document,
     get_manifest,
     get_reference_groups,
@@ -394,19 +394,85 @@ class TestCheckRight:
         assert await check_right(mock_req, "ref_job_client", "read") is False
 
 
-class TestComposeArchivedFilter:
-    """The lifecycle facet of the references find query."""
+class TestComposeReferenceIdsMatch:
+    """The lifecycle facet of the index find query, sourced from Postgres.
 
-    @pytest.mark.parametrize(
-        ("archived", "expected"),
-        [
-            (None, {}),
-            (True, {"archived": True}),
-            (False, {"archived": False}),
-        ],
-    )
-    def test(self, archived, expected):
-        assert compose_archived_filter(archived) == expected
+    Indexes embed either the legacy string reference id or the integer primary key
+    during the migration, so both forms must appear in the match for every reference
+    that passes the lifecycle filter.
+    """
+
+    @pytest.fixture
+    async def references(self, fake: DataFaker, pg: AsyncEngine, static_time):
+        """Seed an active, an archived, and a Postgres-native active reference."""
+        user = await fake.users.create()
+
+        async with AsyncSession(pg) as session:
+            rows = {
+                "active": SQLReference(
+                    legacy_id="ref_active",
+                    name="active",
+                    description="",
+                    created_at=static_time.datetime,
+                    archived=False,
+                    source_types=[],
+                    user_id=user.id,
+                ),
+                "archived": SQLReference(
+                    legacy_id="ref_archived",
+                    name="archived",
+                    description="",
+                    created_at=static_time.datetime,
+                    archived=True,
+                    source_types=[],
+                    user_id=user.id,
+                ),
+                "native_active": SQLReference(
+                    legacy_id=None,
+                    name="native_active",
+                    description="",
+                    created_at=static_time.datetime,
+                    archived=False,
+                    source_types=[],
+                    user_id=user.id,
+                ),
+            }
+
+            session.add_all(rows.values())
+            await session.flush()
+
+            reference_ids = {key: row.id for key, row in rows.items()}
+
+            await session.commit()
+
+        return reference_ids
+
+    async def test_unfiltered(self, pg: AsyncEngine, references: dict[str, int]):
+        """Both id forms of every reference are matched when ``archived`` is None."""
+        match = await compose_reference_ids_match(pg)
+
+        assert set(match["$in"]) == {
+            references["active"],
+            references["archived"],
+            references["native_active"],
+            "ref_active",
+            "ref_archived",
+        }
+
+    async def test_archived(self, pg: AsyncEngine, references: dict[str, int]):
+        match = await compose_reference_ids_match(pg, True)
+
+        assert set(match["$in"]) == {references["archived"], "ref_archived"}
+
+    async def test_active(self, pg: AsyncEngine, references: dict[str, int]):
+        """A Postgres-native reference contributes its integer id and no legacy id."""
+        match = await compose_reference_ids_match(pg, False)
+
+        assert set(match["$in"]) == {
+            references["active"],
+            references["native_active"],
+            "ref_active",
+        }
 
 
 async def test_create_manifest(mongo: Mongo, pg: AsyncEngine, test_otu: dict):

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -74,7 +74,7 @@ class IndexData:
         :param page: the one-indexed page number to return
         :param per_page: the number of documents to return per page
         :param archived: lifecycle filter on the index's reference; see
-            :func:`virtool.references.db.compose_archived_filter`
+            :func:`virtool.references.db.compose_reference_ids_match`
         :return: a list of all index documents
         """
         if not ready:
@@ -92,7 +92,6 @@ class IndexData:
                             "ready": True,
                             "reference.id": await compose_reference_ids_match(
                                 self._pg,
-                                self._mongo,
                                 archived,
                             ),
                         },

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -213,7 +213,7 @@ async def find(
     :param per_page: the number of documents to return per page
     :param ref_id: the id of the reference
     :param archived: lifecycle filter on the index's reference; see
-        :func:`virtool.references.db.compose_archived_filter`
+        :func:`virtool.references.db.compose_reference_ids_match`
     :return: the index document
 
     """
@@ -226,11 +226,11 @@ async def find(
         # filter goes into mongo_query so total_count reflects all indexes whose
         # reference exists, while found_count narrows to the requested
         # lifecycle.
-        base_query = {"reference.id": await compose_reference_ids_match(pg, mongo)}
+        base_query = {"reference.id": await compose_reference_ids_match(pg)}
 
         if archived is not None:
             mongo_query = {
-                "reference.id": await compose_reference_ids_match(pg, mongo, archived),
+                "reference.id": await compose_reference_ids_match(pg, archived),
             }
 
     data = await paginate(

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -442,11 +442,18 @@ async def compose_reference_ids_match(
     are included for every matching reference. This backs the orphan and lifecycle
     filters on the index list, which scope indexes to references that still exist.
 
+    References with no ``legacy_id`` are excluded. ``legacy_id`` remains the public
+    reference identifier until the integer primary key becomes canonical, so a
+    Postgres-native reference cannot yet be shaped into a ``ReferenceNested``. Drop
+    this constraint when the public identifier flips.
+
     :param pg: the application PostgreSQL engine
     :param archived: lifecycle filter mode
     :return: a Mongo ``$in`` match value covering both id forms
     """
-    query = select(SQLReference.id, SQLReference.legacy_id)
+    query = select(SQLReference.id, SQLReference.legacy_id).where(
+        SQLReference.legacy_id.is_not(None),
+    )
 
     if archived is not None:
         query = query.where(SQLReference.archived == archived)
@@ -454,9 +461,7 @@ async def compose_reference_ids_match(
     async with AsyncSession(pg) as session:
         rows = (await session.execute(query)).all()
 
-    return {
-        "$in": [value for row in rows for value in row if value is not None],
-    }
+    return {"$in": [value for row in rows for value in row]}
 
 
 async def get_contributors(pg, ref_id: str) -> list[Document] | None:

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -17,7 +17,6 @@ from virtool.data.errors import ResourceNotFoundError
 from virtool.data.topg import (
     compose_legacy_id_mongo_match,
     compose_legacy_id_multi_expression,
-    compose_legacy_id_multi_mongo_match,
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
     resolve_legacy_id,
@@ -428,29 +427,15 @@ async def check_source_type(
     return True
 
 
-def compose_archived_filter(archived: bool | None) -> dict:
-    """Compose a Mongo filter on ``references.archived`` for the project-wide
-    ``bool | None`` lifecycle convention.
-
-    - ``None`` (default): no constraint → ``{}`` (both states)
-    - ``True``: only archived references → ``{"archived": True}``
-    - ``False``: only active references → ``{"archived": False}``
-
-    :param archived: lifecycle filter mode
-    :return: a Mongo filter dict for the ``archived`` field
-
-    """
-    if archived is None:
-        return {}
-    return {"archived": archived}
-
-
 async def compose_reference_ids_match(
     pg: AsyncEngine,
-    mongo: "Mongo",
     archived: bool | None = None,
 ) -> dict:
     """Build a Mongo ``reference.id`` match for the references matching ``archived``.
+
+    The lifecycle filter follows the project-wide ``bool | None`` convention: ``None``
+    places no constraint, ``True`` selects archived references and ``False`` selects
+    active ones.
 
     ``indexes`` documents embed either the legacy Mongo string reference id or the
     integer ``legacy_references`` primary key during the migration, so both forms
@@ -458,16 +443,20 @@ async def compose_reference_ids_match(
     filters on the index list, which scope indexes to references that still exist.
 
     :param pg: the application PostgreSQL engine
-    :param mongo: the application database client
-    :param archived: lifecycle filter mode; see :func:`compose_archived_filter`
+    :param archived: lifecycle filter mode
     :return: a Mongo ``$in`` match value covering both id forms
     """
-    legacy_ids = await mongo.references.distinct(
-        "_id",
-        compose_archived_filter(archived),
-    )
+    query = select(SQLReference.id, SQLReference.legacy_id)
 
-    return await compose_legacy_id_multi_mongo_match(pg, SQLReference, legacy_ids)
+    if archived is not None:
+        query = query.where(SQLReference.archived == archived)
+
+    async with AsyncSession(pg) as session:
+        rows = (await session.execute(query)).all()
+
+    return {
+        "$in": [value for row in rows for value in row if value is not None],
+    }
 
 
 async def get_contributors(pg, ref_id: str) -> list[Document] | None:


### PR DESCRIPTION
## Summary
- `compose_reference_ids_match` asked Mongo for the reference ids matching the `archived` filter, then expanded them through Postgres. It now selects both id forms from `SQLReference` directly, removing the last Mongo read from the index list path.
- Drops the now-dead `compose_archived_filter` and the `mongo` argument from the three `compose_reference_ids_match` call sites.
- References with no `legacy_id` stay out of the match, since `legacy_id` remains the public reference identifier until the integer primary key becomes canonical. Match output is unchanged.

Closes VIR-2589.