### PR TITLE
refactor: enlist history writes in a caller-provided postgres session

### DIFF
--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -158,14 +158,16 @@ class TestAdd:
             await ensure_reference(session, "hxn167", user.id)
             await session.commit()
 
-        change = await virtool.history.db.add(
-            pg,
-            "This is a description",
-            HistoryMethod.edit,
-            old,
-            new,
-            user.id,
-        )
+        async with AsyncSession(pg) as session:
+            change = await virtool.history.db.add(
+                session,
+                "This is a description",
+                HistoryMethod.edit,
+                old,
+                new,
+                user.id,
+            )
+            await session.commit()
 
         change_id = change["_id"]
 
@@ -209,14 +211,16 @@ class TestAdd:
             await ensure_reference(session, "hxn167", user.id)
             await session.commit()
 
-        change = await virtool.history.db.add(
-            pg,
-            f"Created {new['name']}",
-            HistoryMethod.create,
-            old,
-            new,
-            user.id,
-        )
+        async with AsyncSession(pg) as session:
+            change = await virtool.history.db.add(
+                session,
+                f"Created {new['name']}",
+                HistoryMethod.create,
+                old,
+                new,
+                user.id,
+            )
+            await session.commit()
 
         assert change == snapshot
         assert await get_row_by_id(pg, SQLLegacyHistoryDiff, 1) == snapshot
@@ -250,14 +254,16 @@ class TestAdd:
             await ensure_reference(session, "hxn167", user.id)
             await session.commit()
 
-        change = await virtool.history.db.add(
-            pg,
-            f"Removed {old['name']}",
-            HistoryMethod.remove,
-            old,
-            new,
-            user.id,
-        )
+        async with AsyncSession(pg) as session:
+            change = await virtool.history.db.add(
+                session,
+                f"Removed {old['name']}",
+                HistoryMethod.remove,
+                old,
+                new,
+                user.id,
+            )
+            await session.commit()
 
         assert change == snapshot(name="return_value")
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -125,19 +125,20 @@ async def bulk_insert_diffs(pg: AsyncEngine, rows: list[dict]) -> None:
 
 
 async def bulk_insert_history(
-    pg: AsyncEngine,
+    pg_session: AsyncSession,
     diff_rows: list[dict],
     documents: list[Document],
 ) -> None:
-    """Insert ``history_diffs`` and ``legacy_history`` rows in one transaction.
+    """Insert ``history_diffs`` and ``legacy_history`` rows into ``pg_session``.
 
     ``diff_rows`` and ``documents`` are parallel: ``diff_rows[i]`` must describe
     the same change as ``documents[i]``. They are validated to be aligned by
     ``change_id`` before any write, so a misaligned caller fails loudly rather
     than corrupting history.
 
-    Both tables are written in asyncpg-safe chunks within a single Postgres
-    transaction so they commit or roll back together.
+    Both tables are written in asyncpg-safe chunks into the caller-provided
+    ``pg_session`` without committing, so they commit or roll back together with the
+    caller's surrounding transaction.
     """
     if {row["change_id"] for row in diff_rows} != {
         document["_id"] for document in documents
@@ -153,61 +154,58 @@ async def bulk_insert_history(
 
     embedded_reference_ids = {document["reference"]["id"] for document in documents}
 
-    async with AsyncSession(pg) as session:
-        rows = (
-            (
-                await session.execute(
-                    select(SQLReference.id, SQLReference.legacy_id).where(
-                        compose_legacy_id_multi_expression(
-                            SQLReference,
-                            embedded_reference_ids,
-                        ),
+    rows = (
+        (
+            await pg_session.execute(
+                select(SQLReference.id, SQLReference.legacy_id).where(
+                    compose_legacy_id_multi_expression(
+                        SQLReference,
+                        embedded_reference_ids,
                     ),
-                )
-            ).all()
-            if embedded_reference_ids
-            else []
-        )
-
-        reference_id_map: dict[int | str, int] = {
-            **{id_: id_ for id_, _ in rows},
-            **{legacy_id: id_ for id_, legacy_id in rows if legacy_id is not None},
-        }
-
-        unresolved = embedded_reference_ids - reference_id_map.keys()
-
-        if unresolved:
-            raise ValueError(
-                f"References not found in postgres: {sorted(unresolved, key=str)}",
-            )
-
-        for row, document in zip(legacy_rows, documents, strict=True):
-            row["reference_id"] = reference_id_map[document["reference"]["id"]]
-
-        history_ids: dict[str, int] = {}
-
-        for start in range(0, len(legacy_rows), _LEGACY_HISTORY_CHUNK_SIZE):
-            result = await session.execute(
-                insert(SQLLegacyHistory)
-                .values(legacy_rows[start : start + _LEGACY_HISTORY_CHUNK_SIZE])
-                .returning(SQLLegacyHistory.id, SQLLegacyHistory.legacy_id),
-            )
-
-            for id_, legacy_id in result.all():
-                history_ids[legacy_id] = id_
-
-        diff_values = [
-            {**row, "history_id": history_ids[row["change_id"]]} for row in diff_rows
-        ]
-
-        for start in range(0, len(diff_values), _HISTORY_DIFF_CHUNK_SIZE):
-            await session.execute(
-                insert(SQLLegacyHistoryDiff).values(
-                    diff_values[start : start + _HISTORY_DIFF_CHUNK_SIZE],
                 ),
             )
+        ).all()
+        if embedded_reference_ids
+        else []
+    )
 
-        await session.commit()
+    reference_id_map: dict[int | str, int] = {
+        **{id_: id_ for id_, _ in rows},
+        **{legacy_id: id_ for id_, legacy_id in rows if legacy_id is not None},
+    }
+
+    unresolved = embedded_reference_ids - reference_id_map.keys()
+
+    if unresolved:
+        raise ValueError(
+            f"References not found in postgres: {sorted(unresolved, key=str)}",
+        )
+
+    for row, document in zip(legacy_rows, documents, strict=True):
+        row["reference_id"] = reference_id_map[document["reference"]["id"]]
+
+    history_ids: dict[str, int] = {}
+
+    for start in range(0, len(legacy_rows), _LEGACY_HISTORY_CHUNK_SIZE):
+        result = await pg_session.execute(
+            insert(SQLLegacyHistory)
+            .values(legacy_rows[start : start + _LEGACY_HISTORY_CHUNK_SIZE])
+            .returning(SQLLegacyHistory.id, SQLLegacyHistory.legacy_id),
+        )
+
+        for id_, legacy_id in result.all():
+            history_ids[legacy_id] = id_
+
+    diff_values = [
+        {**row, "history_id": history_ids[row["change_id"]]} for row in diff_rows
+    ]
+
+    for start in range(0, len(diff_values), _HISTORY_DIFF_CHUNK_SIZE):
+        await pg_session.execute(
+            insert(SQLLegacyHistoryDiff).values(
+                diff_values[start : start + _HISTORY_DIFF_CHUNK_SIZE],
+            ),
+        )
 
 
 async def bulk_delete_history(pg: AsyncEngine, change_ids: list[str]) -> None:
@@ -265,7 +263,7 @@ class PreparedChange:
 
 
 async def add(
-    pg: AsyncEngine,
+    pg_session: AsyncSession,
     description: str,
     method_name: HistoryMethod,
     old: dict | None,
@@ -274,7 +272,12 @@ async def add(
 ) -> dict:
     """Add a change document to ``legacy_history``.
 
-    :param pg: the application PostgreSQL database object
+    Writes into the caller-provided ``pg_session`` and does not commit, so the history
+    rows land or roll back atomically with the surrounding transaction (e.g. the paired
+    Mongo write coordinated by ``both_transactions``). The session is flushed to populate
+    the ``legacy_history`` primary key for the diff's foreign key.
+
+    :param pg_session: an active Postgres session owned by the caller
     :param method_name: the name of the handler method that executed the change
     :param old: the otu document prior to the change
     :param new: the otu document after the change
@@ -290,23 +293,21 @@ async def add(
     diff_row = SQLLegacyHistoryDiff(change_id=document["_id"], diff=prepared.diff)
     legacy_row = SQLLegacyHistory(**legacy_history_values(document))
 
-    async with AsyncSession(pg) as pg_session:
-        reference_id = document["reference"]["id"]
+    reference_id = document["reference"]["id"]
 
-        legacy_row.reference_id = await resolve_legacy_id(
-            pg_session,
-            SQLReference,
-            reference_id,
-        )
+    legacy_row.reference_id = await resolve_legacy_id(
+        pg_session,
+        SQLReference,
+        reference_id,
+    )
 
-        if legacy_row.reference_id is None:
-            raise ValueError(f"Reference {reference_id!r} not found in postgres")
+    if legacy_row.reference_id is None:
+        raise ValueError(f"Reference {reference_id!r} not found in postgres")
 
-        pg_session.add(legacy_row)
-        await pg_session.flush()
-        diff_row.history_id = legacy_row.id
-        pg_session.add(diff_row)
-        await pg_session.commit()
+    pg_session.add(legacy_row)
+    await pg_session.flush()
+    diff_row.history_id = legacy_row.id
+    pg_session.add(diff_row)
 
     return {**document, "diff": prepared.diff}
 

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -650,7 +650,11 @@ class OTUData:
                 session=mongo_session,
             )
 
-            await virtool.otus.db.update_otu_verification(self._mongo, new)
+            await virtool.otus.db.update_otu_verification(
+                self._mongo,
+                new,
+                session=mongo_session,
+            )
 
             # Use the old and new entry to add a new history document for the change.
             await virtool.history.db.add(
@@ -681,7 +685,7 @@ class OTUData:
             mongo_session: AsyncIOMotorClientSession,
             pg_session: AsyncSession,
         ):
-            document = await self._mongo.otus.find_one(otu_id)
+            document = await self._mongo.otus.find_one(otu_id, session=mongo_session)
 
             isolates = deepcopy(document["isolates"])
 

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -12,7 +12,7 @@ import virtool.history.db
 import virtool.otus.db
 import virtool.otus.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
-from virtool.data.topg import resolve_legacy_id
+from virtool.data.topg import resolve_legacy_id, retry_both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.history.utils import (
     compose_create_description,
@@ -244,7 +244,10 @@ class OTUData:
         if reference_pk is None:
             raise ResourceNotFoundError("Reference does not exist")
 
-        async def func(session: AsyncIOMotorClientSession) -> Document:
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> Document:
             document_ = await self._mongo.otus.insert_one(
                 {
                     "name": data.name,
@@ -257,11 +260,11 @@ class OTUData:
                     "reference": {"id": reference_pk},
                     "schema": data.dict()["otu_schema"],
                 },
-                session=session,
+                session=mongo_session,
             )
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 compose_create_description(document_),
                 HistoryMethod.create,
                 None,
@@ -271,7 +274,7 @@ class OTUData:
 
             return document_
 
-        document = await self._mongo.with_transaction(func)
+        document = await retry_both_transactions(self._mongo, self._pg, func)
 
         return await self.get(document["_id"])
 
@@ -304,33 +307,36 @@ class OTUData:
         if "schema" in data:
             update["schema"] = data["schema"]
 
-        async def func(session: AsyncIOMotorClientSession):
-            old = await virtool.otus.db.join(self._mongo, otu_id, session=session)
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ):
+            old = await virtool.otus.db.join(self._mongo, otu_id, session=mongo_session)
 
             document_ = await self._mongo.otus.find_one_and_update(
                 {"_id": otu_id},
                 {"$set": update, "$inc": {"version": 1}},
-                session=session,
+                session=mongo_session,
             )
 
             await virtool.otus.db.update_sequence_segments(
                 self._mongo,
                 old,
                 document_,
-                session=session,
+                session=mongo_session,
             )
 
             new = await virtool.otus.db.join(
                 self._mongo,
                 otu_id,
                 document_,
-                session=session,
+                session=mongo_session,
             )
 
-            await update_otu_verification(self._mongo, new, session=session)
+            await update_otu_verification(self._mongo, new, session=mongo_session)
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 compose_edit_description(
                     new["name"],
                     new["abbreviation"],
@@ -343,7 +349,7 @@ class OTUData:
                 user_id,
             )
 
-        await self._mongo.with_transaction(func)
+        await retry_both_transactions(self._mongo, self._pg, func)
 
         return await self.get(otu_id)
 
@@ -362,16 +368,21 @@ class OTUData:
         if not joined:
             return None
 
-        async def func(session: AsyncIOMotorClientSession) -> DeleteResult | None:
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> DeleteResult | None:
             _, delete_result = await asyncio.gather(
-                self._mongo.sequences.delete_many({"otu_id": otu_id}, session=session),
-                self._mongo.otus.delete_one({"_id": otu_id}, session=session),
+                self._mongo.sequences.delete_many(
+                    {"otu_id": otu_id}, session=mongo_session
+                ),
+                self._mongo.otus.delete_one({"_id": otu_id}, session=mongo_session),
             )
 
             description = compose_remove_description(joined)
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 description,
                 HistoryMethod.remove,
                 joined,
@@ -381,7 +392,7 @@ class OTUData:
 
             return delete_result
 
-        return await self._mongo.with_transaction(func)
+        return await retry_both_transactions(self._mongo, self._pg, func)
 
     async def _check_source_type(self, otu_id: str, source_type: str) -> None:
         """Ensure ``source_type`` is allowed by the OTU's parent reference.
@@ -411,8 +422,11 @@ class OTUData:
 
         await self._check_source_type(otu_id, source_type)
 
-        async def func(session: AsyncIOMotorClientSession) -> OTUIsolate:
-            document = await self._mongo.otus.find_one(otu_id, session=session)
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> OTUIsolate:
+            document = await self._mongo.otus.find_one(otu_id, session=mongo_session)
 
             isolates = deepcopy(document["isolates"])
 
@@ -426,7 +440,7 @@ class OTUData:
                 for isolate_ in isolates:
                     isolate_["default"] = False
 
-            document = await self._mongo.otus.find_one(otu_id, session=session)
+            document = await self._mongo.otus.find_one(otu_id, session=mongo_session)
 
             isolates = deepcopy(document["isolates"])
 
@@ -444,7 +458,7 @@ class OTUData:
                 self._mongo,
                 otu_id,
                 document,
-                session=session,
+                session=mongo_session,
             )
 
             existing_isolate_ids = {i["id"] for i in isolates}
@@ -469,13 +483,13 @@ class OTUData:
                     "$set": {"isolates": [*isolates, isolate_], "verified": False},
                     "$inc": {"version": 1},
                 },
-                session=session,
+                session=mongo_session,
             )
 
             # Get the joined entry now that it has been updated.
-            new = await virtool.otus.db.join(self._mongo, otu_id, session=session)
+            new = await virtool.otus.db.join(self._mongo, otu_id, session=mongo_session)
 
-            await update_otu_verification(self._mongo, new, session=session)
+            await update_otu_verification(self._mongo, new, session=mongo_session)
 
             description = f"Added {format_isolate_name(isolate_)}"
 
@@ -483,7 +497,7 @@ class OTUData:
                 description += " as default"
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 description,
                 HistoryMethod.add_isolate,
                 old,
@@ -493,7 +507,7 @@ class OTUData:
 
             return OTUIsolate(**{**isolate_, "sequences": []})
 
-        return await self._mongo.with_transaction(func)
+        return await retry_both_transactions(self._mongo, self._pg, func)
 
     async def update_isolate(
         self,
@@ -521,8 +535,11 @@ class OTUData:
 
         new_isolate_name = format_isolate_name(isolate)
 
-        async def func(session: AsyncIOMotorClientSession) -> Document:
-            old = await virtool.otus.db.join(self._mongo, otu_id, session=session)
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> Document:
+            old = await virtool.otus.db.join(self._mongo, otu_id, session=mongo_session)
 
             # Replace the isolates list with the update one.
             document = await self._mongo.otus.find_one_and_update(
@@ -531,7 +548,7 @@ class OTUData:
                     "$set": {"isolates": isolates, "verified": False},
                     "$inc": {"version": 1},
                 },
-                session=session,
+                session=mongo_session,
             )
 
             # Get the joined entry now that it has been updated.
@@ -539,18 +556,18 @@ class OTUData:
                 self._mongo,
                 otu_id,
                 document,
-                session=session,
+                session=mongo_session,
             )
 
             await virtool.otus.db.update_otu_verification(
                 self._mongo,
                 new_,
-                session=session,
+                session=mongo_session,
             )
 
             # Use the old and new entry to add a new history document for the change.
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 f"Renamed {old_isolate_name} to {new_isolate_name}",
                 HistoryMethod.edit_isolate,
                 old,
@@ -560,7 +577,7 @@ class OTUData:
 
             return new_
 
-        new = await self._mongo.with_transaction(func)
+        new = await retry_both_transactions(self._mongo, self._pg, func)
 
         complete = await virtool.otus.db.join_and_format(
             self._mongo,
@@ -586,8 +603,11 @@ class OTUData:
 
         """
 
-        async def func(session: AsyncIOMotorClientSession) -> Document:
-            document = await self._mongo.otus.find_one(otu_id, session=session)
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> Document:
+            document = await self._mongo.otus.find_one(otu_id, session=mongo_session)
 
             isolate = find_isolate(document["isolates"], isolate_id)
 
@@ -595,7 +615,7 @@ class OTUData:
                 self._mongo,
                 otu_id,
                 document,
-                session=session,
+                session=mongo_session,
             )
 
             # If the default isolate will be unchanged, immediately return the existing
@@ -619,7 +639,7 @@ class OTUData:
                     "$set": {"isolates": isolates, "verified": False},
                     "$inc": {"version": 1},
                 },
-                session=session,
+                session=mongo_session,
             )
 
             # Get the joined entry now that it has been updated.
@@ -627,14 +647,14 @@ class OTUData:
                 self._mongo,
                 otu_id,
                 document,
-                session=session,
+                session=mongo_session,
             )
 
             await virtool.otus.db.update_otu_verification(self._mongo, new)
 
             # Use the old and new entry to add a new history document for the change.
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 f"Set {format_isolate_name(isolate)} as default",
                 HistoryMethod.set_as_default,
                 old,
@@ -646,7 +666,7 @@ class OTUData:
                 find_isolate(new["isolates"], isolate_id),
             )
 
-        return await self._mongo.with_transaction(func)
+        return await retry_both_transactions(self._mongo, self._pg, func)
 
     async def remove_isolate(self, otu_id: str, isolate_id: str, user_id: int) -> None:
         """Remove an isolate.
@@ -657,7 +677,10 @@ class OTUData:
 
         """
 
-        async def func(session: AsyncIOMotorClientSession):
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ):
             document = await self._mongo.otus.find_one(otu_id)
 
             isolates = deepcopy(document["isolates"])
@@ -679,7 +702,7 @@ class OTUData:
                 self._mongo,
                 otu_id,
                 document,
-                session=session,
+                session=mongo_session,
             )
 
             document = await self._mongo.otus.find_one_and_update(
@@ -688,25 +711,25 @@ class OTUData:
                     "$set": {"isolates": isolates, "verified": False},
                     "$inc": {"version": 1},
                 },
-                session=session,
+                session=mongo_session,
             )
 
             new = await virtool.otus.db.join(
                 self._mongo,
                 otu_id,
                 document,
-                session=session,
+                session=mongo_session,
             )
 
             await asyncio.gather(
                 virtool.otus.db.update_otu_verification(
                     self._mongo,
                     new,
-                    session=session,
+                    session=mongo_session,
                 ),
                 self._mongo.sequences.delete_many(
                     {"otu_id": otu_id, "isolate_id": isolate_id},
-                    session=session,
+                    session=mongo_session,
                 ),
             )
 
@@ -716,7 +739,7 @@ class OTUData:
                 description += f" and set {format_isolate_name(new_default)} as default"
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 description,
                 HistoryMethod.remove_isolate,
                 old,
@@ -724,7 +747,7 @@ class OTUData:
                 user_id,
             )
 
-        await self._mongo.with_transaction(func)
+        await retry_both_transactions(self._mongo, self._pg, func)
 
     async def create_sequence(
         self,
@@ -738,8 +761,11 @@ class OTUData:
         segment: str | None = None,
         sequence_id: str | None = None,
     ) -> OTUSequence:
-        async def func(session: AsyncIOMotorClientSession) -> OTUSequence:
-            old = await virtool.otus.db.join(self._mongo, otu_id, session=session)
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> OTUSequence:
+            old = await virtool.otus.db.join(self._mongo, otu_id, session=mongo_session)
 
             to_insert = {
                 "accession": accession,
@@ -757,7 +783,7 @@ class OTUData:
 
             document = await self._mongo.sequences.insert_one(
                 to_insert,
-                session=session,
+                session=mongo_session,
             )
 
             new = await virtool.otus.db.join(
@@ -766,15 +792,15 @@ class OTUData:
                 document=await increment_otu_version(
                     self._mongo,
                     otu_id,
-                    session=session,
+                    session=mongo_session,
                 ),
-                session=session,
+                session=mongo_session,
             )
 
             await virtool.otus.db.update_otu_verification(
                 self._mongo,
                 new,
-                session=session,
+                session=mongo_session,
             )
 
             isolate_name = format_isolate_name(
@@ -782,7 +808,7 @@ class OTUData:
             )
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 f"Created new sequence {accession} in {isolate_name}",
                 HistoryMethod.create_sequence,
                 old,
@@ -792,7 +818,7 @@ class OTUData:
 
             return OTUSequence(**document)
 
-        return await self._mongo.with_transaction(func)
+        return await retry_both_transactions(self._mongo, self._pg, func)
 
     async def get_sequence(
         self,
@@ -837,27 +863,30 @@ class OTUData:
         if "sequence" in data:
             update["sequence"] = data["sequence"].replace(" ", "").replace("\n", "")
 
-        async def func(session: AsyncIOMotorClientSession) -> Document:
-            old = await virtool.otus.db.join(self._mongo, otu_id, session=session)
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> Document:
+            old = await virtool.otus.db.join(self._mongo, otu_id, session=mongo_session)
 
             document = await self._mongo.sequences.find_one_and_update(
                 {"_id": sequence_id},
                 {"$set": update},
-                session=session,
+                session=mongo_session,
             )
 
-            await increment_otu_version(self._mongo, otu_id, session=session)
+            await increment_otu_version(self._mongo, otu_id, session=mongo_session)
 
-            new = await virtool.otus.db.join(self._mongo, otu_id, session=session)
+            new = await virtool.otus.db.join(self._mongo, otu_id, session=mongo_session)
 
-            await update_otu_verification(self._mongo, new, session=session)
+            await update_otu_verification(self._mongo, new, session=mongo_session)
 
             isolate_name = format_isolate_name(
                 find_isolate(old["isolates"], isolate_id),
             )
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 f"Edited sequence {sequence_id} in {isolate_name}",
                 HistoryMethod.edit_sequence,
                 old,
@@ -867,7 +896,9 @@ class OTUData:
 
             return document
 
-        return base_processor(await self._mongo.with_transaction(func))
+        return base_processor(
+            await retry_both_transactions(self._mongo, self._pg, func)
+        )
 
     async def remove_sequence(
         self,
@@ -886,10 +917,13 @@ class OTUData:
         """
         old = await virtool.otus.db.join(self._mongo, otu_id)
 
-        async def func(session: AsyncIOMotorClientSession):
+        async def func(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ):
             await self._mongo.sequences.delete_one(
                 {"_id": sequence_id},
-                session=session,
+                session=mongo_session,
             )
 
             new = await virtool.otus.db.join(
@@ -898,19 +932,19 @@ class OTUData:
                 document=await increment_otu_version(
                     self._mongo,
                     otu_id,
-                    session=session,
+                    session=mongo_session,
                 ),
-                session=session,
+                session=mongo_session,
             )
 
-            await update_otu_verification(self._mongo, new, session=session)
+            await update_otu_verification(self._mongo, new, session=mongo_session)
 
             isolate_name = format_isolate_name(
                 find_isolate(old["isolates"], isolate_id),
             )
 
             await virtool.history.db.add(
-                self._pg,
+                pg_session,
                 f"Removed sequence {sequence_id} from {isolate_name}",
                 HistoryMethod.remove_sequence,
                 old,
@@ -918,4 +952,4 @@ class OTUData:
                 user_id,
             )
 
-        await self._mongo.with_transaction(func)
+        await retry_both_transactions(self._mongo, self._pg, func)

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -1295,11 +1295,13 @@ class ReferencesData(DataLayerDomain):
             for insertion in insertions
         ]
 
-        await bulk_insert_history(
-            self._pg,
-            diff_rows,
-            [insertion.history.document for insertion in insertions],
-        )
+        async with AsyncSession(self._pg) as pg_session:
+            await bulk_insert_history(
+                pg_session,
+                diff_rows,
+                [insertion.history.document for insertion in insertions],
+            )
+            await pg_session.commit()
 
         await tracker.add(1)
 

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -672,11 +672,13 @@ async def populate_insert_only_reference(
         for insertion in insertions
     ]
 
-    await bulk_insert_history(
-        pg,
-        diff_rows,
-        [insertion.history.document for insertion in insertions],
-    )
+    async with AsyncSession(pg) as pg_session:
+        await bulk_insert_history(
+            pg_session,
+            diff_rows,
+            [insertion.history.document for insertion in insertions],
+        )
+        await pg_session.commit()
 
     try:
         sequences = []


### PR DESCRIPTION
## Summary
- `history.db.add` and `bulk_insert_history` now write into a caller-provided `AsyncSession` without committing, matching the existing `delete_history` contract.
- OTU history paths run through `retry_both_transactions` so history rows commit atomically with the paired Mongo transaction, closing a gap where a retried Mongo transaction could leave orphaned or duplicate history.
- Reference import and clone paths now wrap their bulk history inserts in a caller-owned session.