### PR TITLE
feat: identify references by integer id

### DIFF
--- a/tests/analyses/__snapshots__/test_api.ambr
+++ b/tests/analyses/__snapshots__/test_api.ambr
@@ -23,7 +23,7 @@
     'ready': True,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'baz',
+      'id': 1,
       'name': 'Baz',
     }),
     'results': dict({
@@ -73,7 +73,7 @@
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 2,
           'name': 'Foo',
         }),
         'sample': dict({
@@ -109,7 +109,7 @@
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'baz',
+          'id': 1,
           'name': 'Baz',
         }),
         'sample': dict({
@@ -149,7 +149,7 @@
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'baz',
+          'id': 1,
           'name': 'Baz',
         }),
         'sample': dict({
@@ -206,7 +206,7 @@
     'ready': True,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'baz',
+      'id': 1,
       'name': 'Baz',
     }),
     'results': dict({
@@ -268,7 +268,7 @@
     'ready': True,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'baz',
+      'id': 1,
       'name': 'Baz',
     }),
     'results': dict({

--- a/tests/analyses/__snapshots__/test_data.ambr
+++ b/tests/analyses/__snapshots__/test_data.ambr
@@ -21,7 +21,7 @@
     'ready': False,
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Test Reference',
     }),
     'results': None,
@@ -80,7 +80,7 @@
         'ready': False,
         'reference': dict({
           'data_type': <ReferenceDataType.genome: 'genome'>,
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'sample': dict({
@@ -135,7 +135,7 @@
         'ready': False,
         'reference': dict({
           'data_type': <ReferenceDataType.genome: 'genome'>,
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'sample': dict({
@@ -179,7 +179,7 @@
         'ready': False,
         'reference': dict({
           'data_type': <ReferenceDataType.genome: 'genome'>,
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'sample': dict({

--- a/tests/analyses/test_api.py
+++ b/tests/analyses/test_api.py
@@ -10,6 +10,7 @@ from syrupy import SnapshotAssertion
 
 from tests.fixtures.analysis import seed_analysis
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
+from tests.fixtures.references import seed_reference
 from tests.fixtures.response import RespIs
 from virtool.analyses.files import create_analysis_file
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisFile
@@ -342,23 +343,27 @@ async def test_get_archived_reference(
     user = await fake.users.create()
     job = await fake.jobs.create(user=user, state=JobState.SUCCEEDED)
 
-    await asyncio.gather(
-        mongo.references.insert_one(
-            {"_id": "baz", "archived": True, "data_type": "genome", "name": "Baz"},
-        ),
-        mongo.samples.insert_one(
-            {
-                "_id": "baz",
-                "all_read": True,
-                "all_write": False,
-                "group": "tech",
-                "group_read": True,
-                "group_write": True,
-                "labels": [],
-                "subtractions": [],
-                "user": {"id": user.id},
-            },
-        ),
+    reference_id = await seed_reference(
+        mongo,
+        pg,
+        "baz",
+        user.id,
+        name="Baz",
+        archived=True,
+    )
+
+    await mongo.samples.insert_one(
+        {
+            "_id": "baz",
+            "all_read": True,
+            "all_write": False,
+            "group": "tech",
+            "group_read": True,
+            "group_write": True,
+            "labels": [],
+            "subtractions": [],
+            "user": {"id": user.id},
+        },
     )
 
     analysis_id = await seed_analysis(
@@ -384,7 +389,11 @@ async def test_get_archived_reference(
 
     assert resp.status == HTTPStatus.OK
     body = await resp.json()
-    assert body["reference"] == {"id": "baz", "data_type": "genome", "name": "Baz"}
+    assert body["reference"] == {
+        "id": reference_id,
+        "data_type": "genome",
+        "name": "Baz",
+    }
 
 
 async def test_get_by_integer_id(

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -22,6 +22,7 @@ from virtool.fake.next import DataFaker, fake_file_chunker
 from virtool.models.enums import AnalysisWorkflow
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
+from virtool.references.sql import SQLReference
 from virtool.samples.oas import CreateAnalysisRequest
 from virtool.samples.sql import SQLLegacySample
 from virtool.subtractions.pg import SQLSubtraction
@@ -50,11 +51,22 @@ async def subtraction_ids(fake: DataFaker) -> dict[str, int]:
     return {"subtraction_1": first.id, "subtraction_2": second.id}
 
 
+async def _legacy_id(pg: AsyncEngine, reference_pk: int) -> str:
+    """Return the Mongo ``_id`` of a reference, which its public id no longer is."""
+    async with AsyncSession(pg) as session:
+        return (
+            await session.execute(
+                select(SQLReference.legacy_id).where(SQLReference.id == reference_pk),
+            )
+        ).scalar_one()
+
+
 class SampleSetup(NamedTuple):
     """Identifiers for the sample and reference seeded by ``setup_sample``."""
 
-    user_id: str
-    reference_id: str
+    user_id: int
+    reference_id: int
+    reference_legacy_id: str
 
 
 @pytest.fixture
@@ -124,7 +136,11 @@ async def setup_sample(
             },
         ),
     )
-    return SampleSetup(user_id=user.id, reference_id=reference.id)
+    return SampleSetup(
+        user_id=user.id,
+        reference_id=reference.id,
+        reference_legacy_id=await _legacy_id(pg, reference.id),
+    )
 
 
 @pytest.mark.parametrize("number_of_analyses", [0, 1, 2])
@@ -333,7 +349,8 @@ class TestCreate:
         assert row.ready is False
         assert row.results is None
         assert row.sample == "test_sample"
-        assert row.reference == setup_sample.reference_id
+        assert row.reference == setup_sample.reference_legacy_id
+        assert row.reference_id == setup_sample.reference_id
         assert row.created_at == row.updated_at
         assert isinstance(row.user_id, int)
 

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -15,7 +15,7 @@ from virtool.analyses.sql import (
     SQLAnalysisFile,
     SQLAnalysisSubtraction,
 )
-from virtool.api.client import UserClient
+from virtool.api.client import JobClient, UserClient
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker, fake_file_chunker
@@ -365,6 +365,69 @@ class TestFindSampleRights:
         assert found.documents == []
         assert found.total_count == 0
 
+    async def test_full_administrator_sees_private_sample(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A full administrator lists analyses on another user's private sample,
+        matching the single-resource bypass in ``has_sample_right``.
+        """
+        sample_owner = await fake.users.create()
+        administrator = await fake.users.create(
+            administrator_role=AdministratorRole.FULL,
+        )
+
+        await self._insert_sample(pg, "other_private", sample_owner.id, all_read=False)
+
+        hidden = await self._seed_analysis(
+            mongo,
+            pg,
+            "private",
+            "other_private",
+            setup_sample,
+        )
+
+        found = await data_layer.analyses.find(
+            1,
+            25,
+            build_user_client(administrator),
+        )
+
+        assert [document.id for document in found.documents] == [hidden]
+        assert found.total_count == 1
+
+    async def test_base_administrator_scoped_like_user(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """An administrator below the full role is scoped like any other user and does
+        not see another user's private sample.
+        """
+        sample_owner = await fake.users.create()
+        administrator = await fake.users.create(
+            administrator_role=AdministratorRole.BASE,
+        )
+
+        await self._insert_sample(pg, "other_private", sample_owner.id, all_read=False)
+        await self._seed_analysis(mongo, pg, "private", "other_private", setup_sample)
+
+        found = await data_layer.analyses.find(
+            1,
+            25,
+            build_user_client(administrator),
+        )
+
+        assert found.documents == []
+        assert found.total_count == 0
+
 
 class TestHasRight:
     """Rights on an analysis are resolved from the parent sample's Postgres row."""
@@ -632,6 +695,40 @@ class TestHasRight:
             setup_sample.client,
             "read",
         )
+
+    async def test_job_client_has_full_access(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+    ):
+        """A job-authenticated client holds both rights on another user's private
+        sample, since a job's identity is neither a user nor an administrator.
+        """
+        sample_owner = await fake.users.create()
+
+        await self._insert_sample(
+            pg,
+            "owner_private",
+            sample_owner.id,
+            all_read=False,
+            all_write=False,
+        )
+        await self._seed_analysis(
+            mongo,
+            pg,
+            "private",
+            "owner_private",
+            sample_owner.id,
+            setup_sample.reference_id,
+        )
+
+        client = JobClient(job_id=1)
+
+        assert await data_layer.analyses.has_right("private", client, "read")
+        assert await data_layer.analyses.has_right("private", client, "write")
 
     async def test_missing_analysis_raises(
         self,

--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -2,7 +2,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.analyses.sql import SQLAnalysis, SQLAnalysisSubtraction
-from virtool.data.topg import compose_legacy_id_multi_expression
+from virtool.data.topg import (
+    compose_legacy_id_multi_expression,
+    compose_legacy_id_single_expression,
+)
 from virtool.mongo.core import Mongo
 from virtool.references.sql import SQLReference
 from virtool.samples.sql import SQLLegacySample
@@ -57,15 +60,20 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
             await session.flush()
             sample_pg_id = legacy_sample.id
 
-        reference_pg_id = (
+        reference_row = (
             await session.execute(
-                select(SQLReference.id).where(
-                    SQLReference.legacy_id == reference["id"],
+                select(SQLReference.id, SQLReference.legacy_id).where(
+                    compose_legacy_id_single_expression(SQLReference, reference["id"]),
                 ),
             )
-        ).scalar_one_or_none()
+        ).first()
 
-        if reference_pg_id is None:
+        if reference_row is None:
+            if not isinstance(reference["id"], str):
+                raise AssertionError(
+                    f"No reference row for primary key {reference['id']}",
+                )
+
             reference_doc = await mongo.references.find_one(reference["id"], ["name"])
             reference_name = (
                 reference_doc["name"]
@@ -83,6 +91,10 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
             session.add(legacy_reference)
             await session.flush()
             reference_pg_id = legacy_reference.id
+            reference_legacy_id = legacy_reference.legacy_id
+        else:
+            reference_pg_id = reference_row.id
+            reference_legacy_id = reference_row.legacy_id
 
         analysis = SQLAnalysis(
             legacy_id=document["_id"],
@@ -93,7 +105,7 @@ async def seed_analysis(mongo: Mongo, pg: AsyncEngine, document: dict) -> int:
             results=results if isinstance(results, dict) else None,
             sample=sample["id"],
             sample_id=sample_pg_id,
-            reference=reference["id"],
+            reference=reference_legacy_id,
             reference_id=reference_pg_id,
             index=index["id"],
             user_id=document["user"]["id"],

--- a/tests/fixtures/references.py
+++ b/tests/fixtures/references.py
@@ -2,6 +2,70 @@ import aiohttp.web
 import pytest
 from aiohttp.test_utils import make_mocked_coro
 from pytest_mock import MockerFixture
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+import virtool.utils
+from virtool.mongo.core import Mongo
+from virtool.references.sql import SQLReference
+
+
+async def seed_reference(
+    mongo: Mongo,
+    pg: AsyncEngine,
+    legacy_id: str,
+    user_id: int,
+    *,
+    name: str = "Reference",
+    archived: bool = False,
+    **fields,
+) -> int:
+    """Seed a reference into Mongo and Postgres and return its primary key.
+
+    Reference reads come from Postgres, so a Mongo-only reference is invisible to the
+    data layer. Mongo fields not mirrored to Postgres may be passed as ``fields``.
+
+    :return: the integer ``legacy_references.id`` of the seeded reference
+    """
+    created_at = fields.pop("created_at", None) or virtool.utils.timestamp()
+    source_types = fields.pop("source_types", [])
+    description = fields.pop("description", "")
+    organism = fields.pop("organism", "")
+
+    await mongo.references.insert_one(
+        {
+            "_id": legacy_id,
+            "archived": archived,
+            "created_at": created_at,
+            "data_type": "genome",
+            "description": description,
+            "name": name,
+            "organism": organism,
+            "source_types": source_types,
+            "user": {"id": user_id},
+            **fields,
+        },
+    )
+
+    async with AsyncSession(pg) as session:
+        reference = SQLReference(
+            legacy_id=legacy_id,
+            name=name,
+            description=description,
+            organism=organism,
+            created_at=created_at,
+            archived=archived,
+            source_types=source_types,
+            user_id=user_id,
+        )
+
+        session.add(reference)
+        await session.flush()
+
+        reference_pk = reference.id
+
+        await session.commit()
+
+    return reference_pk
 
 
 @pytest.fixture(params=[True, False])

--- a/tests/history/__snapshots__/test_api.ambr
+++ b/tests/history/__snapshots__/test_api.ambr
@@ -32,7 +32,7 @@
     }),
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Test Reference',
     }),
     'user': dict({
@@ -60,7 +60,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({
@@ -84,7 +84,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({

--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -63,7 +63,7 @@
     'ready': False,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'user': dict({
@@ -100,7 +100,7 @@
         'ready': False,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'ref_active_a',
+          'id': 1,
           'name': 'Active A',
         }),
         'user': dict({
@@ -129,7 +129,7 @@
         'ready': False,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'ref_active_b',
+          'id': 2,
           'name': 'Active B',
         }),
         'user': dict({
@@ -172,7 +172,7 @@
         'ready': False,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'ref_archived',
+          'id': 3,
           'name': 'Archived',
         }),
         'user': dict({
@@ -215,7 +215,7 @@
         'ready': False,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'ref_active_a',
+          'id': 1,
           'name': 'Active A',
         }),
         'user': dict({
@@ -244,7 +244,7 @@
         'ready': False,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'ref_active_b',
+          'id': 2,
           'name': 'Active B',
         }),
         'user': dict({
@@ -273,7 +273,7 @@
         'ready': False,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'ref_archived',
+          'id': 3,
           'name': 'Archived',
         }),
         'user': dict({
@@ -314,7 +314,7 @@
       'ready': True,
       'reference': dict({
         'data_type': 'genome',
-        'id': 'ref_active_b',
+        'id': 2,
         'name': 'Active B',
       }),
       'user': dict({
@@ -343,7 +343,7 @@
       'ready': True,
       'reference': dict({
         'data_type': 'genome',
-        'id': 'ref_active_a',
+        'id': 1,
         'name': 'Active A',
       }),
       'user': dict({
@@ -376,7 +376,7 @@
       'ready': True,
       'reference': dict({
         'data_type': 'genome',
-        'id': 'ref_archived',
+        'id': 3,
         'name': 'Archived',
       }),
       'user': dict({
@@ -409,7 +409,7 @@
       'ready': True,
       'reference': dict({
         'data_type': 'genome',
-        'id': 'ref_active_b',
+        'id': 2,
         'name': 'Active B',
       }),
       'user': dict({
@@ -438,7 +438,7 @@
       'ready': True,
       'reference': dict({
         'data_type': 'genome',
-        'id': 'ref_active_a',
+        'id': 1,
         'name': 'Active A',
       }),
       'user': dict({
@@ -467,7 +467,7 @@
       'ready': True,
       'reference': dict({
         'data_type': 'genome',
-        'id': 'ref_archived',
+        'id': 3,
         'name': 'Archived',
       }),
       'user': dict({
@@ -590,7 +590,7 @@
     'ready': True,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'hxn167',
+      'id': 1,
       'name': 'Test A',
     }),
     'user': dict({
@@ -644,7 +644,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'user': dict({
@@ -668,7 +668,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'user': dict({
@@ -692,7 +692,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'user': dict({
@@ -716,7 +716,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'user': dict({
@@ -782,7 +782,7 @@
     'ready': False,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bar',
+      'id': 1,
       'name': 'Bar',
     }),
     'user': dict({

--- a/tests/indexes/__snapshots__/test_data.ambr
+++ b/tests/indexes/__snapshots__/test_data.ambr
@@ -84,7 +84,7 @@
     'ready': True,
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bar',
+      'id': 1,
       'name': 'Bar',
     }),
     'user': dict({

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 from tests.fixtures.client import ClientSpawner, JobClientSpawner
+from tests.fixtures.references import seed_reference
 from tests.fixtures.response import RespIs
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
@@ -585,14 +586,18 @@ class TestCreate:
     async def test_checks(
         self,
         error,
+        fake: DataFaker,
         resp_is,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         check_ref_right,
     ):
         client = await spawn_client(authenticated=True)
 
-        await mongo.references.insert_one({"_id": "foo"})
+        user = await fake.users.create()
+
+        await seed_reference(mongo, pg, "foo", user.id, name="Foo")
 
         if error == "409_running":
             await mongo.indexes.insert_one({"ready": False, "reference": {"id": "foo"}})
@@ -738,36 +743,27 @@ async def test_delete_index(
     user = await fake.users.create()
 
     if error != 404:
-        await asyncio.gather(
-            mongo.references.insert_one(
-                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
-            ),
-            mongo.indexes.insert_one(
-                {
-                    "_id": index_id,
-                    "created_at": static_time.iso,
-                    "has_files": True,
-                    "manifest": {"foo": 2},
-                    "ready": True,
-                    "reference": {"id": "foo"},
-                    "user": {"id": user.id},
-                    "version": 4,
-                },
-            ),
+        await seed_reference(
+            mongo,
+            pg,
+            "foo",
+            user.id,
+            name="Foo",
+            created_at=static_time.datetime,
         )
 
-        async with AsyncSession(pg) as session:
-            session.add(
-                SQLReference(
-                    legacy_id="foo",
-                    name="Foo",
-                    description="",
-                    created_at=static_time.datetime,
-                    source_types=[],
-                    user_id=user.id,
-                ),
-            )
-            await session.commit()
+        await mongo.indexes.insert_one(
+            {
+                "_id": index_id,
+                "created_at": static_time.iso,
+                "has_files": True,
+                "manifest": {"foo": 2},
+                "ready": True,
+                "reference": {"id": "foo"},
+                "user": {"id": user.id},
+                "version": 4,
+            },
+        )
 
     response = await client.delete(f"/indexes/{index_id}")
 
@@ -797,16 +793,10 @@ async def test_upload(
 
     files = {"file": open(path, "rb")}
 
-    user, _ = await asyncio.gather(
-        fake.users.create(),
-        mongo.references.insert_many(
-            [
-                {"_id": "bar", "archived": False, "data_type": "genome", "name": "Bar"},
-                {"_id": "foo", "archived": False, "data_type": "genome", "name": "Foo"},
-            ],
-            session=None,
-        ),
-    )
+    user = await fake.users.create()
+
+    await seed_reference(mongo, pg, "bar", user.id, name="Bar")
+    await seed_reference(mongo, pg, "foo", user.id, name="Foo")
 
     index = {"_id": "foo", "reference": {"id": "bar"}, "user": {"id": user.id}}
 
@@ -950,6 +940,7 @@ async def test_finalize(
 async def test_download(
     status: int,
     example_path: Path,
+    fake: DataFaker,
     memory_storage: StorageBackend,
     mongo: Mongo,
     pg: AsyncEngine,
@@ -957,18 +948,12 @@ async def test_download(
 ):
     client = await spawn_job_client(authenticated=True)
 
-    await asyncio.gather(
-        mongo.indexes.insert_one(
-            {"_id": "test_index", "reference": {"id": "test_reference"}},
-        ),
-        mongo.references.insert_one(
-            {
-                "_id": "test_reference",
-                "archived": False,
-                "data_type": "genome",
-                "name": "Test A",
-            },
-        ),
+    user = await fake.users.create()
+
+    await seed_reference(mongo, pg, "test_reference", user.id, name="Test A")
+
+    await mongo.indexes.insert_one(
+        {"_id": "test_index", "reference": {"id": "test_reference"}},
     )
 
     path = example_path / "indexes" / "reference.1.bt2"

--- a/tests/otus/__snapshots__/test_api.ambr
+++ b/tests/otus/__snapshots__/test_api.ambr
@@ -1,9 +1,9 @@
 # serializer version: 1
 # name: TestAddIsolate.test_default[True-False][history]
   list([
-    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Created Prunus virus F (PVF)', id='fb085f7f.0', method_name=<HistoryMethod.create: 'create'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=0), reference=ReferenceNested(id='bf1b993c', data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff={'_id': 'fb085f7f', 'name': 'Prunus virus F', 'schema': [{'name': 'Genome', 'molecule': 'ssRNA', 'required': True}], 'version': 0, 'isolates': [], 'verified': False, 'reference': {'id': 1}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': None}),
-    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added B isolate as default', id='fb085f7f.1', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=1), reference=ReferenceNested(id='bf1b993c', data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['add', 'isolates', [[0, {'id': '7cf872dc', 'default': True, 'sequences': [], 'source_name': 'isolate', 'source_type': 'b'}]]], ['change', 'version', [0, 1]]]),
-    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added Isolate a', id='fb085f7f.2', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=1, handle='leeashley'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=2), reference=ReferenceNested(id='bf1b993c', data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['add', 'isolates', [[1, {'id': '3cbb22cc', 'default': False, 'sequences': [], 'source_name': 'a', 'source_type': 'isolate'}]]], ['change', 'version', [1, 2]]]),
+    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Created Prunus virus F (PVF)', id='fb085f7f.0', method_name=<HistoryMethod.create: 'create'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=0), reference=ReferenceNested(id=1, data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff={'_id': 'fb085f7f', 'name': 'Prunus virus F', 'schema': [{'name': 'Genome', 'molecule': 'ssRNA', 'required': True}], 'version': 0, 'isolates': [], 'verified': False, 'reference': {'id': 1}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': None}),
+    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added B isolate as default', id='fb085f7f.1', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=1), reference=ReferenceNested(id=1, data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['add', 'isolates', [[0, {'id': '7cf872dc', 'default': True, 'sequences': [], 'source_name': 'isolate', 'source_type': 'b'}]]], ['change', 'version', [0, 1]]]),
+    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added Isolate a', id='fb085f7f.2', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=1, handle='leeashley'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=2), reference=ReferenceNested(id=1, data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['add', 'isolates', [[1, {'id': '3cbb22cc', 'default': False, 'sequences': [], 'source_name': 'a', 'source_type': 'isolate'}]]], ['change', 'version', [1, 2]]]),
   ])
 # ---
 # name: TestAddIsolate.test_default[True-False][json]
@@ -71,7 +71,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Example',
     }),
     'remote': None,
@@ -81,9 +81,9 @@
 # ---
 # name: TestAddIsolate.test_default[True-True][history]
   list([
-    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Created Prunus virus F (PVF)', id='fb085f7f.0', method_name=<HistoryMethod.create: 'create'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=0), reference=ReferenceNested(id='bf1b993c', data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff={'_id': 'fb085f7f', 'name': 'Prunus virus F', 'schema': [{'name': 'Genome', 'molecule': 'ssRNA', 'required': True}], 'version': 0, 'isolates': [], 'verified': False, 'reference': {'id': 1}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': None}),
-    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added B isolate as default', id='fb085f7f.1', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=1), reference=ReferenceNested(id='bf1b993c', data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['add', 'isolates', [[0, {'id': '7cf872dc', 'default': True, 'sequences': [], 'source_name': 'isolate', 'source_type': 'b'}]]], ['change', 'version', [0, 1]]]),
-    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added Isolate a as default', id='fb085f7f.2', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=1, handle='leeashley'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=2), reference=ReferenceNested(id='bf1b993c', data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['change', ['isolates', 0, 'default'], [True, False]], ['add', 'isolates', [[1, {'id': '3cbb22cc', 'default': True, 'sequences': [], 'source_name': 'a', 'source_type': 'isolate'}]]], ['change', 'version', [1, 2]]]),
+    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Created Prunus virus F (PVF)', id='fb085f7f.0', method_name=<HistoryMethod.create: 'create'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=0), reference=ReferenceNested(id=1, data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff={'_id': 'fb085f7f', 'name': 'Prunus virus F', 'schema': [{'name': 'Genome', 'molecule': 'ssRNA', 'required': True}], 'version': 0, 'isolates': [], 'verified': False, 'reference': {'id': 1}, 'lower_name': 'prunus virus f', 'abbreviation': 'PVF', 'last_indexed_version': None}),
+    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added B isolate as default', id='fb085f7f.1', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=2, handle='myersmitchell'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=1), reference=ReferenceNested(id=1, data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['add', 'isolates', [[0, {'id': '7cf872dc', 'default': True, 'sequences': [], 'source_name': 'isolate', 'source_type': 'b'}]]], ['change', 'version', [0, 1]]]),
+    History(created_at=datetime.datetime(2015, 10, 6, 20, 0), description='Added Isolate a as default', id='fb085f7f.2', method_name=<HistoryMethod.add_isolate: 'add_isolate'>, user=UserNested(id=1, handle='leeashley'), index=HistoryIndex(id='unbuilt', version='unbuilt'), otu=HistoryOTU(id='fb085f7f', name='Prunus virus F', version=2), reference=ReferenceNested(id=1, data_type=<ReferenceDataType.genome: 'genome'>, name='Example'), diff=[['change', ['isolates', 0, 'default'], [True, False]], ['add', 'isolates', [[1, {'id': '3cbb22cc', 'default': True, 'sequences': [], 'source_name': 'a', 'source_type': 'isolate'}]]], ['change', 'version', [1, 2]]]),
   ])
 # ---
 # name: TestAddIsolate.test_default[True-True][json]
@@ -151,7 +151,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Example',
     }),
     'remote': None,
@@ -203,7 +203,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -268,7 +268,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -320,7 +320,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -385,7 +385,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -446,7 +446,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -551,7 +551,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -568,7 +568,7 @@
     'otu_id': 'fb085f7f',
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -671,7 +671,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -806,7 +806,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -868,7 +868,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -980,7 +980,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1210,7 +1210,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1262,7 +1262,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1307,7 +1307,7 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1355,7 +1355,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1414,7 +1414,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1459,7 +1459,7 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1507,7 +1507,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1550,7 +1550,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1595,7 +1595,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1643,7 +1643,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1702,7 +1702,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1747,7 +1747,7 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1795,7 +1795,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1854,7 +1854,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -1899,7 +1899,7 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -1947,7 +1947,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2006,7 +2006,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -2051,7 +2051,7 @@
     'name': 'Tobacco mosaic otu',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2099,7 +2099,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2142,7 +2142,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -2187,7 +2187,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2235,7 +2235,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2278,7 +2278,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -2323,7 +2323,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2371,7 +2371,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2414,7 +2414,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -2459,7 +2459,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2507,7 +2507,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2553,7 +2553,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2601,7 +2601,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2649,7 +2649,7 @@
     'name': 'Prunus virus F',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2697,7 +2697,7 @@
     'name': 'Prunus virus G',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2754,7 +2754,7 @@
     'name': 'Squash browning spot virus',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2783,7 +2783,7 @@
     'otu_id': 'fb085f7f',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -2809,7 +2809,7 @@
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'bf1b993c',
+        'id': 1,
         'name': 'Reference',
       }),
       'user': dict({
@@ -2833,7 +2833,7 @@
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'bf1b993c',
+        'id': 1,
         'name': 'Reference',
       }),
       'user': dict({
@@ -2857,7 +2857,7 @@
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'bf1b993c',
+        'id': 1,
         'name': 'Reference',
       }),
       'user': dict({
@@ -2881,7 +2881,7 @@
       }),
       'reference': dict({
         'data_type': 'genome',
-        'id': 'bf1b993c',
+        'id': 1,
         'name': 'Reference',
       }),
       'user': dict({
@@ -2993,7 +2993,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -3119,7 +3119,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -3213,7 +3213,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -3260,7 +3260,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -3354,7 +3354,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -3401,7 +3401,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -3495,7 +3495,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -3572,7 +3572,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -3605,7 +3605,7 @@
     'otu_id': 'fb085f7f',
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,

--- a/tests/otus/__snapshots__/test_data.ambr
+++ b/tests/otus/__snapshots__/test_data.ambr
@@ -32,7 +32,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -69,7 +69,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -105,7 +105,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -146,7 +146,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -183,7 +183,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -219,7 +219,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,
@@ -270,7 +270,7 @@
     'lower_name': 'prunus virus f',
     'name': 'Prunus virus F',
     'reference': dict({
-      'id': 'bf1b993c',
+      'id': 1,
     }),
     'remote_id': None,
     'schema': list([
@@ -330,7 +330,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'user': dict({
@@ -412,7 +412,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Reference',
     }),
     'remote': None,

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -10,7 +10,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'foo',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Foo',
@@ -42,7 +42,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'foo',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Foo',
@@ -64,13 +64,13 @@
   })
 # ---
 # name: TestCreate.test_clone[location]
-  '/references/v1/bf1b993c'
+  '/references/v1/2'
 # ---
 # name: TestCreate.test_clone[resp]
   dict({
     'archived': False,
     'cloned_from': dict({
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'contributors': list([
@@ -80,7 +80,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 2,
     'imported_from': None,
     'latest_build': None,
     'name': 'Test 1',
@@ -128,7 +128,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': str,
+    'id': int,
     'imported_from': dict({
       'created_at': '2015-10-06T20:00:00Z',
       'id': 1,
@@ -181,7 +181,7 @@
   })
 # ---
 # name: TestCreate.test_ok[location]
-  'https://virtool.example.com/references/v1/bf1b993c'
+  'https://virtool.example.com/references/v1/1'
 # ---
 # name: TestCreate.test_ok[resp]
   dict({
@@ -194,7 +194,7 @@
     'description': 'A bunch of viruses used for testing',
     'groups': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Test Viruses',
@@ -256,7 +256,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'user': dict({
@@ -293,7 +293,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'remote': None,
@@ -327,7 +327,7 @@
     'name': 'Tobacco mosaic virus',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'remote': None,
@@ -370,7 +370,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'user': dict({
@@ -407,7 +407,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'remote': None,
@@ -441,7 +441,7 @@
     'name': 'Tobacco mosaic virus',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'remote': None,
@@ -484,7 +484,7 @@
     }),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'user': dict({
@@ -521,7 +521,7 @@
     ]),
     'reference': dict({
       'data_type': <ReferenceDataType.genome: 'genome'>,
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'remote': None,
@@ -555,7 +555,7 @@
     'name': 'Tobacco mosaic virus',
     'reference': dict({
       'data_type': 'genome',
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'remote': None,
@@ -641,7 +641,7 @@
     'description': 'This is a test reference.',
     'groups': list([
     ]),
-    'id': 'foo',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Bar',
@@ -697,7 +697,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({
@@ -721,7 +721,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({
@@ -745,7 +745,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({
@@ -769,7 +769,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({
@@ -793,7 +793,7 @@
         }),
         'reference': dict({
           'data_type': 'genome',
-          'id': 'bf1b993c',
+          'id': 1,
           'name': 'Test Reference',
         }),
         'user': dict({
@@ -820,7 +820,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Bar',
@@ -868,7 +868,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'foo',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Foo',
@@ -900,7 +900,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'foo',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Foo',
@@ -1054,7 +1054,7 @@
     'ready': False,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'foo',
+      'id': 1,
       'name': 'Foo',
     }),
     'user': dict({
@@ -1168,7 +1168,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'group_member_active',
+        'id': 4,
         'imported_from': None,
         'latest_build': None,
         'name': 'Group Member Active',
@@ -1194,7 +1194,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'owned_active',
+        'id': 1,
         'imported_from': None,
         'latest_build': None,
         'name': 'Owned Active',
@@ -1220,7 +1220,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'user_member_active',
+        'id': 3,
         'imported_from': None,
         'latest_build': None,
         'name': 'User Member Active',
@@ -1257,7 +1257,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'owned_archived',
+        'id': 5,
         'imported_from': None,
         'latest_build': None,
         'name': 'Owned Archived',
@@ -1294,7 +1294,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'group_member_active',
+        'id': 4,
         'imported_from': None,
         'latest_build': None,
         'name': 'Group Member Active',
@@ -1320,7 +1320,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'owned_active',
+        'id': 1,
         'imported_from': None,
         'latest_build': None,
         'name': 'Owned Active',
@@ -1346,7 +1346,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'owned_archived',
+        'id': 5,
         'imported_from': None,
         'latest_build': None,
         'name': 'Owned Archived',
@@ -1372,7 +1372,7 @@
         'cloned_from': None,
         'created_at': '2015-10-06T20:00:00Z',
         'data_type': 'genome',
-        'id': 'user_member_active',
+        'id': 3,
         'imported_from': None,
         'latest_build': None,
         'name': 'User Member Active',
@@ -1410,7 +1410,7 @@
         'name': 'Papaya virus q',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': False,
@@ -1470,7 +1470,7 @@
         'name': 'Papaya virus q',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': False,
@@ -1494,7 +1494,7 @@
         'name': 'Papaya virus q',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': False,
@@ -1506,7 +1506,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1530,7 +1530,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1554,7 +1554,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1578,7 +1578,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1602,7 +1602,7 @@
         'name': 'Papaya virus q',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': False,
@@ -1614,7 +1614,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1638,7 +1638,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1662,7 +1662,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1686,7 +1686,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1710,7 +1710,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,
@@ -1734,7 +1734,7 @@
         'name': 'Prunus virus F',
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'verified': True,

--- a/tests/references/__snapshots__/test_data.ambr
+++ b/tests/references/__snapshots__/test_data.ambr
@@ -50,7 +50,7 @@
     'description': '',
     'groups': list([
     ]),
-    'id': 'bf1b993c',
+    'id': 1,
     'imported_from': None,
     'latest_build': None,
     'name': 'Example',

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -5,12 +5,14 @@ from unittest.mock import ANY
 
 import pytest
 from aiohttp.test_utils import make_mocked_coro
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.matchers import path_type
 
 import virtool.utils
 from tests.fixtures.client import ClientSpawner, VirtoolTestClient
+from tests.fixtures.references import seed_reference
 from tests.fixtures.response import RespIs
 from virtool.data.layer import DataLayer
 from virtool.data.topg import both_transactions
@@ -255,9 +257,20 @@ async def test_find(
     resp = await client.get(url)
     body = await resp.json()
 
+    async with AsyncSession(pg) as session:
+        reference_pks = dict(
+            (
+                await session.execute(
+                    select(SQLReference.legacy_id, SQLReference.id),
+                )
+            ).all(),
+        )
+
     assert resp.status == HTTPStatus.OK
     assert body == snapshot
-    assert {d["id"] for d in body["documents"]} == expected_ids
+    assert {d["id"] for d in body["documents"]} == {
+        reference_pks[legacy_id] for legacy_id in expected_ids
+    }
 
 
 async def test_find_archived_invalid(spawn_client: ClientSpawner):
@@ -374,7 +387,7 @@ class TestCreate:
 
         assert resp.status == 201
         assert body == snapshot(
-            matcher=path_type({"id": (str,)}, regex=True),
+            matcher=path_type({"id": (int,)}, regex=True),
         )
 
     async def test_clone(
@@ -1585,33 +1598,33 @@ class TestArchivedReferenceRejectsWrites:
     async def archived_ref(
         self,
         mongo: Mongo,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         static_time: StaticTime,
     ) -> tuple[VirtoolTestClient, str]:
         client = await spawn_client(authenticated=True)
 
-        await mongo.references.insert_one(
-            {
-                "_id": "foo",
-                "archived": True,
-                "created_at": static_time.datetime,
-                "data_type": "genome",
-                "groups": [],
-                "name": "Foo",
-                "organism": "virus",
-                "restrict_source_types": False,
-                "source_types": ["isolate", "strain"],
-                "user": {"id": client.user.id},
-                "users": [
-                    {
-                        "id": client.user.id,
-                        "build": True,
-                        "created_at": static_time.datetime,
-                        "modify": True,
-                        "modify_otu": True,
-                    },
-                ],
-            },
+        await seed_reference(
+            mongo,
+            pg,
+            "foo",
+            client.user.id,
+            name="Foo",
+            archived=True,
+            created_at=static_time.datetime,
+            organism="virus",
+            source_types=["isolate", "strain"],
+            groups=[],
+            restrict_source_types=False,
+            users=[
+                {
+                    "id": client.user.id,
+                    "build": True,
+                    "created_at": static_time.datetime,
+                    "modify": True,
+                    "modify_otu": True,
+                },
+            ],
         )
 
         return client, "foo"

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -30,22 +30,21 @@ async def insert_reference(mongo: Mongo, pg: AsyncEngine, document: dict) -> Non
         await write_legacy_reference(pg_session, document)
 
 
-async def _reference_pk(pg: AsyncEngine, ref_id: str) -> int:
+async def _legacy_id(pg: AsyncEngine, reference_pk: int) -> str:
+    """Return the Mongo ``_id`` of a reference, which its public id no longer is."""
     async with AsyncSession(pg) as session:
         return (
             await session.execute(
-                select(SQLReference.id).where(SQLReference.legacy_id == ref_id),
+                select(SQLReference.legacy_id).where(SQLReference.id == reference_pk),
             )
         ).scalar_one()
 
 
 async def _reference_user_row(
     pg: AsyncEngine,
-    ref_id: str,
+    reference_pk: int,
     user_id: int,
 ) -> SQLReferenceUser | None:
-    reference_pk = await _reference_pk(pg, ref_id)
-
     async with AsyncSession(pg) as session:
         return (
             await session.execute(
@@ -59,11 +58,9 @@ async def _reference_user_row(
 
 async def _reference_group_row(
     pg: AsyncEngine,
-    ref_id: str,
+    reference_pk: int,
     group_id: int,
 ) -> SQLReferenceGroup | None:
-    reference_pk = await _reference_pk(pg, ref_id)
-
     async with AsyncSession(pg) as session:
         return (
             await session.execute(
@@ -247,14 +244,15 @@ class TestCreate:
             user.id,
         )
 
-        assert await mongo.references.find_one(reference.id) is not None
+        assert (
+            await mongo.references.find_one(await _legacy_id(pg, reference.id))
+            is not None
+        )
 
         async with AsyncSession(pg) as session:
             row = (
                 await session.execute(
-                    select(SQLReference).where(
-                        SQLReference.legacy_id == reference.id,
-                    ),
+                    select(SQLReference).where(SQLReference.id == reference.id),
                 )
             ).scalar_one()
 
@@ -303,23 +301,13 @@ class TestCreate:
         )
 
         async with AsyncSession(pg) as session:
-            source_id = (
-                await session.execute(
-                    select(SQLReference.id).where(
-                        SQLReference.legacy_id == source.id,
-                    ),
-                )
-            ).scalar_one()
-
             clone_row = (
                 await session.execute(
-                    select(SQLReference).where(
-                        SQLReference.legacy_id == clone.id,
-                    ),
+                    select(SQLReference).where(SQLReference.id == clone.id),
                 )
             ).scalar_one()
 
-        assert clone_row.cloned_from_id == source_id
+        assert clone_row.cloned_from_id == source.id
 
     async def test_import_sets_upload_id(
         self,
@@ -339,9 +327,7 @@ class TestCreate:
         async with AsyncSession(pg) as session:
             row = (
                 await session.execute(
-                    select(SQLReference).where(
-                        SQLReference.legacy_id == reference.id,
-                    ),
+                    select(SQLReference).where(SQLReference.id == reference.id),
                 )
             ).scalar_one()
 
@@ -383,15 +369,13 @@ class TestUpdate:
             UpdateReferenceRequest(name="After", organism="bacteria"),
         )
 
-        document = await mongo.references.find_one(reference.id)
+        document = await mongo.references.find_one(await _legacy_id(pg, reference.id))
         assert document["name"] == "After"
 
         async with AsyncSession(pg) as session:
             row = (
                 await session.execute(
-                    select(SQLReference).where(
-                        SQLReference.legacy_id == reference.id,
-                    ),
+                    select(SQLReference).where(SQLReference.id == reference.id),
                 )
             ).scalar_one()
 
@@ -415,28 +399,30 @@ class TestArchive:
             user.id,
         )
 
+        legacy_id = await _legacy_id(pg, reference.id)
+
         await data_layer.references.archive(reference.id)
 
-        assert (await mongo.references.find_one(reference.id))["archived"] is True
+        assert (await mongo.references.find_one(legacy_id))["archived"] is True
 
         async with AsyncSession(pg) as session:
             assert (
                 await session.execute(
                     select(SQLReference.archived).where(
-                        SQLReference.legacy_id == reference.id,
+                        SQLReference.id == reference.id,
                     ),
                 )
             ).scalar_one() is True
 
         await data_layer.references.unarchive(reference.id)
 
-        assert (await mongo.references.find_one(reference.id))["archived"] is False
+        assert (await mongo.references.find_one(legacy_id))["archived"] is False
 
         async with AsyncSession(pg) as session:
             assert (
                 await session.execute(
                     select(SQLReference.archived).where(
-                        SQLReference.legacy_id == reference.id,
+                        SQLReference.id == reference.id,
                     ),
                 )
             ).scalar_one() is False
@@ -480,12 +466,15 @@ class TestCreateUser:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that a user cannot be added to a reference if they are already a member."""
         user_1 = await fake.users.create()
         user_2 = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
@@ -532,11 +521,14 @@ class TestCreateUser:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that a `NotFound` error is raised when the user does not exist."""
         user = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
@@ -630,6 +622,7 @@ class TestUpdateUser:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that ``ResourceNotFound`` is raised when the reference or reference user
         do not exist.
@@ -637,7 +630,9 @@ class TestUpdateUser:
         user_1 = await fake.users.create()
 
         if reference_exists:
-            await mongo.references.insert_one(
+            await insert_reference(
+                mongo,
+                pg,
                 {
                     "_id": "foo",
                     "archived": False,
@@ -723,6 +718,7 @@ class TestDeleteUser:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that ``ResourceNotFound`` is raised when the reference or reference user
         do not exist.
@@ -730,7 +726,9 @@ class TestDeleteUser:
         user_1 = await fake.users.create()
 
         if reference_exists:
-            await mongo.references.insert_one(
+            await insert_reference(
+                mongo,
+                pg,
                 {
                     "_id": "foo",
                     "archived": False,
@@ -833,11 +831,14 @@ class TestCreateGroup:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that `ResourceNotFound` is raised when the group does not exist."""
         user = await fake.users.create()
 
-        await mongo.references.insert_one(
+        await insert_reference(
+            mongo,
+            pg,
             {
                 "_id": "foo",
                 "archived": False,
@@ -924,6 +925,7 @@ class TestUpdateGroup:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that ``ResourceNotFound`` is raised when the reference or reference group
         do not exist.
@@ -931,7 +933,9 @@ class TestUpdateGroup:
         user = await fake.users.create()
 
         if reference_exists:
-            await mongo.references.insert_one(
+            await insert_reference(
+                mongo,
+                pg,
                 {
                     "_id": "foo",
                     "archived": False,
@@ -1017,6 +1021,7 @@ class TestDeleteGroup:
         fake: DataFaker,
         mongo: Mongo,
         static_time,
+        pg: AsyncEngine,
     ):
         """Test that ``ResourceNotFound`` is raised when the reference or reference group
         do not exist.
@@ -1024,7 +1029,9 @@ class TestDeleteGroup:
         user = await fake.users.create()
 
         if reference_exists:
-            await mongo.references.insert_one(
+            await insert_reference(
+                mongo,
+                pg,
                 {
                     "_id": "foo",
                     "archived": False,

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -3,6 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+import virtool.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.data.topg import both_transactions
@@ -381,6 +382,38 @@ class TestUpdate:
 
         assert row.name == "After"
         assert row.organism == "bacteria"
+
+    async def test_postgres_native_raises_not_found(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """Updating a Postgres-native reference (no ``legacy_id``, so no Mongo document)
+        raises ``ResourceNotFoundError`` rather than an unhandled ``ValueError``.
+        """
+        user = await fake.users.create()
+
+        async with AsyncSession(pg) as session:
+            reference = SQLReference(
+                legacy_id=None,
+                name="Postgres Native",
+                description="",
+                organism="virus",
+                created_at=virtool.utils.timestamp(),
+                source_types=[],
+                user_id=user.id,
+            )
+            session.add(reference)
+            await session.flush()
+            reference_id = reference.id
+            await session.commit()
+
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.references.update(
+                reference_id,
+                UpdateReferenceRequest(name="After"),
+            )
 
 
 class TestArchive:

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -448,12 +448,13 @@ class TestComposeReferenceIdsMatch:
         return reference_ids
 
     async def test_unfiltered(self, pg: AsyncEngine, references: dict[str, int]):
-        """Both id forms of every legacy reference are matched when ``archived`` is None."""
+        """Both id forms of every reference are matched when ``archived`` is None."""
         match = await compose_reference_ids_match(pg)
 
         assert set(match["$in"]) == {
             references["active"],
             references["archived"],
+            references["native_active"],
             "ref_active",
             "ref_archived",
         }
@@ -466,21 +467,26 @@ class TestComposeReferenceIdsMatch:
     async def test_active(self, pg: AsyncEngine, references: dict[str, int]):
         match = await compose_reference_ids_match(pg, False)
 
-        assert set(match["$in"]) == {references["active"], "ref_active"}
+        assert set(match["$in"]) == {
+            references["active"],
+            references["native_active"],
+            "ref_active",
+        }
 
-    async def test_native_reference_excluded(
+    async def test_native_reference_contributes_only_its_pk(
         self,
         pg: AsyncEngine,
         references: dict[str, int],
     ):
-        """A reference with no ``legacy_id`` never enters the match.
+        """A reference with no ``legacy_id`` is matched by its primary key alone.
 
-        It cannot be shaped into a ``ReferenceNested``, whose ``id`` is a required
-        string, so matching its indexes would fail response validation.
+        Now that the integer primary key is the public identifier, a Postgres-native
+        reference can be shaped into a ``ReferenceNested``. Its ``NULL`` legacy id must
+        not leak into the match, where it would match indexes with no reference.
         """
         match = await compose_reference_ids_match(pg)
 
-        assert references["native_active"] not in match["$in"]
+        assert references["native_active"] in match["$in"]
         assert None not in match["$in"]
 
 

--- a/tests/references/test_transforms.py
+++ b/tests/references/test_transforms.py
@@ -8,7 +8,7 @@ from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 
 
-async def _seed_reference(pg: AsyncEngine, legacy_id: str, user_id: int) -> int:
+async def _seed_reference(pg: AsyncEngine, legacy_id: str | None, user_id: int) -> int:
     async with AsyncSession(pg) as session:
         reference = SQLReference(
             legacy_id=legacy_id,
@@ -32,18 +32,22 @@ class TestAttachReferenceTransform:
         fake: DataFaker,
         pg: AsyncEngine,
     ):
-        """A document embedding the legacy string id resolves against Postgres."""
+        """A document embedding the legacy string id resolves against Postgres.
+
+        The attached nested reference is keyed by the integer primary key regardless
+        of which id form the document embeds.
+        """
         user = await fake.users.create()
-        await _seed_reference(pg, "foo", user.id)
+        reference_id = await _seed_reference(pg, "legacy_reference", user.id)
 
         document = await apply_transforms(
-            {"id": "6116cba1", "reference": {"id": "foo"}},
+            {"id": "6116cba1", "reference": {"id": "legacy_reference"}},
             [AttachReferenceTransform(pg)],
             pg,
         )
 
         assert document["reference"] == {
-            "id": "foo",
+            "id": reference_id,
             "name": "Reference A",
             "data_type": "genome",
         }
@@ -55,7 +59,7 @@ class TestAttachReferenceTransform:
     ):
         """A document embedding the integer primary key resolves against Postgres."""
         user = await fake.users.create()
-        reference_id = await _seed_reference(pg, "foo", user.id)
+        reference_id = await _seed_reference(pg, "legacy_reference", user.id)
 
         document = await apply_transforms(
             {"id": "6116cba1", "reference": {"id": reference_id}},
@@ -64,7 +68,28 @@ class TestAttachReferenceTransform:
         )
 
         assert document["reference"] == {
-            "id": "foo",
+            "id": reference_id,
+            "name": "Reference A",
+            "data_type": "genome",
+        }
+
+    async def test_native_reference(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A reference with no legacy id resolves by its primary key."""
+        user = await fake.users.create()
+        reference_id = await _seed_reference(pg, None, user.id)
+
+        document = await apply_transforms(
+            {"id": "6116cba1", "reference": {"id": reference_id}},
+            [AttachReferenceTransform(pg)],
+            pg,
+        )
+
+        assert document["reference"] == {
+            "id": reference_id,
             "name": "Reference A",
             "data_type": "genome",
         }
@@ -76,18 +101,22 @@ class TestAttachReferenceTransform:
     ):
         """A batch mixing legacy string and integer ids resolves every document."""
         user = await fake.users.create()
-        reference_id = await _seed_reference(pg, "foo", user.id)
+        reference_id = await _seed_reference(pg, "legacy_reference", user.id)
 
         documents = await apply_transforms(
             [
-                {"id": "string_ref", "reference": {"id": "foo"}},
+                {"id": "string_ref", "reference": {"id": "legacy_reference"}},
                 {"id": "integer_ref", "reference": {"id": reference_id}},
             ],
             [AttachReferenceTransform(pg)],
             pg,
         )
 
-        expected = {"id": "foo", "name": "Reference A", "data_type": "genome"}
+        expected = {
+            "id": reference_id,
+            "name": "Reference A",
+            "data_type": "genome",
+        }
 
         assert {d["id"]: d["reference"] for d in documents} == {
             "string_ref": expected,

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -23,7 +23,7 @@
     'ready': False,
     'reference': dict({
       'data_type': 'genome',
-      'id': 'bf1b993c',
+      'id': 1,
       'name': 'Test Reference',
     }),
     'results': None,
@@ -2696,7 +2696,7 @@
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'foo',
+          'id': 1,
           'name': 'Foo',
         }),
         'sample': dict({
@@ -2726,7 +2726,7 @@
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'baz',
+          'id': 2,
           'name': 'Baz',
         }),
         'sample': dict({
@@ -2766,7 +2766,7 @@
         'ready': True,
         'reference': dict({
           'data_type': 'genome',
-          'id': 'baz',
+          'id': 2,
           'name': 'Baz',
         }),
         'sample': dict({

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -20,7 +20,6 @@ from virtool.models.enums import AnalysisWorkflow, LibraryType, Permission
 from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row, get_row_by_id
-from virtool.references.sql import SQLReference
 from virtool.samples.db import AttachUploadsTransform
 from virtool.samples.models import WorkflowState
 from virtool.samples.oas import (
@@ -765,6 +764,7 @@ class TestHasRight:
 class TestHasResourcesForAnalysisJob:
     @staticmethod
     async def _seed(
+        data_layer: DataLayer,
         fake: DataFaker,
         mongo: Mongo,
         *,
@@ -776,15 +776,12 @@ class TestHasResourcesForAnalysisJob:
             upload_type=UploadType.subtraction,
         )
 
-        _, _, subtraction = await asyncio.gather(
-            mongo.references.insert_one(
-                {
-                    "_id": "test_ref",
-                    "archived": archived,
-                    "data_type": "genome",
-                    "name": "Test Reference",
-                },
-            ),
+        reference = await fake.references.create(user=user, id_="test_ref")
+
+        if archived:
+            await data_layer.references.archive(reference.id)
+
+        _, subtraction = await asyncio.gather(
             mongo.indexes.insert_one(
                 {
                     "_id": "test_index",
@@ -799,7 +796,7 @@ class TestHasResourcesForAnalysisJob:
         return subtraction.id
 
     async def test_ok(self, data_layer: DataLayer, fake: DataFaker, mongo: Mongo):
-        subtraction_id = await self._seed(fake, mongo)
+        subtraction_id = await self._seed(data_layer, fake, mongo)
 
         assert (
             await data_layer.samples.has_resources_for_analysis_job(
@@ -823,33 +820,13 @@ class TestHasResourcesForAnalysisJob:
             upload_type=UploadType.subtraction,
         )
 
-        async with AsyncSession(pg) as session:
-            reference = SQLReference(
-                legacy_id="test_ref",
-                name="Test Reference",
-                description="",
-                created_at=virtool.utils.timestamp(),
-                source_types=[],
-                user_id=user.id,
-            )
-            session.add(reference)
-            await session.flush()
-            reference_pk = reference.id
-            await session.commit()
+        reference = await fake.references.create(user=user, id_="test_ref")
 
-        _, _, subtraction = await asyncio.gather(
-            mongo.references.insert_one(
-                {
-                    "_id": "test_ref",
-                    "archived": False,
-                    "data_type": "genome",
-                    "name": "Test Reference",
-                },
-            ),
+        _, subtraction = await asyncio.gather(
             mongo.indexes.insert_one(
                 {
                     "_id": "test_index",
-                    "reference": {"id": reference_pk},
+                    "reference": {"id": reference.id},
                     "ready": True,
                     "version": 1,
                 },
@@ -859,7 +836,7 @@ class TestHasResourcesForAnalysisJob:
 
         assert (
             await data_layer.samples.has_resources_for_analysis_job(
-                "test_ref",
+                reference.id,
                 [subtraction.id],
             )
             is None
@@ -878,7 +855,7 @@ class TestHasResourcesForAnalysisJob:
         fake: DataFaker,
         mongo: Mongo,
     ):
-        subtraction_id = await self._seed(fake, mongo, archived=True)
+        subtraction_id = await self._seed(data_layer, fake, mongo, archived=True)
 
         with pytest.raises(ResourceConflictError, match=r"Reference is archived"):
             await data_layer.samples.has_resources_for_analysis_job(
@@ -892,7 +869,7 @@ class TestHasResourcesForAnalysisJob:
         fake: DataFaker,
         mongo: Mongo,
     ):
-        subtraction_id = await self._seed(fake, mongo)
+        subtraction_id = await self._seed(data_layer, fake, mongo)
 
         with pytest.raises(
             ResourceConflictError,

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -11,7 +11,7 @@ import virtool.utils
 from tests.fixtures.client import ClientSpawner
 from tests.samples.utils import add_sample_uploads
 from virtool.analyses.sql import SQLAnalysis
-from virtool.api.client import UserClient
+from virtool.api.client import JobClient, UserClient
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.data.transforms import apply_transforms
@@ -34,7 +34,7 @@ from virtool.samples.sql import (
     SQLSampleReads,
     SQLSampleUpload,
 )
-from virtool.samples.utils import SampleRight
+from virtool.samples.utils import SampleRight, sample_file_key, sample_prefix
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
@@ -725,6 +725,38 @@ class TestHasRight:
         await insert_rights_sample(pg, "sample_4", user_id=user.id)
 
         assert await data_layer.samples.has_right("sample_4", client, SampleRight.write)
+
+    async def test_job_client_full_access(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A job-authenticated client holds every right regardless of ownership or
+        sharing, since a job's identity is neither a user nor an administrator.
+        """
+        sample_owner = await fake.users.create()
+
+        await insert_rights_sample(
+            pg,
+            "job_sample",
+            user_id=sample_owner.id,
+            all_read=False,
+            all_write=False,
+        )
+
+        client = JobClient(job_id=1)
+
+        assert await data_layer.samples.has_right(
+            "job_sample",
+            client,
+            SampleRight.read,
+        )
+        assert await data_layer.samples.has_right(
+            "job_sample",
+            client,
+            SampleRight.write,
+        )
 
     async def test_non_group_member_denied(
         self,
@@ -1435,3 +1467,48 @@ class TestDelete:
             ).scalars().all() == []
 
         assert await mongo.samples.find_one() is None
+
+    async def test_postgres_native_sample_cleans_storage(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        memory_storage: StorageBackend,
+        pg: AsyncEngine,
+    ):
+        """Deleting a Postgres-native sample (no ``legacy_id``) removes its Postgres row
+        and cleans up its storage prefix instead of raising ``ResourceNotFoundError``.
+
+        The sample has no Mongo document, so the delete's success signal comes from the
+        ``legacy_samples`` rowcount, not ``delete_one``'s ``deleted_count``.
+        """
+        user = await fake.users.create()
+
+        async with AsyncSession(pg) as session:
+            sample = SQLLegacySample(
+                legacy_id=None,
+                name="Postgres Native",
+                library_type=LibraryType.normal.value,
+                created_at=virtool.utils.timestamp(),
+                user_id=user.id,
+                all_read=True,
+                all_write=True,
+            )
+            session.add(sample)
+            await session.flush()
+            sample_id = sample.id
+            await session.commit()
+
+        async def _content() -> AsyncIterator[bytes]:
+            yield b"reads"
+
+        key = sample_file_key(str(sample_id), "reads_1.fq.gz")
+        await memory_storage.write(key, _content())
+
+        await data_layer.samples.delete(sample_id)
+
+        assert await get_row_by_id(pg, SQLLegacySample, sample_id) is None
+
+        remaining = [
+            obj.key async for obj in memory_storage.list(sample_prefix(str(sample_id)))
+        ]
+        assert remaining == []

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -39,7 +39,6 @@ from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import (
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
-    resolve_legacy_id,
 )
 from virtool.data.transforms import apply_transforms
 from virtool.indexes.db import get_current_id_and_version
@@ -74,6 +73,7 @@ FIND_COLUMNS = (
     SQLAnalysis.sample,
     SQLAnalysis.sample_id,
     SQLAnalysis.reference,
+    SQLAnalysis.reference_id,
     SQLAnalysis.index,
     SQLAnalysis.user_id,
     SQLAnalysis.job_id,
@@ -93,6 +93,10 @@ def _row_to_document(row, *, include_results: bool) -> dict:
     internal consumers (storage keys, Mongo dual-writes, and string-keyed SQL tables
     such as ``analysis_files`` and ``nuvs_blast``) that have not yet been migrated off
     the slug.
+
+    The nested reference is keyed by the integer ``reference_id`` foreign key, falling
+    back to the legacy ``reference`` string on rows the backfill has not reached.
+    ``AttachReferenceTransform`` resolves either form.
     """
     document = {
         "_id": row.id,
@@ -102,7 +106,9 @@ def _row_to_document(row, *, include_results: bool) -> dict:
         "workflow": row.workflow,
         "ready": row.ready,
         "sample": {"id": row.sample_id},
-        "reference": {"id": row.reference},
+        "reference": {
+            "id": row.reference_id if row.reference_id is not None else row.reference,
+        },
         "index": {"id": row.index},
         "user": {"id": row.user_id},
         "job": {"id": row.job_id} if row.job_id else None,
@@ -327,14 +333,18 @@ class AnalysisData(DataLayerDomain):
 
             sample_pg_id, sample_legacy_id = sample_row
 
-            reference_pg_id = await resolve_legacy_id(
-                session,
-                SQLReference,
-                data.ref_id,
-            )
+            reference_row = (
+                await session.execute(
+                    select(SQLReference.id, SQLReference.legacy_id).where(
+                        compose_legacy_id_single_expression(SQLReference, data.ref_id),
+                    ),
+                )
+            ).one_or_none()
 
-            if reference_pg_id is None:
+            if reference_row is None:
                 raise ResourceConflictError("Reference does not exist")
+
+            reference_pg_id, reference_legacy_id = reference_row
 
             pg_id = (
                 await session.execute(
@@ -348,7 +358,7 @@ class AnalysisData(DataLayerDomain):
                         results=None,
                         sample=sample_legacy_id or str(sample_pg_id),
                         sample_id=sample_pg_id,
-                        reference=data.ref_id,
+                        reference=reference_legacy_id or str(reference_pg_id),
                         reference_id=reference_pg_id,
                         index=index_id,
                         user_id=user_id,

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -418,7 +418,7 @@ async def find(
     pg: AsyncEngine,
     page: int,
     per_page: int,
-    reference_id: str | None = None,
+    reference_id: int | str | None = None,
     unbuilt: bool | None = None,
 ) -> dict:
     """List history changes from the ``legacy_history`` table.
@@ -567,7 +567,7 @@ async def find_by_index(
 
 async def get_contributors(
     pg: AsyncEngine,
-    reference_id: str | None = None,
+    reference_id: int | str | None = None,
     index_id: str | None = None,
 ) -> list[dict]:
     """Return a list of contributors and their contribution count for a set of history.

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -43,7 +43,10 @@ from virtool.references.db import (
 )
 from virtool.references.models import ReferenceNested
 from virtool.references.sql import SQLReference
-from virtool.references.transforms import AttachReferenceTransform
+from virtool.references.transforms import (
+    AttachReferenceTransform,
+    shape_nested_reference,
+)
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.protocol import StorageBackend
@@ -192,7 +195,7 @@ class IndexData:
         if row is None:
             raise ResourceNotFoundError
 
-        return ReferenceNested(id=row.id, data_type="genome", name=row.name)
+        return ReferenceNested(**shape_nested_reference(row.id, row.name))
 
     async def get_otus_json(
         self,

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -17,7 +17,10 @@ from virtool.data.errors import (
     ResourceNotFoundError,
 )
 from virtool.data.events import Operation, emit, emits
-from virtool.data.topg import retry_both_transactions
+from virtool.data.topg import (
+    compose_legacy_id_single_expression,
+    retry_both_transactions,
+)
 from virtool.data.transforms import apply_transforms
 from virtool.history.models import HistorySearchResult
 from virtool.history.sql import SQLLegacyHistory
@@ -39,6 +42,7 @@ from virtool.references.db import (
     resolve_reference_legacy_id,
 )
 from virtool.references.models import ReferenceNested
+from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.errors import StorageKeyNotFoundError
@@ -170,20 +174,25 @@ class IndexData:
             index_id,
         )
 
-        if reference_field and (
-            reference := await self._mongo.references.find_one(
-                {
-                    "_id": await resolve_reference_legacy_id(
-                        self._pg,
-                        reference_field["id"],
-                    ),
-                },
-                ["data_type", "name"],
-            )
-        ):
-            return ReferenceNested(**reference)
+        if not reference_field:
+            raise ResourceNotFoundError
 
-        raise ResourceNotFoundError
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLReference.id, SQLReference.name).where(
+                        compose_legacy_id_single_expression(
+                            SQLReference,
+                            reference_field["id"],
+                        ),
+                    ),
+                )
+            ).first()
+
+        if row is None:
+            raise ResourceNotFoundError
+
+        return ReferenceNested(id=row.id, data_type="genome", name=row.name)
 
     async def get_otus_json(
         self,

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -131,7 +131,7 @@ class ReferencesView(PydanticView):
 @routes.view("/references/v1/{ref_id}")
 @routes.jobs_api.get("/references/v1/{ref_id}")
 class ReferenceView(PydanticView):
-    async def get(self, ref_id: str, /) -> r200[Reference] | r403 | r404:
+    async def get(self, ref_id: int | str, /) -> r200[Reference] | r403 | r404:
         """Get a reference.
 
         Fetches the details of a reference.
@@ -151,7 +151,7 @@ class ReferenceView(PydanticView):
 
     async def patch(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         data: UpdateReferenceRequest,
     ) -> r200[Reference] | r403 | r404:
@@ -186,7 +186,7 @@ class ReferenceView(PydanticView):
 
 @routes.view("/references/v1/{ref_id}/archive")
 class ReferenceArchiveView(PydanticView):
-    async def post(self, ref_id: str, /) -> r200[Reference] | r403 | r404 | r409:
+    async def post(self, ref_id: int | str, /) -> r200[Reference] | r403 | r404 | r409:
         """Archive a reference.
 
         Marks a reference as archived. Archiving the official plant viruses
@@ -218,7 +218,7 @@ class ReferenceArchiveView(PydanticView):
 
 @routes.view("/references/v1/{ref_id}/unarchive")
 class ReferenceUnarchiveView(PydanticView):
-    async def post(self, ref_id: str, /) -> r200[Reference] | r403 | r404:
+    async def post(self, ref_id: int | str, /) -> r200[Reference] | r403 | r404:
         """Unarchive a reference.
 
         Marks a reference as not archived.
@@ -248,7 +248,7 @@ class ReferenceUnarchiveView(PydanticView):
 class ReferenceOTUsView(PydanticView):
     async def get(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         find: str | None,
         verified: bool | None,
@@ -278,7 +278,7 @@ class ReferenceOTUsView(PydanticView):
 
     async def post(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         data: CreateOTURequest,
     ) -> r201[OTU] | r400 | r403 | r404:
@@ -316,7 +316,7 @@ class ReferenceOTUsView(PydanticView):
 class ReferenceHistoryView(PydanticView):
     async def get(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         unbuilt: bool | None = Field(
             default=None,
@@ -351,7 +351,7 @@ class ReferenceHistoryView(PydanticView):
 class ReferenceIndexesView(PydanticView):
     async def get(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         page: Page = 1,
         per_page: PerPage = 25,
@@ -378,7 +378,7 @@ class ReferenceIndexesView(PydanticView):
 
     async def post(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
     ) -> r201[IndexMinimal] | r403 | r404:
         """Create an index.
@@ -416,7 +416,7 @@ class ReferenceIndexesView(PydanticView):
 
 @routes.view("/references/v1/{ref_id}/groups")
 class ReferenceGroupsView(PydanticView):
-    async def get(self, ref_id: str, /) -> r200[ReferenceGroup] | r404:
+    async def get(self, ref_id: int | str, /) -> r200[ReferenceGroup] | r404:
         """List groups.
 
         Lists all groups that have access to the reference.
@@ -436,7 +436,7 @@ class ReferenceGroupsView(PydanticView):
 
     async def post(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         data: CreateReferenceGroupRequest,
     ) -> r201[ReferenceGroup] | r400 | r403 | r404:
@@ -471,7 +471,7 @@ class ReferenceGroupsView(PydanticView):
 class ReferenceGroupView(PydanticView):
     async def get(
         self,
-        ref_id: str,
+        ref_id: int | str,
         group_id: int | str,
         /,
     ) -> r200[ReferenceGroup] | r404:
@@ -495,7 +495,7 @@ class ReferenceGroupView(PydanticView):
 
     async def patch(
         self,
-        ref_id: str,
+        ref_id: int | str,
         group_id: int | str,
         /,
         data: ReferenceRightsRequest,
@@ -530,7 +530,9 @@ class ReferenceGroupView(PydanticView):
 
         return json_response(group)
 
-    async def delete(self, ref_id: str, group_id: int | str, /) -> r204 | r403 | r404:
+    async def delete(
+        self, ref_id: int | str, group_id: int | str, /
+    ) -> r204 | r403 | r404:
         """Delete a group.
 
         Deletes a group from the reference.
@@ -565,7 +567,7 @@ class ReferenceGroupView(PydanticView):
 class ReferenceUsersView(PydanticView):
     async def post(
         self,
-        ref_id: str,
+        ref_id: int | str,
         /,
         data: CreateReferenceUserRequest,
     ) -> r201[list[ReferenceUser]] | r400 | r403 | r404:
@@ -611,7 +613,7 @@ class ReferenceUsersView(PydanticView):
 class ReferenceUserView(PydanticView):
     async def patch(
         self,
-        ref_id: str,
+        ref_id: int | str,
         user_id: int,
         /,
         data: ReferenceRightsRequest,
@@ -646,7 +648,7 @@ class ReferenceUserView(PydanticView):
 
         return json_response(user)
 
-    async def delete(self, ref_id: str, user_id: int, /) -> r204 | r403 | r404:
+    async def delete(self, ref_id: int | str, user_id: int, /) -> r204 | r403 | r404:
         """Remove a user.
 
         Removes a user from the reference.

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -120,16 +120,76 @@ class ReferencesData(DataLayerDomain):
         self._client = client
         self._storage = storage
 
-    async def _require_not_archived(self, ref_id: str) -> None:
-        document = await self._mongo.references.find_one(
-            {"_id": ref_id},
-            {"archived": 1},
-        )
+    async def _resolve_legacy_id(self, ref_id: int | str) -> str:
+        """Resolve a public reference id to the Mongo ``_id`` of its document.
 
-        if document is None:
+        The public identifier is the Postgres primary key, but the ``references``
+        collection is still keyed by the legacy string id while the dual-write is in
+        place. Every Mongo access in this domain resolves through here.
+
+        :param ref_id: the primary key or legacy id of the reference
+        :return: the legacy id of the reference
+        """
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLReference.id, SQLReference.legacy_id).where(
+                        compose_legacy_id_single_expression(SQLReference, ref_id),
+                    ),
+                )
+            ).first()
+
+        if row is None:
             raise ResourceNotFoundError()
 
-        if document.get("archived"):
+        if row.legacy_id is None:
+            raise ValueError(f"Reference {row.id} has no legacy id")
+
+        return row.legacy_id
+
+    async def _require_exists(self, ref_id: int | str | None) -> None:
+        """Raise ``ResourceNotFoundError`` unless a reference exists.
+
+        A ``None`` id never matches. Passing it to the legacy id expression would
+        otherwise match any Postgres-native reference, whose ``legacy_id`` is ``NULL``.
+
+        :param ref_id: the primary key or legacy id of the reference
+        """
+        if ref_id is None:
+            raise ResourceNotFoundError()
+
+        async with AsyncSession(self._pg) as session:
+            reference_pk = await session.scalar(
+                select(SQLReference.id).where(
+                    compose_legacy_id_single_expression(SQLReference, ref_id),
+                ),
+            )
+
+        if reference_pk is None:
+            raise ResourceNotFoundError()
+
+    async def _get_archived(self, ref_id: int | str) -> bool:
+        """Return the ``archived`` flag of a reference.
+
+        :param ref_id: the primary key or legacy id of the reference
+        :return: whether the reference is archived
+        """
+        async with AsyncSession(self._pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLReference.archived).where(
+                        compose_legacy_id_single_expression(SQLReference, ref_id),
+                    ),
+                )
+            ).first()
+
+        if row is None:
+            raise ResourceNotFoundError()
+
+        return row.archived
+
+    async def _require_not_archived(self, ref_id: int | str) -> None:
+        if await self._get_archived(ref_id):
             raise ResourceConflictError("Reference is archived")
 
     async def _extend_user(self, user: Document) -> Document:
@@ -297,18 +357,18 @@ class ReferencesData(DataLayerDomain):
         settings = await self.data.settings.get_all()
 
         if data.clone_from:
-            if not await self._mongo.references.count_documents(
-                {"_id": data.clone_from},
-            ):
-                raise ResourceNotFoundError("Source reference does not exist")
+            try:
+                clone_from = await self._resolve_legacy_id(data.clone_from)
+            except ResourceNotFoundError:
+                raise ResourceNotFoundError("Source reference does not exist") from None
 
-            manifest = await get_manifest(self._mongo, self._pg, data.clone_from)
+            manifest = await get_manifest(self._mongo, self._pg, clone_from)
 
             document = await virtool.references.db.create_clone(
                 self._mongo,
                 settings,
                 data.name,
-                data.clone_from,
+                clone_from,
                 data.description,
                 user_id,
             )
@@ -429,7 +489,7 @@ class ReferencesData(DataLayerDomain):
             ),
         )
 
-    async def get(self, ref_id: str) -> Reference:
+    async def get(self, ref_id: int | str) -> Reference:
         """Get a reference."""
         async with AsyncSession(self._pg) as session:
             row = (
@@ -453,12 +513,12 @@ class ReferencesData(DataLayerDomain):
             users,
             unbuilt_count,
         ) = await asyncio.gather(
-            get_contributors(self._pg, row.legacy_id),
-            get_latest_build(self._mongo, self._pg, row.legacy_id),
-            get_otu_count(self._mongo, self._pg, row.legacy_id),
+            get_contributors(self._pg, row.id),
+            get_latest_build(self._mongo, self._pg, row.id),
+            get_otu_count(self._mongo, self._pg, row.id),
             get_reference_groups(self._pg, row.id, row.created_at),
             get_reference_users(self._pg, row.id, row.created_at),
-            get_unbuilt_count(self._pg, row.legacy_id),
+            get_unbuilt_count(self._pg, row.id),
         )
 
         document = {
@@ -489,14 +549,13 @@ class ReferencesData(DataLayerDomain):
         return Reference(**document)
 
     @emits(Operation.UPDATE)
-    async def update(self, ref_id: str, data: UpdateReferenceRequest) -> Reference:
+    async def update(
+        self, ref_id: int | str, data: UpdateReferenceRequest
+    ) -> Reference:
         """Update a reference."""
         await self._require_not_archived(ref_id)
 
-        document = await self._mongo.references.find_one(ref_id)
-
-        if document is None:
-            raise ResourceNotFoundError()
+        legacy_id = await self._resolve_legacy_id(ref_id)
 
         data = data.dict(exclude_unset=True)
 
@@ -507,7 +566,7 @@ class ReferencesData(DataLayerDomain):
             pg_session,
         ):
             await self._mongo.references.update_one(
-                {"_id": ref_id},
+                {"_id": legacy_id},
                 {"$set": data},
                 session=mongo_session,
             )
@@ -515,56 +574,44 @@ class ReferencesData(DataLayerDomain):
             if scalars:
                 await pg_session.execute(
                     update(SQLReference)
-                    .where(SQLReference.legacy_id == ref_id)
+                    .where(SQLReference.legacy_id == legacy_id)
                     .values(**scalars),
                 )
 
         return await self.get(ref_id)
 
-    async def _set_archived(self, ref_id: str, archived: bool) -> None:
-        """Dual-write the ``archived`` flag for a reference.
+    async def _set_archived(self, ref_id: int | str, archived: bool) -> None:
+        """Dual-write the ``archived`` flag for a reference."""
+        legacy_id = await self._resolve_legacy_id(ref_id)
 
-        The Postgres statement matches by ``legacy_id`` and is a no-op when the
-        reference has no Postgres row yet, leaving it for the backfill to create.
-        """
         async with both_transactions(self._mongo, self._pg) as (
             mongo_session,
             pg_session,
         ):
             await self._mongo.references.update_one(
-                {"_id": ref_id},
+                {"_id": legacy_id},
                 {"$set": {"archived": archived}},
                 session=mongo_session,
             )
 
             await pg_session.execute(
                 update(SQLReference)
-                .where(SQLReference.legacy_id == ref_id)
+                .where(SQLReference.legacy_id == legacy_id)
                 .values(archived=archived),
             )
 
     @emits(Operation.UPDATE)
-    async def archive(self, ref_id: str) -> Reference:
+    async def archive(self, ref_id: int | str) -> Reference:
         """Archive a reference."""
-        document = await self._mongo.references.find_one(ref_id)
-
-        if document is None:
-            raise ResourceNotFoundError()
-
-        if not document.get("archived", False):
+        if not await self._get_archived(ref_id):
             await self._set_archived(ref_id, True)
 
         return await self.get(ref_id)
 
     @emits(Operation.UPDATE)
-    async def unarchive(self, ref_id: str) -> Reference:
+    async def unarchive(self, ref_id: int | str) -> Reference:
         """Unarchive a reference."""
-        document = await self._mongo.references.find_one(ref_id)
-
-        if document is None:
-            raise ResourceNotFoundError()
-
-        if document.get("archived", False):
+        if await self._get_archived(ref_id):
             await self._set_archived(ref_id, False)
 
         return await self.get(ref_id)
@@ -573,29 +620,28 @@ class ReferencesData(DataLayerDomain):
         self,
         term: str | None,
         verified: bool | None,
-        ref_id: str | None,
+        ref_id: int | str | None,
         page: int,
         per_page: int,
     ) -> OTUSearchResult:
-        if await virtool.mongo.utils.id_exists(self._mongo.references, ref_id):
-            data = await virtool.otus.db.find(
-                self._mongo,
-                self._pg,
-                term,
-                page,
-                per_page,
-                verified,
-                ref_id,
-            )
+        await self._require_exists(ref_id)
 
-            return OTUSearchResult(**data)
+        data = await virtool.otus.db.find(
+            self._mongo,
+            self._pg,
+            term,
+            page,
+            per_page,
+            verified,
+            ref_id,
+        )
 
-        raise ResourceNotFoundError()
+        return OTUSearchResult(**data)
 
     @emits(Operation.CREATE, domain="otus", name="create")
     async def create_otu(
         self,
-        ref_id: str,
+        ref_id: int | str,
         data: CreateOTURequest,
         user_id: int,
     ) -> OTU:
@@ -618,13 +664,12 @@ class ReferencesData(DataLayerDomain):
 
     async def find_history(
         self,
-        ref_id: str,
+        ref_id: int | str,
         unbuilt: bool | None,
         page: int,
         per_page: int,
     ) -> HistorySearchResult:
-        if not await self._mongo.references.count_documents({"_id": ref_id}):
-            raise ResourceNotFoundError()
+        await self._require_exists(ref_id)
 
         data = await virtool.history.db.find(
             self._mongo,
@@ -638,10 +683,9 @@ class ReferencesData(DataLayerDomain):
         return HistorySearchResult(**data)
 
     async def find_indexes(
-        self, ref_id: str, page: int, per_page: int
+        self, ref_id: int | str, page: int, per_page: int
     ) -> IndexSearchResult:
-        if not await virtool.mongo.utils.id_exists(self._mongo.references, ref_id):
-            raise ResourceNotFoundError()
+        await self._require_exists(ref_id)
 
         data = await virtool.indexes.db.find(
             self._mongo, self._pg, page, per_page, ref_id=ref_id
@@ -771,7 +815,9 @@ class ReferencesData(DataLayerDomain):
         :param data: the creation request data
         :return: the new reference griyo
         """
-        document = await self._mongo.references.find_one(ref_id, ["groups"])
+        legacy_id = await self._resolve_legacy_id(ref_id)
+
+        document = await self._mongo.references.find_one(legacy_id, ["groups"])
 
         if document is None:
             raise ResourceNotFoundError()
@@ -805,7 +851,7 @@ class ReferencesData(DataLayerDomain):
             pg_session,
         ):
             await self._mongo.references.update_one(
-                {"_id": ref_id},
+                {"_id": legacy_id},
                 {"$push": {"groups": reference_group}},
                 session=mongo_session,
             )
@@ -851,8 +897,10 @@ class ReferencesData(DataLayerDomain):
         group_id: int | str,
         data: ReferenceRightsRequest,
     ) -> ReferenceGroup:
+        legacy_id = await self._resolve_legacy_id(ref_id)
+
         document = await self._mongo.references.find_one(
-            {"_id": ref_id, "groups.id": group_id},
+            {"_id": legacy_id, "groups.id": group_id},
             ["groups", "users"],
         )
 
@@ -884,7 +932,7 @@ class ReferencesData(DataLayerDomain):
                     pg_session,
                 ):
                     await self._mongo.references.update_one(
-                        {"_id": ref_id},
+                        {"_id": legacy_id},
                         {"$set": {"groups": document["groups"]}},
                         session=mongo_session,
                     )
@@ -920,8 +968,10 @@ class ReferencesData(DataLayerDomain):
         raise ResourceNotFoundError()
 
     async def delete_group(self, ref_id: str, group_id: int | str) -> None:
+        legacy_id = await self._resolve_legacy_id(ref_id)
+
         document = await self._mongo.references.find_one(
-            {"_id": ref_id, "groups.id": group_id},
+            {"_id": legacy_id, "groups.id": group_id},
             ["groups", "users"],
         )
 
@@ -942,7 +992,7 @@ class ReferencesData(DataLayerDomain):
             pg_session,
         ):
             await self._mongo.references.update_one(
-                {"_id": ref_id},
+                {"_id": legacy_id},
                 {
                     "$set": {
                         "groups": [
@@ -978,7 +1028,9 @@ class ReferencesData(DataLayerDomain):
         :param data: the request data
         :param ref_id: the id of the reference
         """
-        document = await self._mongo.references.find_one({"_id": ref_id}, ["users"])
+        legacy_id = await self._resolve_legacy_id(ref_id)
+
+        document = await self._mongo.references.find_one({"_id": legacy_id}, ["users"])
 
         if not document:
             raise ResourceNotFoundError()
@@ -1013,7 +1065,7 @@ class ReferencesData(DataLayerDomain):
             pg_session,
         ):
             await self._mongo.references.update_one(
-                {"_id": ref_id},
+                {"_id": legacy_id},
                 {"$push": {"users": reference_user}},
                 session=mongo_session,
             )
@@ -1041,8 +1093,10 @@ class ReferencesData(DataLayerDomain):
         data: ReferenceRightsRequest,
     ) -> ReferenceUser:
         """Update a reference user."""
+        legacy_id = await self._resolve_legacy_id(ref_id)
+
         document = await self._mongo.references.find_one(
-            {"_id": ref_id, "users.id": user_id},
+            {"_id": legacy_id, "users.id": user_id},
             ["users"],
         )
 
@@ -1062,7 +1116,7 @@ class ReferencesData(DataLayerDomain):
                     pg_session,
                 ):
                     await self._mongo.references.update_one(
-                        {"_id": ref_id},
+                        {"_id": legacy_id},
                         {"$set": {"users": document["users"]}},
                         session=mongo_session,
                     )
@@ -1097,8 +1151,10 @@ class ReferencesData(DataLayerDomain):
         :param user_id: the id of the user to delete
 
         """
+        legacy_id = await self._resolve_legacy_id(ref_id)
+
         document = await self._mongo.references.find_one(
-            {"_id": ref_id, "users.id": user_id},
+            {"_id": legacy_id, "users.id": user_id},
             ["groups", "users"],
         )
 
@@ -1112,7 +1168,7 @@ class ReferencesData(DataLayerDomain):
             pg_session,
         ):
             await self._mongo.references.update_one(
-                {"_id": ref_id},
+                {"_id": legacy_id},
                 {"$set": {"users": filtered_users}},
                 session=mongo_session,
             )

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -143,7 +143,7 @@ class ReferencesData(DataLayerDomain):
             raise ResourceNotFoundError()
 
         if row.legacy_id is None:
-            raise ValueError(f"Reference {row.id} has no legacy id")
+            raise ResourceNotFoundError()
 
         return row.legacy_id
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -159,15 +159,12 @@ def map_reference_minimal(
     ``AttachImportedFromTransform`` transforms expect. ``cloned_from`` is resolved by
     the caller via :func:`get_cloned_from_lookup`.
 
-    The public ``id`` remains the legacy Mongo string id for this migration step; the
-    integer primary key cutover happens later.
-
     :param row: a ``legacy_references`` row
     :param cloned_from: the resolved nested cloned-from doc, or ``None``
     :return: the base reference document
     """
     return {
-        "id": row.legacy_id,
+        "id": row.id,
         "name": row.name,
         "organism": row.organism,
         "created_at": row.created_at,
@@ -187,9 +184,7 @@ async def get_cloned_from_lookup(
     """Map each source ``cloned_from_id`` in ``rows`` to its nested cloned-from doc.
 
     The denormalized ``cloned_from.name`` snapshot is not stored in Postgres; the
-    source reference's current ``name`` is re-derived here via its primary key. The
-    nested ``id`` remains the source's legacy Mongo string id, matching the
-    pre-migration response shape.
+    source reference's current ``name`` is re-derived here via its primary key.
 
     :param session: an active Postgres session
     :param rows: the reference rows whose ``cloned_from`` docs are needed
@@ -201,12 +196,12 @@ async def get_cloned_from_lookup(
         return {}
 
     result = await session.execute(
-        select(SQLReference.id, SQLReference.legacy_id, SQLReference.name).where(
+        select(SQLReference.id, SQLReference.name).where(
             SQLReference.id.in_(source_ids),
         ),
     )
 
-    return {id_: {"id": legacy_id, "name": name} for id_, legacy_id, name in result}
+    return {id_: {"id": id_, "name": name} for id_, name in result}
 
 
 async def processor(
@@ -223,12 +218,10 @@ async def processor(
     :param cloned_from: the resolved nested cloned-from doc, or ``None``
     :return: the processed document
     """
-    ref_id = row.legacy_id
-
     latest_build, otu_count, unbuilt_count = await asyncio.gather(
-        get_latest_build(mongo, pg, ref_id),
-        get_otu_count(mongo, pg, ref_id),
-        get_unbuilt_count(pg, ref_id),
+        get_latest_build(mongo, pg, row.id),
+        get_otu_count(mongo, pg, row.id),
+        get_unbuilt_count(pg, row.id),
     )
 
     return {
@@ -442,18 +435,14 @@ async def compose_reference_ids_match(
     are included for every matching reference. This backs the orphan and lifecycle
     filters on the index list, which scope indexes to references that still exist.
 
-    References with no ``legacy_id`` are excluded. ``legacy_id`` remains the public
-    reference identifier until the integer primary key becomes canonical, so a
-    Postgres-native reference cannot yet be shaped into a ``ReferenceNested``. Drop
-    this constraint when the public identifier flips.
+    A Postgres-native reference has no ``legacy_id``; only its primary key is
+    contributed to the match.
 
     :param pg: the application PostgreSQL engine
     :param archived: lifecycle filter mode
     :return: a Mongo ``$in`` match value covering both id forms
     """
-    query = select(SQLReference.id, SQLReference.legacy_id).where(
-        SQLReference.legacy_id.is_not(None),
-    )
+    query = select(SQLReference.id, SQLReference.legacy_id)
 
     if archived is not None:
         query = query.where(SQLReference.archived == archived)
@@ -461,10 +450,10 @@ async def compose_reference_ids_match(
     async with AsyncSession(pg) as session:
         rows = (await session.execute(query)).all()
 
-    return {"$in": [value for row in rows for value in row]}
+    return {"$in": [value for row in rows for value in row if value is not None]}
 
 
-async def get_contributors(pg, ref_id: str) -> list[Document] | None:
+async def get_contributors(pg, ref_id: int | str) -> list[Document] | None:
     """Return a list of contributors and their contribution count for a specific ref.
 
     :param pg: the PostgreSQL engine
@@ -476,7 +465,7 @@ async def get_contributors(pg, ref_id: str) -> list[Document] | None:
 
 
 async def get_latest_build(
-    mongo: "Mongo", pg: AsyncEngine, ref_id: str
+    mongo: "Mongo", pg: AsyncEngine, ref_id: int | str
 ) -> Document | None:
     """Return the latest index build for the ref.
 
@@ -503,7 +492,7 @@ async def get_latest_build(
         )
 
 
-async def get_manifest(mongo: "Mongo", pg: AsyncEngine, ref_id: str) -> Document:
+async def get_manifest(mongo: "Mongo", pg: AsyncEngine, ref_id: int | str) -> Document:
     """Generate a dict of otu document version numbers keyed by the document id.
 
     This is used to make sure only changes made at the time the index rebuild was
@@ -524,7 +513,7 @@ async def get_manifest(mongo: "Mongo", pg: AsyncEngine, ref_id: str) -> Document
     }
 
 
-async def get_otu_count(mongo: "Mongo", pg: AsyncEngine, ref_id: str) -> int:
+async def get_otu_count(mongo: "Mongo", pg: AsyncEngine, ref_id: int | str) -> int:
     """Get the number of OTUs associated with the given `ref_id`.
 
     :param mongo: the application database client
@@ -538,7 +527,7 @@ async def get_otu_count(mongo: "Mongo", pg: AsyncEngine, ref_id: str) -> int:
     )
 
 
-async def get_unbuilt_count(pg: AsyncEngine, ref_id: str) -> int:
+async def get_unbuilt_count(pg: AsyncEngine, ref_id: int | str) -> int:
     """Return a count of unbuilt history changes associated with a given `ref_id`.
 
     :param pg: the application PostgreSQL database object

--- a/virtool/references/models.py
+++ b/virtool/references/models.py
@@ -8,7 +8,7 @@ from virtool.users.models_base import UserNested
 
 
 class ReferenceClonedFrom(BaseModel):
-    id: str
+    id: int
     name: str
 
 
@@ -61,7 +61,7 @@ class ReferenceBuild(BaseModel):
 
 
 class ReferenceNested(BaseModel):
-    id: str
+    id: int
     data_type: ReferenceDataType
     name: str
 
@@ -91,7 +91,7 @@ class Reference(ReferenceMinimal):
         schema_extra = {
             "example": {
                 "archived": False,
-                "cloned_from": {"id": "pat6xdn3", "name": "Plant Viruses"},
+                "cloned_from": {"id": 12, "name": "Plant Viruses"},
                 "contributors": [
                     {
                         "administrator": True,
@@ -130,7 +130,7 @@ class Reference(ReferenceMinimal):
                         "modify_otu": False,
                     },
                 ],
-                "id": "d19exr83",
+                "id": 25,
                 "latest_build": {
                     "created_at": "2022-07-05T17:41:51.857000Z",
                     "has_json": False,
@@ -173,7 +173,7 @@ class ReferenceSearchResult(SearchResult):
                 "documents": [
                     {
                         "archived": False,
-                        "cloned_from": {"id": "pat6xdn3", "name": "Plant Viruses"},
+                        "cloned_from": {"id": 12, "name": "Plant Viruses"},
                         "created_at": "2022-01-28T23:42:48.321000Z",
                         "data_type": "genome",
                         "groups": [
@@ -185,7 +185,7 @@ class ReferenceSearchResult(SearchResult):
                                 "modify_otu": False,
                             },
                         ],
-                        "id": "d19exr83",
+                        "id": 25,
                         "latest_build": {
                             "created_at": "2022-07-05T17:41:51.857000Z",
                             "has_json": False,

--- a/virtool/references/oas.py
+++ b/virtool/references/oas.py
@@ -25,7 +25,7 @@ class CreateReferenceRequest(BaseModel):
     )
     data_type: str = Field(default="genome", description="the sequence data type")
     organism: str = Field(default="", description="the organism")
-    clone_from: str | None = Field(
+    clone_from: int | str | None = Field(
         description="a valid ref_id that the new reference should be cloned from",
     )
     import_from: int | None = Field(

--- a/virtool/references/transforms.py
+++ b/virtool/references/transforms.py
@@ -20,13 +20,13 @@ if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
 
 
-def _shape_nested_reference(legacy_id: str, name: str) -> Document:
+def _shape_nested_reference(id_: int, name: str) -> Document:
     """Shape a ``legacy_references`` row into a nested reference doc.
 
     ``data_type`` is emitted as the constant ``"genome"`` because the column is
-    dropped from Postgres. The nested ``id`` remains the legacy Mongo string id.
+    dropped from Postgres.
     """
-    return {"id": legacy_id, "data_type": "genome", "name": name}
+    return {"id": id_, "data_type": "genome", "name": name}
 
 
 class AttachReferenceTransform(AbstractTransform):
@@ -53,7 +53,7 @@ class AttachReferenceTransform(AbstractTransform):
 
         row = (
             await session.execute(
-                select(SQLReference.legacy_id, SQLReference.name).where(
+                select(SQLReference.id, SQLReference.name).where(
                     compose_legacy_id_single_expression(SQLReference, reference_id),
                 ),
             )
@@ -62,7 +62,7 @@ class AttachReferenceTransform(AbstractTransform):
         if row is None:
             raise ValueError(f"Reference {reference_id!r} not found in postgres")
 
-        return _shape_nested_reference(row.legacy_id, row.name)
+        return _shape_nested_reference(row.id, row.name)
 
     async def prepare_many(
         self,
@@ -92,7 +92,7 @@ class AttachReferenceTransform(AbstractTransform):
         reference_lookup: dict[int | str, Document] = {}
 
         for row in rows:
-            shaped = _shape_nested_reference(row.legacy_id, row.name)
+            shaped = _shape_nested_reference(row.id, row.name)
             reference_lookup[row.id] = shaped
 
             if row.legacy_id is not None:

--- a/virtool/references/transforms.py
+++ b/virtool/references/transforms.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
 
 
-def _shape_nested_reference(id_: int, name: str) -> Document:
+def shape_nested_reference(id_: int, name: str) -> Document:
     """Shape a ``legacy_references`` row into a nested reference doc.
 
     ``data_type`` is emitted as the constant ``"genome"`` because the column is
@@ -62,7 +62,7 @@ class AttachReferenceTransform(AbstractTransform):
         if row is None:
             raise ValueError(f"Reference {reference_id!r} not found in postgres")
 
-        return _shape_nested_reference(row.id, row.name)
+        return shape_nested_reference(row.id, row.name)
 
     async def prepare_many(
         self,
@@ -92,7 +92,7 @@ class AttachReferenceTransform(AbstractTransform):
         reference_lookup: dict[int | str, Document] = {}
 
         for row in rows:
-            shaped = _shape_nested_reference(row.id, row.name)
+            shaped = shape_nested_reference(row.id, row.name)
             reference_lookup[row.id] = shaped
 
             if row.legacy_id is not None:

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -45,6 +45,7 @@ from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_new_id, get_one_field
 from virtool.pg.utils import delete_row
 from virtool.references.db import compose_reference_id_match
+from virtool.references.sql import SQLReference
 from virtool.samples.checks import (
     check_labels_do_not_exist,
     check_name_is_in_use,
@@ -1037,15 +1038,19 @@ class SamplesData(DataLayerDomain):
         :param ref_id: the reference id
         :param subtractions: list of subtractions
         """
-        reference = await self._mongo.references.find_one(
-            {"_id": ref_id},
-            ["archived"],
-        )
+        async with AsyncSession(self._pg) as session:
+            reference = (
+                await session.execute(
+                    select(SQLReference.archived).where(
+                        compose_legacy_id_single_expression(SQLReference, ref_id),
+                    ),
+                )
+            ).first()
 
         if reference is None:
             raise ResourceConflictError("Reference does not exist")
 
-        if reference.get("archived"):
+        if reference.archived:
             raise ResourceConflictError("Reference is archived")
 
         if not await self._mongo.indexes.count_documents(

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -677,13 +677,18 @@ class SamplesData(DataLayerDomain):
                     ),
                 ),
             )
-            await pg_session.execute(
+            sql_result = await pg_session.execute(
                 delete(SQLLegacySample).where(
                     SQLLegacySample.id == sample_pk,
                 ),
             )
 
-        if result.deleted_count:
+        if legacy_id is None:
+            deleted = sql_result.rowcount > 0
+        else:
+            deleted = result.deleted_count > 0
+
+        if deleted:
             for key, exc in await delete_prefix(
                 self._storage, sample_prefix(sample_storage_id(sample_pk, legacy_id))
             ):

--- a/virtool/samples/db.py
+++ b/virtool/samples/db.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     not_,
     or_,
     select,
+    true,
 )
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from yarl import URL
@@ -25,6 +26,7 @@ from virtool.data.topg import (
 )
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.groups.pg import SQLGroup
+from virtool.models.roles import AdministratorRole
 from virtool.samples.sql import (
     SQLLegacySample,
     SQLSampleArtifact,
@@ -235,8 +237,12 @@ def compose_sample_rights_filter(client) -> ColumnExpressionArgument[bool]:
     """Compose the Postgres predicate scoping samples to those ``client`` can read.
 
     The requesting user owns the sample, the sample is world-readable, or the sample is
-    readable by a group the user belongs to.
+    readable by a group the user belongs to. A full administrator sees every sample,
+    matching the single-resource bypass in :func:`has_sample_right`.
     """
+    if client.administrator_role == AdministratorRole.FULL:
+        return true()
+
     rights_filter = [
         SQLLegacySample.all_read.is_(True),
         SQLLegacySample.user_id == client.user_id,

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -38,9 +38,13 @@ def has_sample_right(
     ``row`` must carry the columns in :data:`SAMPLE_RIGHTS_COLUMNS`. Shared by the
     samples and analyses domains so a sample and the analyses on it never disagree
     about who may read or write them.
+
+    Full administrators, job-authenticated clients, and the sample's owner always
+    hold every right.
     """
     if (
         client.administrator_role == AdministratorRole.FULL
+        or client.is_job
         or client.user_id == row.user_id
     ):
         return True


### PR DESCRIPTION
## Summary
- References are identified by their Postgres primary key everywhere they appear — as the top-level resource id and in every nested reference — while the legacy string id is still accepted inbound.
- Analyses embed the reference by its integer foreign key rather than the legacy string column, and record that column's value correctly on create.
- The remaining reference reads in analyses, indexes and samples move off Mongo onto Postgres, resolving either id form.

Closes VIR-2591.