### PR TITLE
feat: preserve sequence order in postgres

### DIFF
--- a/assets/alembic/versions/f8aa696aa0d3_add_position_to_legacy_sequences.py
+++ b/assets/alembic/versions/f8aa696aa0d3_add_position_to_legacy_sequences.py
@@ -1,0 +1,32 @@
+"""add position to legacy sequences
+
+Revision ID: f8aa696aa0d3
+Revises: 5de38ebeaa78
+Create Date: 2026-07-13 18:48:13.241547+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f8aa696aa0d3"
+down_revision = "5de38ebeaa78"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "legacy_sequences", sa.Column("position", sa.BigInteger(), nullable=True)
+    )
+    op.create_index(
+        "ix_legacy_sequences_otu_id_position",
+        "legacy_sequences",
+        ["otu_id", "position"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_legacy_sequences_otu_id_position", table_name="legacy_sequences")
+    op.drop_column("legacy_sequences", "position")

--- a/assets/revisions/rev_381mcji9pkiw_backfill_sequence_positions.py
+++ b/assets/revisions/rev_381mcji9pkiw_backfill_sequence_positions.py
@@ -1,0 +1,40 @@
+"""Record each sequence's position within its OTU.
+
+Reads every OTU's sequences back in Mongo's natural order -- the order
+``virtool.otus.db.join`` has always returned them in, and therefore the order every
+stored history diff was computed against -- and counts them off into
+``legacy_sequences.position``.
+
+Without it a joined OTU rebuilt from Postgres can present an isolate's sequences in
+a different order than Mongo did, and the ``dictdiffer`` diffs that address them by
+list index silently patch the wrong sequence.
+
+The backfill is authoritative, not skip-existing, so it also repairs rows the
+dual-write mis-numbered before this revision ran. It is idempotent: a second run
+reads the same order and writes the same numbers.
+
+Revision ID: 381mcji9pkiw
+Date: 2026-07-13 18:50:31.446116
+
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+from virtool.otus.migration import backfill_sequence_positions
+
+# Revision identifiers.
+name = "backfill sequence positions"
+created_at = arrow.get("2026-07-13 18:50:31.446116")
+revision_id = "381mcji9pkiw"
+
+alembic_down_revision = "f8aa696aa0d3"
+virtool_down_revision = None
+
+# ``f8aa696aa0d3`` adds the ``legacy_sequences.position`` column this revision fills.
+required_alembic_revision = "f8aa696aa0d3"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Assign every sequence row its position within its OTU."""
+    await backfill_sequence_positions(ctx)

--- a/assets/revisions/rev_irulhq4gaihg_compare_sequence_positions.py
+++ b/assets/revisions/rev_irulhq4gaihg_compare_sequence_positions.py
@@ -1,0 +1,40 @@
+"""Compare the Mongo and Postgres sequence ordering.
+
+Gates the OTU and sequence read cutover on ordering, which
+``compare otu and sequence stores`` cannot check: that revision compares a row
+against the columns derived from a single Mongo document, but ``position`` orders a
+sequence within its OTU and has to be checked an OTU at a time.
+
+Runs after the position backfill and raises if Postgres would hand any OTU's
+sequences back in a different order than Mongo does, so reads never move to a
+Postgres that would make ``patch_to_version`` apply stored diffs to the wrong
+sequence.
+
+The check is read-only and re-runnable: it mutates neither store and reaches the
+same verdict on unchanged stores.
+
+Revision ID: irulhq4gaihg
+Date: 2026-07-13 18:50:32.326408
+
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+from virtool.otus.migration import compare_sequence_positions
+
+# Revision identifiers.
+name = "compare sequence positions"
+created_at = arrow.get("2026-07-13 18:50:32.326408")
+revision_id = "irulhq4gaihg"
+
+alembic_down_revision = None
+virtool_down_revision = "381mcji9pkiw"
+
+# ``f8aa696aa0d3`` adds the ``legacy_sequences.position`` column this revision reads.
+required_alembic_revision = "f8aa696aa0d3"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Raise if Postgres orders any OTU's sequences differently than Mongo."""
+    await compare_sequence_positions(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -736,5 +736,26 @@
       'name': 'compare otu and sequence stores',
       'revision': 'z5qtj25mylrj',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 106,
+      'name': 'add position to legacy sequences',
+      'revision': 'f8aa696aa0d3',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 107,
+      'name': 'backfill sequence positions',
+      'revision': '381mcji9pkiw',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 108,
+      'name': 'compare sequence positions',
+      'revision': 'irulhq4gaihg',
+    }),
   ])
 # ---

--- a/tests/otus/test_data.py
+++ b/tests/otus/test_data.py
@@ -798,3 +798,63 @@ class TestSequencePosition:
         assert [row.id for row in rows] == sequence_ids
         assert [row.id for row in rows] == await _get_mongo_sequence_ids(mongo, otu_id)
         assert [row.segment for row in rows] == ["RNA_0", None, None]
+
+    async def test_isolates_share_one_position_sequence(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """``position`` numbers an OTU's sequences, not each isolate's separately.
+
+        ``merge_otu`` filters one OTU-wide sequence list into each isolate, so what a
+        diff indexes into is the OTU's order narrowed to an isolate. A per-isolate
+        counter would collide across isolates and lose that.
+        """
+        otu_id, first_isolate_id, user_id = await self._make_isolate(data_layer, fake)
+
+        second_isolate = await data_layer.otus.add_isolate(
+            otu_id,
+            "isolate",
+            "B",
+            user_id,
+        )
+
+        interleaved = [
+            (
+                await data_layer.otus.create_sequence(
+                    otu_id,
+                    isolate_id,
+                    f"NC_00001{index}",
+                    f"Segment {index}",
+                    "ATGCGTACGT",
+                    user_id,
+                    "host",
+                    f"RNA_{index}",
+                )
+            ).id
+            for index, isolate_id in enumerate(
+                [
+                    first_isolate_id,
+                    second_isolate.id,
+                    first_isolate_id,
+                    second_isolate.id,
+                ],
+            )
+        ]
+
+        rows = await _get_sequence_rows(pg, otu_id)
+
+        assert [row.position for row in rows] == [0, 1, 2, 3]
+        assert [row.id for row in rows] == interleaved
+        assert [row.id for row in rows] == await _get_mongo_sequence_ids(mongo, otu_id)
+
+        assert [row.id for row in rows if row.isolate_id == first_isolate_id] == [
+            interleaved[0],
+            interleaved[2],
+        ]
+        assert [row.id for row in rows if row.isolate_id == second_isolate.id] == [
+            interleaved[1],
+            interleaved[3],
+        ]

--- a/tests/otus/test_data.py
+++ b/tests/otus/test_data.py
@@ -16,6 +16,7 @@ from syrupy import SnapshotAssertion
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.mongo.core import Mongo
 from virtool.otus.oas import (
     CreateOTURequest,
     UpdateOTURequest,
@@ -328,14 +329,28 @@ async def _get_otu_row(pg: AsyncEngine, otu_id: str) -> SQLOTU | None:
 
 
 async def _get_sequence_rows(pg: AsyncEngine, otu_id: str) -> list[SQLSequence]:
+    """Get an OTU's sequence rows in the order Postgres would join them."""
     async with AsyncSession(pg) as session:
         return list(
             (
                 await session.execute(
-                    select(SQLSequence).where(SQLSequence.otu_id == otu_id),
+                    select(SQLSequence)
+                    .where(SQLSequence.otu_id == otu_id)
+                    .order_by(SQLSequence.position),
                 )
             ).scalars(),
         )
+
+
+async def _get_mongo_sequence_ids(mongo: Mongo, otu_id: str) -> list[str]:
+    """Get an OTU's sequence ids in the natural order ``join`` reads them in."""
+    return [
+        document["_id"]
+        async for document in mongo.sequences.find(
+            {"otu_id": otu_id},
+            projection=["_id"],
+        )
+    ]
 
 
 class TestOTUDualWrite:
@@ -572,3 +587,214 @@ class TestSequenceDualWrite:
 
         assert await _get_sequence_rows(pg, otu_id) == []
         assert (await _get_otu_row(pg, otu_id)).version == version_before + 1
+
+
+class TestSequencePosition:
+    """``legacy_sequences.position`` reproduces Mongo's natural sequence order.
+
+    A joined OTU rebuilt from Postgres feeds ``patch_to_version``, whose stored
+    ``dictdiffer`` diffs address an isolate's sequences by list index. If Postgres
+    returns them in a different order than Mongo does, index builds, reference clones
+    and analysis formatting all apply each change to the wrong sequence.
+    """
+
+    async def _make_isolate(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ) -> tuple[str, str, int]:
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        otu = await data_layer.otus.create(
+            reference.id,
+            CreateOTURequest(name="Example"),
+            user.id,
+        )
+
+        isolate = await data_layer.otus.add_isolate(otu.id, "isolate", "A", user.id)
+
+        return otu.id, isolate.id, user.id
+
+    async def _create_sequences(
+        self,
+        data_layer: DataLayer,
+        otu_id: str,
+        isolate_id: str,
+        user_id: int,
+        count: int,
+    ) -> list[str]:
+        return [
+            (
+                await data_layer.otus.create_sequence(
+                    otu_id,
+                    isolate_id,
+                    f"NC_00000{index}",
+                    f"Segment {index}",
+                    "ATGCGTACGT",
+                    user_id,
+                    "host",
+                    f"RNA_{index}",
+                )
+            ).id
+            for index in range(count)
+        ]
+
+    async def test_create_sequence_appends(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """Each new sequence is appended to the end of its OTU."""
+        otu_id, isolate_id, user_id = await self._make_isolate(data_layer, fake)
+
+        sequence_ids = await self._create_sequences(
+            data_layer,
+            otu_id,
+            isolate_id,
+            user_id,
+            3,
+        )
+
+        rows = await _get_sequence_rows(pg, otu_id)
+
+        assert [row.position for row in rows] == [0, 1, 2]
+        assert [row.id for row in rows] == sequence_ids
+
+    async def test_update_sequence_preserves_order(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Editing a sequence must not move it within its OTU.
+
+        The regression this column exists for. An update rewrites the row, which
+        moves its tuple to the end of the Postgres heap, so an unordered read would
+        hand the OTU's sequences back in a new order.
+        """
+        otu_id, isolate_id, user_id = await self._make_isolate(data_layer, fake)
+
+        sequence_ids = await self._create_sequences(
+            data_layer,
+            otu_id,
+            isolate_id,
+            user_id,
+            3,
+        )
+
+        await data_layer.otus.update_sequence(
+            otu_id,
+            isolate_id,
+            sequence_ids[1],
+            user_id,
+            UpdateSequenceRequest(sequence="TTTTTTTTTT"),
+        )
+
+        rows = await _get_sequence_rows(pg, otu_id)
+
+        assert [row.position for row in rows] == [0, 1, 2]
+        assert [row.id for row in rows] == sequence_ids
+        assert [row.id for row in rows] == await _get_mongo_sequence_ids(mongo, otu_id)
+
+    async def test_remove_sequence_leaves_a_gap(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A removed sequence is not renumbered over, and the next one still appends.
+
+        Only relative order matters, so gaps are harmless. Reusing a freed position
+        would not be.
+        """
+        otu_id, isolate_id, user_id = await self._make_isolate(data_layer, fake)
+
+        sequence_ids = await self._create_sequences(
+            data_layer,
+            otu_id,
+            isolate_id,
+            user_id,
+            3,
+        )
+
+        await data_layer.otus.remove_sequence(
+            otu_id,
+            isolate_id,
+            sequence_ids[1],
+            user_id,
+        )
+
+        rows = await _get_sequence_rows(pg, otu_id)
+
+        assert [row.position for row in rows] == [0, 2]
+        assert [row.id for row in rows] == [sequence_ids[0], sequence_ids[2]]
+
+        appended = await data_layer.otus.create_sequence(
+            otu_id,
+            isolate_id,
+            "NC_000009",
+            "Appended",
+            "ATGCGTACGT",
+            user_id,
+            "host",
+            "RNA_9",
+        )
+
+        rows = await _get_sequence_rows(pg, otu_id)
+
+        assert [row.position for row in rows] == [0, 2, 3]
+        assert rows[-1].id == appended.id
+        assert [row.id for row in rows] == await _get_mongo_sequence_ids(mongo, otu_id)
+
+    async def test_schema_change_preserves_order(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Dropping a segment re-mirrors every sequence without reordering them.
+
+        ``update`` unsets ``segment`` on sequences whose segment left the schema and
+        re-writes each of the OTU's rows. That upsert must not renumber them.
+        """
+        otu_id, isolate_id, user_id = await self._make_isolate(data_layer, fake)
+
+        await data_layer.otus.update(
+            otu_id,
+            UpdateOTURequest(
+                schema=[
+                    {"name": "RNA_0", "molecule": "ssRNA", "required": True},
+                    {"name": "RNA_1", "molecule": "ssRNA", "required": True},
+                    {"name": "RNA_2", "molecule": "ssRNA", "required": True},
+                ],
+            ),
+            user_id,
+        )
+
+        sequence_ids = await self._create_sequences(
+            data_layer,
+            otu_id,
+            isolate_id,
+            user_id,
+            3,
+        )
+
+        await data_layer.otus.update(
+            otu_id,
+            UpdateOTURequest(
+                schema=[{"name": "RNA_0", "molecule": "ssRNA", "required": True}],
+            ),
+            user_id,
+        )
+
+        rows = await _get_sequence_rows(pg, otu_id)
+
+        assert [row.position for row in rows] == [0, 1, 2]
+        assert [row.id for row in rows] == sequence_ids
+        assert [row.id for row in rows] == await _get_mongo_sequence_ids(mongo, otu_id)
+        assert [row.segment for row in rows] == ["RNA_0", None, None]

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -6,13 +6,15 @@ from datetime import datetime
 
 import pytest
 from motor.motor_asyncio import AsyncIOMotorCollection
-from sqlalchemy import insert, text, update
+from sqlalchemy import insert, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.migration.ctx import MigrationContext
 from virtool.otus.db import otu_row_values
 from virtool.otus.migration import (
+    backfill_sequence_positions,
     compare_otu_and_sequence_stores,
+    compare_sequence_positions,
     copy_otus_and_sequences_to_postgres,
 )
 from virtool.otus.sql import SQLOTU, SQLSequence
@@ -146,6 +148,17 @@ async def _insert_otu_row(
             ),
         )
         await session.commit()
+
+
+async def _mongo_sequence_ids(ctx: MigrationContext, otu_id: str) -> list[str]:
+    """Get an OTU's sequence ids in the natural order ``join`` reads them in."""
+    return [
+        document["_id"]
+        async for document in ctx.mongo.sequences.find(
+            {"otu_id": otu_id},
+            projection=["_id"],
+        )
+    ]
 
 
 async def _count(ctx: MigrationContext, table: str) -> int:
@@ -561,3 +574,166 @@ class TestCompareOtuAndSequenceStores:
         await copy_otus_and_sequences_to_postgres(ctx)
 
         await compare_otu_and_sequence_stores(ctx)
+
+
+async def _get_positions(ctx: MigrationContext, otu_id: str) -> list[tuple[str, int]]:
+    """Get an OTU's sequence ids and positions, ordered as Postgres would join them."""
+    async with AsyncSession(ctx.pg) as session:
+        return [
+            (row.id, row.position)
+            for row in (
+                await session.execute(
+                    select(SQLSequence.id, SQLSequence.position)
+                    .where(SQLSequence.otu_id == otu_id)
+                    .order_by(SQLSequence.position),
+                )
+            ).all()
+        ]
+
+
+class TestBackfillSequencePositions:
+    @pytest.fixture
+    async def copied_otu(self, ctx: MigrationContext, reference_id: int) -> list[str]:
+        """Seed one OTU with three sequences and copy them into Postgres.
+
+        Returns the sequence ids in the order Mongo returns them, which is the order
+        the positions must reproduce.
+        """
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_ordered", reference_id, "Tobacco mosaic virus"),
+        )
+
+        for sequence_id in ("seq_first", "seq_second", "seq_third"):
+            await ctx.mongo.sequences.insert_one(
+                _sequence_doc(sequence_id, "otu_ordered"),
+            )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+
+        return await _mongo_sequence_ids(ctx, "otu_ordered")
+
+    async def test_assigns_mongo_order(
+        self,
+        ctx: MigrationContext,
+        copied_otu: list[str],
+    ):
+        """Positions count off the OTU's sequences in Mongo's natural order."""
+        await backfill_sequence_positions(ctx)
+
+        assert await _get_positions(ctx, "otu_ordered") == [
+            (sequence_id, position) for position, sequence_id in enumerate(copied_otu)
+        ]
+
+    async def test_is_idempotent(
+        self,
+        ctx: MigrationContext,
+        copied_otu: list[str],
+    ):
+        """A second run reads the same order and writes the same numbers."""
+        await backfill_sequence_positions(ctx)
+        first = await _get_positions(ctx, "otu_ordered")
+
+        await backfill_sequence_positions(ctx)
+
+        assert await _get_positions(ctx, "otu_ordered") == first
+
+    async def test_repairs_a_mis_numbered_row(
+        self,
+        ctx: MigrationContext,
+        copied_otu: list[str],
+    ):
+        """A row the dual-write mis-numbered before this ran is renumbered.
+
+        A sequence created between the dual-write shipping and this backfill took
+        ``MAX + 1`` over an OTU with no Postgres rows yet, and so wrongly claimed
+        position zero. The backfill is authoritative and must overwrite it.
+        """
+        await backfill_sequence_positions(ctx)
+        await _update_sequence_row(ctx, copied_otu[2], position=0)
+
+        await backfill_sequence_positions(ctx)
+
+        assert await _get_positions(ctx, "otu_ordered") == [
+            (sequence_id, position) for position, sequence_id in enumerate(copied_otu)
+        ]
+
+    async def test_sequence_without_an_otu_row_raises(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """A sequence whose parent OTU was never copied is a loud failure."""
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_uncopied", reference_id, "Cucumber mosaic virus"),
+        )
+        await ctx.mongo.sequences.insert_one(
+            _sequence_doc("seq_uncopied", "otu_uncopied"),
+        )
+
+        with pytest.raises(ValueError, match="no row in postgres"):
+            await backfill_sequence_positions(ctx)
+
+
+class TestCompareSequencePositions:
+    @pytest.fixture
+    async def positioned_otu(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ) -> list[str]:
+        """Seed an OTU with three sequences, copy them, and assign their positions."""
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_ordered", reference_id, "Tobacco mosaic virus"),
+        )
+
+        for sequence_id in ("seq_first", "seq_second", "seq_third"):
+            await ctx.mongo.sequences.insert_one(
+                _sequence_doc(sequence_id, "otu_ordered"),
+            )
+
+        await copy_otus_and_sequences_to_postgres(ctx)
+        await backfill_sequence_positions(ctx)
+
+        return await _mongo_sequence_ids(ctx, "otu_ordered")
+
+    async def test_matching_order_passes(
+        self,
+        ctx: MigrationContext,
+        positioned_otu: list[str],
+    ):
+        await compare_sequence_positions(ctx)
+
+    async def test_is_read_only_and_repeatable(
+        self,
+        ctx: MigrationContext,
+        positioned_otu: list[str],
+    ):
+        await compare_sequence_positions(ctx)
+        await compare_sequence_positions(ctx)
+
+    async def test_swapped_order_raises(
+        self,
+        ctx: MigrationContext,
+        positioned_otu: list[str],
+    ):
+        """Two sequences holding each other's positions is drift."""
+        await _update_sequence_row(ctx, positioned_otu[0], position=1)
+        await _update_sequence_row(ctx, positioned_otu[1], position=0)
+
+        with pytest.raises(ValueError, match="sequence order drift detected in 1 otus"):
+            await compare_sequence_positions(ctx)
+
+    async def test_null_position_raises(
+        self,
+        ctx: MigrationContext,
+        positioned_otu: list[str],
+    ):
+        """An unbackfilled row is drift, not a row that quietly sorts last.
+
+        Postgres orders nulls last on an ascending sort, so a null position would
+        otherwise shuffle the sequence to the end of its OTU and pass unnoticed.
+        """
+        await _update_sequence_row(ctx, positioned_otu[2], position=None)
+
+        with pytest.raises(ValueError, match="sequence order drift detected in 1 otus"):
+            await compare_sequence_positions(ctx)

--- a/tests/references/__snapshots__/test_db.ambr
+++ b/tests/references/__snapshots__/test_db.ambr
@@ -35,7 +35,7 @@
 # ---
 # name: test_populate_insert_only_reference_writes_otu_and_sequence_rows[legacy_sequences]
   list([
-    <SQLSequence(id=orseq001, data={'_id': 'orseq001', 'host': 'h', 'otu_id': 'orotu001', 'remote': {'id': 'remote_seq_1'}, 'segment': '', 'sequence': 'ATCG', 'accession': 'ACC1', 'reference': {'id': 1}, 'definition': 'test', 'isolate_id': 'oriso001'}, otu_id=orotu001, isolate_id=oriso001, segment=)>,
-    <SQLSequence(id=orseq002, data={'_id': 'orseq002', 'host': 'h', 'otu_id': 'orotu002', 'remote': {'id': 'remote_seq_2'}, 'segment': '', 'sequence': 'ATCG', 'accession': 'ACC2', 'reference': {'id': 1}, 'definition': 'test', 'isolate_id': 'oriso002'}, otu_id=orotu002, isolate_id=oriso002, segment=)>,
+    <SQLSequence(id=orseq001, data={'_id': 'orseq001', 'host': 'h', 'otu_id': 'orotu001', 'remote': {'id': 'remote_seq_1'}, 'segment': '', 'sequence': 'ATCG', 'accession': 'ACC1', 'reference': {'id': 1}, 'definition': 'test', 'isolate_id': 'oriso001'}, otu_id=orotu001, isolate_id=oriso001, segment=, position=0)>,
+    <SQLSequence(id=orseq002, data={'_id': 'orseq002', 'host': 'h', 'otu_id': 'orotu002', 'remote': {'id': 'remote_seq_2'}, 'segment': '', 'sequence': 'ATCG', 'accession': 'ACC2', 'reference': {'id': 1}, 'definition': 'test', 'isolate_id': 'oriso002'}, otu_id=orotu002, isolate_id=oriso002, segment=, position=0)>,
   ])
 # ---

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,5 +1,6 @@
 """Work with OTUs in the database."""
 
+from collections import Counter
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -270,7 +271,12 @@ def otu_row_values(document: Document, reference_id: int) -> dict[str, Any]:
 
 
 def sequence_row_values(document: Document) -> dict[str, Any]:
-    """Map a Mongo sequence ``document`` to ``legacy_sequences`` column values."""
+    """Map a Mongo sequence ``document`` to ``legacy_sequences`` column values.
+
+    ``position`` is deliberately absent. It orders a sequence within its OTU and so
+    cannot be derived from the document alone; every write path supplies it
+    separately.
+    """
     return {
         "id": document["_id"],
         "data": document,
@@ -280,6 +286,20 @@ def sequence_row_values(document: Document) -> dict[str, Any]:
     }
 
 
+def next_sequence_position(otu_id: str):
+    """Compose a scalar subquery for the next free ``position`` in an OTU.
+
+    Evaluated by Postgres inside the insert, so the read and the write cannot be
+    interleaved. Callers hold the OTU's :func:`lock_legacy_otu` row lock, which
+    serializes concurrent appends to the same OTU.
+    """
+    return (
+        select(func.coalesce(func.max(SQLSequence.position) + 1, 0))
+        .where(SQLSequence.otu_id == otu_id)
+        .scalar_subquery()
+    )
+
+
 _OTU_ROW_CHUNK_SIZE = 32767 // 7
 """Max ``legacy_otus`` rows per statement.
 
@@ -287,11 +307,11 @@ asyncpg caps bind parameters per statement at 32767. Each row binds the seven
 columns produced by :func:`otu_row_values`.
 """
 
-_SEQUENCE_ROW_CHUNK_SIZE = 32767 // 5
+_SEQUENCE_ROW_CHUNK_SIZE = 32767 // 6
 """Max ``legacy_sequences`` rows per statement.
 
 asyncpg caps bind parameters per statement at 32767. Each row binds the five
-columns produced by :func:`sequence_row_values`.
+columns produced by :func:`sequence_row_values` plus ``position``.
 """
 
 
@@ -323,13 +343,27 @@ async def bulk_insert_sequence_rows(
 ) -> None:
     """Insert ``legacy_sequences`` rows for ``documents`` into ``pg_session``.
 
+    ``position`` is assigned by counting off each OTU's sequences in the order they
+    appear in ``documents``. That is the order they are handed to
+    ``sequences.insert_many``, so it is the Mongo natural order the rows must
+    reproduce. Callers insert whole OTUs at a time, so an OTU's sequences are never
+    split across two calls and the count always starts at zero for a new OTU.
+
     The rows are written in asyncpg-safe chunks without committing, so they commit
     or roll back together with the caller's surrounding transaction.
     """
     if not documents:
         return
 
-    rows = [sequence_row_values(document) for document in documents]
+    positions = Counter()
+    rows = []
+
+    for document in documents:
+        otu_id = document["otu_id"]
+
+        rows.append({**sequence_row_values(document), "position": positions[otu_id]})
+
+        positions[otu_id] += 1
 
     for start in range(0, len(rows), _SEQUENCE_ROW_CHUNK_SIZE):
         await pg_session.execute(
@@ -386,12 +420,16 @@ async def write_legacy_otu(pg_session: AsyncSession, document: Document) -> None
 async def write_legacy_sequence(pg_session: AsyncSession, document: Document) -> None:
     """Upsert a Mongo sequence ``document`` into ``legacy_sequences`` within
     ``pg_session``.
+
+    A new sequence is appended to the end of its OTU. An existing one keeps the
+    ``position`` it already holds: the column is left out of the conflict update so
+    re-mirroring a sequence never renumbers it and never reorders the OTU.
     """
     values = sequence_row_values(document)
 
     await pg_session.execute(
         pg_insert(SQLSequence)
-        .values(**values)
+        .values(**values, position=next_sequence_position(document["otu_id"]))
         .on_conflict_do_update(
             index_elements=["id"],
             set_={key: value for key, value in values.items() if key != "id"},

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -596,10 +596,14 @@ async def backfill_sequence_positions(ctx: MigrationContext) -> None:
     from Mongo repairs that, and makes the revision idempotent: a second run reads
     the same order and writes the same numbers.
 
-    Each OTU is locked with :func:`virtool.otus.db.lock_legacy_otu` while it is
-    renumbered, which is the same lock every dual-write path takes, so a concurrent
-    edit cannot append a sequence half-way through. The lock is released by the
-    commit at the end of each OTU, bounding both the transaction and memory.
+    Each OTU is locked with :func:`virtool.otus.db.lock_legacy_otu` *before* its
+    sequences are read from Mongo, which is the same lock every dual-write path takes.
+    Taking it first is what makes the renumber safe: a ``create_sequence`` landing
+    between the read and the write would append a sequence this run cannot see, and
+    that sequence would compute its own position as ``MAX + 1`` over an OTU whose rows
+    are still unpositioned -- taking position zero, which this run then also assigns
+    to the OTU's true first sequence. The lock is released by the commit at the end of
+    each OTU, bounding both the transaction and memory.
     """
     otu_ids = [
         document["_id"]
@@ -612,36 +616,37 @@ async def backfill_sequence_positions(ctx: MigrationContext) -> None:
         otu_ids_present = {row[0] for row in await session.execute(select(SQLOTU.id))}
 
         for otu_id in otu_ids:
+            await lock_legacy_otu(session, otu_id)
+
             documents = [
                 document
                 async for document in ctx.mongo.sequences.find({"otu_id": otu_id})
             ]
 
-            if not documents:
-                continue
+            if documents:
+                if otu_id not in otu_ids_present and not await _otu_exists(
+                    session,
+                    otu_id,
+                ):
+                    msg = (
+                        f"otu {otu_id!r} has sequences in mongo but no row in postgres; "
+                        f"run the otu and sequence backfill first"
+                    )
+                    raise ValueError(msg)
 
-            if otu_id not in otu_ids_present and not await _otu_exists(session, otu_id):
-                msg = (
-                    f"otu {otu_id!r} has sequences in mongo but no row in postgres; "
-                    f"run the otu and sequence backfill first"
-                )
-                raise ValueError(msg)
+                for position, document in enumerate(documents):
+                    await session.execute(
+                        insert(SQLSequence)
+                        .values(**sequence_row_values(document), position=position)
+                        .on_conflict_do_update(
+                            index_elements=["id"],
+                            set_={"position": position},
+                        ),
+                    )
 
-            await lock_legacy_otu(session, otu_id)
-
-            for position, document in enumerate(documents):
-                await session.execute(
-                    insert(SQLSequence)
-                    .values(**sequence_row_values(document), position=position)
-                    .on_conflict_do_update(
-                        index_elements=["id"],
-                        set_={"position": position},
-                    ),
-                )
+                positioned_count += len(documents)
 
             await session.commit()
-
-            positioned_count += len(documents)
 
     logger.info(
         "sequence position backfill complete",

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -20,7 +20,7 @@ from structlog import get_logger
 from virtool.api.custom_json import dump_string, loads
 from virtool.data.topg import resolve_legacy_id
 from virtool.migration import MigrationContext
-from virtool.otus.db import otu_row_values, sequence_row_values
+from virtool.otus.db import lock_legacy_otu, otu_row_values, sequence_row_values
 from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.references.sql import SQLReference
 from virtool.types import Document
@@ -579,3 +579,166 @@ def _diff_data(mongo_data: Document, postgres_data: Document) -> dict[str, dict]
         for key in sorted(set(mongo_data) | set(postgres_data))
         if mongo_data.get(key) != postgres_data.get(key)
     }
+
+
+async def backfill_sequence_positions(ctx: MigrationContext) -> None:
+    """Assign every ``legacy_sequences`` row its position within its OTU.
+
+    An OTU's sequences are read back with the same unsorted
+    ``find({"otu_id": otu_id})`` that :func:`virtool.otus.db.join` uses, so the order
+    Mongo returns them in is by definition the order every historical diff was
+    computed against. Counting them off in that order records it.
+
+    The backfill is authoritative rather than skip-existing. A sequence created
+    between the dual-write shipping and this revision running computed its position
+    as ``MAX + 1`` over an OTU with no Postgres rows yet and so wrongly took position
+    zero, colliding with the OTU's true first sequence. Re-deriving every position
+    from Mongo repairs that, and makes the revision idempotent: a second run reads
+    the same order and writes the same numbers.
+
+    Each OTU is locked with :func:`virtool.otus.db.lock_legacy_otu` while it is
+    renumbered, which is the same lock every dual-write path takes, so a concurrent
+    edit cannot append a sequence half-way through. The lock is released by the
+    commit at the end of each OTU, bounding both the transaction and memory.
+    """
+    otu_ids = [
+        document["_id"]
+        async for document in ctx.mongo.otus.find({}, projection=["_id"])
+    ]
+
+    positioned_count = 0
+
+    async with AsyncSession(ctx.pg) as session:
+        otu_ids_present = {row[0] for row in await session.execute(select(SQLOTU.id))}
+
+        for otu_id in otu_ids:
+            documents = [
+                document
+                async for document in ctx.mongo.sequences.find({"otu_id": otu_id})
+            ]
+
+            if not documents:
+                continue
+
+            if otu_id not in otu_ids_present and not await _otu_exists(session, otu_id):
+                msg = (
+                    f"otu {otu_id!r} has sequences in mongo but no row in postgres; "
+                    f"run the otu and sequence backfill first"
+                )
+                raise ValueError(msg)
+
+            await lock_legacy_otu(session, otu_id)
+
+            for position, document in enumerate(documents):
+                await session.execute(
+                    insert(SQLSequence)
+                    .values(**sequence_row_values(document), position=position)
+                    .on_conflict_do_update(
+                        index_elements=["id"],
+                        set_={"position": position},
+                    ),
+                )
+
+            await session.commit()
+
+            positioned_count += len(documents)
+
+    logger.info(
+        "sequence position backfill complete",
+        otus=len(otu_ids),
+        sequences=positioned_count,
+    )
+
+
+async def compare_sequence_positions(ctx: MigrationContext) -> None:
+    """Verify Postgres orders each OTU's sequences exactly as Mongo returns them.
+
+    A gating check for the OTU read cutover, and the one thing
+    :func:`compare_otu_and_sequence_stores` cannot do. That check compares a row
+    against the columns :func:`sequence_row_values` derives from a single Mongo
+    document, but ``position`` orders a sequence *within its OTU* and so is not
+    derivable from one document. It has to be checked an OTU at a time.
+
+    The check matters because a joined OTU rebuilt from Postgres feeds
+    :func:`virtool.history.db.patch_to_version`, whose ``dictdiffer`` diffs address
+    an isolate's sequences by list index. If Postgres hands them back in a different
+    order than Mongo did, index builds, reference clones and analysis formatting all
+    silently apply each stored change to the wrong sequence.
+
+    A ``NULL`` position is drift. Postgres sorts nulls last on an ascending order,
+    so an unbackfilled row would otherwise be quietly shuffled to the end of its OTU
+    instead of failing the check.
+
+    Like the other drift checks this is read-only and re-runnable, and re-verifies
+    each candidate OTU individually before reporting it, so an OTU written between
+    the two reads is not mistaken for drift.
+    """
+    otu_ids = [
+        document["_id"]
+        async for document in ctx.mongo.otus.find({}, projection=["_id"])
+    ]
+
+    async with AsyncSession(ctx.pg) as session:
+        candidates = [
+            otu_id
+            for otu_id in otu_ids
+            if await _compare_otu_sequence_order(ctx, session, otu_id)
+        ]
+
+    async with AsyncSession(ctx.pg) as session:
+        drifted = [
+            report
+            for otu_id in candidates
+            if (report := await _compare_otu_sequence_order(ctx, session, otu_id))
+        ]
+
+    if drifted:
+        for report in drifted:
+            logger.error("sequence order drift", **report)
+
+        msg = f"sequence order drift detected in {len(drifted)} otus"
+        raise ValueError(msg)
+
+    logger.info("sequence order matches mongo in every otu", otus=len(otu_ids))
+
+
+async def _compare_otu_sequence_order(
+    ctx: MigrationContext,
+    session: AsyncSession,
+    otu_id: str,
+) -> dict | None:
+    """Report an OTU whose Postgres sequence order does not match Mongo's."""
+    mongo_ids = [
+        document["_id"]
+        async for document in ctx.mongo.sequences.find(
+            {"otu_id": otu_id},
+            projection=["_id"],
+        )
+    ]
+
+    rows = (
+        await session.execute(
+            select(SQLSequence.id, SQLSequence.position)
+            .where(SQLSequence.otu_id == otu_id)
+            .order_by(SQLSequence.position),
+        )
+    ).all()
+
+    if any(row.position is None for row in rows):
+        return {
+            "otu_id": otu_id,
+            "issue": "sequences without a position",
+            "sequence_ids": [row.id for row in rows if row.position is None],
+        }
+
+    postgres_ids = [row.id for row in rows]
+
+    if mongo_ids != postgres_ids:
+        return {
+            "otu_id": otu_id,
+            "issue": "sequence order differs",
+            "mongo": mongo_ids,
+            "postgres": postgres_ids,
+        }
+
+    return None

--- a/virtool/otus/sql.py
+++ b/virtool/otus/sql.py
@@ -60,6 +60,15 @@ class SQLSequence(Base):
     ``isolate_id`` identifies the embedded isolate the sequence belongs to and is
     promoted so isolate-scoped operations (such as removing an isolate) can filter
     and delete on it directly. ``segment`` is the optional segment name.
+
+    ``position`` records the sequence's insertion order within its OTU, recovering
+    the Mongo natural order that the ``sequences`` collection returns. Historical
+    diffs encode changes to an isolate's sequence list by index, so a joined OTU
+    rebuilt from Postgres must present its sequences in this order or
+    :func:`virtool.history.db.patch_to_version` will apply them to the wrong
+    sequence. Only relative order matters, so deletes leave gaps rather than
+    renumbering. It is nullable because rows written before the column existed have
+    no position until the backfill assigns one.
     """
 
     __tablename__ = "legacy_sequences"
@@ -71,3 +80,8 @@ class SQLSequence(Base):
     )
     isolate_id: Mapped[str]
     segment: Mapped[str | None]
+    position: Mapped[int | None] = mapped_column(BigInteger)
+
+    __table_args__ = (
+        Index("ix_legacy_sequences_otu_id_position", "otu_id", "position"),
+    )


### PR DESCRIPTION
## Summary
- Record each sequence's position within its OTU in `legacy_sequences` so an OTU rebuilt from Postgres presents an isolate's sequences in the order Mongo returns them. Stored history diffs address sequences by list index, so a reordered join makes `patch_to_version` apply each change to the wrong sequence, silently corrupting index builds, reference clones and analysis formatting.
- Backfill `position` from Mongo's natural order, and gate the OTU read cutover on the ordering with a separate revision. The existing parity check cannot verify it: `position` orders a sequence within its OTU and so is not derivable from a single Mongo document.