### PR TITLE
feat: read references only from postgres

### DIFF
--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -478,12 +478,6 @@
     }),
   ])
 # ---
-# name: test_finalize[404_reference]
-  dict({
-    'id': 'not_found',
-    'message': 'Not found',
-  })
-# ---
 # name: test_finalize[409_fasta]
   dict({
     'id': 'conflict',

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -854,7 +854,7 @@ async def test_upload(
         ).scalar() == snapshot
 
 
-@pytest.mark.parametrize("error", [None, "409_genome", "409_fasta", "404_reference"])
+@pytest.mark.parametrize("error", [None, "409_genome", "409_fasta"])
 async def test_finalize(
     error: str | None,
     fake: DataFaker,
@@ -878,28 +878,27 @@ async def test_finalize(
     else:
         files = INDEX_FILE_NAMES
 
-    if error != "404_reference":
-        await mongo.references.insert_one(
-            {
-                "_id": "hxn167",
-                "archived": False,
-                "data_type": "genome",
-                "name": "Test A",
-            },
-        )
+    await mongo.references.insert_one(
+        {
+            "_id": "hxn167",
+            "archived": False,
+            "data_type": "genome",
+            "name": "Test A",
+        },
+    )
 
-        async with AsyncSession(pg) as session:
-            session.add(
-                SQLReference(
-                    legacy_id="hxn167",
-                    name="Test A",
-                    description="",
-                    created_at=static_time.datetime,
-                    source_types=[],
-                    user_id=user.id,
-                ),
-            )
-            await session.commit()
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLReference(
+                legacy_id="hxn167",
+                name="Test A",
+                description="",
+                created_at=static_time.datetime,
+                source_types=[],
+                user_id=user.id,
+            ),
+        )
+        await session.commit()
 
     await asyncio.gather(
         mongo.indexes.insert_one(

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -1,8 +1,10 @@
 import asyncio
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from virtool.data.errors import ResourceError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
@@ -109,6 +111,37 @@ async def test_finalize(
 
     # Ensure document in database is correct.
     assert await mongo.indexes.find_one() == snapshot
+
+
+async def test_finalize_reference_missing_from_postgres(
+    data_layer: DataLayer,
+    fake: DataFaker,
+    mongo: Mongo,
+    static_time,
+):
+    """An index whose reference has no Postgres row is corrupt data, not a missing
+    resource.
+    """
+    user = await fake.users.create()
+    job = await fake.jobs.create(user=user)
+
+    await mongo.indexes.insert_one(
+        {
+            "_id": "foo",
+            "reference": {"id": "missing"},
+            "user": {"id": user.id},
+            "version": 2,
+            "created_at": static_time.datetime,
+            "job": {"id": job.id},
+            "has_files": True,
+            "manifest": {},
+        },
+    )
+
+    with pytest.raises(ResourceError, match="Could not find reference missing"):
+        await data_layer.index.finalize("foo")
+
+    assert await mongo.indexes.find_one("foo", ["ready"]) == {"_id": "foo"}
 
 
 class TestDelete:

--- a/tests/otus/test_data.py
+++ b/tests/otus/test_data.py
@@ -11,9 +11,11 @@ from asyncio import gather
 import pytest
 from syrupy import SnapshotAssertion
 
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.otus.oas import CreateOTURequest, UpdateOTURequest
+from virtool.references.oas import UpdateReferenceRequest
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
 
@@ -158,3 +160,154 @@ async def test_get_isolate_fasta(mongo, data_layer, test_otu, test_sequence):
         ">Prunus virus F|Isolate 8816-v2|abcd1234|27\nTGTTTAAGAGATTAAACAACCGCTTTC\n"
         ">Prunus virus F|Isolate 8816-v2|AX12345|12\nATAGAGGAGTTA",
     )
+
+
+class TestAddIsolateSourceType:
+    """The parent reference's source type configuration governs new isolates."""
+
+    async def _create_otu(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        *,
+        restrict_source_types: bool,
+        source_types: list[str],
+    ):
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        otu = await fake.otus.create_empty(reference.id, user)
+
+        await data_layer.references.update(
+            reference.id,
+            UpdateReferenceRequest(
+                restrict_source_types=restrict_source_types,
+                source_types=source_types,
+            ),
+        )
+
+        return otu, user
+
+    async def test_allowed_when_restricted(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        otu, user = await self._create_otu(
+            data_layer,
+            fake,
+            restrict_source_types=True,
+            source_types=["isolate", "strain"],
+        )
+
+        isolate = await data_layer.otus.add_isolate(otu.id, "Isolate", "8816", user.id)
+
+        assert isolate.source_type == "isolate"
+
+    async def test_disallowed_when_restricted(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        otu, user = await self._create_otu(
+            data_layer,
+            fake,
+            restrict_source_types=True,
+            source_types=["isolate", "strain"],
+        )
+
+        with pytest.raises(ResourceConflictError, match="Source type is not allowed"):
+            await data_layer.otus.add_isolate(otu.id, "genotype", "8816", user.id)
+
+    async def test_allowed_when_unrestricted(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        otu, user = await self._create_otu(
+            data_layer,
+            fake,
+            restrict_source_types=False,
+            source_types=["isolate"],
+        )
+
+        isolate = await data_layer.otus.add_isolate(otu.id, "genotype", "8816", user.id)
+
+        assert isolate.source_type == "genotype"
+
+    async def test_unknown_is_always_allowed(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        otu, user = await self._create_otu(
+            data_layer,
+            fake,
+            restrict_source_types=True,
+            source_types=["isolate"],
+        )
+
+        isolate = await data_layer.otus.add_isolate(otu.id, "unknown", "8816", user.id)
+
+        assert isolate.source_type == "unknown"
+
+    async def test_otu_not_found(self, data_layer: DataLayer, fake: DataFaker):
+        user = await fake.users.create()
+
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.otus.add_isolate("missing", "isolate", "8816", user.id)
+
+
+class TestUpdateIsolateSourceType:
+    async def test_disallowed_when_restricted(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        otu = await fake.otus.create(reference.id, user)
+
+        await data_layer.references.update(
+            reference.id,
+            UpdateReferenceRequest(
+                restrict_source_types=True,
+                source_types=["isolate"],
+            ),
+        )
+
+        isolate_id = otu.isolates[0].id
+
+        with pytest.raises(ResourceConflictError, match="Source type is not allowed"):
+            await data_layer.otus.update_isolate(
+                otu.id,
+                isolate_id,
+                user.id,
+                source_type="genotype",
+            )
+
+    async def test_source_name_only_skips_check(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        """A rename that leaves ``source_type`` alone is not source type checked."""
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        otu = await fake.otus.create(reference.id, user)
+
+        await data_layer.references.update(
+            reference.id,
+            UpdateReferenceRequest(
+                restrict_source_types=True,
+                source_types=["strain"],
+            ),
+        )
+
+        isolate = await data_layer.otus.update_isolate(
+            otu.id,
+            otu.isolates[0].id,
+            user.id,
+            source_name="Renamed",
+        )
+
+        assert isolate["source_name"] == "Renamed"

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 from virtool.api.client import UserClient
-from virtool.data.errors import ResourceError, ResourceNotFoundError
+from virtool.data.errors import ResourceNotFoundError
 from virtool.data.topg import compose_legacy_id_subquery
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
@@ -16,7 +16,6 @@ from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.references.db import (
     check_right,
-    check_source_type,
     compose_reference_ids_match,
     create_document,
     get_manifest,
@@ -739,143 +738,3 @@ async def test_populate_insert_only_reference_writes_legacy_history(
     assert all(row.otu_version == "0" for row in rows)
     assert all(row.index is None and row.index_version is None for row in rows)
     assert rows == snapshot(name="legacy_history")
-
-
-async def seed_source_type_reference(
-    pg: AsyncEngine,
-    *,
-    legacy_id: str,
-    user_id: int,
-    created_at,
-    restrict_source_types: bool,
-    source_types: list[str],
-) -> int:
-    """Insert a reference with a source type configuration.
-
-    :return: the reference's Postgres primary key
-    """
-    async with AsyncSession(pg) as session:
-        reference = SQLReference(
-            legacy_id=legacy_id,
-            name=legacy_id,
-            description="",
-            created_at=created_at,
-            restrict_source_types=restrict_source_types,
-            source_types=source_types,
-            user_id=user_id,
-        )
-
-        session.add(reference)
-        await session.flush()
-
-        reference_id = reference.id
-
-        await session.commit()
-
-    return reference_id
-
-
-class TestCheckSourceType:
-    async def test_allowed_when_restricted(
-        self,
-        fake: DataFaker,
-        pg: AsyncEngine,
-        static_time,
-    ):
-        user = await fake.users.create()
-
-        reference_id = await seed_source_type_reference(
-            pg,
-            legacy_id="restricted",
-            user_id=user.id,
-            created_at=static_time.datetime,
-            restrict_source_types=True,
-            source_types=["isolate", "strain"],
-        )
-
-        assert await check_source_type(pg, reference_id, "isolate") is True
-
-    async def test_disallowed_when_restricted(
-        self,
-        fake: DataFaker,
-        pg: AsyncEngine,
-        static_time,
-    ):
-        user = await fake.users.create()
-
-        reference_id = await seed_source_type_reference(
-            pg,
-            legacy_id="restricted",
-            user_id=user.id,
-            created_at=static_time.datetime,
-            restrict_source_types=True,
-            source_types=["isolate", "strain"],
-        )
-
-        assert await check_source_type(pg, reference_id, "genotype") is False
-
-    async def test_allowed_when_unrestricted(
-        self,
-        fake: DataFaker,
-        pg: AsyncEngine,
-        static_time,
-    ):
-        user = await fake.users.create()
-
-        reference_id = await seed_source_type_reference(
-            pg,
-            legacy_id="unrestricted",
-            user_id=user.id,
-            created_at=static_time.datetime,
-            restrict_source_types=False,
-            source_types=["isolate"],
-        )
-
-        assert await check_source_type(pg, reference_id, "genotype") is True
-
-    async def test_unknown_is_always_allowed(
-        self,
-        fake: DataFaker,
-        pg: AsyncEngine,
-        static_time,
-    ):
-        user = await fake.users.create()
-
-        reference_id = await seed_source_type_reference(
-            pg,
-            legacy_id="restricted",
-            user_id=user.id,
-            created_at=static_time.datetime,
-            restrict_source_types=True,
-            source_types=["isolate"],
-        )
-
-        assert await check_source_type(pg, reference_id, "unknown") is True
-
-    async def test_legacy_id(
-        self,
-        fake: DataFaker,
-        pg: AsyncEngine,
-        static_time,
-    ):
-        """A reference addressed by its legacy Mongo id resolves."""
-        user = await fake.users.create()
-
-        await seed_source_type_reference(
-            pg,
-            legacy_id="restricted",
-            user_id=user.id,
-            created_at=static_time.datetime,
-            restrict_source_types=True,
-            source_types=["isolate"],
-        )
-
-        assert await check_source_type(pg, "restricted", "isolate") is True
-        assert await check_source_type(pg, "restricted", "genotype") is False
-
-    async def test_reference_missing_from_postgres(self, pg: AsyncEngine):
-        """An OTU referring to a reference with no Postgres row is corrupt data, not a
-        missing resource.
-        """
-        with pytest.raises(ResourceError, match="Could not find reference 9999"):
-            await check_source_type(pg, 9999, "isolate")

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 from virtool.api.client import UserClient
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceError, ResourceNotFoundError
 from virtool.data.topg import compose_legacy_id_subquery
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
@@ -16,6 +16,7 @@ from virtool.models.roles import AdministratorRole
 from virtool.mongo.core import Mongo
 from virtool.references.db import (
     check_right,
+    check_source_type,
     compose_reference_ids_match,
     create_document,
     get_manifest,
@@ -738,3 +739,143 @@ async def test_populate_insert_only_reference_writes_legacy_history(
     assert all(row.otu_version == "0" for row in rows)
     assert all(row.index is None and row.index_version is None for row in rows)
     assert rows == snapshot(name="legacy_history")
+
+
+async def seed_source_type_reference(
+    pg: AsyncEngine,
+    *,
+    legacy_id: str,
+    user_id: int,
+    created_at,
+    restrict_source_types: bool,
+    source_types: list[str],
+) -> int:
+    """Insert a reference with a source type configuration.
+
+    :return: the reference's Postgres primary key
+    """
+    async with AsyncSession(pg) as session:
+        reference = SQLReference(
+            legacy_id=legacy_id,
+            name=legacy_id,
+            description="",
+            created_at=created_at,
+            restrict_source_types=restrict_source_types,
+            source_types=source_types,
+            user_id=user_id,
+        )
+
+        session.add(reference)
+        await session.flush()
+
+        reference_id = reference.id
+
+        await session.commit()
+
+    return reference_id
+
+
+class TestCheckSourceType:
+    async def test_allowed_when_restricted(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        user = await fake.users.create()
+
+        reference_id = await seed_source_type_reference(
+            pg,
+            legacy_id="restricted",
+            user_id=user.id,
+            created_at=static_time.datetime,
+            restrict_source_types=True,
+            source_types=["isolate", "strain"],
+        )
+
+        assert await check_source_type(pg, reference_id, "isolate") is True
+
+    async def test_disallowed_when_restricted(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        user = await fake.users.create()
+
+        reference_id = await seed_source_type_reference(
+            pg,
+            legacy_id="restricted",
+            user_id=user.id,
+            created_at=static_time.datetime,
+            restrict_source_types=True,
+            source_types=["isolate", "strain"],
+        )
+
+        assert await check_source_type(pg, reference_id, "genotype") is False
+
+    async def test_allowed_when_unrestricted(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        user = await fake.users.create()
+
+        reference_id = await seed_source_type_reference(
+            pg,
+            legacy_id="unrestricted",
+            user_id=user.id,
+            created_at=static_time.datetime,
+            restrict_source_types=False,
+            source_types=["isolate"],
+        )
+
+        assert await check_source_type(pg, reference_id, "genotype") is True
+
+    async def test_unknown_is_always_allowed(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        user = await fake.users.create()
+
+        reference_id = await seed_source_type_reference(
+            pg,
+            legacy_id="restricted",
+            user_id=user.id,
+            created_at=static_time.datetime,
+            restrict_source_types=True,
+            source_types=["isolate"],
+        )
+
+        assert await check_source_type(pg, reference_id, "unknown") is True
+
+    async def test_legacy_id(
+        self,
+        fake: DataFaker,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        """A reference addressed by its legacy Mongo id resolves."""
+        user = await fake.users.create()
+
+        await seed_source_type_reference(
+            pg,
+            legacy_id="restricted",
+            user_id=user.id,
+            created_at=static_time.datetime,
+            restrict_source_types=True,
+            source_types=["isolate"],
+        )
+
+        assert await check_source_type(pg, "restricted", "isolate") is True
+        assert await check_source_type(pg, "restricted", "genotype") is False
+
+    async def test_reference_missing_from_postgres(self, pg: AsyncEngine):
+        """An OTU referring to a reference with no Postgres row is corrupt data, not a
+        missing resource.
+        """
+        with pytest.raises(ResourceError, match="Could not find reference 9999"):
+            await check_source_type(pg, 9999, "isolate")

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -37,10 +37,7 @@ from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_one_field
 from virtool.pg.utils import get_rows
-from virtool.references.db import (
-    compose_reference_ids_match,
-    resolve_reference_legacy_id,
-)
+from virtool.references.db import compose_reference_ids_match
 from virtool.references.models import ReferenceNested
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import (
@@ -318,26 +315,25 @@ class IndexData:
         except KeyError:
             raise ResourceError("Could not find index reference id")
 
-        data_type = await get_one_field(
-            self._mongo.references,
-            "data_type",
-            await resolve_reference_legacy_id(self._pg, ref_id),
-        )
+        async with AsyncSession(self._pg) as session:
+            reference_id = await session.scalar(
+                select(SQLReference.id).where(
+                    compose_legacy_id_single_expression(SQLReference, ref_id),
+                ),
+            )
 
-        if data_type is None:
-            raise ResourceNotFoundError
+        if reference_id is None:
+            raise ResourceError(f"Could not find reference {ref_id} in postgres")
 
         results = {
             f.name: f.type
             for f in await get_rows(self._pg, SQLIndexFile, "index", index_id)
         }
 
-        aws = [check_fasta_file_uploaded(results)]
-
-        if data_type == "genome":
-            aws.append(check_index_files_uploaded(results))
-
-        await wait_for_checks(*aws)
+        await wait_for_checks(
+            check_fasta_file_uploaded(results),
+            check_index_files_uploaded(results),
+        )
 
         async with self._mongo.create_session() as session:
             await update_last_indexed_versions(self._mongo, self._pg, ref_id, session)

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -202,7 +202,6 @@ class IsolatesView(PydanticView):
 
         # All source types are stored in lower case.
         if not await virtool.references.db.check_source_type(
-            mongo,
             pg,
             reference["id"],
             source_type,
@@ -321,7 +320,6 @@ class IsolateView(PydanticView):
             source_type = data["source_type"].lower()
 
             if not await virtool.references.db.check_source_type(
-                mongo,
                 pg,
                 ref_id,
                 source_type,

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -13,7 +13,7 @@ from virtool.api.errors import (
     APINotFound,
 )
 from virtool.api.routes import Routes
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.utils import get_data_from_req
 from virtool.mongo.utils import get_mongo_from_req, get_one_field
 from virtool.otus.db import SEQUENCE_PROJECTION
@@ -184,7 +184,6 @@ class IsolatesView(PydanticView):
 
         """
         mongo = get_mongo_from_req(self.request)
-        pg: AsyncEngine = self.request.app["pg"]
 
         reference = await get_one_field(mongo.otus, "reference", otu_id)
 
@@ -198,23 +197,16 @@ class IsolatesView(PydanticView):
         ):
             raise APIInsufficientRights()
 
-        source_type = data.source_type.lower()
-
-        # All source types are stored in lower case.
-        if not await virtool.references.db.check_source_type(
-            pg,
-            reference["id"],
-            source_type,
-        ):
-            raise APIBadRequest("Source type is not allowed")
-
-        isolate = await get_data_from_req(self.request).otus.add_isolate(
-            otu_id,
-            source_type,
-            data.source_name,
-            self.request["client"].user_id,
-            data.default,
-        )
+        try:
+            isolate = await get_data_from_req(self.request).otus.add_isolate(
+                otu_id,
+                data.source_type,
+                data.source_name,
+                self.request["client"].user_id,
+                data.default,
+            )
+        except ResourceConflictError as err:
+            raise APIBadRequest(str(err))
 
         return json_response(
             isolate,
@@ -291,7 +283,6 @@ class IsolateView(PydanticView):
 
         """
         mongo = get_mongo_from_req(self.request)
-        pg: AsyncEngine = self.request.app["pg"]
 
         reference = await get_one_field(
             mongo.otus,
@@ -302,37 +293,25 @@ class IsolateView(PydanticView):
         if not reference:
             raise APINotFound()
 
-        ref_id = reference["id"]
-
         if not await virtool.references.db.check_right(
             self.request,
-            ref_id,
+            reference["id"],
             "modify_otu",
         ):
             raise APIInsufficientRights()
 
         data = data.dict(exclude_unset=True)
 
-        source_type = None
-
-        # All source types are stored in lower case.
-        if "source_type" in data:
-            source_type = data["source_type"].lower()
-
-            if not await virtool.references.db.check_source_type(
-                pg,
-                ref_id,
-                source_type,
-            ):
-                raise APIBadRequest("Source type is not allowed")
-
-        isolate = await get_data_from_req(self.request).otus.update_isolate(
-            otu_id,
-            isolate_id,
-            self.request["client"].user_id,
-            source_type=source_type,
-            source_name=data.get("source_name"),
-        )
+        try:
+            isolate = await get_data_from_req(self.request).otus.update_isolate(
+                otu_id,
+                isolate_id,
+                self.request["client"].user_id,
+                source_type=data.get("source_type"),
+                source_name=data.get("source_name"),
+            )
+        except ResourceConflictError as err:
+            raise APIBadRequest(str(err))
 
         return json_response(isolate, status=200)
 

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 import virtool.history.db
 import virtool.otus.db
 import virtool.otus.utils
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.topg import resolve_legacy_id
 from virtool.data.transforms import apply_transforms
 from virtool.history.utils import (
@@ -36,6 +36,7 @@ from virtool.otus.utils import (
     format_isolate_name,
     strip_sequence_references,
 )
+from virtool.references.db import check_source_type
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
@@ -382,6 +383,22 @@ class OTUData:
 
         return await self._mongo.with_transaction(func)
 
+    async def _check_source_type(self, otu_id: str, source_type: str) -> None:
+        """Ensure ``source_type`` is allowed by the OTU's parent reference.
+
+        :param otu_id: the id of the OTU the isolate belongs to
+        :param source_type: the lowercased source type
+        :raises ResourceNotFoundError: the OTU does not exist
+        :raises ResourceConflictError: the reference does not allow the source type
+        """
+        reference = await get_one_field(self._mongo.otus, "reference", otu_id)
+
+        if not reference:
+            raise ResourceNotFoundError
+
+        if not await check_source_type(self._pg, reference["id"], source_type):
+            raise ResourceConflictError("Source type is not allowed")
+
     async def add_isolate(
         self,
         otu_id: str,
@@ -390,6 +407,10 @@ class OTUData:
         user_id: int,
         default: bool = False,
     ) -> OTUIsolate:
+        source_type = source_type.lower()
+
+        await self._check_source_type(otu_id, source_type)
+
         async def func(session: AsyncIOMotorClientSession) -> OTUIsolate:
             document = await self._mongo.otus.find_one(otu_id, session=session)
 
@@ -482,6 +503,11 @@ class OTUData:
         source_type: str | None = None,
         source_name: str | None = None,
     ):
+        if source_type is not None:
+            source_type = source_type.lower()
+
+            await self._check_source_type(otu_id, source_type)
+
         isolates = await get_one_field(self._mongo.otus, "isolates", otu_id)
 
         isolate = find_isolate(isolates, isolate_id)

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine
 import virtool.history.db
 import virtool.mongo.utils
 import virtool.utils
-from virtool.data.errors import ResourceNotFoundError
+from virtool.data.errors import ResourceError, ResourceNotFoundError
 from virtool.data.topg import (
     compose_legacy_id_mongo_match,
     compose_legacy_id_single_expression,
@@ -52,29 +52,6 @@ async def compose_reference_id_match(pg: AsyncEngine, ref_id: int | str) -> dict
     ``legacy_references`` primary key, so both forms must match.
     """
     return await compose_legacy_id_mongo_match(pg, SQLReference, ref_id)
-
-
-async def resolve_reference_legacy_id(pg: AsyncEngine, ref_id: int | str) -> str:
-    """Return the legacy Mongo string id for a reference.
-
-    ``references`` still live in Mongo keyed by their legacy string ``_id`` while
-    ``otus`` and ``sequences`` may already embed the integer
-    ``legacy_references`` primary key. Callers that hold an embedded id and need
-    to reach the Mongo ``references`` document resolve it here. A legacy string id
-    passes through unchanged.
-    """
-    if isinstance(ref_id, str):
-        return ref_id
-
-    async with AsyncSession(pg) as session:
-        legacy_id = await session.scalar(
-            select(SQLReference.legacy_id).where(SQLReference.id == ref_id),
-        )
-
-    if legacy_id is None:
-        raise ResourceNotFoundError
-
-    return legacy_id
 
 
 async def write_legacy_reference(
@@ -377,36 +354,37 @@ async def check_right(req: Request, ref_id: int | str, right: str) -> bool:
 
 
 async def check_source_type(
-    mongo: "Mongo",
     pg: AsyncEngine,
     ref_id: int | str,
     source_type: str,
 ) -> bool:
     """Check `source_type` is valid based on the reference configuration.
 
-    :param mongo: the application MongoDB client
     :param pg: the application PostgreSQL engine
     :param ref_id: the reference context
     :param source_type: the source type to check
     :return: source type is valid
 
     """
-    ref_id = await resolve_reference_legacy_id(pg, ref_id)
-
-    document = await mongo.references.find_one(
-        ref_id,
-        ["restrict_source_types", "source_types"],
-    )
-
-    restrict_source_types = document.get("restrict_source_types", False)
-    source_types = document.get("source_types", [])
-
     if source_type == "unknown":
         return True
 
+    async with AsyncSession(pg) as session:
+        row = (
+            await session.execute(
+                select(
+                    SQLReference.restrict_source_types,
+                    SQLReference.source_types,
+                ).where(compose_legacy_id_single_expression(SQLReference, ref_id)),
+            )
+        ).one_or_none()
+
+    if row is None:
+        raise ResourceError(f"Could not find reference {ref_id} in postgres")
+
     # Return `False` when source_types are restricted and source_type is not allowed.
-    if source_type and restrict_source_types:
-        return source_type in source_types
+    if source_type and row.restrict_source_types:
+        return source_type in row.source_types
 
     # Return `True` when:
     # - source_type is empty string (unknown)


### PR DESCRIPTION
## Summary
- Remove the last Mongo reads of the `references` collection, in index finalization and source type validation, and drop the `resolve_reference_legacy_id` helper they depended on.
- A reference missing from Postgres is now a `ResourceError` rather than a 404. Every reference lives in Postgres, so the absence is corrupt data, not a missing resource.