### PR TITLE
fix: reject forked and orphaned migration revisions

### DIFF
--- a/tests/migration/test_show.py
+++ b/tests/migration/test_show.py
@@ -331,6 +331,45 @@ class TestOrderRevisions:
         ):
             order_revisions(revisions)
 
+    def test_duplicate_ids(self):
+        """Test that an error is raised when two revisions share an id.
+
+        Such a chain orders cleanly, but `apply` records applied revisions by id and
+        would silently skip the second as already applied.
+        """
+        revisions = [
+            GenericRevision(
+                alembic_downgrade=None,
+                created_at=arrow.get("2021-01-01T00:00:00").naive,
+                id="root",
+                name="Root",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="root",
+                created_at=arrow.get("2021-01-02T00:00:00").naive,
+                id="copied",
+                name="Copied",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="copied",
+                created_at=arrow.get("2021-01-03T00:00:00").naive,
+                id="copied",
+                name="Copied Again",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="Revision ids are not unique: copied."):
+            order_revisions(revisions)
+
 
 class TestLoadAllRevisions:
     def test_chain_is_intact(self):

--- a/tests/migration/test_show.py
+++ b/tests/migration/test_show.py
@@ -2,7 +2,12 @@ import arrow
 import pytest
 
 from virtool.migration.cls import GenericRevision, RevisionSource
-from virtool.migration.show import order_revisions
+from virtool.migration.show import (
+    load_alembic_revisions,
+    load_all_revisions,
+    load_virtool_revisions,
+    order_revisions,
+)
 
 
 class TestOrderRevisions:
@@ -189,3 +194,154 @@ class TestOrderRevisions:
             ValueError, match="Root revision is not an Alembic revision."
         ):
             order_revisions(revisions)
+
+    def test_alembic_fork(self):
+        """Test that an error is raised when two Alembic revisions share a downgrade."""
+        revisions = [
+            GenericRevision(
+                alembic_downgrade=None,
+                created_at=arrow.get("2021-01-01T00:00:00").naive,
+                id="root",
+                name="Root",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="root",
+                created_at=arrow.get("2021-01-02T00:00:00").naive,
+                id="branch_a",
+                name="Branch A",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="root",
+                created_at=arrow.get("2021-01-03T00:00:00").naive,
+                id="branch_b",
+                name="Branch B",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match="Revisions branch_a and branch_b both downgrade to root.",
+        ):
+            order_revisions(revisions)
+
+    def test_virtool_fork(self):
+        """Test that an error is raised when two Virtool revisions share a downgrade."""
+        revisions = [
+            GenericRevision(
+                alembic_downgrade=None,
+                created_at=arrow.get("2021-01-01T00:00:00").naive,
+                id="root",
+                name="Root",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="root",
+                created_at=arrow.get("2021-01-02T00:00:00").naive,
+                id="trunk",
+                name="Trunk",
+                source=RevisionSource.VIRTOOL,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade=None,
+                created_at=arrow.get("2021-01-03T00:00:00").naive,
+                id="branch_a",
+                name="Branch A",
+                source=RevisionSource.VIRTOOL,
+                upgrade=None,
+                virtool_downgrade="trunk",
+            ),
+            GenericRevision(
+                alembic_downgrade=None,
+                created_at=arrow.get("2021-01-04T00:00:00").naive,
+                id="branch_b",
+                name="Branch B",
+                source=RevisionSource.VIRTOOL,
+                upgrade=None,
+                virtool_downgrade="trunk",
+            ),
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match="Revisions branch_a and branch_b both downgrade to trunk.",
+        ):
+            order_revisions(revisions)
+
+    def test_orphaned(self):
+        """Test that an error is raised when a revision cannot be reached from the root.
+
+        The orphans form a valid chain of their own, but it hangs off a revision that
+        is not in the loaded set.
+        """
+        revisions = [
+            GenericRevision(
+                alembic_downgrade=None,
+                created_at=arrow.get("2021-01-01T00:00:00").naive,
+                id="root",
+                name="Root",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="root",
+                created_at=arrow.get("2021-01-02T00:00:00").naive,
+                id="reachable",
+                name="Reachable",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="missing",
+                created_at=arrow.get("2021-01-03T00:00:00").naive,
+                id="orphan_a",
+                name="Orphan A",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+            GenericRevision(
+                alembic_downgrade="orphan_a",
+                created_at=arrow.get("2021-01-04T00:00:00").naive,
+                id="orphan_b",
+                name="Orphan B",
+                source=RevisionSource.ALEMBIC,
+                upgrade=None,
+                virtool_downgrade=None,
+            ),
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match="Revisions could not be reached from the root: orphan_a, orphan_b.",
+        ):
+            order_revisions(revisions)
+
+
+class TestLoadAllRevisions:
+    def test_chain_is_intact(self):
+        """Test that every revision in the repository is ordered exactly once.
+
+        This fails if a revision is added that forks the chain or that cannot be
+        reached from the root.
+        """
+        loaded = [*load_alembic_revisions(), *load_virtool_revisions()]
+
+        ordered_ids = [revision.id for revision in load_all_revisions()]
+
+        assert sorted(ordered_ids) == sorted(revision.id for revision in loaded)
+        assert len(ordered_ids) == len(set(ordered_ids))

--- a/virtool/migration/show.py
+++ b/virtool/migration/show.py
@@ -80,11 +80,22 @@ def order_revisions(revisions: list[GenericRevision]) -> list[GenericRevision]:
 
     :param revisions: the revisions to order
     :return: the ordered revisions
-    :raises ValueError: if there are no root revisions
+    :raises ValueError: if the revisions do not form a single unbroken chain
     """
     revisions_by_downgrade: dict[DowngradeSpecifier, GenericRevision] = {}
 
     ordered_revisions = []
+
+    def add_downgrade(specifier: DowngradeSpecifier, revision: GenericRevision) -> None:
+        existing = revisions_by_downgrade.get(specifier)
+
+        if existing is not None:
+            raise ValueError(
+                f"Revisions {existing.id} and {revision.id} both downgrade to "
+                f"{specifier.downgrade}.",
+            )
+
+        revisions_by_downgrade[specifier] = revision
 
     for revision in revisions:
         if revision.alembic_downgrade and revision.virtool_downgrade:
@@ -93,23 +104,25 @@ def order_revisions(revisions: list[GenericRevision]) -> list[GenericRevision]:
             )
 
         if revision.alembic_downgrade:
-            revisions_by_downgrade[
+            add_downgrade(
                 DowngradeSpecifier(
                     revision.alembic_downgrade,
                     RevisionSource.ALEMBIC,
                     revision.source,
-                )
-            ] = revision
+                ),
+                revision,
+            )
 
         elif revision.virtool_downgrade:
             # Only Virtool revisions have Virtool downgrades.
-            revisions_by_downgrade[
+            add_downgrade(
                 DowngradeSpecifier(
                     revision.virtool_downgrade,
                     RevisionSource.VIRTOOL,
                     revision.source,
-                )
-            ] = revision
+                ),
+                revision,
+            )
 
         else:
             ordered_revisions.append(revision)
@@ -164,6 +177,19 @@ def order_revisions(revisions: list[GenericRevision]) -> list[GenericRevision]:
                 break
 
         ordered_revisions.append(next_revision)
+
+    if revisions_by_downgrade:
+        orphaned = sorted(revision.id for revision in revisions_by_downgrade.values())
+
+        raise ValueError(
+            f"Revisions could not be reached from the root: {', '.join(orphaned)}.",
+        )
+
+    if len(ordered_revisions) != len(revisions):
+        raise ValueError(
+            f"Ordered {len(ordered_revisions)} revisions from {len(revisions)} "
+            f"loaded revisions.",
+        )
 
     return ordered_revisions
 

--- a/virtool/migration/show.py
+++ b/virtool/migration/show.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import NamedTuple
 
 import arrow
@@ -82,6 +83,17 @@ def order_revisions(revisions: list[GenericRevision]) -> list[GenericRevision]:
     :return: the ordered revisions
     :raises ValueError: if the revisions do not form a single unbroken chain
     """
+    duplicated_ids = sorted(
+        id_ for id_, count in Counter(r.id for r in revisions).items() if count > 1
+    )
+
+    if duplicated_ids:
+        # Revisions are applied and recorded by id, so two revisions sharing an id
+        # would leave the second silently skipped as already applied.
+        raise ValueError(
+            f"Revision ids are not unique: {', '.join(duplicated_ids)}.",
+        )
+
     revisions_by_downgrade: dict[DowngradeSpecifier, GenericRevision] = {}
 
     ordered_revisions = []
@@ -183,12 +195,6 @@ def order_revisions(revisions: list[GenericRevision]) -> list[GenericRevision]:
 
         raise ValueError(
             f"Revisions could not be reached from the root: {', '.join(orphaned)}.",
-        )
-
-    if len(ordered_revisions) != len(revisions):
-        raise ValueError(
-            f"Ordered {len(ordered_revisions)} revisions from {len(revisions)} "
-            f"loaded revisions.",
         )
 
     return ordered_revisions


### PR DESCRIPTION
## Summary
- `order_revisions` silently dropped revisions when two shared a downgrade pointer (a fork), and silently omitted any it could not reach from the root (an orphan). Both now raise, naming the offending revisions.
- The guard lives in `order_revisions`, the chokepoint for `apply`, `show`, `depend`, and `create`, so a broken chain fails on every invocation rather than only in CI.
- Covers structural errors only. Data-dependency inversions remain out of scope (VIR-2749).