### PR TITLE
feat: address samples by integer id over the jobs API

### DIFF
--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -229,6 +229,39 @@ class TestCreatePostgres:
         fetched_job = await jobs_data.get(job.id)
         assert fetched_job.args == {"sample_id": sample_pk}
 
+    async def test_sample_id_resolved_without_legacy_id(
+        self,
+        jobs_data: JobsData,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """``get`` exposes the sample id for a sample created natively in Postgres.
+
+        Such a sample has no legacy id, so the job argument can only come from the
+        integer primary key.
+        """
+        user = await fake.users.create()
+
+        job = await jobs_data.create("create_sample", {}, user.id, 0)
+
+        async with AsyncSession(pg) as session:
+            sample = SQLLegacySample(
+                legacy_id=None,
+                name="Sample 123",
+                library_type="normal",
+                created_at=arrow.utcnow().naive,
+                job_id=job.id,
+            )
+            session.add(sample)
+            await session.flush()
+
+            sample_pk = sample.id
+
+            await session.commit()
+
+        fetched_job = await jobs_data.get(job.id)
+        assert fetched_job.args == {"sample_id": sample_pk}
+
     async def test_index_join_table(
         self,
         jobs_data: JobsData,

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -197,11 +197,10 @@ class TestCreatePostgres:
     ):
         """``get`` resolves the sample from the legacy sample linked by job_id.
 
-        Unlike subtractions and analyses, which expose the integer id, the sample
-        reference is exposed as the legacy Mongo string so the create_sample
-        workflow can address the sample over the jobs API, whose endpoints still
-        resolve samples by their Mongo ``_id``. The public flip to the integer PK
-        is VIR-2529.
+        The sample is exposed as its integer primary key, which the create_sample
+        workflow uses to address the sample over the jobs API. A sample created
+        natively in Postgres has no legacy id, so the legacy string cannot be the
+        job argument.
         """
         user = await fake.users.create()
 
@@ -213,19 +212,22 @@ class TestCreatePostgres:
         )
 
         async with AsyncSession(pg) as session:
-            session.add(
-                SQLLegacySample(
-                    legacy_id="sample_123",
-                    name="Sample 123",
-                    library_type="normal",
-                    created_at=arrow.utcnow().naive,
-                    job_id=job.id,
-                ),
+            sample = SQLLegacySample(
+                legacy_id="sample_123",
+                name="Sample 123",
+                library_type="normal",
+                created_at=arrow.utcnow().naive,
+                job_id=job.id,
             )
+            session.add(sample)
+            await session.flush()
+
+            sample_pk = sample.id
+
             await session.commit()
 
         fetched_job = await jobs_data.get(job.id)
-        assert fetched_job.args == {"sample_id": "sample_123"}
+        assert fetched_job.args == {"sample_id": sample_pk}
 
     async def test_index_join_table(
         self,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1740,20 +1740,23 @@ class TestUploadArtifact:
     """Test that new artifacts can be uploaded after sample creation using the Jobs API."""
 
     @staticmethod
-    async def _insert_sample(mongo: Mongo, pg: AsyncEngine) -> None:
+    async def _insert_sample(mongo: Mongo, pg: AsyncEngine) -> int:
         await mongo.samples.insert_one({"_id": "test", "ready": True})
         async with AsyncSession(pg) as session:
-            await _ensure_legacy_sample_id(session, "test")
+            sample_pk = await _ensure_legacy_sample_id(session, "test")
             await session.commit()
+
+        return sample_pk
 
     @staticmethod
     async def _post(
         client: VirtoolTestClient,
         path: Path,
         artifact_type: str,
+        sample_id: int | str = "test",
     ):
         return await client.post(
-            f"/samples/test/artifacts?name=small.fq.gz&type={artifact_type}",
+            f"/samples/{sample_id}/artifacts?name=small.fq.gz&type={artifact_type}",
             data={"file": open(path, "rb")},
         )
 
@@ -1779,6 +1782,52 @@ class TestUploadArtifact:
 
         keys = {obj.key async for obj in memory_storage.list("samples/test/")}
         assert keys == {"samples/test/small.fq.gz"}
+
+    async def test_addressed_by_primary_key(
+        self,
+        example_path: Path,
+        memory_storage,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        """An artifact can be uploaded to a sample addressed by its integer id.
+
+        The stored object stays under the sample's legacy storage prefix.
+        """
+        client = await spawn_job_client(authenticated=True)
+        sample_pk = await self._insert_sample(mongo, pg)
+
+        resp = await self._post(
+            client,
+            example_path / "sample" / "reads_1.fq.gz",
+            "fastq",
+            sample_id=sample_pk,
+        )
+
+        assert resp.status == 201
+
+        keys = {obj.key async for obj in memory_storage.list("samples/test/")}
+        assert keys == {"samples/test/small.fq.gz"}
+
+    async def test_not_found(
+        self,
+        example_path: Path,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        resp = await self._post(
+            client,
+            example_path / "sample" / "reads_1.fq.gz",
+            "fastq",
+            sample_id=999999,
+        )
+
+        await resp_is.not_found(resp)
 
     async def test_unsupported_type(
         self,
@@ -1874,6 +1923,51 @@ class TestUploadReads:
         assert resp_3.status == 409
         assert await resp_3.json() == snapshot(name="409")
 
+    async def test_addressed_by_primary_key(
+        self,
+        example_path: Path,
+        memory_storage,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        spawn_job_client: JobClientSpawner,
+    ):
+        """Reads can be uploaded to a sample addressed by its integer id.
+
+        The stored object stays under the sample's legacy storage prefix.
+        """
+        client = await spawn_job_client(authenticated=True)
+
+        await mongo.samples.insert_one({"_id": "test", "ready": True})
+
+        async with AsyncSession(pg) as session:
+            sample_pk = await _ensure_legacy_sample_id(session, "test")
+            await session.commit()
+
+        resp = await client.put(
+            f"/samples/{sample_pk}/reads/reads_1.fq.gz",
+            data={"file": open(example_path / "sample" / "reads_1.fq.gz", "rb")},
+        )
+
+        assert resp.status == 201
+
+        keys = {obj.key async for obj in memory_storage.list("samples/test/")}
+        assert keys == {"samples/test/reads_1.fq.gz"}
+
+    async def test_not_found(
+        self,
+        example_path: Path,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        resp = await client.put(
+            "/samples/999999/reads/reads_1.fq.gz",
+            data={"file": open(example_path / "sample" / "reads_1.fq.gz", "rb")},
+        )
+
+        await resp_is.not_found(resp)
+
     async def test_uncompressed(
         self,
         example_path: Path,
@@ -1895,6 +1989,10 @@ class TestUploadReads:
                 "ready": True,
             },
         )
+
+        async with AsyncSession(pg) as session:
+            await _ensure_legacy_sample_id(session, "test")
+            await session.commit()
 
         upload = await fake.uploads.create(user=await fake.users.create())
 
@@ -1939,6 +2037,10 @@ class TestUploadReads:
             },
         )
 
+        async with AsyncSession(pg) as session:
+            await _ensure_legacy_sample_id(session, "test")
+            await session.commit()
+
         resp = await client.put(
             "/samples/test/reads/reads_1.fq.gz",
             data={"file": io.BytesIO(b"")},
@@ -1957,6 +2059,124 @@ class TestUploadReads:
             )
 
         assert rows == []
+
+
+class TestJobRemove:
+    """Test removal of unfinalized samples over the Jobs API."""
+
+    async def setup_sample(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        spawn_job_client: JobClientSpawner,
+        finalized: bool,
+        job_state: JobState,
+    ) -> tuple[VirtoolTestClient, int]:
+        """Create a sample with a creation job in ``job_state`` and return its id."""
+        client = await spawn_job_client(authenticated=True)
+
+        user = await fake.users.create()
+
+        await create_fake_sample(client.app, "test", user.id, finalized=finalized)
+
+        job = await fake.jobs.create(user, state=job_state, workflow="create_sample")
+
+        await mongo.samples.update_one(
+            {"_id": "test"},
+            {"$set": {"job": {"id": job.id}}},
+        )
+
+        async with AsyncSession(client.app["pg"]) as session:
+            await session.execute(
+                update(SQLLegacySample)
+                .where(SQLLegacySample.legacy_id == "test")
+                .values(job_id=job.id),
+            )
+            await session.commit()
+
+            sample_id = (
+                await session.execute(
+                    select(SQLLegacySample.id).where(
+                        SQLLegacySample.legacy_id == "test",
+                    ),
+                )
+            ).scalar_one()
+
+        return client, sample_id
+
+    async def test_ok(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        """An unfinalized sample addressed by integer id can be removed."""
+        client, sample_id = await self.setup_sample(
+            fake,
+            mongo,
+            spawn_job_client,
+            finalized=False,
+            job_state=JobState.FAILED,
+        )
+
+        resp = await client.delete(f"/samples/{sample_id}")
+
+        assert resp.status == 204
+
+    async def test_finalized(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        client, sample_id = await self.setup_sample(
+            fake,
+            mongo,
+            spawn_job_client,
+            finalized=True,
+            job_state=JobState.SUCCEEDED,
+        )
+
+        resp = await client.delete(f"/samples/{sample_id}")
+
+        await resp_is.bad_request(resp, "Only unfinalized samples can be deleted")
+
+    async def test_active_job(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+        static_time,
+    ):
+        client, sample_id = await self.setup_sample(
+            fake,
+            mongo,
+            spawn_job_client,
+            finalized=False,
+            job_state=JobState.RUNNING,
+        )
+
+        resp = await client.delete(f"/samples/{sample_id}")
+
+        await resp_is.bad_request(
+            resp,
+            "Cannot delete sample with active job (current state: running)",
+        )
+
+    async def test_not_found(
+        self,
+        resp_is,
+        spawn_job_client: JobClientSpawner,
+    ):
+        client = await spawn_job_client(authenticated=True)
+
+        resp = await client.delete("/samples/999999")
+
+        await resp_is.not_found(resp)
 
 
 class TestDownloadReads:

--- a/tests/samples/test_files.py
+++ b/tests/samples/test_files.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
@@ -14,14 +13,17 @@ async def test_create_reads_file(
     pg: AsyncEngine, snapshot: SnapshotAssertion, static_time
 ):
     async with AsyncSession(pg) as session:
-        session.add(
-            SQLLegacySample(
-                legacy_id="sample_1",
-                name="sample_1",
-                library_type=LibraryType.normal.value,
-                created_at=datetime(2015, 10, 6, 20, 0),
-            ),
+        sample = SQLLegacySample(
+            legacy_id="sample_1",
+            name="sample_1",
+            library_type=LibraryType.normal.value,
+            created_at=datetime(2015, 10, 6, 20, 0),
         )
+        session.add(sample)
+        await session.flush()
+
+        sample_pk = sample.id
+
         await session.commit()
 
     await create_reads_file(
@@ -29,6 +31,7 @@ async def test_create_reads_file(
         123456,
         "reads_1.fq.gz",
         "reads_1.fq.gz",
+        sample_pk,
         "sample_1",
     )
 
@@ -36,18 +39,4 @@ async def test_create_reads_file(
         reads = (await session.execute(select(SQLSampleReads).filter_by(id=1))).scalar()
 
     assert reads == snapshot
-    assert reads.sample_id is not None
-
-
-async def test_create_reads_file_unknown_sample_raises(pg: AsyncEngine):
-    """Creating a reads file for a sample with no ``legacy_samples`` row is a
-    data-integrity error and must fail loudly rather than store a NULL sample_id.
-    """
-    with pytest.raises(ValueError, match="No legacy_samples row for sample"):
-        await create_reads_file(
-            pg,
-            123456,
-            "reads_1.fq.gz",
-            "reads_1.fq.gz",
-            "missing_sample",
-        )
+    assert reads.sample_id == sample_pk

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -252,7 +252,7 @@ class JobsData:
                 select(
                     SQLJob,
                     SQLUser,
-                    SQLLegacySample.legacy_id.label("sample_id"),
+                    SQLLegacySample.id.label("sample_id"),
                     SQLJobIndex.index_id,
                     SQLSubtraction.id.label("subtraction_id"),
                     SQLAnalysis.legacy_id,
@@ -273,12 +273,7 @@ class JobsData:
 
         # The create_sample job's sample is resolved through the reverse
         # ``legacy_samples.job_id`` foreign key rather than a ``job_samples`` link
-        # row. ``sample_id`` is exposed as the legacy sample string
-        # (``legacy_samples.legacy_id``), not the integer ``legacy_samples.id``
-        # primary key: the create_sample workflow uses this value to address the
-        # sample over the jobs API, whose endpoints still resolve samples by their
-        # Mongo ``_id``. The public identifier flips to the integer primary key in
-        # VIR-2529.
+        # row.
         args = {
             field: value
             for field, value in (

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -33,7 +33,6 @@ from virtool.data.errors import (
 from virtool.data.utils import get_data_from_req
 from virtool.jobs.models import TERMINAL_JOB_STATES
 from virtool.models.roles import AdministratorRole
-from virtool.mongo.utils import get_mongo_from_req
 from virtool.samples.models import Sample, SampleSearchResult
 from virtool.samples.oas import (
     CreateAnalysisRequest,
@@ -46,7 +45,6 @@ from virtool.uploads.utils import (
     multipart_file_chunker,
     naive_validator,
 )
-from virtool.utils import get_safely
 
 logger = get_logger("samples")
 
@@ -335,33 +333,20 @@ async def job_remove(req):
     Only usable in the Jobs API and when samples are unfinalized.
 
     """
-    mongo = get_mongo_from_req(req)
-
     sample_id = req.match_info["sample_id"]
 
-    sample_document = await mongo.samples.find_one(
-        {"_id": sample_id},
-        {"ready": 1, "job": 1},
-    )
-
-    if not sample_document:
+    try:
+        sample = await get_data_from_req(req).samples.get(sample_id)
+    except ResourceNotFoundError:
         raise APINotFound()
 
-    if sample_document.get("ready") is not False:
+    if sample.ready:
         raise APIBadRequest("Only unfinalized samples can be deleted")
 
-    job_id = get_safely(sample_document, "job", "id")
-
-    if job_id:
-        try:
-            job = await get_data_from_req(req).jobs.get(job_id)
-        except ResourceNotFoundError:
-            job = None
-
-        if job is not None and job.state.value not in DELETABLE_JOB_STATES:
-            raise APIBadRequest(
-                f"Cannot delete sample with active job (current state: {job.state.value})"
-            )
+    if sample.job is not None and sample.job.state.value not in DELETABLE_JOB_STATES:
+        raise APIBadRequest(
+            f"Cannot delete sample with active job (current state: {sample.job.state.value})"
+        )
 
     try:
         await get_data_from_req(req).samples.delete(sample_id)
@@ -458,13 +443,8 @@ async def upload_artifact(req):
 
     Uploads artifact created during sample creation using the Jobs API.
     """
-    mongo = get_mongo_from_req(req)
-
     sample_id = req.match_info["sample_id"]
     artifact_type = req.query.get("type")
-
-    if not await mongo.samples.find_one(sample_id):
-        raise APINotFound()
 
     if errors := naive_validator(req):
         raise APIInvalidQuery(errors)
@@ -478,6 +458,8 @@ async def upload_artifact(req):
             name,
             multipart_file_chunker(await req.multipart()),
         )
+    except ResourceNotFoundError:
+        raise APINotFound()
     except ResourceConflictError as err:
         if "Unsupported" in str(err):
             raise APIBadRequest(str(err))
@@ -502,8 +484,6 @@ async def upload_reads(req):
 
     Uploads sample reads using the Jobs API.
     """
-    mongo = get_mongo_from_req(req)
-
     name = req.match_info["filename"]
     sample_id = req.match_info["sample_id"]
 
@@ -515,9 +495,6 @@ async def upload_reads(req):
     if name not in ["reads_1.fq.gz", "reads_2.fq.gz"]:
         raise APIBadRequest("File name is not an accepted reads file")
 
-    if not await mongo.samples.find_one(sample_id):
-        raise APINotFound()
-
     try:
         reads = await get_data_from_req(req).samples.upload_reads(
             sample_id,
@@ -525,6 +502,8 @@ async def upload_reads(req):
             multipart_file_chunker(await req.multipart()),
             upload_id=upload,
         )
+    except ResourceNotFoundError:
+        raise APINotFound()
     except EOFError:
         raise APIBadRequest("Reads file is empty")
     except OSError:

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -76,6 +76,7 @@ from virtool.samples.utils import (
     define_initial_workflows,
     sample_file_key,
     sample_prefix,
+    sample_storage_id,
 )
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
@@ -735,11 +736,11 @@ class SamplesData(DataLayerDomain):
 
         if result.deleted_count:
             for key, exc in await delete_prefix(
-                self._storage, sample_prefix(legacy_id)
+                self._storage, sample_prefix(sample_storage_id(sample_pk, legacy_id))
             ):
                 logger.error(
                     "storage cleanup failed; file orphaned",
-                    sample_id=legacy_id,
+                    sample_id=sample_pk,
                     key=key,
                     error=repr(exc),
                 )
@@ -1070,20 +1071,29 @@ class SamplesData(DataLayerDomain):
 
     async def upload_artifact(
         self,
-        sample_id: str,
+        sample_id: int | str,
         artifact_type: str | None,
         filename: str,
         chunker: AsyncGenerator[bytearray],
     ) -> dict:
+        resolved = await self._resolve_ids(sample_id)
+
+        if resolved is None:
+            raise ResourceNotFoundError
+
         if artifact_type and artifact_type not in ArtifactType.to_list():
             raise ResourceConflictError("Unsupported sample artifact type")
+
+        sample_pk, legacy_id = resolved
+        storage_id = sample_storage_id(sample_pk, legacy_id)
 
         try:
             artifact = await create_artifact_file(
                 self._pg,
                 filename,
                 filename,
-                sample_id,
+                sample_pk,
+                storage_id,
                 artifact_type,
             )
         except exc.IntegrityError:
@@ -1091,7 +1101,7 @@ class SamplesData(DataLayerDomain):
                 "Artifact file has already been uploaded for this sample",
             )
 
-        key = sample_file_key(sample_id, filename)
+        key = sample_file_key(storage_id, filename)
 
         try:
             size = await self._storage.write(key, chunker)
@@ -1109,12 +1119,20 @@ class SamplesData(DataLayerDomain):
 
     async def upload_reads(
         self,
-        sample_id: str,
+        sample_id: int | str,
         filename: str,
         chunker: AsyncGenerator[bytearray],
         upload_id: int | None = None,
     ) -> dict:
-        key = sample_file_key(sample_id, filename)
+        resolved = await self._resolve_ids(sample_id)
+
+        if resolved is None:
+            raise ResourceNotFoundError
+
+        sample_pk, legacy_id = resolved
+        storage_id = sample_storage_id(sample_pk, legacy_id)
+
+        key = sample_file_key(storage_id, filename)
 
         first = await anext(chunker, None)
 
@@ -1136,7 +1154,8 @@ class SamplesData(DataLayerDomain):
                 size,
                 filename,
                 filename,
-                sample_id,
+                sample_pk,
+                storage_id,
                 upload_id=upload_id,
             )
         except exc.IntegrityError:

--- a/virtool/samples/fake.py
+++ b/virtool/samples/fake.py
@@ -10,7 +10,7 @@ from virtool.mongo.utils import get_mongo_from_app
 from virtool.samples.db import create_sample
 from virtool.samples.files import create_reads_file
 from virtool.samples.sql import SQLLegacySample, SQLLegacySampleSubtraction
-from virtool.samples.utils import sample_file_key
+from virtool.samples.utils import sample_file_key, sample_storage_id
 from virtool.settings.models import Settings
 from virtool.storage.protocol import STORAGE_CHUNK_SIZE, StorageBackend
 from virtool.subtractions.pg import SQLSubtraction
@@ -130,15 +130,19 @@ async def create_fake_sample(
         session.add(sample)
         await session.flush()
 
+        sample_pk = sample.id
+
         for subtraction_id in document["subtractions"]:
             session.add(
                 SQLLegacySampleSubtraction(
-                    sample_id=sample.id,
+                    sample_id=sample_pk,
                     subtraction_id=subtraction_id,
                 ),
             )
 
         await session.commit()
+
+    storage_id = sample_storage_id(sample_pk, sample_id)
 
     if finalized is True:
         if paired:
@@ -149,7 +153,7 @@ async def create_fake_sample(
                     storage,
                     file_path,
                     f"reads_{n}.fq.gz",
-                    sample_id,
+                    storage_id,
                 )
 
                 await create_reads_file(
@@ -157,19 +161,21 @@ async def create_fake_sample(
                     file_path.stat().st_size,
                     f"reads_{n}.fq.gz",
                     f"reads_{n}.fq.gz",
-                    sample_id,
+                    sample_pk,
+                    storage_id,
                 )
         else:
             file_path = example_path / "sample" / "reads_1.fq.gz"
 
-            await copy_reads_file(storage, file_path, "reads_1.fq.gz", sample_id)
+            await copy_reads_file(storage, file_path, "reads_1.fq.gz", storage_id)
 
             await create_reads_file(
                 pg,
                 file_path.stat().st_size,
                 "reads_1.fq.gz",
                 "reads_1.fq.gz",
-                sample_id,
+                sample_pk,
+                storage_id,
             )
 
         await get_data_from_app(app).samples.finalize(
@@ -188,7 +194,7 @@ async def copy_reads_file(
     storage: StorageBackend,
     file_path: Path,
     filename: str,
-    sample_id: str,
+    storage_id: str,
 ) -> None:
-    key = sample_file_key(sample_id, filename)
+    key = sample_file_key(storage_id, filename)
     await storage.write(key, _stream_file(file_path))

--- a/virtool/samples/files.py
+++ b/virtool/samples/files.py
@@ -2,25 +2,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.utils
-from virtool.data.topg import compose_legacy_id_subquery, resolve_legacy_id
+from virtool.data.topg import compose_legacy_id_subquery
 from virtool.samples.sql import SQLLegacySample, SQLSampleArtifact, SQLSampleReads
 from virtool.uploads.sql import SQLUpload
-
-
-async def _resolve_sample_id(session: AsyncSession, sample: str) -> int:
-    """Resolve a sample's Mongo id to its ``legacy_samples`` integer primary key.
-
-    A sample file's parent sample is a required relationship, so a sample that
-    has not been backfilled into Postgres is a data-integrity error rather than a
-    row to store with a ``NULL`` ``sample_id``.
-    """
-    sample_id = await resolve_legacy_id(session, SQLLegacySample, sample)
-
-    if sample_id is None:
-        msg = f"No legacy_samples row for sample {sample!r}"
-        raise ValueError(msg)
-
-    return sample_id
 
 
 async def get_existing_reads(pg: AsyncEngine, sample_id: str) -> list[str]:
@@ -45,7 +29,8 @@ async def create_artifact_file(
     pg: AsyncEngine,
     name: str,
     name_on_disk: str,
-    sample: str,
+    sample_id: int,
+    storage_id: str,
     artifact_type: str,
 ) -> dict[str, any]:
     """Create a row in an SQL table that represents uploaded sample artifact file.
@@ -53,7 +38,8 @@ async def create_artifact_file(
     :param pg: PostgreSQL AsyncEngine object
     :param name: Name of the sample artifact file
     :param name_on_disk: Name of the sample artifact file as it appears on disk
-    :param sample: ID that corresponds to a parent sample
+    :param sample_id: Primary key of the parent sample
+    :param storage_id: Identifier the parent sample's storage objects are keyed under
     :param artifact_type: Type of artifact to be uploaded
     :return: A dictionary representation of the newly created row
     """
@@ -61,8 +47,8 @@ async def create_artifact_file(
         artifact = SQLSampleArtifact(
             name=name,
             name_on_disk=name_on_disk,
-            sample=sample,
-            sample_id=await _resolve_sample_id(session, sample),
+            sample=storage_id,
+            sample_id=sample_id,
             type=artifact_type,
             uploaded_at=virtool.utils.timestamp(),
         )
@@ -82,7 +68,8 @@ async def create_reads_file(
     size: int,
     name: str,
     name_on_disk: str,
-    sample_id: str,
+    sample_id: int,
+    storage_id: str,
     upload_id: int | None = None,
 ) -> dict[str, any]:
     """Create a row in a SQL table that represents uploaded sample reads files.
@@ -91,15 +78,16 @@ async def create_reads_file(
     :param size: Size of a newly uploaded file in bytes
     :param name: Name of the file (either `reads_1.fq.gz` or `reads_2.fq.gz`)
     :param name_on_disk: Name of the newly uploaded file on disk
-    :param sample_id: ID that corresponds to a parent sample
+    :param sample_id: Primary key of the parent sample
+    :param storage_id: Identifier the parent sample's storage objects are keyed under
     :param upload_id: ID for a row in the `uploads` table to pair with
     :return: List of dictionary representations of the newly created row(s)
 
     """
     async with AsyncSession(pg) as session:
         reads = SQLSampleReads(
-            sample=sample_id,
-            sample_id=await _resolve_sample_id(session, sample_id),
+            sample=storage_id,
+            sample_id=sample_id,
             name=name,
             name_on_disk=name_on_disk,
             size=size,

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -137,9 +137,22 @@ def bad_labels_response(labels: list[int]) -> Response:
     )
 
 
-def sample_file_key(sample_id: str, filename: str) -> str:
-    return f"samples/{sample_id}/{filename}"
+def sample_storage_id(sample_id: int, legacy_id: str | None) -> str:
+    """Get the identifier a sample's storage objects are keyed under.
+
+    A sample keeps a single storage prefix for its whole life: its Mongo ``_id`` if
+    it has one, and its integer primary key otherwise. Samples created natively in
+    Postgres have no ``legacy_id`` and are keyed by primary key from the start.
+
+    Deleting a sample removes its prefix in one operation, so a sample whose files
+    were split across two prefixes would have half of them orphaned.
+    """
+    return legacy_id or str(sample_id)
 
 
-def sample_prefix(sample_id: str) -> str:
-    return f"samples/{sample_id}/"
+def sample_file_key(storage_id: str, filename: str) -> str:
+    return f"samples/{storage_id}/{filename}"
+
+
+def sample_prefix(storage_id: str) -> str:
+    return f"samples/{storage_id}/"


### PR DESCRIPTION
## Summary
- The `create_sample` job argument now carries the sample's integer primary key instead of the legacy Mongo string id, which will be null for samples created natively in Postgres.
- The jobs-API sample removal and upload handlers resolve samples through the data layer, accepting either the integer id or the legacy string id.
- A sample keeps a single storage prefix for its whole life: its legacy id if it has one, otherwise its primary key.