### PR TITLE
feat(migration): gate index read cutover on store parity

### DIFF
--- a/assets/revisions/rev_wcpztunkc49f_compare_index_stores.py
+++ b/assets/revisions/rev_wcpztunkc49f_compare_index_stores.py
@@ -1,0 +1,38 @@
+"""Compare the Mongo and Postgres index stores.
+
+Gates the index read cutover. Runs after the backfill has copied every ``indexes``
+document into the ``indexes`` table, and raises if the two stores still disagree, so
+reads never move to a Postgres that has silently fallen behind Mongo.
+
+Every promoted field is compared, with ``created_at`` floored to the millisecond
+BSON stores it at, embedded ``reference`` and ``user`` ids resolved to their Postgres
+keys, and ``manifest`` compared as a whole map -- the silent corruption a key-set
+check would miss. The check is read-only and re-runnable: it mutates neither store
+and reaches the same verdict on unchanged stores.
+
+Revision ID: wcpztunkc49f
+Date: 2026-07-17 18:56:39.490214
+
+"""
+
+import arrow
+
+from virtool.indexes.migration import compare_index_stores
+from virtool.migration import MigrationContext
+
+# Revision identifiers.
+name = "compare index stores"
+created_at = arrow.get("2026-07-17 18:56:39.490214")
+revision_id = "wcpztunkc49f"
+
+alembic_down_revision = None
+virtool_down_revision = "9ws3adnisz85"
+
+# ``6ffca63a8b95`` creates the ``indexes`` table and every promoted column this
+# check compares, so requiring it guarantees they exist before the check runs.
+required_alembic_revision = "6ffca63a8b95"
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    """Raise if the Mongo and Postgres index stores have drifted."""
+    await compare_index_stores(ctx)

--- a/tests/indexes/test_migration.py
+++ b/tests/indexes/test_migration.py
@@ -447,6 +447,27 @@ class TestCompareIndexStores:
         with pytest.raises(ValueError, match="1 indexes"):
             await compare_index_stores(ctx)
 
+    async def test_wrong_storage_key_fails(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A row whose load-bearing ``storage_key`` is not the Mongo id is drift."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_storage_key",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        await _update_index(ctx, "index_storage_key", storage_key="wrong_key")
+
+        with pytest.raises(ValueError, match="1 indexes"):
+            await compare_index_stores(ctx)
+
     async def test_legacy_string_reference_matches_integer_key(
         self,
         ctx: MigrationContext,

--- a/tests/indexes/test_migration.py
+++ b/tests/indexes/test_migration.py
@@ -1,14 +1,17 @@
-"""Tests for the Mongo-to-Postgres index backfill."""
+"""Tests for the Mongo-to-Postgres index backfill and drift gate."""
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from virtool.indexes.migration import copy_indexes_to_postgres
+from virtool.indexes.migration import (
+    compare_index_stores,
+    copy_indexes_to_postgres,
+)
 from virtool.indexes.sql import SQLIndex
 from virtool.jobs.pg import SQLJob
 from virtool.migration.ctx import MigrationContext
@@ -368,3 +371,258 @@ class TestCopyIndexes:
 
         with pytest.raises(ValueError, match="references job"):
             await copy_indexes_to_postgres(ctx)
+
+
+async def _update_index(ctx: MigrationContext, legacy_id: str, **values) -> None:
+    """Rewrite fields of the ``indexes`` row identified by ``legacy_id``."""
+    async with AsyncSession(ctx.pg) as session:
+        await session.execute(
+            update(SQLIndex).where(SQLIndex.legacy_id == legacy_id).values(**values),
+        )
+        await session.commit()
+
+
+async def _insert_index_row(ctx: MigrationContext, **values) -> None:
+    """Insert a single ``indexes`` row from explicit column values."""
+    async with AsyncSession(ctx.pg) as session:
+        session.add(SQLIndex(**values))
+        await session.commit()
+
+
+class TestCompareIndexStores:
+    """The drift gate over the Mongo and Postgres index stores."""
+
+    async def _seed_parity(self, ctx: MigrationContext, document: dict) -> None:
+        """Insert a Mongo document and backfill it, leaving the stores in parity."""
+        await ctx.mongo.indexes.insert_one(document)
+        await copy_indexes_to_postgres(ctx)
+
+    async def test_matching_stores_pass_and_re_run(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """Stores in parity raise nothing, and the read-only check repeats itself."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_job",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=seeded["job_id"],
+            ),
+        )
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_task",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+                version=1,
+            ),
+        )
+
+        await compare_index_stores(ctx)
+        await compare_index_stores(ctx)
+
+    async def test_wrong_manifest_version_fails(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A single otu version rewritten under an existing key is drift."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_manifest",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        await _update_index(ctx, "index_manifest", manifest={"otu_a": 0, "otu_b": 4})
+
+        with pytest.raises(ValueError, match="1 indexes"):
+            await compare_index_stores(ctx)
+
+    async def test_legacy_string_reference_matches_integer_key(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A pre-migration ``reference.id`` string resolves to its integer key."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_legacy_reference",
+                "ref_legacy",
+                "index_owner_legacy",
+                job="job_legacy",
+            ),
+        )
+
+        await compare_index_stores(ctx)
+
+    async def test_sub_millisecond_created_at_passes(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """Postgres keeping microseconds Mongo dropped on write is not drift."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_created_at",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        await _update_index(
+            ctx,
+            "index_created_at",
+            created_at=_CREATED_AT.replace(microsecond=999),
+        )
+
+        await compare_index_stores(ctx)
+
+    async def test_created_at_interval_difference_fails(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A difference above the millisecond is drift."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_created_at",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        await _update_index(
+            ctx,
+            "index_created_at",
+            created_at=_CREATED_AT + timedelta(seconds=1),
+        )
+
+        with pytest.raises(ValueError, match="1 indexes"):
+            await compare_index_stores(ctx)
+
+    async def test_document_missing_from_postgres_fails(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A Mongo document with no backfilled row is drift."""
+        await ctx.mongo.indexes.insert_one(
+            _index_doc(
+                "index_unbackfilled",
+                seeded["reference_id"],
+                seeded["user_id"],
+                task=seeded["task_id"],
+            ),
+        )
+
+        with pytest.raises(ValueError, match="1 indexes"):
+            await compare_index_stores(ctx)
+
+    async def test_orphan_postgres_row_fails(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A migrated row whose Mongo document is gone is drift."""
+        await _insert_index_row(
+            ctx,
+            legacy_id="index_orphan",
+            version=0,
+            created_at=_CREATED_AT,
+            manifest=_MANIFEST,
+            ready=True,
+            storage_key="index_orphan",
+            reference_id=seeded["reference_id"],
+            user_id=seeded["user_id"],
+            task_id=seeded["task_id"],
+        )
+
+        with pytest.raises(ValueError, match="1 indexes"):
+            await compare_index_stores(ctx)
+
+    async def test_job_id_mismatch_fails(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A resolvable Mongo job that points at a different Postgres job is drift."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_job",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=seeded["job_id"],
+            ),
+        )
+
+        other_job_id = await _seed_job(ctx, "other_job_legacy", seeded["user_id"])
+        await _update_index(ctx, "index_job", job_id=other_job_id)
+
+        with pytest.raises(ValueError, match="1 indexes"):
+            await compare_index_stores(ctx)
+
+    async def test_missing_task_key_matches_null_task_id(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A legacy job-backed document with no ``task`` key has a null ``task_id``."""
+        await ctx.mongo.indexes.insert_one(
+            {
+                "_id": "index_no_task_key",
+                "version": 0,
+                "created_at": _CREATED_AT,
+                "manifest": _MANIFEST,
+                "ready": True,
+                "job": {"id": seeded["job_id"]},
+                "user": {"id": seeded["user_id"]},
+                "reference": {"id": seeded["reference_id"]},
+            },
+        )
+        await _insert_index_row(
+            ctx,
+            legacy_id="index_no_task_key",
+            version=0,
+            created_at=_CREATED_AT,
+            manifest=_MANIFEST,
+            ready=True,
+            storage_key="index_no_task_key",
+            reference_id=seeded["reference_id"],
+            user_id=seeded["user_id"],
+            job_id=seeded["job_id"],
+        )
+
+        await compare_index_stores(ctx)
+
+    async def test_null_task_matches_null_task_id(
+        self,
+        ctx: MigrationContext,
+        seeded: dict[str, int],
+    ):
+        """A null ``task`` holds a null ``task_id``, as a job-backed build does."""
+        await self._seed_parity(
+            ctx,
+            _index_doc(
+                "index_null_task",
+                seeded["reference_id"],
+                seeded["user_id"],
+                job=seeded["job_id"],
+            ),
+        )
+
+        await compare_index_stores(ctx)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -806,5 +806,12 @@
       'name': 'copy indexes to postgres',
       'revision': '9ws3adnisz85',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 116,
+      'name': 'compare index stores',
+      'revision': 'wcpztunkc49f',
+    }),
   ])
 # ---

--- a/virtool/indexes/migration.py
+++ b/virtool/indexes/migration.py
@@ -1,8 +1,12 @@
 """Migration logic for the Mongo-to-Postgres index move.
 
-This module holds the idempotent copy used by the index backfill revision. Keeping
-it here rather than in the revision file keeps the logic unit-testable and reusable.
+This module holds the idempotent copy used by the index backfill revision and the
+drift check that gates the read cutover. Keeping them here rather than in the
+revision files keeps the logic unit-testable and reusable.
 """
+
+from dataclasses import dataclass, field
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
@@ -209,3 +213,372 @@ async def _resolve_required_id(
     cache[id_] = resolved
 
     return resolved
+
+
+_INDEX_CHUNK_SIZE = 500
+"""How many shared indexes to load from each store per round of the scan."""
+
+
+@dataclass
+class _ResolutionCaches:
+    """Memoised resolutions of embedded legacy or modern ids to Postgres keys.
+
+    Indexes cluster heavily by reference, user and (for legacy builds) job, so a
+    hit is reused rather than re-queried. Held for the length of one comparison and
+    shared between the scan and the re-verify pass, whose resolutions are identical.
+    """
+
+    reference: dict[int | str, int] = field(default_factory=dict)
+    user: dict[int | str, int] = field(default_factory=dict)
+    job: dict[int | str, int] = field(default_factory=dict)
+
+
+async def compare_index_stores(ctx: MigrationContext) -> None:
+    """Verify the Mongo and Postgres index stores agree.
+
+    A gating drift check run after the index backfill and before index reads switch
+    to Postgres. It changes nothing: it reads every production index (no sampling)
+    and raises if the two stores disagree, so reads never move to a Postgres that has
+    silently fallen behind Mongo.
+
+    Every promoted field is compared, and each embedded id is normalised the way the
+    dual-write and backfill normalise it, so nothing they store faithfully is
+    mistaken for drift:
+
+    - ``version``, ``ready`` and ``manifest`` are compared directly. The ``manifest``
+      is compared as a whole map, not a key set: a single otu version rewritten under
+      an existing key is the silent corruption this gate exists to catch, because a
+      wrong manifest builds a wrong index months downstream.
+    - ``created_at`` is compared at millisecond precision. ``virtool.utils.timestamp``
+      is microsecond-precise, but BSON holds a datetime as int64 milliseconds and
+      drops the microseconds on write, while the Postgres column keeps them. So the
+      two stores hold the same instant to a different precision, and both sides are
+      floored to the millisecond -- Mongo's precision -- before they are compared.
+    - ``reference.id`` may be a legacy Mongo string id or the integer primary key
+      written since references were migrated; both forms resolve to the same
+      ``legacy_references`` id, which is what ``reference_id`` must equal.
+    - ``user.id`` resolves the same way against ``users``.
+    - ``task.id`` is a native Postgres ``tasks`` id and is compared directly. A
+      document with no ``task`` -- a null value or, on a legacy build, no key at all
+      -- must hold a ``NULL`` ``task_id``.
+    - ``job.id`` resolves against ``jobs``, but a ``NULL`` ``job_id`` against a Mongo
+      ``job`` that no longer resolves is expected, not drift: a job-backed index
+      outlives the job that built it, and a deleted job leaves the row's optional
+      foreign key null. A Mongo job that *does* resolve must match ``job_id``.
+
+    The check runs in two passes, in two sessions. The first walks both stores and
+    collects candidates: present in one store but not the other, or holding a row
+    that does not match its document. The second re-reads each candidate from both
+    stores once, in a fresh session so the row is really re-read rather than handed
+    back from the first session's identity map, and reports only the ones that still
+    disagree. The application keeps writing while a migration runs, so a document
+    written or deleted between the two reads would otherwise be reported as drift; the
+    second pass costs nothing on a clean run, where there are no candidates.
+
+    The check is exhaustive before it fails: drift is accumulated across every index,
+    the full per-document report is logged with ``logger.error``, and a single
+    :class:`ValueError` is raised at the end. A clean run logs zero drift with the
+    document count.
+    """
+    drift = await _compare_indexes(ctx)
+
+    if not drift:
+        logger.info("index stores match; no drift")
+        return
+
+    for report in drift:
+        logger.error("index drift", **report)
+
+    msg = f"store drift detected in {len(drift)} indexes"
+    raise ValueError(msg)
+
+
+async def _compare_indexes(ctx: MigrationContext) -> list[dict]:
+    """Compare the Mongo ``indexes`` collection against the ``indexes`` table.
+
+    Indexes are keyed across the stores by the Mongo ``_id``, which the table holds
+    as ``legacy_id``. Native Postgres rows carry no ``legacy_id`` and have no Mongo
+    counterpart, so they are excluded rather than reported as orphans.
+
+    The scan and the verification of its candidates run in separate sessions so the
+    verification really re-reads each row. See :func:`compare_index_stores`.
+    """
+    mongo_ids = {
+        document["_id"]
+        async for document in ctx.mongo.indexes.find({}, projection=["_id"])
+    }
+
+    caches = _ResolutionCaches()
+
+    async with AsyncSession(ctx.pg) as session:
+        postgres_ids = {
+            row[0]
+            for row in await session.execute(select(SQLIndex.legacy_id))
+            if row[0] is not None
+        }
+
+        candidates = mongo_ids ^ postgres_ids
+        shared = sorted(mongo_ids & postgres_ids)
+
+        for start in range(0, len(shared), _INDEX_CHUNK_SIZE):
+            chunk = shared[start : start + _INDEX_CHUNK_SIZE]
+
+            documents = {
+                document["_id"]: document
+                async for document in ctx.mongo.indexes.find({"_id": {"$in": chunk}})
+            }
+
+            rows = {
+                row.legacy_id: row
+                for row in (
+                    await session.execute(
+                        select(SQLIndex).where(SQLIndex.legacy_id.in_(chunk)),
+                    )
+                ).scalars()
+            }
+
+            for index_id in chunk:
+                document = documents.get(index_id)
+                row = rows.get(index_id)
+
+                if document is None or row is None:
+                    candidates.add(index_id)
+                    continue
+
+                if await _diff_index(session, row, document, caches):
+                    candidates.add(index_id)
+
+    async with AsyncSession(ctx.pg) as session:
+        drifted = [
+            report
+            for index_id in sorted(candidates)
+            if (report := await _verify_index(ctx, session, index_id, caches))
+        ]
+
+    logger.info("compared indexes", indexes=len(mongo_ids), drifted=len(drifted))
+
+    return drifted
+
+
+async def _verify_index(
+    ctx: MigrationContext,
+    session: AsyncSession,
+    index_id: str,
+    caches: _ResolutionCaches,
+) -> dict | None:
+    """Re-read one candidate index from both stores and report it if it still drifts.
+
+    Returns ``None`` when the candidate turns out to agree after all, which happens
+    when the application wrote or deleted the index between the reads that flagged it.
+    """
+    document = await ctx.mongo.indexes.find_one({"_id": index_id})
+
+    row = (
+        await session.execute(select(SQLIndex).where(SQLIndex.legacy_id == index_id))
+    ).scalar_one_or_none()
+
+    if document is None and row is None:
+        return None
+
+    if document is None:
+        return {"index_id": index_id, "issue": "missing from mongo"}
+
+    if row is None:
+        return {"index_id": index_id, "issue": "missing from postgres"}
+
+    differences = await _diff_index(session, row, document, caches)
+
+    if differences:
+        return {"index_id": index_id, "differences": differences}
+
+    return None
+
+
+async def _diff_index(
+    session: AsyncSession,
+    row: SQLIndex,
+    document: Document,
+    caches: _ResolutionCaches,
+) -> dict[str, dict]:
+    """Diff an ``indexes`` row against the Mongo document it mirrors.
+
+    Reports by the fields that differ. Embedded ids are resolved to their Postgres
+    keys before comparison; ``created_at`` is floored to the millisecond on both
+    sides. See :func:`compare_index_stores` for the field-by-field contract.
+    """
+    differences: dict[str, dict] = {}
+
+    if row.version != document["version"]:
+        differences["version"] = {
+            "mongo": document["version"],
+            "postgres": row.version,
+        }
+
+    mongo_created_at = _floor_to_millisecond(document["created_at"])
+    postgres_created_at = _floor_to_millisecond(row.created_at)
+
+    if mongo_created_at != postgres_created_at:
+        differences["created_at"] = {
+            "mongo": mongo_created_at,
+            "postgres": postgres_created_at,
+        }
+
+    if row.ready != document["ready"]:
+        differences["ready"] = {"mongo": document["ready"], "postgres": row.ready}
+
+    if row.manifest != document["manifest"]:
+        differences["manifest"] = _diff_manifest(document["manifest"], row.manifest)
+
+    reference_difference = await _diff_resolved_id(
+        session,
+        SQLReference,
+        document["reference"]["id"],
+        row.reference_id,
+        caches.reference,
+        "reference",
+    )
+
+    if reference_difference is not None:
+        differences["reference"] = reference_difference
+
+    user_difference = await _diff_resolved_id(
+        session,
+        SQLUser,
+        document["user"]["id"],
+        row.user_id,
+        caches.user,
+        "user",
+    )
+
+    if user_difference is not None:
+        differences["user"] = user_difference
+
+    job_difference = await _diff_job(session, row, document, caches.job)
+
+    if job_difference is not None:
+        differences["job"] = job_difference
+
+    task = document.get("task")
+    expected_task_id = task["id"] if task is not None else None
+
+    if row.task_id != expected_task_id:
+        differences["task"] = {"mongo": expected_task_id, "postgres": row.task_id}
+
+    return differences
+
+
+async def _diff_resolved_id(
+    session: AsyncSession,
+    model: HasLegacyAndModernIDs,
+    embedded_id: int | str,
+    actual_id: int,
+    cache: dict[int | str, int],
+    relationship: str,
+) -> dict | None:
+    """Diff a required embedded reference against the row's resolved foreign key.
+
+    The embedded id may be a legacy string or a modern integer; both resolve to the
+    same Postgres key, which is what the row must hold. An embedded id that does not
+    resolve is reported: the relationship is required and its target is already
+    migrated, so an unresolvable id is drift.
+    """
+    resolved = await _resolve(session, model, embedded_id, cache)
+
+    if resolved is None:
+        return {
+            "issue": f"{relationship} missing from postgres",
+            relationship: embedded_id,
+        }
+
+    if actual_id != resolved:
+        return {"mongo": resolved, "postgres": actual_id}
+
+    return None
+
+
+async def _diff_job(
+    session: AsyncSession,
+    row: SQLIndex,
+    document: Document,
+    cache: dict[int | str, int],
+) -> dict | None:
+    """Diff an index's ``job_id`` against its Mongo ``job``.
+
+    A job-backed index outlives the job that built it, so a Mongo ``job`` whose id no
+    longer resolves in Postgres is expected to leave ``job_id`` null rather than
+    drift. A Mongo job that does resolve must match ``job_id``; a task-backed index,
+    which carries no ``job``, must hold a null one.
+    """
+    job = document.get("job")
+
+    if job is None:
+        if row.job_id is not None:
+            return {"mongo": None, "postgres": row.job_id}
+        return None
+
+    job_id = await _resolve(session, SQLJob, job["id"], cache)
+
+    if job_id is None:
+        if row.job_id is not None:
+            return {
+                "issue": "mongo job unresolvable but postgres holds a job_id",
+                "mongo": job["id"],
+                "postgres": row.job_id,
+            }
+        return None
+
+    if row.job_id != job_id:
+        return {"mongo": job_id, "postgres": row.job_id}
+
+    return None
+
+
+def _diff_manifest(
+    mongo_manifest: dict,
+    postgres_manifest: dict,
+) -> dict[str, list | dict]:
+    """Summarise how two otu manifests differ, keeping a report readable.
+
+    The pass/fail verdict is the whole-map comparison in :func:`_diff_index`; this
+    only shapes the report of a manifest already known to differ into the otus added,
+    removed or rewritten, so a large manifest does not have to be dumped whole.
+    """
+    mongo_keys = set(mongo_manifest)
+    postgres_keys = set(postgres_manifest)
+
+    return {
+        "only_in_mongo": sorted(mongo_keys - postgres_keys),
+        "only_in_postgres": sorted(postgres_keys - mongo_keys),
+        "changed": {
+            key: {"mongo": mongo_manifest[key], "postgres": postgres_manifest[key]}
+            for key in sorted(mongo_keys & postgres_keys)
+            if mongo_manifest[key] != postgres_manifest[key]
+        },
+    }
+
+
+async def _resolve(
+    session: AsyncSession,
+    model: HasLegacyAndModernIDs,
+    id_: int | str,
+    cache: dict[int | str, int],
+) -> int | None:
+    """Resolve an embedded legacy or modern id to a Postgres key, memoising hits.
+
+    Misses are not cached: the application keeps writing while a migration runs, so an
+    id that does not resolve now may resolve on a later call.
+    """
+    if id_ in cache:
+        return cache[id_]
+
+    resolved = await resolve_legacy_id(session, model, id_)
+
+    if resolved is not None:
+        cache[id_] = resolved
+
+    return resolved
+
+
+def _floor_to_millisecond(created_at: datetime) -> datetime:
+    """Drop a datetime's sub-millisecond precision, as a write to Mongo would."""
+    return created_at.replace(microsecond=created_at.microsecond // 1000 * 1000)

--- a/virtool/indexes/migration.py
+++ b/virtool/indexes/migration.py
@@ -249,6 +249,10 @@ async def compare_index_stores(ctx: MigrationContext) -> None:
       is compared as a whole map, not a key set: a single otu version rewritten under
       an existing key is the silent corruption this gate exists to catch, because a
       wrong manifest builds a wrong index months downstream.
+    - ``storage_key`` must equal the Mongo ``_id``. A migrated row carries the legacy
+      id in ``storage_key``, and it is load-bearing -- it addresses the index's files
+      in object storage -- so a row pointing at the wrong key is drift even when every
+      other field agrees.
     - ``created_at`` is compared at millisecond precision. ``virtool.utils.timestamp``
       is microsecond-precise, but BSON holds a datetime as int64 milliseconds and
       drops the microseconds on write, while the Postgres column keeps them. So the
@@ -407,6 +411,12 @@ async def _diff_index(
     sides. See :func:`compare_index_stores` for the field-by-field contract.
     """
     differences: dict[str, dict] = {}
+
+    if row.storage_key != document["_id"]:
+        differences["storage_key"] = {
+            "mongo": document["_id"],
+            "postgres": row.storage_key,
+        }
 
     if row.version != document["version"]:
         differences["version"] = {


### PR DESCRIPTION
## Summary
- Add a read-only drift-check revision that compares the Mongo `indexes` collection against the Postgres `indexes` table field-by-field and raises if they disagree, so the read cutover only proceeds once the two stores are proven in sync.
- Resolve embedded `reference`, `user`, `job`, and `task` ids to their Postgres keys before comparing, floor `created_at` to millisecond precision, and diff `manifest` as a whole map so a silently rewritten OTU version isn't mistaken for parity.
- Re-verify any candidate drift in a second, fresh session before reporting it, so documents written or deleted mid-scan aren't flagged as false positives.