### PR TITLE
fix: stop analyses list from leaking samples user can't read

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -3,7 +3,6 @@ from http import HTTPStatus
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
@@ -17,6 +16,7 @@ from virtool.fake.next import DataFaker
 from virtool.jobs.models import Job, JobState
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
+from virtool.samples.sql import SQLLegacySample
 from virtool.users.models import User
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
@@ -39,15 +39,12 @@ def get_handle(example_path: Path):
 
 async def test_find(
     fake: DataFaker,
-    mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     spawn_client: ClientSpawner,
     static_time,
 ):
-    mocker.patch("virtool.samples.utils.get_sample_rights", return_value=(True, True))
-
     client = await spawn_client(authenticated=True)
 
     user_1 = await fake.users.create()
@@ -86,6 +83,20 @@ async def test_find(
             },
         ),
     )
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLLegacySample(
+                legacy_id="test",
+                name="Test",
+                library_type="normal",
+                created_at=static_time.datetime,
+                user_id=user_1.id,
+                all_read=True,
+                all_write=True,
+            ),
+        )
+        await session.commit()
 
     for document in [
         {

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -50,11 +50,24 @@ async def subtraction_ids(fake: DataFaker) -> dict[str, int]:
     return {"subtraction_1": first.id, "subtraction_2": second.id}
 
 
+def build_user_client(user) -> UserClient:
+    """Build a ``UserClient`` authenticated as ``user``."""
+    return UserClient(
+        administrator_role=user.administrator_role,
+        authenticated=True,
+        force_reset=False,
+        groups=[group.id for group in user.groups],
+        permissions=user.permissions.dict(),
+        user_id=user.id,
+    )
+
+
 class SampleSetup(NamedTuple):
     """Identifiers for the sample and reference seeded by ``setup_sample``."""
 
     user_id: str
     reference_id: str
+    client: UserClient
 
 
 @pytest.fixture
@@ -124,7 +137,11 @@ async def setup_sample(
             },
         ),
     )
-    return SampleSetup(user_id=user.id, reference_id=reference.id)
+    return SampleSetup(
+        user_id=user.id,
+        reference_id=reference.id,
+        client=build_user_client(user),
+    )
 
 
 @pytest.mark.parametrize("number_of_analyses", [0, 1, 2])
@@ -136,11 +153,9 @@ async def test_find(
     pg: AsyncEngine,
     setup_sample: SampleSetup,
     subtraction_ids: dict[str, int],
-    mocker,
 ):
     """Tests that all analysis are listed."""
-    mocker.patch("virtool.samples.utils.get_sample_rights", return_value=(True, True))
-    client = mocker.Mock(spec=UserClient)
+    client = setup_sample.client
     user_id = setup_sample.user_id
 
     await mongo.samples.insert_one({"_id": "test_false", "name": "Test False"})
@@ -193,6 +208,150 @@ async def test_find(
     assert analyses_found.total_count == analyses_found.found_count
 
 
+class TestFindSampleRights:
+    """The analysis list is scoped to samples the requesting client can read."""
+
+    @staticmethod
+    async def _insert_sample(pg: AsyncEngine, legacy_id: str, user_id: int, **rights):
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLLegacySample(
+                    legacy_id=legacy_id,
+                    name=legacy_id,
+                    library_type="normal",
+                    created_at=timestamp(),
+                    user_id=user_id,
+                    **rights,
+                ),
+            )
+            await session.commit()
+
+    @staticmethod
+    async def _seed_analysis(
+        mongo: Mongo,
+        pg: AsyncEngine,
+        legacy_id: str,
+        sample_id: str,
+        setup: SampleSetup,
+    ) -> int:
+        return await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": legacy_id,
+                "workflow": "pathoscope",
+                "created_at": timestamp(),
+                "ready": True,
+                "job": None,
+                "index": {"id": "test_index", "version": 11},
+                "user": {"id": setup.user_id},
+                "sample": {"id": sample_id},
+                "reference": {"id": setup.reference_id},
+                "results": {"hits": []},
+                "subtractions": [],
+            },
+        )
+
+    async def test_private_sample_of_other_user_hidden(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """An analysis on another user's private sample is absent from the documents
+        and from ``total_count``.
+        """
+        other_user = await fake.users.create()
+
+        await self._insert_sample(pg, "other_private", other_user.id, all_read=False)
+        await self._seed_analysis(mongo, pg, "hidden", "other_private", setup_sample)
+
+        owned = await self._seed_analysis(
+            mongo,
+            pg,
+            "visible",
+            "test_sample",
+            setup_sample,
+        )
+
+        found = await data_layer.analyses.find(1, 25, setup_sample.client)
+
+        assert [document.id for document in found.documents] == [owned]
+        assert found.total_count == 1
+        assert found.found_count == 1
+
+    async def test_group_readable_sample_visible(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """An analysis on another user's sample is listed when the client belongs to a
+        group the sample is readable by.
+        """
+        group = await fake.groups.create()
+        sample_owner = await fake.users.create()
+        group_member = await fake.users.create(groups=[group])
+
+        await self._insert_sample(
+            pg,
+            "group_readable",
+            sample_owner.id,
+            all_read=False,
+            group_read=True,
+            group_id=group.id,
+        )
+
+        shared = await self._seed_analysis(
+            mongo,
+            pg,
+            "shared",
+            "group_readable",
+            setup_sample,
+        )
+
+        found = await data_layer.analyses.find(
+            1,
+            25,
+            build_user_client(group_member),
+        )
+
+        assert [document.id for document in found.documents] == [shared]
+
+    async def test_private_sample_hidden_from_non_member(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A group-readable sample stays hidden from a user outside the group."""
+        group = await fake.groups.create()
+        sample_owner = await fake.users.create()
+        outsider = await fake.users.create()
+
+        await self._insert_sample(
+            pg,
+            "group_readable",
+            sample_owner.id,
+            all_read=False,
+            group_read=True,
+            group_id=group.id,
+        )
+
+        await self._seed_analysis(mongo, pg, "shared", "group_readable", setup_sample)
+
+        found = await data_layer.analyses.find(1, 25, build_user_client(outsider))
+
+        assert found.documents == []
+        assert found.total_count == 0
+
+
 class TestHideIimi:
     """Iimi analyses are hidden from the data-layer find and get operations ahead of
     the iimi purge migration.
@@ -224,14 +383,9 @@ class TestHideIimi:
         mongo: Mongo,
         pg: AsyncEngine,
         setup_sample: SampleSetup,
-        mocker,
     ):
         """An iimi analysis is excluded from both the documents and the counts."""
-        mocker.patch(
-            "virtool.samples.utils.get_sample_rights",
-            return_value=(True, True),
-        )
-        client = mocker.Mock(spec=UserClient)
+        client = setup_sample.client
         user_id = setup_sample.user_id
 
         visible = await data_layer.analyses.create(

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1439,6 +1439,8 @@ async def test_find_analyses(
             library_type="normal",
             created_at=static_time.datetime,
             user_id=user_1.id,
+            all_read=True,
+            all_write=True,
         )
         session.add(legacy_sample)
         await session.flush()

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -18,7 +18,6 @@ from virtool.analyses.checks import (
 from virtool.analyses.db import (
     AttachAnalysisSubtractionsTransform,
     bump_analysis_updated_at,
-    filter_analyses_by_sample_rights,
 )
 from virtool.analyses.files import create_analysis_file
 from virtool.analyses.models import Analysis, AnalysisFile, AnalysisSearchResult
@@ -50,6 +49,7 @@ from virtool.mongo.utils import get_new_id
 from virtool.pg.utils import delete_row, get_row_by_id
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
+from virtool.samples.db import compose_sample_rights_filter
 from virtool.samples.oas import CreateAnalysisRequest
 from virtool.samples.sql import SQLLegacySample
 from virtool.samples.utils import get_sample_rights
@@ -148,6 +148,8 @@ class AnalysisData(DataLayerDomain):
     ) -> AnalysisSearchResult:
         """List all analysis documents.
 
+        Only analyses on samples the client has read rights to are listed.
+
         :param page: the page number
         :param per_page: the number of documents per page
         :param client: the client object
@@ -159,26 +161,30 @@ class AnalysisData(DataLayerDomain):
         if page > 1:
             skip_count = (page - 1) * per_page
 
-        count_statement = (
-            select(func.count())
-            .select_from(SQLAnalysis)
-            .where(SQLAnalysis.workflow != IIMI_WORKFLOW)
+        readable_sample_ids = select(SQLLegacySample.id).where(
+            await compose_sample_rights_filter(self._pg, client),
         )
+
+        filters = [
+            SQLAnalysis.workflow != IIMI_WORKFLOW,
+            SQLAnalysis.sample_id.in_(readable_sample_ids),
+        ]
+
+        if sample_id is not None:
+            filters.append(
+                SQLAnalysis.sample_id
+                == compose_legacy_id_subquery(SQLLegacySample, sample_id),
+            )
+
+        count_statement = select(func.count()).select_from(SQLAnalysis).where(*filters)
         statement = (
             select(*FIND_COLUMNS)
-            .where(SQLAnalysis.workflow != IIMI_WORKFLOW)
+            .where(*filters)
             .order_by(
                 SQLAnalysis.created_at.desc(),
                 SQLAnalysis.id.desc(),
             )
         )
-
-        if sample_id is not None:
-            sample_subquery = compose_legacy_id_subquery(SQLLegacySample, sample_id)
-            count_statement = count_statement.where(
-                SQLAnalysis.sample_id == sample_subquery,
-            )
-            statement = statement.where(SQLAnalysis.sample_id == sample_subquery)
 
         async with AsyncSession(self._pg) as session:
             total_count = (await session.execute(count_statement)).scalar_one()
@@ -187,12 +193,6 @@ class AnalysisData(DataLayerDomain):
             ).all()
 
         documents = [_row_to_document(row, include_results=False) for row in rows]
-
-        documents = await filter_analyses_by_sample_rights(
-            client,
-            self._pg,
-            documents,
-        )
 
         documents = await apply_transforms(
             [base_processor(d) for d in documents],

--- a/virtool/analyses/db.py
+++ b/virtool/analyses/db.py
@@ -8,8 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisSubtraction
 from virtool.data.transforms import AbstractTransform
-from virtool.samples.sql import SQLLegacySample
-from virtool.samples.utils import get_sample_rights
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.types import Document
 
@@ -86,63 +84,3 @@ async def bump_analysis_updated_at(
         .where(SQLAnalysis.id == analysis_id)
         .values(updated_at=updated_at),
     )
-
-
-async def filter_analyses_by_sample_rights(
-    client,
-    pg: AsyncEngine,
-    analyses: list[dict],
-) -> list[dict]:
-    """Filter a list of analyses based on the user's rights to the samples they are
-    associated with.
-
-    Sample rights are read from the ``legacy_samples`` Postgres table, keyed by the
-    integer sample id the analyses now carry.
-
-    :param client: the client making the request
-    :param pg: the application Postgres engine
-    :param analyses: the analyses to filter
-    :return: the filtered analyses
-
-    """
-    sample_ids = {a["sample"]["id"] for a in analyses}
-
-    if not sample_ids:
-        return []
-
-    async with AsyncSession(pg) as session:
-        rows = (
-            await session.execute(
-                select(
-                    SQLLegacySample.id,
-                    SQLLegacySample.group_id,
-                    SQLLegacySample.group_read,
-                    SQLLegacySample.group_write,
-                    SQLLegacySample.all_read,
-                    SQLLegacySample.all_write,
-                    SQLLegacySample.user_id,
-                ).where(SQLLegacySample.id.in_(sample_ids)),
-            )
-        ).all()
-
-    sample_rights_lookup = {
-        row.id: {
-            "group": row.group_id,
-            "group_read": row.group_read,
-            "group_write": row.group_write,
-            "all_read": row.all_read,
-            "all_write": row.all_write,
-            "user": {"id": row.user_id},
-        }
-        for row in rows
-    }
-
-    filtered = []
-
-    for analysis in analyses:
-        rights = sample_rights_lookup.get(analysis["sample"]["id"])
-
-        if rights is not None and get_sample_rights(rights, client):
-            filtered.append(analysis)
-
-    return filtered

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -9,7 +9,6 @@ from typing import Any
 from pymongo.results import UpdateResult
 from sqlalchemy import (
     ColumnExpressionArgument,
-    and_,
     delete,
     exc,
     func,
@@ -30,7 +29,6 @@ from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import (
     both_transactions,
-    compose_legacy_id_multi_expression,
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
     retry_both_transactions,
@@ -54,7 +52,9 @@ from virtool.samples.db import (
     AttachArtifactsAndReadsTransform,
     AttachUploadsTransform,
     DeriveWorkflowTagsTransform,
+    compose_sample_rights_filter,
     compose_sample_workflow_filter,
+    resolve_client_group_ids,
 )
 from virtool.samples.files import (
     create_artifact_file,
@@ -225,7 +225,7 @@ class SamplesData(DataLayerDomain):
         client,
     ) -> SampleSearchResult:
         """Find and filter samples."""
-        filters = [await self._compose_rights_filter(client)]
+        filters = [await compose_sample_rights_filter(self._pg, client)]
 
         if term:
             filters.append(_compose_sample_search_filter(term))
@@ -298,58 +298,6 @@ class SamplesData(DataLayerDomain):
             page_count=int(math.ceil(found_count / per_page)),
             per_page=per_page,
         )
-
-    async def _resolve_client_group_ids(self, client) -> list[int]:
-        """Resolve the Postgres group ids for the groups ``client`` belongs to.
-
-        Shared by ``_compose_rights_filter`` and ``has_right`` so the two rights
-        paths resolve group membership the same way.
-        """
-        if not client.groups:
-            return []
-
-        async with AsyncSession(self._pg) as session:
-            return list(
-                (
-                    await session.execute(
-                        select(SQLGroup.id).where(
-                            compose_legacy_id_multi_expression(
-                                SQLGroup,
-                                client.groups,
-                            ),
-                        ),
-                    )
-                )
-                .scalars()
-                .all(),
-            )
-
-    async def _compose_rights_filter(
-        self,
-        client,
-    ) -> ColumnExpressionArgument[bool]:
-        """Compose the Postgres predicate scoping samples to those ``client`` can read.
-
-        Mirrors the Mongo ``$or`` rights filter: the requesting user owns the sample,
-        the sample is world-readable, or the sample is readable by a group the user
-        belongs to.
-        """
-        rights_filter = [
-            SQLLegacySample.all_read.is_(True),
-            SQLLegacySample.user_id == client.user_id,
-        ]
-
-        group_ids = await self._resolve_client_group_ids(client)
-
-        if group_ids:
-            rights_filter.append(
-                and_(
-                    SQLLegacySample.group_read.is_(True),
-                    SQLLegacySample.group_id.in_(group_ids),
-                ),
-            )
-
-        return or_(*rights_filter)
 
     async def get(self, sample_id: int | str) -> Sample:
         """Get a sample by its id.
@@ -1021,7 +969,7 @@ class SamplesData(DataLayerDomain):
         is_group_member = False
 
         if row.group_id is not None:
-            member_group_ids = await self._resolve_client_group_ids(client)
+            member_group_ids = await resolve_client_group_ids(self._pg, client)
             is_group_member = row.group_id in member_group_ids
 
         if right == SampleRight.read:

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -3,7 +3,15 @@
 from collections import defaultdict
 from typing import Any
 
-from sqlalchemy import and_, exists, func, not_, or_, select
+from sqlalchemy import (
+    ColumnExpressionArgument,
+    and_,
+    exists,
+    func,
+    not_,
+    or_,
+    select,
+)
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from yarl import URL
 
@@ -14,7 +22,10 @@ import virtool.utils
 from virtool.analyses.sql import SQLAnalysis
 from virtool.analyses.utils import WORKFLOW_NAMES
 from virtool.api.errors import APINotFound
-from virtool.data.topg import compose_legacy_id_subquery
+from virtool.data.topg import (
+    compose_legacy_id_multi_expression,
+    compose_legacy_id_subquery,
+)
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
@@ -261,6 +272,53 @@ async def check_rights(db, sample_id: str | None, client, write: bool = True) ->
     has_read, has_write = virtool.samples.utils.get_sample_rights(sample_rights, client)
 
     return has_read and (write is False or has_write)
+
+
+async def resolve_client_group_ids(pg: AsyncEngine, client) -> list[int]:
+    """Resolve the Postgres group ids for the groups ``client`` belongs to."""
+    if not client.groups:
+        return []
+
+    async with AsyncSession(pg) as session:
+        return list(
+            (
+                await session.execute(
+                    select(SQLGroup.id).where(
+                        compose_legacy_id_multi_expression(SQLGroup, client.groups),
+                    ),
+                )
+            )
+            .scalars()
+            .all(),
+        )
+
+
+async def compose_sample_rights_filter(
+    pg: AsyncEngine,
+    client,
+) -> ColumnExpressionArgument[bool]:
+    """Compose the Postgres predicate scoping samples to those ``client`` can read.
+
+    Mirrors the Mongo ``$or`` rights filter: the requesting user owns the sample,
+    the sample is world-readable, or the sample is readable by a group the user
+    belongs to.
+    """
+    rights_filter = [
+        SQLLegacySample.all_read.is_(True),
+        SQLLegacySample.user_id == client.user_id,
+    ]
+
+    group_ids = await resolve_client_group_ids(pg, client)
+
+    if group_ids:
+        rights_filter.append(
+            and_(
+                SQLLegacySample.group_read.is_(True),
+                SQLLegacySample.group_id.in_(group_ids),
+            ),
+        )
+
+    return or_(*rights_filter)
 
 
 WORKFLOW_CONDITIONS = ("none", "pending", "ready")


### PR DESCRIPTION
## Summary

- The analyses list checked the truthiness of the 2-tuple returned by `get_sample_rights`, which is always true, so every authenticated user saw every analysis in the instance. Filtering also ran after SQL `offset`/`limit`, misaligning `total_count` with the returned page.
- Push the sample-rights predicate into the query instead, sharing the filter with `GET /samples`. Administrators are now scoped like any other user on this endpoint, matching the sample list.

Closes VIR-2627.