### PR TITLE
feat(migration): add postgres table for reference indexes

### DIFF
--- a/assets/alembic/env.py
+++ b/assets/alembic/env.py
@@ -10,7 +10,7 @@ from virtool.analyses.sql import SQLAnalysisFile
 from virtool.blast.sql import SQLNuVsBlast
 from virtool.groups.pg import SQLGroup
 from virtool.hmm.sql import SQLHMMStatus
-from virtool.indexes.sql import SQLIndexFile
+from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.labels.sql import SQLLabel
 from virtool.messages.sql import SQLInstanceMessage
 from virtool.otus.sql import SQLOTU, SQLSequence
@@ -46,6 +46,7 @@ __models__ = (
     SQLAnalysisFile,
     SQLGroup,
     SQLHMMStatus,
+    SQLIndex,
     SQLIndexFile,
     SQLInstanceMessage,
     SQLLabel,

--- a/assets/alembic/versions/6ffca63a8b95_create_indexes_table.py
+++ b/assets/alembic/versions/6ffca63a8b95_create_indexes_table.py
@@ -1,0 +1,51 @@
+"""create indexes table
+
+Revision ID: 6ffca63a8b95
+Revises: c6fcaf6c86ad
+Create Date: 2026-07-17 16:36:52.495637+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "6ffca63a8b95"
+down_revision = "c6fcaf6c86ad"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "indexes",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=True), nullable=False),
+        sa.Column("legacy_id", sa.String(), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("manifest", JSONB(), nullable=False),
+        sa.Column("ready", sa.Boolean(), nullable=False),
+        sa.Column("storage_key", sa.String(), nullable=False),
+        sa.Column("reference_id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("job_id", sa.Integer(), nullable=True),
+        sa.Column("task_id", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("legacy_id"),
+        sa.UniqueConstraint("storage_key"),
+        sa.UniqueConstraint(
+            "reference_id", "version", name="uq_indexes_reference_id_version"
+        ),
+        sa.CheckConstraint(
+            "num_nonnulls(job_id, task_id) = 1", name="ck_indexes_job_or_task"
+        ),
+        sa.ForeignKeyConstraint(["reference_id"], ["legacy_references.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"]),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("indexes")

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -792,5 +792,12 @@
       'name': 'compare otu and sequence stores',
       'revision': 't96ls24modzv',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 114,
+      'name': 'create indexes table',
+      'revision': '6ffca63a8b95',
+    }),
   ])
 # ---

--- a/virtool/indexes/sql.py
+++ b/virtool/indexes/sql.py
@@ -1,14 +1,68 @@
+from datetime import datetime
+
 from sqlalchemy import (
     BigInteger,
+    Boolean,
+    CheckConstraint,
     Column,
+    DateTime,
     Enum,
+    ForeignKey,
+    Identity,
     Integer,
     String,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from virtool.pg.base import Base
 from virtool.pg.utils import SQLEnum
+
+
+class SQLIndex(Base):
+    """SQL model for a reference index build.
+
+    Mongo stores each index as a small, flat document with several embedded
+    objects that are flattened here:
+
+    - ``job`` and ``task`` collapse to the ``job_id`` and ``task_id`` foreign
+      keys. Legacy builds carry a ``job``; builds created after the task
+      migration carry a ``task``. Exactly one is set, enforced by the
+      ``ck_indexes_job_or_task`` check constraint.
+    - ``user`` collapses to ``user_id``.
+    - ``reference`` collapses to ``reference_id``, a foreign key to
+      ``legacy_references.id``.
+
+    ``legacy_id`` holds the Mongo ``_id`` and is nullable so indexes created
+    natively in Postgres can omit it. ``storage_key`` is load-bearing and
+    cannot be derived from ``legacy_id``: it holds the legacy id slug for
+    migrated rows and a UUID for native rows.
+    """
+
+    __tablename__ = "indexes"
+    __table_args__ = (
+        UniqueConstraint(
+            "reference_id", "version", name="uq_indexes_reference_id_version"
+        ),
+        CheckConstraint(
+            "num_nonnulls(job_id, task_id) = 1", name="ck_indexes_job_or_task"
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
+    legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    version: Mapped[int] = mapped_column(Integer)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    manifest: Mapped[dict] = mapped_column(JSONB)
+    ready: Mapped[bool] = mapped_column(Boolean, default=False)
+    storage_key: Mapped[str] = mapped_column(unique=True)
+    reference_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("legacy_references.id")
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"))
+    task_id: Mapped[int | None] = mapped_column(ForeignKey("tasks.id"))
 
 
 class IndexType(str, SQLEnum):


### PR DESCRIPTION
## Summary
- Adds the `indexes` Postgres table and `SQLIndex` model, step 1 of migrating index data off MongoDB.
- Flattens the Mongo `job`/`task`/`user`/`reference` embeds into foreign keys, enforcing exactly one of `job_id`/`task_id` via a check constraint.
- Table is schema-only for now — no dual-write, backfill, or read cutover yet.