### PR TITLE
fix: store otu created_at faithfully in postgres

### DIFF
--- a/tests/fixtures/otus.py
+++ b/tests/fixtures/otus.py
@@ -1,4 +1,52 @@
+from datetime import datetime
+
 import pytest
+
+IMPORTED_CREATED_AT = datetime(2015, 10, 6, 20, 0, 0, 123456)
+"""The ``created_at`` carried by an imported OTU, at microsecond precision.
+
+Deliberately not a whole number of milliseconds. Mongo floors a datetime to the
+millisecond, and ``static_time`` carries no microseconds at all, so a timestamp that
+survives that truncation unchanged cannot catch a write path that stores more precision
+than Mongo can hold.
+"""
+
+
+@pytest.fixture
+def test_imported_otu():
+    """An OTU in the shape a reference import or clone writes.
+
+    This is what ``prepare_otu_insertion`` produces: a ``created_at`` copied from the
+    parent reference, the ``imported``, ``remote`` and ``user`` keys, and isolates whose
+    sequences have been lifted out into the ``sequences`` collection.
+
+    ``test_otu`` is the shape the API produces and carries no ``created_at`` at all,
+    which is why it cannot exercise the datetime handling in the OTU write path.
+    """
+    return {
+        "_id": "6116cba1",
+        "abbreviation": "PVF",
+        "created_at": IMPORTED_CREATED_AT,
+        "imported": True,
+        "isolates": [
+            {
+                "default": True,
+                "id": "cab8b360",
+                "source_name": "8816-v2",
+                "source_type": "isolate",
+            },
+        ],
+        "issues": None,
+        "last_indexed_version": None,
+        "lower_name": "prunus virus f",
+        "name": "Prunus virus F",
+        "reference": {"id": 1},
+        "remote": {"id": "remote_otu"},
+        "schema": [],
+        "user": {"id": 1},
+        "verified": True,
+        "version": 0,
+    }
 
 
 @pytest.fixture

--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -2,6 +2,8 @@ import pytest
 from aiohttp.test_utils import make_mocked_coro
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from tests.fixtures.otus import IMPORTED_CREATED_AT
+from virtool.api.custom_json import dump_string, loads
 from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
 from virtool.otus.db import (
@@ -10,7 +12,13 @@ from virtool.otus.db import (
     find,
     increment_otu_version,
     join,
+    otu_document_from_row,
+    otu_row_values,
+    sequence_document_from_row,
+    sequence_row_values,
 )
+from virtool.otus.sql import SQLOTU, SQLSequence
+from virtool.types import Document
 
 
 @pytest.mark.parametrize(
@@ -172,3 +180,77 @@ class TestFindModifiedCount:
         data = await find(mongo, pg, None, 1, 25, None)
 
         assert data["modified_count"] == 1
+
+
+def _as_stored(values: dict) -> Document:
+    """Render row values as the ``data`` JSONB column holds and returns them."""
+    return loads(dump_string(values["data"]))
+
+
+class TestOTUDataRoundTrip:
+    """``legacy_otus.data`` must be a faithful lift of the Mongo OTU document.
+
+    A JSONB column cannot hold a datetime and Mongo cannot hold microseconds, so an
+    imported OTU's ``created_at`` has to survive both. These tests assert against a real
+    Mongo round trip rather than a hardcoded millisecond value, so they pin the write
+    path to what Mongo actually stores.
+    """
+
+    async def test_stores_the_instant_mongo_stores(
+        self,
+        mongo: Mongo,
+        test_imported_otu: Document,
+    ):
+        """The stored ISO string is the truncated instant Mongo holds, not a finer one."""
+        await mongo.otus.insert_one(test_imported_otu)
+
+        document = await mongo.otus.find_one({"_id": test_imported_otu["_id"]})
+
+        assert _as_stored(otu_row_values(test_imported_otu, 1)) == loads(
+            dump_string(document),
+        )
+
+    async def test_recovers_the_mongo_document(
+        self,
+        mongo: Mongo,
+        test_imported_otu: Document,
+    ):
+        """Reading the row back yields the document Mongo would have returned."""
+        await mongo.otus.insert_one(test_imported_otu)
+
+        row = SQLOTU(data=_as_stored(otu_row_values(test_imported_otu, 1)))
+
+        assert otu_document_from_row(row) == await mongo.otus.find_one(
+            {"_id": test_imported_otu["_id"]},
+        )
+
+    def test_does_not_mutate_the_document(self, test_imported_otu: Document):
+        """The bulk insert path hands the same dict to Mongo afterwards."""
+        otu_row_values(test_imported_otu, 1)
+
+        assert test_imported_otu["created_at"] == IMPORTED_CREATED_AT
+
+    def test_otu_without_created_at(self, test_otu: Document):
+        """An OTU created through the API carries no ``created_at`` to encode."""
+        row = SQLOTU(data=_as_stored(otu_row_values(test_otu, 1)))
+
+        assert "created_at" not in row.data
+        assert otu_document_from_row(row) == row.data
+
+
+class TestSequenceDataRoundTrip:
+    async def test_recovers_the_mongo_document(
+        self,
+        mongo: Mongo,
+        test_sequence: Document,
+    ):
+        """Sequences hold nothing JSON cannot express, so the column returns what
+        was put in it.
+        """
+        await mongo.sequences.insert_one(test_sequence)
+
+        row = SQLSequence(data=_as_stored(sequence_row_values(test_sequence)))
+
+        assert sequence_document_from_row(row) == await mongo.sequences.find_one(
+            {"_id": test_sequence["_id"]},
+        )

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -10,7 +10,7 @@ from sqlalchemy import insert, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.migration.ctx import MigrationContext
-from virtool.otus.db import otu_row_values
+from virtool.otus.db import bulk_insert_otu_rows, otu_row_values
 from virtool.otus.migration import (
     backfill_sequence_positions,
     compare_otu_and_sequence_stores,
@@ -377,6 +377,33 @@ class TestCompareOtuAndSequenceStores:
         A ``datetime`` cannot survive the JSONB round trip as a ``datetime``: it is
         stored and read back as an ISO string. The gate must not read that as drift.
         """
+        await compare_otu_and_sequence_stores(ctx)
+
+    async def test_bulk_written_otu_passes(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """An OTU written by the bulk import path passes, despite a ``created_at``
+        carrying microseconds Mongo cannot hold.
+
+        The bulk path hands the same in-memory dict to Postgres and to Mongo, making it
+        the one writer whose datetime never round-tripped through BSON. Mongo floors it
+        to the millisecond, so the row has to hold that same instant and not the finer
+        one it was handed. Every other writer passes a document read back out of Mongo
+        and so is already truncated.
+        """
+        document = {
+            **_otu_doc("otu_bulk", reference_id, "Bulk written virus"),
+            "created_at": datetime(2025, 7, 2, 21, 18, 48, 420789),
+        }
+
+        async with AsyncSession(ctx.pg) as session:
+            await bulk_insert_otu_rows(session, [document], reference_id)
+            await session.commit()
+
+        await ctx.mongo.otus.insert_one(document)
+
         await compare_otu_and_sequence_stores(ctx)
 
     async def test_is_read_only_and_repeatable(

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 
 import pytest
 from pytest_mock import MockerFixture
@@ -6,6 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
+from virtool.api.custom_json import dump_string, loads
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.data.topg import compose_legacy_id_subquery
@@ -831,6 +833,55 @@ async def test_populate_insert_only_reference_writes_otu_and_sequence_rows(
 
     assert otu_rows == snapshot(name="legacy_otus")
     assert sequence_rows == snapshot(name="legacy_sequences")
+
+
+async def test_populate_insert_only_reference_stores_created_at_faithfully(
+    fake: DataFaker,
+    mocker: MockerFixture,
+    mongo: Mongo,
+    pg: AsyncEngine,
+):
+    """The ``legacy_otus.data`` written by a bulk populate is a faithful lift of the
+    Mongo document, including a ``created_at`` with microsecond precision.
+
+    This is the one write path that hands Postgres a datetime that never round-tripped
+    through Mongo: the same in-memory dicts go to ``bulk_insert_otu_rows`` and to
+    ``mongo.otus.insert_many``. Mongo floors a datetime to the millisecond, so without
+    a matching truncation Postgres would hold a finer instant than Mongo does and the
+    store parity check would report every imported OTU as drifted.
+
+    ``static_time`` cannot catch this: its ``created_at`` has no microseconds to lose.
+    """
+    user = await fake.users.create()
+    ref_id = "ref_created_at_test"
+
+    created_at = datetime(2015, 10, 6, 20, 0, 0, 123456)
+
+    await seed_reference(pg, ref_id, user.id, created_at)
+
+    mocker.patch(
+        "virtool.references.alot.random_alphanumeric",
+        side_effect=["caotu001", "caiso001", "caseq001"],
+    )
+
+    await populate_insert_only_reference(
+        created_at,
+        HistoryMethod.remote,
+        mongo,
+        pg,
+        build_source_otus([1]),
+        ref_id,
+        user.id,
+    )
+
+    document = await mongo.otus.find_one({"_id": "caotu001"})
+
+    assert document["created_at"] == datetime(2015, 10, 6, 20, 0, 0, 123000)
+
+    async with AsyncSession(pg) as pg_session:
+        row = await pg_session.scalar(select(SQLOTU).where(SQLOTU.id == "caotu001"))
+
+    assert row.data == loads(dump_string(document))
 
 
 async def test_populate_insert_only_reference_chunks_inserts(

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -265,9 +265,11 @@ def _encode_otu_data(document: Document) -> Document:
     same truncation pymongo applies -- means the stored ISO string is exactly the
     instant Mongo holds, so ``data`` stays a faithful lift of the document.
 
-    The document is copied because the caller keeps using it: the bulk insert path
-    hands the very same dict to ``mongo.otus.insert_many`` afterwards, and the OTU data
-    layer reuses it for history diffs and returns it.
+    ``created_at`` is rewritten on a copy, never in place, because the caller keeps
+    using the document it passed: the bulk insert path hands that very dict to
+    ``mongo.otus.insert_many`` afterwards, and the OTU data layer reuses it for history
+    diffs and returns it. A document with no ``created_at`` to rewrite -- every OTU
+    created through the API -- is returned as-is.
     """
     created_at = document.get("created_at")
 

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,6 +1,7 @@
 """Work with OTUs in the database."""
 
 from collections import Counter
+from datetime import datetime
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
@@ -10,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
 import virtool.otus.utils
+from virtool.api.custom_json import isoformat_to_datetime
 from virtool.api.utils import compose_regex_query, paginate
 from virtool.data.topg import (
     compose_legacy_id_mongo_match,
@@ -253,15 +255,73 @@ async def update_otu_verification(
     return issues
 
 
+def _encode_otu_data(document: Document) -> Document:
+    """Render a Mongo OTU ``document`` as the ``data`` JSONB column must store it.
+
+    Only OTUs created by a reference import or clone carry a ``created_at``, and only
+    the bulk insert path writes one that never round-tripped through Mongo. BSON holds
+    a datetime as int64 milliseconds and drops the microseconds, while the engine's
+    JSON serializer would write every one of them. Flooring to the millisecond -- the
+    same truncation pymongo applies -- means the stored ISO string is exactly the
+    instant Mongo holds, so ``data`` stays a faithful lift of the document.
+
+    The document is copied because the caller keeps using it: the bulk insert path
+    hands the very same dict to ``mongo.otus.insert_many`` afterwards, and the OTU data
+    layer reuses it for history diffs and returns it.
+    """
+    created_at = document.get("created_at")
+
+    if not isinstance(created_at, datetime):
+        return document
+
+    return {
+        **document,
+        "created_at": created_at.replace(
+            microsecond=created_at.microsecond // 1000 * 1000,
+        ),
+    }
+
+
+def otu_document_from_row(row: SQLOTU) -> Document:
+    """Recover the Mongo OTU document a ``legacy_otus`` row was written from.
+
+    The inverse of :func:`_encode_otu_data`. A JSONB column cannot hold a datetime, so
+    ``created_at`` comes back out as the ISO string it was stored as and is parsed back
+    to the naive datetime the rest of the codebase expects. OTUs created through the API
+    carry no ``created_at`` at all, so its absence is normal rather than an error.
+    """
+    document = row.data
+
+    created_at = document.get("created_at")
+
+    if created_at is None:
+        return document
+
+    return {**document, "created_at": isoformat_to_datetime(created_at)}
+
+
+def sequence_document_from_row(row: SQLSequence) -> Document:
+    """Recover the Mongo sequence document a ``legacy_sequences`` row was written from.
+
+    A passthrough. Sequence documents hold nothing JSON cannot express -- no datetimes
+    in particular -- so the column returns what was put in it. It exists so the read
+    path has one obvious entry point per collection, matching
+    :func:`otu_document_from_row`.
+    """
+    return row.data
+
+
 def otu_row_values(document: Document, reference_id: int) -> dict[str, Any]:
     """Map a Mongo OTU ``document`` to ``legacy_otus`` column values.
 
-    The whole document is stored verbatim in ``data``; the remaining columns are
-    promoted from it so they can be queried, filtered and sorted directly.
+    The whole document is stored verbatim in ``data``, save for the millisecond
+    truncation :func:`_encode_otu_data` applies to ``created_at`` so the column can
+    hold it. The remaining columns are promoted from the document so they can be
+    queried, filtered and sorted directly.
     """
     return {
         "id": document["_id"],
-        "data": document,
+        "data": _encode_otu_data(document),
         "name": document["name"],
         "abbreviation": document.get("abbreviation") or "",
         "reference_id": reference_id,


### PR DESCRIPTION
## Summary

- The bulk reference import and clone path handed the same in-memory OTU dicts to Postgres and to Mongo. Mongo floors a datetime to the millisecond while the engine's JSON serializer wrote every microsecond, so `legacy_otus.data` held a finer instant than Mongo did and the store parity check reported every imported OTU as drifted. `otu_row_values` now truncates `created_at` to the millisecond when encoding the `data` column, and `otu_document_from_row` parses it back to a naive datetime when decoding a row.
- Adds an imported-shape OTU fixture carrying microseconds. Every existing fixture is microsecond-zero, which is why this went unnoticed.

Rows already written with microsecond precision are repaired by the reconciliation revision (VIR-2661), not here.

Closes VIR-2659