### PR TITLE
feat: add indexes to postgres

### DIFF
--- a/tests/indexes/__snapshots__/test_db.ambr
+++ b/tests/indexes/__snapshots__/test_db.ambr
@@ -39,7 +39,7 @@
       'id': 1,
     }),
     'user': dict({
-      'id': 'test',
+      'id': 1,
     }),
     'version': 0,
   })
@@ -58,7 +58,7 @@
       'id': 1,
     }),
     'user': dict({
-      'id': 'test',
+      'id': 1,
     }),
     'version': 0,
   })

--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -6,7 +6,7 @@ from virtool.data.errors import ResourceError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
-from virtool.indexes.sql import SQLIndexFile
+from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.mongo.core import Mongo
 from virtool.otus.sql import SQLOTU
 
@@ -70,6 +70,14 @@ async def test_finalize(
 
     # Ensure document in database is correct.
     assert await mongo.indexes.find_one() == snapshot
+
+    # The Postgres row is marked ready alongside the Mongo document.
+    async with AsyncSession(pg) as session:
+        row = await session.scalar(
+            select(SQLIndex).where(SQLIndex.legacy_id == index.id),
+        )
+
+    assert row.ready is True
 
 
 @pytest.mark.usefixtures("static_time")
@@ -223,8 +231,15 @@ class TestDelete:
                 for row in (await session.execute(select(SQLLegacyHistory))).scalars()
             }
 
+            index_row = await session.scalar(
+                select(SQLIndex).where(SQLIndex.legacy_id == deleted_index.id),
+            )
+
         assert rows == {
             "otu_a.0": (None, None),
             "otu_b.0": (None, None),
             "otu_c.0": ("other_index", "2"),
         }
+
+        # The Postgres index row is deleted alongside the Mongo document.
+        assert index_row is None

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -19,7 +19,7 @@ from virtool.indexes.db import (
     upsert_index_file,
 )
 from virtool.indexes.models import Index
-from virtool.indexes.sql import SQLIndexFile
+from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.mongo.core import Mongo
 from virtool.otus.sql import SQLOTU
 
@@ -33,12 +33,14 @@ async def test_create(
     snapshot: SnapshotAssertion,
     static_time,
 ):
-    """The new index embeds the integer ``legacy_references`` primary key of its
-    reference rather than the legacy Mongo string id.
+    """The new index is dual-written. The Mongo document embeds the integer
+    ``legacy_references`` primary key of its reference rather than the legacy Mongo
+    string id, and a matching ``indexes`` row carries the Mongo id as both its
+    ``legacy_id`` and ``storage_key``.
     """
     user = await fake.users.create()
-
-    await fake.references.create(user=user, id_="foo")
+    reference = await fake.references.create(user=user, id_="foo")
+    task = await fake.tasks.create()
 
     async with both_transactions(mongo, pg) as (mongo_session, pg_session):
         created = await virtool.indexes.db.create(
@@ -46,15 +48,33 @@ async def test_create(
             mongo_session,
             pg_session,
             "foo",
-            "test",
+            user.id,
             0,
             "manifest",
-            task_id=1,
+            task_id=task.id,
             index_id=index_id,
         )
 
     assert created["created_at"] == static_time.datetime
     assert created == snapshot
+
+    async with AsyncSession(pg) as session:
+        row = (
+            await session.execute(
+                select(SQLIndex).where(SQLIndex.legacy_id == created["_id"]),
+            )
+        ).scalar_one()
+
+    assert row.legacy_id == created["_id"]
+    assert row.storage_key == created["_id"]
+    assert row.version == 0
+    assert row.ready is False
+    assert row.manifest == "manifest"
+    assert row.created_at == static_time.datetime
+    assert row.reference_id == reference.id
+    assert row.user_id == user.id
+    assert row.job_id is None
+    assert row.task_id == task.id
 
 
 async def test_create_assigns_index_in_postgres(
@@ -70,6 +90,7 @@ async def test_create_assigns_index_in_postgres(
     user = await fake.users.create()
     built_ref = await fake.references.create(user=user, id_="built_ref")
     other_ref = await fake.references.create(user=user, id_="other_ref")
+    task = await fake.tasks.create()
 
     prior_index = await fake.indexes.create(built_ref, user, version=0, ready=True)
 
@@ -109,7 +130,7 @@ async def test_create_assigns_index_in_postgres(
             user.id,
             1,
             "manifest",
-            task_id=1,
+            task_id=task.id,
             index_id="new_index",
         )
 
@@ -186,8 +207,15 @@ async def test_create_rolls_back_both_stores_on_failure(
             )
         ).scalar_one()
 
+        index_row = (
+            await session.execute(
+                select(SQLIndex).where(SQLIndex.legacy_id == "new_index"),
+            )
+        ).scalar_one_or_none()
+
     assert row.index is None
     assert row.index_version is None
+    assert index_row is None
 
 
 async def _seed_index_series(

--- a/tests/indexes/test_faker_contract.py
+++ b/tests/indexes/test_faker_contract.py
@@ -5,8 +5,54 @@ The field-by-field shape the domain emits is pinned by the ``test_upload`` snaps
 exercises on its own.
 """
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
 from virtool.fake.next import DataFaker
+from virtool.indexes.sql import SQLIndex
 from virtool.mongo.core import Mongo
+
+
+class TestPostgresRow:
+    """The faker dual-writes each index to Postgres as production does."""
+
+    async def test_job_backed(self, fake: DataFaker, pg: AsyncEngine):
+        """A job-backed index row carries the job id and leaves ``task_id`` null."""
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        job = await fake.jobs.create(user=user)
+
+        index = await fake.indexes.create(reference, user, job=job, version=0)
+
+        async with AsyncSession(pg) as session:
+            row = await session.scalar(
+                select(SQLIndex).where(SQLIndex.legacy_id == index.id),
+            )
+
+        assert row.legacy_id == index.id
+        assert row.storage_key == index.id
+        assert row.version == 0
+        assert row.ready is False
+        assert row.reference_id == reference.id
+        assert row.user_id == user.id
+        assert row.job_id == job.id
+        assert row.task_id is None
+
+    async def test_task_backed(self, fake: DataFaker, pg: AsyncEngine):
+        """A task-backed index row carries the task id and leaves ``job_id`` null."""
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        index = await fake.indexes.create(reference, user, version=0, ready=True)
+
+        async with AsyncSession(pg) as session:
+            row = await session.scalar(
+                select(SQLIndex).where(SQLIndex.legacy_id == index.id),
+            )
+
+        assert row.ready is True
+        assert row.job_id is None
+        assert row.task_id is not None
 
 
 class TestBuildBacking:

--- a/tests/indexes/test_tasks.py
+++ b/tests/indexes/test_tasks.py
@@ -14,7 +14,7 @@ from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.indexes.data import update_last_indexed_versions
 from virtool.indexes.db import REFERENCE_JSON_V2_FILE_NAME
-from virtool.indexes.sql import SQLIndexFile
+from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.indexes.tasks import CreateIndexTask
 from virtool.indexes.utils import compose_index_file_key
 from virtool.mongo.core import Mongo
@@ -179,6 +179,13 @@ class TestCreateIndexTask:
 
         index = await self.mongo.indexes.find_one(self.index_id)
         assert index["ready"] is True
+
+        async with AsyncSession(self.pg) as session:
+            index_row = await session.scalar(
+                select(SQLIndex).where(SQLIndex.legacy_id == self.index_id),
+            )
+
+        assert index_row.ready is True
 
         response = await self.data_layer.index.get(self.index_id)
         assert response.ready is True

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -32,6 +32,7 @@ from virtool.groups.pg import SQLGroup
 from virtool.hmm.models import HMM
 from virtool.hmm.sql import SQLHMM
 from virtool.indexes.models import Index
+from virtool.indexes.sql import SQLIndex
 from virtool.indexes.tasks import CreateIndexTask
 from virtool.jobs.models import TERMINAL_JOB_STATES, Job, JobState
 from virtool.jobs.pg import SQLJob
@@ -505,11 +506,13 @@ class IndexesFakerDomain(DataFakerDomain):
                 {"index_id": index_id},
             )
 
+        created_at = created_at or virtool.utils.timestamp()
+
         await self._mongo.indexes.insert_one(
             {
                 "_id": index_id,
                 "version": version,
-                "created_at": created_at or virtool.utils.timestamp(),
+                "created_at": created_at,
                 "manifest": manifest,
                 "ready": ready,
                 "job": {"id": job.id} if job else None,
@@ -518,6 +521,23 @@ class IndexesFakerDomain(DataFakerDomain):
                 "reference": {"id": reference.id},
             },
         )
+
+        async with AsyncSession(self._pg) as session:
+            session.add(
+                SQLIndex(
+                    legacy_id=index_id,
+                    version=version,
+                    created_at=created_at,
+                    manifest=manifest,
+                    ready=ready,
+                    storage_key=index_id,
+                    reference_id=reference.id,
+                    user_id=user.id,
+                    job_id=job.id if job else None,
+                    task_id=task.id if task else None,
+                ),
+            )
+            await session.commit()
 
         return await self._layer.index.get(index_id)
 

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -3,7 +3,7 @@ import gzip
 from collections.abc import AsyncIterator
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from structlog import get_logger
@@ -36,7 +36,7 @@ from virtool.indexes.db import (
     update_last_indexed_versions,
 )
 from virtool.indexes.models import Index, IndexFile, IndexMinimal, IndexSearchResult
-from virtool.indexes.sql import SQLIndexFile
+from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.indexes.utils import (
     compose_index_file_key,
     compose_index_prefix,
@@ -379,6 +379,12 @@ class IndexData:
                 session=mongo_session,
             )
 
+            await pg_session.execute(
+                update(SQLIndex)
+                .where(SQLIndex.legacy_id == index_id)
+                .values(ready=True),
+            )
+
         await retry_both_transactions(self._mongo, self._pg, finalize_index)
 
         return await self.get(index_id)
@@ -477,6 +483,12 @@ class IndexData:
                     session=mongo_session,
                 )
 
+                await pg_session.execute(
+                    update(SQLIndex)
+                    .where(SQLIndex.legacy_id == index_id)
+                    .values(ready=True),
+                )
+
             await retry_both_transactions(
                 self._mongo,
                 self._pg,
@@ -552,6 +564,10 @@ class IndexData:
                 update(SQLLegacyHistory)
                 .where(SQLLegacyHistory.index == index_id)
                 .values(index=None, index_version=None),
+            )
+
+            await pg_session.execute(
+                delete(SQLIndex).where(SQLIndex.legacy_id == index_id),
             )
 
         await retry_both_transactions(self._mongo, self._pg, remove)

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -30,7 +30,7 @@ from virtool.data.topg import (
 )
 from virtool.data.transforms import AbstractTransform, apply_transforms
 from virtool.history.sql import SQLLegacyHistory
-from virtool.indexes.sql import SQLIndexFile
+from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.jobs.transforms import AttachJobTransform
 from virtool.mongo.core import Mongo
 from virtool.otus.sql import SQLOTU
@@ -171,6 +171,21 @@ async def create(
     document["reference"] = {"id": reference_pk}
 
     document = await mongo.indexes.insert_one(document, session=mongo_session)
+
+    pg_session.add(
+        SQLIndex(
+            legacy_id=document["_id"],
+            version=index_version,
+            created_at=document["created_at"],
+            manifest=manifest,
+            ready=False,
+            storage_key=document["_id"],
+            reference_id=reference_pk,
+            user_id=user_id,
+            job_id=None,
+            task_id=task_id,
+        ),
+    )
 
     await pg_session.execute(
         update(SQLLegacyHistory)


### PR DESCRIPTION
## Summary
- Create the `indexes` Postgres table and SQLAlchemy model, and dual-write index create/finalize/delete to Postgres alongside MongoDB, keeping Mongo the read authority (step 2 of the indexes migration).
- Add an indexes domain to the data faker so fixtures write both stores, with contract tests pinning the new table's shape.