### PR TITLE
feat: move sample uploads to postgres

### DIFF
--- a/assets/revisions/rev_n03aryu6frku_backfill_sample_uploads_to_postgres.py
+++ b/assets/revisions/rev_n03aryu6frku_backfill_sample_uploads_to_postgres.py
@@ -1,0 +1,36 @@
+"""backfill sample uploads to postgres
+
+Revision ID: n03aryu6frku
+Date: 2026-07-08 22:26:30.163459
+
+"""
+
+import arrow
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.samples.migration import backfill_sample_uploads_to_postgres
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "backfill sample uploads to postgres"
+created_at = arrow.get("2026-07-08 22:26:30.163459")
+revision_id = "n03aryu6frku"
+
+alembic_down_revision = "1ffbe2dcb108"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+#
+# ``1ffbe2dcb108`` creates the ``sample_uploads`` table. Chaining off it as the
+# alembic down revision already guarantees it is applied before this runs.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Backfill the sample-to-uploads membership into ``sample_uploads``.
+
+    The implementation lives in :func:`backfill_sample_uploads_to_postgres`.
+    """
+    await backfill_sample_uploads_to_postgres(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -701,5 +701,12 @@
       'name': 'create sample uploads table',
       'revision': '1ffbe2dcb108',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 101,
+      'name': 'backfill sample uploads to postgres',
+      'revision': 'n03aryu6frku',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_sample_uploads_to_postgres.py
+++ b/tests/migration/test_backfill_sample_uploads_to_postgres.py
@@ -1,0 +1,260 @@
+"""Tests for the backfill sample uploads to postgres migration."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import arrow
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_n03aryu6frku_backfill_sample_uploads_to_postgres import (
+    upgrade,
+)
+from virtool.migration.ctx import MigrationContext
+from virtool.samples.sql import SQLLegacySample, SQLSampleUpload
+from virtool.uploads.sql import SQLUpload
+from virtool.utils import timestamp
+
+
+@pytest.fixture
+def static_datetime() -> datetime:
+    return arrow.get(2024, 1, 15, 12, 0, 0).naive
+
+
+@pytest.fixture
+async def setup(ctx: MigrationContext, apply_alembic: Callable) -> int:
+    """Apply alembic to head and seed a user, returning its id."""
+    await asyncio.to_thread(apply_alembic, "head")
+
+    async with AsyncSession(ctx.pg) as session:
+        user_id = (
+            await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES (
+                        'testuser', 'legacy_user', true, '', false,
+                        false, :now, :password, '{}'::jsonb
+                    )
+                    RETURNING id
+                """),
+                {"now": timestamp(), "password": b"hashed_password"},
+            )
+        ).scalar_one()
+        await session.commit()
+
+    return user_id
+
+
+async def insert_sample(
+    session: AsyncSession,
+    legacy_id: str,
+    user_id: int,
+    created_at: datetime,
+) -> int:
+    """Insert a ``legacy_samples`` row and return its integer primary key."""
+    sample = SQLLegacySample(
+        legacy_id=legacy_id,
+        name=legacy_id,
+        library_type="normal",
+        created_at=created_at,
+        user_id=user_id,
+    )
+    session.add(sample)
+    await session.flush()
+    sample_pk = sample.id
+    await session.commit()
+
+    return sample_pk
+
+
+async def insert_upload(
+    session: AsyncSession,
+    name_on_disk: str,
+    user_id: int,
+    created_at: datetime,
+) -> int:
+    """Insert an ``uploads`` row and return its integer primary key."""
+    upload = SQLUpload(
+        name=name_on_disk,
+        name_on_disk=name_on_disk,
+        ready=True,
+        removed=False,
+        reserved=True,
+        user_id=user_id,
+        created_at=created_at,
+    )
+    session.add(upload)
+    await session.flush()
+    upload_pk = upload.id
+    await session.commit()
+
+    return upload_pk
+
+
+def make_sample_document(sample_id: str, uploads: list[int]) -> dict:
+    """Build a minimal Mongo sample document carrying an ``uploads`` array."""
+    return {
+        "_id": sample_id,
+        "name": sample_id,
+        "uploads": [{"id": upload_id} for upload_id in uploads],
+    }
+
+
+async def get_rows(session: AsyncSession, legacy_id: str) -> list[SQLSampleUpload]:
+    """Return the ``sample_uploads`` rows for a sample, ordered by index."""
+    return list(
+        (
+            await session.execute(
+                select(SQLSampleUpload)
+                .where(SQLSampleUpload.sample == legacy_id)
+                .order_by(SQLSampleUpload.index),
+            )
+        )
+        .scalars()
+        .all(),
+    )
+
+
+class TestUpgrade:
+    async def test_writes_rows_in_order(
+        self,
+        ctx: MigrationContext,
+        setup: int,
+        static_datetime: datetime,
+    ):
+        """Each upload becomes a row with its array position preserved as index."""
+        async with AsyncSession(ctx.pg) as session:
+            sample_pk = await insert_sample(session, "paired", setup, static_datetime)
+            left = await insert_upload(session, "reads_1.fq.gz", setup, static_datetime)
+            right = await insert_upload(
+                session, "reads_2.fq.gz", setup, static_datetime
+            )
+
+        await ctx.mongo.samples.insert_one(
+            make_sample_document("paired", [left, right]),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = await get_rows(session, "paired")
+
+        assert [(row.sample_id, row.upload_id, row.index) for row in rows] == [
+            (sample_pk, left, 0),
+            (sample_pk, right, 1),
+        ]
+
+    async def test_missing_sample_raises(
+        self,
+        ctx: MigrationContext,
+        setup: int,
+        static_datetime: datetime,
+    ):
+        """A sample with uploads but no legacy_samples row aborts the migration."""
+        async with AsyncSession(ctx.pg) as session:
+            upload_id = await insert_upload(
+                session,
+                "reads_1.fq.gz",
+                setup,
+                static_datetime,
+            )
+
+        await ctx.mongo.samples.insert_one(
+            make_sample_document("orphan", [upload_id]),
+        )
+
+        with pytest.raises(ValueError, match="no legacy_samples row"):
+            await upgrade(ctx)
+
+    async def test_missing_upload_skipped(
+        self,
+        ctx: MigrationContext,
+        setup: int,
+        static_datetime: datetime,
+    ):
+        """An upload id absent from postgres is skipped while the rest are written."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_sample(session, "partial", setup, static_datetime)
+            present = await insert_upload(
+                session,
+                "reads_1.fq.gz",
+                setup,
+                static_datetime,
+            )
+
+        await ctx.mongo.samples.insert_one(
+            make_sample_document("partial", [999999, present]),
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = await get_rows(session, "partial")
+
+        assert [(row.upload_id, row.index) for row in rows] == [(present, 1)]
+
+    async def test_skips_sample_without_uploads(
+        self,
+        ctx: MigrationContext,
+        setup: int,
+        static_datetime: datetime,
+    ):
+        """A sample with an empty or absent uploads array writes no rows."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_sample(session, "empty", setup, static_datetime)
+
+        await ctx.mongo.samples.insert_one(
+            {"_id": "empty", "name": "empty", "uploads": []},
+        )
+
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = await get_rows(session, "empty")
+
+        assert rows == []
+
+    async def test_idempotent_rerun(
+        self,
+        ctx: MigrationContext,
+        setup: int,
+        static_datetime: datetime,
+    ):
+        """A re-run leaves a single row per upload."""
+        async with AsyncSession(ctx.pg) as session:
+            await insert_sample(session, "repeat", setup, static_datetime)
+            upload_id = await insert_upload(
+                session,
+                "reads_1.fq.gz",
+                setup,
+                static_datetime,
+            )
+
+        await ctx.mongo.samples.insert_one(
+            make_sample_document("repeat", [upload_id]),
+        )
+
+        await upgrade(ctx)
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            rows = await get_rows(session, "repeat")
+
+        assert [row.upload_id for row in rows] == [upload_id]
+
+    @pytest.mark.usefixtures("setup")
+    async def test_empty_collection(self, ctx: MigrationContext):
+        """An empty samples collection is a no-op."""
+        await upgrade(ctx)
+
+        async with AsyncSession(ctx.pg) as session:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM sample_uploads"))
+            ).scalar_one()
+
+        assert count == 0

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner, VirtoolTestClient
+from tests.samples.utils import add_sample_uploads
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisSubtraction
 from virtool.data.layer import DataLayer
 from virtool.data.utils import get_data_from_app
@@ -1309,10 +1310,7 @@ class TestDelete:
             reserved=True,
         )
 
-        await mongo.samples.update_one(
-            {"_id": "test"},
-            {"$set": {"uploads": [{"id": upload.id}]}},
-        )
+        await add_sample_uploads(mongo, pg, "test", [upload.id])
 
         resp = await client.delete(f"/samples/{sample_id}")
 

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -9,16 +9,19 @@ from syrupy import SnapshotAssertion
 
 import virtool.utils
 from tests.fixtures.client import ClientSpawner
+from tests.samples.utils import add_sample_uploads
 from virtool.analyses.sql import SQLAnalysis
 from virtool.api.client import UserClient
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
+from virtool.data.transforms import apply_transforms
 from virtool.fake.next import DataFaker
 from virtool.models.enums import AnalysisWorkflow, LibraryType, Permission
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
 from virtool.references.sql import SQLReference
+from virtool.samples.db import AttachUploadsTransform
 from virtool.samples.models import WorkflowState
 from virtool.samples.oas import (
     CreateAnalysisRequest,
@@ -361,6 +364,85 @@ class TestCreate:
         assert await mongo.samples.find_one() is None
 
 
+class TestAttachUploadsTransform:
+    """The uploads array is sourced from ``sample_uploads``, ordered by ``index``."""
+
+    @staticmethod
+    async def get_sample_pk(pg: AsyncEngine) -> int:
+        async with AsyncSession(pg) as session:
+            return (
+                await session.execute(
+                    select(SQLLegacySample.id).where(
+                        SQLLegacySample.legacy_id == "test",
+                    ),
+                )
+            ).scalar_one()
+
+    async def test_orders_one_by_index(
+        self,
+        fake: DataFaker,
+        get_sample_ready_false,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A single sample's uploads come back in their stored index order."""
+        user = await fake.users.create()
+        first = await fake.uploads.create(user=user)
+        second = await fake.uploads.create(user=user)
+
+        await add_sample_uploads(mongo, pg, "test", [second.id, first.id])
+
+        document = await apply_transforms(
+            {"id": await self.get_sample_pk(pg)},
+            [AttachUploadsTransform(pg)],
+            pg,
+        )
+
+        assert [upload["id"] for upload in document["uploads"]] == [
+            second.id,
+            first.id,
+        ]
+
+    async def test_orders_many_by_index(
+        self,
+        fake: DataFaker,
+        get_sample_ready_false,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """The batched path groups uploads by sample and preserves index order."""
+        user = await fake.users.create()
+        first = await fake.uploads.create(user=user)
+        second = await fake.uploads.create(user=user)
+
+        await add_sample_uploads(mongo, pg, "test", [second.id, first.id])
+
+        documents = await apply_transforms(
+            [{"id": await self.get_sample_pk(pg)}],
+            [AttachUploadsTransform(pg)],
+            pg,
+        )
+
+        assert [upload["id"] for upload in documents[0]["uploads"]] == [
+            second.id,
+            first.id,
+        ]
+
+    async def test_no_uploads_is_none(
+        self,
+        get_sample_ready_false,
+        pg: AsyncEngine,
+    ):
+        """A sample with no ``sample_uploads`` rows gets ``None``, not an empty list."""
+        document = await apply_transforms(
+            {"id": await self.get_sample_pk(pg)},
+            [AttachUploadsTransform(pg)],
+            pg,
+        )
+
+        assert document["uploads"] is None
+
+
 async def test_finalize(
     data_layer: DataLayer,
     fake: DataFaker,
@@ -377,10 +459,7 @@ async def test_finalize(
     upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
     upload_name_on_disk = upload_row.name_on_disk
 
-    await mongo.samples.update_one(
-        {"_id": "test"},
-        {"$set": {"uploads": [{"id": upload.id}]}},
-    )
+    await add_sample_uploads(mongo, pg, "test", [upload.id])
 
     async with AsyncSession(pg) as session:
         legacy_sample_id = (
@@ -460,10 +539,7 @@ async def test_finalize_cleans_up_uploads_without_reads_link(
     upload_row = await get_row_by_id(pg, SQLUpload, upload.id)
     upload_key = upload_file_key(upload_row.name_on_disk)
 
-    await mongo.samples.update_one(
-        {"_id": "test"},
-        {"$set": {"uploads": [{"id": upload.id}]}},
-    )
+    await add_sample_uploads(mongo, pg, "test", [upload.id])
 
     async with AsyncSession(pg) as session:
         session.add(
@@ -1286,10 +1362,7 @@ class TestDelete:
             reserved=True,
         )
 
-        await mongo.samples.update_one(
-            {"_id": "test_sample"},
-            {"$set": {"uploads": [{"id": upload.id}]}},
-        )
+        await add_sample_uploads(mongo, pg, "test_sample", [upload.id])
 
         await data_layer.samples.delete("test_sample")
 

--- a/tests/samples/utils.py
+++ b/tests/samples/utils.py
@@ -1,0 +1,46 @@
+"""Helpers for seeding sample state that spans Mongo and Postgres."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.mongo.core import Mongo
+from virtool.samples.sql import SQLLegacySample, SQLSampleUpload
+
+
+async def add_sample_uploads(
+    mongo: Mongo,
+    pg: AsyncEngine,
+    legacy_id: str,
+    upload_ids: list[int],
+) -> None:
+    """Attach ``upload_ids`` to the sample ``legacy_id`` in both stores.
+
+    Mirrors what the dual-write in :meth:`SamplesData.create` does: the ordered
+    ``uploads`` array on the Mongo document, and one ``sample_uploads`` row per
+    upload with ``index`` recording its position.
+    """
+    await mongo.samples.update_one(
+        {"_id": legacy_id},
+        {"$set": {"uploads": [{"id": upload_id} for upload_id in upload_ids]}},
+    )
+
+    async with AsyncSession(pg) as session:
+        sample_pk = (
+            await session.execute(
+                select(SQLLegacySample.id).where(
+                    SQLLegacySample.legacy_id == legacy_id,
+                ),
+            )
+        ).scalar_one()
+
+        for index, upload_id in enumerate(upload_ids):
+            session.add(
+                SQLSampleUpload(
+                    sample=legacy_id,
+                    sample_id=sample_pk,
+                    upload_id=upload_id,
+                    index=index,
+                ),
+            )
+
+        await session.commit()

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -52,7 +52,6 @@ from virtool.samples.checks import (
 )
 from virtool.samples.db import (
     AttachArtifactsAndReadsTransform,
-    AttachMongoUploadsTransform,
     AttachUploadsTransform,
     DeriveWorkflowTagsTransform,
     compose_sample_workflow_filter,
@@ -282,7 +281,6 @@ class SamplesData(DataLayerDomain):
                 for row in rows
             ],
             [
-                AttachMongoUploadsTransform(self._mongo),
                 DeriveWorkflowTagsTransform(),
                 AttachJobTransform(self._pg),
                 AttachLabelsTransform(self._pg),
@@ -418,7 +416,6 @@ class SamplesData(DataLayerDomain):
         document = await apply_transforms(
             _map_sample_row(row, label_ids, subtraction_ids),
             [
-                AttachMongoUploadsTransform(self._mongo),
                 DeriveWorkflowTagsTransform(),
                 AttachArtifactsAndReadsTransform(self._pg),
                 AttachJobTransform(self._pg),
@@ -792,16 +789,18 @@ class SamplesData(DataLayerDomain):
                 .values(quality=quality, ready=True),
             )
 
-        uploads = await get_one_field(self._mongo.samples, "uploads", legacy_id) or []
-        upload_ids = [upload["id"] for upload in uploads]
-
         names_on_disk = []
 
         async with AsyncSession(self._pg) as session:
             rows = (
                 (
                     await session.execute(
-                        select(SQLUpload).where(SQLUpload.id.in_(upload_ids)),
+                        select(SQLUpload)
+                        .join(
+                            SQLSampleUpload,
+                            SQLSampleUpload.upload_id == SQLUpload.id,
+                        )
+                        .where(SQLSampleUpload.sample_id == sample_pk),
                     )
                 )
                 .unique()

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -18,8 +18,12 @@ from virtool.data.topg import compose_legacy_id_subquery
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
-from virtool.mongo.core import Mongo
-from virtool.samples.sql import SQLLegacySample, SQLSampleArtifact, SQLSampleReads
+from virtool.samples.sql import (
+    SQLLegacySample,
+    SQLSampleArtifact,
+    SQLSampleReads,
+    SQLSampleUpload,
+)
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.uploads.data import serialize as serialize_upload
@@ -102,132 +106,68 @@ class AttachArtifactsAndReadsTransform(AbstractTransform):
 
 
 class AttachUploadsTransform(AbstractTransform):
-    """Attaches upload details to samples that have an uploads field."""
+    """Attach the input uploads of a sample, ordered as they were on creation.
+
+    Membership comes from the ``sample_uploads`` table, keyed by the integer
+    ``sample_id``. The ``index`` column preserves the order the uploads were
+    supplied in.
+
+    A sample with no uploads is given ``None`` rather than an empty list.
+    """
 
     def __init__(self, pg: AsyncEngine):
         self._pg = pg
 
     async def attach_one(self, document: Document, prepared: Any) -> Document:
-        if prepared is None:
-            return {**document, "uploads": None}
+        return {**document, "uploads": prepared}
 
-        uploads = [
-            prepared.get(u["id"])
-            for u in document.get("uploads", [])
-            if u["id"] in prepared
-        ]
-
-        return {**document, "uploads": uploads}
+    async def _serialize(self, uploads: list[SQLUpload]) -> list[Document]:
+        return await apply_transforms(
+            [serialize_upload(upload) for upload in uploads],
+            [AttachUserTransform(self._pg, ignore_errors=True)],
+            self._pg,
+        )
 
     async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
-        uploads = document.get("uploads")
+        result = await session.execute(
+            select(SQLUpload)
+            .join(SQLSampleUpload, SQLSampleUpload.upload_id == SQLUpload.id)
+            .where(SQLSampleUpload.sample_id == document["id"])
+            .order_by(SQLSampleUpload.index),
+        )
+
+        uploads = list(result.unique().scalars())
 
         if not uploads:
             return None
 
-        upload_ids = [u["id"] for u in uploads]
-
-        result = await session.execute(
-            select(SQLUpload).where(SQLUpload.id.in_(upload_ids)),
-        )
-
-        upload_dicts = [serialize_upload(upload) for upload in result.scalars()]
-
-        upload_dicts = await apply_transforms(
-            upload_dicts,
-            [AttachUserTransform(self._pg, ignore_errors=True)],
-            self._pg,
-        )
-
-        return {u["id"]: u for u in upload_dicts}
+        return await self._serialize(uploads)
 
     async def prepare_many(
         self,
         documents: list[Document],
         session: AsyncSession,
-    ) -> dict[str, dict[int, dict] | None]:
-        all_upload_ids = set()
-
-        for document in documents:
-            uploads = document.get("uploads")
-            if uploads:
-                all_upload_ids.update(u["id"] for u in uploads)
-
-        if not all_upload_ids:
-            return {document["id"]: None for document in documents}
+    ) -> dict[int, list[Document] | None]:
+        sample_ids = [document["id"] for document in documents]
 
         result = await session.execute(
-            select(SQLUpload).where(SQLUpload.id.in_(list(all_upload_ids))),
+            select(SQLSampleUpload.sample_id, SQLUpload)
+            .join(SQLUpload, SQLSampleUpload.upload_id == SQLUpload.id)
+            .where(SQLSampleUpload.sample_id.in_(sample_ids))
+            .order_by(SQLSampleUpload.sample_id, SQLSampleUpload.index),
         )
 
-        upload_dicts = [serialize_upload(upload) for upload in result.scalars()]
+        rows = result.unique().all()
 
-        upload_dicts = await apply_transforms(
-            upload_dicts,
-            [AttachUserTransform(self._pg, ignore_errors=True)],
-            self._pg,
-        )
+        upload_dicts = await self._serialize([upload for _, upload in rows])
 
-        uploads_by_id = {u["id"]: u for u in upload_dicts}
+        uploads_by_sample = defaultdict(list)
+
+        for (sample_id, _), upload_dict in zip(rows, upload_dicts, strict=True):
+            uploads_by_sample[sample_id].append(upload_dict)
 
         return {
-            document["id"]: uploads_by_id if document.get("uploads") else None
-            for document in documents
-        }
-
-
-MONGO_UPLOADS_FIELD = ["uploads"]
-
-
-class AttachMongoUploadsTransform(AbstractTransform):
-    """Attach the reserved ``uploads`` array still sourced from MongoDB.
-
-    Sample metadata is read from Postgres, but the ``uploads`` array is not stored
-    there yet. This transform bridges it from Mongo so read responses are unchanged.
-
-    It must run before :class:`~virtool.samples.db.AttachUploadsTransform`, which
-    enriches the bridged ``uploads`` array with upload details from Postgres.
-    """
-
-    def __init__(self, mongo: Mongo):
-        self._mongo = mongo
-
-    async def attach_one(self, document: Document, prepared: Any) -> Document:
-        return {**document, "uploads": prepared}
-
-    async def prepare_one(self, document: Document, session: AsyncSession) -> Any:
-        mongo_document = await self._mongo.samples.find_one(
-            {"_id": document["legacy_id"]},
-            MONGO_UPLOADS_FIELD,
-        )
-
-        if mongo_document is None:
-            raise KeyError(f"Sample missing from Mongo: {document['legacy_id']}")
-
-        return mongo_document.get("uploads")
-
-    async def prepare_many(
-        self,
-        documents: list[Document],
-        session: AsyncSession,
-    ) -> dict[str, Any]:
-        legacy_ids = [document["legacy_id"] for document in documents]
-
-        mongo_documents = {
-            mongo_document["_id"]: mongo_document
-            async for mongo_document in self._mongo.samples.find(
-                {"_id": {"$in": legacy_ids}},
-                MONGO_UPLOADS_FIELD,
-            )
-        }
-
-        missing = set(legacy_ids) - mongo_documents.keys()
-
-        if missing:
-            raise KeyError(f"Samples missing from Mongo: {missing}")
-
-        return {
-            document["id"]: mongo_documents[document["legacy_id"]].get("uploads")
+            document["id"]: uploads_by_sample.get(document["id"])
             for document in documents
         }
 

--- a/virtool/samples/migration.py
+++ b/virtool/samples/migration.py
@@ -17,7 +17,9 @@ from virtool.samples.sql import (
     SQLLegacySample,
     SQLLegacySampleLabel,
     SQLLegacySampleSubtraction,
+    SQLSampleUpload,
 )
+from virtool.uploads.sql import SQLUpload
 from virtool.users.pg import SQLUser
 
 logger = get_logger("migration")
@@ -190,6 +192,117 @@ async def _insert_join_rows(
             insert(SQLLegacySampleSubtraction)
             .values(sample_id=sample_pk, subtraction_id=subtraction_id)
             .on_conflict_do_nothing(),
+        )
+
+
+async def backfill_sample_uploads_to_postgres(ctx: MigrationContext) -> None:
+    """Backfill the sample-to-uploads membership from Mongo into ``sample_uploads``.
+
+    The membership lives on each Mongo ``samples`` document as an ordered
+    ``uploads`` array of ``{"id": <upload id>}`` entries. One ``sample_uploads``
+    row is written per entry, with ``index`` preserving the array position so the
+    read side can reproduce the original order.
+
+    Documents are processed one at a time and committed individually so memory
+    stays bounded and an interruption keeps the rows already written. Samples that
+    already have ``sample_uploads`` rows are skipped wholesale, and every insert
+    uses ``ON CONFLICT (upload_id) DO NOTHING`` as a second line of defence, so the
+    backfill is safe to re-run.
+
+    ``sample_id`` is resolved from ``legacy_samples`` by ``legacy_id``; a sample
+    document with no matching Postgres row raises, since the sample copy must have
+    run first. Individual upload ids that no longer exist in Postgres are skipped
+    with a warning rather than aborting the run: a hard-deleted upload is already
+    dropped from the Mongo-backed read today, so skipping it keeps the two stores
+    consistent.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_result = await session.execute(
+            select(SQLSampleUpload.sample).distinct(),
+        )
+        backfilled_samples = {row[0] for row in existing_result}
+
+        logger.info(
+            "found samples with uploads already in postgres",
+            count=len(backfilled_samples),
+        )
+
+        sample_ids = [
+            document["_id"]
+            async for document in ctx.mongo.samples.find({}, projection=["_id"])
+        ]
+
+        migrated_count = 0
+        skipped_count = 0
+        missing_upload_count = 0
+
+        for sample_id in sample_ids:
+            if sample_id in backfilled_samples:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.samples.find_one(
+                {"_id": sample_id},
+                projection=["uploads"],
+            )
+
+            if document is None or not document.get("uploads"):
+                skipped_count += 1
+                continue
+
+            sample_pk = (
+                await session.execute(
+                    select(SQLLegacySample.id).where(
+                        SQLLegacySample.legacy_id == sample_id,
+                    ),
+                )
+            ).scalar_one_or_none()
+
+            if sample_pk is None:
+                msg = (
+                    f"sample {sample_id!r} has uploads but no legacy_samples row; "
+                    "run the sample copy first"
+                )
+                raise ValueError(msg)
+
+            for index, upload in enumerate(document["uploads"]):
+                upload_id = upload["id"]
+
+                upload_exists = (
+                    await session.execute(
+                        select(SQLUpload.id).where(SQLUpload.id == upload_id),
+                    )
+                ).scalar_one_or_none()
+
+                if upload_exists is None:
+                    missing_upload_count += 1
+                    logger.warning(
+                        "sample references an upload that no longer exists; skipping",
+                        sample_id=sample_id,
+                        upload_id=upload_id,
+                    )
+                    continue
+
+                await session.execute(
+                    insert(SQLSampleUpload)
+                    .values(
+                        sample=sample_id,
+                        sample_id=sample_pk,
+                        upload_id=upload_id,
+                        index=index,
+                    )
+                    .on_conflict_do_nothing(index_elements=["upload_id"]),
+                )
+
+            await session.commit()
+
+            migrated_count += 1
+
+        logger.info(
+            "sample uploads migration complete",
+            migrated=migrated_count,
+            skipped=skipped_count,
+            missing_uploads=missing_upload_count,
         )
 
 


### PR DESCRIPTION
## Summary
- Add a `sample_uploads` table that records sample-to-upload membership, with `index` preserving the order uploads were supplied in, and dual-write it alongside Mongo on sample creation and deletion.
- Backfill the existing Mongo `uploads` arrays into the new table. The backfill is idempotent and runs after dual-write, so no re-backfill revision is needed.
- Read uploads from Postgres. `AttachMongoUploadsTransform` is gone and `AttachUploadsTransform` now joins `sample_uploads` to `uploads`, ordered by `index`.

Removing the dual-write and dropping the Mongo `uploads` array are deferred to VIR-2532.