### PR TITLE
feat(migration): gate otu read cutover on mongo/postgres parity

### DIFF
--- a/assets/revisions/rev_z5qtj25mylrj_compare_otu_and_sequence_stores.py
+++ b/assets/revisions/rev_z5qtj25mylrj_compare_otu_and_sequence_stores.py
@@ -1,0 +1,37 @@
+"""Compare the Mongo and Postgres OTU and sequence stores.
+
+Gates the OTU and sequence read cutover. Runs after the backfill has copied every
+``otus`` and ``sequences`` document into Postgres and the application is
+dual-writing, and raises if the two stores disagree about any document, so reads
+never move to a Postgres that has silently fallen behind Mongo.
+
+The check is read-only and re-runnable: it mutates neither store and reaches the
+same verdict on unchanged stores.
+
+Revision ID: z5qtj25mylrj
+Date: 2026-07-13 16:23:17.861824
+
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+from virtool.otus.migration import compare_otu_and_sequence_stores
+
+# Revision identifiers.
+name = "compare otu and sequence stores"
+created_at = arrow.get("2026-07-13 16:23:17.861824")
+revision_id = "z5qtj25mylrj"
+
+alembic_down_revision = None
+virtool_down_revision = "gkdk4xtpkwi2"
+
+# ``5de38ebeaa78`` adds ``legacy_sequences.isolate_id``/``segment`` and the
+# ``legacy_otus.reference_id`` index, so requiring it guarantees every compared
+# column exists.
+required_alembic_revision = "5de38ebeaa78"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Raise if the Mongo and Postgres OTU and sequence stores have drifted."""
+    await compare_otu_and_sequence_stores(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -729,5 +729,12 @@
       'name': 'copy otus and sequences to postgres',
       'revision': 'gkdk4xtpkwi2',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 105,
+      'name': 'compare otu and sequence stores',
+      'revision': 'z5qtj25mylrj',
+    }),
   ])
 # ---

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -466,6 +466,43 @@ class TestCompareOtuAndSequenceStores:
         with pytest.raises(ValueError, match="2 otus and 1 sequences"):
             await compare_otu_and_sequence_stores(ctx)
 
+    async def test_row_written_mid_run_is_not_drift(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+        mocker,
+    ):
+        """A dual-write that lands between the scan and the re-read is not drift.
+
+        The scan sees a Postgres row that has fallen behind Mongo and flags the
+        OTU. The application then dual-writes the row before the candidate is
+        re-read. The re-read must go back to Postgres rather than reuse the row the
+        scan already loaded, or the stores are reported as drifted after they have
+        converged.
+        """
+        await ctx.mongo.otus.update_one(
+            {"_id": "otu_matched"},
+            {"$set": {"version": 4}},
+        )
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_matched"})
+
+        real_find_one = AsyncIOMotorCollection.find_one
+
+        async def find_one_after_dual_write(self, *args, **kwargs):
+            if self.name == "otus":
+                await _update_otu_row(ctx, "otu_matched", data=document, version=4)
+
+            return await real_find_one(self, *args, **kwargs)
+
+        mocker.patch.object(
+            AsyncIOMotorCollection,
+            "find_one",
+            find_one_after_dual_write,
+        )
+
+        await compare_otu_and_sequence_stores(ctx)
+
     async def test_null_abbreviation_and_missing_segment_pass(
         self,
         ctx: MigrationContext,

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -1,17 +1,20 @@
-"""Tests for the Mongo-to-Postgres OTU and sequence backfill."""
+"""Tests for the Mongo-to-Postgres OTU and sequence backfill and parity gate."""
 
 import asyncio
 from collections.abc import Callable
 
 import pytest
 from motor.motor_asyncio import AsyncIOMotorCollection
-from sqlalchemy import insert, text
+from sqlalchemy import insert, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.migration.ctx import MigrationContext
 from virtool.otus.db import otu_row_values
-from virtool.otus.migration import copy_otus_and_sequences_to_postgres
-from virtool.otus.sql import SQLOTU
+from virtool.otus.migration import (
+    compare_otu_and_sequence_stores,
+    copy_otus_and_sequences_to_postgres,
+)
+from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.utils import timestamp
 
 
@@ -297,3 +300,209 @@ class TestCopyOtusAndSequences:
         await copy_otus_and_sequences_to_postgres(ctx)
 
         assert await _fetch_sequence(ctx, "seq_dual_written") is not None
+
+
+async def _update_otu_row(ctx: MigrationContext, otu_id: str, **values) -> None:
+    """Change a ``legacy_otus`` row's columns without touching Mongo."""
+    async with AsyncSession(ctx.pg) as session:
+        await session.execute(
+            update(SQLOTU).where(SQLOTU.id == otu_id).values(**values),
+        )
+        await session.commit()
+
+
+async def _update_sequence_row(
+    ctx: MigrationContext,
+    sequence_id: str,
+    **values,
+) -> None:
+    """Change a ``legacy_sequences`` row's columns without touching Mongo."""
+    async with AsyncSession(ctx.pg) as session:
+        await session.execute(
+            update(SQLSequence).where(SQLSequence.id == sequence_id).values(**values),
+        )
+        await session.commit()
+
+
+class TestCompareOtuAndSequenceStores:
+    @pytest.fixture
+    async def matching_stores(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ) -> None:
+        """Seed one OTU and one sequence and copy both into Postgres."""
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_matched", reference_id, "Tobacco mosaic virus"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_matched", "otu_matched"),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+    async def test_matching_stores_pass(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        await compare_otu_and_sequence_stores(ctx)
+
+    async def test_is_read_only_and_repeatable(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        """Two runs over unchanged stores agree, and neither writes anything."""
+        await compare_otu_and_sequence_stores(ctx)
+        await compare_otu_and_sequence_stores(ctx)
+
+        assert await _count(ctx, "legacy_otus") == 1
+        assert await _count(ctx, "legacy_sequences") == 1
+        assert await ctx.mongo.otus.count_documents({}) == 1
+        assert await ctx.mongo.sequences.count_documents({}) == 1
+
+    async def test_otu_missing_from_postgres_raises(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+        matching_stores: None,
+    ):
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_not_written", reference_id, "Potato virus Y"),
+        )
+
+        with pytest.raises(ValueError, match="1 otus and 0 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_sequence_missing_from_postgres_raises(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_not_written", "otu_matched"),
+        )
+
+        with pytest.raises(ValueError, match="0 otus and 1 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_otu_missing_from_mongo_raises(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        """A Postgres row whose Mongo document was deleted is drift, not an aside."""
+        await ctx.mongo.otus.delete_one({"_id": "otu_matched"})
+
+        with pytest.raises(ValueError, match="1 otus and 0 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_sequence_missing_from_mongo_raises(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        await ctx.mongo.sequences.delete_one({"_id": "seq_matched"})
+
+        with pytest.raises(ValueError, match="0 otus and 1 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_otu_data_drift_raises(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        """A Mongo edit that never reached Postgres is drift."""
+        await ctx.mongo.otus.update_one(
+            {"_id": "otu_matched"},
+            {"$set": {"version": 4, "verified": False}},
+        )
+
+        with pytest.raises(ValueError, match="1 otus and 0 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_otu_column_drift_raises(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        """A promoted column that disagrees with an otherwise-matching ``data``."""
+        await _update_otu_row(ctx, "otu_matched", name="Wrong name")
+
+        with pytest.raises(ValueError, match="1 otus and 0 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_sequence_column_drift_raises(
+        self,
+        ctx: MigrationContext,
+        matching_stores: None,
+    ):
+        await _update_sequence_row(ctx, "seq_matched", segment="RNA2")
+
+        with pytest.raises(ValueError, match="0 otus and 1 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_reports_every_drifted_document(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+        matching_stores: None,
+    ):
+        """Drift is accumulated across the whole run, not raised on the first hit."""
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_second", reference_id, "Potato virus Y"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_second", "otu_second"),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        await _update_otu_row(ctx, "otu_matched", verified=False)
+        await _update_otu_row(ctx, "otu_second", version=99)
+        await _update_sequence_row(ctx, "seq_second", isolate_id="isolate_wrong")
+
+        with pytest.raises(ValueError, match="2 otus and 1 sequences"):
+            await compare_otu_and_sequence_stores(ctx)
+
+    async def test_null_abbreviation_and_missing_segment_pass(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """The write path's own normalizations must not read as drift.
+
+        Mongo stores a null abbreviation and omits ``segment`` entirely; Postgres
+        holds ``""`` and ``NULL``. Both stores are in parity.
+        """
+        otu = _otu_doc("otu_null_abbreviation", reference_id, "Potato virus Y")
+        otu["abbreviation"] = None
+
+        sequence = _sequence_doc("seq_no_segment", "otu_null_abbreviation")
+        del sequence["segment"]
+
+        await ctx.mongo.otus.insert_one(otu)
+        await ctx.mongo.sequences.insert_one(sequence)
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        await compare_otu_and_sequence_stores(ctx)
+
+    async def test_legacy_string_reference_id_passes(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """An OTU still holding the legacy string ``reference.id`` is in parity.
+
+        Postgres promotes it to the integer ``legacy_references`` primary key, so
+        the two forms must resolve to the same reference.
+        """
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_legacy_reference", "ref_legacy", "Cucumber mosaic virus"),
+        )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        await compare_otu_and_sequence_stores(ctx)

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -286,14 +286,19 @@ async def compare_otu_and_sequence_stores(ctx: MigrationContext) -> None:
     deleted between the two chunk reads would otherwise be reported as drift; the
     second pass costs nothing on a clean run, where there are no candidates.
 
+    Each pass runs in its own :class:`AsyncSession`. The scanning session's
+    identity map still holds every row it loaded, and a ``select()`` against it
+    would hand those instances back rather than re-reading the row -- which would
+    leave the second pass unable to see the very dual-write it exists to
+    tolerate.
+
     The check is exhaustive before it fails: drift is accumulated across every OTU
     and sequence, the full per-document diff is logged, and a single
     :class:`ValueError` is raised at the end. A clean run logs zero drift with the
     document counts.
     """
-    async with AsyncSession(ctx.pg) as session:
-        otu_drift = await _compare_otus(ctx, session)
-        sequence_drift = await _compare_sequences(ctx, session)
+    otu_drift = await _compare_otus(ctx)
+    sequence_drift = await _compare_sequences(ctx)
 
     if otu_drift or sequence_drift:
         for report in otu_drift:
@@ -311,117 +316,131 @@ async def compare_otu_and_sequence_stores(ctx: MigrationContext) -> None:
     logger.info("otu and sequence stores match; no drift")
 
 
-async def _compare_otus(ctx: MigrationContext, session: AsyncSession) -> list[dict]:
-    """Compare the Mongo ``otus`` collection against ``legacy_otus``."""
+async def _compare_otus(ctx: MigrationContext) -> list[dict]:
+    """Compare the Mongo ``otus`` collection against ``legacy_otus``.
+
+    The scan and the verification of its candidates run in separate sessions so
+    the verification really re-reads each row. See
+    :func:`compare_otu_and_sequence_stores`.
+    """
     mongo_ids = {
         document["_id"]
         async for document in ctx.mongo.otus.find({}, projection=["_id"])
     }
-    postgres_ids = {row[0] for row in await session.execute(select(SQLOTU.id))}
-
-    candidates = mongo_ids ^ postgres_ids
-    shared = sorted(mongo_ids & postgres_ids)
 
     reference_id_cache: dict[int | str, int] = {}
 
-    for start in range(0, len(shared), _OTU_CHUNK_SIZE):
-        chunk = shared[start : start + _OTU_CHUNK_SIZE]
+    async with AsyncSession(ctx.pg) as session:
+        postgres_ids = {row[0] for row in await session.execute(select(SQLOTU.id))}
 
-        documents = {
-            document["_id"]: document
-            async for document in ctx.mongo.otus.find({"_id": {"$in": chunk}})
-        }
+        candidates = mongo_ids ^ postgres_ids
+        shared = sorted(mongo_ids & postgres_ids)
 
-        rows = {
-            row.id: row
-            for row in (
-                await session.execute(select(SQLOTU).where(SQLOTU.id.in_(chunk)))
-            ).scalars()
-        }
+        for start in range(0, len(shared), _OTU_CHUNK_SIZE):
+            chunk = shared[start : start + _OTU_CHUNK_SIZE]
 
-        for otu_id in chunk:
-            document = documents.get(otu_id)
-            row = rows.get(otu_id)
+            documents = {
+                document["_id"]: document
+                async for document in ctx.mongo.otus.find({"_id": {"$in": chunk}})
+            }
 
-            if document is None or row is None:
-                candidates.add(otu_id)
-                continue
+            rows = {
+                row.id: row
+                for row in (
+                    await session.execute(select(SQLOTU).where(SQLOTU.id.in_(chunk)))
+                ).scalars()
+            }
 
-            reference_id = await _lookup_reference_id(
-                session,
-                document["reference"]["id"],
-                reference_id_cache,
-            )
+            for otu_id in chunk:
+                document = documents.get(otu_id)
+                row = rows.get(otu_id)
 
-            if reference_id is None or _diff_row(
-                row,
-                otu_row_values(document, reference_id),
-            ):
-                candidates.add(otu_id)
+                if document is None or row is None:
+                    candidates.add(otu_id)
+                    continue
 
-    drifted = [
-        report
-        for otu_id in sorted(candidates)
-        if (report := await _verify_otu(ctx, session, otu_id, reference_id_cache))
-    ]
+                reference_id = await _lookup_reference_id(
+                    session,
+                    document["reference"]["id"],
+                    reference_id_cache,
+                )
+
+                if reference_id is None or _diff_row(
+                    row,
+                    otu_row_values(document, reference_id),
+                ):
+                    candidates.add(otu_id)
+
+    async with AsyncSession(ctx.pg) as session:
+        drifted = [
+            report
+            for otu_id in sorted(candidates)
+            if (report := await _verify_otu(ctx, session, otu_id, reference_id_cache))
+        ]
 
     logger.info("compared otus", otus=len(mongo_ids), drifted=len(drifted))
 
     return drifted
 
 
-async def _compare_sequences(
-    ctx: MigrationContext,
-    session: AsyncSession,
-) -> list[dict]:
+async def _compare_sequences(ctx: MigrationContext) -> list[dict]:
     """Compare the Mongo ``sequences`` collection against ``legacy_sequences``.
 
     A sequence whose parent OTU has no ``legacy_otus`` row cannot have a
     ``legacy_sequences`` row either -- the not-null foreign key would reject it --
     so such a sequence surfaces here as missing from Postgres.
+
+    The scan and the verification of its candidates run in separate sessions so
+    the verification really re-reads each row. See
+    :func:`compare_otu_and_sequence_stores`.
     """
     mongo_ids = {
         document["_id"]
         async for document in ctx.mongo.sequences.find({}, projection=["_id"])
     }
-    postgres_ids = {row[0] for row in await session.execute(select(SQLSequence.id))}
 
-    candidates = mongo_ids ^ postgres_ids
-    shared = sorted(mongo_ids & postgres_ids)
+    async with AsyncSession(ctx.pg) as session:
+        postgres_ids = {row[0] for row in await session.execute(select(SQLSequence.id))}
 
-    for start in range(0, len(shared), _SEQUENCE_CHUNK_SIZE):
-        chunk = shared[start : start + _SEQUENCE_CHUNK_SIZE]
+        candidates = mongo_ids ^ postgres_ids
+        shared = sorted(mongo_ids & postgres_ids)
 
-        documents = {
-            document["_id"]: document
-            async for document in ctx.mongo.sequences.find({"_id": {"$in": chunk}})
-        }
+        for start in range(0, len(shared), _SEQUENCE_CHUNK_SIZE):
+            chunk = shared[start : start + _SEQUENCE_CHUNK_SIZE]
 
-        rows = {
-            row.id: row
-            for row in (
-                await session.execute(
-                    select(SQLSequence).where(SQLSequence.id.in_(chunk)),
+            documents = {
+                document["_id"]: document
+                async for document in ctx.mongo.sequences.find(
+                    {"_id": {"$in": chunk}},
                 )
-            ).scalars()
-        }
+            }
 
-        for sequence_id in chunk:
-            document = documents.get(sequence_id)
-            row = rows.get(sequence_id)
+            rows = {
+                row.id: row
+                for row in (
+                    await session.execute(
+                        select(SQLSequence).where(SQLSequence.id.in_(chunk)),
+                    )
+                ).scalars()
+            }
 
-            if (
-                document is None
-                or row is None
-                or _diff_row(row, sequence_row_values(document))
-            ):
-                candidates.add(sequence_id)
+            for sequence_id in chunk:
+                document = documents.get(sequence_id)
+                row = rows.get(sequence_id)
 
-    drifted = [
-        report
-        for sequence_id in sorted(candidates)
-        if (report := await _verify_sequence(ctx, session, sequence_id))
-    ]
+                if (
+                    document is None
+                    or row is None
+                    or _diff_row(row, sequence_row_values(document))
+                ):
+                    candidates.add(sequence_id)
+
+    async with AsyncSession(ctx.pg) as session:
+        drifted = [
+            report
+            for sequence_id in sorted(candidates)
+            if (report := await _verify_sequence(ctx, session, sequence_id))
+        ]
 
     logger.info(
         "compared sequences",

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -1,13 +1,16 @@
-"""Shared backfill logic for copying Mongo OTUs and sequences into Postgres.
+"""Shared migration logic for the Mongo-to-Postgres OTU and sequence move.
 
-This module holds the idempotent copy used by the OTU/sequence backfill
-revision. Keeping it here keeps the logic unit-testable and reusable.
+This module holds the idempotent copy used by the OTU/sequence backfill revision
+and the drift check that gates the read cutover. Keeping them here keeps the
+logic unit-testable and reusable.
 
 Unlike the standard migration playbook, ``legacy_otus`` and ``legacy_sequences``
 have no ``legacy_id`` column: their primary key ``id`` is the Mongo ``_id``
 string itself. Idempotency and skip-existing therefore key on ``id`` rather than
 ``legacy_id``.
 """
+
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
@@ -196,18 +199,13 @@ async def _resolve_reference_id(
 ) -> int:
     """Resolve an OTU document's embedded ``reference.id`` to a Postgres id.
 
-    The reference may be a legacy string id or a modern integer id;
-    :func:`resolve_legacy_id` tolerates both. Every OTU belongs to a reference and
-    references are already migrated, so a reference that no longer resolves raises
-    rather than being backfilled as ``NULL``. Results are memoised because OTUs
-    cluster heavily by reference.
+    Every OTU belongs to a reference and references are already migrated, so a
+    reference that no longer resolves raises rather than being backfilled as
+    ``NULL``.
     """
     reference = document["reference"]["id"]
 
-    if reference in cache:
-        return cache[reference]
-
-    reference_id = await resolve_legacy_id(session, SQLReference, reference)
+    reference_id = await _lookup_reference_id(session, reference, cache)
 
     if reference_id is None:
         msg = (
@@ -216,6 +214,331 @@ async def _resolve_reference_id(
         )
         raise ValueError(msg)
 
-    cache[reference] = reference_id
+    return reference_id
+
+
+async def _lookup_reference_id(
+    session: AsyncSession,
+    reference: int | str,
+    cache: dict[int | str, int],
+) -> int | None:
+    """Look up an embedded ``reference.id`` in Postgres, memoising hits.
+
+    The reference may be a legacy string id or a modern integer id;
+    :func:`resolve_legacy_id` tolerates both. Hits are memoised because OTUs
+    cluster heavily by reference. Misses are not cached: the application keeps
+    writing while a migration runs, so a reference that does not resolve now may
+    resolve on a later call.
+    """
+    if reference in cache:
+        return cache[reference]
+
+    reference_id = await resolve_legacy_id(session, SQLReference, reference)
+
+    if reference_id is not None:
+        cache[reference] = reference_id
 
     return reference_id
+
+
+_OTU_CHUNK_SIZE = 500
+"""How many OTUs to hold in memory at once while comparing the two stores."""
+
+_SEQUENCE_CHUNK_SIZE = 200
+"""How many sequences to hold in memory at once while comparing the two stores.
+
+Smaller than the OTU chunk because a sequence document carries its nucleotide
+string. Both constants exist to bound memory; cutting them costs run time and
+nothing else.
+"""
+
+
+async def compare_otu_and_sequence_stores(ctx: MigrationContext) -> None:
+    """Verify the Mongo and Postgres OTU and sequence stores agree.
+
+    A gating drift check run after the OTU/sequence backfill and before OTU and
+    sequence reads switch to Postgres. It changes nothing: it reads every
+    production OTU and sequence (no sampling) and raises if the two stores
+    disagree.
+
+    A Postgres row is compared against the row the write path would produce from
+    the current Mongo document, by rebuilding it with the very functions the
+    dual-write and backfill use -- :func:`otu_row_values` and
+    :func:`sequence_row_values`. Everything they normalise is therefore normalised
+    identically here and cannot be mistaken for drift:
+
+    - A Mongo ``abbreviation`` of ``None`` or a missing key becomes ``""``.
+    - A missing ``segment`` key becomes SQL ``NULL``.
+    - An embedded ``reference.id`` in either form -- the legacy string id or the
+      integer id written since references were migrated -- resolves to the same
+      integer ``legacy_references`` primary key.
+
+    The verbatim ``data`` JSONB is compared to the Mongo document directly. OTU and
+    sequence documents hold only values that survive a JSON round trip unchanged
+    (no datetimes), and ``data`` retains ``_id``, so no canonicalisation is needed
+    and none is applied: normalising here would only hide real drift.
+
+    The check runs in two passes. The first walks both stores in chunks and
+    collects *candidate* ids: present in one store but not the other, or holding a
+    row that does not match its document. The second re-reads each candidate from
+    both stores individually and only reports the ones that still disagree. The
+    application keeps writing while a migration runs, so a document written or
+    deleted between the two chunk reads would otherwise be reported as drift; the
+    second pass costs nothing on a clean run, where there are no candidates.
+
+    The check is exhaustive before it fails: drift is accumulated across every OTU
+    and sequence, the full per-document diff is logged, and a single
+    :class:`ValueError` is raised at the end. A clean run logs zero drift with the
+    document counts.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        otu_drift = await _compare_otus(ctx, session)
+        sequence_drift = await _compare_sequences(ctx, session)
+
+    if otu_drift or sequence_drift:
+        for report in otu_drift:
+            logger.error("otu drift", **report)
+
+        for report in sequence_drift:
+            logger.error("sequence drift", **report)
+
+        msg = (
+            f"store drift detected in {len(otu_drift)} otus and "
+            f"{len(sequence_drift)} sequences"
+        )
+        raise ValueError(msg)
+
+    logger.info("otu and sequence stores match; no drift")
+
+
+async def _compare_otus(ctx: MigrationContext, session: AsyncSession) -> list[dict]:
+    """Compare the Mongo ``otus`` collection against ``legacy_otus``."""
+    mongo_ids = {
+        document["_id"]
+        async for document in ctx.mongo.otus.find({}, projection=["_id"])
+    }
+    postgres_ids = {row[0] for row in await session.execute(select(SQLOTU.id))}
+
+    candidates = mongo_ids ^ postgres_ids
+    shared = sorted(mongo_ids & postgres_ids)
+
+    reference_id_cache: dict[int | str, int] = {}
+
+    for start in range(0, len(shared), _OTU_CHUNK_SIZE):
+        chunk = shared[start : start + _OTU_CHUNK_SIZE]
+
+        documents = {
+            document["_id"]: document
+            async for document in ctx.mongo.otus.find({"_id": {"$in": chunk}})
+        }
+
+        rows = {
+            row.id: row
+            for row in (
+                await session.execute(select(SQLOTU).where(SQLOTU.id.in_(chunk)))
+            ).scalars()
+        }
+
+        for otu_id in chunk:
+            document = documents.get(otu_id)
+            row = rows.get(otu_id)
+
+            if document is None or row is None:
+                candidates.add(otu_id)
+                continue
+
+            reference_id = await _lookup_reference_id(
+                session,
+                document["reference"]["id"],
+                reference_id_cache,
+            )
+
+            if reference_id is None or _diff_row(
+                row,
+                otu_row_values(document, reference_id),
+            ):
+                candidates.add(otu_id)
+
+    drifted = [
+        report
+        for otu_id in sorted(candidates)
+        if (report := await _verify_otu(ctx, session, otu_id, reference_id_cache))
+    ]
+
+    logger.info("compared otus", otus=len(mongo_ids), drifted=len(drifted))
+
+    return drifted
+
+
+async def _compare_sequences(
+    ctx: MigrationContext,
+    session: AsyncSession,
+) -> list[dict]:
+    """Compare the Mongo ``sequences`` collection against ``legacy_sequences``.
+
+    A sequence whose parent OTU has no ``legacy_otus`` row cannot have a
+    ``legacy_sequences`` row either -- the not-null foreign key would reject it --
+    so such a sequence surfaces here as missing from Postgres.
+    """
+    mongo_ids = {
+        document["_id"]
+        async for document in ctx.mongo.sequences.find({}, projection=["_id"])
+    }
+    postgres_ids = {row[0] for row in await session.execute(select(SQLSequence.id))}
+
+    candidates = mongo_ids ^ postgres_ids
+    shared = sorted(mongo_ids & postgres_ids)
+
+    for start in range(0, len(shared), _SEQUENCE_CHUNK_SIZE):
+        chunk = shared[start : start + _SEQUENCE_CHUNK_SIZE]
+
+        documents = {
+            document["_id"]: document
+            async for document in ctx.mongo.sequences.find({"_id": {"$in": chunk}})
+        }
+
+        rows = {
+            row.id: row
+            for row in (
+                await session.execute(
+                    select(SQLSequence).where(SQLSequence.id.in_(chunk)),
+                )
+            ).scalars()
+        }
+
+        for sequence_id in chunk:
+            document = documents.get(sequence_id)
+            row = rows.get(sequence_id)
+
+            if (
+                document is None
+                or row is None
+                or _diff_row(row, sequence_row_values(document))
+            ):
+                candidates.add(sequence_id)
+
+    drifted = [
+        report
+        for sequence_id in sorted(candidates)
+        if (report := await _verify_sequence(ctx, session, sequence_id))
+    ]
+
+    logger.info(
+        "compared sequences",
+        sequences=len(mongo_ids),
+        drifted=len(drifted),
+    )
+
+    return drifted
+
+
+async def _verify_otu(
+    ctx: MigrationContext,
+    session: AsyncSession,
+    otu_id: str,
+    cache: dict[int | str, int],
+) -> dict | None:
+    """Re-read one candidate OTU from both stores and report it if it still drifts.
+
+    Returns ``None`` when the candidate turns out to agree after all, which happens
+    when the application wrote or deleted the OTU between the chunked reads that
+    flagged it.
+    """
+    document = await ctx.mongo.otus.find_one({"_id": otu_id})
+
+    row = (
+        await session.execute(select(SQLOTU).where(SQLOTU.id == otu_id))
+    ).scalar_one_or_none()
+
+    if document is None and row is None:
+        return None
+
+    if document is None:
+        return {"otu_id": otu_id, "issue": "missing from mongo"}
+
+    if row is None:
+        return {"otu_id": otu_id, "issue": "missing from postgres"}
+
+    reference = document["reference"]["id"]
+    reference_id = await _lookup_reference_id(session, reference, cache)
+
+    if reference_id is None:
+        return {
+            "otu_id": otu_id,
+            "issue": "reference missing from postgres",
+            "reference": reference,
+        }
+
+    differences = _diff_row(row, otu_row_values(document, reference_id))
+
+    if differences:
+        return {"otu_id": otu_id, "differences": differences}
+
+    return None
+
+
+async def _verify_sequence(
+    ctx: MigrationContext,
+    session: AsyncSession,
+    sequence_id: str,
+) -> dict | None:
+    """Re-read one candidate sequence from both stores and report remaining drift.
+
+    Returns ``None`` when the candidate turns out to agree after all. See
+    :func:`_verify_otu`.
+    """
+    document = await ctx.mongo.sequences.find_one({"_id": sequence_id})
+
+    row = (
+        await session.execute(select(SQLSequence).where(SQLSequence.id == sequence_id))
+    ).scalar_one_or_none()
+
+    if document is None and row is None:
+        return None
+
+    if document is None:
+        return {"sequence_id": sequence_id, "issue": "missing from mongo"}
+
+    if row is None:
+        return {"sequence_id": sequence_id, "issue": "missing from postgres"}
+
+    differences = _diff_row(row, sequence_row_values(document))
+
+    if differences:
+        return {"sequence_id": sequence_id, "differences": differences}
+
+    return None
+
+
+def _diff_row(
+    row: SQLOTU | SQLSequence,
+    expected: dict[str, Any],
+) -> dict[str, dict]:
+    """Diff a Postgres row against the column values the write path would produce.
+
+    ``data`` is reduced to the top-level keys that differ rather than reported
+    whole, so a report stays readable when one field of a large document drifted.
+    """
+    differences: dict[str, dict] = {}
+
+    for column, expected_value in expected.items():
+        actual_value = getattr(row, column)
+
+        if actual_value == expected_value:
+            continue
+
+        if column == "data":
+            differences["data"] = _diff_data(expected_value, actual_value)
+        else:
+            differences[column] = {"mongo": expected_value, "postgres": actual_value}
+
+    return differences
+
+
+def _diff_data(mongo_data: Document, postgres_data: Document) -> dict[str, dict]:
+    """Diff the Mongo document against the ``data`` JSONB, key by top-level key."""
+    return {
+        key: {"mongo": mongo_data.get(key), "postgres": postgres_data.get(key)}
+        for key in sorted(set(mongo_data) | set(postgres_data))
+        if mongo_data.get(key) != postgres_data.get(key)
+    }


### PR DESCRIPTION
## Summary
- Add a drift check that compares every Mongo `otus`/`sequences` document against its Postgres row and raises on any mismatch, gating the upcoming OTU/sequence read cutover.
- Rebuild the expected row with the same `otu_row_values`/`sequence_row_values` the dual-write and backfill use, so the write path's own normalizations (null abbreviation, missing segment, dual-form `reference.id`) are never mistaken for drift.
- Re-read each drift candidate from both stores before reporting it, so a document the application writes or deletes mid-run is not flagged, and report every drifted document in one pass rather than failing on the first.