### PR TITLE
feat: activate task-backed index creation

### DIFF
--- a/tests/indexes/__snapshots__/test_api.ambr
+++ b/tests/indexes/__snapshots__/test_api.ambr
@@ -5,9 +5,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'has_files': True,
     'has_json': False,
-    'job': dict({
-      'id': 1,
-    }),
+    'job': None,
     'manifest': dict({
       'bar': 2,
       'foo': 1,
@@ -16,7 +14,9 @@
     'reference': dict({
       'id': 1,
     }),
-    'task': None,
+    'task': dict({
+      'id': 1,
+    }),
     'user': dict({
       'id': 1,
     }),
@@ -38,17 +38,7 @@
     ]),
     'has_files': True,
     'id': 'bf1b993c',
-    'job': dict({
-      'created_at': '2015-10-06T20:00:00Z',
-      'id': 1,
-      'progress': 0,
-      'state': 'pending',
-      'user': dict({
-        'handle': 'leeashley',
-        'id': 1,
-      }),
-      'workflow': 'build_index',
-    }),
+    'job': None,
     'manifest': dict({
       'bar': 2,
       'foo': 1,

--- a/tests/indexes/__snapshots__/test_db.ambr
+++ b/tests/indexes/__snapshots__/test_db.ambr
@@ -31,15 +31,15 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'has_files': True,
     'has_json': False,
-    'job': dict({
-      'id': 'bar',
-    }),
+    'job': None,
     'manifest': 'manifest',
     'ready': False,
     'reference': dict({
       'id': 1,
     }),
-    'task': None,
+    'task': dict({
+      'id': 1,
+    }),
     'user': dict({
       'id': 'test',
     }),
@@ -52,15 +52,15 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'has_files': True,
     'has_json': False,
-    'job': dict({
-      'id': 'bar',
-    }),
+    'job': None,
     'manifest': 'manifest',
     'ready': False,
     'reference': dict({
       'id': 1,
     }),
-    'task': None,
+    'task': dict({
+      'id': 1,
+    }),
     'user': dict({
       'id': 'test',
     }),

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -28,10 +28,12 @@ from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import JOB_INDEX_FILE_NAMES
 from virtool.indexes.sql import SQLIndexFile
 from virtool.indexes.utils import check_index_file_type, compose_index_file_key
+from virtool.jobs.pg import SQLJob, SQLJobIndex
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 from virtool.mongo.utils import get_mongo_from_app
 from virtool.storage.protocol import StorageBackend
+from virtool.tasks.sql import SQLTask
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
 
@@ -486,6 +488,31 @@ class TestCreate:
         index = await mongo.indexes.find_one()
 
         assert index == snapshot(name="index")
+        assert index["job"] is None
+        assert index["task"] is not None
+
+        body = await resp.json()
+        assert body["ready"] is False
+        assert body["job"] is None
+        assert "task" not in body
+
+        async with AsyncSession(pg) as session:
+            task = await session.scalar(
+                select(SQLTask).where(SQLTask.id == index["task"]["id"]),
+            )
+            history = await session.scalar(
+                select(SQLLegacyHistory).where(
+                    SQLLegacyHistory.legacy_id == "history_1",
+                ),
+            )
+
+            assert task is not None
+            assert task.type == "create_index"
+            assert task.context == {"index_id": index["_id"]}
+            assert history is not None
+            assert (history.index, history.index_version) == (index["_id"], "0")
+            assert await session.scalar(select(SQLJob.id)) is None
+            assert await session.scalar(select(SQLJobIndex.job_id)) is None
 
         m_create_manifest.assert_called_with(ANY, ANY, reference["id"])
 

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from aiohttp.test_utils import make_mocked_coro
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -27,7 +26,6 @@ from virtool.otus.sql import SQLOTU
 @pytest.mark.parametrize("index_id", [None, "abc"])
 async def test_create(
     index_id: str | None,
-    mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
     fake,
@@ -41,23 +39,24 @@ async def test_create(
 
     await fake.references.create(user=user, id_="foo")
 
-    mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
-
-    created = await virtool.indexes.db.create(
-        mongo,
-        pg,
-        "foo",
-        "test",
-        "bar",
-        index_id=index_id,
-    )
+    async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+        created = await virtool.indexes.db.create(
+            mongo,
+            mongo_session,
+            pg_session,
+            "foo",
+            "test",
+            0,
+            "manifest",
+            task_id=1,
+            index_id=index_id,
+        )
 
     assert created["created_at"] == static_time.datetime
     assert created == snapshot
 
 
 async def test_create_assigns_index_in_postgres(
-    mocker: MockerFixture,
     mongo: Mongo,
     pg: AsyncEngine,
     fake,
@@ -107,16 +106,18 @@ async def test_create_assigns_index_in_postgres(
         )
         await session.commit()
 
-    mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
-
-    await virtool.indexes.db.create(
-        mongo,
-        pg,
-        "built_ref",
-        user.id,
-        1,
-        index_id="new_index",
-    )
+    async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+        await virtool.indexes.db.create(
+            mongo,
+            mongo_session,
+            pg_session,
+            "built_ref",
+            user.id,
+            1,
+            "manifest",
+            task_id=1,
+            index_id="new_index",
+        )
 
     async with AsyncSession(pg) as session:
         rows = {
@@ -161,21 +162,24 @@ async def test_create_rolls_back_both_stores_on_failure(
         )
         await session.commit()
 
-    mocker.patch("virtool.references.db.get_manifest", make_mocked_coro("manifest"))
     mocker.patch(
         "virtool.indexes.db.update",
         side_effect=RuntimeError("postgres write failed"),
     )
 
     with pytest.raises(RuntimeError, match="postgres write failed"):
-        await virtool.indexes.db.create(
-            mongo,
-            pg,
-            "built_ref",
-            user.id,
-            1,
-            index_id="new_index",
-        )
+        async with both_transactions(mongo, pg) as (mongo_session, pg_session):
+            await virtool.indexes.db.create(
+                mongo,
+                mongo_session,
+                pg_session,
+                "built_ref",
+                user.id,
+                1,
+                "manifest",
+                task_id=1,
+                index_id="new_index",
+            )
 
     assert await mongo.indexes.find_one("new_index") is None
 

--- a/tests/references/__snapshots__/test_api.ambr
+++ b/tests/references/__snapshots__/test_api.ambr
@@ -214,17 +214,7 @@
     ]),
     'has_files': True,
     'id': 'bf1b993c',
-    'job': dict({
-      'created_at': '2015-10-06T20:00:00Z',
-      'id': 1,
-      'progress': 0,
-      'state': 'pending',
-      'user': dict({
-        'handle': 'leeashley',
-        'id': 1,
-      }),
-      'workflow': 'build_index',
-    }),
+    'job': None,
     'manifest': dict({
       'bar': 5,
       'foo': 2,
@@ -256,9 +246,7 @@
     'created_at': datetime.datetime(2015, 10, 6, 20, 0),
     'has_files': True,
     'has_json': False,
-    'job': dict({
-      'id': 1,
-    }),
+    'job': None,
     'manifest': dict({
       'bar': 5,
       'foo': 2,
@@ -267,7 +255,9 @@
     'reference': dict({
       'id': 1,
     }),
-    'task': None,
+    'task': dict({
+      'id': 1,
+    }),
     'user': dict({
       'id': 1,
     }),

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -18,6 +18,7 @@ from virtool.data.layer import DataLayer
 from virtool.data.topg import both_transactions
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
+from virtool.jobs.pg import SQLJob, SQLJobIndex
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 from virtool.otus.oas import (
@@ -950,16 +951,31 @@ class TestCreateIndex:
         assert await resp.json() == snapshot
         index = await mongo.indexes.find_one()
         assert index == snapshot
-        assert index["job"] is not None
-        assert index["task"] is None
+        assert index["job"] is None
+        assert index["task"] is not None
+
+        body = await resp.json()
+        assert body["ready"] is False
+        assert body["job"] is None
+        assert "task" not in body
 
         async with AsyncSession(pg) as session:
-            assert (
-                await session.scalar(
-                    select(SQLTask.id).where(SQLTask.type == "create_index"),
-                )
-                is None
+            task = await session.scalar(
+                select(SQLTask).where(SQLTask.id == index["task"]["id"]),
             )
+            history = await session.scalar(
+                select(SQLLegacyHistory).where(
+                    SQLLegacyHistory.legacy_id == "history_1",
+                ),
+            )
+
+            assert task is not None
+            assert task.type == "create_index"
+            assert task.context == {"index_id": index["_id"]}
+            assert history is not None
+            assert (history.index, history.index_version) == (index["_id"], "0")
+            assert await session.scalar(select(SQLJob.id)) is None
+            assert await session.scalar(select(SQLJobIndex.job_id)) is None
 
         m_create_manifest.assert_called_with(ANY, ANY, reference["id"])
 

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.history.sql import SQLLegacyHistory
+from virtool.mongo.core import Mongo
 from virtool.references.oas import (
     CreateReferenceGroupRequest,
     CreateReferenceRequest,
@@ -14,6 +16,7 @@ from virtool.references.oas import (
     UpdateReferenceRequest,
 )
 from virtool.references.sql import SQLReference
+from virtool.tasks.sql import SQLTask
 
 
 class TestCreate:
@@ -87,6 +90,60 @@ class TestCreate:
             )
 
         assert rows == []
+
+
+class TestCreateIndex:
+    async def test_rolls_back_task_index_and_history_on_failure(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        static_time,
+    ):
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLLegacyHistory(
+                    legacy_id="unbuilt_change",
+                    created_at=static_time.datetime,
+                    description="Created OTU",
+                    method_name="create",
+                    user_id=user.id,
+                    otu="otu_1",
+                    otu_name="Tobacco mosaic virus",
+                    otu_version="0",
+                    reference_id=reference.id,
+                    index=None,
+                    index_version=None,
+                ),
+            )
+            await session.commit()
+
+        mocker.patch(
+            "virtool.indexes.db.update",
+            side_effect=RuntimeError("history assignment failed"),
+        )
+
+        with pytest.raises(RuntimeError, match="history assignment failed"):
+            await data_layer.references.create_index(reference.id, user.id)
+
+        assert await mongo.indexes.find_one() is None
+
+        async with AsyncSession(pg) as session:
+            history = await session.scalar(
+                select(SQLLegacyHistory).where(
+                    SQLLegacyHistory.legacy_id == "unbuilt_change",
+                ),
+            )
+
+            assert history is not None
+            assert history.index is None
+            assert history.index_version is None
+            assert await session.scalar(select(SQLTask.id)) is None
 
 
 class TestUpdate:

--- a/tests/tasks/test_db.py
+++ b/tests/tasks/test_db.py
@@ -1,0 +1,45 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+import virtool.tasks.db
+from virtool.tasks.sql import SQLTask
+from virtool.tasks.task import BaseTask
+
+
+class DummyTask(BaseTask):
+    name = "dummy_task"
+
+
+class TestCreate:
+    async def test_commits_with_caller_session(self, pg: AsyncEngine):
+        async with AsyncSession(pg) as session:
+            task = await virtool.tasks.db.create(
+                session,
+                DummyTask,
+                {"owner": "caller"},
+            )
+            await session.commit()
+
+        async with AsyncSession(pg) as session:
+            persisted = await session.scalar(
+                select(SQLTask).where(SQLTask.id == task.id)
+            )
+
+        assert persisted is not None
+        assert persisted.context == {"owner": "caller"}
+        assert persisted.type == DummyTask.name
+
+    async def test_rolls_back_with_caller_session(self, pg: AsyncEngine):
+        async with AsyncSession(pg) as session:
+            task = await virtool.tasks.db.create(
+                session,
+                DummyTask,
+                {"owner": "caller"},
+            )
+            await session.rollback()
+
+        async with AsyncSession(pg) as session:
+            assert (
+                await session.scalar(select(SQLTask).where(SQLTask.id == task.id))
+                is None
+            )

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -22,11 +22,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
 import virtool.pg.utils
-import virtool.references.db
 import virtool.utils
 from virtool.api.utils import paginate
 from virtool.data.topg import (
-    both_transactions,
     compose_legacy_id_subquery,
     resolve_legacy_id,
 )
@@ -127,28 +125,31 @@ class IndexCountsTransform(AbstractTransform):
 
 async def create(
     mongo: "Mongo",
-    pg: AsyncEngine,
-    ref_id: str,
+    mongo_session: AsyncIOMotorClientSession,
+    pg_session: AsyncSession,
+    ref_id: int | str,
     user_id: int,
-    job_id: int,
+    index_version: int,
+    manifest: dict,
+    task_id: int,
     index_id: str | None = None,
 ) -> dict:
-    """Create a new index and update history to show the version and id of the new
-    index.
+    """Create a pending index in caller-owned database sessions.
+
+    The index insert and history association are flushed by the caller's coordinated
+    transaction without being committed here.
 
     :param mongo: the application database client
-    :param pg: the application Postgres client
-    :param ref_id: the ID of the reference to create index for
-    :param user_id: the ID of the current user
-    :param job_id: the ID of the job
-    :param index_id: the ID of the index
-    :return: the new index document
+    :param mongo_session: the caller-owned MongoDB session
+    :param pg_session: the caller-owned PostgreSQL session
+    :param ref_id: the reference to create an index for
+    :param user_id: the user requesting the index
+    :param index_version: the version assigned to the index
+    :param manifest: the OTU manifest captured for the index
+    :param task_id: the task backing the index
+    :param index_id: the preallocated index id
+    :return: the inserted index document
     """
-    index_version, manifest = await asyncio.gather(
-        get_next_version(mongo, pg, ref_id),
-        virtool.references.db.get_manifest(mongo, pg, ref_id),
-    )
-
     document = {
         "version": index_version,
         "created_at": virtool.utils.timestamp(),
@@ -156,33 +157,32 @@ async def create(
         "ready": False,
         "has_files": True,
         "has_json": False,
-        "job": {"id": job_id},
-        "task": None,
+        "job": None,
+        "task": {"id": task_id},
         "user": {"id": user_id},
     }
 
     if index_id:
         document["_id"] = index_id
 
-    async with both_transactions(mongo, pg) as (mongo_session, pg_session):
-        reference_pk = await resolve_legacy_id(pg_session, SQLReference, ref_id)
+    reference_pk = await resolve_legacy_id(pg_session, SQLReference, ref_id)
 
-        if reference_pk is None:
-            raise ValueError(f"Reference {ref_id!r} not found in postgres")
+    if reference_pk is None:
+        raise ValueError(f"Reference {ref_id!r} not found in postgres")
 
-        document["reference"] = {"id": reference_pk}
+    document["reference"] = {"id": reference_pk}
 
-        document = await mongo.indexes.insert_one(document, session=mongo_session)
+    document = await mongo.indexes.insert_one(document, session=mongo_session)
 
-        await pg_session.execute(
-            update(SQLLegacyHistory)
-            .where(
-                SQLLegacyHistory.reference_id
-                == compose_legacy_id_subquery(SQLReference, ref_id),
-                SQLLegacyHistory.index.is_(None),
-            )
-            .values(index=document["_id"], index_version=str(index_version)),
+    await pg_session.execute(
+        update(SQLLegacyHistory)
+        .where(
+            SQLLegacyHistory.reference_id
+            == compose_legacy_id_subquery(SQLReference, ref_id),
+            SQLLegacyHistory.index.is_(None),
         )
+        .values(index=document["_id"], index_version=str(index_version)),
+    )
 
     return document
 
@@ -340,7 +340,7 @@ async def get_otus(pg: AsyncEngine, index_id: str) -> list[dict]:
     )
 
 
-async def get_next_version(mongo: "Mongo", pg: AsyncEngine, ref_id: str) -> int:
+async def get_next_version(mongo: "Mongo", pg: AsyncEngine, ref_id: int | str) -> int:
     """Get the version number that should be used for the next index build.
 
     :param mongo: the application mongodb client

--- a/virtool/references/api.py
+++ b/virtool/references/api.py
@@ -409,7 +409,7 @@ class ReferenceIndexesView(PydanticView):
     ) -> r201[IndexMinimal] | r403 | r404:
         """Create an index.
 
-        Starts a job to rebuild the otus Bowtie2 index on disk.
+        Starts a task that generates the structured reference artifact.
 
         Does a check to make sure there are no unverified OTUs in the collection
         and updates otu history to show the version and id of the new index.

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 import virtool.history.db
 import virtool.indexes.db
 import virtool.otus.db
+import virtool.tasks.db
 import virtool.utils
 from virtool.config import Config
 from virtool.data.domain import DataLayerDomain
@@ -20,6 +21,7 @@ from virtool.data.errors import (
 )
 from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import (
+    both_transactions,
     compose_legacy_id_multi_expression,
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
@@ -32,6 +34,7 @@ from virtool.history.db import (
 from virtool.history.models import HistorySearchResult
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.models import IndexMinimal, IndexSearchResult
+from virtool.indexes.tasks import CreateIndexTask
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
 from virtool.otus.models import OTU, OTUSearchResult
@@ -709,7 +712,7 @@ class ReferencesData(DataLayerDomain):
         return IndexSearchResult(**data)
 
     @emits(Operation.CREATE, domain="indexes", name="create")
-    async def create_index(self, ref_id: str, user_id: int) -> IndexMinimal:
+    async def create_index(self, ref_id: int | str, user_id: int) -> IndexMinimal:
         await self._require_not_archived(ref_id)
 
         if await self._mongo.indexes.count_documents(
@@ -746,23 +749,35 @@ class ReferencesData(DataLayerDomain):
         if not has_unbuilt:
             raise ResourceError("There are no unbuilt changes")
 
-        index_id = await virtool.mongo.utils.get_new_id(self._mongo.indexes)
-
-        job = await self.data.jobs.create(
-            "build_index",
-            {"index_id": index_id},
-            user_id,
-            0,
+        index_id, index_version, manifest = await asyncio.gather(
+            virtool.mongo.utils.get_new_id(self._mongo.indexes),
+            virtool.indexes.db.get_next_version(self._mongo, self._pg, ref_id),
+            virtool.references.db.get_manifest(self._mongo, self._pg, ref_id),
         )
 
-        document = await virtool.indexes.db.create(
-            self._mongo,
-            self._pg,
-            ref_id,
-            user_id,
-            job.id,
-            index_id=index_id,
-        )
+        async with both_transactions(self._mongo, self._pg) as (
+            mongo_session,
+            pg_session,
+        ):
+            task = await virtool.tasks.db.create(
+                pg_session,
+                CreateIndexTask,
+                {"index_id": index_id},
+            )
+
+            document = await virtool.indexes.db.create(
+                self._mongo,
+                mongo_session,
+                pg_session,
+                ref_id,
+                user_id,
+                index_version,
+                manifest,
+                task_id=task.id,
+                index_id=index_id,
+            )
+
+        emit(task, "tasks", "create", Operation.CREATE)
 
         return await self.data.index.get(document["_id"])
 

--- a/virtool/tasks/data.py
+++ b/virtool/tasks/data.py
@@ -6,6 +6,7 @@ from sqlalchemy import desc, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
 
+import virtool.tasks.db
 import virtool.utils
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
@@ -146,19 +147,6 @@ class TasksData:
 
             raise ResourceNotFoundError
 
-    @staticmethod
-    def _create_sql_task(task_class: type[BaseTask], context: dict | None) -> SQLTask:
-        """Build an unsaved :class:`SQLTask` for a new task of ``task_class``."""
-        return SQLTask(
-            complete=False,
-            context=context or {},
-            step=task_class.name,
-            count=0,
-            created_at=virtool.utils.timestamp(),
-            progress=0,
-            type=task_class.name,
-        )
-
     @emits(Operation.CREATE)
     async def create(
         self,
@@ -172,12 +160,8 @@ class TasksData:
         :return: the task record
 
         """
-        sql_task = self._create_sql_task(task_class, context)
-
         async with AsyncSession(self._pg) as session:
-            session.add(sql_task)
-            await session.flush()
-            task = Task(**sql_task.to_dict())
+            task = await virtool.tasks.db.create(session, task_class, context)
             await session.commit()
 
         return task
@@ -221,11 +205,7 @@ class TasksData:
             if existing_task is not None:
                 return None
 
-            sql_task = self._create_sql_task(task_class, None)
-
-            session.add(sql_task)
-            await session.flush()
-            task = Task(**sql_task.to_dict())
+            task = await virtool.tasks.db.create(session, task_class)
             await session.commit()
 
         emit(task, self.name, "create", Operation.CREATE)

--- a/virtool/tasks/db.py
+++ b/virtool/tasks/db.py
@@ -1,0 +1,39 @@
+"""Database operations for tasks."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import virtool.utils
+from virtool.tasks.models import Task
+from virtool.tasks.sql import SQLTask
+from virtool.tasks.task import BaseTask
+
+
+async def create(
+    session: AsyncSession,
+    task_class: type[BaseTask],
+    context: dict | None = None,
+) -> Task:
+    """Create a task in a caller-owned PostgreSQL session.
+
+    The task is flushed so its generated ID is available, but the caller owns the
+    transaction and must commit it.
+
+    :param session: the PostgreSQL session to create the task in
+    :param task_class: the task implementation to register
+    :param context: data to pass to the task
+    :return: the uncommitted task record
+    """
+    sql_task = SQLTask(
+        complete=False,
+        context=context or {},
+        step=task_class.name,
+        count=0,
+        created_at=virtool.utils.timestamp(),
+        progress=0,
+        type=task_class.name,
+    )
+
+    session.add(sql_task)
+    await session.flush()
+
+    return Task(**sql_task.to_dict())


### PR DESCRIPTION
## Changes ##

- Route new reference index builds through the task system instead of legacy jobs.
- Associate pending indexes with their task while preserving the existing API response shape.
- Roll back the index, task, and history updates together when index creation fails.

#### PR breaks compatiblity with older workflows. Task is a draft until all relevant workflows are updated ####