### PR TITLE
feat: read analysis rights from postgres

### DIFF
--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -226,6 +226,15 @@ async def test_get(
         )
         await create_analysis_file(pg, analysis_id, "fasta", "reference.fa")
 
+    if error == "404_sample":
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis_id)
+                .values(sample_id=None),
+            )
+            await session.commit()
+
     resp = await client.get("/analyses/foobar")
 
     if error is None:

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -226,15 +226,6 @@ async def test_get(
         )
         await create_analysis_file(pg, analysis_id, "fasta", "reference.fa")
 
-    if error == "404_sample":
-        async with AsyncSession(pg) as session:
-            await session.execute(
-                update(SQLAnalysis)
-                .where(SQLAnalysis.id == analysis_id)
-                .values(sample_id=None),
-            )
-            await session.commit()
-
     resp = await client.get("/analyses/foobar")
 
     if error is None:
@@ -624,7 +615,7 @@ async def test_remove(
         case "403":
             await resp_is.insufficient_rights(resp)
 
-        case ("404_analysis", "404_sample"):
+        case "404_analysis" | "404_sample":
             await resp_is.not_found(resp)
 
         case "409":
@@ -788,7 +779,6 @@ class TestDownloadAnalysisResult:
         "404_analysis",
         "404_sample",
         "404_sequence",
-        "404_sequence",
         "409_workflow",
         "409_ready",
     ],
@@ -875,7 +865,7 @@ async def test_blast(
     elif error == "403":
         await resp_is.insufficient_rights(resp)
 
-    elif error == "404_analysis":
+    elif error in ("404_analysis", "404_sample"):
         await resp_is.not_found(resp)
 
     elif error == "404_sequence":

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -20,6 +20,7 @@ from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.models.enums import AnalysisWorkflow
+from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
 from virtool.samples.oas import CreateAnalysisRequest
@@ -350,6 +351,289 @@ class TestFindSampleRights:
 
         assert found.documents == []
         assert found.total_count == 0
+
+
+class TestHasRight:
+    """Rights on an analysis are resolved from the parent sample's Postgres row."""
+
+    @staticmethod
+    async def _insert_sample(pg: AsyncEngine, legacy_id: str, user_id: int, **rights):
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLLegacySample(
+                    legacy_id=legacy_id,
+                    name=legacy_id,
+                    library_type="normal",
+                    created_at=timestamp(),
+                    user_id=user_id,
+                    **rights,
+                ),
+            )
+            await session.commit()
+
+    @staticmethod
+    async def _seed_analysis(
+        mongo: Mongo,
+        pg: AsyncEngine,
+        legacy_id: str,
+        sample_id: str,
+        owner_id: int,
+        reference_id: str,
+    ) -> int:
+        return await seed_analysis(
+            mongo,
+            pg,
+            {
+                "_id": legacy_id,
+                "workflow": "pathoscope",
+                "created_at": timestamp(),
+                "ready": True,
+                "job": None,
+                "index": {"id": "test_index", "version": 11},
+                "user": {"id": owner_id},
+                "sample": {"id": sample_id},
+                "reference": {"id": reference_id},
+                "results": {"hits": []},
+                "subtractions": [],
+            },
+        )
+
+    async def test_owner_has_read_and_write(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """The owner of the parent sample holds both rights on its analyses."""
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "owned",
+            "test_sample",
+            setup_sample.user_id,
+            setup_sample.reference_id,
+        )
+
+        assert await data_layer.analyses.has_right(
+            "owned",
+            setup_sample.client,
+            "read",
+        )
+        assert await data_layer.analyses.has_right(
+            "owned",
+            setup_sample.client,
+            "write",
+        )
+
+    async def test_full_administrator_has_write(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A full administrator holds both rights on another user's private sample."""
+        sample_owner = await fake.users.create()
+        administrator = await fake.users.create(
+            administrator_role=AdministratorRole.FULL,
+        )
+
+        await self._insert_sample(pg, "owner_private", sample_owner.id, all_read=False)
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "private",
+            "owner_private",
+            sample_owner.id,
+            setup_sample.reference_id,
+        )
+
+        assert await data_layer.analyses.has_right(
+            "private",
+            build_user_client(administrator),
+            "write",
+        )
+
+    async def test_base_administrator_denied(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """An administrator below the full role is scoped like any other user, matching
+        how ``SamplesData.has_right`` treats the parent sample.
+        """
+        sample_owner = await fake.users.create()
+        administrator = await fake.users.create(
+            administrator_role=AdministratorRole.BASE,
+        )
+
+        await self._insert_sample(pg, "owner_private", sample_owner.id, all_read=False)
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "private",
+            "owner_private",
+            sample_owner.id,
+            setup_sample.reference_id,
+        )
+
+        assert not await data_layer.analyses.has_right(
+            "private",
+            build_user_client(administrator),
+            "read",
+        )
+
+    async def test_all_read_grants_read_not_write(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A world-readable sample grants read but withholds write."""
+        sample_owner = await fake.users.create()
+        other_user = await fake.users.create()
+
+        await self._insert_sample(
+            pg,
+            "world_readable",
+            sample_owner.id,
+            all_read=True,
+            all_write=False,
+        )
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "public",
+            "world_readable",
+            sample_owner.id,
+            setup_sample.reference_id,
+        )
+
+        client = build_user_client(other_user)
+
+        assert await data_layer.analyses.has_right("public", client, "read")
+        assert not await data_layer.analyses.has_right("public", client, "write")
+
+    async def test_group_member_has_group_rights(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A member of the sample's group holds the rights the group is granted."""
+        group = await fake.groups.create()
+        sample_owner = await fake.users.create()
+        group_member = await fake.users.create(groups=[group])
+
+        await self._insert_sample(
+            pg,
+            "group_shared",
+            sample_owner.id,
+            all_read=False,
+            all_write=False,
+            group_read=True,
+            group_write=True,
+            group_id=group.id,
+        )
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "shared",
+            "group_shared",
+            sample_owner.id,
+            setup_sample.reference_id,
+        )
+
+        client = build_user_client(group_member)
+
+        assert await data_layer.analyses.has_right("shared", client, "read")
+        assert await data_layer.analyses.has_right("shared", client, "write")
+
+    async def test_non_member_denied(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A user outside the sample's group holds neither right."""
+        group = await fake.groups.create()
+        sample_owner = await fake.users.create()
+        outsider = await fake.users.create()
+
+        await self._insert_sample(
+            pg,
+            "group_shared",
+            sample_owner.id,
+            all_read=False,
+            group_read=True,
+            group_id=group.id,
+        )
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "shared",
+            "group_shared",
+            sample_owner.id,
+            setup_sample.reference_id,
+        )
+
+        client = build_user_client(outsider)
+
+        assert not await data_layer.analyses.has_right("shared", client, "read")
+        assert not await data_layer.analyses.has_right("shared", client, "write")
+
+    async def test_postgres_only_sample_readable(
+        self,
+        data_layer: DataLayer,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """An analysis whose parent sample has no Mongo document resolves its rights
+        from Postgres.
+        """
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "owned",
+            "test_sample",
+            setup_sample.user_id,
+            setup_sample.reference_id,
+        )
+
+        await mongo.samples.delete_one({"_id": "test_sample"})
+
+        assert await data_layer.analyses.has_right(
+            "owned",
+            setup_sample.client,
+            "read",
+        )
+
+    async def test_missing_analysis_raises(
+        self,
+        data_layer: DataLayer,
+        setup_sample: SampleSetup,
+    ):
+        """An analysis that does not exist raises ``ResourceNotFoundError`` so the API
+        can return a 404 rather than a 403.
+        """
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.analyses.has_right(
+                "missing",
+                setup_sample.client,
+                "read",
+            )
 
 
 class TestHideIimi:

--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -18,6 +18,11 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
     Non-integer ``job.id`` placeholders are stored as a null ``job_id`` since the
     Postgres column is a foreign key to ``jobs.id``.
 
+    When the parent sample has no ``legacy_samples`` row yet, one is created from the
+    sample's Mongo document so that its rights columns match. Rights are read from
+    Postgres, so a row seeded with the column defaults would deny access to a sample
+    the Mongo document marks readable.
+
     :return: the integer ``analyses.id`` of the seeded row
     """
     index = document["index"]
@@ -46,12 +51,18 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
         ).scalar_one_or_none()
 
         if sample_pg_id is None:
+            sample_document = await mongo.samples.find_one({"_id": sample["id"]}) or {}
+
             legacy_sample = SQLLegacySample(
                 legacy_id=sample["id"],
                 name=sample.get("name", sample["id"]),
                 library_type="normal",
                 created_at=document["created_at"],
                 user_id=document["user"]["id"],
+                all_read=sample_document.get("all_read", False),
+                all_write=sample_document.get("all_write", False),
+                group_read=sample_document.get("group_read", False),
+                group_write=sample_document.get("group_write", False),
             )
             session.add(legacy_sample)
             await session.flush()

--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -23,6 +23,10 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
     Postgres, so a row seeded with the column defaults would deny access to a sample
     the Mongo document marks readable.
 
+    A sample with no Mongo document is left unseeded, giving the analysis a null
+    ``sample_id``. That is the only shape a parentless analysis can take in Postgres,
+    where the foreign key guarantees a non-null ``sample_id`` points at a real row.
+
     :return: the integer ``analyses.id`` of the seeded row
     """
     index = document["index"]
@@ -51,22 +55,23 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
         ).scalar_one_or_none()
 
         if sample_pg_id is None:
-            sample_document = await mongo.samples.find_one({"_id": sample["id"]}) or {}
+            sample_document = await mongo.samples.find_one({"_id": sample["id"]})
 
-            legacy_sample = SQLLegacySample(
-                legacy_id=sample["id"],
-                name=sample.get("name", sample["id"]),
-                library_type="normal",
-                created_at=document["created_at"],
-                user_id=document["user"]["id"],
-                all_read=sample_document.get("all_read", False),
-                all_write=sample_document.get("all_write", False),
-                group_read=sample_document.get("group_read", False),
-                group_write=sample_document.get("group_write", False),
-            )
-            session.add(legacy_sample)
-            await session.flush()
-            sample_pg_id = legacy_sample.id
+            if sample_document is not None:
+                legacy_sample = SQLLegacySample(
+                    legacy_id=sample["id"],
+                    name=sample.get("name", sample["id"]),
+                    library_type="normal",
+                    created_at=document["created_at"],
+                    user_id=document["user"]["id"],
+                    all_read=sample_document.get("all_read", False),
+                    all_write=sample_document.get("all_write", False),
+                    group_read=sample_document.get("group_read", False),
+                    group_write=sample_document.get("group_write", False),
+                )
+                session.add(legacy_sample)
+                await session.flush()
+                sample_pg_id = legacy_sample.id
 
         reference_pg_id = (
             await session.execute(

--- a/tests/labels/__snapshots__/test_transforms.ambr
+++ b/tests/labels/__snapshots__/test_transforms.ambr
@@ -64,30 +64,3 @@
     'name': 'Foo',
   })
 # ---
-# name: TestAttachSampleCounts.test_multiple
-  list([
-    dict({
-      'color': '#03fc20',
-      'count': 2,
-      'description': 'This is a question',
-      'id': 2,
-      'name': 'Question',
-    }),
-    dict({
-      'color': '#02db21',
-      'count': 0,
-      'description': 'This is a info',
-      'id': 3,
-      'name': 'Info',
-    }),
-  ])
-# ---
-# name: TestAttachSampleCounts.test_single
-  dict({
-    'color': '#a83432',
-    'count': 1,
-    'description': 'This is a bug',
-    'id': 1,
-    'name': 'Bug',
-  })
-# ---

--- a/tests/labels/test_data.py
+++ b/tests/labels/test_data.py
@@ -13,6 +13,16 @@ from virtool.samples.oas import CreateSampleRequest
 from virtool.samples.sql import SQLLegacySample, SQLLegacySampleLabel
 
 
+class TestCreate:
+    async def test_count_is_zero(self, data_layer: DataLayer):
+        """A newly created label has no samples, so its count is zero. Nothing can
+        reference the label's primary key before it is inserted.
+        """
+        label = await data_layer.labels.create("Bug", "#a83432", "This is a bug")
+
+        assert label.count == 0
+
+
 class TestDelete:
     async def test_missing(self, data_layer: DataLayer):
         """Deleting a non-existent label raises ``ResourceNotFoundError``."""

--- a/tests/labels/test_transforms.py
+++ b/tests/labels/test_transforms.py
@@ -3,66 +3,7 @@ from syrupy import SnapshotAssertion
 
 from virtool.data.transforms import apply_transforms
 from virtool.labels.sql import SQLLabel
-from virtool.labels.transforms import AttachLabelsTransform, AttachSampleCountsTransform
-from virtool.mongo.core import Mongo
-
-
-class TestAttachSampleCounts:
-    async def test_single(self, mongo: Mongo, snapshot: SnapshotAssertion):
-        await mongo.samples.insert_many(
-            [
-                {"_id": "foo", "name": "Foo", "labels": [1, 2, 4]},
-                {"_id": "bar", "name": "Bar", "labels": []},
-                {"_id": "baz", "name": "Baz", "labels": [2]},
-            ],
-            session=None,
-        )
-
-        assert (
-            await apply_transforms(
-                {
-                    "id": 1,
-                    "name": "Bug",
-                    "color": "#a83432",
-                    "description": "This is a bug",
-                },
-                [AttachSampleCountsTransform(mongo)],
-                None,
-            )
-            == snapshot
-        )
-
-    async def test_multiple(self, mongo: Mongo, snapshot: SnapshotAssertion):
-        await mongo.samples.insert_many(
-            [
-                {"_id": "foo", "name": "Foo", "labels": [1, 2, 4]},
-                {"_id": "bar", "name": "Bar", "labels": []},
-                {"_id": "baz", "name": "Baz", "labels": [2]},
-            ],
-            session=None,
-        )
-
-        assert (
-            await apply_transforms(
-                [
-                    {
-                        "id": 2,
-                        "name": "Question",
-                        "color": "#03fc20",
-                        "description": "This is a question",
-                    },
-                    {
-                        "id": 3,
-                        "name": "Info",
-                        "color": "#02db21",
-                        "description": "This is a info",
-                    },
-                ],
-                [AttachSampleCountsTransform(mongo)],
-                None,
-            )
-            == snapshot
-        )
+from virtool.labels.transforms import AttachLabelsTransform
 
 
 class TestAttachLabels:

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1262,7 +1262,7 @@ async def test_update_group(
             assert resp.status == HTTPStatus.OK
             assert await resp.json() == snapshot(name="resp")
             assert await mongo.references.find_one() == snapshot(name="mongo")
-        case ("404_group", "404_ref"):
+        case "404_group" | "404_ref":
             await resp_is.not_found(resp)
 
 

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -315,36 +315,6 @@ class TestCheckRight:
 
         assert await check_right(mock_req, "ref_group_wins", "modify_otu") is True
 
-    async def test_group_matched_by_legacy_id(
-        self,
-        mock_req,
-        mocker,
-        pg: AsyncEngine,
-        fake: DataFaker,
-        static_time,
-    ):
-        """A client group held as a legacy string id resolves to its integer row."""
-        owner = await fake.users.create()
-        member = await fake.users.create()
-        group = await fake.groups.create(legacy_id="legacy_group")
-
-        await seed_reference_rights(
-            pg,
-            legacy_id="ref_legacy_group",
-            owner_id=owner.id,
-            created_at=static_time.datetime,
-            groups=[(group.id, RIGHTS_NONE)],
-        )
-
-        mock_req.app = {"pg": pg}
-        mock_req["client"] = make_client(
-            mocker,
-            user_id=member.id,
-            groups=[group.legacy_id],
-        )
-
-        assert await check_right(mock_req, "ref_legacy_group", "read") is True
-
     async def test_reference_matched_by_integer_pk(
         self,
         mock_req,

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -1522,14 +1522,8 @@ class TestAnalyze:
     @pytest.fixture
     async def analyze_client(
         self,
-        mocker,
         spawn_client: ClientSpawner,
     ) -> VirtoolTestClient:
-        mocker.patch(
-            "virtool.samples.utils.get_sample_rights",
-            return_value=(True, True),
-        )
-
         client = await spawn_client(authenticated=True)
         client.app["jobs"] = MockJobInterface()
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -44,7 +44,6 @@ from virtool.data.transforms import apply_transforms
 from virtool.indexes.db import get_current_id_and_version
 from virtool.indexes.transforms import AttachIndexTransform
 from virtool.jobs.transforms import AttachJobTransform
-from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id
 from virtool.pg.utils import delete_row, get_row_by_id
@@ -53,6 +52,11 @@ from virtool.references.transforms import AttachReferenceTransform
 from virtool.samples.db import compose_sample_rights_filter
 from virtool.samples.oas import CreateAnalysisRequest
 from virtool.samples.sql import SQLLegacySample
+from virtool.samples.utils import (
+    SAMPLE_RIGHTS_COLUMNS,
+    SampleRight,
+    has_sample_right,
+)
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.pg import SQLSubtraction
@@ -400,14 +404,7 @@ class AnalysisData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             row = (
                 await session.execute(
-                    select(
-                        SQLLegacySample.all_read,
-                        SQLLegacySample.all_write,
-                        SQLLegacySample.group_read,
-                        SQLLegacySample.group_write,
-                        SQLLegacySample.group_id,
-                        SQLLegacySample.user_id,
-                    )
+                    select(*SAMPLE_RIGHTS_COLUMNS)
                     .join(SQLAnalysis, SQLAnalysis.sample_id == SQLLegacySample.id)
                     .where(
                         compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
@@ -422,23 +419,7 @@ class AnalysisData(DataLayerDomain):
             )
             raise ResourceNotFoundError
 
-        if (
-            client.administrator_role == AdministratorRole.FULL
-            or client.user_id == row.user_id
-        ):
-            return True
-
-        is_group_member = row.group_id is not None and client.is_group_member(
-            row.group_id,
-        )
-
-        if right == "read":
-            return row.all_read or (is_group_member and row.group_read)
-
-        if right == "write":
-            return row.all_write or (is_group_member and row.group_write)
-
-        raise ValueError(f"Invalid sample right: {right}")
+        return has_sample_right(row, client, SampleRight(right))
 
     async def delete(self, analysis_id: str, jobs_api_flag: bool) -> None:
         """Delete a single analysis by its ID.

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -44,6 +44,7 @@ from virtool.data.transforms import apply_transforms
 from virtool.indexes.db import get_current_id_and_version
 from virtool.indexes.transforms import AttachIndexTransform
 from virtool.jobs.transforms import AttachJobTransform
+from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id
 from virtool.pg.utils import delete_row, get_row_by_id
@@ -52,7 +53,6 @@ from virtool.references.transforms import AttachReferenceTransform
 from virtool.samples.db import compose_sample_rights_filter
 from virtool.samples.oas import CreateAnalysisRequest
 from virtool.samples.sql import SQLLegacySample
-from virtool.samples.utils import get_sample_rights
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
 from virtool.subtractions.pg import SQLSubtraction
@@ -162,7 +162,7 @@ class AnalysisData(DataLayerDomain):
             skip_count = (page - 1) * per_page
 
         readable_sample_ids = select(SQLLegacySample.id).where(
-            await compose_sample_rights_filter(self._pg, client),
+            compose_sample_rights_filter(client),
         )
 
         filters = [
@@ -398,37 +398,47 @@ class AnalysisData(DataLayerDomain):
         :return: boolean value
         """
         async with AsyncSession(self._pg) as session:
-            sample_id = (
+            row = (
                 await session.execute(
-                    select(SQLAnalysis.sample).where(
+                    select(
+                        SQLLegacySample.all_read,
+                        SQLLegacySample.all_write,
+                        SQLLegacySample.group_read,
+                        SQLLegacySample.group_write,
+                        SQLLegacySample.group_id,
+                        SQLLegacySample.user_id,
+                    )
+                    .join(SQLAnalysis, SQLAnalysis.sample_id == SQLLegacySample.id)
+                    .where(
                         compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
                     ),
                 )
-            ).scalar_one_or_none()
+            ).first()
 
-        if sample_id is None:
-            raise ResourceNotFoundError
-
-        sample = await self._mongo.samples.find_one(
-            {"_id": sample_id},
-            ["user", "group", "all_read", "group_read", "group_write", "all_write"],
-        )
-
-        if not sample:
+        if row is None:
             logger.warning(
-                "parent sample not found for analysis",
+                "analysis or parent sample not found",
                 analysis_id=analysis_id,
-                sample_id=sample_id,
             )
             raise ResourceNotFoundError
 
-        read, write = get_sample_rights(sample, client)
+        if (
+            client.administrator_role == AdministratorRole.FULL
+            or client.user_id == row.user_id
+        ):
+            return True
+
+        is_group_member = row.group_id is not None and client.is_group_member(
+            row.group_id,
+        )
 
         if right == "read":
-            return read
+            return row.all_read or (is_group_member and row.group_read)
 
         if right == "write":
-            return write
+            return row.all_write or (is_group_member and row.group_write)
+
+        raise ValueError(f"Invalid sample right: {right}")
 
     async def delete(self, analysis_id: str, jobs_api_flag: bool) -> None:
         """Delete a single analysis by its ID.

--- a/virtool/api/client.py
+++ b/virtool/api/client.py
@@ -20,7 +20,7 @@ class AbstractClient(ABC):
     def has_permission(self, permission: str) -> bool: ...
 
     @abstractmethod
-    def is_group_member(self, group_id: str) -> bool: ...
+    def is_group_member(self, group_id: int) -> bool: ...
 
     @property
     @abstractmethod
@@ -54,7 +54,7 @@ class JobClient(AbstractClient):
     def has_permission(self, permission: str) -> bool:
         return False
 
-    def is_group_member(self, _: str) -> bool:
+    def is_group_member(self, _: int) -> bool:
         return False
 
     @property
@@ -72,7 +72,7 @@ class UserClient(AbstractClient):
         administrator_role: AdministratorRole | None,
         authenticated: bool,
         force_reset: bool,
-        groups: list[int | str],
+        groups: list[int],
         permissions: dict[str, bool],
         user_id: int | None,
         session_id: str | None = None,
@@ -102,7 +102,7 @@ class UserClient(AbstractClient):
     def has_permission(self, permission: str) -> bool:
         return self.permissions.get(permission, False)
 
-    def is_group_member(self, group_id: str) -> bool:
+    def is_group_member(self, group_id: int) -> bool:
         return group_id in self.groups
 
     @property

--- a/virtool/groups/models.py
+++ b/virtool/groups/models.py
@@ -16,7 +16,7 @@ class Permissions(BaseModel):
 
 
 class GroupMinimal(BaseModel):
-    id: int | str
+    id: int
     legacy_id: str | None
     name: str
 

--- a/virtool/labels/data.py
+++ b/virtool/labels/data.py
@@ -5,10 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import both_transactions
-from virtool.data.transforms import apply_transforms
 from virtool.labels.models import Label
 from virtool.labels.sql import SQLLabel
-from virtool.labels.transforms import AttachSampleCountsTransform
 from virtool.mongo.core import Mongo
 from virtool.samples.sql import SQLLegacySampleLabel
 
@@ -41,13 +39,7 @@ class LabelsData:
             except IntegrityError:
                 raise ResourceConflictError()
 
-        document = await apply_transforms(
-            row,
-            [AttachSampleCountsTransform(self._mongo)],
-            self._pg,
-        )
-
-        return Label(**document)
+        return Label(**row, count=0)
 
     async def delete(self, label_id: int) -> None:
         """Delete an existing label.

--- a/virtool/labels/transforms.py
+++ b/virtool/labels/transforms.py
@@ -1,4 +1,3 @@
-from collections.abc import Awaitable
 from typing import Any
 
 from sqlalchemy import select
@@ -6,7 +5,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.transforms import AbstractTransform
 from virtool.labels.sql import SQLLabel
-from virtool.mongo.core import Mongo
 from virtool.types import Document
 
 
@@ -49,16 +47,3 @@ class AttachLabelsTransform(AbstractTransform):
             document["id"]: [labels_by_id[label_id] for label_id in document["labels"]]
             for document in documents
         }
-
-
-class AttachSampleCountsTransform(AbstractTransform):
-    """Attach the number of associated samples to each label document."""
-
-    def __init__(self, mongo: Mongo):
-        self._mongo = mongo
-
-    async def attach_one(self, document: Document, prepared: int) -> Document:
-        return {**document, "count": prepared}
-
-    async def prepare_one(self, document, session: AsyncSession) -> Awaitable[Any]:
-        return await self._mongo.samples.count_documents({"labels": document["id"]})

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -16,7 +16,6 @@ import virtool.utils
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.topg import (
     compose_legacy_id_mongo_match,
-    compose_legacy_id_multi_expression,
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
     resolve_legacy_id,
@@ -368,13 +367,9 @@ async def check_right(req: Request, ref_id: int | str, right: str) -> bool:
                 return True
 
         if client.groups:
-            group_query = (
-                select(SQLReferenceGroup.reference_id)
-                .join(SQLGroup, SQLGroup.id == SQLReferenceGroup.group_id)
-                .where(
-                    SQLReferenceGroup.reference_id == reference_pk,
-                    compose_legacy_id_multi_expression(SQLGroup, client.groups),
-                )
+            group_query = select(SQLReferenceGroup.reference_id).where(
+                SQLReferenceGroup.reference_id == reference_pk,
+                SQLReferenceGroup.group_id.in_(client.groups),
             )
 
             if right != "read":

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -38,7 +38,6 @@ from virtool.groups.models import GroupMinimal
 from virtool.groups.pg import SQLGroup
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.labels.transforms import AttachLabelsTransform
-from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id, get_one_field
 from virtool.pg.utils import delete_row
@@ -71,8 +70,10 @@ from virtool.samples.sql import (
     SQLSampleUpload,
 )
 from virtool.samples.utils import (
+    SAMPLE_RIGHTS_COLUMNS,
     SampleRight,
     define_initial_workflows,
+    has_sample_right,
     sample_file_key,
     sample_prefix,
     sample_storage_id,
@@ -941,14 +942,7 @@ class SamplesData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             row = (
                 await session.execute(
-                    select(
-                        SQLLegacySample.all_read,
-                        SQLLegacySample.all_write,
-                        SQLLegacySample.group_read,
-                        SQLLegacySample.group_write,
-                        SQLLegacySample.group_id,
-                        SQLLegacySample.user_id,
-                    ).where(
+                    select(*SAMPLE_RIGHTS_COLUMNS).where(
                         compose_legacy_id_single_expression(
                             SQLLegacySample,
                             sample_id,
@@ -960,23 +954,7 @@ class SamplesData(DataLayerDomain):
         if row is None:
             return True
 
-        if (
-            client.administrator_role == AdministratorRole.FULL
-            or client.user_id == row.user_id
-        ):
-            return True
-
-        is_group_member = row.group_id is not None and client.is_group_member(
-            row.group_id,
-        )
-
-        if right == SampleRight.read:
-            return row.all_read or (is_group_member and row.group_read)
-
-        if right == SampleRight.write:
-            return row.all_write or (is_group_member and row.group_write)
-
-        raise ValueError(f"Invalid sample right: {right}")
+        return has_sample_right(row, client, right)
 
     async def has_resources_for_analysis_job(self, ref_id, subtractions) -> None:
         """Checks that resources for analysis job exist.

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -54,7 +54,6 @@ from virtool.samples.db import (
     DeriveWorkflowTagsTransform,
     compose_sample_rights_filter,
     compose_sample_workflow_filter,
-    resolve_client_group_ids,
 )
 from virtool.samples.files import (
     create_artifact_file,
@@ -225,7 +224,7 @@ class SamplesData(DataLayerDomain):
         client,
     ) -> SampleSearchResult:
         """Find and filter samples."""
-        filters = [await compose_sample_rights_filter(self._pg, client)]
+        filters = [compose_sample_rights_filter(client)]
 
         if term:
             filters.append(_compose_sample_search_filter(term))
@@ -966,11 +965,9 @@ class SamplesData(DataLayerDomain):
         ):
             return True
 
-        is_group_member = False
-
-        if row.group_id is not None:
-            member_group_ids = await resolve_client_group_ids(self._pg, client)
-            is_group_member = row.group_id in member_group_ids
+        is_group_member = row.group_id is not None and client.is_group_member(
+            row.group_id,
+        )
 
         if right == SampleRight.read:
             return row.all_read or (is_group_member and row.group_read)

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -15,19 +15,15 @@ from sqlalchemy import (
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from yarl import URL
 
-import virtool.errors
 import virtool.mongo.utils
 import virtool.samples.utils
 import virtool.utils
 from virtool.analyses.sql import SQLAnalysis
 from virtool.analyses.utils import WORKFLOW_NAMES
-from virtool.api.errors import APINotFound
 from virtool.data.topg import (
-    compose_legacy_id_multi_expression,
     compose_legacy_id_subquery,
 )
 from virtool.data.transforms import AbstractTransform, apply_transforms
-from virtool.errors import DatabaseError
 from virtool.groups.pg import SQLGroup
 from virtool.samples.sql import (
     SQLLegacySample,
@@ -41,16 +37,6 @@ from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
-
-SAMPLE_RIGHTS_PROJECTION = {
-    "_id": False,
-    "group": True,
-    "group_read": True,
-    "group_write": True,
-    "all_read": True,
-    "all_write": True,
-    "user": True,
-}
 
 
 class AttachArtifactsAndReadsTransform(AbstractTransform):
@@ -245,76 +231,22 @@ class DeriveWorkflowTagsTransform(AbstractTransform):
         }
 
 
-async def check_rights_error_check(
-    db,
-    sample_id: str | None,
-    client,
-    write: bool = True,
-) -> bool:
-    try:
-        check_right = await check_rights(db, sample_id, client, write=write)
-    except DatabaseError as err:
-        if "Sample does not exist" in str(err):
-            raise APINotFound()
-        raise
-
-    return check_right
-
-
-async def check_rights(db, sample_id: str | None, client, write: bool = True) -> bool:
-    sample_rights = await db.samples.find_one(
-        {"_id": sample_id},
-        SAMPLE_RIGHTS_PROJECTION,
-    )
-    if not sample_rights:
-        raise virtool.errors.DatabaseError("Sample does not exist")
-
-    has_read, has_write = virtool.samples.utils.get_sample_rights(sample_rights, client)
-
-    return has_read and (write is False or has_write)
-
-
-async def resolve_client_group_ids(pg: AsyncEngine, client) -> list[int]:
-    """Resolve the Postgres group ids for the groups ``client`` belongs to."""
-    if not client.groups:
-        return []
-
-    async with AsyncSession(pg) as session:
-        return list(
-            (
-                await session.execute(
-                    select(SQLGroup.id).where(
-                        compose_legacy_id_multi_expression(SQLGroup, client.groups),
-                    ),
-                )
-            )
-            .scalars()
-            .all(),
-        )
-
-
-async def compose_sample_rights_filter(
-    pg: AsyncEngine,
-    client,
-) -> ColumnExpressionArgument[bool]:
+def compose_sample_rights_filter(client) -> ColumnExpressionArgument[bool]:
     """Compose the Postgres predicate scoping samples to those ``client`` can read.
 
-    Mirrors the Mongo ``$or`` rights filter: the requesting user owns the sample,
-    the sample is world-readable, or the sample is readable by a group the user
-    belongs to.
+    The requesting user owns the sample, the sample is world-readable, or the sample is
+    readable by a group the user belongs to.
     """
     rights_filter = [
         SQLLegacySample.all_read.is_(True),
         SQLLegacySample.user_id == client.user_id,
     ]
 
-    group_ids = await resolve_client_group_ids(pg, client)
-
-    if group_ids:
+    if client.groups:
         rights_filter.append(
             and_(
                 SQLLegacySample.group_read.is_(True),
-                SQLLegacySample.group_id.in_(group_ids),
+                SQLLegacySample.group_id.in_(client.groups),
             ),
         )
 

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -4,7 +4,6 @@ from aiohttp.web import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.api.client import AbstractClient
 from virtool.api.errors import APIBadRequest
 from virtool.labels.sql import SQLLabel
 from virtool.samples.models import WorkflowState
@@ -99,31 +98,6 @@ async def check_labels(pg: AsyncEngine, labels: list[int]) -> list[int]:
         results = set(query.scalars().all())
 
     return [label for label in labels if label not in results]
-
-
-def get_sample_rights(sample: dict, client: AbstractClient):
-    if (
-        client.administrator_role
-        or sample["user"]["id"] == client.user_id
-        or client.is_job
-    ):
-        return True, True
-
-    # Handle both None and "none" during the transition period
-    group = sample["group"]
-    if group == "none":
-        group = None
-
-    is_group_member = group and client.is_group_member(group)
-
-    read = sample["all_read"] or (is_group_member and sample["group_read"])
-
-    if not read:
-        return False, False
-
-    write = sample["all_write"] or (is_group_member and sample["group_write"])
-
-    return read, write
 
 
 def bad_labels_response(labels: list[int]) -> Response:

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -1,17 +1,59 @@
 from enum import Enum
 
 from aiohttp.web import Response
-from sqlalchemy import select
+from sqlalchemy import Row, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.api.client import AbstractClient
 from virtool.api.errors import APIBadRequest
 from virtool.labels.sql import SQLLabel
+from virtool.models.roles import AdministratorRole
 from virtool.samples.models import WorkflowState
+from virtool.samples.sql import SQLLegacySample
 
 
 class SampleRight(Enum):
     read = "read"
     write = "write"
+
+
+SAMPLE_RIGHTS_COLUMNS = (
+    SQLLegacySample.all_read,
+    SQLLegacySample.all_write,
+    SQLLegacySample.group_read,
+    SQLLegacySample.group_write,
+    SQLLegacySample.group_id,
+    SQLLegacySample.user_id,
+)
+"""The ``legacy_samples`` columns :func:`has_sample_right` needs to resolve a right."""
+
+
+def has_sample_right(
+    row: Row,
+    client: AbstractClient,
+    right: SampleRight,
+) -> bool:
+    """Resolve whether ``client`` holds ``right`` on a sample.
+
+    ``row`` must carry the columns in :data:`SAMPLE_RIGHTS_COLUMNS`. Shared by the
+    samples and analyses domains so a sample and the analyses on it never disagree
+    about who may read or write them.
+    """
+    if (
+        client.administrator_role == AdministratorRole.FULL
+        or client.user_id == row.user_id
+    ):
+        return True
+
+    is_group_member = row.group_id is not None and client.is_group_member(row.group_id)
+
+    if right is SampleRight.read:
+        return row.all_read or (is_group_member and row.group_read)
+
+    if right is SampleRight.write:
+        return row.all_write or (is_group_member and row.group_write)
+
+    raise ValueError(f"Invalid sample right: {right}")
 
 
 def define_initial_workflows(library_type: str) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- Resolve analysis rights from `legacy_samples` instead of the Mongo `samples` collection, so analyses on samples that exist only in Postgres stay readable. This is the last cross-domain Mongo sample read, and unblocks VIR-2532.
- Scope administrators below the full role like any other user, matching `GET /samples`. `get_sample_rights` granted full read and write to any administrator role, which `SamplesData.has_right` already denied.
- Remove the label sample count transform and the group id resolution queries. The transform counted samples on a label inserted moments earlier, so the count is always zero; `client.groups` holds integer group ids, so matching them against `groups.legacy_id` returned the ids it was given.

Closes VIR-2624.