### PR TITLE
refactor: remove dead mongo wiring from uploads

### DIFF
--- a/virtool/data/layer.py
+++ b/virtool/data/layer.py
@@ -99,6 +99,6 @@ def create_data_layer(
         SessionData(pg),
         SettingsData(pg),
         TasksData(pg),
-        UploadsData(config, mongo, pg, storage),
+        UploadsData(pg, storage),
         UsersData(pg),
     )

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -386,7 +386,7 @@ class ReferencesData(DataLayerDomain):
             documents,
             [
                 AttachUserTransform(self._pg),
-                AttachImportedFromTransform(self._mongo, self._pg),
+                AttachImportedFromTransform(self._pg),
                 AttachTaskTransform(self._pg),
             ],
             self._pg,
@@ -577,7 +577,7 @@ class ReferencesData(DataLayerDomain):
 
         document = await apply_transforms(
             document,
-            [AttachImportedFromTransform(self._mongo, self._pg)],
+            [AttachImportedFromTransform(self._pg)],
             self._pg,
         )
 

--- a/virtool/references/transforms.py
+++ b/virtool/references/transforms.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -15,9 +15,6 @@ from virtool.uploads.data import serialize as serialize_upload
 from virtool.uploads.sql import SQLUpload
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import get_safely
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
 
 
 def shape_nested_reference(id_: int, name: str) -> Document:
@@ -114,8 +111,7 @@ class AttachReferenceTransform(AbstractTransform):
 class AttachImportedFromTransform(AbstractTransform):
     """Attach the upload and upload user data to an imported reference."""
 
-    def __init__(self, mongo: "Mongo", pg: AsyncEngine):
-        self._mongo = mongo
+    def __init__(self, pg: AsyncEngine):
         self._pg = pg
 
     async def prepare_one(

--- a/virtool/uploads/data.py
+++ b/virtool/uploads/data.py
@@ -2,7 +2,6 @@ import math
 import uuid
 from collections.abc import AsyncIterator
 from datetime import timedelta
-from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -18,9 +17,6 @@ from virtool.uploads.models import Upload, UploadSearchResult
 from virtool.uploads.sql import SQLUpload, UploadType
 from virtool.uploads.utils import upload_file_key
 from virtool.users.transforms import AttachUserTransform
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
 
 
 def serialize(upload: SQLUpload) -> dict:
@@ -44,11 +40,7 @@ def serialize(upload: SQLUpload) -> dict:
 class UploadsData(DataLayerDomain):
     name = "uploads"
 
-    def __init__(
-        self, config, mongo: "Mongo", pg: AsyncEngine, storage: StorageBackend
-    ):
-        self._config = config
-        self._mongo: Mongo = mongo
+    def __init__(self, pg: AsyncEngine, storage: StorageBackend):
         self._pg: AsyncEngine = pg
         self._storage = storage
 


### PR DESCRIPTION
## Summary
- `UploadsData` accepted `mongo` and `config` constructor args but never read either, since uploads are already fully backed by Postgres.
- `AttachImportedFromTransform` carried the same unused `mongo` handle in the upload-attachment path; both are dropped along with their now-unneeded imports.