### PR TITLE
chore: serialize cross-worktree test runs with flock

### DIFF
--- a/.config/test.sh
+++ b/.config/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Serialize test stack access across git worktrees. The Docker compose project
+# name is pinned to "virtool", so every worktree shares one stack and one
+# bind-mounted /app. A single flock held across both "up" and "exec" prevents a
+# sibling worktree from rebinding /app between our up and exec.
+flock /tmp/virtool-test.lock bash -c '
+  docker compose up -d test
+  docker compose exec test uv run pytest "$@"
+' bash "$@"

--- a/.config/test.sh
+++ b/.config/test.sh
@@ -5,7 +5,19 @@ set -euo pipefail
 # name is pinned to "virtool", so every worktree shares one stack and one
 # bind-mounted /app. A single flock held across both "up" and "exec" prevents a
 # sibling worktree from rebinding /app between our up and exec.
+
+# When VT_TEST_PARALLEL is set, run pytest under xdist with half the host's
+# cores (floored at 1). Falls back to 2 cores if nproc is unavailable.
+worker_args=()
+if [ -n "${VT_TEST_PARALLEL:-}" ]; then
+  cores=$(nproc 2>/dev/null || echo 2)
+  workers=$(( cores / 2 ))
+  (( workers < 1 )) && workers=1
+  worker_args=(-n "$workers")
+fi
+
 flock /tmp/virtool-test.lock bash -c '
+  set -euo pipefail
   docker compose up -d test
   docker compose exec test uv run pytest "$@"
-' bash "$@"
+' bash "${worker_args[@]}" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@ API server using aiohttp, with PostgreSQL and MongoDB backends.
 Tests run in Docker containers with PostgreSQL and MongoDB services.
 
 ```bash
-# Run full test suite
-mise run test
+# Run specific tests, single worker (use for targeted runs)
+mise run test -- tests/account
 
-# Run specific tests with pytest args
-mise run test -- tests/account -n4
+# Run the full suite in parallel (nproc/2 workers)
+mise run test:multi
 
 # Update snapshots
 mise run test -- --su
@@ -28,6 +28,18 @@ mise run test:shell
 # Stop test environment
 mise run test:down
 ```
+
+The Docker test stack is **shared across all git worktrees** — the compose
+project name is pinned to `virtool`, so every worktree binds the same container
+and the same `/app` mount. To stop concurrent runs from clobbering each other,
+`test` and `test:multi` serialize stack access with an OS-level `flock` on
+`/tmp/virtool-test.lock`; a waiting run queues behind the active one instead of
+recreating the container.
+
+Use `test` (single worker) for targeted runs and `test:multi` for the full
+suite. Cross-worktree database-name collisions (`vt_test_{worker_id}`,
+`test/{worker_id}/...`) are tracked separately and only bite when runs overlap,
+which the lock now prevents.
 
 We use Syrupy-based snapshot testing.
 

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ run = './.config/test.sh $usage_pytest_args'
 [tasks."test:multi"]
 description = "Run the full test suite in parallel (nproc/2 workers), serialized across worktrees."
 usage = 'arg "[<pytest_args>...]" help="Arguments passed to pytest"'
-run = './.config/test.sh -n "$(( $(nproc) / 2 ))" $usage_pytest_args'
+run = 'VT_TEST_PARALLEL=1 ./.config/test.sh $usage_pytest_args'
 
 [tasks."test:build"]
 description = "Build test Docker image."

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,12 @@
 [tasks.test]
-description = "Run Python tests in Docker."
+description = "Run Python tests in Docker (single worker by default), serialized across worktrees."
 usage = 'arg "[<pytest_args>...]" help="Arguments passed to pytest"'
-run = [
-  "docker compose up -d test",
-  "docker compose exec test uv run pytest $usage_pytest_args"
-]
+run = './.config/test.sh $usage_pytest_args'
+
+[tasks."test:multi"]
+description = "Run the full test suite in parallel (nproc/2 workers), serialized across worktrees."
+usage = 'arg "[<pytest_args>...]" help="Arguments passed to pytest"'
+run = './.config/test.sh -n "$(( $(nproc) / 2 ))" $usage_pytest_args'
 
 [tasks."test:build"]
 description = "Build test Docker image."


### PR DESCRIPTION
## Summary

- Wrap `mise run test` in a `flock` on `/tmp/virtool-test.lock` so concurrent runs from sibling git worktrees queue instead of clobbering the shared `virtool` compose stack and `/app` bind mount
- Add a `test:multi` task for running the full suite in parallel (nproc/2 workers), keeping single-worker `test` for targeted runs
- Document the shared-stack/locking behavior and cross-worktree database-name caveats in AGENTS.md