### PR TITLE
refactor: read joined otus through a caller-provided postgres session

### DIFF
--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -18,10 +18,13 @@ from virtool.otus.db import (
     increment_otu_version,
     join,
     join_legacy_otu,
+    join_legacy_otu_in_session,
     otu_document_from_row,
     otu_row_values,
     sequence_document_from_row,
     sequence_row_values,
+    write_legacy_otu,
+    write_legacy_sequence,
 )
 from virtool.otus.models import OTUSegment
 from virtool.otus.oas import CreateOTURequest, UpdateOTURequest
@@ -742,3 +745,174 @@ class TestJoinLegacyOTU:
     async def test_returns_none_when_the_otu_has_no_row(self, pg: AsyncEngine):
         """A missing OTU is ``None``, as it is on the Mongo path."""
         assert await join_legacy_otu(pg, "6116cba1") is None
+
+
+class TestJoinLegacyOTUInSession:
+    """``join_legacy_otu_in_session`` joins through the caller's own session.
+
+    The OTU write path composes its history diff from the OTU as it stands before and
+    after its own writes, all inside one uncommitted transaction. A join that opened a
+    session of its own would see neither, so the diff would come out empty and the
+    change would be recorded as a no-op.
+    """
+
+    async def _create_otu(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ) -> tuple[str, str]:
+        """Create ``Prunus virus F`` with one isolate and one sequence.
+
+        Returns the OTU id and the sequence id.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        otu = await data_layer.otus.create(
+            reference.id,
+            CreateOTURequest(name="Prunus virus F", abbreviation="PVF"),
+            user.id,
+        )
+
+        isolate = await data_layer.otus.add_isolate(
+            otu.id,
+            "isolate",
+            "8816-v2",
+            user.id,
+        )
+
+        sequence = await data_layer.otus.create_sequence(
+            otu.id,
+            isolate.id,
+            "KX269872",
+            "Prunus virus F segment",
+            "TGTTTAAGAGATTAAACAACCGCTTTC",
+            user.id,
+            "sweet cherry",
+        )
+
+        return otu.id, sequence.id
+
+    async def test_matches_the_engine_join(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A committed OTU joins to the same document either entry point reads it."""
+        otu_id, _ = await self._create_otu(data_layer, fake)
+
+        async with AsyncSession(pg) as session:
+            assert await join_legacy_otu_in_session(session, otu_id) == (
+                await join_legacy_otu(pg, otu_id)
+            )
+
+    async def test_returns_none_when_the_otu_has_no_row(self, pg: AsyncEngine):
+        """A missing OTU is ``None``, as it is on the engine path."""
+        async with AsyncSession(pg) as session:
+            assert await join_legacy_otu_in_session(session, "6116cba1") is None
+
+    async def test_reads_an_uncommitted_write(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """An OTU written but not committed joins as it now stands.
+
+        The engine join is checked from outside the transaction in the same breath: it
+        must still read the committed name, or the test would pass on a session that
+        had quietly committed rather than on one that reads its own writes.
+        """
+        otu_id, _ = await self._create_otu(data_layer, fake)
+        document = await mongo.otus.find_one({"_id": otu_id})
+
+        async with AsyncSession(pg) as session:
+            await write_legacy_otu(
+                session,
+                {**document, "name": "Prunus virus G", "lower_name": "prunus virus g"},
+            )
+
+            assert (await join_legacy_otu_in_session(session, otu_id))["name"] == (
+                "Prunus virus G"
+            )
+            assert (await join_legacy_otu(pg, otu_id))["name"] == "Prunus virus F"
+
+    async def test_rejoins_an_otu_written_after_it_was_joined(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """Joining, writing and joining again reflects the write the second time.
+
+        This is the write path's diff-composing sequence. ``write_legacy_otu`` upserts
+        through Core DML, which does not synchronize the session's identity map, so a
+        rejoin that trusted the map would hand back the pre-write document and diff the
+        OTU against itself.
+
+        The row is deliberately held in ``row`` for the length of the transaction. The
+        identity map holds its rows weakly and the join keeps no reference to the ones it
+        loads, so without something holding it the stale row is collected before the
+        rejoin and the lookup falls through to a fresh ``SELECT`` -- passing for a reason
+        that has nothing to do with the behaviour under test. Holding it reproduces what
+        any caller that touched the row itself would do.
+        """
+        otu_id, _ = await self._create_otu(data_layer, fake)
+        document = await mongo.otus.find_one({"_id": otu_id})
+
+        async with AsyncSession(pg) as session:
+            before = await join_legacy_otu_in_session(session, otu_id)
+
+            row = await session.get(SQLOTU, otu_id)
+
+            await write_legacy_otu(
+                session,
+                {**document, "name": "Prunus virus G", "lower_name": "prunus virus g"},
+            )
+
+            assert row.data["name"] == "Prunus virus F"
+
+            after = await join_legacy_otu_in_session(session, otu_id)
+
+        assert before["name"] == "Prunus virus F"
+        assert after["name"] == "Prunus virus G"
+
+    async def test_rejoins_a_sequence_written_after_it_was_joined(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mongo: Mongo,
+        pg: AsyncEngine,
+    ):
+        """A sequence rewritten after the first join comes back rewritten.
+
+        The sequences are loaded by an ORM ``select`` rather than by primary key, and it
+        caches into the same identity map the OTU row does, so it needs its own
+        ``populate_existing``. Editing a sequence is the commonest OTU change there is,
+        so a stale sequence would empty out most diffs the write path takes.
+
+        The row is held for the same reason as in the OTU case above: the identity map
+        holds it weakly, and an unheld row is collected before the rejoin can read it
+        back stale.
+        """
+        otu_id, sequence_id = await self._create_otu(data_layer, fake)
+        document = await mongo.sequences.find_one({"_id": sequence_id})
+
+        async with AsyncSession(pg) as session:
+            before = await join_legacy_otu_in_session(session, otu_id)
+
+            row = await session.get(SQLSequence, sequence_id)
+
+            await write_legacy_sequence(session, {**document, "sequence": "ATGAAC"})
+
+            assert row.data["sequence"] == "TGTTTAAGAGATTAAACAACCGCTTTC"
+
+            after = await join_legacy_otu_in_session(session, otu_id)
+
+        assert before["isolates"][0]["sequences"][0]["sequence"] == (
+            "TGTTTAAGAGATTAAACAACCGCTTTC"
+        )
+        assert after["isolates"][0]["sequences"][0]["sequence"] == "ATGAAC"

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -368,11 +368,50 @@ def sequence_document_from_row(row: SQLSequence) -> Document:
 
 
 async def join_legacy_otu(pg: AsyncEngine, otu_id: str) -> Document | None:
-    """Reconstruct a joined OTU document from Postgres.
+    """Reconstruct a joined OTU document from Postgres in a session of its own.
 
     The Postgres counterpart of :func:`join`, and the read primitive OTU reads and
-    :func:`virtool.history.db.patch_to_version` are built on. Returns ``None`` for an
-    OTU that has no row, as :func:`join` does for one that has no document.
+    :func:`virtool.history.db.patch_to_version` are built on. Sees only committed rows,
+    which is what a read outside a write transaction wants.
+    :func:`join_legacy_otu_in_session` is the variant for a caller that has to see its
+    own uncommitted writes.
+    """
+    async with AsyncSession(pg) as session:
+        return await join_legacy_otu_in_session(session, otu_id)
+
+
+async def join_legacy_otu_in_session(
+    pg_session: AsyncSession,
+    otu_id: str,
+) -> Document | None:
+    """Reconstruct a joined OTU document from Postgres within ``pg_session``.
+
+    Reads through the caller's session, so an OTU written earlier in the caller's
+    transaction joins as it now stands rather than as it was last committed. The OTU
+    write path needs this: it composes a history diff from the OTU before and after its
+    own uncommitted writes. The session's lifecycle is left alone -- nothing here
+    commits, rolls back or closes it. Returns ``None`` for an OTU that has no row, as
+    :func:`join` does for one that has no document.
+
+    Both reads pass ``populate_existing`` so a row already in the session's identity map
+    is refreshed from the database rather than handed back as it was first loaded. The
+    write path upserts through Core DML (:func:`write_legacy_otu`), which does not
+    synchronize the identity map, so a caller that joins an OTU, writes it and joins it
+    again -- exactly the diff-composing sequence above -- can otherwise be handed its
+    pre-write ``data`` the second time and diff the OTU against itself. Autoflush does
+    not cover this: it pushes pending changes out, it does not invalidate what has
+    already been loaded.
+
+    Without ``populate_existing`` that second join is correct only by accident. The
+    identity map holds its rows weakly, and this function keeps no reference to the ones
+    it loads, so the stale row is usually collected before the rejoin and the lookup
+    falls through to a fresh ``SELECT``. Anything else in the transaction that still
+    holds the row -- a caller that read it itself, a lazy attribute, a debugger --
+    pins it in the map and the stale read comes back. Read correctness cannot rest on
+    garbage collection timing.
+
+    Erasing pending object state is the documented cost of ``populate_existing`` and
+    costs nothing here, because this domain's writes mutate no mapped objects.
 
     Both documents are recovered from the verbatim ``data`` JSONB column, via
     :func:`otu_document_from_row` and :func:`sequence_document_from_row`, rather than
@@ -394,22 +433,22 @@ async def join_legacy_otu(pg: AsyncEngine, otu_id: str) -> Document | None:
     would misapply every diff that addresses them by index -- the failure ``position``
     exists to prevent.
     """
-    async with AsyncSession(pg) as session:
-        otu_row = await session.get(SQLOTU, otu_id)
+    otu_row = await pg_session.get(SQLOTU, otu_id, populate_existing=True)
 
-        if otu_row is None:
-            return None
+    if otu_row is None:
+        return None
 
-        sequence_rows = await session.scalars(
-            select(SQLSequence)
-            .where(SQLSequence.otu_id == otu_id)
-            .order_by(SQLSequence.position),
-        )
+    sequence_rows = await pg_session.scalars(
+        select(SQLSequence)
+        .where(SQLSequence.otu_id == otu_id)
+        .order_by(SQLSequence.position)
+        .execution_options(populate_existing=True),
+    )
 
-        return virtool.otus.utils.merge_otu(
-            otu_document_from_row(otu_row),
-            [sequence_document_from_row(row) for row in sequence_rows],
-        )
+    return virtool.otus.utils.merge_otu(
+        otu_document_from_row(otu_row),
+        [sequence_document_from_row(row) for row in sequence_rows],
+    )
 
 
 def compose_isolate_match(isolate_id: str):


### PR DESCRIPTION
## Summary

- Split `join_legacy_otu` into a thin engine entry point and `join_legacy_otu_in_session`, which reads through a caller-supplied session so an OTU written earlier in the same transaction joins as it now stands. The OTU write path needs this to compose history diffs from its own uncommitted writes.
- Both reads pass `populate_existing`. The write path upserts through Core DML, which doesn't synchronize the session's identity map, so a rejoin after a write could otherwise be handed the pre-write document and diff the OTU against itself.
- No caller changes: the engine entry point keeps its signature, and nothing calls the session variant until the read cutover in VIR-2758.