### PR TITLE
feat: read cross-domain otu data from postgres

### DIFF
--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -903,7 +903,6 @@ class TestFinalize:
     async def test_writes_results(
         self,
         data_layer: DataLayer,
-        mongo: Mongo,
         pg: AsyncEngine,
         setup_sample: SampleSetup,
         subtraction_ids: dict[str, int],
@@ -912,7 +911,7 @@ class TestFinalize:
         """Finalize marks the Postgres row ready and stores the results."""
         m_format_analysis = mocker.patch(
             "virtool.analyses.format.format_analysis",
-            side_effect=lambda _mongo, _pg, *, results, **_: results,
+            side_effect=lambda _pg, *, results, **_: results,
         )
 
         analysis = await data_layer.analyses.create(
@@ -936,7 +935,6 @@ class TestFinalize:
         # The PostgreSQL engine must be threaded through to format_analysis so it can
         # resolve Postgres-stored history diffs.
         m_format_analysis.assert_called_with(
-            mongo,
             pg,
             workflow=ANY,
             results=ANY,

--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -12,7 +12,6 @@ from virtool.analyses.format import (
     format_nuvs,
     transform_coverage_to_coordinates,
 )
-from virtool.mongo.core import Mongo
 
 
 @pytest.mark.parametrize(
@@ -146,27 +145,25 @@ def test_transform_coverage_to_coordinates(
 class TestFormatAnalysis:
     """Test workflow dispatch in ``format_analysis``."""
 
-    async def test_no_workflow(self, mongo: Mongo):
+    async def test_no_workflow(self):
         """A ``None`` workflow raises a descriptive ``ValueError``."""
         with pytest.raises(ValueError, match="Analysis has no workflow field"):
             await virtool.analyses.format.format_analysis(
-                mongo,
                 None,
                 workflow=None,
                 results={"hits": []},
             )
 
-    async def test_unknown_workflow(self, mongo: Mongo):
+    async def test_unknown_workflow(self):
         """An unrecognised workflow raises a descriptive ``ValueError``."""
         with pytest.raises(ValueError, match="Unknown workflow: foobar"):
             await virtool.analyses.format.format_analysis(
-                mongo,
                 None,
                 workflow="foobar",
                 results={"hits": []},
             )
 
-    async def test_nuvs(self, mocker: MockerFixture, mongo: Mongo):
+    async def test_nuvs(self, mocker: MockerFixture):
         """The nuvs workflow dispatches to ``format_nuvs``."""
         m_format_nuvs = mocker.patch(
             "virtool.analyses.format.format_nuvs",
@@ -178,7 +175,6 @@ class TestFormatAnalysis:
         results = {"hits": []}
 
         formatted = await virtool.analyses.format.format_analysis(
-            mongo,
             pg,
             workflow="nuvs",
             results=results,
@@ -188,7 +184,7 @@ class TestFormatAnalysis:
         m_format_nuvs.assert_called_with(pg, results=results)
         assert not m_format_pathoscope.called
 
-    async def test_pathoscope(self, mocker: MockerFixture, mongo: Mongo):
+    async def test_pathoscope(self, mocker: MockerFixture):
         """The pathoscope workflow dispatches to ``format_pathoscope``."""
         m_format_nuvs = mocker.patch("virtool.analyses.format.format_nuvs")
         m_format_pathoscope = mocker.patch(
@@ -200,14 +196,13 @@ class TestFormatAnalysis:
         results = {"hits": []}
 
         formatted = await virtool.analyses.format.format_analysis(
-            mongo,
             pg,
             workflow="pathoscope",
             results=results,
         )
 
         assert formatted == {"is_nuvs": False, "is_pathoscope": True}
-        m_format_pathoscope.assert_called_with(mongo, pg, results=results)
+        m_format_pathoscope.assert_called_with(pg, results=results)
         assert not m_format_nuvs.called
 
 
@@ -275,11 +270,10 @@ class TestDownloadResults:
             },
         )
 
-    async def test_csv(self, mocker: MockerFixture, mongo: Mongo):
+    async def test_csv(self, mocker: MockerFixture):
         self._patch_format_analysis(mocker)
 
         csv_data = await virtool.analyses.format.format_analysis_to_csv(
-            mongo,
             mocker.Mock(),
             results=self.results,
             workflow="pathoscope",
@@ -290,11 +284,10 @@ class TestDownloadResults:
         assert rows[0] == list(CSV_HEADERS)
         assert rows[1] == ["OTU", "Isolate A", "AB000", "3", "0.5", "2", "1.0"]
 
-    async def test_excel(self, mocker: MockerFixture, mongo: Mongo):
+    async def test_excel(self, mocker: MockerFixture):
         self._patch_format_analysis(mocker)
 
         excel_data = await virtool.analyses.format.format_analysis_to_excel(
-            mongo,
             mocker.Mock(),
             results=self.results,
             workflow="pathoscope",

--- a/tests/fixtures/history.py
+++ b/tests/fixtures/history.py
@@ -5,6 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtool.history.db import bulk_insert_diffs, legacy_history_values
 from virtool.history.sql import SQLLegacyHistory
+from virtool.otus.db import otu_row_values
+from virtool.otus.sql import SQLOTU
 from virtool.references.sql import SQLReference
 
 
@@ -285,6 +287,9 @@ def create_mock_history(fake, mongo, pg):
             )
             session.add(reference)
             await session.flush()
+
+            if otu is not None:
+                session.add(SQLOTU(**otu_row_values(otu, reference.id)))
 
             for document in documents:
                 session.add(

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -9,7 +9,6 @@ import virtool.history.db
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.models.enums import HistoryMethod
-from virtool.mongo.core import Mongo
 from virtool.pg.utils import get_row_by_id
 from virtool.references.sql import SQLReference
 from virtool.workflow.pytest_plugin.utils import StaticTime
@@ -346,14 +345,12 @@ class TestGetMostRecentChange:
 async def test_patch_to_version(
     remove: bool,
     create_mock_history,
-    mongo: Mongo,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
     await create_mock_history(remove=remove)
 
     current, patched = await virtool.history.db.patch_to_version(
-        mongo,
         pg,
         "6116cba1",
         1,
@@ -394,7 +391,6 @@ def test_stamp_reference():
 
 async def test_patch_to_version_intermediate(
     create_mock_history,
-    mongo: Mongo,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
@@ -404,7 +400,6 @@ async def test_patch_to_version_intermediate(
     await create_mock_history(remove=False)
 
     current, patched = await virtool.history.db.patch_to_version(
-        mongo,
         pg,
         "6116cba1",
         2,
@@ -416,7 +411,6 @@ async def test_patch_to_version_intermediate(
 
 async def test_patch_to_version_missing_diff(
     fake: DataFaker,
-    mongo: Mongo,
     pg: AsyncEngine,
 ):
     """A ``legacy_history`` change with no matching ``SQLLegacyHistoryDiff`` row raises
@@ -430,7 +424,7 @@ async def test_patch_to_version_missing_diff(
         ValueError,
         match="Missing legacy_history_diff rows.*6116cba1.1",
     ):
-        await virtool.history.db.patch_to_version(mongo, pg, "6116cba1", 0)
+        await virtool.history.db.patch_to_version(pg, "6116cba1", 0)
 
 
 async def test_resolve_diffs_inline_diff(pg: AsyncEngine):

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -27,11 +27,12 @@ from virtool.history.db import legacy_history_values
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import JOB_INDEX_FILE_NAMES
 from virtool.indexes.sql import SQLIndexFile
+from virtool.otus.db import bulk_insert_otu_rows
+from virtool.otus.sql import SQLOTU
 from virtool.indexes.utils import check_index_file_type, compose_index_file_key
 from virtool.jobs.pg import SQLJob, SQLJobIndex
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
-from virtool.mongo.utils import get_mongo_from_app
 from virtool.storage.protocol import StorageBackend
 from virtool.tasks.sql import SQLTask
 from virtool.workflow.pytest_plugin.utils import StaticTime
@@ -419,7 +420,6 @@ async def test_download_otus_json(
 
     if not file_exists:
         m_iter_patched_otus.assert_called_with(
-            get_mongo_from_app(client.app),
             client.app["pg"],
             manifest,
         )
@@ -514,7 +514,7 @@ class TestCreate:
             assert await session.scalar(select(SQLJob.id)) is None
             assert await session.scalar(select(SQLJobIndex.job_id)) is None
 
-        m_create_manifest.assert_called_with(ANY, ANY, reference["id"])
+        m_create_manifest.assert_called_with(ANY, reference["id"])
 
     async def test_insufficient_rights(
         self,
@@ -561,7 +561,7 @@ class TestCreate:
 
     async def test_unverified(
         self,
-        mongo: Mongo,
+        pg: AsyncEngine,
         resp_is: RespIs,
         spawn_client: ClientSpawner,
     ):
@@ -575,9 +575,20 @@ class TestCreate:
 
         reference = await create_reference(client, name="Foo")
 
-        await mongo.otus.insert_one(
-            {"verified": False, "reference": {"id": reference["id"]}},
-        )
+        async with AsyncSession(pg) as session:
+            session.add(
+                SQLOTU(
+                    id="unverified_otu",
+                    data={"_id": "unverified_otu"},
+                    name="Unverified OTU",
+                    abbreviation="",
+                    last_indexed_version=None,
+                    reference_id=reference["id"],
+                    verified=False,
+                    version=0,
+                ),
+            )
+            await session.commit()
 
         resp = await client.post(f"/references/v1/{reference['id']}/indexes", {})
 
@@ -851,6 +862,11 @@ async def test_finalize(
 
     reference = await fake.references.create(user=user)
 
+    # A change of `version` that should be reflected in `last_indexed_version` after
+    # finalizing. The OTU is written to both stores, as it is in production, so the
+    # Postgres-backed read that drives the stamp can see it.
+    otu = {**test_otu, "version": 1, "reference": {"id": reference.id}}
+
     await asyncio.gather(
         mongo.indexes.insert_one(
             {
@@ -865,10 +881,7 @@ async def test_finalize(
                 "task": None,
             },
         ),
-        # change `version` that should be reflected in `last_indexed_version` after calling
-        mongo.otus.insert_one(
-            {**test_otu, "version": 1, "reference": {"id": reference.id}},
-        ),
+        mongo.otus.insert_one(otu),
     )
 
     async with AsyncSession(pg) as session:
@@ -883,6 +896,7 @@ async def test_finalize(
                 for file_name in files
             ],
         )
+        await bulk_insert_otu_rows(session, [otu], reference.id)
         await session.commit()
 
     resp = await client.patch("/indexes/test_index")

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -266,9 +266,8 @@ async def test_reads_tolerate_integer_embedded_reference_id(
 
 async def test_iter_patched_otus_starts_when_consumed(
     mocker: MockerFixture,
-    mongo: Mongo,
 ):
-    async def patch_to_version(_mongo, _pg, otu_id, version):
+    async def patch_to_version(_pg, otu_id, version):
         return None, {"_id": otu_id, "version": version}
 
     m = mocker.patch(
@@ -277,15 +276,15 @@ async def test_iter_patched_otus_starts_when_consumed(
     )
 
     pg = mocker.Mock()
-    stream = iter_patched_otus(mongo, pg, {"foo": 2, "bar": 10})
+    stream = iter_patched_otus(pg, {"foo": 2, "bar": 10})
 
     assert m.call_count == 0
 
     assert await anext(stream) == {"_id": "foo", "version": 2}
-    assert m.call_args_list[0] == mocker.call(mongo, pg, "foo", 2)
+    assert m.call_args_list[0] == mocker.call(pg, "foo", 2)
 
     assert await anext(stream) == {"_id": "bar", "version": 10}
-    assert m.call_args_list[-1] == mocker.call(mongo, pg, "bar", 10)
+    assert m.call_args_list[-1] == mocker.call(pg, "bar", 10)
 
     with pytest.raises(StopAsyncIteration):
         await anext(stream)
@@ -295,7 +294,6 @@ async def test_iter_patched_otus_starts_when_consumed(
 
 async def test_iter_patched_otus_preserves_order_when_patches_finish_out_of_order(
     mocker: MockerFixture,
-    mongo: Mongo,
 ):
     gates = {
         "slow": asyncio.Event(),
@@ -304,7 +302,7 @@ async def test_iter_patched_otus_preserves_order_when_patches_finish_out_of_orde
     all_started = asyncio.Event()
     started = []
 
-    async def patch_to_version(_mongo, _pg, otu_id, version):
+    async def patch_to_version(_pg, otu_id, version):
         started.append(otu_id)
 
         if len(started) == 2:
@@ -320,7 +318,6 @@ async def test_iter_patched_otus_preserves_order_when_patches_finish_out_of_orde
     )
 
     stream = iter_patched_otus(
-        mongo,
         mocker.Mock(),
         {"slow": 1, "fast": 2},
     )
@@ -345,7 +342,6 @@ async def test_iter_patched_otus_preserves_order_when_patches_finish_out_of_orde
 
 async def test_iter_patched_otus_limits_concurrent_patches(
     mocker: MockerFixture,
-    mongo: Mongo,
 ):
     concurrency = 3
     manifest = {f"otu_{i}": i for i in range(concurrency + 1)}
@@ -354,7 +350,7 @@ async def test_iter_patched_otus_limits_concurrent_patches(
     next_patch_started = asyncio.Event()
     started = []
 
-    async def patch_to_version(_mongo, _pg, otu_id, version):
+    async def patch_to_version(_pg, otu_id, version):
         started.append(otu_id)
 
         if len(started) == concurrency:
@@ -373,7 +369,6 @@ async def test_iter_patched_otus_limits_concurrent_patches(
     )
 
     stream = iter_patched_otus(
-        mongo,
         mocker.Mock(),
         manifest,
         concurrency=concurrency,
@@ -399,7 +394,6 @@ async def test_iter_patched_otus_limits_concurrent_patches(
 
 async def test_iter_patched_otus_limits_scheduled_lookahead(
     mocker: MockerFixture,
-    mongo: Mongo,
 ):
     concurrency = 2
     window_size = 5
@@ -410,7 +404,7 @@ async def test_iter_patched_otus_limits_scheduled_lookahead(
     beyond_window_started = asyncio.Event()
     started = []
 
-    async def patch_to_version(_mongo, _pg, otu_id, version):
+    async def patch_to_version(_pg, otu_id, version):
         started.append(otu_id)
 
         if len(started) == concurrency:
@@ -432,7 +426,6 @@ async def test_iter_patched_otus_limits_scheduled_lookahead(
     )
 
     stream = iter_patched_otus(
-        mongo,
         mocker.Mock(),
         manifest,
         concurrency=concurrency,
@@ -588,7 +581,6 @@ class TestUpdateLastIndexedVersions:
         async with both_transactions(mongo, pg) as (mongo_session, pg_session):
             await update_last_indexed_versions(
                 mongo,
-                pg,
                 reference.id,
                 mongo_session,
                 pg_session,
@@ -631,7 +623,6 @@ class TestUpdateLastIndexedVersions:
         async with both_transactions(mongo, pg) as (mongo_session, pg_session):
             await update_last_indexed_versions(
                 mongo,
-                pg,
                 reference.id,
                 mongo_session,
                 pg_session,
@@ -658,18 +649,19 @@ class TestUpdateLastIndexedVersions:
             assert rows[otu.id].last_indexed_version == document["version"]
             assert rows[otu.id].data["last_indexed_version"] == document["version"]
 
-    async def test_otu_not_in_postgres(
+    async def test_mongo_only_otu_is_not_stamped(
         self,
         fake: DataFaker,
         mongo: Mongo,
         pg: AsyncEngine,
         test_otu,
     ):
-        """An OTU that has not been backfilled yet is stamped in Mongo and skipped in
-        Postgres, rather than raising.
+        """An OTU that exists only in Mongo is stamped in neither store.
 
-        The backfill carries the stamped Mongo document over, so there is nothing to
-        write here.
+        Postgres is the read authority: the OTUs to stamp are read from it, so an OTU
+        with no Postgres row is invisible here and is not stamped in Mongo either. The
+        read cutover is gated on the backfill and the parity check, so no such OTU
+        exists in production by the time this runs.
         """
         user = await fake.users.create()
         reference = await fake.references.create(user=user)
@@ -681,7 +673,6 @@ class TestUpdateLastIndexedVersions:
         async with both_transactions(mongo, pg) as (mongo_session, pg_session):
             await update_last_indexed_versions(
                 mongo,
-                pg,
                 reference.id,
                 mongo_session,
                 pg_session,
@@ -689,7 +680,7 @@ class TestUpdateLastIndexedVersions:
 
         document = await mongo.otus.find_one({"_id": test_otu["_id"]})
 
-        assert document["last_indexed_version"] == 3
+        assert document["last_indexed_version"] == test_otu["last_indexed_version"]
 
         async with AsyncSession(pg) as session:
             assert (

--- a/tests/indexes/test_tasks.py
+++ b/tests/indexes/test_tasks.py
@@ -18,13 +18,15 @@ from virtool.indexes.sql import SQLIndexFile
 from virtool.indexes.tasks import CreateIndexTask
 from virtool.indexes.utils import compose_index_file_key
 from virtool.mongo.core import Mongo
+from virtool.otus.db import bulk_insert_otu_rows, bulk_insert_sequence_rows
 from virtool.storage.protocol import StorageBackend
 from virtool.workflow.pytest_plugin.utils import StaticTime
 
 
 async def _insert_indexed_otu(
     mongo: Mongo,
-    reference_id: str,
+    pg: AsyncEngine,
+    reference_id: int,
     test_otu: dict,
     test_sequence: dict,
 ) -> dict[str, int]:
@@ -36,15 +38,19 @@ async def _insert_indexed_otu(
         "version": 1,
     }
 
-    await mongo.otus.insert_one(otu)
+    sequence = {
+        **test_sequence,
+        "reference": otu["reference"],
+        "otu_id": otu["_id"],
+    }
 
-    await mongo.sequences.insert_one(
-        {
-            **test_sequence,
-            "reference": otu["reference"],
-            "otu_id": otu["_id"],
-        },
-    )
+    await mongo.otus.insert_one(otu)
+    await mongo.sequences.insert_one(sequence)
+
+    async with AsyncSession(pg) as session:
+        await bulk_insert_otu_rows(session, [otu], reference_id)
+        await bulk_insert_sequence_rows(session, [sequence])
+        await session.commit()
 
     return {otu["_id"]: otu["version"]}
 
@@ -78,6 +84,7 @@ class TestCreateIndexTask:
     async def task_id(self) -> int:
         self.manifest = await _insert_indexed_otu(
             self.mongo,
+            self.pg,
             self.reference.id,
             self.test_otu,
             self.test_sequence,
@@ -193,6 +200,7 @@ class TestCreateIndexTask:
         """A task-backed build accepts an integer embedded reference id."""
         manifest = await _insert_indexed_otu(
             self.mongo,
+            self.pg,
             self.reference.id,
             self.test_otu,
             self.test_sequence,

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -977,7 +977,7 @@ class TestCreateIndex:
             assert await session.scalar(select(SQLJob.id)) is None
             assert await session.scalar(select(SQLJobIndex.job_id)) is None
 
-        m_create_manifest.assert_called_with(ANY, ANY, reference["id"])
+        m_create_manifest.assert_called_with(ANY, reference["id"])
 
     async def test_insufficient_rights(
         self,

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -514,22 +514,18 @@ class TestComposeReferenceIdsMatch:
         assert None not in match["$in"]
 
 
-async def test_create_manifest(mongo: Mongo, pg: AsyncEngine, test_otu: dict):
-    await mongo.otus.insert_many(
-        [
-            test_otu,
-            {**test_otu, "_id": "foo", "version": 5},
-            {**test_otu, "_id": "baz", "version": 3, "reference": {"id": "123"}},
-            {**test_otu, "_id": "bar", "version": 11},
-        ],
-        session=None,
-    )
+async def test_create_manifest(fake: DataFaker, pg: AsyncEngine):
+    """The manifest maps each of a reference's OTU ids to its version, and excludes
+    OTUs belonging to other references.
+    """
+    user = await fake.users.create()
+    reference = await fake.references.create(user=user)
+    other_reference = await fake.references.create(user=user)
 
-    assert await get_manifest(mongo, pg, "hxn167") == {
-        "6116cba1": 0,
-        "foo": 5,
-        "bar": 11,
-    }
+    otus = [await fake.otus.create(reference.id, user) for _ in range(3)]
+    await fake.otus.create(other_reference.id, user)
+
+    assert await get_manifest(pg, reference.id) == {otu.id: otu.version for otu in otus}
 
 
 async def test_get_reference_groups(

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -173,7 +173,7 @@ async def test_clone_reference_task(
     mongo: Mongo,
     pg: AsyncEngine,
 ):
-    manifest = await get_manifest(mongo, pg, create_reference)
+    manifest = await get_manifest(pg, create_reference)
 
     assert len(manifest) == 20
 

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -253,7 +253,6 @@ class AnalysisData(DataLayerDomain):
 
         if document["ready"]:
             document["results"] = await virtool.analyses.format.format_analysis(
-                self._mongo,
                 self._pg,
                 workflow=document["workflow"],
                 results=document["results"],
@@ -578,7 +577,6 @@ class AnalysisData(DataLayerDomain):
         if extension == "xlsx":
             return (
                 await virtool.analyses.format.format_analysis_to_excel(
-                    self._mongo,
                     self._pg,
                     results=analysis.results,
                     workflow=analysis.workflow,
@@ -589,7 +587,6 @@ class AnalysisData(DataLayerDomain):
 
         return (
             await virtool.analyses.format.format_analysis_to_csv(
-                self._mongo,
                 self._pg,
                 results=analysis.results,
                 workflow=analysis.workflow,

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -9,7 +9,7 @@ import io
 import statistics
 from asyncio import gather
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import openpyxl.styles
 import visvalingamwyatt as vw
@@ -21,10 +21,6 @@ from virtool.history.db import patch_to_version
 from virtool.hmm.sql import SQLHMM
 from virtool.models.enums import AnalysisWorkflow
 from virtool.otus.utils import format_isolate_name
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
-
 
 CSV_HEADERS = (
     "OTU",
@@ -49,7 +45,6 @@ def calculate_median_depths(hits: list[dict]) -> dict[str, int]:
 
 
 async def format_pathoscope(
-    mongo: "Mongo",
     pg: AsyncEngine,
     *,
     results: dict[str, Any],
@@ -59,7 +54,6 @@ async def format_pathoscope(
 
     Calculate metrics for different organizational levels: OTU, isolate, and sequence.
 
-    :param mongo: the application Mongo object
     :param pg: the application PostgreSQL database object
     :param results: the results to format
     :return: the formatted results
@@ -77,20 +71,18 @@ async def format_pathoscope(
 
     for otu_specifier, hits in hits_by_otu.items():
         otu_id, otu_version = otu_specifier
-        coros.append(format_pathoscope_hits(mongo, pg, otu_id, otu_version, hits))
+        coros.append(format_pathoscope_hits(pg, otu_id, otu_version, hits))
 
     return {**results, "hits": await gather(*coros)}
 
 
 async def format_pathoscope_hits(
-    mongo: "Mongo",
     pg: AsyncEngine,
     otu_id: str,
     otu_version,
     hits: list[dict],
 ):
     _, patched_otu = await patch_to_version(
-        mongo,
         pg,
         otu_id,
         otu_version,
@@ -215,7 +207,6 @@ async def format_nuvs(
 
 
 async def format_analysis_to_excel(
-    mongo: "Mongo",
     pg: AsyncEngine,
     *,
     results: dict[str, Any],
@@ -235,7 +226,6 @@ async def format_analysis_to_excel(
     depths = calculate_median_depths(results["hits"])
 
     formatted = await format_analysis(
-        mongo,
         pg,
         workflow=workflow,
         results=results,
@@ -285,7 +275,6 @@ async def format_analysis_to_excel(
 
 
 async def format_analysis_to_csv(
-    mongo: "Mongo",
     pg: AsyncEngine,
     *,
     results: dict[str, Any],
@@ -293,7 +282,6 @@ async def format_analysis_to_csv(
 ) -> str:
     """Convert pathoscope analysis results to CSV format for download.
 
-    :param mongo: the app mongo object
     :param pg: the application PostgreSQL database object
     :param results: the results to format
     :param workflow: the analysis workflow
@@ -303,7 +291,6 @@ async def format_analysis_to_csv(
     depths = calculate_median_depths(results["hits"])
 
     formatted = await format_analysis(
-        mongo,
         pg,
         workflow=workflow,
         results=results,
@@ -334,7 +321,6 @@ async def format_analysis_to_csv(
 
 
 async def format_analysis(
-    mongo: "Mongo",
     pg: AsyncEngine,
     *,
     workflow: str | None,
@@ -342,7 +328,6 @@ async def format_analysis(
 ) -> dict[str, Any]:
     """Format analysis results to be returned by the API.
 
-    :param mongo: the database object
     :param pg: the application PostgreSQL database object
     :param workflow: the analysis workflow used to dispatch formatting
     :param results: the results to format
@@ -356,7 +341,7 @@ async def format_analysis(
         return await format_nuvs(pg, results=results)
 
     if "pathoscope" in workflow:
-        return await format_pathoscope(mongo, pg, results=results)
+        return await format_pathoscope(pg, results=results)
 
     raise ValueError(f"Unknown workflow: {workflow}")
 

--- a/virtool/history/data.py
+++ b/virtool/history/data.py
@@ -10,6 +10,7 @@ from virtool.history.models import History, HistoryMinimal, HistorySearchResult
 from virtool.history.sql import SQLLegacyHistory
 from virtool.history.transforms import AttachDiffTransform
 from virtool.mongo.core import Mongo
+from virtool.otus.sql import SQLOTU
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.users.pg import SQLUser
 from virtool.utils import base_processor
@@ -42,10 +43,12 @@ class HistoryData:
         :param otu_id: the ID of the OTU
         :return: the OTU's changes
         """
-        if not await self._mongo.otus.count_documents({"_id": otu_id}, limit=1):
-            raise ResourceNotFoundError()
-
         async with AsyncSession(self._pg) as session:
+            if not await session.scalar(
+                select(select(SQLOTU.id).where(SQLOTU.id == otu_id).exists()),
+            ):
+                raise ResourceNotFoundError()
+
             rows = (
                 await session.execute(
                     select(SQLLegacyHistory, SQLUser.handle)

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -713,7 +713,6 @@ async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, 
 
 
 async def patch_to_version(
-    mongo: "Mongo",
     pg: AsyncEngine,
     otu_id: str,
     version: str | int,
@@ -722,14 +721,13 @@ async def patch_to_version(
 
     Uses the diffs in the change documents associated with the otu.
 
-    :param mongo: the database object
     :param pg: the application PostgreSQL database object
     :param otu_id: the id of the otu to patch
     :param version: the version to patch to
     :return: the current joined otu and the patched otu
 
     """
-    current = await virtool.otus.db.join(mongo, otu_id) or {}
+    current = await virtool.otus.db.join_legacy_otu(pg, otu_id) or {}
 
     if "version" in current and current["version"] == version:
         return current, deepcopy(current)

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -241,7 +241,6 @@ class IndexData:
             patched_otus = [
                 otu
                 async for otu in virtool.indexes.db.iter_patched_otus(
-                    self._mongo,
                     self._pg,
                     index["manifest"],
                 )
@@ -369,7 +368,6 @@ class IndexData:
         ) -> None:
             await update_last_indexed_versions(
                 self._mongo,
-                self._pg,
                 ref_id,
                 mongo_session,
                 pg_session,
@@ -432,7 +430,6 @@ class IndexData:
         patched_otus = [
             otu
             async for otu in virtool.indexes.db.iter_patched_otus(
-                self._mongo,
                 self._pg,
                 index["manifest"],
             )
@@ -469,7 +466,6 @@ class IndexData:
 
                 await update_last_indexed_versions(
                     self._mongo,
-                    self._pg,
                     ref_id,
                     mongo_session,
                     pg_session,

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -248,7 +248,7 @@ async def find(
         sort="version",
     )
 
-    unbuilt_stats = await get_unbuilt_stats(mongo, pg, ref_id)
+    unbuilt_stats = await get_unbuilt_stats(pg, ref_id)
 
     documents = [base_processor(d) for d in data["documents"]]
     transforms = [
@@ -359,7 +359,6 @@ async def get_next_version(mongo: "Mongo", pg: AsyncEngine, ref_id: int | str) -
 
 
 async def get_unbuilt_stats(
-    mongo: "Mongo",
     pg: AsyncEngine,
     ref_id: str | None = None,
 ) -> dict:
@@ -368,21 +367,22 @@ async def get_unbuilt_stats(
     Used to populate the metadata for an index find request. Can search against a
     specific reference or all references.
 
-    :param mongo: the application mongodb client
     :param pg: the application PostgreSQL database object
     :param ref_id: the ref id to search unbuilt changes for
 
     :return: the change count and modified OTU count
 
     """
-    ref_query = {}
     history_filters = [SQLLegacyHistory.index.is_(None)]
+    otu_filters = []
 
     if ref_id:
-        ref_query["reference.id"] = await compose_reference_id_match(pg, ref_id)
         history_filters.append(
             SQLLegacyHistory.reference_id
             == compose_legacy_id_subquery(SQLReference, ref_id),
+        )
+        otu_filters.append(
+            SQLOTU.reference_id == compose_legacy_id_subquery(SQLReference, ref_id),
         )
 
     async with AsyncSession(pg) as session:
@@ -395,15 +395,18 @@ async def get_unbuilt_stats(
             )
         ).one()
 
+        total_otu_count = await session.scalar(
+            select(func.count()).select_from(SQLOTU).where(*otu_filters),
+        )
+
     return {
-        "total_otu_count": await mongo.otus.count_documents(ref_query),
+        "total_otu_count": total_otu_count,
         "change_count": change_count,
         "modified_otu_count": modified_otu_count,
     }
 
 
 async def iter_patched_otus(
-    mongo: "Mongo",
     pg: AsyncEngine,
     manifest: dict[str, int],
     *,
@@ -412,7 +415,6 @@ async def iter_patched_otus(
 ) -> AsyncIterator[dict]:
     """Iterate joined OTUs patched to the versions in the manifest.
 
-    :param mongo: the application mongodb client
     :param pg: the application PostgreSQL database object
     :param manifest: the manifest
     :param concurrency: the maximum number of OTUs to patch concurrently
@@ -431,7 +433,6 @@ async def iter_patched_otus(
         patch_version: int,
     ) -> tuple[int, dict]:
         _, patched = await virtool.history.db.patch_to_version(
-            mongo,
             pg,
             patch_id,
             patch_version,
@@ -512,49 +513,41 @@ async def upsert_index_file(
 
 async def update_last_indexed_versions(
     mongo: "Mongo",
-    pg: AsyncEngine,
     ref_id: str,
     mongo_session: AsyncIOMotorClientSession,
     pg_session: AsyncSession,
 ) -> None:
     """Update the `last_indexed_version` field for OTUs associated with `ref_id`
 
-    Both stores are stamped from the same ``{version: [otu_id]}`` grouping, so the
-    same OTUs are stamped with the same version in each. On ``legacy_otus`` the value
-    is held twice -- in the promoted ``last_indexed_version`` column and in the
-    ``data`` JSONB that mirrors the Mongo document -- and both are written by the same
-    statement, so they cannot come out of a stamp disagreeing. OTUs with no Postgres
-    row yet are simply not matched -- the backfill will carry the stamped Mongo
-    document over.
+    The OTUs to stamp, and the version to stamp each with, are read from Postgres as
+    the rows whose ``version`` still differs from their ``last_indexed_version``. Both
+    stores are then stamped from that same ``{version: [otu_id]}`` grouping, so the same
+    OTUs are stamped with the same version in each. On ``legacy_otus`` the value is held
+    twice -- in the promoted ``last_indexed_version`` column and in the ``data`` JSONB
+    that mirrors the Mongo document -- and both are written by the same statement, so
+    they cannot come out of a stamp disagreeing.
+
+    Postgres is the read authority: an OTU with no Postgres row is invisible here and is
+    stamped in neither store. The read cutover is gated on the backfill and the
+    Mongo-Postgres parity check, so every OTU has a row by the time this runs.
 
     :param mongo: the application mongo client
-    :param pg: the application Postgres client
     :param ref_id: the id of the reference whose otus should be updated
     :param mongo_session: the motor session to use
     :param pg_session: the Postgres session to use
 
     """
-    pipeline = [
-        {
-            "$project": {
-                "reference": True,
-                "version": True,
-                "last_indexed_version": True,
-                "comp": {"$cmp": ["$version", "$last_indexed_version"]},
-            },
-        },
-        {
-            "$match": {
-                "reference.id": await compose_reference_id_match(pg, ref_id),
-                "comp": {"$ne": 0},
-            },
-        },
-        {"$group": {"_id": "$version", "id_list": {"$addToSet": "$_id"}}},
-    ]
+    changed_otus = await pg_session.execute(
+        select(SQLOTU.id, SQLOTU.version).where(
+            SQLOTU.reference_id == compose_legacy_id_subquery(SQLReference, ref_id),
+            SQLOTU.version.is_distinct_from(SQLOTU.last_indexed_version),
+        ),
+    )
 
-    id_version_key = {
-        agg["_id"]: agg["id_list"] async for agg in mongo.otus.aggregate(pipeline)
-    }
+    id_version_key: dict[int, list[str]] = {}
+
+    for otu_id, version in changed_otus:
+        id_version_key.setdefault(version, []).append(otu_id)
 
     for version, id_list in id_version_key.items():
         await mongo.otus.update_many(

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -39,6 +39,7 @@ from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
 from virtool.otus.models import OTU, OTUSearchResult
 from virtool.otus.oas import CreateOTURequest
+from virtool.otus.sql import SQLOTU
 from virtool.pg.utils import get_row_by_id
 from virtool.references.db import (
     compose_reference_id_match,
@@ -417,7 +418,7 @@ class ReferencesData(DataLayerDomain):
             except ResourceNotFoundError:
                 raise ResourceNotFoundError("Source reference does not exist") from None
 
-            manifest = await get_manifest(self._mongo, self._pg, clone_from)
+            manifest = await get_manifest(self._pg, clone_from)
 
             document = await virtool.references.db.create_clone(
                 self._pg,
@@ -551,7 +552,7 @@ class ReferencesData(DataLayerDomain):
         ) = await asyncio.gather(
             get_contributors(self._pg, row.id),
             get_latest_build(self._mongo, self._pg, row.id),
-            get_otu_count(self._mongo, self._pg, row.id),
+            get_otu_count(self._pg, row.id),
             get_reference_groups(self._pg, row.id, row.created_at),
             get_reference_users(self._pg, row.id, row.created_at),
             get_unbuilt_count(self._pg, row.id),
@@ -722,16 +723,22 @@ class ReferencesData(DataLayerDomain):
         ):
             raise ResourceConflictError("Index build already in progress")
 
-        if await self._mongo.otus.count_documents(
-            {
-                "reference.id": await compose_reference_id_match(self._pg, ref_id),
-                "verified": False,
-            },
-            limit=1,
-        ):
-            raise ResourceError("There are unverified OTUs")
-
         async with AsyncSession(self._pg) as session:
+            has_unverified = await session.scalar(
+                select(
+                    select(SQLOTU.id)
+                    .where(
+                        SQLOTU.reference_id
+                        == compose_legacy_id_subquery(SQLReference, ref_id),
+                        SQLOTU.verified.is_(False),
+                    )
+                    .exists(),
+                ),
+            )
+
+            if has_unverified:
+                raise ResourceError("There are unverified OTUs")
+
             has_unbuilt = await session.scalar(
                 select(
                     select(SQLLegacyHistory.id)
@@ -750,7 +757,7 @@ class ReferencesData(DataLayerDomain):
         index_id, index_version, manifest = await asyncio.gather(
             virtool.mongo.utils.get_new_id(self._mongo.indexes),
             virtool.indexes.db.get_next_version(self._mongo, self._pg, ref_id),
-            virtool.references.db.get_manifest(self._mongo, self._pg, ref_id),
+            virtool.references.db.get_manifest(self._pg, ref_id),
         )
 
         async with both_transactions(self._mongo, self._pg) as (
@@ -1166,7 +1173,6 @@ class ReferencesData(DataLayerDomain):
 
         for source_otu_id, version in manifest.items():
             _, patched = await patch_to_version(
-                self._mongo,
                 self._pg,
                 source_otu_id,
                 version,

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -198,7 +198,7 @@ async def processor(
     """
     latest_build, otu_count, unbuilt_count = await asyncio.gather(
         get_latest_build(mongo, pg, row.id),
-        get_otu_count(mongo, pg, row.id),
+        get_otu_count(pg, row.id),
         get_unbuilt_count(pg, row.id),
     )
 
@@ -420,39 +420,43 @@ async def get_latest_build(
         )
 
 
-async def get_manifest(mongo: "Mongo", pg: AsyncEngine, ref_id: int | str) -> Document:
+async def get_manifest(pg: AsyncEngine, ref_id: int | str) -> Document:
     """Generate a dict of otu document version numbers keyed by the document id.
 
     This is used to make sure only changes made at the time the index rebuild was
     started are included in the build.
 
-    :param mongo: the application database client
     :param pg: the application PostgreSQL engine
     :param ref_id: the id of the reference to get the current index for
     :return: a manifest of otu ids and versions
 
     """
-    return {
-        document["_id"]: document["version"]
-        async for document in mongo.otus.find(
-            {"reference.id": await compose_reference_id_match(pg, ref_id)},
-            ["version"],
+    async with AsyncSession(pg) as session:
+        rows = await session.execute(
+            select(SQLOTU.id, SQLOTU.version).where(
+                SQLOTU.reference_id == compose_legacy_id_subquery(SQLReference, ref_id),
+            ),
         )
-    }
+
+    return {row.id: row.version for row in rows}
 
 
-async def get_otu_count(mongo: "Mongo", pg: AsyncEngine, ref_id: int | str) -> int:
+async def get_otu_count(pg: AsyncEngine, ref_id: int | str) -> int:
     """Get the number of OTUs associated with the given `ref_id`.
 
-    :param mongo: the application database client
     :param pg: the application PostgreSQL engine
     :param ref_id: the id of the reference to get the current index for
     :return: the OTU count
 
     """
-    return await mongo.otus.count_documents(
-        {"reference.id": await compose_reference_id_match(pg, ref_id)},
-    )
+    async with AsyncSession(pg) as session:
+        return await session.scalar(
+            select(func.count())
+            .select_from(SQLOTU)
+            .where(
+                SQLOTU.reference_id == compose_legacy_id_subquery(SQLReference, ref_id),
+            ),
+        )
 
 
 async def get_unbuilt_count(pg: AsyncEngine, ref_id: int | str) -> int:


### PR DESCRIPTION
## Summary
- Switches the last cross-domain reads of the Mongo `otus` collection in the references, indexes, and history domains to the extracted columns on the Postgres `legacy_otus` table (`reference_id`, `version`, `last_indexed_version`, `verified`), reconstructing patched OTUs via `join_legacy_otu`.
- Mongo dual-writes remain in place until the separate write-path cutover.
- `update_last_indexed_versions` no longer stamps an OTU that exists only in Mongo, since Postgres is now the read authority and the backfill + parity gate guarantee no such OTU exists at cutover.