### PR TITLE
feat(migration): add otus and sequences tables to postgres

### DIFF
--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -13,6 +13,7 @@ from virtool.hmm.sql import SQLHMMStatus
 from virtool.indexes.sql import SQLIndexFile
 from virtool.labels.sql import SQLLabel
 from virtool.messages.sql import SQLInstanceMessage
+from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.pg.base import Base
 from virtool.references.sql import (
     SQLReference,
@@ -49,11 +50,13 @@ __models__ = (
     SQLInstanceMessage,
     SQLLabel,
     SQLNuVsBlast,
+    SQLOTU,
     SQLReference,
     SQLReferenceGroup,
     SQLReferenceUser,
     SQLSampleArtifact,
     SQLSampleReads,
+    SQLSequence,
     SQLSession,
     SQLSettings,
     SQLSpace,

--- a/assets/alembic/versions/8bbc31ae5a8a_create_otus_and_sequences_tables.py
+++ b/assets/alembic/versions/8bbc31ae5a8a_create_otus_and_sequences_tables.py
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "otus",
+        "legacy_otus",
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("data", JSONB(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
@@ -30,20 +30,22 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["reference_id"], ["legacy_references.id"]),
     )
-    op.create_index("otus_name_lower", "otus", [sa.text("lower(name)"), "id"])
+    op.create_index(
+        "legacy_otus_name_lower", "legacy_otus", [sa.text("lower(name)"), "id"]
+    )
     op.create_table(
-        "sequences",
+        "legacy_sequences",
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("data", JSONB(), nullable=False),
         sa.Column("otu_id", sa.String(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
-        sa.ForeignKeyConstraint(["otu_id"], ["otus.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["otu_id"], ["legacy_otus.id"], ondelete="CASCADE"),
     )
-    op.create_index("ix_sequences_otu_id", "sequences", ["otu_id"])
+    op.create_index("ix_legacy_sequences_otu_id", "legacy_sequences", ["otu_id"])
 
 
 def downgrade() -> None:
-    op.drop_index("ix_sequences_otu_id", table_name="sequences")
-    op.drop_table("sequences")
-    op.drop_index("otus_name_lower", table_name="otus")
-    op.drop_table("otus")
+    op.drop_index("ix_legacy_sequences_otu_id", table_name="legacy_sequences")
+    op.drop_table("legacy_sequences")
+    op.drop_index("legacy_otus_name_lower", table_name="legacy_otus")
+    op.drop_table("legacy_otus")

--- a/assets/alembic/versions/8bbc31ae5a8a_create_otus_and_sequences_tables.py
+++ b/assets/alembic/versions/8bbc31ae5a8a_create_otus_and_sequences_tables.py
@@ -1,0 +1,49 @@
+"""create otus and sequences tables
+
+Revision ID: 8bbc31ae5a8a
+Revises: 1ffbe2dcb108
+Create Date: 2026-07-10 17:59:21.484146+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "8bbc31ae5a8a"
+down_revision = "1ffbe2dcb108"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "otus",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("data", JSONB(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("abbreviation", sa.String(), nullable=False),
+        sa.Column("reference_id", sa.BigInteger(), nullable=False),
+        sa.Column("verified", sa.Boolean(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["reference_id"], ["legacy_references.id"]),
+    )
+    op.create_index("otus_name_lower", "otus", [sa.text("lower(name)"), "id"])
+    op.create_table(
+        "sequences",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("data", JSONB(), nullable=False),
+        sa.Column("otu_id", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["otu_id"], ["otus.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_sequences_otu_id", "sequences", ["otu_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sequences_otu_id", table_name="sequences")
+    op.drop_table("sequences")
+    op.drop_index("otus_name_lower", table_name="otus")
+    op.drop_table("otus")

--- a/tests/fixtures/pg.py
+++ b/tests/fixtures/pg.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engin
 import virtool.account.sql
 import virtool.hmm.sql
 import virtool.messages.sql
+import virtool.otus.sql
 import virtool.references.sql
 import virtool.settings.sql  # noqa: F401  schema mirror, no app importer
 from virtool.api.custom_json import dump_string

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -708,5 +708,12 @@
       'name': 'backfill sample uploads to postgres',
       'revision': 'n03aryu6frku',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 102,
+      'name': 'create otus and sequences tables',
+      'revision': '8bbc31ae5a8a',
+    }),
   ])
 # ---

--- a/virtool/otus/sql.py
+++ b/virtool/otus/sql.py
@@ -1,0 +1,67 @@
+"""SQL models for OTUs and their sequences."""
+
+from sqlalchemy import (
+    BigInteger,
+    ForeignKey,
+    Index,
+    String,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from virtool.pg.base import Base
+
+
+class SQLOTU(Base):
+    """SQL model for an OTU.
+
+    This is a hybrid model backing a JSONB lift of the Mongo ``otus`` collection.
+    The complete Mongo document is stored verbatim in ``data`` and is the source
+    of truth for reconstruction and diffs. The remaining columns are derived from
+    that document and kept in sync on every write so they can be queried, filtered
+    and sorted on directly.
+
+    This model intentionally departs from the standard migration playbook. The
+    primary key ``id`` is the 8-character Mongo ``_id`` string rather than a
+    ``BigInteger`` identity, and there is no ``legacy_id`` column. The application
+    compensates for the ``_id``/``id`` naming difference. This is deliberate
+    scaffolding for a reference rewrite; normalization is skipped for now.
+
+    ``reference_id`` is a real integer foreign key to ``legacy_references.id``
+    because references are already migrated and the embedded ``reference.id`` is
+    already an integer.
+    """
+
+    __tablename__ = "otus"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    data: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    name: Mapped[str]
+    abbreviation: Mapped[str] = mapped_column(default="")
+    reference_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("legacy_references.id")
+    )
+    verified: Mapped[bool]
+    version: Mapped[int]
+
+    __table_args__ = (Index("otus_name_lower", text("lower(name)"), "id"),)
+
+
+class SQLSequence(Base):
+    """SQL model for a sequence.
+
+    Like :class:`SQLOTU` this is a hybrid model: the verbatim Mongo document lives
+    in ``data`` and ``otu_id`` is the only promoted column. ``otu_id`` is a real
+    foreign key to ``otus.id`` with ``ON DELETE CASCADE`` so a deleted OTU takes
+    its sequences with it. The column is indexed because Postgres does not index
+    foreign key columns automatically.
+    """
+
+    __tablename__ = "sequences"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    data: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    otu_id: Mapped[str] = mapped_column(
+        ForeignKey("otus.id", ondelete="CASCADE"), index=True
+    )

--- a/virtool/otus/sql.py
+++ b/virtool/otus/sql.py
@@ -33,7 +33,7 @@ class SQLOTU(Base):
     already an integer.
     """
 
-    __tablename__ = "otus"
+    __tablename__ = "legacy_otus"
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     data: Mapped[dict] = mapped_column(JSONB, nullable=False)
@@ -45,7 +45,7 @@ class SQLOTU(Base):
     verified: Mapped[bool]
     version: Mapped[int]
 
-    __table_args__ = (Index("otus_name_lower", text("lower(name)"), "id"),)
+    __table_args__ = (Index("legacy_otus_name_lower", text("lower(name)"), "id"),)
 
 
 class SQLSequence(Base):
@@ -53,15 +53,15 @@ class SQLSequence(Base):
 
     Like :class:`SQLOTU` this is a hybrid model: the verbatim Mongo document lives
     in ``data`` and ``otu_id`` is the only promoted column. ``otu_id`` is a real
-    foreign key to ``otus.id`` with ``ON DELETE CASCADE`` so a deleted OTU takes
-    its sequences with it. The column is indexed because Postgres does not index
-    foreign key columns automatically.
+    foreign key to ``legacy_otus.id`` with ``ON DELETE CASCADE`` so a deleted OTU
+    takes its sequences with it. The column is indexed because Postgres does not
+    index foreign key columns automatically.
     """
 
-    __tablename__ = "sequences"
+    __tablename__ = "legacy_sequences"
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     data: Mapped[dict] = mapped_column(JSONB, nullable=False)
     otu_id: Mapped[str] = mapped_column(
-        ForeignKey("otus.id", ondelete="CASCADE"), index=True
+        ForeignKey("legacy_otus.id", ondelete="CASCADE"), index=True
     )


### PR DESCRIPTION
## Summary

- Adds Postgres `otus` and `sequences` tables plus SQLAlchemy models using a hybrid JSONB design (verbatim Mongo document in `data`, promoted columns for querying)
- Uses the Mongo `_id` string as the primary key directly rather than a `legacy_id`/integer identity, since these tables intentionally depart from the standard migration pattern for now
- No reads or writes go through these tables yet; dual-write and backfill land in follow-up issues