### PR TITLE
feat(migration): add sequence isolate_id/segment and otu reference_id index

### DIFF
--- a/assets/alembic/versions/5de38ebeaa78_add_sequence_isolate_id_and_segment_.py
+++ b/assets/alembic/versions/5de38ebeaa78_add_sequence_isolate_id_and_segment_.py
@@ -1,0 +1,30 @@
+"""add sequence isolate_id and segment columns and otu reference_id index
+
+Revision ID: 5de38ebeaa78
+Revises: 8bbc31ae5a8a
+Create Date: 2026-07-10 20:20:06.481417+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5de38ebeaa78"
+down_revision = "8bbc31ae5a8a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "legacy_sequences", sa.Column("isolate_id", sa.String(), nullable=False)
+    )
+    op.add_column("legacy_sequences", sa.Column("segment", sa.String(), nullable=True))
+    op.create_index("ix_legacy_otus_reference_id", "legacy_otus", ["reference_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_legacy_otus_reference_id", table_name="legacy_otus")
+    op.drop_column("legacy_sequences", "segment")
+    op.drop_column("legacy_sequences", "isolate_id")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -715,5 +715,12 @@
       'name': 'create otus and sequences tables',
       'revision': '8bbc31ae5a8a',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 103,
+      'name': 'add sequence isolate_id and segment columns and otu reference_id index',
+      'revision': '5de38ebeaa78',
+    }),
   ])
 # ---

--- a/virtool/otus/sql.py
+++ b/virtool/otus/sql.py
@@ -40,7 +40,7 @@ class SQLOTU(Base):
     name: Mapped[str]
     abbreviation: Mapped[str] = mapped_column(default="")
     reference_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("legacy_references.id")
+        BigInteger, ForeignKey("legacy_references.id"), index=True
     )
     verified: Mapped[bool]
     version: Mapped[int]
@@ -52,10 +52,14 @@ class SQLSequence(Base):
     """SQL model for a sequence.
 
     Like :class:`SQLOTU` this is a hybrid model: the verbatim Mongo document lives
-    in ``data`` and ``otu_id`` is the only promoted column. ``otu_id`` is a real
-    foreign key to ``legacy_otus.id`` with ``ON DELETE CASCADE`` so a deleted OTU
-    takes its sequences with it. The column is indexed because Postgres does not
-    index foreign key columns automatically.
+    in ``data`` and the remaining columns are promoted from it for querying.
+    ``otu_id`` is a real foreign key to ``legacy_otus.id`` with ``ON DELETE
+    CASCADE`` so a deleted OTU takes its sequences with it. The column is indexed
+    because Postgres does not index foreign key columns automatically.
+
+    ``isolate_id`` identifies the embedded isolate the sequence belongs to and is
+    promoted so isolate-scoped operations (such as removing an isolate) can filter
+    and delete on it directly. ``segment`` is the optional segment name.
     """
 
     __tablename__ = "legacy_sequences"
@@ -65,3 +69,5 @@ class SQLSequence(Base):
     otu_id: Mapped[str] = mapped_column(
         ForeignKey("legacy_otus.id", ondelete="CASCADE"), index=True
     )
+    isolate_id: Mapped[str]
+    segment: Mapped[str | None]


### PR DESCRIPTION
## Summary
- Promote `isolate_id` and `segment` onto `legacy_sequences` so isolate-scoped operations (e.g. removing an isolate) can filter/delete on real columns instead of JSONB queries
- Add the missing `ix_legacy_otus_reference_id` index so reference-scoped OTU list reads don't sequential-scan once that path moves to Postgres
- Completes the promoted-column contract from VIR-2637 ahead of dual-write landing in VIR-2638