### PR TITLE
fix: apply migrations with long revision names

### DIFF
--- a/tests/fixtures/migration.py
+++ b/tests/fixtures/migration.py
@@ -22,8 +22,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from virtool.api.custom_json import dump_string
 from virtool.config.cls import MigrationConfig
+from virtool.migration.apply import ensure_revisions_table
 from virtool.migration.ctx import MigrationContext, create_migration_context
-from virtool.migration.pg import SQLRevision
 from virtool.pg.utils import (
     PgOptions,
     get_sqlalchemy_url,
@@ -71,9 +71,7 @@ async def migration_pg_connection_string(
         pool_recycle=1800,
     )
 
-    async with engine.connect() as conn:
-        await conn.run_sync(SQLRevision.__table__.create)
-        await conn.commit()
+    await ensure_revisions_table(engine)
 
     return connection_string
 

--- a/tests/migration/test_apply.py
+++ b/tests/migration/test_apply.py
@@ -3,11 +3,12 @@ from dataclasses import asdict
 
 import arrow
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy.matchers import path_type
 
 from virtool.config.cls import MigrationConfig
-from virtool.migration.apply import apply
+from virtool.migration.apply import apply, ensure_revisions_table
 from virtool.migration.pg import SQLRevision, list_applied_revisions
 from virtool.migration.show import load_all_revisions
 
@@ -78,6 +79,54 @@ async def test_apply_revisions_with_missing_last_applied(
     # All real revisions should be present.
     for revision in all_revisions:
         assert any(r.revision == revision.id for r in applied)
+
+
+class TestEnsureRevisionsTable:
+    async def test_widens_legacy_columns(self, migration_pg: AsyncEngine):
+        """A revision name longer than the legacy 64-character limit can be recorded.
+
+        The table was originally created with `name varchar(64)` and
+        `revision varchar(18)`. Revision names have since outgrown that limit, and
+        `CREATE TABLE IF NOT EXISTS` will not widen a table that already exists.
+        """
+        async with AsyncSession(migration_pg) as session, session.begin():
+            await session.execute(text("DROP TABLE revisions"))
+            await session.execute(
+                text(
+                    """
+                    CREATE TABLE revisions (
+                        id SERIAL PRIMARY KEY,
+                        name varchar(64) NOT NULL,
+                        revision varchar(18) NOT NULL,
+                        created_at timestamp without time zone NOT NULL,
+                        applied_at timestamp without time zone NOT NULL
+                    )
+                    """,
+                ),
+            )
+
+        await ensure_revisions_table(migration_pg)
+
+        now = arrow.utcnow().naive
+        long_name = (
+            "add sequence isolate_id and segment columns and otu reference_id index"
+        )
+
+        async with AsyncSession(migration_pg) as session:
+            session.add(
+                SQLRevision(
+                    applied_at=now,
+                    created_at=now,
+                    name=long_name,
+                    revision="5de38ebeaa78",
+                ),
+            )
+
+            await session.commit()
+
+        assert [r.name for r in await list_applied_revisions(migration_pg)] == [
+            long_name,
+        ]
 
 
 @pytest.mark.timeout(30)

--- a/virtool/migration/apply.py
+++ b/virtool/migration/apply.py
@@ -134,6 +134,10 @@ async def apply_alembic(revision: str) -> None:
 async def ensure_revisions_table(pg: AsyncEngine) -> None:
     """Ensure that the `revisions` table exists in the database.
 
+    The `name` and `revision` columns were originally length-limited. Existing
+    databases are widened here because `CREATE TABLE IF NOT EXISTS` will not alter a
+    table that already exists.
+
     :param pg: the PostgreSQL database connection
     """
     async with AsyncSession(pg) as session, session.begin():
@@ -142,11 +146,19 @@ async def ensure_revisions_table(pg: AsyncEngine) -> None:
                 """
                     CREATE TABLE IF NOT EXISTS revisions (
                         id SERIAL PRIMARY KEY,
-                        name varchar(64) NOT NULL,
-                        revision varchar(18) NOT NULL,
+                        name varchar NOT NULL,
+                        revision varchar NOT NULL,
                         created_at timestamp without time zone NOT NULL,
                         applied_at timestamp without time zone NOT NULL
                     )
                     """,
             ),
+        )
+
+        await session.execute(
+            text("ALTER TABLE revisions ALTER COLUMN name TYPE varchar"),
+        )
+
+        await session.execute(
+            text("ALTER TABLE revisions ALTER COLUMN revision TYPE varchar"),
         )

--- a/virtool/migration/apply.py
+++ b/virtool/migration/apply.py
@@ -156,9 +156,11 @@ async def ensure_revisions_table(pg: AsyncEngine) -> None:
         )
 
         await session.execute(
-            text("ALTER TABLE revisions ALTER COLUMN name TYPE varchar"),
-        )
-
-        await session.execute(
-            text("ALTER TABLE revisions ALTER COLUMN revision TYPE varchar"),
+            text(
+                """
+                    ALTER TABLE revisions
+                        ALTER COLUMN name TYPE varchar,
+                        ALTER COLUMN revision TYPE varchar
+                    """,
+            ),
         )


### PR DESCRIPTION
## Summary
- Widen the `revisions` table's `name` and `revision` columns, which were capped at 64 and 18 characters, so revisions with longer names can be recorded.
- Alter existing tables as well as widening the `CREATE TABLE IF NOT EXISTS` DDL, since that clause won't widen a table that already exists.
- Create the `revisions` table in tests with the same DDL production uses so the two can't drift apart again.