### PR TITLE
feat(migration): backfill existing otus and sequences to postgres

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,9 +242,10 @@ register it as a revision in `assets/revisions/`:
   `user`), raise if the reference cannot be resolved — do not silently store
   `NULL`. For relationships that are explicitly optional or were historically
   deletable (e.g. `job`), log a warning and store `NULL`.
-- After the initial backfill revision ships, add a second "re-backfill" revision
-  to catch documents created between the first backfill and the dual-write
-  rollout.
+A single backfill revision is enough. Dual-write (step 2) always ships and
+deploys before the backfill runs, so every write is already landing in Postgres
+by the time the backfill executes and there is no gap to catch up. Do not add a
+second "re-backfill" revision.
 
 #### Step 4 — Switch reads to Postgres
 

--- a/assets/revisions/rev_gkdk4xtpkwi2_copy_otus_and_sequences_to_postgres.py
+++ b/assets/revisions/rev_gkdk4xtpkwi2_copy_otus_and_sequences_to_postgres.py
@@ -1,0 +1,40 @@
+"""Copy Mongo OTUs and sequences to Postgres.
+
+Backfills every existing ``otus`` and ``sequences`` document into the
+``legacy_otus`` and ``legacy_sequences`` tables before OTU and sequence
+mutations begin dual-writing to Postgres, so both stores are consistent ahead of
+the read cutover.
+
+The copy is idempotent: rows already present in Postgres (by ``id``, which is the
+Mongo ``_id``) are skipped and every insert uses ``ON CONFLICT (id) DO NOTHING``,
+and each document is committed individually so an interrupted run can be re-run
+from where it stopped.
+
+Revision ID: gkdk4xtpkwi2
+Date: 2026-07-10 23:45:44.567131
+
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+from virtool.otus.migration import copy_otus_and_sequences_to_postgres
+
+# Revision identifiers.
+name = "copy otus and sequences to postgres"
+created_at = arrow.get("2026-07-10 23:45:44.567131")
+revision_id = "gkdk4xtpkwi2"
+
+alembic_down_revision = "5de38ebeaa78"
+virtool_down_revision = None
+
+# ``5de38ebeaa78`` adds ``legacy_sequences.isolate_id``/``segment`` and the
+# ``legacy_otus.reference_id`` index on top of ``8bbc31ae5a8a`` (create otus and
+# sequences tables), so requiring it guarantees the destination tables and every
+# promoted column exist before this runs.
+required_alembic_revision = "5de38ebeaa78"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Copy the Mongo ``otus`` and ``sequences`` collections into Postgres."""
+    await copy_otus_and_sequences_to_postgres(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -722,5 +722,12 @@
       'name': 'add sequence isolate_id and segment columns and otu reference_id index',
       'revision': '5de38ebeaa78',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 104,
+      'name': 'copy otus and sequences to postgres',
+      'revision': 'gkdk4xtpkwi2',
+    }),
   ])
 # ---

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -4,11 +4,14 @@ import asyncio
 from collections.abc import Callable
 
 import pytest
-from sqlalchemy import text
+from motor.motor_asyncio import AsyncIOMotorCollection
+from sqlalchemy import insert, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.migration.ctx import MigrationContext
+from virtool.otus.db import otu_row_values
 from virtool.otus.migration import copy_otus_and_sequences_to_postgres
+from virtool.otus.sql import SQLOTU
 from virtool.utils import timestamp
 
 
@@ -111,6 +114,22 @@ async def _fetch_sequence(ctx: MigrationContext, sequence_id: str):
                 {"id": sequence_id},
             )
         ).one_or_none()
+
+
+async def _insert_otu_row(
+    ctx: MigrationContext, otu_id: str, reference_id: int
+) -> None:
+    """Insert a ``legacy_otus`` row directly, as an application dual-write would."""
+    async with AsyncSession(ctx.pg) as session:
+        await session.execute(
+            insert(SQLOTU).values(
+                **otu_row_values(
+                    _otu_doc(otu_id, reference_id, "Cucumber mosaic virus"),
+                    reference_id,
+                ),
+            ),
+        )
+        await session.commit()
 
 
 async def _count(ctx: MigrationContext, table: str) -> int:
@@ -244,3 +263,37 @@ class TestCopyOtusAndSequences:
 
         with pytest.raises(ValueError, match="does not exist in postgres"):
             await copy_otus_and_sequences_to_postgres(ctx)
+
+    async def test_otu_dual_written_mid_run_is_not_an_orphan(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+        mocker,
+    ):
+        """A parent OTU that lands in Postgres mid-run must not be called an orphan.
+
+        The application keeps dual-writing while the backfill runs, so a parent OTU
+        can appear in Postgres after the sequence pass cached its OTU id set. The
+        stale set must not be the only thing consulted before rejecting a sequence.
+        """
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_dual_written", "otu_dual_written"),
+        )
+
+        real_find_one = AsyncIOMotorCollection.find_one
+
+        async def find_one_after_dual_write(self, *args, **kwargs):
+            if self.name == "sequences":
+                await _insert_otu_row(ctx, "otu_dual_written", reference_id)
+
+            return await real_find_one(self, *args, **kwargs)
+
+        mocker.patch.object(
+            AsyncIOMotorCollection,
+            "find_one",
+            find_one_after_dual_write,
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        assert await _fetch_sequence(ctx, "seq_dual_written") is not None

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -1,0 +1,246 @@
+"""Tests for the Mongo-to-Postgres OTU and sequence backfill."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+from virtool.otus.migration import copy_otus_and_sequences_to_postgres
+from virtool.utils import timestamp
+
+
+async def _seed_reference(ctx: MigrationContext, legacy_id: str = "ref_legacy") -> int:
+    """Insert an owning user and a ``legacy_references`` row; return its id."""
+    async with AsyncSession(ctx.pg) as session:
+        user_id = (
+            await session.execute(
+                text("""
+                    INSERT INTO users (
+                        handle, legacy_id, active, email, force_reset,
+                        invalidate_sessions, last_password_change, password, settings
+                    )
+                    VALUES (
+                        'reference_owner', 'reference_owner_legacy', true, '',
+                        false, false, :now, :pw, '{}'::jsonb
+                    )
+                    RETURNING id
+                """),
+                {"now": timestamp(), "pw": b"hashed"},
+            )
+        ).scalar_one()
+
+        reference_id = (
+            await session.execute(
+                text("""
+                    INSERT INTO legacy_references (
+                        legacy_id, name, description, organism, created_at,
+                        archived, restrict_source_types, source_types, user_id
+                    )
+                    VALUES (
+                        :legacy_id, 'Plant Viruses', '', '', :now,
+                        false, false, '[]'::jsonb, :user_id
+                    )
+                    RETURNING id
+                """),
+                {"legacy_id": legacy_id, "now": timestamp(), "user_id": user_id},
+            )
+        ).scalar_one()
+        await session.commit()
+
+    return reference_id
+
+
+def _otu_doc(otu_id: str, reference_id: int, name: str) -> dict:
+    return {
+        "_id": otu_id,
+        "name": name,
+        "abbreviation": name[:3].upper(),
+        "reference": {"id": reference_id},
+        "verified": True,
+        "version": 3,
+        "isolates": [
+            {"id": "isolate_a", "source_type": "isolate", "source_name": "A"},
+        ],
+        "schema": [],
+    }
+
+
+def _sequence_doc(
+    sequence_id: str,
+    otu_id: str,
+    isolate_id: str = "isolate_a",
+    segment: str | None = "RNA1",
+) -> dict:
+    return {
+        "_id": sequence_id,
+        "otu_id": otu_id,
+        "isolate_id": isolate_id,
+        "segment": segment,
+        "accession": "AB000001",
+        "definition": "A test sequence",
+        "host": "",
+        "sequence": "ATGC",
+    }
+
+
+async def _fetch_otu(ctx: MigrationContext, otu_id: str):
+    async with AsyncSession(ctx.pg) as session:
+        return (
+            await session.execute(
+                text("""
+                    SELECT id, data, name, abbreviation, reference_id,
+                           verified, version
+                    FROM legacy_otus WHERE id = :id
+                """),
+                {"id": otu_id},
+            )
+        ).one_or_none()
+
+
+async def _fetch_sequence(ctx: MigrationContext, sequence_id: str):
+    async with AsyncSession(ctx.pg) as session:
+        return (
+            await session.execute(
+                text("""
+                    SELECT id, data, otu_id, isolate_id, segment
+                    FROM legacy_sequences WHERE id = :id
+                """),
+                {"id": sequence_id},
+            )
+        ).one_or_none()
+
+
+async def _count(ctx: MigrationContext, table: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        return (
+            await session.execute(text(f"SELECT count(*) FROM {table}"))  # noqa: S608
+        ).scalar_one()
+
+
+@pytest.fixture
+async def reference_id(ctx: MigrationContext, apply_alembic: Callable) -> int:
+    """Apply the full schema and seed one reference; return its integer id."""
+    await asyncio.to_thread(apply_alembic, "head")
+    return await _seed_reference(ctx)
+
+
+class TestCopyOtusAndSequences:
+    async def test_backfills_otus_and_sequences(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        otu = _otu_doc("otu_00000000", reference_id, "Tobacco mosaic virus")
+        sequence = _sequence_doc("seq_00000000", "otu_00000000")
+
+        await ctx.mongo.otus.insert_one(otu)
+        await ctx.mongo.sequences.insert_one(sequence)
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        otu_row = await _fetch_otu(ctx, "otu_00000000")
+        assert otu_row.data == otu
+        assert otu_row.name == "Tobacco mosaic virus"
+        assert otu_row.abbreviation == "TOB"
+        assert otu_row.reference_id == reference_id
+        assert otu_row.verified is True
+        assert otu_row.version == 3
+
+        sequence_row = await _fetch_sequence(ctx, "seq_00000000")
+        assert sequence_row.data == sequence
+        assert sequence_row.otu_id == "otu_00000000"
+        assert sequence_row.isolate_id == "isolate_a"
+        assert sequence_row.segment == "RNA1"
+
+    async def test_missing_segment_backfills_null(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_00000000", reference_id, "Potato virus Y"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_00000000", "otu_00000000", segment=None),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        sequence_row = await _fetch_sequence(ctx, "seq_00000000")
+        assert sequence_row.segment is None
+
+    async def test_is_idempotent(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_00000000", reference_id, "Tobacco mosaic virus"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_00000000", "otu_00000000"),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        assert await _count(ctx, "legacy_otus") == 1
+        assert await _count(ctx, "legacy_sequences") == 1
+
+    async def test_converges_documents_added_after_first_run(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_existing", reference_id, "Tobacco mosaic virus"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_existing", "otu_existing"),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_gap", reference_id, "Potato virus Y"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_gap", "otu_gap"),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        assert await _fetch_otu(ctx, "otu_gap") is not None
+        assert await _fetch_sequence(ctx, "seq_gap") is not None
+        assert await _count(ctx, "legacy_otus") == 2
+        assert await _count(ctx, "legacy_sequences") == 2
+
+    async def test_unresolvable_reference_raises(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_00000000", 999999, "Ghost virus"),
+        )
+
+        with pytest.raises(ValueError, match="which does not exist in postgres"):
+            await copy_otus_and_sequences_to_postgres(ctx)
+
+    async def test_orphan_sequence_raises(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_00000000", reference_id, "Tobacco mosaic virus"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_orphan", "otu_missing"),
+        )
+
+        with pytest.raises(ValueError, match="does not exist in postgres"):
+            await copy_otus_and_sequences_to_postgres(ctx)

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -115,7 +115,9 @@ async def _copy_sequences(ctx: MigrationContext, session: AsyncSession) -> None:
     Runs after :func:`_copy_otus` so every parent OTU already has a
     ``legacy_otus`` row. The full set of OTU ids is loaded up front so an orphan
     sequence can be caught with a clear error before the not-null foreign key
-    rejects it with an opaque ``IntegrityError``.
+    rejects it with an opaque ``IntegrityError``. That set is only a cache: a miss
+    is re-checked against Postgres before raising, because the dual-writing
+    application may have created the parent OTU after the set was loaded.
     """
     otu_ids_present = {row[0] for row in await session.execute(select(SQLOTU.id))}
     existing_sequence_ids = {
@@ -146,12 +148,17 @@ async def _copy_sequences(ctx: MigrationContext, session: AsyncSession) -> None:
             skipped_count += 1
             continue
 
-        if document["otu_id"] not in otu_ids_present:
-            msg = (
-                f"sequence {sequence_id!r} references otu "
-                f"{document['otu_id']!r} which does not exist in postgres"
-            )
-            raise ValueError(msg)
+        otu_id = document["otu_id"]
+
+        if otu_id not in otu_ids_present:
+            if not await _otu_exists(session, otu_id):
+                msg = (
+                    f"sequence {sequence_id!r} references otu "
+                    f"{otu_id!r} which does not exist in postgres"
+                )
+                raise ValueError(msg)
+
+            otu_ids_present.add(otu_id)
 
         await session.execute(
             insert(SQLSequence)
@@ -167,6 +174,19 @@ async def _copy_sequences(ctx: MigrationContext, session: AsyncSession) -> None:
         migrated=migrated_count,
         skipped=skipped_count,
     )
+
+
+async def _otu_exists(session: AsyncSession, otu_id: str) -> bool:
+    """Check Postgres directly for a ``legacy_otus`` row.
+
+    Used to confirm a sequence's parent really is missing before raising. The OTU
+    may have been dual-written by the running application after the up-front id set
+    was loaded, in which case the sequence is not an orphan and the backfill must
+    not abort.
+    """
+    return (
+        await session.execute(select(SQLOTU.id).where(SQLOTU.id == otu_id))
+    ).scalar_one_or_none() is not None
 
 
 async def _resolve_reference_id(

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -1,0 +1,201 @@
+"""Shared backfill logic for copying Mongo OTUs and sequences into Postgres.
+
+This module holds the idempotent copy used by the OTU/sequence backfill
+revision. Keeping it here keeps the logic unit-testable and reusable.
+
+Unlike the standard migration playbook, ``legacy_otus`` and ``legacy_sequences``
+have no ``legacy_id`` column: their primary key ``id`` is the Mongo ``_id``
+string itself. Idempotency and skip-existing therefore key on ``id`` rather than
+``legacy_id``.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.data.topg import resolve_legacy_id
+from virtool.migration import MigrationContext
+from virtool.otus.db import otu_row_values, sequence_row_values
+from virtool.otus.sql import SQLOTU, SQLSequence
+from virtool.references.sql import SQLReference
+from virtool.types import Document
+
+logger = get_logger("migration")
+
+
+async def copy_otus_and_sequences_to_postgres(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``otus`` and ``sequences`` document into Postgres.
+
+    One row is written per Mongo document into ``legacy_otus`` and
+    ``legacy_sequences``. The whole document is stored verbatim in the ``data``
+    JSONB column and the remaining columns are promoted from it, exactly as the
+    dual-write path does. Documents are processed one at a time and committed
+    individually, so memory stays bounded and a failure part-way through keeps the
+    rows already written rather than rolling back the whole collection.
+
+    The document ``_id`` values are snapshotted up front with a projection-only
+    query so the rest of the run fetches one document at a time by id, rather than
+    holding a single Mongo cursor open for the entire migration.
+
+    OTUs are backfilled before sequences because ``legacy_sequences.otu_id`` is a
+    foreign key to ``legacy_otus.id``. Documents already present in Postgres (by
+    ``id``) are skipped, and every insert uses ``ON CONFLICT (id) DO NOTHING`` as a
+    second line of defence, so the backfill is safe to re-run after an
+    interruption.
+
+    Two integrity failures are loud rather than silent, matching the required
+    relationships they represent:
+
+    - An OTU whose embedded ``reference.id`` does not resolve to a
+      ``legacy_references`` row raises. Every OTU belongs to a reference, and
+      references are already migrated, so an unresolvable one is a data-integrity
+      problem, not a nullable relationship.
+    - A sequence whose ``otu_id`` matches no ``legacy_otus`` row raises. Such a
+      sequence is an orphan that should have been removed upstream by
+      :func:`virtool.references.migration.purge_orphaned_references`; the not-null
+      foreign key would reject it regardless.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        await _copy_otus(ctx, session)
+        await _copy_sequences(ctx, session)
+
+
+async def _copy_otus(ctx: MigrationContext, session: AsyncSession) -> None:
+    """Backfill the Mongo ``otus`` collection into ``legacy_otus``."""
+    existing_otu_ids = {row[0] for row in await session.execute(select(SQLOTU.id))}
+
+    logger.info("found existing otus in postgres", count=len(existing_otu_ids))
+
+    otu_ids = [
+        document["_id"]
+        async for document in ctx.mongo.otus.find({}, projection=["_id"])
+    ]
+
+    migrated_count = 0
+    skipped_count = 0
+    reference_id_cache: dict[int | str, int] = {}
+
+    for otu_id in otu_ids:
+        if otu_id in existing_otu_ids:
+            skipped_count += 1
+            continue
+
+        document = await ctx.mongo.otus.find_one({"_id": otu_id})
+
+        if document is None:
+            skipped_count += 1
+            continue
+
+        reference_id = await _resolve_reference_id(
+            session,
+            document,
+            reference_id_cache,
+        )
+
+        await session.execute(
+            insert(SQLOTU)
+            .values(**otu_row_values(document, reference_id))
+            .on_conflict_do_nothing(index_elements=["id"]),
+        )
+        await session.commit()
+
+        migrated_count += 1
+
+    logger.info(
+        "otu migration complete",
+        migrated=migrated_count,
+        skipped=skipped_count,
+    )
+
+
+async def _copy_sequences(ctx: MigrationContext, session: AsyncSession) -> None:
+    """Backfill the Mongo ``sequences`` collection into ``legacy_sequences``.
+
+    Runs after :func:`_copy_otus` so every parent OTU already has a
+    ``legacy_otus`` row. The full set of OTU ids is loaded up front so an orphan
+    sequence can be caught with a clear error before the not-null foreign key
+    rejects it with an opaque ``IntegrityError``.
+    """
+    otu_ids_present = {row[0] for row in await session.execute(select(SQLOTU.id))}
+    existing_sequence_ids = {
+        row[0] for row in await session.execute(select(SQLSequence.id))
+    }
+
+    logger.info(
+        "found existing sequences in postgres",
+        count=len(existing_sequence_ids),
+    )
+
+    sequence_ids = [
+        document["_id"]
+        async for document in ctx.mongo.sequences.find({}, projection=["_id"])
+    ]
+
+    migrated_count = 0
+    skipped_count = 0
+
+    for sequence_id in sequence_ids:
+        if sequence_id in existing_sequence_ids:
+            skipped_count += 1
+            continue
+
+        document = await ctx.mongo.sequences.find_one({"_id": sequence_id})
+
+        if document is None:
+            skipped_count += 1
+            continue
+
+        if document["otu_id"] not in otu_ids_present:
+            msg = (
+                f"sequence {sequence_id!r} references otu "
+                f"{document['otu_id']!r} which does not exist in postgres"
+            )
+            raise ValueError(msg)
+
+        await session.execute(
+            insert(SQLSequence)
+            .values(**sequence_row_values(document))
+            .on_conflict_do_nothing(index_elements=["id"]),
+        )
+        await session.commit()
+
+        migrated_count += 1
+
+    logger.info(
+        "sequence migration complete",
+        migrated=migrated_count,
+        skipped=skipped_count,
+    )
+
+
+async def _resolve_reference_id(
+    session: AsyncSession,
+    document: Document,
+    cache: dict[int | str, int],
+) -> int:
+    """Resolve an OTU document's embedded ``reference.id`` to a Postgres id.
+
+    The reference may be a legacy string id or a modern integer id;
+    :func:`resolve_legacy_id` tolerates both. Every OTU belongs to a reference and
+    references are already migrated, so a reference that no longer resolves raises
+    rather than being backfilled as ``NULL``. Results are memoised because OTUs
+    cluster heavily by reference.
+    """
+    reference = document["reference"]["id"]
+
+    if reference in cache:
+        return cache[reference]
+
+    reference_id = await resolve_legacy_id(session, SQLReference, reference)
+
+    if reference_id is None:
+        msg = (
+            f"otu {document['_id']!r} references reference {reference!r} "
+            "which does not exist in postgres"
+        )
+        raise ValueError(msg)
+
+    cache[reference] = reference_id
+
+    return reference_id


### PR DESCRIPTION
## Summary
- Add a revision that backfills existing Mongo `otus` and `sequences` documents into their Postgres tables, resolving `reference_id` FKs and skipping already-backfilled rows via `ON CONFLICT DO NOTHING`
- Drop the "re-backfill" step from the migration playbook — dual-write ships before the backfill runs, so there's no gap left to catch