### PR TITLE
refactor: stop reading mongo.analyses and writing analysis legacy ids

### DIFF
--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -1,10 +1,10 @@
 import asyncio
 from pathlib import Path
 from typing import NamedTuple
-from unittest.mock import ANY
+from unittest.mock import ANY, AsyncMock
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
@@ -213,7 +213,6 @@ async def test_find(
         ),
         "test_false",
         user_id,
-        0,
     )
 
     for _ in range(number_of_analyses):
@@ -228,7 +227,6 @@ async def test_find(
             ),
             "test_sample",
             user_id,
-            0,
         )
 
     analyses_found = await data_layer.analyses.find(1, 25, client, "test_sample")
@@ -776,7 +774,6 @@ class TestHideIimi:
             ),
             "test_sample",
             user_id,
-            0,
         )
 
         await self._seed_iimi(mongo, pg, setup_sample)
@@ -821,7 +818,6 @@ async def test_create(
         ),
         "test_sample",
         user_id,
-        0,
     )
 
     assert analysis == snapshot(name="obj", exclude=props("created_at", "updated_at"))
@@ -856,13 +852,13 @@ class TestCreate:
             _create_request(subtraction_ids, setup_sample.reference_id),
             "test_sample",
             setup_sample.user_id,
-            0,
         )
 
         row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
 
         assert row is not None
         assert row.id == analysis.id
+        assert row.legacy_id is None
         assert row.workflow == "nuvs"
         assert row.ready is False
         assert row.results is None
@@ -892,6 +888,32 @@ class TestCreate:
             [subtraction_ids["subtraction_1"], subtraction_ids["subtraction_2"]],
         )
 
+    async def test_links_job_with_integer_analysis_id(
+        self,
+        data_layer: DataLayer,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+        subtraction_ids: dict[str, int],
+    ):
+        """The analysis is linked to a job whose ``analysis_id`` argument is the
+        analysis's integer id, resolved through the ``analyses.job_id`` foreign key.
+        """
+        analysis = await data_layer.analyses.create(
+            _create_request(subtraction_ids, setup_sample.reference_id),
+            "test_sample",
+            setup_sample.user_id,
+        )
+
+        row = await get_row(pg, SQLAnalysis, ("id", analysis.id))
+
+        assert row is not None
+        assert row.job_id is not None
+
+        job = await data_layer.jobs.get(row.job_id)
+
+        assert job.args["analysis_id"] == analysis.id
+        assert isinstance(job.args["analysis_id"], int)
+
     async def test_subtractions_default_to_list(
         self,
         data_layer: DataLayer,
@@ -906,7 +928,6 @@ class TestCreate:
             ),
             "test_sample",
             setup_sample.user_id,
-            0,
         )
 
         async with AsyncSession(pg) as session:
@@ -940,7 +961,6 @@ class TestCreate:
                 ),
                 "test_sample",
                 setup_sample.user_id,
-                0,
             )
 
     async def test_unknown_sample_raises(
@@ -957,7 +977,6 @@ class TestCreate:
                 _create_request(subtraction_ids, setup_sample.reference_id),
                 "unknown_sample",
                 setup_sample.user_id,
-                0,
             )
 
     async def test_unknown_reference_raises(
@@ -981,7 +1000,6 @@ class TestCreate:
                 ),
                 "test_sample",
                 setup_sample.user_id,
-                0,
             )
 
     async def test_rolls_back_when_pg_write_fails(
@@ -1003,7 +1021,6 @@ class TestCreate:
                 _create_request(subtraction_ids, setup_sample.reference_id),
                 "test_sample",
                 setup_sample.user_id,
-                0,
             )
 
         async with AsyncSession(pg) as session:
@@ -1033,7 +1050,6 @@ class TestFinalize:
             _create_request(subtraction_ids, setup_sample.reference_id),
             "test_sample",
             setup_sample.user_id,
-            0,
         )
 
         created = await get_row(pg, SQLAnalysis, ("id", analysis.id))
@@ -1073,12 +1089,71 @@ class TestDelete:
             _create_request(subtraction_ids, setup_sample.reference_id),
             "test_sample",
             setup_sample.user_id,
-            0,
         )
 
         await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
 
         assert await get_row(pg, SQLAnalysis, ("id", analysis.id)) is None
+
+    async def test_native_analysis_skips_storage_cleanup(
+        self,
+        data_layer: DataLayer,
+        mocker,
+        setup_sample: SampleSetup,
+        subtraction_ids: dict[str, int],
+    ):
+        """A Postgres-native analysis has a NULL legacy id, so no slug-prefixed
+        storage objects exist to clean up.
+        """
+        delete_prefix = mocker.patch(
+            "virtool.analyses.data.delete_prefix",
+            new=AsyncMock(return_value=[]),
+        )
+
+        analysis = await data_layer.analyses.create(
+            _create_request(subtraction_ids, setup_sample.reference_id),
+            "test_sample",
+            setup_sample.user_id,
+        )
+
+        await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
+
+        delete_prefix.assert_not_awaited()
+
+    async def test_legacy_analysis_cleans_storage(
+        self,
+        data_layer: DataLayer,
+        mocker,
+        pg: AsyncEngine,
+        setup_sample: SampleSetup,
+        subtraction_ids: dict[str, int],
+    ):
+        """A Mongo-migrated analysis still removes its slug-prefixed storage objects."""
+        delete_prefix = mocker.patch(
+            "virtool.analyses.data.delete_prefix",
+            new=AsyncMock(return_value=[]),
+        )
+
+        analysis = await data_layer.analyses.create(
+            _create_request(subtraction_ids, setup_sample.reference_id),
+            "test_sample",
+            setup_sample.user_id,
+        )
+
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                update(SQLAnalysis)
+                .where(SQLAnalysis.id == analysis.id)
+                .values(legacy_id="oldslug"),
+            )
+            await session.commit()
+
+        await data_layer.analyses.delete(analysis.id, jobs_api_flag=True)
+
+        delete_prefix.assert_awaited_once()
+        assert (
+            delete_prefix.await_args.args[1] == "samples/test_sample/analysis/oldslug/"
+        )
 
 
 async def test_get_without_if_modified_since(
@@ -1098,7 +1173,6 @@ async def test_get_without_if_modified_since(
         ),
         "test_sample",
         setup_sample.user_id,
-        0,
     )
 
     fetched = await data_layer.analyses.get(analysis.id)
@@ -1131,7 +1205,6 @@ async def test_upload_file(
         ),
         "test_sample",
         user_id,
-        0,
     )
 
     chunks = fake_file_chunker(example_path / "sample" / "reads_1.fq.gz")

--- a/tests/analyses/test_utils.py
+++ b/tests/analyses/test_utils.py
@@ -5,7 +5,7 @@ from syrupy import SnapshotAssertion
 import virtool.analyses.files
 import virtool.analyses.utils
 from virtool.analyses.sql import SQLAnalysis
-from virtool.analyses.utils import analysis_file_key, analysis_result_key
+from virtool.analyses.utils import analysis_file_key
 from virtool.users.pg import SQLUser
 
 
@@ -66,10 +66,3 @@ async def test_attach_analysis_files(
 
 def test_analysis_file_key():
     assert analysis_file_key("1-output.fasta") == "analyses/1-output.fasta"
-
-
-def test_analysis_result_key():
-    assert (
-        analysis_result_key("abc123", "sample1")
-        == "samples/sample1/analysis/abc123/results.json"
-    )

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -329,35 +329,32 @@ class TestCreatePostgres:
         fake: DataFaker,
         pg: AsyncEngine,
     ):
-        """``get`` resolves the analysis id from the analysis row linked by job_id."""
+        """``get`` resolves the integer analysis id from the analysis row linked by
+        job_id.
+        """
         user = await fake.users.create()
 
-        job = await jobs_data.create(
-            workflow,
-            {"analysis_id": "analysis_abc"},
-            user.id,
-            0,
-        )
+        job = await jobs_data.create(workflow, {}, user.id, 0)
 
         async with AsyncSession(pg) as session:
-            session.add(
-                SQLAnalysis(
-                    legacy_id="analysis_abc",
-                    created_at=arrow.utcnow().naive,
-                    updated_at=arrow.utcnow().naive,
-                    workflow=workflow,
-                    ready=False,
-                    sample="sample_abc",
-                    reference="ref_abc",
-                    index="index_abc",
-                    user_id=user.id,
-                    job_id=job.id,
-                ),
+            analysis = SQLAnalysis(
+                created_at=arrow.utcnow().naive,
+                updated_at=arrow.utcnow().naive,
+                workflow=workflow,
+                ready=False,
+                sample="sample_abc",
+                reference="ref_abc",
+                index="index_abc",
+                user_id=user.id,
+                job_id=job.id,
             )
+            session.add(analysis)
+            await session.flush()
+            analysis_id = analysis.id
             await session.commit()
 
         fetched_job = await jobs_data.get(job.id)
-        assert fetched_job.args == {"analysis_id": "analysis_abc"}
+        assert fetched_job.args == {"analysis_id": analysis_id}
 
 
 class TestStartStepPostgres:

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -1417,7 +1417,6 @@ class TestDelete:
             ),
             "test_sample",
             user_id,
-            0,
         )
 
         await data_layer.analyses.finalize(analysis.id, {"hits": []})

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -43,7 +43,6 @@ from virtool.indexes.db import get_current_id_and_version
 from virtool.indexes.transforms import AttachIndexTransform
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
-from virtool.mongo.utils import get_new_id
 from virtool.pg.utils import delete_row, get_row_by_id
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
@@ -92,10 +91,10 @@ def _row_to_document(row, *, include_results: bool) -> dict:
     formatters expect.
 
     The integer ``id`` is the outward-facing identifier; ``base_processor`` later
-    renames ``_id`` to ``id``. The legacy Mongo slug is carried in ``legacy_id`` for
-    internal consumers (storage keys, Mongo dual-writes, and string-keyed SQL tables
-    such as ``analysis_files`` and ``nuvs_blast``) that have not yet been migrated off
-    the slug.
+    renames ``_id`` to ``id``. The legacy Mongo slug is carried in ``legacy_id`` so
+    analyses migrated from Mongo can still be addressed by their old string id and
+    have their slug-prefixed storage objects cleaned up; Postgres-native analyses
+    have a ``NULL`` slug.
 
     The nested reference is keyed by the integer ``reference_id`` foreign key, falling
     back to the legacy ``reference`` string on rows the backfill has not reached.
@@ -135,9 +134,10 @@ class AnalysisData(DataLayerDomain):
         """Resolve the integer id and legacy slug for an analysis by either identifier.
 
         Accepts the outward-facing integer id or the legacy Mongo slug and returns the
-        row's ``(id, legacy_id)``, or ``None`` if no analysis matches. The slug is still
-        needed for Mongo dual-writes and the string-keyed ``analysis_files``,
-        ``nuvs_blast``, and ``analysis_results`` tables.
+        row's ``(id, legacy_id)``, or ``None`` if no analysis matches. The slug is only
+        retained for analyses migrated from Mongo, where it locates their slug-prefixed
+        objects in storage during deletion; Postgres-native analyses have a ``NULL``
+        slug.
         """
         async with AsyncSession(self._pg) as session:
             return (
@@ -288,7 +288,6 @@ class AnalysisData(DataLayerDomain):
         data: CreateAnalysisRequest,
         sample_id: str,
         user_id: int,
-        space_id: int,
     ) -> Analysis:
         """Creates a new analysis.
 
@@ -299,7 +298,6 @@ class AnalysisData(DataLayerDomain):
         :param data: the analysis creation input data
         :param sample_id: the ID of the sample to create an analysis for
         :param user_id: the ID of the user starting the job
-        :param space_id: the ID of the parent space
         :return: the analysis
 
         """
@@ -311,18 +309,20 @@ class AnalysisData(DataLayerDomain):
             data.ref_id,
         )
 
-        analysis_id = await get_new_id(self._mongo.analyses)
-
-        job = await self.data.jobs.create(
-            data.workflow.value,
-            {"analysis_id": analysis_id},
-            user_id,
-            space_id,
-        )
-
         subtractions = data.subtractions if data.subtractions is not None else []
 
         async with AsyncSession(self._pg) as session:
+            # Create the job inside the analysis's transaction so the job and its
+            # analysis commit atomically. The job's ``analysis_id`` argument is
+            # derived from ``analyses.job_id`` on read, so the job must not become
+            # claimable before its analysis row exists.
+            job_id = await self.data.jobs.create_in_session(
+                session,
+                data.workflow.value,
+                {},
+                user_id,
+            )
+
             sample_row = (
                 await session.execute(
                     select(SQLLegacySample.id, SQLLegacySample.legacy_id).where(
@@ -353,7 +353,6 @@ class AnalysisData(DataLayerDomain):
                 await session.execute(
                     insert(SQLAnalysis)
                     .values(
-                        legacy_id=analysis_id,
                         created_at=created_at,
                         updated_at=created_at,
                         workflow=data.workflow.value,
@@ -365,7 +364,7 @@ class AnalysisData(DataLayerDomain):
                         reference_id=reference_pg_id,
                         index=index_id,
                         user_id=user_id,
-                        job_id=job.id,
+                        job_id=job_id,
                     )
                     .returning(SQLAnalysis.id),
                 )
@@ -400,7 +399,9 @@ class AnalysisData(DataLayerDomain):
 
             await session.commit()
 
-        return await self.get(analysis_id, None)
+        emit(await self.data.jobs.get(job_id), "jobs", "create", Operation.CREATE)
+
+        return await self.get(pg_id, None)
 
     async def has_right(self, analysis_id: str, client, right: str) -> bool:
         """Checks if the client has the `read` or `write` rights.
@@ -460,17 +461,21 @@ class AnalysisData(DataLayerDomain):
 
             await session.commit()
 
-        for key, exc in await delete_prefix(
-            self._storage,
-            f"samples/{sample_legacy_id}/analysis/{legacy_id}/",
-        ):
-            logger.error(
-                "storage cleanup failed; file orphaned",
-                analysis_id=analysis.id,
-                sample_id=analysis.sample.id,
-                key=key,
-                error=repr(exc),
-            )
+        # Only analyses migrated from Mongo have a ``legacy_id`` and slug-prefixed
+        # storage objects to clean up. Postgres-native analyses store no results in
+        # object storage, so there is nothing to delete.
+        if legacy_id is not None:
+            for key, exc in await delete_prefix(
+                self._storage,
+                f"samples/{sample_legacy_id}/analysis/{legacy_id}/",
+            ):
+                logger.error(
+                    "storage cleanup failed; file orphaned",
+                    analysis_id=analysis.id,
+                    sample_id=analysis.sample.id,
+                    key=key,
+                    error=repr(exc),
+                )
 
         emit(
             await self.data.samples.get(analysis.sample.id),

--- a/virtool/analyses/utils.py
+++ b/virtool/analyses/utils.py
@@ -13,11 +13,6 @@ def analysis_file_key(name_on_disk: str) -> str:
     return f"analyses/{name_on_disk}"
 
 
-def analysis_result_key(analysis_id: str, sample_id: str) -> str:
-    """Derive the storage key for an analysis results JSON file."""
-    return f"samples/{sample_id}/analysis/{analysis_id}/results.json"
-
-
 async def attach_analysis_files(
     pg: AsyncEngine,
     analysis_id: int,

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -255,7 +255,7 @@ class JobsData:
                     SQLLegacySample.id.label("sample_id"),
                     SQLJobIndex.index_id,
                     SQLSubtraction.id.label("subtraction_id"),
-                    SQLAnalysis.legacy_id,
+                    SQLAnalysis.id.label("analysis_id"),
                 )
                 .join(SQLUser, SQLJob.user_id == SQLUser.id)
                 .outerjoin(SQLLegacySample, SQLLegacySample.job_id == SQLJob.id)

--- a/virtool/jobs/pg.py
+++ b/virtool/jobs/pg.py
@@ -70,7 +70,7 @@ class SQLJobAnalysis(Base):
 
     No longer written: analyses now reference their job directly via
     ``SQLAnalysis.job_id``. The model and ``job_analyses`` table are retained
-    pending their drop in VIR-2438.
+    pending their drop in VIR-2394.
     """
 
     __tablename__ = "job_analyses"

--- a/virtool/samples/api.py
+++ b/virtool/samples/api.py
@@ -433,7 +433,6 @@ class AnalysesView(PydanticView):
             data,
             sample_id,
             self.request["client"].user_id,
-            0,
         )
 
         return json_response(

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -19,7 +19,7 @@ from structlog import get_logger
 
 import virtool.uploads.db
 import virtool.utils
-from virtool.analyses.sql import SQLAnalysis, SQLAnalysisResult
+from virtool.analyses.sql import SQLAnalysis
 from virtool.api.client import UserClient
 from virtool.config.cls import Config
 from virtool.data.domain import DataLayerDomain
@@ -542,15 +542,6 @@ class SamplesData(DataLayerDomain):
                     .values(reserved=False),
                 )
 
-            await pg_session.execute(
-                delete(SQLAnalysisResult).where(
-                    SQLAnalysisResult.analysis_id.in_(
-                        select(SQLAnalysis.legacy_id).where(
-                            SQLAnalysis.sample_id == sample_pk,
-                        ),
-                    ),
-                ),
-            )
             await pg_session.execute(
                 delete(SQLAnalysis).where(
                     SQLAnalysis.sample_id == sample_pk,

--- a/virtool/workflow/data/analyses.py
+++ b/virtool/workflow/data/analyses.py
@@ -20,7 +20,7 @@ class WFAnalysis:
     def __init__(
         self,
         api: WorkflowAPIClient,
-        analysis_id: str,
+        analysis_id: int,
         index: IndexNested,
         reference: ReferenceNested,
         sample: AnalysisSample,


### PR DESCRIPTION
## Summary
- Create Postgres-native analyses without a Mongo-backed `legacy_id`, generating the job in the same transaction as the analysis instead of pre-allocating a Mongo `analyses` document id — removes the last `mongo.analyses` read.
- Resolve the job's `analysis_id` from the `analyses.job_id` foreign key as an integer, and guard delete-time storage cleanup so native (NULL `legacy_id`) analyses skip it.
- Drop dead dual-write-era code: the `analysis_results` delete in sample deletion, `analysis_result_key`, and stale slug docstrings.