### PR TITLE
feat: read otus from postgres

### DIFF
--- a/tests/fixtures/otus.py
+++ b/tests/fixtures/otus.py
@@ -1,6 +1,10 @@
 from datetime import datetime
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.otus.db import write_legacy_otu, write_legacy_sequence
+from virtool.types import Document
 
 IMPORTED_CREATED_AT = datetime(2015, 10, 6, 20, 0, 0, 123456)
 """The ``created_at`` carried by an imported OTU, at microsecond precision.
@@ -10,6 +14,45 @@ millisecond, and ``static_time`` carries no microseconds at all, so a timestamp 
 survives that truncation unchanged cannot catch a write path that stores more precision
 than Mongo can hold.
 """
+
+
+@pytest.fixture
+def insert_otu(mongo, pg):
+    """Insert an OTU document, and any sequences, into both stores.
+
+    Seeds a literal OTU document the way the dual-write path would, for a test that
+    needs a specific ``_id``, isolate id or version rather than whatever
+    ``fake.otus.create`` invents. OTUs are read from Postgres, so a test that seeds only
+    Mongo gets a ``404``.
+
+    ``reference_id`` is written onto the document, so the caller does not have to know
+    that an OTU's reference is embedded rather than a column.
+    """
+
+    async def func(
+        document: Document,
+        reference_id: int,
+        sequences: list[Document] | None = None,
+    ) -> Document:
+        document = {**document, "reference": {"id": reference_id}}
+        sequences = sequences or []
+
+        await mongo.otus.insert_one(document)
+
+        if sequences:
+            await mongo.sequences.insert_many(sequences, session=None)
+
+        async with AsyncSession(pg) as session:
+            await write_legacy_otu(session, document)
+
+            for sequence in sequences:
+                await write_legacy_sequence(session, sequence)
+
+            await session.commit()
+
+        return document
+
+    return func
 
 
 @pytest.fixture

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -27,12 +27,12 @@ from virtool.history.db import legacy_history_values
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import JOB_INDEX_FILE_NAMES
 from virtool.indexes.sql import SQLIndexFile
-from virtool.otus.db import bulk_insert_otu_rows
-from virtool.otus.sql import SQLOTU
 from virtool.indexes.utils import check_index_file_type, compose_index_file_key
 from virtool.jobs.pg import SQLJob, SQLJobIndex
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
+from virtool.otus.db import bulk_insert_otu_rows
+from virtool.otus.sql import SQLOTU
 from virtool.storage.protocol import StorageBackend
 from virtool.tasks.sql import SQLTask
 from virtool.workflow.pytest_plugin.utils import StaticTime

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -1,4 +1,3 @@
-import asyncio
 from http import HTTPStatus
 
 import pytest
@@ -138,7 +137,7 @@ class TestEdit:
         data_layer: DataLayer,
         existing_abbreviation: str,
         description: str,
-        mongo: Mongo,
+        insert_otu,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         test_otu,
@@ -156,12 +155,9 @@ class TestEdit:
 
         reference = await create_reference(client)
 
-        await mongo.otus.insert_one(
-            {
-                **test_otu,
-                "existing_abbreviation": existing_abbreviation,
-                "reference": {"id": reference["id"]},
-            },
+        await insert_otu(
+            {**test_otu, "existing_abbreviation": existing_abbreviation},
+            reference["id"],
         )
 
         resp = await client.patch("/otus/6116cba1", data)
@@ -175,7 +171,7 @@ class TestEdit:
 
     async def test_insufficient_rights(
         self,
-        mongo: Mongo,
+        insert_otu,
         resp_is: RespIs,
         spawn_client: ClientSpawner,
         test_otu,
@@ -190,9 +186,7 @@ class TestEdit:
 
         reference = await create_reference(owner)
 
-        await mongo.otus.insert_one(
-            {**test_otu, "reference": {"id": reference["id"]}},
-        )
+        await insert_otu(test_otu, reference["id"])
 
         client = await spawn_client(authenticated=True)
 
@@ -226,11 +220,12 @@ class TestEdit:
         self,
         data,
         message: str,
-        mongo: Mongo,
+        insert_otu,
+        test_otu,
         spawn_client: ClientSpawner,
         resp_is: RespIs,
     ):
-        """Test that the request fails with ``409 Conflict`` if the requested name or
+        """Test that the request fails with ``400 Bad Request`` if the requested name or
         abbreviation already exists.
         """
         client = await spawn_client(
@@ -240,28 +235,31 @@ class TestEdit:
 
         reference = await create_reference(client)
 
-        await mongo.otus.insert_many(
-            [
-                {
-                    "_id": "test",
-                    "name": "Prunus virus F",
-                    "lower_name": "prunus virus f",
-                    "isolates": [],
-                    "reference": {"id": reference["id"]},
-                },
-                {
-                    "_id": "conflict",
-                    "name": "Tobacco mosaic virus",
-                    "abbreviation": "TMV",
-                    "lower_name": "tobacco mosaic virus",
-                    "isolates": [],
-                    "reference": {"id": reference["id"]},
-                },
-            ],
-            session=None,
+        await insert_otu(
+            {
+                **test_otu,
+                "_id": "edited",
+                "name": "Prunus virus F",
+                "abbreviation": "",
+                "lower_name": "prunus virus f",
+                "isolates": [],
+            },
+            reference["id"],
         )
 
-        resp = await client.patch("/otus/test", data)
+        await insert_otu(
+            {
+                **test_otu,
+                "_id": "conflict",
+                "name": "Tobacco mosaic virus",
+                "abbreviation": "TMV",
+                "lower_name": "tobacco mosaic virus",
+                "isolates": [],
+            },
+            reference["id"],
+        )
+
+        resp = await client.patch("/otus/edited", data)
 
         await resp_is.bad_request(resp, message)
 
@@ -278,7 +276,7 @@ class TestEdit:
         self,
         change_count: int,
         data: dict,
-        mongo: Mongo,
+        insert_otu,
         pg: AsyncEngine,
         spawn_client: ClientSpawner,
         snapshot: SnapshotAssertion,
@@ -295,10 +293,7 @@ class TestEdit:
 
         reference = await create_reference(client)
 
-        await asyncio.gather(
-            mongo.otus.insert_one({**test_otu, "reference": {"id": reference["id"]}}),
-            mongo.sequences.insert_one(test_sequence),
-        )
+        await insert_otu(test_otu, reference["id"], [test_sequence])
 
         async with AsyncSession(pg) as session:
             session.add(SQLLegacyHistory(**legacy_history_values(change)))
@@ -406,13 +401,16 @@ class TestDelete:
 class TestListIsolates:
     async def test_ok(
         self,
-        mongo: Mongo,
+        fake: DataFaker,
+        insert_otu,
         snapshot: SnapshotAssertion,
         spawn_client: ClientSpawner,
         test_otu: dict,
     ):
         """Test the isolates can be listed for an OTU."""
         client = await spawn_client(authenticated=True)
+
+        reference = await fake.references.create(user=client.user)
 
         test_otu["isolates"].append(
             {
@@ -423,7 +421,7 @@ class TestListIsolates:
             },
         )
 
-        await mongo.otus.insert_one(test_otu)
+        await insert_otu(test_otu, reference.id)
 
         resp = await client.get("/otus/6116cba1/isolates")
 
@@ -1535,60 +1533,78 @@ class TestDeleteSequence:
             assert resp.status == 204
 
 
-@pytest.mark.parametrize("error", [None, "404"])
-async def test_download_otu(
-    error,
-    mongo: Mongo,
-    spawn_client,
-    resp_is,
-    test_sequence,
-    test_otu,
-):
-    client = await spawn_client(authenticated=True)
+class TestDownloadOTU:
+    async def test_ok(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        spawn_client,
+        test_sequence,
+        test_otu,
+    ):
+        client = await spawn_client(authenticated=True)
 
-    if error != "404_otu":
-        await mongo.otus.insert_one(test_otu)
+        reference = await fake.references.create(user=client.user)
 
-    await mongo.sequences.insert_one(test_sequence)
+        await insert_otu(test_otu, reference.id, [test_sequence])
 
-    resp = await client.get("/otus/6116cba1.fa")
+        resp = await client.get("/otus/6116cba1.fa")
 
-    if error == "404_otu":
-        await resp_is.not_found(resp, "OTU not found")
-        return
-
-    assert resp.status == HTTPStatus.OK
-
-
-@pytest.mark.parametrize("error", [None, "404_otu", "404_isolate"])
-async def test_download_isolate(
-    error,
-    resp_is,
-    mongo: Mongo,
-    spawn_client,
-    test_otu,
-    test_isolate,
-    test_sequence,
-):
-    client = await spawn_client(authenticated=True)
-
-    isolate = test_otu["isolates"][0]
-
-    isolate_id = isolate["id"]
-
-    if error == "404_isolate":
-        isolate["id"] = "different"
-
-    if error != "404_otu":
-        await mongo.otus.insert_one(test_otu)
-
-    await mongo.sequences.insert_one(test_sequence)
-
-    resp = await client.get(f"/otus/{test_otu['_id']}/isolates/{isolate_id}.fa")
-
-    if error is None:
         assert resp.status == HTTPStatus.OK
-        return
 
-    await resp_is.not_found(resp)
-    return
+    async def test_not_found(self, spawn_client, resp_is):
+        client = await spawn_client(authenticated=True)
+
+        resp = await client.get("/otus/6116cba1.fa")
+
+        await resp_is.not_found(resp)
+
+
+class TestDownloadIsolate:
+    async def test_ok(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        spawn_client,
+        test_otu,
+        test_sequence,
+    ):
+        client = await spawn_client(authenticated=True)
+
+        reference = await fake.references.create(user=client.user)
+
+        await insert_otu(test_otu, reference.id, [test_sequence])
+
+        isolate_id = test_otu["isolates"][0]["id"]
+
+        resp = await client.get(f"/otus/6116cba1/isolates/{isolate_id}.fa")
+
+        assert resp.status == HTTPStatus.OK
+
+    async def test_otu_not_found(self, spawn_client, resp_is, test_otu):
+        client = await spawn_client(authenticated=True)
+
+        isolate_id = test_otu["isolates"][0]["id"]
+
+        resp = await client.get(f"/otus/6116cba1/isolates/{isolate_id}.fa")
+
+        await resp_is.not_found(resp)
+
+    async def test_isolate_not_found(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        spawn_client,
+        resp_is,
+        test_otu,
+        test_sequence,
+    ):
+        client = await spawn_client(authenticated=True)
+
+        reference = await fake.references.create(user=client.user)
+
+        await insert_otu(test_otu, reference.id, [test_sequence])
+
+        resp = await client.get("/otus/6116cba1/isolates/different.fa")
+
+        await resp_is.not_found(resp)

--- a/tests/otus/test_data.py
+++ b/tests/otus/test_data.py
@@ -14,7 +14,9 @@ from syrupy import SnapshotAssertion
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.models.enums import Molecule
 from virtool.mongo.core import Mongo
+from virtool.otus.models import OTUSegment
 from virtool.otus.oas import (
     CreateOTURequest,
     UpdateOTURequest,
@@ -381,6 +383,19 @@ class TestUpdateIsolateSourceType:
         assert isolate["source_name"] == "Renamed"
 
 
+def _segments(count: int) -> list[OTUSegment]:
+    """Compose an OTU schema defining the segments ``RNA_0`` through ``RNA_{count-1}``.
+
+    ``create_sequence`` and ``update_sequence`` reject a segment the parent OTU's schema
+    does not define, so a test that names a segment has to give the OTU one that carries
+    it.
+    """
+    return [
+        OTUSegment(molecule=Molecule.ss_rna, name=f"RNA_{index}", required=False)
+        for index in range(count)
+    ]
+
+
 async def _get_otu_row(pg: AsyncEngine, otu_id: str) -> SQLOTU | None:
     async with AsyncSession(pg) as session:
         return (
@@ -546,7 +561,7 @@ class TestSequenceDualWrite:
 
         otu = await data_layer.otus.create(
             reference.id,
-            CreateOTURequest(name="Example"),
+            CreateOTURequest(name="Example", schema=_segments(10)),
             user.id,
         )
 
@@ -668,7 +683,7 @@ class TestSequencePosition:
 
         otu = await data_layer.otus.create(
             reference.id,
-            CreateOTURequest(name="Example"),
+            CreateOTURequest(name="Example", schema=_segments(10)),
             user.id,
         )
 

--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -8,11 +8,13 @@ from virtool.api.custom_json import dump_string, loads
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
+from virtool.models.enums import Molecule
 from virtool.mongo.core import Mongo
 from virtool.otus.db import (
     check_name_and_abbreviation,
     check_sequence_segment,
     find,
+    get_legacy_otu_fields,
     increment_otu_version,
     join,
     join_legacy_otu,
@@ -21,32 +23,95 @@ from virtool.otus.db import (
     sequence_document_from_row,
     sequence_row_values,
 )
-from virtool.otus.oas import CreateOTURequest
+from virtool.otus.models import OTUSegment
+from virtool.otus.oas import CreateOTURequest, UpdateOTURequest
 from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.otus.utils import find_isolate
 from virtool.types import Document
 
 
-@pytest.mark.parametrize(
-    "name,abbreviation,return_value",
-    [
-        ("Foobar Virus", "FBR", None),
-        ("Prunus virus F", "FBR", "Name already exists"),
-        ("Foobar Virus", "PVF", "Abbreviation already exists"),
-        ("Prunus virus F", "PVF", "Name and abbreviation already exist"),
-    ],
-    ids=["name_exists", "abbreviation_exists", "both_exist", "neither exist"],
-)
-async def test_check_name_and_abbreviation(
-    name, abbreviation, return_value, mongo, pg, test_otu
-):
-    """Test that the function works properly for all possible inputs."""
-    await mongo.otus.insert_one(test_otu)
+class TestCheckNameAndAbbreviation:
+    """An OTU's name and abbreviation are unique within its parent reference."""
 
-    assert (
-        await check_name_and_abbreviation(mongo, pg, "hxn167", name, abbreviation)
-        == return_value
+    async def _create_otu(self, data_layer: DataLayer, fake: DataFaker) -> int:
+        """Create ``Prunus virus F`` (``PVF``) and return its reference's id."""
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        await data_layer.otus.create(
+            reference.id,
+            CreateOTURequest(name="Prunus virus F", abbreviation="PVF"),
+            user.id,
+        )
+
+        return reference.id
+
+    @pytest.mark.parametrize(
+        "name,abbreviation,message",
+        [
+            ("Foobar Virus", "FBR", None),
+            ("Prunus virus F", "FBR", "Name already exists"),
+            ("Foobar Virus", "PVF", "Abbreviation already exists"),
+            ("Prunus virus F", "PVF", "Name and abbreviation already exist"),
+        ],
+        ids=["neither_exists", "name_exists", "abbreviation_exists", "both_exist"],
     )
+    async def test_messages(
+        self,
+        name: str,
+        abbreviation: str,
+        message: str | None,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        reference_id = await self._create_otu(data_layer, fake)
+
+        assert (
+            await check_name_and_abbreviation(pg, reference_id, name, abbreviation)
+            == message
+        )
+
+    async def test_name_match_is_case_insensitive(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A name differing only in case is still taken.
+
+        The Mongo query matched a denormalised ``lower_name`` field. Postgres matches
+        ``lower(name)`` instead, so this is the behaviour that field existed to provide.
+        """
+        reference_id = await self._create_otu(data_layer, fake)
+
+        assert (
+            await check_name_and_abbreviation(pg, reference_id, "PRUNUS VIRUS F")
+            == "Name already exists"
+        )
+
+    async def test_scoped_to_reference(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """An OTU in another reference does not make the name or abbreviation taken."""
+        await self._create_otu(data_layer, fake)
+
+        other_reference = await fake.references.create(
+            user=await fake.users.create(),
+        )
+
+        assert (
+            await check_name_and_abbreviation(
+                pg,
+                other_reference.id,
+                "Prunus virus F",
+                "PVF",
+            )
+            is None
+        )
 
 
 @pytest.mark.parametrize("in_db", [True, False])
@@ -83,26 +148,183 @@ async def test_increment_otu_version(mongo, snapshot):
     assert await mongo.otus.find_one() == snapshot
 
 
+class TestFindOrder:
+    """``find`` orders by ``lower(name)`` then ``id``."""
+
+    async def _insert(
+        self,
+        insert_otu,
+        reference_id: int,
+        test_otu: Document,
+        rows: list[tuple[str, str]],
+    ) -> None:
+        for otu_id, name in rows:
+            await insert_otu(
+                {**test_otu, "_id": otu_id, "name": name, "lower_name": name.lower()},
+                reference_id,
+            )
+
+    async def test_case_insensitive(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+    ):
+        """Names are ordered alphabetically regardless of case.
+
+        The Mongo sort this replaces collated by byte value, which filed every
+        capitalised name ahead of every lowercase one.
+        """
+        reference = await fake.references.create(user=await fake.users.create())
+
+        await self._insert(
+            insert_otu,
+            reference.id,
+            test_otu,
+            [
+                ("zucchini", "Zucchini yellow mosaic virus"),
+                ("alfalfa", "alfalfa mosaic virus"),
+            ],
+        )
+
+        data = await find(pg, None, 1, 25, None, reference.id)
+
+        assert [document["name"] for document in data["documents"]] == [
+            "alfalfa mosaic virus",
+            "Zucchini yellow mosaic virus",
+        ]
+
+    async def test_shared_name_breaks_tie_on_id(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+    ):
+        """OTUs sharing a name are ordered by id, so paging cannot repeat or skip one."""
+        reference = await fake.references.create(user=await fake.users.create())
+
+        await self._insert(
+            insert_otu,
+            reference.id,
+            test_otu,
+            [
+                ("second", "Shared Name"),
+                ("first", "Shared Name"),
+                ("third", "Shared Name"),
+            ],
+        )
+
+        first_page = await find(pg, None, 1, 2, None, reference.id)
+        second_page = await find(pg, None, 2, 2, None, reference.id)
+
+        assert [document["id"] for document in first_page["documents"]] == [
+            "first",
+            "second",
+        ]
+        assert [document["id"] for document in second_page["documents"]] == ["third"]
+
+
+class TestGetLegacyOTUFields:
+    """``get_legacy_otu_fields`` stands in for a projected ``mongo.otus.find_one``."""
+
+    async def test_omits_absent_field(self, insert_otu, fake: DataFaker, pg, test_otu):
+        """A field the document does not carry is left out rather than returned as None.
+
+        A Mongo projection omits it too, and ``evaluate_changes`` relies on that: it
+        defaults a missing ``abbreviation`` to ``""`` via ``get("abbreviation", "")``,
+        which a present-and-``None`` key would defeat.
+        """
+        reference = await fake.references.create(user=await fake.users.create())
+
+        del test_otu["abbreviation"]
+
+        await insert_otu(test_otu, reference.id)
+
+        assert await get_legacy_otu_fields(
+            pg,
+            test_otu["_id"],
+            ["abbreviation", "name"],
+        ) == {"name": "Prunus virus F"}
+
+    async def test_keeps_null_field(self, insert_otu, fake: DataFaker, pg, test_otu):
+        """A field the document carries as null is present, not omitted."""
+        reference = await fake.references.create(user=await fake.users.create())
+
+        await insert_otu({**test_otu, "abbreviation": None}, reference.id)
+
+        assert await get_legacy_otu_fields(pg, test_otu["_id"], ["abbreviation"]) == {
+            "abbreviation": None,
+        }
+
+    async def test_no_otu(self, pg):
+        assert await get_legacy_otu_fields(pg, "missing", ["name"]) is None
+
+
 class TestCheckSequenceSegment:
     """Test that a sequence's segment is validated against the parent OTU's schema."""
 
-    async def test_defined(self, mongo):
-        await mongo.otus.insert_one({"_id": "foo", "schema": [{"name": "RNA1"}]})
+    async def _create_otu(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        *,
+        with_schema: bool,
+    ) -> str:
+        """Create an OTU, optionally carrying an ``RNA1`` segment, and return its id."""
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
 
-        assert await check_sequence_segment(mongo, "foo", {"segment": "RNA1"}) is None
+        otu = await data_layer.otus.create(
+            reference.id,
+            CreateOTURequest(name="Prunus virus F", abbreviation="PVF"),
+            user.id,
+        )
 
-    async def test_not_defined(self, mongo):
-        await mongo.otus.insert_one({"_id": "foo", "schema": [{"name": "RNA1"}]})
+        if with_schema:
+            otu = await data_layer.otus.update(
+                otu.id,
+                UpdateOTURequest(
+                    schema=[
+                        OTUSegment(
+                            molecule=Molecule.ss_rna,
+                            name="RNA1",
+                            required=True,
+                        ),
+                    ],
+                ),
+                user.id,
+            )
+
+        return otu.id
+
+    async def test_defined(self, data_layer: DataLayer, fake: DataFaker, pg):
+        otu_id = await self._create_otu(data_layer, fake, with_schema=True)
+
+        assert await check_sequence_segment(pg, otu_id, {"segment": "RNA1"}) is None
+
+    async def test_not_defined(self, data_layer: DataLayer, fake: DataFaker, pg):
+        otu_id = await self._create_otu(data_layer, fake, with_schema=True)
 
         assert (
-            await check_sequence_segment(mongo, "foo", {"segment": "RNA2"})
+            await check_sequence_segment(pg, otu_id, {"segment": "RNA2"})
             == "Segment RNA2 is not defined for the parent OTU"
         )
 
-    async def test_no_segment(self, mongo):
-        await mongo.otus.insert_one({"_id": "foo", "schema": [{"name": "RNA1"}]})
+    async def test_no_segment(self, data_layer: DataLayer, fake: DataFaker, pg):
+        otu_id = await self._create_otu(data_layer, fake, with_schema=True)
 
-        assert await check_sequence_segment(mongo, "foo", {}) is None
+        assert await check_sequence_segment(pg, otu_id, {}) is None
+
+    async def test_no_schema(self, data_layer: DataLayer, fake: DataFaker, pg):
+        """An OTU that carries no schema defines no segment."""
+        otu_id = await self._create_otu(data_layer, fake, with_schema=False)
+
+        assert (
+            await check_sequence_segment(pg, otu_id, {"segment": "RNA1"})
+            == "Segment RNA1 is not defined for the parent OTU"
+        )
 
 
 class TestFindModifiedCount:
@@ -159,7 +381,7 @@ class TestFindModifiedCount:
             ],
         )
 
-        data = await find(mongo, pg, None, 1, 25, None)
+        data = await find(pg, None, 1, 25, None)
 
         assert data["modified_count"] == 2
 
@@ -183,7 +405,7 @@ class TestFindModifiedCount:
             ],
         )
 
-        data = await find(mongo, pg, None, 1, 25, None)
+        data = await find(pg, None, 1, 25, None)
 
         assert data["modified_count"] == 1
 

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -1,4 +1,3 @@
-import asyncio
 from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import ANY
@@ -880,7 +879,6 @@ class TestCreateOTU:
             # Abbreviation defaults to empty string for OTU creation.
             m_check_name_and_abbreviation.assert_called_with(
                 ANY,
-                ANY,
                 "foo",
                 "Tobacco mosaic virus",
                 "TMV",
@@ -1425,6 +1423,7 @@ async def test_find_otus(
     find: str | None,
     verified: bool | None,
     fake: DataFaker,
+    insert_otu,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
     mongo: Mongo,
@@ -1438,51 +1437,53 @@ async def test_find_otus(
     user = await fake.users.create()
 
     async with AsyncSession(pg) as session:
-        session.add(
-            SQLReference(
-                legacy_id="foo",
-                name="Foo",
-                description="",
-                created_at=virtool.utils.timestamp(),
-                source_types=[],
-                user_id=user.id,
-            ),
+        reference = SQLReference(
+            legacy_id="foo",
+            name="Foo",
+            description="",
+            created_at=virtool.utils.timestamp(),
+            source_types=[],
+            user_id=user.id,
         )
+        session.add(reference)
+        await session.flush()
+
+        reference_id = reference.id
+
         await session.commit()
 
-    await asyncio.gather(
-        mongo.references.insert_one(
-            {"_id": "foo", "name": "Foo", "data_type": "genome"},
-        ),
-        mongo.otus.insert_many(
-            [
-                {
-                    "_id": "6116cba1",
-                    "name": "Prunus virus F",
-                    "abbreviation": "PVF",
-                    "last_indexed_version": None,
-                    "verified": True,
-                    "lower_name": "prunus virus f",
-                    "isolates": [],
-                    "version": 0,
-                    "reference": {"id": "foo"},
-                    "schema": [],
-                },
-                {
-                    "_id": "5316cbz2",
-                    "name": "Papaya virus q",
-                    "abbreviation": "P",
-                    "last_indexed_version": None,
-                    "verified": False,
-                    "lower_name": "papaya virus q",
-                    "isolates": [],
-                    "version": 0,
-                    "reference": {"id": "foo"},
-                    "schema": [],
-                },
-            ],
-            session=None,
-        ),
+    await mongo.references.insert_one(
+        {"_id": "foo", "name": "Foo", "data_type": "genome"},
+    )
+
+    await insert_otu(
+        {
+            "_id": "6116cba1",
+            "name": "Prunus virus F",
+            "abbreviation": "PVF",
+            "last_indexed_version": None,
+            "verified": True,
+            "lower_name": "prunus virus f",
+            "isolates": [],
+            "version": 0,
+            "schema": [],
+        },
+        reference_id,
+    )
+
+    await insert_otu(
+        {
+            "_id": "5316cbz2",
+            "name": "Papaya virus q",
+            "abbreviation": "P",
+            "last_indexed_version": None,
+            "verified": False,
+            "lower_name": "papaya virus q",
+            "isolates": [],
+            "version": 0,
+            "schema": [],
+        },
+        reference_id,
     )
 
     query = []

--- a/virtool/otus/api.py
+++ b/virtool/otus/api.py
@@ -1,9 +1,7 @@
 from aiohttp import web
 from aiohttp_pydantic import PydanticView
 from aiohttp_pydantic.oas.typing import r200, r201, r204, r400, r401, r403, r404
-from sqlalchemy.ext.asyncio import AsyncEngine
 
-import virtool.otus.db
 from virtool.api.custom_json import json_response
 from virtool.api.errors import (
     APIBadRequest,
@@ -12,10 +10,13 @@ from virtool.api.errors import (
     APINotFound,
 )
 from virtool.api.routes import Routes
-from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
+from virtool.data.errors import (
+    ResourceConflictError,
+    ResourceError,
+    ResourceNotFoundError,
+)
 from virtool.data.utils import get_data_from_req
 from virtool.models.roles import AdministratorRole
-from virtool.mongo.utils import get_mongo_from_req, get_one_field
 from virtool.otus.models import OTU, OTUIsolate, OTUSequence, Sequence
 from virtool.otus.oas import (
     CreateIsolateRequest,
@@ -24,9 +25,46 @@ from virtool.otus.oas import (
     UpdateOTURequest,
     UpdateSequenceRequest,
 )
-from virtool.otus.utils import evaluate_changes
 
 routes = Routes()
+
+
+async def check_otu_right(
+    request,
+    otu_id: str,
+    isolate_id: str | None = None,
+) -> None:
+    """Raise unless the requesting client may modify the OTU's parent reference.
+
+    Every OTU handler but the reads guards on ``modify_otu`` against the reference the
+    OTU belongs to, so the lookup of that reference and the translation of its absence
+    into a ``404`` are shared here rather than repeated per handler. The authorization
+    decision itself stays in the API layer.
+
+    :param request: the request
+    :param otu_id: the ID of the OTU being addressed
+    :param isolate_id: the ID of an isolate the OTU must carry
+    :raises APINotFound: the OTU, or the named isolate, does not exist
+    :raises APIInsufficientRights: the client may not modify the OTU
+    """
+    try:
+        reference_id = await get_data_from_req(request).otus.get_reference_id(
+            otu_id,
+            isolate_id=isolate_id,
+        )
+    except ResourceNotFoundError:
+        raise APINotFound()
+
+    client = request["client"]
+
+    if not await get_data_from_req(request).references.check_right(
+        reference_id,
+        "modify_otu",
+        user_id=client.user_id,
+        group_ids=client.groups,
+        administrator=client.administrator_role == AdministratorRole.FULL,
+    ):
+        raise APIInsufficientRights()
 
 
 @routes.view("/otus/{otu_id}")
@@ -74,57 +112,18 @@ class OTUView(PydanticView):
         in the parent reference.
 
         """
-        mongo = get_mongo_from_req(self.request)
-        pg: AsyncEngine = self.request.app["pg"]
+        await check_otu_right(self.request, otu_id)
 
-        # Get existing complete otu record, at the same time ensuring it exists. Send a
-        # ``404`` if not.
-        document = await mongo.otus.find_one(
-            otu_id,
-            ["abbreviation", "name", "reference", "schema"],
-        )
-
-        if not document:
+        try:
+            otu = await get_data_from_req(self.request).otus.update(
+                otu_id,
+                data,
+                self.request["client"].user_id,
+            )
+        except ResourceNotFoundError:
             raise APINotFound()
-
-        ref_id = document["reference"]["id"]
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            ref_id,
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
-
-        name, abbreviation, otu_schema = evaluate_changes(
-            data.dict(by_alias=True, exclude_unset=True),
-            document,
-        )
-
-        # Send ``200`` with the existing otu record if no change will be made.
-        if name is None and abbreviation is None and otu_schema is None:
-            otu = await get_data_from_req(self.request).otus.get(otu_id)
-            return json_response(otu)
-
-        # Make sure new name or abbreviation are not already in use.
-        if message := await virtool.otus.db.check_name_and_abbreviation(
-            mongo,
-            pg,
-            ref_id,
-            name,
-            abbreviation,
-        ):
-            raise APIBadRequest(message)
-
-        otu = await get_data_from_req(self.request).otus.update(
-            otu_id,
-            data,
-            self.request["client"].user_id,
-        )
+        except ResourceError as err:
+            raise APIBadRequest(str(err))
 
         return json_response(otu)
 
@@ -134,23 +133,7 @@ class OTUView(PydanticView):
         Deletes and OTU and its associated isolates and sequences.
 
         """
-        mongo = get_mongo_from_req(self.request)
-
-        document = await mongo.otus.find_one(otu_id, ["reference"])
-
-        if document is None:
-            raise APINotFound()
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            document["reference"]["id"],
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
+        await check_otu_right(self.request, otu_id)
 
         await get_data_from_req(self.request).otus.remove(
             otu_id,
@@ -168,15 +151,12 @@ class IsolatesView(PydanticView):
         Lists all the isolates and sequences for an OTU.
 
         """
-        mongo = get_mongo_from_req(self.request)
-        pg: AsyncEngine = self.request.app["pg"]
-
-        document = await virtool.otus.db.join_and_format(mongo, pg, otu_id)
-
-        if not document:
+        try:
+            isolates = await get_data_from_req(self.request).otus.list_isolates(otu_id)
+        except ResourceNotFoundError:
             raise APINotFound()
 
-        return json_response(document["isolates"])
+        return json_response(isolates)
 
     async def post(
         self,
@@ -189,23 +169,7 @@ class IsolatesView(PydanticView):
         Creates an isolate on the OTU specified by `otu_id`.
 
         """
-        mongo = get_mongo_from_req(self.request)
-
-        reference = await get_one_field(mongo.otus, "reference", otu_id)
-
-        if not reference:
-            raise APINotFound()
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            reference["id"],
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
+        await check_otu_right(self.request, otu_id)
 
         try:
             isolate = await get_data_from_req(self.request).otus.add_isolate(
@@ -280,27 +244,7 @@ class IsolateView(PydanticView):
         Updates an isolate using 'otu_id' and 'isolate_id'.
 
         """
-        mongo = get_mongo_from_req(self.request)
-
-        reference = await get_one_field(
-            mongo.otus,
-            "reference",
-            {"_id": otu_id, "isolates.id": isolate_id},
-        )
-
-        if not reference:
-            raise APINotFound()
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            reference["id"],
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
+        await check_otu_right(self.request, otu_id, isolate_id=isolate_id)
 
         data = data.dict(exclude_unset=True)
 
@@ -323,27 +267,7 @@ class IsolateView(PydanticView):
         Deletes an isolate using its 'otu id' and 'isolate id'.
 
         """
-        mongo = get_mongo_from_req(self.request)
-
-        reference = await get_one_field(
-            mongo.otus,
-            "reference",
-            {"_id": otu_id, "isolates.id": isolate_id},
-        )
-
-        if not reference:
-            raise APINotFound()
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            reference["id"],
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
+        await check_otu_right(self.request, otu_id, isolate_id=isolate_id)
 
         await get_data_from_req(self.request).otus.remove_isolate(
             otu_id,
@@ -388,46 +312,21 @@ class SequencesView(PydanticView):
         Creates a new sequence for an isolate identified by `otu_id` and `isolate_id`.
 
         """
-        mongo = get_mongo_from_req(self.request)
+        await check_otu_right(self.request, otu_id, isolate_id=isolate_id)
 
-        document = await mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id},
-            ["reference", "schema"],
-        )
-
-        if not document:
-            raise APINotFound()
-
-        ref_id = document["reference"]["id"]
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            ref_id,
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
-
-        if message := await virtool.otus.db.check_sequence_segment(
-            mongo,
-            otu_id,
-            data.dict(),
-        ):
-            raise APIBadRequest(message)
-
-        sequence = await get_data_from_req(self.request).otus.create_sequence(
-            otu_id,
-            isolate_id,
-            data.accession,
-            data.definition,
-            data.sequence,
-            self.request["client"].user_id,
-            host=data.host,
-            segment=data.segment,
-        )
+        try:
+            sequence = await get_data_from_req(self.request).otus.create_sequence(
+                otu_id,
+                isolate_id,
+                data.accession,
+                data.definition,
+                data.sequence,
+                self.request["client"].user_id,
+                host=data.host,
+                segment=data.segment,
+            )
+        except ResourceError as err:
+            raise APIBadRequest(str(err))
 
         location = f"/otus/{otu_id}/isolates/{isolate_id}/sequences/{sequence.id}"
 
@@ -494,43 +393,23 @@ class SequenceView(PydanticView):
         Updates a sequence using its 'otu id', 'isolate id' and 'sequence id'.
 
         """
-        mongo = get_mongo_from_req(self.request)
-
-        document = await mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id},
-            ["reference", "segment"],
-        )
-
-        if not document or not await get_data_from_req(
-            self.request,
-        ).otus.sequence_exists(sequence_id):
+        if not await get_data_from_req(self.request).otus.sequence_exists(sequence_id):
             raise APINotFound()
 
-        client = self.request["client"]
+        await check_otu_right(self.request, otu_id, isolate_id=isolate_id)
 
-        if not await get_data_from_req(self.request).references.check_right(
-            document["reference"]["id"],
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
-
-        if message := await virtool.otus.db.check_sequence_segment(
-            mongo,
-            otu_id,
-            data.dict(exclude_unset=True),
-        ):
-            raise APIBadRequest(message)
-
-        sequence_document = await get_data_from_req(self.request).otus.update_sequence(
-            otu_id,
-            isolate_id,
-            sequence_id,
-            self.request["client"].user_id,
-            data,
-        )
+        try:
+            sequence_document = await get_data_from_req(
+                self.request,
+            ).otus.update_sequence(
+                otu_id,
+                isolate_id,
+                sequence_id,
+                self.request["client"].user_id,
+                data,
+            )
+        except ResourceError as err:
+            raise APIBadRequest(str(err))
 
         return json_response(sequence_document)
 
@@ -540,29 +419,10 @@ class SequenceView(PydanticView):
         Deletes the specified sequence.
 
         """
-        mongo = get_mongo_from_req(self.request)
-
         if not await get_data_from_req(self.request).otus.sequence_exists(sequence_id):
             raise APINotFound()
 
-        document = await mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id},
-            ["reference"],
-        )
-
-        if document is None:
-            raise APINotFound()
-
-        client = self.request["client"]
-
-        if not await get_data_from_req(self.request).references.check_right(
-            document["reference"]["id"],
-            "modify_otu",
-            user_id=client.user_id,
-            group_ids=client.groups,
-            administrator=client.administrator_role == AdministratorRole.FULL,
-        ):
-            raise APIInsufficientRights()
+        await check_otu_right(self.request, otu_id, isolate_id=isolate_id)
 
         await get_data_from_req(self.request).otus.remove_sequence(
             otu_id,
@@ -600,24 +460,7 @@ async def set_as_default(req):
     otu_id = req.match_info["otu_id"]
     isolate_id = req.match_info["isolate_id"]
 
-    document = await get_mongo_from_req(req).otus.find_one(
-        {"_id": otu_id, "isolates.id": isolate_id},
-        ["reference"],
-    )
-
-    if not document:
-        raise APINotFound()
-
-    client = req["client"]
-
-    if not await get_data_from_req(req).references.check_right(
-        document["reference"]["id"],
-        "modify_otu",
-        user_id=client.user_id,
-        group_ids=client.groups,
-        administrator=client.administrator_role == AdministratorRole.FULL,
-    ):
-        raise APIInsufficientRights()
+    await check_otu_right(req, otu_id, isolate_id=isolate_id)
 
     isolate = await get_data_from_req(req).otus.set_isolate_as_default(
         otu_id,

--- a/virtool/otus/data.py
+++ b/virtool/otus/data.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 import virtool.history.db
 import virtool.otus.db
 import virtool.otus.utils
-from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
+from virtool.data.errors import (
+    ResourceConflictError,
+    ResourceError,
+    ResourceNotFoundError,
+)
 from virtool.data.topg import resolve_legacy_id, retry_both_transactions
 from virtool.data.transforms import apply_transforms
 from virtool.history.utils import (
@@ -22,11 +26,13 @@ from virtool.history.utils import (
 )
 from virtool.models.enums import HistoryMethod
 from virtool.mongo.core import Mongo
-from virtool.mongo.utils import get_one_field
 from virtool.otus.db import (
+    get_legacy_otu_fields,
+    get_legacy_otu_reference_id,
     get_legacy_sequence,
     get_legacy_sequence_body,
     increment_otu_version,
+    legacy_isolate_exists,
     legacy_sequence_exists,
     list_legacy_isolate_sequence_bodies,
     list_legacy_isolate_sequences,
@@ -36,6 +42,7 @@ from virtool.otus.db import (
 from virtool.otus.models import OTU, OTUIsolate, OTUSequence, Sequence
 from virtool.otus.oas import CreateOTURequest, UpdateOTURequest, UpdateSequenceRequest
 from virtool.otus.utils import (
+    evaluate_changes,
     find_isolate,
     format_fasta_entry,
     format_fasta_filename,
@@ -63,9 +70,51 @@ class OTUData:
         self, page: int, per_page: int, term: str | None, verified: bool | None
     ) -> dict[str, Any] | list[dict | None]:
         """Find OTUs matching the given query."""
-        return await virtool.otus.db.find(
-            self._mongo, self._pg, term, page, per_page, verified
+        return await virtool.otus.db.find(self._pg, term, page, per_page, verified)
+
+    async def get_reference_id(
+        self,
+        otu_id: str,
+        isolate_id: str | None = None,
+    ) -> int:
+        """Get the id of the reference an OTU belongs to.
+
+        Backs the authorization checks on the OTU handlers, which need the parent
+        reference to resolve a right but nothing else about the OTU. The handler owns
+        the resulting decision.
+
+        Passing ``isolate_id`` additionally requires the OTU to carry that isolate, so a
+        handler addressing an isolate gets its existence check from the same read.
+
+        :param otu_id: the ID of the OTU
+        :param isolate_id: the ID of an isolate the OTU must carry
+        :return: the ID of the parent reference
+        :raises ResourceNotFoundError: the OTU, or the named isolate, does not exist
+        """
+        reference_id = await get_legacy_otu_reference_id(
+            self._pg,
+            otu_id,
+            isolate_id=isolate_id,
         )
+
+        if reference_id is None:
+            raise ResourceNotFoundError
+
+        return reference_id
+
+    async def list_isolates(self, otu_id: str) -> list[Document]:
+        """List an OTU's isolates and their sequences.
+
+        :param otu_id: the ID of the OTU
+        :return: the isolates
+        :raises ResourceNotFoundError: the OTU does not exist
+        """
+        document = await virtool.otus.db.join_and_format(self._pg, otu_id)
+
+        if document is None:
+            raise ResourceNotFoundError
+
+        return document["isolates"]
 
     async def get(self, otu_id: str) -> OTU:
         """Get a single OTU by ID.
@@ -73,7 +122,7 @@ class OTUData:
         :param otu_id: the ID of the OTU to get
         :return: the OTU
         """
-        document = await virtool.otus.db.join_and_format(self._mongo, self._pg, otu_id)
+        document = await virtool.otus.db.join_and_format(self._pg, otu_id)
 
         if document is None:
             raise ResourceNotFoundError
@@ -108,7 +157,7 @@ class OTUData:
         :return: a FASTA filename and body
 
         """
-        otu = await self._mongo.otus.find_one(otu_id, ["name", "isolates"])
+        otu = await get_legacy_otu_fields(self._pg, otu_id, ["name", "isolates"])
 
         if otu is None:
             raise ResourceNotFoundError
@@ -146,18 +195,17 @@ class OTUData:
         :return: an OTU name and isolate name
 
         """
-        otu = await self._mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id},
+        otu = await get_legacy_otu_fields(
+            self._pg,
+            otu_id,
             ["name", "isolates"],
+            isolate_id=isolate_id,
         )
 
         if not otu:
             raise ResourceNotFoundError("OTU does not exist")
 
         isolate = virtool.otus.utils.find_isolate(otu["isolates"], isolate_id)
-
-        if not isolate:
-            raise ResourceNotFoundError("Isolate does not exist")
 
         return otu["name"], virtool.otus.utils.format_isolate_name(isolate)
 
@@ -286,12 +334,42 @@ class OTUData:
         Modifiable fields are `name`, `abbreviation`, and `schema`. Method creates a
         corresponding history record.
 
+        A request that would leave every modifiable field as it already is makes no
+        change and creates no history record; the OTU is returned as-is.
+
         :param otu_id: the ID of the OTU to edit
         :param data: the update request
         :param user_id: the requesting user id
         :return: the updated and joined OTU document
+        :raises ResourceNotFoundError: the OTU does not exist
+        :raises ResourceError: the new name or abbreviation is already in use
 
         """
+        existing = await get_legacy_otu_fields(
+            self._pg,
+            otu_id,
+            ["abbreviation", "name", "reference", "schema"],
+        )
+
+        if existing is None:
+            raise ResourceNotFoundError
+
+        name, abbreviation, otu_schema = evaluate_changes(
+            data.dict(by_alias=True, exclude_unset=True),
+            existing,
+        )
+
+        if name is None and abbreviation is None and otu_schema is None:
+            return await self.get(otu_id)
+
+        if message := await virtool.otus.db.check_name_and_abbreviation(
+            self._pg,
+            existing["reference"]["id"],
+            name,
+            abbreviation,
+        ):
+            raise ResourceError(message)
+
         # Update the ``modified`` and ``verified`` fields in the otu document now,
         # because we are definitely going to modify the otu.
         update = {"verified": False}
@@ -424,12 +502,12 @@ class OTUData:
         :raises ResourceNotFoundError: the OTU does not exist
         :raises ResourceConflictError: the reference does not allow the source type
         """
-        reference = await get_one_field(self._mongo.otus, "reference", otu_id)
+        reference_id = await get_legacy_otu_reference_id(self._pg, otu_id)
 
-        if not reference:
+        if reference_id is None:
             raise ResourceNotFoundError
 
-        if not await check_source_type(self._pg, reference["id"], source_type):
+        if not await check_source_type(self._pg, reference_id, source_type):
             raise ResourceConflictError("Source type is not allowed")
 
     async def add_isolate(
@@ -536,7 +614,9 @@ class OTUData:
 
             await self._check_source_type(otu_id, source_type)
 
-        isolates = await get_one_field(self._mongo.otus, "isolates", otu_id)
+        isolates = (await get_legacy_otu_fields(self._pg, otu_id, ["isolates"]))[
+            "isolates"
+        ]
 
         isolate = find_isolate(isolates, isolate_id)
         old_isolate_name = format_isolate_name(isolate)
@@ -600,7 +680,6 @@ class OTUData:
         new = await retry_both_transactions(self._mongo, self._pg, func)
 
         complete = await virtool.otus.db.join_and_format(
-            self._mongo,
             self._pg,
             otu_id,
             joined=new,
@@ -803,6 +882,17 @@ class OTUData:
         segment: str | None = None,
         sequence_id: str | None = None,
     ) -> OTUSequence:
+        """Create a sequence on an isolate.
+
+        :raises ResourceError: the segment is not defined in the parent OTU's schema
+        """
+        if message := await virtool.otus.db.check_sequence_segment(
+            self._pg,
+            otu_id,
+            {"segment": segment},
+        ):
+            raise ResourceError(message)
+
         async def func(
             mongo_session: AsyncIOMotorClientSession,
             pg_session: AsyncSession,
@@ -876,10 +966,7 @@ class OTUData:
         isolate_id: str,
         sequence_id: str,
     ) -> Sequence:
-        if await self._mongo.otus.count_documents(
-            {"_id": otu_id, "isolates.id": isolate_id},
-            limit=1,
-        ) and (
+        if await legacy_isolate_exists(self._pg, otu_id, isolate_id) and (
             document := await get_legacy_sequence(
                 self._pg,
                 otu_id,
@@ -908,10 +995,7 @@ class OTUData:
         :return: the isolate's sequences
         :raises ResourceNotFoundError: the OTU or isolate does not exist
         """
-        if not await self._mongo.otus.count_documents(
-            {"_id": otu_id, "isolates.id": isolate_id},
-            limit=1,
-        ):
+        if not await legacy_isolate_exists(self._pg, otu_id, isolate_id):
             raise ResourceNotFoundError
 
         return [
@@ -931,9 +1015,11 @@ class OTUData:
         :return: the isolate
         :raises ResourceNotFoundError: the OTU or isolate does not exist
         """
-        document = await self._mongo.otus.find_one(
-            {"_id": otu_id, "isolates.id": isolate_id},
+        document = await get_legacy_otu_fields(
+            self._pg,
+            otu_id,
             ["isolates"],
+            isolate_id=isolate_id,
         )
 
         if not document:
@@ -968,7 +1054,18 @@ class OTUData:
         user_id: int,
         data: UpdateSequenceRequest,
     ):
+        """Update a sequence.
+
+        :raises ResourceError: the segment is not defined in the parent OTU's schema
+        """
         data = data.dict(exclude_unset=True)
+
+        if message := await virtool.otus.db.check_sequence_segment(
+            self._pg,
+            otu_id,
+            data,
+        ):
+            raise ResourceError(message)
 
         update = {
             key: data[key]

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,40 +1,51 @@
 """Work with OTUs in the database."""
 
+import math
 from collections import Counter
 from collections.abc import Collection
 from datetime import datetime
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import delete, distinct, func, select
+from sqlalchemy import delete, distinct, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import virtool.history.db
 import virtool.otus.utils
 from virtool.api.custom_json import isoformat_to_datetime
-from virtool.api.utils import compose_regex_query, paginate
 from virtool.data.topg import (
-    compose_legacy_id_mongo_match,
     compose_legacy_id_subquery,
     resolve_legacy_id,
 )
 from virtool.data.transforms import apply_transforms
-from virtool.errors import DatabaseError
 from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
-from virtool.mongo.utils import get_one_field
 from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.references.sql import SQLReference
 from virtool.references.transforms import AttachReferenceTransform
 from virtool.types import Document
-from virtool.utils import base_processor, to_bool
+
+
+def compose_otu_search_filter(term: str):
+    """Compose a case-insensitive substring match on ``name`` and ``abbreviation``.
+
+    Mirrors the Mongo ``compose_regex_query`` behaviour the find endpoint used before
+    reading from Postgres: the term is matched literally, so SQL ``LIKE`` wildcards in
+    the term are escaped rather than interpreted.
+    """
+    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped}%"
+
+    return or_(
+        SQLOTU.name.ilike(pattern, escape="\\"),
+        SQLOTU.abbreviation.ilike(pattern, escape="\\"),
+    )
 
 
 async def check_name_and_abbreviation(
-    mongo: "Mongo",
     pg: AsyncEngine,
-    ref_id: str,
+    ref_id: int | str,
     name: str | None = None,
     abbreviation: str | None = None,
 ) -> str | None:
@@ -42,24 +53,41 @@ async def check_name_and_abbreviation(
 
     Returns an error message if the ``name`` or ``abbreviation`` are already in use.
 
-    :param mongo: the application database client
+    The name is matched on ``lower(name)`` rather than the ``lower_name`` field the
+    Mongo query used. The ``legacy_otus_name_lower`` index makes that expression a
+    lookup rather than a scan, so the denormalised field does not need promoting to a
+    column of its own.
+
     :param pg: the application PostgreSQL engine
     :param ref_id: the id of the reference to check in
     :param name: an OTU name
     :param abbreviation: an OTU abbreviation
 
     """
-    reference_id_match = await compose_legacy_id_mongo_match(pg, SQLReference, ref_id)
+    reference_id = compose_legacy_id_subquery(SQLReference, ref_id)
 
-    name_exists = name and await mongo.otus.count_documents(
-        {"lower_name": name.lower(), "reference.id": reference_id_match},
-        limit=1,
-    )
+    async with AsyncSession(pg) as session:
+        name_exists = bool(name) and await session.scalar(
+            select(
+                select(SQLOTU.id)
+                .where(
+                    func.lower(SQLOTU.name) == name.lower(),
+                    SQLOTU.reference_id == reference_id,
+                )
+                .exists(),
+            ),
+        )
 
-    abbreviation_exists = abbreviation and await mongo.otus.count_documents(
-        {"abbreviation": abbreviation, "reference.id": reference_id_match},
-        limit=1,
-    )
+        abbreviation_exists = bool(abbreviation) and await session.scalar(
+            select(
+                select(SQLOTU.id)
+                .where(
+                    SQLOTU.abbreviation == abbreviation,
+                    SQLOTU.reference_id == reference_id,
+                )
+                .exists(),
+            ),
+        )
 
     if name_exists and abbreviation_exists:
         return "Name and abbreviation already exist"
@@ -70,48 +98,48 @@ async def check_name_and_abbreviation(
     if abbreviation_exists:
         return "Abbreviation already exists"
 
+    return None
+
 
 async def find(
-    mongo: "Mongo",
     pg: AsyncEngine,
     term: str | None,
     page: int,
     per_page: int,
     verified: bool | None,
-    ref_id: str | None = None,
-) -> dict[str, Any] | list[dict | None]:
-    mongo_query = {}
+    ref_id: int | str | None = None,
+) -> dict[str, Any]:
+    """Find OTUs matching a search term, in ``paginate``'s result shape.
 
-    if term:
-        mongo_query.update(compose_regex_query(term, ["name", "abbreviation"]))
+    ``ref_id`` scopes both counts, so ``total_count`` is the size of the reference
+    rather than of every OTU, exactly as the ``base_query`` it replaces did.
 
-    if verified is not None:
-        mongo_query["verified"] = to_bool(verified)
+    Only the promoted columns behind :class:`virtool.otus.models.OTUMinimal` are
+    selected, standing in for the projection the Mongo query passed. Selecting whole
+    rows would drag the entire ``data`` JSONB -- every isolate of every OTU on the page
+    -- over the wire to build a response that names none of it.
 
-    base_query = None
+    Rows are ordered by ``lower(name)`` then ``id``, which the ``legacy_otus_name_lower``
+    index covers. This is a deliberate change of order rather than a port of the Mongo
+    one: ``sort="name"`` collated by byte value, so it filed every capitalised name ahead
+    of every lowercase one, and it had no tiebreaker, so OTUs sharing a name could swap
+    places between pages of one walk. Case-folding gives the alphabetical order the
+    endpoint has always appeared to promise, and ``id`` makes paging stable.
+    """
+    base_filters = []
 
     if ref_id is not None:
-        base_query = {
-            "reference.id": await compose_legacy_id_mongo_match(
-                pg, SQLReference, ref_id
-            ),
-        }
+        base_filters.append(
+            SQLOTU.reference_id == compose_legacy_id_subquery(SQLReference, ref_id),
+        )
 
-    data = await paginate(
-        mongo.otus,
-        mongo_query,
-        page,
-        per_page,
-        base_query=base_query,
-        sort="name",
-        projection=["_id", "abbreviation", "name", "reference", "verified", "version"],
-    )
+    search_filters = list(base_filters)
 
-    data["documents"] = await apply_transforms(
-        [base_processor(d) for d in data["documents"]],
-        [AttachReferenceTransform(pg)],
-        pg,
-    )
+    if term:
+        search_filters.append(compose_otu_search_filter(term))
+
+    if verified is not None:
+        search_filters.append(SQLOTU.verified.is_(verified))
 
     history_filters = [SQLLegacyHistory.index.is_(None)]
 
@@ -122,13 +150,60 @@ async def find(
         )
 
     async with AsyncSession(pg) as session:
-        data["modified_count"] = await session.scalar(
-            select(func.count(distinct(SQLLegacyHistory.otu))).where(
-                *history_filters,
-            ),
+        total_count = await session.scalar(
+            select(func.count()).select_from(SQLOTU).where(*base_filters),
         )
 
-    return data
+        found_count = await session.scalar(
+            select(func.count()).select_from(SQLOTU).where(*search_filters),
+        )
+
+        rows = (
+            await session.execute(
+                select(
+                    SQLOTU.id,
+                    SQLOTU.abbreviation,
+                    SQLOTU.name,
+                    SQLOTU.reference_id,
+                    SQLOTU.verified,
+                    SQLOTU.version,
+                )
+                .where(*search_filters)
+                .order_by(func.lower(SQLOTU.name), SQLOTU.id)
+                .offset(per_page * (page - 1))
+                .limit(per_page),
+            )
+        ).all()
+
+        modified_count = await session.scalar(
+            select(func.count(distinct(SQLLegacyHistory.otu))).where(*history_filters),
+        )
+
+    documents = await apply_transforms(
+        [
+            {
+                "id": row.id,
+                "abbreviation": row.abbreviation,
+                "name": row.name,
+                "reference": {"id": row.reference_id},
+                "verified": row.verified,
+                "version": row.version,
+            }
+            for row in rows
+        ],
+        [AttachReferenceTransform(pg)],
+        pg,
+    )
+
+    return {
+        "documents": documents,
+        "total_count": total_count,
+        "found_count": found_count,
+        "page_count": int(math.ceil(found_count / per_page)),
+        "per_page": per_page,
+        "page": page,
+        "modified_count": modified_count,
+    }
 
 
 async def join(
@@ -160,7 +235,6 @@ async def join(
 
 
 async def join_and_format(
-    mongo: "Mongo",
     pg: AsyncEngine,
     otu_id: str,
     joined: dict | None = None,
@@ -171,15 +245,20 @@ async def join_and_format(
     Reuses the ``joined`` otu document if available to save a database query. Then,
     format the joined otu into a format that can be directly returned to API clients.
 
-    :param mongo: the application database client
+    Unresolved ``issues`` are computed from the joined document in hand rather than by
+    re-reading the OTU. The old Mongo path called :func:`verify`, which joined the OTU a
+    second time purely to hand it to :func:`virtool.otus.utils.verify`; the two joins
+    always described the same OTU, so collapsing them changes nothing but the query
+    count.
+
     :param pg: the application PostgreSQL database object
     :param otu_id: the id of the otu to join
-    :param joined:
+    :param joined: use this joined otu document rather than reading one
     :param issues: an object describing issues in the otu
     :return: a joined and formatted otu
 
     """
-    joined = joined or await join(mongo, otu_id)
+    joined = joined or await join_legacy_otu(pg, otu_id)
 
     if not joined:
         return None
@@ -187,23 +266,9 @@ async def join_and_format(
     most_recent_change = await virtool.history.db.get_most_recent_change(pg, otu_id)
 
     if issues is False:
-        issues = await verify(mongo, otu_id)
+        issues = virtool.otus.utils.verify(joined)
 
     return virtool.otus.utils.format_otu(joined, issues, most_recent_change)
-
-
-async def verify(mongo: "Mongo", otu_id: str, joined: dict = None) -> dict | None:
-    """Verifies that the associated otu is ready to be included in an index rebuild.
-
-    Returns verification errors if necessary.
-
-    """
-    joined = joined or await join(mongo, otu_id)
-
-    if not joined:
-        raise DatabaseError(f"Could not find otu '{otu_id}'")
-
-    return virtool.otus.utils.verify(joined)
 
 
 async def increment_otu_version(
@@ -345,6 +410,119 @@ async def join_legacy_otu(pg: AsyncEngine, otu_id: str) -> Document | None:
             otu_document_from_row(otu_row),
             [sequence_document_from_row(row) for row in sequence_rows],
         )
+
+
+def compose_isolate_match(isolate_id: str):
+    """Compose a match on an OTU that carries the isolate identified by ``isolate_id``.
+
+    The Postgres counterpart of the Mongo ``{"isolates.id": isolate_id}`` predicate.
+    Isolates are embedded in the OTU document rather than promoted to a table of their
+    own, so the match is a JSONB containment test against the ``isolates`` array in
+    ``data``. Containment is used rather than pulling the array back and scanning it in
+    Python so an isolate-scoped read stays a single scalar query.
+    """
+    return SQLOTU.data["isolates"].contains([{"id": isolate_id}])
+
+
+async def get_legacy_otu_reference_id(
+    pg: AsyncEngine,
+    otu_id: str,
+    isolate_id: str | None = None,
+) -> int | None:
+    """Return the id of an OTU's parent reference, or ``None`` if it has no row.
+
+    Backs the authorization reads on the OTU handlers, which need nothing about an OTU
+    but the reference whose rights govern it. Only ``reference_id`` is selected, so the
+    check never reads the ``data`` JSONB.
+
+    When ``isolate_id`` is given the OTU must also carry that isolate, and ``None`` is
+    returned if it does not. The handlers that take an isolate in their path rely on
+    this: the read is their existence check for the isolate as well as for the OTU, and
+    dropping the scope would turn a bad ``isolate_id`` into a ``403``/``200`` rather
+    than the ``404`` it has always been.
+    """
+    filters = [SQLOTU.id == otu_id]
+
+    if isolate_id is not None:
+        filters.append(compose_isolate_match(isolate_id))
+
+    async with AsyncSession(pg) as session:
+        return await session.scalar(select(SQLOTU.reference_id).where(*filters))
+
+
+async def legacy_isolate_exists(pg: AsyncEngine, otu_id: str, isolate_id: str) -> bool:
+    """Return whether an OTU exists and carries the isolate identified by ``isolate_id``.
+
+    The Postgres counterpart of the ``count_documents({"_id": otu_id, "isolates.id":
+    isolate_id})`` guard the sequence reads use. Only the ``id`` column is selected, so
+    the check never reads the ``data`` JSONB it matches against.
+    """
+    async with AsyncSession(pg) as session:
+        return (
+            await session.scalar(
+                select(SQLOTU.id).where(
+                    SQLOTU.id == otu_id,
+                    compose_isolate_match(isolate_id),
+                ),
+            )
+        ) is not None
+
+
+async def get_legacy_otu_fields(
+    pg: AsyncEngine,
+    otu_id: str,
+    fields: list[str],
+    isolate_id: str | None = None,
+) -> Document | None:
+    """Return selected fields of an OTU document from Postgres, or ``None``.
+
+    The Postgres counterpart of a projected ``mongo.otus.find_one``. The fields are read
+    out of the ``data`` JSONB rather than from the promoted columns, so they reach the
+    ones -- ``isolates``, ``schema`` -- the promotion does not carry, and only the
+    requested fields cross the wire.
+
+    ``None`` means the OTU has no row. A field the document does not carry is left out of
+    the returned dict rather than returned as ``None``, because a Mongo projection omits
+    it too and callers lean on that: ``evaluate_changes`` defaults a missing
+    ``abbreviation`` to ``""`` with ``document.get("abbreviation", "")``, and a key
+    present-and-``None`` would defeat that default and make an unchanged abbreviation
+    read as an edit.
+
+    When ``isolate_id`` is given the OTU must also carry that isolate, and ``None`` is
+    returned if it does not.
+    """
+    filters = [SQLOTU.id == otu_id]
+
+    if isolate_id is not None:
+        filters.append(compose_isolate_match(isolate_id))
+
+    async with AsyncSession(pg) as session:
+        row = (
+            await session.execute(
+                select(
+                    *[
+                        SQLOTU.data[field].label(f"value_{index}")
+                        for index, field in enumerate(fields)
+                    ],
+                    *[
+                        SQLOTU.data.has_key(field).label(f"present_{index}")
+                        for index, field in enumerate(fields)
+                    ],
+                ).where(*filters),
+            )
+        ).first()
+
+    if row is None:
+        return None
+
+    values = row[: len(fields)]
+    present = row[len(fields) :]
+
+    return {
+        field: value
+        for field, value, is_present in zip(fields, values, present, strict=True)
+        if is_present
+    }
 
 
 async def get_legacy_sequence(
@@ -840,7 +1018,7 @@ async def update_sequence_segments(
 
 
 async def check_sequence_segment(
-    mongo: "Mongo",
+    pg: AsyncEngine,
     otu_id: str,
     data: dict,
 ) -> str | None:
@@ -851,16 +1029,19 @@ async def check_sequence_segment(
 
     Returns `None` if the check passes.
 
-    :param mongo: the application database object
+    :param pg: the application PostgreSQL engine
     :param otu_id: the ID of the parent OTU
     :param data: the data dict containing a segment value
     :return: message or `None` if check passes
 
     """
-    if data.get("segment"):
-        schema = await get_one_field(mongo.otus, "schema", otu_id) or []
+    segment = data.get("segment")
 
-        segment = data.get("segment")
+    if segment:
+        otu = await get_legacy_otu_fields(pg, otu_id, ["schema"])
+        schema = (otu or {}).get("schema") or []
 
         if segment not in {s["name"] for s in schema}:
             return f"Segment {segment} is not defined for the parent OTU"
+
+    return None

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -644,7 +644,6 @@ class ReferencesData(DataLayerDomain):
         await self._require_exists(ref_id)
 
         data = await virtool.otus.db.find(
-            self._mongo,
             self._pg,
             term,
             page,
@@ -667,7 +666,6 @@ class ReferencesData(DataLayerDomain):
         # Check if either the name or abbreviation are already in use. Send a ``400`` if
         # they are.
         if message := await virtool.otus.db.check_name_and_abbreviation(
-            self._mongo,
             self._pg,
             ref_id,
             data.name,


### PR DESCRIPTION
## Summary
- Move OTU list, search, single-get and uniqueness checks off Mongo and onto the `legacy_otus`/`legacy_sequences` tables (step 4 of the OTU migration).
- Order the OTU list by `lower(name)` then `id`. The Mongo sort collated by byte value, filing every capitalised name ahead of every lowercase one, and had no tiebreaker, so OTUs sharing a name could swap places between pages of one walk.
- Remove the inline Mongo reads from the OTU handlers, which now reach the parent reference through the data layer and keep only the authorization decision. Reads inside `both_transactions` still run against Mongo; they belong to the write path.