### PR TITLE
feat: add otu index stamping to postgres

### DIFF
--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -8,6 +8,39 @@ from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndexFile
 from virtool.mongo.core import Mongo
+from virtool.otus.sql import SQLOTU
+
+
+async def add_index_files(pg: AsyncEngine, index_id: str) -> None:
+    """Add the complete set of files that finalizing ``index_id`` requires.
+
+    Finalization blocks on the bowtie2 and FASTA checks, so an index missing any of
+    these never reaches the code under test.
+    """
+    names = [
+        ("reference.1.bt2", "bowtie2"),
+        ("reference.2.bt2", "bowtie2"),
+        ("reference.3.bt2", "bowtie2"),
+        ("reference.4.bt2", "bowtie2"),
+        ("reference.rev.1.bt2", "bowtie2"),
+        ("reference.rev.2.bt2", "bowtie2"),
+        ("reference.fa.gz", "fasta"),
+    ]
+
+    async with AsyncSession(pg) as session:
+        session.add_all(
+            [
+                SQLIndexFile(
+                    id=id_,
+                    name=name,
+                    index=index_id,
+                    type=type_,
+                    size=1234567,
+                )
+                for id_, (name, type_) in enumerate(names, start=1)
+            ],
+        )
+        await session.commit()
 
 
 async def test_finalize(
@@ -36,67 +69,56 @@ async def test_finalize(
         },
     )
 
-    async with AsyncSession(pg) as session:
-        session.add_all(
-            [
-                SQLIndexFile(
-                    id=1,
-                    name="reference.1.bt2",
-                    index="foo",
-                    type="bowtie2",
-                    size=1234567,
-                ),
-                SQLIndexFile(
-                    id=2,
-                    name="reference.2.bt2",
-                    index="foo",
-                    type="bowtie2",
-                    size=1234567,
-                ),
-                SQLIndexFile(
-                    id=3,
-                    name="reference.3.bt2",
-                    index="foo",
-                    type="bowtie2",
-                    size=1234567,
-                ),
-                SQLIndexFile(
-                    id=4,
-                    name="reference.4.bt2",
-                    index="foo",
-                    type="bowtie2",
-                    size=1234567,
-                ),
-                SQLIndexFile(
-                    id=5,
-                    name="reference.rev.1.bt2",
-                    index="foo",
-                    type="bowtie2",
-                    size=1234567,
-                ),
-                SQLIndexFile(
-                    id=6,
-                    name="reference.rev.2.bt2",
-                    index="foo",
-                    type="bowtie2",
-                    size=1234567,
-                ),
-                SQLIndexFile(
-                    id=7,
-                    name="reference.fa.gz",
-                    index="foo",
-                    type="fasta",
-                    size=1234567,
-                ),
-            ],
-        )
-        await session.commit()
+    await add_index_files(pg, "foo")
 
     # Ensure return value is correct.
     assert await data_layer.index.finalize("foo") == snapshot
 
     # Ensure document in database is correct.
     assert await mongo.indexes.find_one() == snapshot
+
+
+async def test_finalize_stamps_last_indexed_version(
+    data_layer: DataLayer,
+    fake: DataFaker,
+    mongo: Mongo,
+    pg: AsyncEngine,
+    static_time,
+):
+    """Finalizing an index stamps ``last_indexed_version`` in Postgres as well as
+    Mongo, so ``legacy_otus`` does not drift from the OTU document it mirrors.
+    """
+    user = await fake.users.create()
+    job = await fake.jobs.create(user=user)
+
+    reference = await fake.references.create(user=user)
+    otu = await fake.otus.create(reference.id, user)
+
+    await mongo.indexes.insert_one(
+        {
+            "_id": "foo",
+            "reference": {"id": reference.id},
+            "user": {"id": user.id},
+            "version": 2,
+            "created_at": static_time.datetime,
+            "job": {"id": job.id},
+            "has_files": True,
+            "manifest": {},
+        },
+    )
+
+    await add_index_files(pg, "foo")
+
+    await data_layer.index.finalize("foo")
+
+    document = await mongo.otus.find_one({"_id": otu.id})
+
+    assert document["last_indexed_version"] == document["version"]
+
+    async with AsyncSession(pg) as session:
+        row = await session.scalar(select(SQLOTU).where(SQLOTU.id == otu.id))
+
+    assert row.data["last_indexed_version"] == document["version"]
 
 
 async def test_finalize_reference_missing_from_postgres(

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 import virtool.indexes.db
-from tests.fixtures.client import ClientSpawner
+from virtool.data.topg import both_transactions
+from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import (
     attach_files,
@@ -17,6 +18,7 @@ from virtool.indexes.db import (
 )
 from virtool.indexes.sql import SQLIndexFile
 from virtool.mongo.core import Mongo
+from virtool.otus.sql import SQLOTU
 
 
 @pytest.mark.parametrize("index_id", [None, "abc"])
@@ -280,23 +282,81 @@ async def test_get_patched_otus(mocker: MockerFixture, mongo: Mongo):
     )
 
 
-async def test_update_last_indexed_versions(
-    mongo: Mongo,
-    pg: AsyncEngine,
-    spawn_client: ClientSpawner,
-    test_otu,
-):
-    await spawn_client(authenticated=True)
-    test_otu["version"] = 1
+class TestUpdateLastIndexedVersions:
+    async def test_stamps_both_stores(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """The stamp lands in Postgres as well as Mongo.
 
-    await mongo.otus.insert_one(test_otu)
+        The OTU is created through the data layer so it exists in both stores, as it
+        would in production. Seeding Mongo alone would leave the Postgres update
+        matching no rows and the test would pass without proving anything.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        otu = await fake.otus.create(reference.id, user)
 
-    async with mongo.create_session() as session:
-        await update_last_indexed_versions(mongo, pg, "hxn167", session)
+        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+            await update_last_indexed_versions(
+                mongo,
+                pg,
+                reference.id,
+                mongo_session,
+                pg_session,
+            )
 
-    document = await mongo.otus.find_one({"reference.id": "hxn167"})
+        document = await mongo.otus.find_one({"_id": otu.id})
 
-    assert document["last_indexed_version"] == document["version"]
+        assert document["last_indexed_version"] == document["version"]
+
+        async with AsyncSession(pg) as session:
+            row = await session.scalar(select(SQLOTU).where(SQLOTU.id == otu.id))
+
+        assert row.data["last_indexed_version"] == document["version"]
+
+    async def test_otu_not_in_postgres(
+        self,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        test_otu,
+    ):
+        """An OTU that has not been backfilled yet is stamped in Mongo and skipped in
+        Postgres, rather than raising.
+
+        The backfill carries the stamped Mongo document over, so there is nothing to
+        write here.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        await mongo.otus.insert_one(
+            {**test_otu, "reference": {"id": reference.id}, "version": 3},
+        )
+
+        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+            await update_last_indexed_versions(
+                mongo,
+                pg,
+                reference.id,
+                mongo_session,
+                pg_session,
+            )
+
+        document = await mongo.otus.find_one({"_id": test_otu["_id"]})
+
+        assert document["last_indexed_version"] == 3
+
+        async with AsyncSession(pg) as session:
+            assert (
+                await session.scalar(
+                    select(SQLOTU).where(SQLOTU.id == test_otu["_id"]),
+                )
+                is None
+            )
 
 
 async def test_attach_files(snapshot, pg: AsyncEngine):

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -317,6 +317,59 @@ class TestUpdateLastIndexedVersions:
 
         assert row.data["last_indexed_version"] == document["version"]
 
+    async def test_stamps_every_chunk(
+        self,
+        fake: DataFaker,
+        mocker: MockerFixture,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Every OTU is stamped when the id list spans more than one chunk.
+
+        The ids are chunked because asyncpg binds one parameter per id. A reference
+        whose OTUs all sit in one version bucket -- a fresh import, where every OTU is
+        version 0 -- would otherwise blow the parameter limit.
+
+        The OTUs are created empty so they all stay at version 0 and so group into a
+        single bucket. An OTU with isolates lands on a version of its own, which would
+        leave every bucket holding one id and never exercise a chunk boundary.
+        """
+        mocker.patch("virtool.indexes.db.OTU_ID_CHUNK_SIZE", 2)
+
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        otus = [await fake.otus.create_empty(reference.id, user) for _ in range(5)]
+
+        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+            await update_last_indexed_versions(
+                mongo,
+                pg,
+                reference.id,
+                mongo_session,
+                pg_session,
+            )
+
+        async with AsyncSession(pg) as session:
+            rows = {
+                row.id: row
+                for row in (
+                    await session.execute(
+                        select(SQLOTU).where(
+                            SQLOTU.id.in_([otu.id for otu in otus]),
+                        ),
+                    )
+                ).scalars()
+            }
+
+        assert len(rows) == 5
+
+        for otu in otus:
+            document = await mongo.otus.find_one({"_id": otu.id})
+
+            assert document["last_indexed_version"] == document["version"]
+            assert rows[otu.id].data["last_indexed_version"] == document["version"]
+
     async def test_otu_not_in_postgres(
         self,
         fake: DataFaker,

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -2,6 +2,7 @@ import asyncio
 import gzip
 from collections.abc import AsyncIterator
 
+from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -335,14 +336,25 @@ class IndexData:
             check_index_files_uploaded(results),
         )
 
-        async with self._mongo.create_session() as session:
-            await update_last_indexed_versions(self._mongo, self._pg, ref_id, session)
+        async def finalize_index(
+            mongo_session: AsyncIOMotorClientSession,
+            pg_session: AsyncSession,
+        ) -> None:
+            await update_last_indexed_versions(
+                self._mongo,
+                self._pg,
+                ref_id,
+                mongo_session,
+                pg_session,
+            )
 
             await self._mongo.indexes.update_one(
                 {"_id": index_id},
                 {"$set": {"ready": True}},
-                session=session,
+                session=mongo_session,
             )
+
+        await retry_both_transactions(self._mongo, self._pg, finalize_index)
 
         return await self.get(index_id)
 

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -45,6 +45,14 @@ from virtool.types import Document
 from virtool.users.transforms import AttachUserTransform
 from virtool.utils import base_processor
 
+OTU_ID_CHUNK_SIZE = 500
+"""The number of OTU ids bound into a single ``last_indexed_version`` update.
+
+asyncpg binds one parameter per id, so an unbounded ``IN`` would blow its parameter
+limit on a reference whose OTUs all sit in one version bucket. A freshly imported
+reference is exactly that: every OTU is version 0.
+"""
+
 INDEX_FILE_NAMES = (
     "reference.fa.gz",
     "reference.json.gz",
@@ -503,17 +511,18 @@ async def update_last_indexed_versions(
     )
 
     for version, id_list in id_version_key.items():
-        await pg_session.execute(
-            update(SQLOTU)
-            .where(SQLOTU.id.in_(id_list))
-            .values(
-                data=func.jsonb_set(
-                    SQLOTU.data,
-                    literal(["last_indexed_version"], ARRAY(Text)),
-                    func.to_jsonb(cast(version, Integer)),
+        for start in range(0, len(id_list), OTU_ID_CHUNK_SIZE):
+            await pg_session.execute(
+                update(SQLOTU)
+                .where(SQLOTU.id.in_(id_list[start : start + OTU_ID_CHUNK_SIZE]))
+                .values(
+                    data=func.jsonb_set(
+                        SQLOTU.data,
+                        literal(["last_indexed_version"], ARRAY(Text)),
+                        func.to_jsonb(cast(version, Integer)),
+                    ),
                 ),
-            ),
-        )
+            )
 
 
 async def attach_files(pg: AsyncEngine, base_url: str, document: dict) -> dict:

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -6,7 +6,17 @@ from typing import Any
 
 import pymongo
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import Integer, cast, distinct, func, select, update
+from sqlalchemy import (
+    ARRAY,
+    Integer,
+    Text,
+    cast,
+    distinct,
+    func,
+    literal,
+    select,
+    update,
+)
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
@@ -24,6 +34,7 @@ from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndexFile
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
+from virtool.otus.sql import SQLOTU
 from virtool.references.db import (
     compose_reference_id_match,
     compose_reference_ids_match,
@@ -440,14 +451,22 @@ async def update_last_indexed_versions(
     mongo: "Mongo",
     pg: AsyncEngine,
     ref_id: str,
-    session: AsyncIOMotorClientSession,
+    mongo_session: AsyncIOMotorClientSession,
+    pg_session: AsyncSession,
 ) -> None:
     """Update the `last_indexed_version` field for OTUs associated with `ref_id`
+
+    Both stores are stamped from the same ``{version: [otu_id]}`` grouping, so the
+    same OTUs are stamped with the same version in each. ``last_indexed_version`` has
+    no promoted column on ``legacy_otus``; it lives in the ``data`` JSONB, so only
+    that key is rewritten. OTUs with no Postgres row yet are simply not matched --
+    the backfill will carry the stamped Mongo document over.
 
     :param mongo: the application mongo client
     :param pg: the application Postgres client
     :param ref_id: the id of the reference whose otus should be updated
-    :param session: the motor session to use
+    :param mongo_session: the motor session to use
+    :param pg_session: the Postgres session to use
 
     """
     pipeline = [
@@ -477,11 +496,24 @@ async def update_last_indexed_versions(
             mongo.otus.update_many(
                 {"_id": {"$in": id_list}},
                 {"$set": {"last_indexed_version": version}},
-                session=session,
+                session=mongo_session,
             )
             for version, id_list in id_version_key.items()
         ],
     )
+
+    for version, id_list in id_version_key.items():
+        await pg_session.execute(
+            update(SQLOTU)
+            .where(SQLOTU.id.in_(id_list))
+            .values(
+                data=func.jsonb_set(
+                    SQLOTU.data,
+                    literal(["last_indexed_version"], ARRAY(Text)),
+                    func.to_jsonb(cast(version, Integer)),
+                ),
+            ),
+        )
 
 
 async def attach_files(pg: AsyncEngine, base_url: str, document: dict) -> dict:


### PR DESCRIPTION
## Summary
- Index finalization stamped `last_indexed_version` in Mongo only, drifting `legacy_otus` from the OTU document it mirrors and tripping the parity gate that blocks the OTU read cutover.
- Mirror the stamp into the `data` JSONB from the same `{version: [otu_id]}` grouping the Mongo write uses, and move `IndexData.finalize` onto `retry_both_transactions` so both stores commit together.
- Closes VIR-2657. The history-revert gap originally scoped into that issue is moot — `b0bdfb72c` removed the revert path entirely.