### PR TITLE
feat: add postgres-native otu version bump and verification

### DIFF
--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -15,6 +15,7 @@ from virtool.otus.db import (
     check_sequence_segment,
     find,
     get_legacy_otu_fields,
+    increment_legacy_otu_version,
     increment_otu_version,
     join,
     join_legacy_otu,
@@ -23,6 +24,9 @@ from virtool.otus.db import (
     otu_row_values,
     sequence_document_from_row,
     sequence_row_values,
+    update_legacy_otu_verification,
+    update_legacy_sequence_segments,
+    update_sequence_segments,
     write_legacy_otu,
     write_legacy_sequence,
 )
@@ -916,3 +920,386 @@ class TestJoinLegacyOTUInSession:
             "TGTTTAAGAGATTAAACAACCGCTTTC"
         )
         assert after["isolates"][0]["sequences"][0]["sequence"] == "ATGAAC"
+
+
+class TestIncrementLegacyOTUVersion:
+    """``increment_legacy_otu_version`` bumps an OTU's version and unverifies it.
+
+    ``version`` and ``verified`` are each held twice -- once in a promoted column and
+    once in the ``data`` JSONB the document is recovered from. A bump that moved one
+    without the other would leave the OTU reading differently depending on which the
+    caller looked at, so both are asserted every time.
+    """
+
+    async def _insert(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        test_otu: Document,
+        **overrides,
+    ) -> str:
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        await insert_otu({**test_otu, **overrides}, reference.id)
+
+        return test_otu["_id"]
+
+    async def test_bumps_version_and_clears_verified(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+    ):
+        """The column and its ``data`` counterpart move together."""
+        otu_id = await self._insert(
+            fake,
+            insert_otu,
+            test_otu,
+            version=3,
+            verified=True,
+        )
+
+        async with AsyncSession(pg) as session:
+            await increment_legacy_otu_version(session, otu_id)
+            await session.commit()
+
+            row = await session.get(SQLOTU, otu_id, populate_existing=True)
+
+        assert (row.version, row.verified) == (4, False)
+        assert (row.data["version"], row.data["verified"]) == (4, False)
+
+    async def test_returns_the_updated_document(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        test_otu: Document,
+    ):
+        """The document returned is the OTU as it now stands, as Mongo's helper's is.
+
+        The write path passes it straight to ``join`` as the OTU half of the joined
+        document, so it has to be the whole OTU document at its new version rather
+        than the fields the bump touched.
+        """
+        otu_id = await self._insert(
+            fake,
+            insert_otu,
+            test_otu,
+            version=3,
+            verified=True,
+        )
+
+        async with AsyncSession(pg) as session:
+            document = await increment_legacy_otu_version(session, otu_id)
+            await session.commit()
+
+            row = await session.get(SQLOTU, otu_id, populate_existing=True)
+
+        assert document["version"] == 4
+        assert document["verified"] is False
+        assert document == otu_document_from_row(row)
+
+    async def test_decodes_created_at(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_imported_otu: Document,
+    ):
+        """An imported OTU's ``created_at`` comes back as a datetime, not a string.
+
+        The bump reads ``data`` straight out of Postgres rather than through a mapped
+        row, so it has to decode the column itself.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        await insert_otu(test_imported_otu, reference.id)
+
+        async with AsyncSession(pg) as session:
+            document = await increment_legacy_otu_version(
+                session,
+                test_imported_otu["_id"],
+            )
+            await session.commit()
+
+        assert document["created_at"] == IMPORTED_CREATED_AT.replace(microsecond=123000)
+
+    async def test_leaves_other_fields_alone(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+    ):
+        """Only ``version`` and ``verified`` change; the rest of ``data`` is untouched."""
+        otu_id = await self._insert(fake, insert_otu, test_otu)
+
+        before = await join_legacy_otu(pg, otu_id)
+
+        async with AsyncSession(pg) as session:
+            await increment_legacy_otu_version(session, otu_id)
+            await session.commit()
+
+        after = await join_legacy_otu(pg, otu_id)
+
+        assert {**after, "version": 0, "verified": False} == before
+
+    async def test_missing_otu(self, pg: AsyncEngine):
+        """An OTU with no row has no version to bump."""
+        async with AsyncSession(pg) as session:
+            assert await increment_legacy_otu_version(session, "6116cba1") is None
+
+
+class TestUpdateLegacyOTUVerification:
+    """``update_legacy_otu_verification`` verifies an OTU that ``verify`` passes."""
+
+    async def _insert(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        test_otu: Document,
+        test_sequence: Document,
+        *,
+        with_sequence: bool,
+    ) -> str:
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        await insert_otu(
+            test_otu,
+            reference.id,
+            [test_sequence] if with_sequence else None,
+        )
+
+        return test_otu["_id"]
+
+    async def test_verifies_otu_without_issues(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """``verified`` is set in the column and in ``data``, and ``None`` returned."""
+        otu_id = await self._insert(
+            fake,
+            insert_otu,
+            test_otu,
+            test_sequence,
+            with_sequence=True,
+        )
+
+        joined = await join_legacy_otu(pg, otu_id)
+
+        async with AsyncSession(pg) as session:
+            assert await update_legacy_otu_verification(session, joined) is None
+            await session.commit()
+
+            row = await session.get(SQLOTU, otu_id, populate_existing=True)
+
+        assert row.verified is True
+        assert row.data["verified"] is True
+
+    async def test_mutates_the_joined_otu(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """The caller's copy agrees with the row it just wrote.
+
+        The OTU write path composes its history diff from the joined OTU it passed in,
+        so a copy left saying ``verified: False`` would diff against a row that says
+        otherwise.
+        """
+        otu_id = await self._insert(
+            fake,
+            insert_otu,
+            test_otu,
+            test_sequence,
+            with_sequence=True,
+        )
+
+        joined = await join_legacy_otu(pg, otu_id)
+
+        assert joined["verified"] is False
+
+        async with AsyncSession(pg) as session:
+            await update_legacy_otu_verification(session, joined)
+            await session.commit()
+
+        assert joined["verified"] is True
+
+    async def test_leaves_otu_with_issues_unverified(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """An OTU whose isolate has no sequences is returned its issues and not written."""
+        otu_id = await self._insert(
+            fake,
+            insert_otu,
+            test_otu,
+            test_sequence,
+            with_sequence=False,
+        )
+
+        joined = await join_legacy_otu(pg, otu_id)
+
+        async with AsyncSession(pg) as session:
+            issues = await update_legacy_otu_verification(session, joined)
+            await session.commit()
+
+            row = await session.get(SQLOTU, otu_id, populate_existing=True)
+
+        assert issues["empty_isolate"] == ["cab8b360"]
+        assert joined["verified"] is False
+        assert row.verified is False
+        assert row.data["verified"] is False
+
+
+class TestUpdateLegacySequenceSegments:
+    """``update_legacy_sequence_segments`` unsets segments dropped from an OTU's schema.
+
+    The segment has to be *removed* from ``data`` rather than nulled. ``data`` is a lift
+    of the Mongo document and Mongo's ``$unset`` removes the field, so a lingering
+    ``segment: null`` would make the joined OTU -- and every ``dictdiffer`` patch taken
+    against it -- disagree with the Mongo path.
+    """
+
+    async def _insert(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        test_otu: Document,
+        test_sequence: Document,
+        segment: str,
+    ) -> None:
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        await insert_otu(
+            {**test_otu, "schema": [{"name": "RNA1"}, {"name": "RNA2"}]},
+            reference.id,
+            [{**test_sequence, "segment": segment}],
+        )
+
+    async def _drop_rna2(
+        self,
+        pg: AsyncEngine,
+        otu_id: str,
+    ) -> None:
+        old = await join_legacy_otu(pg, otu_id)
+        new = {**old, "schema": [{"name": "RNA1"}]}
+
+        async with AsyncSession(pg) as session:
+            await update_legacy_sequence_segments(session, old, new)
+            await session.commit()
+
+    async def test_removes_the_segment_key(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """The column goes null and the key leaves ``data`` entirely."""
+        await self._insert(fake, insert_otu, test_otu, test_sequence, "RNA2")
+
+        await self._drop_rna2(pg, test_otu["_id"])
+
+        async with AsyncSession(pg) as session:
+            row = await session.get(
+                SQLSequence,
+                test_sequence["_id"],
+                populate_existing=True,
+            )
+
+        assert row.segment is None
+        assert "segment" not in row.data
+
+    async def test_matches_the_mongo_unset(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        mongo: Mongo,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """The joined OTU is the one the Mongo helper's ``$unset`` leaves behind."""
+        await self._insert(fake, insert_otu, test_otu, test_sequence, "RNA2")
+
+        old = await join(mongo, test_otu["_id"])
+        new = {**old, "schema": [{"name": "RNA1"}]}
+
+        await update_sequence_segments(mongo, old, new)
+        await self._drop_rna2(pg, test_otu["_id"])
+
+        assert await join_legacy_otu(pg, test_otu["_id"]) == await join(
+            mongo,
+            test_otu["_id"],
+        )
+
+    async def test_keeps_a_retained_segment(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """A sequence naming a segment the schema still defines is left alone."""
+        await self._insert(fake, insert_otu, test_otu, test_sequence, "RNA1")
+
+        await self._drop_rna2(pg, test_otu["_id"])
+
+        async with AsyncSession(pg) as session:
+            row = await session.get(
+                SQLSequence,
+                test_sequence["_id"],
+                populate_existing=True,
+            )
+
+        assert row.segment == "RNA1"
+        assert row.data["segment"] == "RNA1"
+
+    async def test_otu_gaining_its_first_schema(
+        self,
+        fake: DataFaker,
+        insert_otu,
+        pg: AsyncEngine,
+        test_otu: Document,
+        test_sequence: Document,
+    ):
+        """An OTU with no ``schema`` before the edit has no segment names to drop."""
+        await self._insert(fake, insert_otu, test_otu, test_sequence, "RNA2")
+
+        old = await join_legacy_otu(pg, test_otu["_id"])
+
+        async with AsyncSession(pg) as session:
+            await update_legacy_sequence_segments(
+                session,
+                {key: value for key, value in old.items() if key != "schema"},
+                {**old, "schema": [{"name": "RNA1"}]},
+            )
+            await session.commit()
+
+            row = await session.get(
+                SQLSequence,
+                test_sequence["_id"],
+                populate_existing=True,
+            )
+
+        assert row.segment == "RNA2"

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -8,12 +8,10 @@ from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from sqlalchemy import (
-    String,
     delete,
     distinct,
     false,
     func,
-    literal,
     or_,
     select,
     true,
@@ -1009,20 +1007,20 @@ async def increment_legacy_otu_version(
     serializes the whole edit around this; the single statement means the increment
     itself does not depend on them having taken it.
     """
-    values = func.jsonb_build_object(
-        literal("version", String),
-        SQLOTU.version + 1,
-        literal("verified", String),
-        false(),
-    )
-
     data = await pg_session.scalar(
         update(SQLOTU)
         .where(SQLOTU.id == otu_id)
         .values(
             version=SQLOTU.version + 1,
             verified=False,
-            data=SQLOTU.data.concat(values),
+            data=SQLOTU.data.concat(
+                func.jsonb_build_object(
+                    "version",
+                    SQLOTU.version + 1,
+                    "verified",
+                    false(),
+                ),
+            ),
         )
         .returning(SQLOTU.data),
     )
@@ -1060,7 +1058,7 @@ async def update_legacy_otu_verification(
         .values(
             verified=True,
             data=SQLOTU.data.concat(
-                func.jsonb_build_object(literal("verified", String), true()),
+                func.jsonb_build_object("verified", true()),
             ),
         ),
     )
@@ -1109,7 +1107,7 @@ async def update_legacy_sequence_segments(
         )
         .values(
             segment=None,
-            data=SQLSequence.data.op("-")(literal("segment", String)),
+            data=SQLSequence.data.op("-")("segment"),
         ),
     )
 

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -7,7 +7,18 @@ from datetime import datetime
 from typing import Any
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import delete, distinct, func, or_, select
+from sqlalchemy import (
+    String,
+    delete,
+    distinct,
+    false,
+    func,
+    literal,
+    or_,
+    select,
+    true,
+    update,
+)
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -338,22 +349,25 @@ def _encode_otu_data(document: Document) -> Document:
     }
 
 
-def otu_document_from_row(row: SQLOTU) -> Document:
-    """Recover the Mongo OTU document a ``legacy_otus`` row was written from.
+def otu_document_from_data(data: Document) -> Document:
+    """Recover the Mongo OTU document a ``legacy_otus.data`` value was written from.
 
     The inverse of :func:`_encode_otu_data`. A JSONB column cannot hold a datetime, so
     ``created_at`` comes back out as the ISO string it was stored as and is parsed back
     to the naive datetime the rest of the codebase expects. OTUs created through the API
     carry no ``created_at`` at all, so its absence is normal rather than an error.
     """
-    document = row.data
-
-    created_at = document.get("created_at")
+    created_at = data.get("created_at")
 
     if created_at is None:
-        return document
+        return data
 
-    return {**document, "created_at": isoformat_to_datetime(created_at)}
+    return {**data, "created_at": isoformat_to_datetime(created_at)}
+
+
+def otu_document_from_row(row: SQLOTU) -> Document:
+    """Recover the Mongo OTU document a ``legacy_otus`` row was written from."""
+    return otu_document_from_data(row.data)
 
 
 def sequence_document_from_row(row: SQLSequence) -> Document:
@@ -970,6 +984,132 @@ async def write_legacy_sequence(pg_session: AsyncSession, document: Document) ->
         .on_conflict_do_update(
             index_elements=["id"],
             set_={key: value for key, value in values.items() if key != "id"},
+        ),
+    )
+
+
+async def increment_legacy_otu_version(
+    pg_session: AsyncSession,
+    otu_id: str,
+) -> Document | None:
+    """Bump an OTU's ``version`` and clear its ``verified`` flag within ``pg_session``.
+
+    The Postgres counterpart of :func:`increment_otu_version`, and like it returns the
+    OTU document as it now stands, or ``None`` for an OTU that has no row.
+
+    Both fields live twice: once in a promoted column and once in the ``data`` JSONB the
+    document is recovered from. They are written in the same statement, so no reader can
+    observe the column disagreeing with its counterpart. The new ``version`` is derived
+    from the column rather than from ``data``, because the column is what
+    :func:`virtool.otus.migration.reconcile_otus_and_sequences` compares against Mongo.
+
+    The bump is one statement, so ``version + 1`` is computed by Postgres from the row it
+    is writing and two concurrent bumps cannot both read the same version and write the
+    same successor. Callers hold the OTU's :func:`lock_legacy_otu` row lock, which
+    serializes the whole edit around this; the single statement means the increment
+    itself does not depend on them having taken it.
+    """
+    values = func.jsonb_build_object(
+        literal("version", String),
+        SQLOTU.version + 1,
+        literal("verified", String),
+        false(),
+    )
+
+    data = await pg_session.scalar(
+        update(SQLOTU)
+        .where(SQLOTU.id == otu_id)
+        .values(
+            version=SQLOTU.version + 1,
+            verified=False,
+            data=SQLOTU.data.concat(values),
+        )
+        .returning(SQLOTU.data),
+    )
+
+    if data is None:
+        return None
+
+    return otu_document_from_data(data)
+
+
+async def update_legacy_otu_verification(
+    pg_session: AsyncSession,
+    joined: Document,
+) -> Document | None:
+    """Mark a ``joined`` OTU verified in Postgres if it has no issues.
+
+    The Postgres counterpart of :func:`update_otu_verification`. Returns the issues
+    :func:`virtool.otus.utils.verify` found, or ``None`` if it found none, and mirrors
+    the Mongo helper in mutating ``joined`` so the caller's copy agrees with the row.
+
+    ``verified`` is written to the promoted column and to its ``data`` counterpart in the
+    same statement, as :func:`increment_legacy_otu_version` writes them.
+
+    Nothing is written for an OTU that has issues. It was already left unverified by the
+    version bump that preceded this call.
+    """
+    issues = virtool.otus.utils.verify(joined)
+
+    if issues is not None:
+        return issues
+
+    await pg_session.execute(
+        update(SQLOTU)
+        .where(SQLOTU.id == joined["_id"])
+        .values(
+            verified=True,
+            data=SQLOTU.data.concat(
+                func.jsonb_build_object(literal("verified", String), true()),
+            ),
+        ),
+    )
+
+    joined["verified"] = True
+
+    return None
+
+
+async def update_legacy_sequence_segments(
+    pg_session: AsyncSession,
+    old: Document | None,
+    new: Document | None,
+) -> None:
+    """Unset ``segment`` on sequences naming a segment ``new`` no longer defines.
+
+    The Postgres counterpart of :func:`update_sequence_segments`, taking the same joined
+    OTU before and after an edit. An OTU that gained a schema for the first time has no
+    ``old`` names to drop, so it is left alone, matching the Mongo helper's ``"schema"
+    not in old`` guard.
+
+    The segment is *removed* from ``data`` with the JSONB ``-`` operator rather than set
+    to null, because Mongo's ``$unset`` removes the field and ``data`` must stay a
+    faithful lift of the document. The two are not interchangeable: a joined OTU feeds
+    ``dictdiffer`` diffs, so a lingering ``"segment": null`` would diff as a changed
+    field where the Mongo path diffs a removed one, and every patch built on it would
+    disagree. The promoted column has no such distinction to preserve and simply goes
+    null, which is what an absent ``segment`` renders as in
+    :func:`sequence_row_values`.
+    """
+    if old is None or new is None or "schema" not in old:
+        return
+
+    dropped = {segment["name"] for segment in old["schema"]} - {
+        segment["name"] for segment in new["schema"]
+    }
+
+    if not dropped:
+        return
+
+    await pg_session.execute(
+        update(SQLSequence)
+        .where(
+            SQLSequence.otu_id == old["_id"],
+            SQLSequence.segment.in_(dropped),
+        )
+        .values(
+            segment=None,
+            data=SQLSequence.data.op("-")(literal("segment", String)),
         ),
     )
 


### PR DESCRIPTION
## Summary
- Add Postgres counterparts for the OTU write path's Mongo helpers: `increment_legacy_otu_version`, `update_legacy_otu_verification` and `update_legacy_sequence_segments`, each keeping a promoted column and its `data` JSONB counterpart in sync in one statement.
- Match Mongo's `$unset` semantics for dropped segments by removing the key from `data` rather than nulling it, so joined OTUs and the `dictdiffer` diffs taken against them stay identical across both stores.
- Nothing is wired into the write path yet; that cutover is VIR-2758, which this blocks.