### PR TITLE
fix: restore aodp workflow state in sample responses

### DIFF
--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -251,6 +251,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -467,6 +468,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -679,6 +681,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -895,6 +898,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1107,6 +1111,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1197,6 +1202,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1277,6 +1283,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1361,6 +1368,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1575,6 +1583,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1671,6 +1680,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -1738,6 +1748,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -1795,6 +1806,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -1852,6 +1864,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -1920,6 +1933,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -1994,6 +2008,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -2051,6 +2066,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2136,6 +2152,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -2193,6 +2210,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2261,6 +2279,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2335,6 +2354,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -2392,6 +2412,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2449,6 +2470,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2523,6 +2545,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -2580,6 +2603,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2637,6 +2661,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2711,6 +2736,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -2768,6 +2794,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2836,6 +2863,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -2910,6 +2938,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -2967,6 +2996,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3024,6 +3054,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3098,6 +3129,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -3172,6 +3204,7 @@
           'id': 1,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'complete',
           'pathoscope': 'complete',
         }),
@@ -3229,6 +3262,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3286,6 +3320,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3354,6 +3389,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3411,6 +3447,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3479,6 +3516,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3536,6 +3574,7 @@
           'id': 2,
         }),
         'workflows': dict({
+          'aodp': 'none',
           'nuvs': 'none',
           'pathoscope': 'none',
         }),
@@ -3755,6 +3794,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -3950,6 +3990,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -4158,6 +4199,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),
@@ -4365,6 +4407,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': 'none',
       'nuvs': 'none',
       'pathoscope': 'none',
     }),

--- a/tests/samples/__snapshots__/test_data.ambr
+++ b/tests/samples/__snapshots__/test_data.ambr
@@ -78,6 +78,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': <WorkflowState.NONE: 'none'>,
       'nuvs': <WorkflowState.NONE: 'none'>,
       'pathoscope': <WorkflowState.NONE: 'none'>,
     }),
@@ -158,6 +159,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': <WorkflowState.NONE: 'none'>,
       'nuvs': <WorkflowState.NONE: 'none'>,
       'pathoscope': <WorkflowState.NONE: 'none'>,
     }),
@@ -242,6 +244,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': <WorkflowState.NONE: 'none'>,
       'nuvs': <WorkflowState.NONE: 'none'>,
       'pathoscope': <WorkflowState.NONE: 'none'>,
     }),
@@ -368,6 +371,7 @@
       'id': 1,
     }),
     'workflows': dict({
+      'aodp': <WorkflowState.NONE: 'none'>,
       'nuvs': <WorkflowState.NONE: 'none'>,
       'pathoscope': <WorkflowState.NONE: 'none'>,
     }),

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -325,6 +325,23 @@ class TestGet:
         assert resp.status == HTTPStatus.OK
         assert await resp.json() == snapshot(name="resp")
 
+    async def test_aodp_workflow_state_retained(
+        self,
+        get_sample_data,
+        spawn_client: ClientSpawner,
+    ):
+        """The removed AODP workflow is still reported as ``none``.
+
+        Workflow images built against Virtool ``39.59.0`` and earlier require
+        ``workflows.aodp`` when they validate a sample response and crash without it.
+        """
+        client = await spawn_client(administrator=True, authenticated=True)
+
+        resp = await client.get(f"/samples/{get_sample_data.id}")
+
+        assert resp.status == HTTPStatus.OK
+        assert (await resp.json())["workflows"]["aodp"] == "none"
+
     async def test_owner(
         self,
         data_layer: DataLayer,

--- a/virtool/samples/models.py
+++ b/virtool/samples/models.py
@@ -34,6 +34,15 @@ class WorkflowState(Enum):
 
 
 class SampleWorkflows(BaseModel):
+    """The state of each workflow for a sample.
+
+    The AODP workflow was removed, but workflow images built against Virtool
+    ``39.59.0`` and earlier require ``aodp`` when they validate a sample response and
+    crash without it. It is always ``none`` and can be dropped once every workflow
+    image has been rebuilt.
+    """
+
+    aodp: WorkflowState = WorkflowState.NONE
     nuvs: WorkflowState
     pathoscope: WorkflowState
 
@@ -75,6 +84,7 @@ class SampleMinimal(SampleNested):
                         "id": "ihvze2u9",
                     },
                     "workflows": {
+                        "aodp": "none",
                         "nuvs": "none",
                         "pathoscope": "none",
                     },
@@ -189,6 +199,7 @@ class Sample(SampleMinimal):
                 "subtractions": [{"id": 21, "name": "Malus domestica"}],
                 "user": {"administrator": True, "handle": "mrott", "id": "ihvze2u9"},
                 "workflows": {
+                    "aodp": "none",
                     "nuvs": "none",
                     "pathoscope": "none",
                 },


### PR DESCRIPTION
## Summary

- `39.59.0` removed `aodp` from `SampleWorkflows`, but workflow images built against that release or earlier require `workflows.aodp` when they validate a sample response. Deployed images crashed with `ValidationError: workflows -> aodp field required`, taking down sample creation and analysis in production (WORKFLOWS-BD, WORKFLOWS-BC).
- Restore `aodp` as a defaulted field on `SampleWorkflows` only. It is always `"none"` and is deliberately kept out of `WORKFLOW_NAMES`, so workflow tag derivation and the `?workflows=` filter stay free of it.
- It was the sole breaking removal in that commit — `WorkflowCounts.aodp` had a default, and the dropped `LibraryType.amplicon` / `WorkflowState.INCOMPATIBLE` / `Workflow.AODP` enum members only stop values being *sent*, which older enums still accept.

This is a compatibility shim, not a revival of AODP. It can be dropped once every workflow image is rebuilt against this release or later.