### PR TITLE
fix(migration): repair otu created_at stored as a string in mongo

### DIFF
--- a/assets/revisions/rev_t96ls24modzv_compare_otu_and_sequence_stores.py
+++ b/assets/revisions/rev_t96ls24modzv_compare_otu_and_sequence_stores.py
@@ -30,7 +30,7 @@ created_at = arrow.get("2026-07-13 23:10:46.510454")
 revision_id = "t96ls24modzv"
 
 alembic_down_revision = None
-virtool_down_revision = "ztimons6l9au"
+virtool_down_revision = "yok1ouqta8nf"
 
 # ``f8aa696aa0d3`` adds ``legacy_sequences.position``, which this check verifies.
 required_alembic_revision = "f8aa696aa0d3"

--- a/assets/revisions/rev_yok1ouqta8nf_repair_string_otu_created_at.py
+++ b/assets/revisions/rev_yok1ouqta8nf_repair_string_otu_created_at.py
@@ -1,0 +1,39 @@
+"""Rewrite a Mongo OTU ``created_at`` held as a string as the datetime it means.
+
+Every OTU of a reference cloned before December 2022 holds its ``created_at`` as an
+ISO string rather than a BSON date. The clone task read the timestamp from its task
+context -- a JSONB column -- so the reference's creation datetime came back out of
+Postgres as a string, and was written into each OTU document as one.
+
+The read cutover cannot tolerate it. ``legacy_otus.data`` is JSONB and holds
+``created_at`` as a string whatever Mongo holds, so the read path parses it back to a
+datetime, and for these OTUs recovers a datetime where Mongo still has a string. The
+two stores hold the same instant as different types, and the drift gate fails on it.
+
+Mongo is the store that is wrong, so the string is parsed and written back as the
+datetime every other OTU carries. Runs before the gate and after the reconciliation.
+
+Revision ID: yok1ouqta8nf
+Date: 2026-07-14 19:35:35.246783
+
+"""
+
+import arrow
+
+from virtool.migration import MigrationContext
+from virtool.otus.migration import repair_string_otu_created_at
+
+# Revision identifiers.
+name = "repair string otu created at"
+created_at = arrow.get("2026-07-14 19:35:35.246783")
+revision_id = "yok1ouqta8nf"
+
+alembic_down_revision = None
+virtool_down_revision = "ztimons6l9au"
+
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Repair every OTU document whose ``created_at`` is a string."""
+    await repair_string_otu_created_at(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -775,6 +775,13 @@
       'applied_at': datetime,
       'created_at': datetime,
       'id': 111,
+      'name': 'repair string otu created at',
+      'revision': 'yok1ouqta8nf',
+    }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 112,
       'name': 'compare otu and sequence stores',
       'revision': 't96ls24modzv',
     }),

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -1111,6 +1111,43 @@ class TestRepairStringOtuCreatedAt:
 
         assert document["created_at"] == _CREATED_AT_JSON
 
+    async def test_a_failed_postgres_write_leaves_the_otu_repairable(
+        self,
+        ctx: MigrationContext,
+        cloned_otu: None,
+        mocker,
+    ):
+        """An interrupted repair keeps the string that makes the OTU findable.
+
+        The string is the only thing that puts an OTU in the candidate query. Landing
+        the Mongo write ahead of the Postgres one would take it away the moment the
+        write committed, and an OTU whose row never got written would then be drifted,
+        unfindable and unrepairable. The Mongo write commits after Postgres, so a failed
+        Postgres write takes the Mongo write down with it.
+        """
+        mocker.patch(
+            "virtool.otus.migration.update",
+            side_effect=OSError("postgres is gone"),
+        )
+
+        with pytest.raises(OSError, match="postgres is gone"):
+            await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_cloned"})
+
+        assert document["created_at"] == _CREATED_AT_JSON
+
+        mocker.stopall()
+
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_cloned"})
+
+        assert document["created_at"] == _CREATED_AT
+        assert (await _fetch_otu(ctx, "otu_cloned")).data["created_at"] == (
+            _CREATED_AT_JSON
+        )
+
     async def test_is_idempotent(self, ctx: MigrationContext, cloned_otu: None):
         """A second run finds nothing left to repair and changes nothing."""
         await repair_string_otu_created_at(ctx)

--- a/tests/otus/test_migration.py
+++ b/tests/otus/test_migration.py
@@ -16,6 +16,7 @@ from virtool.otus.migration import (
     compare_otu_and_sequence_stores,
     copy_otus_and_sequences_to_postgres,
     reconcile_otus_and_sequences,
+    repair_string_otu_created_at,
 )
 from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.utils import timestamp
@@ -969,6 +970,176 @@ class TestReconcileOtusAndSequences:
 
         with pytest.raises(ValueError, match="which does not exist in postgres"):
             await reconcile_otus_and_sequences(ctx)
+
+
+class TestRepairStringOtuCreatedAt:
+    @pytest.fixture
+    async def cloned_otu(self, ctx: MigrationContext, reference_id: int) -> None:
+        """Seed an OTU whose Mongo ``created_at`` is a string, as a legacy clone's is,
+        and reconcile it into Postgres.
+        """
+        await ctx.mongo.otus.insert_one(
+            {
+                **_otu_doc("otu_cloned", reference_id, "Cucumber mosaic virus"),
+                "created_at": _CREATED_AT_JSON,
+            },
+        )
+
+        await reconcile_otus_and_sequences(ctx)
+
+    async def test_string_is_rewritten_as_a_datetime(
+        self,
+        ctx: MigrationContext,
+        cloned_otu: None,
+    ):
+        """The string becomes the datetime it means, in both stores."""
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_cloned"})
+        row = await _fetch_otu(ctx, "otu_cloned")
+
+        assert document["created_at"] == _CREATED_AT
+        assert row.data["created_at"] == _CREATED_AT_JSON
+
+    async def test_repaired_otu_passes_the_gate(
+        self,
+        ctx: MigrationContext,
+        cloned_otu: None,
+    ):
+        """The drift the gate fails the cutover on is the drift the repair clears."""
+        with pytest.raises(ValueError, match="store drift detected in 1 otus"):
+            await compare_otu_and_sequence_stores(ctx)
+
+        await repair_string_otu_created_at(ctx)
+
+        await compare_otu_and_sequence_stores(ctx)
+
+    async def test_sub_millisecond_string_is_floored(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """A string finer than Mongo can hold is floored before it is written.
+
+        BSON holds a datetime as int64 milliseconds. Writing the string's full
+        precision would leave Mongo holding an instant the ``data`` column does not,
+        which is the drift this repair exists to clear.
+        """
+        await ctx.mongo.otus.insert_one(
+            {
+                **_otu_doc("otu_precise", reference_id, "Tobacco mosaic virus"),
+                "created_at": "2025-07-02T21:18:48.420789Z",
+            },
+        )
+
+        await reconcile_otus_and_sequences(ctx)
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_precise"})
+        row = await _fetch_otu(ctx, "otu_precise")
+
+        assert document["created_at"] == _CREATED_AT
+        assert row.data["created_at"] == _CREATED_AT_JSON
+
+        await compare_otu_and_sequence_stores(ctx)
+
+    async def test_datetime_otu_is_untouched(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """An OTU that already holds a datetime is left exactly as it is."""
+        await ctx.mongo.otus.insert_one(
+            _otu_doc("otu_sound", reference_id, "Tobacco mosaic virus"),
+        )
+
+        await reconcile_otus_and_sequences(ctx)
+
+        row_before = await _fetch_otu(ctx, "otu_sound")
+
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_sound"})
+
+        assert document["created_at"] == _CREATED_AT
+        assert (await _fetch_otu(ctx, "otu_sound")).data == row_before.data
+
+    async def test_string_without_an_offset_is_read_as_utc(
+        self,
+        ctx: MigrationContext,
+        reference_id: int,
+    ):
+        """An unqualified datetime is UTC, as the convention says it is."""
+        await ctx.mongo.otus.insert_one(
+            {
+                **_otu_doc("otu_unqualified", reference_id, "Tobacco mosaic virus"),
+                "created_at": "2025-07-02T21:18:48.420000",
+            },
+        )
+
+        await reconcile_otus_and_sequences(ctx)
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_unqualified"})
+
+        assert document["created_at"] == _CREATED_AT
+
+    async def test_non_utc_offset_raises_before_anything_is_written(
+        self,
+        ctx: MigrationContext,
+        cloned_otu: None,
+        reference_id: int,
+    ):
+        """A string this cannot read stops the repair rather than being guessed at.
+
+        ``arrow`` strips an offset instead of applying it, so reading such a string as
+        naive UTC would file it two hours from the instant it names. Nothing is written
+        at all: the strings are all parsed before the first store is touched, so the
+        readable OTUs of a store holding an unreadable one are not left half repaired.
+        """
+        await ctx.mongo.otus.insert_one(
+            {
+                **_otu_doc("otu_offset", reference_id, "Tobacco mosaic virus"),
+                "created_at": "2025-07-02T21:18:48.420000+02:00",
+            },
+        )
+
+        with pytest.raises(ValueError, match="non-utc offset"):
+            await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_cloned"})
+
+        assert document["created_at"] == _CREATED_AT_JSON
+
+    async def test_is_idempotent(self, ctx: MigrationContext, cloned_otu: None):
+        """A second run finds nothing left to repair and changes nothing."""
+        await repair_string_otu_created_at(ctx)
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_cloned"})
+        row = await _fetch_otu(ctx, "otu_cloned")
+
+        assert document["created_at"] == _CREATED_AT
+        assert row.data["created_at"] == _CREATED_AT_JSON
+
+    async def test_otu_without_a_row_is_repaired_in_mongo(
+        self,
+        ctx: MigrationContext,
+        cloned_otu: None,
+    ):
+        """An OTU whose row is being deleted right now is still repaired in Mongo.
+
+        Postgres is never behind Mongo, so a document with no row is one a concurrent
+        delete has already removed from Postgres. The repair has no row to rewrite and
+        must not fail over it.
+        """
+        await _delete_otu_row(ctx, "otu_cloned")
+
+        await repair_string_otu_created_at(ctx)
+
+        document = await ctx.mongo.otus.find_one({"_id": "otu_cloned"})
+
+        assert document["created_at"] == _CREATED_AT
 
 
 class TestCompareOtuAndSequenceStores:

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -1,9 +1,9 @@
 """Shared migration logic for the Mongo-to-Postgres OTU and sequence move.
 
 This module holds the idempotent copy used by the OTU/sequence backfill revision,
-the authoritative reconciliation that repairs rows the copy left behind, and the
-drift check that gates the read cutover. Keeping them here keeps the logic
-unit-testable and reusable.
+the authoritative reconciliation that repairs rows the copy left behind, the repair
+of OTU documents Mongo itself holds malformed, and the drift check that gates the
+read cutover. Keeping them here keeps the logic unit-testable and reusable.
 
 Unlike the standard migration playbook, ``legacy_otus`` and ``legacy_sequences``
 have no ``legacy_id`` column: their primary key ``id`` is the Mongo ``_id``
@@ -13,10 +13,12 @@ string itself. Idempotency and skip-existing therefore key on ``id`` rather than
 
 import asyncio
 from collections import Counter
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, NamedTuple
 
-from sqlalchemy import Row, select
+import arrow
+from sqlalchemy import Row, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -671,6 +673,139 @@ async def _delete_removed_otus(ctx: MigrationContext, deletable: set[str]) -> in
             deleted_count += deleted
 
     return deleted_count
+
+
+async def repair_string_otu_created_at(ctx: MigrationContext) -> None:
+    """Rewrite a Mongo OTU ``created_at`` held as a string as the datetime it means.
+
+    An OTU cloned before December 2022 carries its ``created_at`` as an ISO string
+    rather than a BSON date. The clone task took the timestamp from its task context,
+    which is a JSONB column, so the datetime the reference was created with came back
+    out of Postgres as the string the JSON serializer wrote -- and
+    ``insert_joined_otu`` put that string straight into the OTU document. Every OTU of
+    such a clone holds one, and they have sat in Mongo ever since.
+
+    Nothing in Mongo minded, because nothing read ``created_at`` as anything but a
+    value to serialize back out, and a string serializes to itself. The move to
+    Postgres does mind. ``data`` is JSONB and cannot hold a datetime either, so
+    :func:`virtool.otus.db.otu_document_from_row` parses ``created_at`` back to the
+    datetime an OTU document is supposed to carry -- which is the right thing to do
+    for every OTU written since, and which recovers a *datetime* for these, where
+    Mongo still holds a string. The two stores then disagree on the type of a field
+    they agree on the value of, and :func:`compare_otu_and_sequence_stores` fails the
+    read cutover on it.
+
+    The document is the store that is wrong: a Mongo ``created_at`` is a date
+    everywhere else in the codebase, and the read path will hand back a datetime for
+    these OTUs whether or not the document is repaired. So the string is parsed and
+    written back as the datetime it always meant.
+
+    The datetime is floored to the millisecond first, because BSON holds a datetime as
+    int64 milliseconds and would drop the microseconds itself. Writing the floored
+    value to *both* stores keeps the ``data`` column a faithful lift of the document
+    Mongo ends up holding, rather than one microsecond-precise string ahead of it.
+
+    The row is rewritten from the row, not from the document: only ``created_at`` is
+    replaced, and every other field of ``data`` is left exactly as the writer that last
+    touched it left it. A concurrent dual-write cannot be clobbered by a stale
+    snapshot, so no version guard is needed here. The row is locked with
+    ``SELECT … FOR UPDATE`` before Mongo is read, as every dual-write path does, so a
+    writer that reads the document while the repair holds the lock reads it after the
+    repair has landed rather than before.
+
+    Every string is parsed and checked before anything is written, so a store holding
+    one this cannot read is left untouched rather than half repaired. See
+    :func:`_parse_utc_timestamp` for what it will not read.
+
+    Idempotent: a repaired OTU no longer matches ``{"created_at": {"$type": "string"}}``
+    and a second run finds nothing to do.
+    """
+    candidates = {
+        document["_id"]: (
+            document["created_at"],
+            _parse_utc_timestamp(document["_id"], document["created_at"]),
+        )
+        async for document in ctx.mongo.otus.find(
+            {"created_at": {"$type": "string"}},
+            projection=["created_at"],
+        )
+    }
+
+    if not candidates:
+        logger.info("no otus hold a string created_at")
+        return
+
+    logger.info("repairing otus that hold a string created_at", otus=len(candidates))
+
+    repaired = 0
+
+    for otu_id, (raw, created_at) in candidates.items():
+        async with AsyncSession(ctx.pg) as session:
+            row = (
+                await session.execute(
+                    select(SQLOTU.data).where(SQLOTU.id == otu_id).with_for_update(),
+                )
+            ).one_or_none()
+
+            document = await ctx.mongo.otus.find_one(
+                {"_id": otu_id},
+                projection=["created_at"],
+            )
+
+            if document is None or document["created_at"] != raw:
+                await session.rollback()
+                continue
+
+            await ctx.mongo.otus.update_one(
+                {"_id": otu_id},
+                {"$set": {"created_at": created_at}},
+            )
+
+            if row is not None:
+                await session.execute(
+                    update(SQLOTU)
+                    .where(SQLOTU.id == otu_id)
+                    .values(data={**row.data, "created_at": created_at}),
+                )
+
+            await session.commit()
+
+            repaired += 1
+
+    logger.info("repaired otus that held a string created_at", otus=repaired)
+
+
+def _parse_utc_timestamp(otu_id: str, created_at: str) -> datetime:
+    """Parse an OTU's string ``created_at`` as the naive UTC datetime it denotes.
+
+    Virtool datetimes are naive UTC, and the strings this repairs were written by the
+    JSON serializer, which renders one as UTC with a ``Z``. So a string that carries a
+    *non-UTC* offset came from somewhere this does not know about, and is refused
+    rather than guessed at: ``arrow.get(...).naive`` strips the offset instead of
+    applying it, and would file ``01:32:35+02:00`` as ``01:32:35`` UTC -- the same
+    wall clock, two hours from the instant it names. Being loud about a handful of
+    unreadable documents is worth more than silently shifting them.
+
+    A string with no offset at all is read as UTC, which is what the convention says an
+    unqualified Virtool datetime is.
+
+    The result is floored to the millisecond, the precision BSON stores a datetime at.
+    """
+    parsed = arrow.get(created_at)
+
+    if parsed.utcoffset() != timedelta(0):
+        msg = (
+            f"otu {otu_id} holds a created_at with a non-utc offset: {created_at!r}. "
+            f"it cannot be read as the naive utc datetime the store expects"
+        )
+        raise ValueError(msg)
+
+    return _floor_to_millisecond(parsed.naive)
+
+
+def _floor_to_millisecond(created_at: datetime) -> datetime:
+    """Drop a datetime's sub-millisecond precision, as a write to Mongo would."""
+    return created_at.replace(microsecond=created_at.microsecond // 1000 * 1000)
 
 
 _OTU_CHUNK_SIZE = 500

--- a/virtool/otus/migration.py
+++ b/virtool/otus/migration.py
@@ -717,6 +717,20 @@ async def repair_string_otu_created_at(ctx: MigrationContext) -> None:
     one this cannot read is left untouched rather than half repaired. See
     :func:`_parse_utc_timestamp` for what it will not read.
 
+    **The string is what makes an OTU findable, so it is the last thing to go.** The
+    Mongo write is made inside a transaction that commits *after* the Postgres one, as
+    :func:`virtool.data.topg.both_transactions` does. An interrupted run -- or a
+    Postgres write that fails -- therefore aborts the Mongo write with it, and the OTU
+    is still holding the string that puts it in ``candidates`` next time.
+
+    The alternative loses the OTU. A Mongo write that commits on its own, ahead of the
+    Postgres one, is durable the moment it lands: kill the run before the row is
+    written, and Mongo holds the floored datetime while ``data`` still holds the
+    sub-millisecond string it was floored from. Those disagree, and the OTU no longer
+    matches the ``$type: "string"`` query that would have found it, so no re-run
+    repairs it and the gate fails on it forever. Nothing recovers what the query cannot
+    see.
+
     Idempotent: a repaired OTU no longer matches ``{"created_at": {"$type": "string"}}``
     and a second run finds nothing to do.
     """
@@ -740,7 +754,11 @@ async def repair_string_otu_created_at(ctx: MigrationContext) -> None:
     repaired = 0
 
     for otu_id, (raw, created_at) in candidates.items():
-        async with AsyncSession(ctx.pg) as session:
+        async with (
+            AsyncSession(ctx.pg) as session,
+            await ctx.mongo.client.start_session() as mongo_session,
+            mongo_session.start_transaction(),
+        ):
             row = (
                 await session.execute(
                     select(SQLOTU.data).where(SQLOTU.id == otu_id).with_for_update(),
@@ -750,15 +768,18 @@ async def repair_string_otu_created_at(ctx: MigrationContext) -> None:
             document = await ctx.mongo.otus.find_one(
                 {"_id": otu_id},
                 projection=["created_at"],
+                session=mongo_session,
             )
 
             if document is None or document["created_at"] != raw:
                 await session.rollback()
+                await mongo_session.abort_transaction()
                 continue
 
             await ctx.mongo.otus.update_one(
                 {"_id": otu_id},
                 {"$set": {"created_at": created_at}},
+                session=mongo_session,
             )
 
             if row is not None:

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -427,7 +427,6 @@ class ReferencesData(DataLayerDomain):
 
             task_class = CloneReferenceTask
             context = {
-                "created_at": document["created_at"],
                 "manifest": manifest,
                 "user_id": user_id,
             }
@@ -450,7 +449,6 @@ class ReferencesData(DataLayerDomain):
 
             task_class = ImportReferenceTask
             context = {
-                "created_at": document["created_at"],
                 "name_on_disk": upload.name_on_disk,
                 "user_id": user_id,
             }


### PR DESCRIPTION
## Summary
- Repair OTUs cloned before December 2022, whose `created_at` was written as an ISO string instead of a date because the clone task sourced it from the JSONB task context. A string carrying a non-UTC offset is refused rather than shifted.
- Run the repair ahead of the Mongo-Postgres parity gate, which fails the read cutover on the type mismatch: the read path parses `created_at` back to a datetime where Mongo still holds a string.
- Drop the now-dead `created_at` from the clone and import task contexts, the mechanism that minted the bad strings.