### PR TITLE
fix: stop blast searches from failing when restarted

### DIFF
--- a/tests/blast/__snapshots__/test_data.ambr
+++ b/tests/blast/__snapshots__/test_data.ambr
@@ -7,7 +7,7 @@
     'last_checked_at': datetime.datetime(2015, 10, 6, 20, 0),
     'ready': False,
     'result': None,
-    'rid': None,
+    'rid': 'RID_12345',
     'task': None,
     'updated_at': datetime.datetime(2015, 10, 6, 20, 0),
   })

--- a/tests/blast/test_data.py
+++ b/tests/blast/test_data.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.analyses.sql import SQLAnalysis
 from virtool.blast.data import BLASTData
 from virtool.blast.sql import SQLNuVsBlast
+from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.pg.utils import get_row
 from virtool.tasks.data import TasksData
@@ -122,8 +123,14 @@ async def _insert_blast(
     analysis_id: int,
     sequence_index: int,
     static_time,
+    rid: str | None = None,
 ) -> None:
-    """Insert a pending NuVs BLAST row directly, as ``AnalysisData.blast`` would."""
+    """Insert a NuVs BLAST row directly.
+
+    ``AnalysisData.blast`` creates rows with ``rid=None``; the ``BLASTTask`` fills
+    the RID in once NCBI responds. Pass ``rid`` to simulate a row that has already
+    reached NCBI.
+    """
     async with AsyncSession(pg) as session:
         session.add(
             SQLNuVsBlast(
@@ -133,6 +140,7 @@ async def _insert_blast(
                 updated_at=static_time.datetime,
                 last_checked_at=static_time.datetime,
                 ready=False,
+                rid=rid,
             ),
         )
         await session.commit()
@@ -224,6 +232,31 @@ class TestCheckNuvsBlast:
 
         assert await blast_data.get_nuvs_blast(analysis_id, 12) == snapshot
 
+    async def test_missing_rid(
+        self,
+        blast_data: BLASTData,
+        analysis_ids: dict[str, int],
+        mocker,
+        pg,
+        static_time,
+    ):
+        """A row whose ``rid`` is still ``NULL`` has no NCBI search to check.
+
+        This happens when a re-BLAST deletes and recreates the row while an older
+        task is still polling. Treat it as a missing record so callers stop, rather
+        than passing ``None`` to NCBI.
+        """
+        check_rid = mocker.patch("virtool.blast.data.check_rid")
+
+        analysis_id = analysis_ids["analysis"]
+
+        await _insert_blast(pg, analysis_id, 12, static_time)
+
+        with pytest.raises(ResourceNotFoundError):
+            await blast_data.check_nuvs_blast(analysis_id, 12)
+
+        check_rid.assert_not_called()
+
     async def test_bad_zip_file(
         self,
         blast_data: BLASTData,
@@ -244,7 +277,7 @@ class TestCheckNuvsBlast:
             "virtool.blast.data.fetch_nuvs_blast_result", side_effect=BadZipFile()
         )
 
-        await _insert_blast(pg, analysis_id, 12, static_time)
+        await _insert_blast(pg, analysis_id, 12, static_time, rid="RID_12345")
         await blast_data.check_nuvs_blast(analysis_id, 12)
 
         assert await blast_data.get_nuvs_blast(analysis_id, 12) == snapshot
@@ -275,7 +308,9 @@ class TestAnalysisUpdatedAtBump:
     ):
         mocker.patch("virtool.blast.data.check_rid", return_value=False)
 
-        await _insert_blast(pg, analysis_ids["analysis"], 12, static_time)
+        await _insert_blast(
+            pg, analysis_ids["analysis"], 12, static_time, rid="RID_12345"
+        )
 
         # Reset to an old timestamp so the assertions prove that ``check_nuvs_blast``
         # performed the bump, not the insert.

--- a/tests/blast/test_tasks.py
+++ b/tests/blast/test_tasks.py
@@ -6,6 +6,7 @@ from syrupy import SnapshotAssertion
 
 from tests.fixtures.analysis import seed_analysis
 from virtool.blast.task import BLASTTask
+from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.mongo.core import Mongo
@@ -112,3 +113,66 @@ async def test_task(
     assert await data_layer.blast.get_nuvs_blast(analysis_id, 5) == snapshot(
         name="blast",
     )
+
+
+class TestWaitForBlastSearch:
+    """Polling stops cleanly when the record it owns is gone or superseded."""
+
+    async def test_superseded_record_exits_without_error(
+        self,
+        mocker: MockerFixture,
+    ):
+        """A re-BLAST can delete and recreate the row while an older task polls.
+
+        ``check_nuvs_blast`` then raises ``ResourceNotFoundError`` (the new row has
+        no RID yet, or was deleted). The task should leave the poll loop quietly
+        without flagging an error, because nothing failed.
+        """
+        mocker.patch("virtool.blast.task.asyncio.sleep")
+
+        data_layer = mocker.Mock()
+        data_layer.blast.check_nuvs_blast = mocker.AsyncMock(
+            side_effect=ResourceNotFoundError,
+        )
+
+        task = BLASTTask(
+            1,
+            data_layer,
+            {"analysis_id": 7, "sequence_index": 5},
+            get_temp_dir(),
+        )
+        task.rid = "RID_OLD"
+        set_error = mocker.patch.object(task, "_set_error")
+
+        await task.wait_for_blast_search()
+
+        set_error.assert_not_called()
+        assert task.errored is False
+
+    async def test_replacement_rid_exits_without_error(
+        self,
+        mocker: MockerFixture,
+    ):
+        """If the replacement row already carries a different RID, the older task
+        recognizes it does not own the search and stops without erroring.
+        """
+        mocker.patch("virtool.blast.task.asyncio.sleep")
+
+        data_layer = mocker.Mock()
+        data_layer.blast.check_nuvs_blast = mocker.AsyncMock(
+            return_value=mocker.Mock(rid="RID_NEW", ready=False, error=None),
+        )
+
+        task = BLASTTask(
+            1,
+            data_layer,
+            {"analysis_id": 7, "sequence_index": 5},
+            get_temp_dir(),
+        )
+        task.rid = "RID_OLD"
+        set_error = mocker.patch.object(task, "_set_error")
+
+        await task.wait_for_blast_search()
+
+        set_error.assert_not_called()
+        assert task.errored is False

--- a/virtool/blast/data.py
+++ b/virtool/blast/data.py
@@ -95,7 +95,7 @@ class BLASTData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             blast_row = await get_nuvs_blast(session, analysis_id, sequence_index)
 
-            if blast_row is None:
+            if blast_row is None or blast_row.rid is None:
                 raise ResourceNotFoundError
 
             rid = blast_row.rid

--- a/virtool/blast/task.py
+++ b/virtool/blast/task.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from structlog import get_logger
 
+from virtool.data.errors import ResourceNotFoundError
 from virtool.tasks.task import BaseTask
 
 if TYPE_CHECKING:
@@ -109,10 +110,25 @@ class BLASTTask(BaseTask):
         while True:
             await asyncio.sleep(interval)
 
-            blast = await self.data.blast.check_nuvs_blast(
-                self.analysis_id,
-                self.sequence_index,
-            )
+            try:
+                blast = await self.data.blast.check_nuvs_blast(
+                    self.analysis_id,
+                    self.sequence_index,
+                )
+            except ResourceNotFoundError:
+                logger.info(
+                    "BLAST record gone or superseded by a newer search",
+                    rid=self.rid,
+                )
+                break
+
+            if blast.rid != self.rid:
+                logger.info(
+                    "BLAST record replaced by a newer search",
+                    rid=self.rid,
+                    new_rid=blast.rid,
+                )
+                break
 
             if blast.ready:
                 logger.info("retrieved result for blast", rid=blast.rid)


### PR DESCRIPTION
## Summary
- Re-BLASTing a contig deletes and recreates the `nuvs_blast` row while an older task is still polling it. The task read the new row before its RID was set and passed `None` to the NCBI request, raising a `TypeError`.
- Treat a null RID as a missing record, and let a superseded polling task exit quietly rather than erroring.

Closes VIR-2622. VIR-2623 tracks replacing the per-search task with a periodic sweeper, which removes the underlying race.