### PR TITLE
fix: stop pathoscope analyses from slowing other requests

### DIFF
--- a/tests/analyses/test_format.py
+++ b/tests/analyses/test_format.py
@@ -4,14 +4,20 @@ import io
 import openpyxl
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncEngine
 from syrupy import SnapshotAssertion
 
 import virtool.analyses
 from virtool.analyses.format import (
     CSV_HEADERS,
     format_nuvs,
+    format_pathoscope,
     transform_coverage_to_coordinates,
 )
+from virtool.data.layer import DataLayer
+from virtool.fake.next import DataFaker
+from virtool.otus.oas import CreateOTURequest
 
 
 @pytest.mark.parametrize(
@@ -204,6 +210,146 @@ class TestFormatAnalysis:
         assert formatted == {"is_nuvs": False, "is_pathoscope": True}
         m_format_pathoscope.assert_called_with(pg, results=results)
         assert not m_format_nuvs.called
+
+
+class TestFormatPathoscope:
+    """``format_pathoscope`` patches every detected OTU to the version the analysis saw.
+
+    The OTUs are read in one batch, on the same collect-then-load shape ``format_nuvs``
+    uses. Reading them per detected OTU instead -- a handful of queries and a pool
+    connection each -- is what let a result with a few hundred hits saturate the pool and
+    the event loop, slowing every request the server was handling concurrently.
+    """
+
+    async def _create_otus(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        count: int,
+    ) -> list[str]:
+        """Create ``count`` OTUs, each an isolate carrying two sequences.
+
+        Each OTU reaches version 3: created, given an isolate, then given
+        ``sequence_{index}_a`` and ``sequence_{index}_b`` in turn. An analysis that
+        detected one at version 2 therefore has a change to unwind, which is what makes
+        the history and diff reads run.
+
+        Returns the OTU ids.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        otu_ids = []
+
+        for index in range(count):
+            otu = await data_layer.otus.create(
+                reference.id,
+                CreateOTURequest(name=f"Virus {index}", abbreviation=f"V{index}"),
+                user.id,
+            )
+
+            isolate = await data_layer.otus.add_isolate(
+                otu.id,
+                "isolate",
+                "8816-v2",
+                user.id,
+            )
+
+            for suffix in ("a", "b"):
+                await data_layer.otus.create_sequence(
+                    otu.id,
+                    isolate.id,
+                    f"KX2698{index}{suffix}",
+                    f"Virus {index} segment {suffix}",
+                    "TGTTTAAGAGATTAAACAACCGCTTTC",
+                    user.id,
+                    sequence_id=f"sequence_{index}_{suffix}",
+                )
+
+            otu_ids.append(otu.id)
+
+        return otu_ids
+
+    def _compose_results(self, otu_ids: list[str]) -> dict:
+        """Compose a pathoscope result detecting every OTU at version 2."""
+        return {
+            "hits": [
+                {
+                    "id": f"sequence_{index}_a",
+                    "otu": {"id": otu_id, "version": 2},
+                    "align": [1, 2, 3],
+                    "coverage": 0.5,
+                    "final": {"pi": 0.5, "best": 2, "reads": 3},
+                }
+                for index, otu_id in enumerate(otu_ids)
+            ],
+        }
+
+    async def test_formats_every_detected_otu(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """Each hit is formatted against its own OTU, patched back to version 2."""
+        otu_ids = await self._create_otus(data_layer, fake, 3)
+
+        formatted = await format_pathoscope(pg, results=self._compose_results(otu_ids))
+
+        assert [hit["name"] for hit in formatted["hits"]] == [
+            "Virus 0",
+            "Virus 1",
+            "Virus 2",
+        ]
+
+        for index, hit in enumerate(formatted["hits"]):
+            assert hit["id"] == otu_ids[index]
+            assert hit["version"] == 2
+
+            sequences = [
+                sequence
+                for isolate in hit["isolates"]
+                for sequence in isolate["sequences"]
+            ]
+
+            # Only the sequence the OTU carried at version 2, and it took the hit's
+            # weighting rather than another OTU's.
+            assert [sequence["id"] for sequence in sequences] == [f"sequence_{index}_a"]
+            assert [sequence["pi"] for sequence in sequences] == [0.5]
+
+    async def test_reads_do_not_scale_with_detected_otus(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """Detecting more OTUs costs no more queries.
+
+        The number itself is not the contract and is free to change -- that it does not
+        grow with the number of detected OTUs is.
+        """
+        otu_ids = await self._create_otus(data_layer, fake, 6)
+
+        counts = []
+
+        for count in (2, 6):
+            results = self._compose_results(otu_ids[:count])
+
+            statements = []
+
+            def record(conn, cursor, statement, parameters, context, executemany):
+                statements.append(statement)
+
+            event.listen(pg.sync_engine, "before_cursor_execute", record)
+
+            try:
+                await format_pathoscope(pg, results=results)
+            finally:
+                event.remove(pg.sync_engine, "before_cursor_execute", record)
+
+            counts.append(len(statements))
+
+        assert counts[0] == counts[1]
 
 
 class TestFormatNuvs:

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -6,9 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
 import virtool.history.db
+from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
 from virtool.models.enums import HistoryMethod
+from virtool.otus.oas import CreateOTURequest
 from virtool.pg.utils import get_row_by_id
 from virtool.references.sql import SQLReference
 from virtool.workflow.pytest_plugin.utils import StaticTime
@@ -407,6 +409,93 @@ async def test_patch_to_version_intermediate(
 
     assert current == snapshot(name="current")
     assert patched == snapshot(name="patched")
+
+
+class TestPatchOTUsToVersions:
+    """``patch_otus_to_versions`` patches a whole set of OTUs in one batched read.
+
+    It is where the patching lives -- :func:`patch_to_version` is a single-OTU face on
+    it -- so a specifier patched alongside others has to resolve to exactly what it
+    resolves to alone.
+    """
+
+    @pytest.mark.parametrize("remove", [True, False])
+    async def test_same_otu_at_two_versions(
+        self,
+        remove: bool,
+        create_mock_history,
+        pg: AsyncEngine,
+    ):
+        """An OTU patched to two versions at once resolves as each version does alone.
+
+        The history for the set is read only as far back as the lowest version any of
+        its OTUs is being patched to, so the specifier bound for the higher version is
+        handed rows reaching past its own target that it must not revert.
+        """
+        await create_mock_history(remove=remove)
+
+        specifiers = [("6116cba1", 1), ("6116cba1", 2)]
+
+        patched_otus = await virtool.history.db.patch_otus_to_versions(pg, specifiers)
+
+        assert len(patched_otus) == 2
+
+        for specifier in specifiers:
+            assert patched_otus[specifier] == await virtool.history.db.patch_to_version(
+                pg,
+                *specifier,
+            )
+
+    async def test_patches_each_otu_from_its_own_history(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """Every OTU is patched from its own changes, not another OTU's.
+
+        The whole set's history comes back from one query, so the rows have to be
+        bucketed by OTU here rather than by the ``WHERE`` clause.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        otu_ids = []
+
+        for name, abbreviation in (
+            ("Prunus virus F", "PVF"),
+            ("Cherry virus A", "CVA"),
+        ):
+            otu = await data_layer.otus.create(
+                reference.id,
+                CreateOTURequest(name=name, abbreviation=abbreviation),
+                user.id,
+            )
+
+            await data_layer.otus.add_isolate(otu.id, "isolate", "8816-v2", user.id)
+
+            otu_ids.append(otu.id)
+
+        specifiers = [(otu_id, 0) for otu_id in otu_ids]
+
+        patched_otus = await virtool.history.db.patch_otus_to_versions(pg, specifiers)
+
+        for specifier in specifiers:
+            assert patched_otus[specifier] == await virtool.history.db.patch_to_version(
+                pg,
+                *specifier,
+            )
+
+        # The isolate each OTU gained at version 1 is unwound, and neither OTU comes
+        # back as the other.
+        assert [
+            (patched_otus[specifier][1]["name"], patched_otus[specifier][1]["isolates"])
+            for specifier in specifiers
+        ] == [("Prunus virus F", []), ("Cherry virus A", [])]
+
+    async def test_no_specifiers(self, pg: AsyncEngine):
+        """Asking for no OTUs is empty rather than an error or every OTU."""
+        assert await virtool.history.db.patch_otus_to_versions(pg, []) == {}
 
 
 async def test_patch_to_version_missing_diff(

--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -19,6 +19,7 @@ from virtool.otus.db import (
     join,
     join_legacy_otu,
     join_legacy_otu_in_session,
+    join_legacy_otus,
     otu_document_from_row,
     otu_row_values,
     sequence_document_from_row,
@@ -745,6 +746,104 @@ class TestJoinLegacyOTU:
     async def test_returns_none_when_the_otu_has_no_row(self, pg: AsyncEngine):
         """A missing OTU is ``None``, as it is on the Mongo path."""
         assert await join_legacy_otu(pg, "6116cba1") is None
+
+
+class TestJoinLegacyOTUs:
+    """``join_legacy_otus`` joins a whole set of OTUs in two queries.
+
+    It is the read every OTU join resolves to, so a batch has to hand back exactly what
+    joining each OTU on its own does. The sequences of every OTU come back from one
+    query and are bucketed by ``otu_id`` here rather than by the ``WHERE`` clause, which
+    is the part a batch can get wrong and the single-OTU read cannot.
+    """
+
+    async def _create_otus(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ) -> list[str]:
+        """Create two OTUs whose sequences are written interleaved across both.
+
+        Interleaved because OTUs filled one after the other would join correctly even if
+        their sequences were bucketed by the wrong key, or left in the order one query
+        happened to return them in.
+
+        Returns the two OTU ids.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        otu_ids = []
+        isolate_ids = []
+
+        for name, abbreviation in (
+            ("Prunus virus F", "PVF"),
+            ("Cherry virus A", "CVA"),
+        ):
+            otu = await data_layer.otus.create(
+                reference.id,
+                CreateOTURequest(name=name, abbreviation=abbreviation),
+                user.id,
+            )
+
+            isolate = await data_layer.otus.add_isolate(
+                otu.id,
+                "isolate",
+                "8816-v2",
+                user.id,
+            )
+
+            otu_ids.append(otu.id)
+            isolate_ids.append(isolate.id)
+
+        for index in range(4):
+            otu_index = index % 2
+
+            await data_layer.otus.create_sequence(
+                otu_ids[otu_index],
+                isolate_ids[otu_index],
+                f"KX26987{index}",
+                f"Prunus virus F segment {index}",
+                "TGTTTAAGAGATTAAACAACCGCTTTC",
+                user.id,
+                "sweet cherry",
+            )
+
+        return otu_ids
+
+    async def test_equals_single_joins(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """Every OTU joins as it does on its own, sequences and their order included."""
+        otu_ids = await self._create_otus(data_layer, fake)
+
+        assert await join_legacy_otus(pg, otu_ids) == {
+            otu_id: await join_legacy_otu(pg, otu_id) for otu_id in otu_ids
+        }
+
+    async def test_omits_otu_with_no_row(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """A missing OTU is absent from the mapping rather than mapped to ``None``.
+
+        The rest of the batch still joins, so one bad id cannot cost a caller the OTUs
+        it asked for alongside it.
+        """
+        otu_ids = await self._create_otus(data_layer, fake)
+
+        joined = await join_legacy_otus(pg, [*otu_ids, "6116cba1"])
+
+        assert sorted(joined) == sorted(otu_ids)
+
+    async def test_no_otu_ids(self, pg: AsyncEngine):
+        """Asking for no OTUs is empty rather than an error or every OTU."""
+        assert await join_legacy_otus(pg, []) == {}
 
 
 class TestJoinLegacyOTUInSession:

--- a/virtool/analyses/format.py
+++ b/virtool/analyses/format.py
@@ -7,7 +7,6 @@ downloads.
 import csv
 import io
 import statistics
-from asyncio import gather
 from collections import defaultdict
 from typing import Any
 
@@ -17,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from virtool.data.topg import compose_legacy_id_multi_expression
-from virtool.history.db import patch_to_version
+from virtool.history.db import patch_otus_to_versions
 from virtool.hmm.sql import SQLHMM
 from virtool.models.enums import AnalysisWorkflow
 from virtool.otus.utils import format_isolate_name
@@ -54,6 +53,12 @@ async def format_pathoscope(
 
     Calculate metrics for different organizational levels: OTU, isolate, and sequence.
 
+    Every detected OTU is patched to the version the analysis saw in one batched read,
+    on the same collect-then-load shape :func:`format_nuvs` uses for its annotations.
+    Reading each OTU as its hits were formatted instead -- a ``patch_to_version`` per
+    OTU, fanned out with a ``gather`` -- issued a query and took a pool connection per
+    detected OTU, which is enough to saturate both for a result with a few hundred hits.
+
     :param pg: the application PostgreSQL database object
     :param results: the results to format
     :return: the formatted results
@@ -67,27 +72,24 @@ async def format_pathoscope(
 
         hits_by_otu[(otu_id, otu_version)].append(hit)
 
-    coros = []
+    patched_otus = await patch_otus_to_versions(pg, hits_by_otu.keys())
+
+    formatted_hits = []
 
     for otu_specifier, hits in hits_by_otu.items():
-        otu_id, otu_version = otu_specifier
-        coros.append(format_pathoscope_hits(pg, otu_id, otu_version, hits))
+        otu_id, _ = otu_specifier
+        _, patched_otu = patched_otus[otu_specifier]
 
-    return {**results, "hits": await gather(*coros)}
+        formatted_hits.append(format_pathoscope_hits(otu_id, patched_otu, hits))
+
+    return {**results, "hits": formatted_hits}
 
 
-async def format_pathoscope_hits(
-    pg: AsyncEngine,
+def format_pathoscope_hits(
     otu_id: str,
-    otu_version,
+    patched_otu: dict[str, Any],
     hits: list[dict],
 ):
-    _, patched_otu = await patch_to_version(
-        pg,
-        otu_id,
-        otu_version,
-    )
-
     max_sequence_length = 0
 
     for isolate in patched_otu["isolates"]:

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -717,7 +717,7 @@ async def _resolve_diffs(pg: AsyncEngine, changes: list[Document]) -> dict[str, 
 async def patch_to_version(
     pg: AsyncEngine,
     otu_id: str,
-    version: str | int,
+    version: int,
 ) -> tuple:
     """Take a joined otu back in time to the passed ``version``.
 
@@ -740,14 +740,19 @@ async def patch_to_version(
 
 async def patch_otus_to_versions(
     pg: AsyncEngine,
-    specifiers: Collection[tuple[str, str | int]],
-) -> dict[tuple[str, str | int], tuple[Document | None, Document | None]]:
+    specifiers: Collection[tuple[str, int]],
+) -> dict[tuple[str, int], tuple[Document | None, Document | None]]:
     """Take each of the joined otus identified by ``specifiers`` back to its version.
 
     The batched counterpart of :func:`patch_to_version`, and where the patching itself
     lives. Each specifier is an ``(otu_id, version)`` pair, and each maps to the
-    ``(current, patched)`` pair that :func:`patch_to_version` returns for it. The same
-    OTU may appear under more than one version.
+    ``(current, patched)`` pair that :func:`patch_to_version` returns for it. Every
+    specifier is present in the returned mapping. The same OTU may appear under more
+    than one version.
+
+    A target ``version`` is an OTU ``version``, which is an integer -- never the
+    ``"removed"`` sentinel an :class:`SQLLegacyHistory` row's ``otu_version`` can carry.
+    It is compared against other targets and bound into the history predicate as one.
 
     The whole set is resolved in a fixed handful of queries -- two to join the OTUs, one
     for the history, one for the diffs -- rather than four or so per OTU. The per-OTU
@@ -771,11 +776,11 @@ async def patch_otus_to_versions(
     )
 
     patched_otus: dict[
-        tuple[str, str | int],
+        tuple[str, int],
         tuple[Document | None, Document | None],
     ] = {}
 
-    to_patch: dict[tuple[str, str | int], Document] = {}
+    to_patch: dict[tuple[str, int], Document] = {}
 
     for specifier in specifiers:
         otu_id, version = specifier
@@ -814,7 +819,7 @@ async def patch_otus_to_versions(
 
 async def _read_history_to_revert(
     pg: AsyncEngine,
-    specifiers: Collection[tuple[str, str | int]],
+    specifiers: Collection[tuple[str, int]],
 ) -> dict[str, list[SQLLegacyHistory]]:
     """Read the history rows that patching ``specifiers`` could have to revert.
 
@@ -829,7 +834,7 @@ async def _read_history_to_revert(
     ``"removed"`` sentinel and sorts above every numbered version, and the rest sort
     below it in order -- so nothing that is dropped could have been reverted.
     """
-    lowest_versions: dict[str, str | int] = {}
+    lowest_versions: dict[str, int] = {}
 
     for otu_id, version in specifiers:
         if otu_id not in lowest_versions or version < lowest_versions[otu_id]:
@@ -869,7 +874,7 @@ async def _read_history_to_revert(
 
 def _changes_to_revert(
     history_rows: list[SQLLegacyHistory],
-    version: str | int,
+    version: int,
 ) -> list[Document]:
     """Select the changes to revert to take an otu back to ``version``.
 

--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -1,12 +1,14 @@
 """Work with OTU history in the database."""
 
 import math
+from collections import defaultdict
+from collections.abc import Collection
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import dictdiffer
-from sqlalchemy import Integer, cast, func, select
+from sqlalchemy import Integer, and_, cast, func, or_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -721,48 +723,186 @@ async def patch_to_version(
 
     Uses the diffs in the change documents associated with the otu.
 
+    A thin single-OTU face on :func:`patch_otus_to_versions`. A caller with more than
+    one OTU to patch should use that directly rather than awaiting this in a loop or a
+    ``gather``.
+
     :param pg: the application PostgreSQL database object
     :param otu_id: the id of the otu to patch
     :param version: the version to patch to
     :return: the current joined otu and the patched otu
 
     """
-    current = await virtool.otus.db.join_legacy_otu(pg, otu_id) or {}
+    specifier = (otu_id, version)
 
-    if "version" in current and current["version"] == version:
-        return current, deepcopy(current)
+    return (await patch_otus_to_versions(pg, [specifier]))[specifier]
 
-    patched = deepcopy(current)
 
-    # Collect the changes to revert, sorted by descending version. Stream the ordered
-    # rows and stop at the first change at or below the target version, preserving the
-    # early break of the legacy Mongo cursor so a heavily-edited otu never loads its
-    # whole history.
-    changes_to_revert = []
-    reference_id_from_history: int | str | None = None
+async def patch_otus_to_versions(
+    pg: AsyncEngine,
+    specifiers: Collection[tuple[str, str | int]],
+) -> dict[tuple[str, str | int], tuple[Document | None, Document | None]]:
+    """Take each of the joined otus identified by ``specifiers`` back to its version.
+
+    The batched counterpart of :func:`patch_to_version`, and where the patching itself
+    lives. Each specifier is an ``(otu_id, version)`` pair, and each maps to the
+    ``(current, patched)`` pair that :func:`patch_to_version` returns for it. The same
+    OTU may appear under more than one version.
+
+    The whole set is resolved in a fixed handful of queries -- two to join the OTUs, one
+    for the history, one for the diffs -- rather than four or so per OTU. The per-OTU
+    reads this replaces were the cost that made formatting a pathoscope analysis
+    saturate the connection pool and the event loop, slowing down every request the
+    server was handling concurrently.
+
+    :param pg: the application PostgreSQL database object
+    :param specifiers: the ``(otu_id, version)`` pairs to patch
+    :return: a mapping of specifier to its current and patched otu
+
+    """
+    specifiers = set(specifiers)
+
+    if not specifiers:
+        return {}
+
+    current_otus = await virtool.otus.db.join_legacy_otus(
+        pg,
+        {otu_id for otu_id, _ in specifiers},
+    )
+
+    patched_otus: dict[
+        tuple[str, str | int],
+        tuple[Document | None, Document | None],
+    ] = {}
+
+    to_patch: dict[tuple[str, str | int], Document] = {}
+
+    for specifier in specifiers:
+        otu_id, version = specifier
+        current = current_otus.get(otu_id, {})
+
+        if "version" in current and current["version"] == version:
+            patched_otus[specifier] = (current, deepcopy(current))
+        else:
+            to_patch[specifier] = current
+
+    if to_patch:
+        history_rows = await _read_history_to_revert(pg, to_patch)
+
+        changes_to_revert = {
+            (otu_id, version): _changes_to_revert(history_rows[otu_id], version)
+            for otu_id, version in to_patch
+        }
+
+        diffs = await _resolve_diffs(
+            pg,
+            [change for changes in changes_to_revert.values() for change in changes],
+        )
+
+        for (otu_id, version), current in to_patch.items():
+            rows = history_rows[otu_id]
+
+            patched_otus[(otu_id, version)] = _apply_changes_to_revert(
+                current,
+                changes_to_revert[(otu_id, version)],
+                diffs,
+                rows[0] if rows else None,
+            )
+
+    return patched_otus
+
+
+async def _read_history_to_revert(
+    pg: AsyncEngine,
+    specifiers: Collection[tuple[str, str | int]],
+) -> dict[str, list[SQLLegacyHistory]]:
+    """Read the history rows that patching ``specifiers`` could have to revert.
+
+    One query covers every OTU. Each contributes a predicate matching the changes above
+    the lowest version it is being patched to, which is the most any of its specifiers
+    can need, and the rows come back ordered as :func:`_changes_to_revert` walks them.
+
+    The version predicate is what keeps the early break of the legacy Mongo cursor: the
+    changes at or below the target version are never read, so a heavily-edited otu still
+    does not load its whole history. Ordered by descending version, the rows it selects
+    are exactly the leading run the break stopped at -- a ``NULL`` ``otu_version`` is the
+    ``"removed"`` sentinel and sorts above every numbered version, and the rest sort
+    below it in order -- so nothing that is dropped could have been reverted.
+    """
+    lowest_versions: dict[str, str | int] = {}
+
+    for otu_id, version in specifiers:
+        if otu_id not in lowest_versions or version < lowest_versions[otu_id]:
+            lowest_versions[otu_id] = version
+
+    history_rows = defaultdict(list)
 
     async with AsyncSession(pg) as session:
         result = await session.stream_scalars(
             select(SQLLegacyHistory)
-            .where(SQLLegacyHistory.otu == otu_id)
+            .where(
+                or_(
+                    *[
+                        and_(
+                            SQLLegacyHistory.otu == otu_id,
+                            or_(
+                                SQLLegacyHistory.otu_version.is_(None),
+                                cast(SQLLegacyHistory.otu_version, Integer) > version,
+                            ),
+                        )
+                        for otu_id, version in lowest_versions.items()
+                    ],
+                ),
+            )
             .order_by(
+                SQLLegacyHistory.otu,
                 cast(SQLLegacyHistory.otu_version, Integer).desc().nulls_first(),
                 SQLLegacyHistory.id.desc(),
             ),
         )
 
         async for row in result:
-            if reference_id_from_history is None:
-                reference_id_from_history = row.reference_id or row.reference
+            history_rows[row.otu].append(row)
 
-            otu_version = coerce_otu_version(row.otu_version)
+    return history_rows
 
-            if otu_version == "removed" or otu_version > version:
-                changes_to_revert.append(_change_to_revert(row))
-            else:
-                break
 
-    diffs = await _resolve_diffs(pg, changes_to_revert)
+def _changes_to_revert(
+    history_rows: list[SQLLegacyHistory],
+    version: str | int,
+) -> list[Document]:
+    """Select the changes to revert to take an otu back to ``version``.
+
+    ``history_rows`` are ordered by descending version and reach further back than this
+    version may need, because they cover every version its otu is being patched to. The
+    walk stops at the first change at or below the target, as the legacy Mongo cursor's
+    did.
+    """
+    changes_to_revert = []
+
+    for row in history_rows:
+        otu_version = coerce_otu_version(row.otu_version)
+
+        if otu_version == "removed" or otu_version > version:
+            changes_to_revert.append(_change_to_revert(row))
+        else:
+            break
+
+    return changes_to_revert
+
+
+def _apply_changes_to_revert(
+    current: Document,
+    changes_to_revert: list[Document],
+    diffs: dict[str, object],
+    latest_change: SQLLegacyHistory | None,
+) -> tuple[Document | None, Document | None]:
+    """Revert ``changes_to_revert`` from ``current`` to recover a patched otu.
+
+    ``latest_change`` is the otu's most recent history row, and carries the parent
+    reference for an otu with no live document left to read it from.
+    """
+    patched = deepcopy(current)
 
     for change in changes_to_revert:
         diff = diffs[change["_id"]]
@@ -778,15 +918,16 @@ async def patch_to_version(
 
     if patched:
         # An OTU's parent reference is immutable, so the authoritative id is the live
-        # OTU's when it still exists, falling back to the history rows for an OTU that
-        # was removed and no longer has a live document.
+        # OTU's when it still exists, falling back to the history for an OTU that was
+        # removed and no longer has a live document. Only a reverted change can leave a
+        # patched OTU without a live one, so there is always a latest change to fall
+        # back to by the time this is reached.
         reference_id = (
-            current["reference"]["id"] if current else reference_id_from_history
+            current["reference"]["id"]
+            if current
+            else latest_change.reference_id or latest_change.reference
         )
 
         _stamp_reference(patched, reference_id)
 
-    if current == {}:
-        current = None
-
-    return current, patched
+    return current or None, patched

--- a/virtool/otus/db.py
+++ b/virtool/otus/db.py
@@ -1,7 +1,7 @@
 """Work with OTUs in the database."""
 
 import math
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Collection
 from datetime import datetime
 from typing import Any
@@ -380,6 +380,25 @@ async def join_legacy_otu(pg: AsyncEngine, otu_id: str) -> Document | None:
         return await join_legacy_otu_in_session(session, otu_id)
 
 
+async def join_legacy_otus(
+    pg: AsyncEngine,
+    otu_ids: Collection[str],
+) -> dict[str, Document]:
+    """Reconstruct many joined OTU documents from Postgres in a session of its own.
+
+    The batched counterpart of :func:`join_legacy_otu`, reading every requested OTU in
+    two queries rather than two per OTU. A caller holding a set of OTUs to join -- an
+    analysis formatting a hit per detected OTU, an index build walking a manifest --
+    should reach for this rather than awaiting the single-OTU read in a loop or a
+    ``gather``, which issues a query and takes a pool connection per OTU.
+
+    Only the OTUs that have a row appear in the returned mapping, so a missing key
+    carries what a ``None`` from :func:`join_legacy_otu` does.
+    """
+    async with AsyncSession(pg) as session:
+        return await join_legacy_otus_in_session(session, otu_ids)
+
+
 async def join_legacy_otu_in_session(
     pg_session: AsyncSession,
     otu_id: str,
@@ -392,6 +411,26 @@ async def join_legacy_otu_in_session(
     own uncommitted writes. The session's lifecycle is left alone -- nothing here
     commits, rolls back or closes it. Returns ``None`` for an OTU that has no row, as
     :func:`join` does for one that has no document.
+
+    A thin single-OTU face on :func:`join_legacy_otus_in_session`, which is where the
+    read itself lives.
+    """
+    return (await join_legacy_otus_in_session(pg_session, [otu_id])).get(otu_id)
+
+
+async def join_legacy_otus_in_session(
+    pg_session: AsyncSession,
+    otu_ids: Collection[str],
+) -> dict[str, Document]:
+    """Reconstruct joined OTU documents for ``otu_ids`` from Postgres within
+    ``pg_session``.
+
+    The read every OTU join in this codebase resolves to, batched or not. Reads through
+    the caller's session on the same terms as :func:`join_legacy_otu_in_session`, and
+    leaves its lifecycle alone.
+
+    The OTUs are read in one query and their sequences in a second, so the cost is two
+    queries and one pool connection however many OTUs are asked for.
 
     Both reads pass ``populate_existing`` so a row already in the session's identity map
     is refreshed from the database rather than handed back as it was first loaded. The
@@ -426,29 +465,51 @@ async def join_legacy_otu_in_session(
     ``isolate_id`` exactly as they are on the Mongo path, and an isolate with no
     sequences still gets an empty list.
 
-    The sequences are ordered by ``position``, which reproduces the natural order
-    Mongo's unsorted cursor returns them in. A ``NULL`` or duplicated position is not
-    sorted around: :func:`virtool.otus.migration.compare_otu_and_sequence_stores` gates
-    the read switch on neither existing, and quietly shuffling such an OTU's sequences
-    would misapply every diff that addresses them by index -- the failure ``position``
-    exists to prevent.
+    The sequences are ordered by ``position`` within their OTU, which reproduces the
+    natural order Mongo's unsorted cursor returns them in. A ``NULL`` or duplicated
+    position is not sorted around:
+    :func:`virtool.otus.migration.compare_otu_and_sequence_stores` gates the read switch
+    on neither existing, and quietly shuffling such an OTU's sequences would misapply
+    every diff that addresses them by index -- the failure ``position`` exists to
+    prevent.
     """
-    otu_row = await pg_session.get(SQLOTU, otu_id, populate_existing=True)
+    otu_ids = set(otu_ids)
 
-    if otu_row is None:
-        return None
+    if not otu_ids:
+        return {}
+
+    otu_rows = (
+        await pg_session.scalars(
+            select(SQLOTU)
+            .where(SQLOTU.id.in_(otu_ids))
+            .execution_options(populate_existing=True),
+        )
+    ).all()
+
+    if not otu_rows:
+        return {}
 
     sequence_rows = await pg_session.scalars(
         select(SQLSequence)
-        .where(SQLSequence.otu_id == otu_id)
-        .order_by(SQLSequence.position)
+        .where(SQLSequence.otu_id.in_([otu_row.id for otu_row in otu_rows]))
+        .order_by(SQLSequence.otu_id, SQLSequence.position)
         .execution_options(populate_existing=True),
     )
 
-    return virtool.otus.utils.merge_otu(
-        otu_document_from_row(otu_row),
-        [sequence_document_from_row(row) for row in sequence_rows],
-    )
+    sequence_documents = defaultdict(list)
+
+    for sequence_row in sequence_rows:
+        sequence_documents[sequence_row.otu_id].append(
+            sequence_document_from_row(sequence_row),
+        )
+
+    return {
+        otu_row.id: virtool.otus.utils.merge_otu(
+            otu_document_from_row(otu_row),
+            sequence_documents[otu_row.id],
+        )
+        for otu_row in otu_rows
+    }
 
 
 def compose_isolate_match(isolate_id: str):


### PR DESCRIPTION
## Summary

- `format_pathoscope` patched every detected OTU through its own `patch_to_version`, fanned out with an unbounded `gather` — roughly four queries and a pool connection each. A result with a few hundred hits saturated the connection pool and the event loop and stalled unrelated requests. The session query AIOHTTP-54 flags as slow is collateral damage rather than the cause: it sat 2.7s inside cursor-execute while Postgres itself did 30ms of work, and `sessions.session_id` has been indexed since the table was created.
- `join_legacy_otus` and `patch_otus_to_versions` are now where the OTU and history reads live, with `join_legacy_otu` and `patch_to_version` as thin single-item faces on them, so there is one implementation of each. `format_pathoscope` collects its `(otu_id, version)` specifiers and loads them in one batch, on the same collect-then-load shape `format_nuvs` already used. A whole result now costs a fixed four queries — OTUs, sequences, history, diffs — however many OTUs it detected.
- `patch_to_version`'s early break is preserved by pushing the version predicate into SQL, so a heavily-edited OTU still never loads its whole history. Under the existing descending sort that predicate selects exactly the leading run the break stopped at, `NULL` (the `"removed"` sentinel) sorting above every numbered version.