### PR TITLE
chore: add copy to the storage backend protocol

### DIFF
--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -88,6 +88,60 @@ class TestWrite:
         assert not (tmp_path / "target.txt").exists()
 
 
+class TestCopy:
+    async def test_ok(self, provider, tmp_path):
+        await provider.write("samples/abc/reads.fq.gz", _async_iter(b"read data"))
+
+        await provider.copy("samples/abc/reads.fq.gz", "samples/12/reads.fq.gz")
+
+        assert (
+            tmp_path / "samples" / "12" / "reads.fq.gz"
+        ).read_bytes() == b"read data"
+
+    async def test_leaves_source_in_place(self, provider, tmp_path):
+        await provider.write("src.txt", _async_iter(b"payload"))
+
+        await provider.copy("src.txt", "dst.txt")
+
+        assert (tmp_path / "src.txt").read_bytes() == b"payload"
+
+    async def test_creates_parent_directories(self, provider, tmp_path):
+        await provider.write("src.txt", _async_iter(b"data"))
+
+        await provider.copy("src.txt", "deep/nested/path/file.txt")
+
+        assert (tmp_path / "deep" / "nested" / "path" / "file.txt").exists()
+
+    async def test_overwrites_destination(self, provider, tmp_path):
+        await provider.write("src.txt", _async_iter(b"new"))
+        await provider.write("dst.txt", _async_iter(b"stale"))
+
+        await provider.copy("src.txt", "dst.txt")
+
+        assert (tmp_path / "dst.txt").read_bytes() == b"new"
+
+    async def test_leaves_no_temporary_file(self, provider, tmp_path):
+        await provider.write("src.txt", _async_iter(b"data"))
+
+        await provider.copy("src.txt", "dst.txt")
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["dst.txt", "src.txt"]
+
+    async def test_nonexistent_source(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.copy("does/not/exist", "dst.txt")
+
+    async def test_source_outside_base_path(self, provider):
+        with pytest.raises(StorageError, match="resolves outside the base path"):
+            await provider.copy("../escape.txt", "dst.txt")
+
+    async def test_destination_outside_base_path(self, provider):
+        await provider.write("src.txt", _async_iter(b"data"))
+
+        with pytest.raises(StorageError, match="resolves outside the base path"):
+            await provider.copy("src.txt", "../escape.txt")
+
+
 class TestDelete:
     async def test_existing_key(self, provider, tmp_path):
         path = tmp_path / "to_delete"

--- a/tests/storage/test_integration.py
+++ b/tests/storage/test_integration.py
@@ -70,6 +70,53 @@ class TestRoundtrip:
         assert await _collect_bytes(provider.read(key)) == b"second"
 
 
+class TestCopy:
+    async def test_ok(self, provider, request, worker_id):
+        src = _key(request, worker_id, "src.txt")
+        dst = _key(request, worker_id, "dst.txt")
+
+        await provider.write(src, _async_iter(b"read data"))
+        await provider.copy(src, dst)
+
+        assert await _collect_bytes(provider.read(dst)) == b"read data"
+        assert await _collect_bytes(provider.read(src)) == b"read data"
+
+    async def test_overwrites_destination(self, provider, request, worker_id):
+        src = _key(request, worker_id, "src.txt")
+        dst = _key(request, worker_id, "dst.txt")
+
+        await provider.write(src, _async_iter(b"new"))
+        await provider.write(dst, _async_iter(b"stale"))
+        await provider.copy(src, dst)
+
+        assert await _collect_bytes(provider.read(dst)) == b"new"
+
+    async def test_object_larger_than_chunk_size(self, provider, request, worker_id):
+        """Copy an object spanning more than one write chunk.
+
+        This does not cover S3's 5 GiB single-request ``CopyObject`` ceiling,
+        above which a multipart copy is required. Sample reads files exceed
+        that, so any migration that re-keys them must establish separately that
+        the backend switches to multipart.
+        """
+        src = _key(request, worker_id, "large-src.bin")
+        dst = _key(request, worker_id, "large-dst.bin")
+        payload = b"x" * (STORAGE_CHUNK_SIZE * 2 + 123)
+
+        await provider.write(src, _async_iter(payload, chunk_size=512 * 1024))
+        await provider.copy(src, dst)
+
+        assert await provider.size(dst) == len(payload)
+        assert await _collect_bytes(provider.read(dst)) == payload
+
+    async def test_nonexistent_source(self, provider, request, worker_id):
+        src = _key(request, worker_id, "never-existed.txt")
+        dst = _key(request, worker_id, "dst.txt")
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.copy(src, dst)
+
+
 class TestDelete:
     async def test_existing(self, provider, request, worker_id):
         key = _key(request, worker_id, "to-delete.txt")

--- a/tests/storage/test_legacy.py
+++ b/tests/storage/test_legacy.py
@@ -85,6 +85,37 @@ class TestSize:
         assert await adapter.size("samples/sample1/reads.fq.gz") == len(b"reads")
 
 
+class TestCopy:
+    async def test_translates_both_index_keys(self, adapter, tmp_path):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"payload")
+        _seed_legacy_index(tmp_path, "ref2", "idx2", "placeholder", b"")
+
+        await adapter.copy("indexes/idx1/reference.json.gz", "indexes/idx2/copied.gz")
+
+        assert (
+            tmp_path / "references" / "ref2" / "idx2" / "copied.gz"
+        ).read_bytes() == b"payload"
+
+    async def test_passes_through_non_index_keys(self, adapter, tmp_path):
+        path = tmp_path / "samples" / "sample1" / "reads.fq.gz"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"reads")
+
+        await adapter.copy("samples/sample1/reads.fq.gz", "samples/12/reads.fq.gz")
+
+        assert (tmp_path / "samples" / "12" / "reads.fq.gz").read_bytes() == b"reads"
+
+    async def test_unknown_source_index_raises(self, adapter):
+        with pytest.raises(StorageKeyNotFoundError):
+            await adapter.copy("indexes/missing/reference.json.gz", "samples/12/x.gz")
+
+    async def test_unknown_destination_index_raises(self, adapter, tmp_path):
+        _seed_legacy_index(tmp_path, "ref1", "idx1", "reference.json.gz", b"payload")
+
+        with pytest.raises(StorageError, match="cannot copy to index key"):
+            await adapter.copy("indexes/idx1/reference.json.gz", "indexes/missing/x.gz")
+
+
 class TestDelete:
     async def test_translates_index_key(self, adapter, tmp_path):
         path = _seed_legacy_index(

--- a/tests/storage/test_memory.py
+++ b/tests/storage/test_memory.py
@@ -69,6 +69,37 @@ class TestWrite:
         assert await _collect_bytes(provider.read("key")) == b"second"
 
 
+class TestCopy:
+    async def test_ok(self, provider):
+        await provider.write("samples/abc/reads.fq.gz", _async_iter(b"read data"))
+
+        await provider.copy("samples/abc/reads.fq.gz", "samples/12/reads.fq.gz")
+
+        assert (
+            await _collect_bytes(provider.read("samples/12/reads.fq.gz"))
+            == b"read data"
+        )
+
+    async def test_leaves_source_in_place(self, provider):
+        await provider.write("src", _async_iter(b"payload"))
+
+        await provider.copy("src", "dst")
+
+        assert await _collect_bytes(provider.read("src")) == b"payload"
+
+    async def test_overwrites_destination(self, provider):
+        await provider.write("src", _async_iter(b"new"))
+        await provider.write("dst", _async_iter(b"stale"))
+
+        await provider.copy("src", "dst")
+
+        assert await _collect_bytes(provider.read("dst")) == b"new"
+
+    async def test_nonexistent_source(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.copy("does/not/exist", "dst")
+
+
 class TestDelete:
     async def test_existing_key(self, provider):
         await provider.write("to_delete", _async_iter(b"data"))

--- a/tests/storage/test_object.py
+++ b/tests/storage/test_object.py
@@ -101,6 +101,65 @@ class TestErrorTranslation:
         with pytest.raises(StorageError):
             await provider.delete("present")
 
+    async def test_copy_missing_source_raises_key_not_found(self, provider):
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.copy("does/not/exist", "dst")
+
+    async def test_copy_translates_s3_compatible_no_such_key(self, provider, mocker):
+        """Unlike ``delete``, a missing source is an error for ``copy``.
+
+        Garage-style backends wrap not-found as a GenericError carrying a
+        structured ``code: "NoSuchKey"`` marker, which must surface as
+        StorageKeyNotFoundError rather than a bare StorageError.
+        """
+        mocker.patch(
+            "virtool.storage.object.obs.copy_async",
+            side_effect=GenericError(
+                "Generic S3 error: CopyObject request failed for key foo: "
+                "Key not found (code: NoSuchKey)",
+            ),
+        )
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await provider.copy("missing", "dst")
+
+    async def test_copy_does_not_swallow_unrelated_error_code(self, provider, mocker):
+        mocker.patch(
+            "virtool.storage.object.obs.copy_async",
+            side_effect=GenericError(
+                "Generic S3 error: bucket missing (code: NoSuchBucket)",
+            ),
+        )
+
+        with pytest.raises(StorageError) as info:
+            await provider.copy("present", "dst")
+
+        assert not isinstance(info.value, StorageKeyNotFoundError)
+
+
+class TestCopy:
+    async def test_ok(self, provider):
+        await provider.write("samples/abc/reads.fq.gz", _async_iter(b"read data"))
+
+        await provider.copy("samples/abc/reads.fq.gz", "samples/12/reads.fq.gz")
+
+        assert (
+            await _collect_bytes(provider.read("samples/12/reads.fq.gz"))
+            == b"read data"
+        )
+        assert (
+            await _collect_bytes(provider.read("samples/abc/reads.fq.gz"))
+            == b"read data"
+        )
+
+    async def test_overwrites_destination(self, provider):
+        await provider.write("src", _async_iter(b"new"))
+        await provider.write("dst", _async_iter(b"stale"))
+
+        await provider.copy("src", "dst")
+
+        assert await _collect_bytes(provider.read("dst")) == b"new"
+
 
 class TestSize:
     async def test_ok(self, provider):

--- a/tests/storage/test_routing.py
+++ b/tests/storage/test_routing.py
@@ -150,6 +150,69 @@ class TestWrite:
         primary_write.assert_not_called()
 
 
+class TestCopy:
+    async def test_copies_within_primary(self, primary, router):
+        await primary.write("src", _async_iter(b"data"))
+
+        await router.copy("src", "dst")
+
+        assert await _collect_bytes(primary.read("dst")) == b"data"
+
+    async def test_uses_primary_copy_when_source_is_on_primary(
+        self, primary, fallback, router, mocker
+    ):
+        """A primary-resident source must be copied server-side, not streamed.
+
+        Falling back to read-then-write would pull the object through this
+        process, which for a multi-gigabyte reads file is the difference
+        between a metadata-scale operation and a full transfer.
+        """
+        await primary.write("src", _async_iter(b"data"))
+
+        primary_copy = mocker.spy(primary, "copy")
+        primary_write = mocker.spy(primary, "write")
+
+        await router.copy("src", "dst")
+
+        primary_copy.assert_called_once_with("src", "dst")
+        primary_write.assert_not_called()
+
+    async def test_promotes_source_from_fallback(self, primary, fallback, router):
+        await fallback.write("src", _async_iter(b"legacy"))
+
+        await router.copy("src", "dst")
+
+        assert await _collect_bytes(primary.read("dst")) == b"legacy"
+
+    async def test_leaves_fallback_source_in_place(self, fallback, router):
+        await fallback.write("src", _async_iter(b"legacy"))
+
+        await router.copy("src", "dst")
+
+        assert await _collect_bytes(fallback.read("src")) == b"legacy"
+
+    async def test_drains_stale_fallback_destination(self, primary, fallback, router):
+        """A stale fallback object at ``dst`` must never outlive the copy.
+
+        Reads probe the primary first, so a surviving fallback copy would only
+        surface if the primary object were later lost -- serving stale bytes
+        under a key the migration believes it rewrote.
+        """
+        await primary.write("src", _async_iter(b"new"))
+        await fallback.write("dst", _async_iter(b"stale"))
+
+        await router.copy("src", "dst")
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await _collect_bytes(fallback.read("dst"))
+
+        assert await _collect_bytes(router.read("dst")) == b"new"
+
+    async def test_nonexistent_source(self, router):
+        with pytest.raises(StorageKeyNotFoundError):
+            await router.copy("does/not/exist", "dst")
+
+
 class TestDelete:
     async def test_deletes_from_both(self, primary, fallback, router):
         await primary.write("key", _async_iter(b"a"))

--- a/virtool/storage/filesystem.py
+++ b/virtool/storage/filesystem.py
@@ -3,6 +3,7 @@
 import asyncio
 import errno
 import os
+import shutil
 import tempfile
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
@@ -78,6 +79,35 @@ class FilesystemProvider:
             raise
 
         return size
+
+    async def copy(self, src: str, dst: str) -> None:
+        """Copy the object at ``src`` to ``dst``, overwriting ``dst``.
+
+        Uses a temporary file and atomic rename, so a failure part-way through
+        never leaves a truncated object at ``dst``.
+        """
+        src_path = await self._resolve(src)
+        dst_path = await self._resolve(dst)
+
+        if not await asyncio.to_thread(src_path.is_file):
+            raise StorageKeyNotFoundError(src)
+
+        await asyncio.to_thread(dst_path.parent.mkdir, parents=True, exist_ok=True)
+
+        tmp_fd = await asyncio.to_thread(
+            tempfile.NamedTemporaryFile,
+            dir=dst_path.parent,
+            delete=False,
+        )
+        tmp_path = Path(tmp_fd.name)
+
+        try:
+            await asyncio.to_thread(tmp_fd.close)
+            await asyncio.to_thread(shutil.copyfile, src_path, tmp_path)
+            await asyncio.to_thread(os.replace, tmp_path, dst_path)
+        except BaseException:
+            await asyncio.to_thread(tmp_path.unlink, True)
+            raise
 
     async def delete(self, key: str) -> None:
         """Delete the object at ``key``. Idempotent."""

--- a/virtool/storage/legacy.py
+++ b/virtool/storage/legacy.py
@@ -99,6 +99,21 @@ class LegacyIndexFilesystemAdapter:
             raise StorageError(msg)
         return await self._inner.write(translated, data)
 
+    async def copy(self, src: str, dst: str) -> None:
+        translated_src = await self._translate(src)
+        if translated_src is None:
+            raise StorageKeyNotFoundError(src)
+
+        translated_dst = await self._translate(dst)
+        if translated_dst is None:
+            msg = (
+                f"cannot copy to index key {dst!r} through the legacy fallback: "
+                "no on-disk reference directory contains this index_id"
+            )
+            raise StorageError(msg)
+
+        await self._inner.copy(translated_src, translated_dst)
+
     async def delete(self, key: str) -> None:
         translated = await self._translate(key)
         if translated is None:

--- a/virtool/storage/memory.py
+++ b/virtool/storage/memory.py
@@ -44,6 +44,17 @@ class MemoryStorageProvider:
 
         return len(blob)
 
+    async def copy(self, src: str, dst: str) -> None:
+        try:
+            obj = self._store[src]
+        except KeyError as exc:
+            raise StorageKeyNotFoundError(src) from exc
+
+        self._store[dst] = _StoredObject(
+            data=obj.data,
+            last_modified=datetime.now(tz=UTC),
+        )
+
     async def delete(self, key: str) -> None:
         self._store.pop(key, None)
 

--- a/virtool/storage/object.py
+++ b/virtool/storage/object.py
@@ -124,6 +124,25 @@ class ObjectProvider:
 
         return size
 
+    async def copy(self, src: str, dst: str) -> None:
+        """Copy the object at ``src`` to ``dst``, overwriting ``dst``.
+
+        ``obstore`` issues a server-side copy, so the object never transits this
+        process.
+        """
+        try:
+            await obs.copy_async(self._store, src, dst)
+        except FileNotFoundError as exc:
+            raise StorageKeyNotFoundError(src) from exc
+        except GenericError as exc:
+            # See `delete` for why the structured S3 error code is matched here.
+            msg = str(exc)
+            if _S3_NOT_FOUND_CODE_RE.search(msg):
+                raise StorageKeyNotFoundError(src) from exc
+            raise StorageError(msg) from exc
+        except Exception as exc:
+            raise StorageError(str(exc)) from exc
+
     async def delete(self, key: str) -> None:
         """Delete the object at ``key``. Idempotent."""
         try:

--- a/virtool/storage/protocol.py
+++ b/virtool/storage/protocol.py
@@ -33,6 +33,18 @@ class StorageBackend(Protocol):
         """
         ...
 
+    async def copy(self, src: str, dst: str) -> None:
+        """Copy the object at ``src`` to ``dst``, overwriting ``dst``.
+
+        Backends that can copy server-side must do so rather than streaming the
+        object through the caller: this is used to re-key multi-gigabyte sample
+        reads files.
+
+        Raises :class:`~virtool.storage.errors.StorageKeyNotFoundError` if
+        ``src`` does not exist.
+        """
+        ...
+
     async def delete(self, key: str) -> None:
         """Delete the object at ``key``.
 

--- a/virtool/storage/routing.py
+++ b/virtool/storage/routing.py
@@ -47,6 +47,25 @@ class FallbackStorageRouter:
         await self._fallback.delete(key)
         return await self._primary.write(key, data)
 
+    async def copy(self, src: str, dst: str) -> None:
+        """Copy ``src`` to ``dst``, always landing the destination on the primary.
+
+        When ``src`` lives on the primary the copy stays there and can be done
+        server-side. When it only exists on the fallback it is promoted:
+        streamed out of the fallback and written to the primary. Either way the
+        fallback copy of ``dst`` is dropped first, matching ``write``, so a
+        stale fallback object is never served in place of the new one.
+        """
+        await self._fallback.delete(dst)
+
+        try:
+            await self._primary.size(src)
+        except StorageKeyNotFoundError:
+            await self._primary.write(dst, self._fallback.read(src))
+            return
+
+        await self._primary.copy(src, dst)
+
     async def delete(self, key: str) -> None:
         primary_result, fallback_result = await asyncio.gather(
             self._primary.delete(key),


### PR DESCRIPTION
Object stores have no rename — re-keying an object is always a copy followed by a delete. This adds `copy` to `StorageBackend` and implements it across all five backends, as groundwork for VIR-2626 (keying sample storage objects by integer primary key).

`ObjectProvider` issues a server-side copy via obstore, so multi-gigabyte reads files never transit the API server. `FallbackStorageRouter` promotes a fallback-resident source into the primary rather than moving it, leaving the source in place until the caller has committed.

The re-keying migration itself is deferred until after the Mongo work, so `copy` has no call site yet. Note it must land before `legacy_id` can be dropped from `legacy_samples`, since sample storage prefixes still derive from it.

One known gap: S3's single-request `CopyObject` caps at 5 GiB and larger objects need a multipart copy. The integration tests cover objects spanning multiple write chunks but not that ceiling, and sample reads files exceed it. Whether obstore switches to multipart transparently needs to be established before any migration re-keys real reads files.