### PR TITLE
feat(migration): backfill existing indexes to postgres

### DIFF
--- a/assets/revisions/rev_9ws3adnisz85_copy_indexes_to_postgres.py
+++ b/assets/revisions/rev_9ws3adnisz85_copy_indexes_to_postgres.py
@@ -1,0 +1,38 @@
+"""Copy Mongo indexes to Postgres.
+
+Backfills every existing ``indexes`` document into the ``indexes`` table now that
+index mutations dual-write to Postgres, so both stores are consistent ahead of the
+read cutover.
+
+The copy is idempotent: rows already present in Postgres (by ``legacy_id``, which
+is the Mongo ``_id``) are skipped and every insert uses ``ON CONFLICT (legacy_id)
+DO NOTHING``, and each document is committed individually so an interrupted run can
+be re-run from where it stopped.
+
+Revision ID: 9ws3adnisz85
+Date: 2026-07-17 18:18:14.064540
+
+"""
+
+import arrow
+
+from virtool.indexes.migration import copy_indexes_to_postgres
+from virtool.migration import MigrationContext
+
+# Revision identifiers.
+name = "copy indexes to postgres"
+created_at = arrow.get("2026-07-17 18:18:14.064540")
+revision_id = "9ws3adnisz85"
+
+alembic_down_revision = "6ffca63a8b95"
+virtool_down_revision = None
+
+# ``6ffca63a8b95`` creates the ``indexes`` table this copy writes into, so requiring
+# it guarantees the destination table and every promoted column exist before the
+# copy runs.
+required_alembic_revision = "6ffca63a8b95"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Copy the Mongo ``indexes`` collection into Postgres."""
+    await copy_indexes_to_postgres(ctx)

--- a/tests/indexes/test_migration.py
+++ b/tests/indexes/test_migration.py
@@ -1,0 +1,370 @@
+"""Tests for the Mongo-to-Postgres index backfill."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.indexes.migration import copy_indexes_to_postgres
+from virtool.indexes.sql import SQLIndex
+from virtool.jobs.pg import SQLJob
+from virtool.migration.ctx import MigrationContext
+from virtool.tasks.sql import SQLTask
+from virtool.users.pg import SQLUser
+from virtool.utils import timestamp
+
+_CREATED_AT = datetime(2026, 7, 1, 12, 0, 0)
+"""The ``created_at`` carried by index documents; millisecond precision as Mongo holds."""
+
+_MANIFEST = {"otu_a": 0, "otu_b": 3}
+"""A representative OTU manifest."""
+
+
+async def _seed_user(ctx: MigrationContext, handle: str, legacy_id: str) -> int:
+    """Insert a ``users`` row; return its integer id."""
+    async with AsyncSession(ctx.pg) as session:
+        user = SQLUser(
+            handle=handle,
+            legacy_id=legacy_id,
+            last_password_change=timestamp(),
+            password=b"hashed",
+            settings={},
+        )
+        session.add(user)
+        await session.flush()
+        user_id = user.id
+        await session.commit()
+
+    return user_id
+
+
+async def _seed_reference(
+    ctx: MigrationContext,
+    user_id: int,
+    legacy_id: str,
+) -> int:
+    """Insert a ``legacy_references`` row; return its integer id."""
+    async with AsyncSession(ctx.pg) as session:
+        reference_id = (
+            await session.execute(
+                text("""
+                    INSERT INTO legacy_references (
+                        legacy_id, name, description, organism, created_at,
+                        archived, restrict_source_types, source_types, user_id
+                    )
+                    VALUES (
+                        :legacy_id, 'Plant Viruses', '', '', :now,
+                        false, false, '[]'::jsonb, :user_id
+                    )
+                    RETURNING id
+                """),
+                {"legacy_id": legacy_id, "now": timestamp(), "user_id": user_id},
+            )
+        ).scalar_one()
+        await session.commit()
+
+    return reference_id
+
+
+async def _seed_job(ctx: MigrationContext, legacy_id: str, user_id: int) -> int:
+    """Insert a ``jobs`` row; return its integer id."""
+    async with AsyncSession(ctx.pg) as session:
+        job = SQLJob(
+            legacy_id=legacy_id,
+            created_at=timestamp(),
+            state="succeeded",
+            user_id=user_id,
+            workflow="build_index",
+        )
+        session.add(job)
+        await session.flush()
+        job_id = job.id
+        await session.commit()
+
+    return job_id
+
+
+async def _seed_task(ctx: MigrationContext) -> int:
+    """Insert a ``tasks`` row; return its integer id."""
+    async with AsyncSession(ctx.pg) as session:
+        task = SQLTask(created_at=timestamp(), type="create_index")
+        session.add(task)
+        await session.flush()
+        task_id = task.id
+        await session.commit()
+
+    return task_id
+
+
+def _index_doc(
+    index_id: str,
+    reference: int | str,
+    user: int | str,
+    *,
+    job: int | str | None = None,
+    task: int | None = None,
+    version: int = 0,
+    ready: bool = True,
+) -> dict:
+    """Build an index document in the shape the dual-write path writes."""
+    return {
+        "_id": index_id,
+        "version": version,
+        "created_at": _CREATED_AT,
+        "manifest": _MANIFEST,
+        "ready": ready,
+        "job": {"id": job} if job is not None else None,
+        "task": {"id": task} if task is not None else None,
+        "user": {"id": user},
+        "reference": {"id": reference},
+    }
+
+
+async def _fetch_index(ctx: MigrationContext, legacy_id: str) -> SQLIndex | None:
+    async with AsyncSession(ctx.pg) as session:
+        return (
+            await session.execute(
+                select(SQLIndex).where(SQLIndex.legacy_id == legacy_id),
+            )
+        ).scalar_one_or_none()
+
+
+async def _count(ctx: MigrationContext) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        return (
+            await session.execute(text("SELECT count(*) FROM indexes"))
+        ).scalar_one()
+
+
+@pytest.fixture
+async def seeded(ctx: MigrationContext, apply_alembic: Callable) -> dict[str, int]:
+    """Apply the full schema and seed a user, reference, job and task.
+
+    Returns the integer primary keys the index documents reference.
+    """
+    await asyncio.to_thread(apply_alembic, "head")
+
+    user_id = await _seed_user(ctx, "index_owner", "index_owner_legacy")
+    reference_id = await _seed_reference(ctx, user_id, "ref_legacy")
+    job_id = await _seed_job(ctx, "job_legacy", user_id)
+    task_id = await _seed_task(ctx)
+
+    return {
+        "user_id": user_id,
+        "reference_id": reference_id,
+        "job_id": job_id,
+        "task_id": task_id,
+    }
+
+
+class TestCopyIndexes:
+    async def test_backfills_a_job_backed_index(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_job",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=seeded["job_id"],
+                version=2,
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+
+        row = await _fetch_index(ctx, "index_job")
+        assert row.legacy_id == "index_job"
+        assert row.storage_key == "index_job"
+        assert row.version == 2
+        assert row.created_at == _CREATED_AT
+        assert row.manifest == _MANIFEST
+        assert row.ready is True
+        assert row.reference_id == seeded["reference_id"]
+        assert row.user_id == seeded["user_id"]
+        assert row.job_id == seeded["job_id"]
+        assert row.task_id is None
+
+    async def test_backfills_a_task_backed_index(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_task",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+
+        row = await _fetch_index(ctx, "index_task")
+        assert row.task_id == seeded["task_id"]
+        assert row.job_id is None
+
+    async def test_resolves_embedded_legacy_string_ids(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A pre-migration document embeds legacy string reference, user and job ids."""
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_legacy",
+                "ref_legacy",
+                "index_owner_legacy",
+                job="job_legacy",
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+
+        row = await _fetch_index(ctx, "index_legacy")
+        assert row.reference_id == seeded["reference_id"]
+        assert row.user_id == seeded["user_id"]
+        assert row.job_id == seeded["job_id"]
+
+    async def test_is_idempotent(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_job",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=seeded["job_id"],
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+        await copy_indexes_to_postgres(ctx)
+
+        assert await _count(ctx) == 1
+
+    async def test_converges_documents_added_after_first_run(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_existing",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=seeded["job_id"],
+                version=0,
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_gap",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+                version=1,
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+
+        assert await _fetch_index(ctx, "index_gap") is not None
+        assert await _count(ctx) == 2
+
+    async def test_leaves_an_already_migrated_row_untouched(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A row the dual-write path already wrote is skipped, not overwritten."""
+        async with AsyncSession(ctx.pg) as session:
+            session.add(
+                SQLIndex(
+                    legacy_id="index_dual_written",
+                    version=0,
+                    created_at=_CREATED_AT,
+                    manifest=_MANIFEST,
+                    ready=True,
+                    storage_key="index_dual_written",
+                    reference_id=seeded["reference_id"],
+                    user_id=seeded["user_id"],
+                    task_id=seeded["task_id"],
+                ),
+            )
+            await session.commit()
+
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_dual_written",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        await copy_indexes_to_postgres(ctx)
+
+        assert await _count(ctx) == 1
+
+    async def test_unresolvable_reference_raises(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_bad_reference",
+                999999,
+                seeded["user_id"],
+                job=seeded["job_id"],
+            ),
+        )
+
+        with pytest.raises(ValueError, match="references reference"):
+            await copy_indexes_to_postgres(ctx)
+
+    async def test_unresolvable_user_raises(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_bad_user",
+                seeded["reference_id"],
+                999999,
+                job=seeded["job_id"],
+            ),
+        )
+
+        with pytest.raises(ValueError, match="references user"):
+            await copy_indexes_to_postgres(ctx)
+
+    async def test_unresolvable_job_raises(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_bad_job",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=999999,
+            ),
+        )
+
+        with pytest.raises(ValueError, match="references job"):
+            await copy_indexes_to_postgres(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -799,5 +799,12 @@
       'name': 'create indexes table',
       'revision': '6ffca63a8b95',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 115,
+      'name': 'copy indexes to postgres',
+      'revision': '9ws3adnisz85',
+    }),
   ])
 # ---

--- a/virtool/indexes/migration.py
+++ b/virtool/indexes/migration.py
@@ -1,0 +1,211 @@
+"""Migration logic for the Mongo-to-Postgres index move.
+
+This module holds the idempotent copy used by the index backfill revision. Keeping
+it here rather than in the revision file keeps the logic unit-testable and reusable.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.data.topg import resolve_legacy_id
+from virtool.indexes.sql import SQLIndex
+from virtool.jobs.pg import SQLJob
+from virtool.migration import MigrationContext
+from virtool.pg.base import HasLegacyAndModernIDs
+from virtool.references.sql import SQLReference
+from virtool.types import Document
+from virtool.users.pg import SQLUser
+
+logger = get_logger("migration")
+
+
+async def copy_indexes_to_postgres(ctx: MigrationContext) -> None:
+    """Backfill every Mongo ``indexes`` document into the ``indexes`` table.
+
+    One row is written per Mongo document. The embedded ``reference``, ``user``,
+    ``job`` and ``task`` objects are flattened onto the ``reference_id``,
+    ``user_id``, ``job_id`` and ``task_id`` columns exactly as the dual-write path
+    does, and ``legacy_id`` and ``storage_key`` both hold the Mongo ``_id``.
+
+    The document ``_id`` values are snapshotted up front with a projection-only
+    query so the rest of the run fetches one document at a time by id, rather than
+    holding a single Mongo cursor open for the entire migration. Documents already
+    present in Postgres (by ``legacy_id``) are skipped, and every insert uses
+    ``ON CONFLICT (legacy_id) DO NOTHING`` as a second line of defence, so the
+    backfill is safe to re-run after an interruption. Each document is committed
+    individually, so memory stays bounded and a failure part-way through keeps the
+    rows already written rather than rolling back the whole collection.
+
+    An index is backed by exactly one build: a legacy build carries a ``job`` and a
+    build created since the task migration carries a ``task``. The
+    ``ck_indexes_job_or_task`` check constraint enforces that exactly one of
+    ``job_id`` and ``task_id`` is set, so a document that somehow carries both or
+    neither is rejected loudly by the database rather than silently coerced.
+
+    Three integrity failures are loud rather than silent, matching the required
+    relationships they represent:
+
+    - An index whose embedded ``reference.id`` does not resolve to a
+      ``legacy_references`` row raises. Every index belongs to a reference, and
+      references are already migrated.
+    - An index whose embedded ``user.id`` does not resolve to a ``users`` row
+      raises. Every index is attributed to a user, and users are already migrated.
+    - A job-backed index whose ``job.id`` does not resolve to a ``jobs`` row raises.
+      The production audit found no such index, so an unresolvable job is a
+      data-integrity problem, not a nullable relationship -- and the check
+      constraint would reject the ``NULL`` job on a task-less document regardless.
+
+    The embedded ``task.id`` is a native Postgres ``tasks`` primary key, so it is
+    used directly; an id with no ``tasks`` row is rejected by the foreign key.
+    """
+    async with AsyncSession(ctx.pg) as session:
+        existing_legacy_ids = {
+            row[0]
+            for row in await session.execute(select(SQLIndex.legacy_id))
+            if row[0] is not None
+        }
+
+        logger.info(
+            "found existing indexes in postgres", count=len(existing_legacy_ids)
+        )
+
+        index_ids = [
+            document["_id"]
+            async for document in ctx.mongo.indexes.find({}, projection=["_id"])
+        ]
+
+        migrated_count = 0
+        skipped_count = 0
+
+        reference_id_cache: dict[int | str, int] = {}
+        user_id_cache: dict[int | str, int] = {}
+        job_id_cache: dict[int | str, int] = {}
+
+        for index_id in index_ids:
+            if index_id in existing_legacy_ids:
+                skipped_count += 1
+                continue
+
+            document = await ctx.mongo.indexes.find_one({"_id": index_id})
+
+            if document is None:
+                skipped_count += 1
+                continue
+
+            values = await _index_row_values(
+                session,
+                document,
+                reference_id_cache,
+                user_id_cache,
+                job_id_cache,
+            )
+
+            await session.execute(
+                insert(SQLIndex)
+                .values(**values)
+                .on_conflict_do_nothing(index_elements=["legacy_id"]),
+            )
+            await session.commit()
+
+            migrated_count += 1
+
+    logger.info(
+        "index migration complete",
+        migrated=migrated_count,
+        skipped=skipped_count,
+    )
+
+
+async def _index_row_values(
+    session: AsyncSession,
+    document: Document,
+    reference_id_cache: dict[int | str, int],
+    user_id_cache: dict[int | str, int],
+    job_id_cache: dict[int | str, int],
+) -> dict:
+    """Flatten a Mongo index document into ``indexes`` row values.
+
+    The embedded ``reference``, ``user`` and (for legacy builds) ``job`` ids are
+    resolved to their Postgres primary keys, raising when a required reference does
+    not resolve. The ``task`` id is a native Postgres id and is used directly.
+    """
+    index_id = document["_id"]
+
+    reference_id = await _resolve_required_id(
+        session,
+        SQLReference,
+        document["reference"]["id"],
+        reference_id_cache,
+        index_id,
+        "reference",
+    )
+
+    user_id = await _resolve_required_id(
+        session,
+        SQLUser,
+        document["user"]["id"],
+        user_id_cache,
+        index_id,
+        "user",
+    )
+
+    job = document["job"]
+    task = document["task"]
+
+    job_id = None
+
+    if job is not None:
+        job_id = await _resolve_required_id(
+            session,
+            SQLJob,
+            job["id"],
+            job_id_cache,
+            index_id,
+            "job",
+        )
+
+    return {
+        "legacy_id": index_id,
+        "version": document["version"],
+        "created_at": document["created_at"],
+        "manifest": document["manifest"],
+        "ready": document["ready"],
+        "storage_key": index_id,
+        "reference_id": reference_id,
+        "user_id": user_id,
+        "job_id": job_id,
+        "task_id": task["id"] if task is not None else None,
+    }
+
+
+async def _resolve_required_id(
+    session: AsyncSession,
+    model: HasLegacyAndModernIDs,
+    id_: int | str,
+    cache: dict[int | str, int],
+    index_id: str,
+    relationship: str,
+) -> int:
+    """Resolve an embedded legacy or modern id to a Postgres primary key.
+
+    Hits are memoised because indexes cluster heavily by reference and job. Misses
+    are not cached and raise: the relationship is required, and the referenced
+    resource is already migrated, so an unresolvable id is a data-integrity problem.
+    """
+    if id_ in cache:
+        return cache[id_]
+
+    resolved = await resolve_legacy_id(session, model, id_)
+
+    if resolved is None:
+        msg = (
+            f"index {index_id!r} references {relationship} {id_!r} "
+            "which does not exist in postgres"
+        )
+        raise ValueError(msg)
+
+    cache[id_] = resolved
+
+    return resolved


### PR DESCRIPTION
## Summary
- Adds an idempotent, resumable backfill in `virtool/indexes/migration.py` that copies every existing Mongo `indexes` document into the Postgres `indexes` table, resolving `reference`, `user` and `job` FKs (raising on any unresolvable reference) and taking `task` directly.
- Registers it as a Virtool revision after the table-creation revision, so both stores are consistent ahead of the read cutover.