### PR TITLE
test: build otu history through data-layer mutations

### DIFF
--- a/tests/fixtures/history.py
+++ b/tests/fixtures/history.py
@@ -1,41 +1,6 @@
-import datetime
-
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from virtool.history.db import bulk_insert_diffs, legacy_history_values
-from virtool.history.sql import SQLLegacyHistory
-from virtool.otus.db import otu_row_values
-from virtool.otus.sql import SQLOTU
-from virtool.references.sql import SQLReference
-
-
-@pytest.fixture
-def test_change(static_time):
-    return {
-        "_id": "6116cba1.1",
-        "method_name": "edit",
-        "description": "Edited Prunus virus E",
-        "created_at": static_time.datetime,
-        "diff": [
-            ["change", "abbreviation", ["PVF", ""]],
-            ["change", "name", ["Prunus virus F", "Prunus virus E"]],
-            ["change", "version", [0, 1]],
-        ],
-        "index": {"id": "unbuilt", "version": 1},
-        "reference": {"id": "hxn167"},
-        "user": {"id": "test"},
-        "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-    }
-
-
-@pytest.fixture
-def test_changes(test_change):
-    return [
-        test_change,
-        dict(test_change, _id="foobar.1"),
-        dict(test_change, _id="foobar.2"),
-    ]
+from virtool.otus.oas import CreateOTURequest, UpdateOTURequest
 
 
 @pytest.fixture
@@ -106,209 +71,62 @@ def test_otu_edit():
 
 
 @pytest.fixture
-def create_mock_history(fake, mongo, pg):
-    async def func(remove):
+def build_otu_history(data_layer, fake):
+    """Build a multi-version OTU history through real data-layer mutations.
+
+    The change records come from the same producer production uses, so they can drift
+    from real behaviour no more than the OTU data layer itself does. The OTU passes
+    through five versions:
+
+    * ``0`` -- created
+    * ``1`` -- an isolate added
+    * ``2`` -- a sequence added to the isolate
+    * ``3`` -- renamed
+    * ``4`` -- the isolate removed
+    * ``removed`` -- the OTU removed (only when ``remove`` is ``True``)
+
+    Returns the id of the OTU the mutations created so callers address it rather than a
+    hand-picked literal id.
+    """
+
+    async def func(remove: bool) -> str:
         user = await fake.users.create()
+        reference = await fake.references.create(user=user)
 
-        documents = [
-            {
-                "_id": "6116cba1.0",
-                "created_at": datetime.datetime(2017, 7, 12, 16, 0, 50, 495000),
-                "description": "Description",
-                "diff": {
-                    "_id": "6116cba1",
-                    "abbreviation": "PVF",
-                    "imported": True,
-                    "isolates": [
-                        {
-                            "source_name": "8816-v2",
-                            "source_type": "isolate",
-                            "default": True,
-                            "id": "cab8b360",
-                            "sequences": [
-                                {
-                                    "_id": "KX269872",
-                                    "definition": "Prunus virus F isolate "
-                                    "8816-s2 segment RNA2 "
-                                    "polyprotein 2 gene, "
-                                    "complete cds.",
-                                    "host": "sweet cherry",
-                                    "isolate_id": "cab8b360",
-                                    "sequence": "TGTTTAAGAGATTAAACAACCGCTTTC",
-                                    "otu_id": "6116cba1",
-                                    "segment": None,
-                                }
-                            ],
-                        }
-                    ],
-                    "reference": {"id": "hxn167"},
-                    "schema": [],
-                    "last_indexed_version": 0,
-                    "lower_name": "prunus virus f",
-                    "verified": False,
-                    "name": "Prunus virus F",
-                    "version": 0,
-                },
-                "index": {"id": "unbuilt", "version": "unbuilt"},
-                "method_name": "create",
-                "user": {"id": "test"},
-                "reference": {"id": "hxn167"},
-                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 0},
-            },
-            {
-                "_id": "6116cba1.1",
-                "created_at": datetime.datetime(2017, 7, 12, 16, 0, 50, 600000),
-                "description": "Description",
-                "diff": [
-                    ["change", "version", [0, 1]],
-                    ["change", "abbreviation", ["PVF", "TST"]],
-                ],
-                "index": {"id": "unbuilt", "version": "unbuilt"},
-                "method_name": "update",
-                "user": {"id": "test"},
-                "reference": {"id": "hxn167"},
-                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 1},
-            },
-            {
-                "_id": "6116cba1.2",
-                "created_at": datetime.datetime(2017, 7, 12, 16, 0, 50, 602000),
-                "description": "Description",
-                "diff": [
-                    ["change", "version", [1, 2]],
-                    ["change", "name", ["Prunus virus F", "Test Virus"]],
-                ],
-                "index": {"id": "unbuilt", "version": "unbuilt"},
-                "method_name": "update",
-                "user": {"id": "test"},
-                "reference": {"id": "hxn167"},
-                "otu": {"id": "6116cba1", "name": "Prunus virus F", "version": 2},
-            },
-            {
-                "_id": "6116cba1.3",
-                "created_at": datetime.datetime(2017, 7, 12, 16, 0, 50, 603000),
-                "description": "Description",
-                "diff": [
-                    ["change", "version", [2, 3]],
-                    [
-                        "remove",
-                        "isolates",
-                        [
-                            [
-                                0,
-                                {
-                                    "default": True,
-                                    "id": "cab8b360",
-                                    "sequences": [
-                                        {
-                                            "_id": "KX269872",
-                                            "definition": "Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete "
-                                            "cds.",
-                                            "host": "sweet cherry",
-                                            "isolate_id": "cab8b360",
-                                            "sequence": "TGTTTAAGAGATTAAACAACCGCTTTC",
-                                            "otu_id": "6116cba1",
-                                            "segment": None,
-                                        }
-                                    ],
-                                    "source_name": "8816-v2",
-                                    "source_type": "isolate",
-                                },
-                            ]
-                        ],
-                    ],
-                ],
-                "index": {"id": "unbuilt", "version": "unbuilt"},
-                "method_name": "remove_isolate",
-                "user": {"id": "test"},
-                "reference": {"id": "hxn167"},
-                "otu": {"id": "6116cba1", "name": "Test Virus", "version": 3},
-            },
-        ]
-
-        otu = None
-
-        if remove:
-            documents.append(
-                {
-                    "_id": "6116cba1.removed",
-                    "created_at": datetime.datetime(2017, 7, 12, 16, 0, 50, 605000),
-                    "description": "Description",
-                    "diff": {
-                        "_id": "6116cba1",
-                        "abbreviation": "TST",
-                        "imported": True,
-                        "isolates": [],
-                        "last_indexed_version": 0,
-                        "lower_name": "prunus virus f",
-                        "verified": False,
-                        "name": "Test Virus",
-                        "reference": {"id": "hxn167"},
-                        "version": 3,
-                        "schema": [],
-                    },
-                    "index": {"id": "unbuilt", "version": "unbuilt"},
-                    "reference": {"id": "hxn167"},
-                    "method_name": "remove",
-                    "user": {"id": "test"},
-                    "otu": {
-                        "id": "6116cba1",
-                        "name": "Test Virus",
-                        "version": "removed",
-                    },
-                }
-            )
-        else:
-            otu = {
-                "_id": "6116cba1",
-                "abbreviation": "TST",
-                "imported": True,
-                "isolates": [],
-                "last_indexed_version": 0,
-                "lower_name": "prunus virus f",
-                "verified": False,
-                "name": "Test Virus",
-                "reference": {"id": "hxn167"},
-                "version": 3,
-                "schema": [],
-            }
-
-            await mongo.otus.insert_one(otu)
-
-        # One legacy_history row per change with the real diff in Postgres keyed by
-        # history_id. History is Postgres-only, so nothing is written to Mongo.
-        async with AsyncSession(pg) as session:
-            reference = SQLReference(
-                legacy_id="hxn167",
-                name="Reference A",
-                description="",
-                created_at=datetime.datetime(2017, 7, 12, 16, 0, 50),
-                source_types=[],
-                user_id=user.id,
-            )
-            session.add(reference)
-            await session.flush()
-
-            if otu is not None:
-                session.add(SQLOTU(**otu_row_values(otu, reference.id)))
-
-            for document in documents:
-                session.add(
-                    SQLLegacyHistory(
-                        **legacy_history_values({**document, "user": {"id": user.id}}),
-                        reference_id=reference.id,
-                    ),
-                )
-
-            await session.commit()
-
-        await bulk_insert_diffs(
-            pg,
-            [
-                {"change_id": document["_id"], "diff": document["diff"]}
-                for document in documents
-            ],
+        otu = await data_layer.otus.create(
+            reference.id,
+            CreateOTURequest(name="Prunus virus F", abbreviation="PVF"),
+            user.id,
         )
 
-        return otu
+        isolate = await data_layer.otus.add_isolate(
+            otu.id,
+            "isolate",
+            "8816-v2",
+            user.id,
+        )
+
+        await data_layer.otus.create_sequence(
+            otu.id,
+            isolate.id,
+            "KX269872",
+            "Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene",
+            "TGTTTAAGAGATTAAACAACCGCTTTC",
+            user.id,
+            host="sweet cherry",
+        )
+
+        await data_layer.otus.update(
+            otu.id,
+            UpdateOTURequest(name="Test Virus"),
+            user.id,
+        )
+
+        await data_layer.otus.remove_isolate(otu.id, isolate.id, user.id)
+
+        if remove:
+            await data_layer.otus.remove(otu.id, user.id)
+
+        return otu.id
 
     return func

--- a/tests/history/__snapshots__/test_db.ambr
+++ b/tests/history/__snapshots__/test_db.ambr
@@ -242,55 +242,41 @@
 # ---
 # name: test_patch_to_version[False][current]
   dict({
-    '_id': '6116cba1',
-    'abbreviation': 'TST',
-    'imported': True,
+    '_id': 'bf1b993c',
+    'abbreviation': 'PVF',
     'isolates': list([
     ]),
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
+    'last_indexed_version': None,
+    'lower_name': 'test virus',
     'name': 'Test Virus',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 1,
     }),
     'schema': list([
     ]),
     'verified': False,
-    'version': 3,
+    'version': 4,
   })
 # ---
 # name: test_patch_to_version[False][patched]
   dict({
-    '_id': '6116cba1',
-    'abbreviation': 'TST',
-    'imported': True,
+    '_id': 'bf1b993c',
+    'abbreviation': 'PVF',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'cab8b360',
+        'id': 'fb085f7f',
         'sequences': list([
-          dict({
-            '_id': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-            'host': 'sweet cherry',
-            'isolate_id': 'cab8b360',
-            'otu_id': '6116cba1',
-            'reference': dict({
-              'id': 'hxn167',
-            }),
-            'segment': None,
-            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-          }),
         ]),
         'source_name': '8816-v2',
         'source_type': 'isolate',
       }),
     ]),
-    'last_indexed_version': 0,
+    'last_indexed_version': None,
     'lower_name': 'prunus virus f',
     'name': 'Prunus virus F',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 1,
     }),
     'schema': list([
     ]),
@@ -303,32 +289,19 @@
 # ---
 # name: test_patch_to_version[True][patched]
   dict({
-    '_id': '6116cba1',
-    'abbreviation': 'TST',
-    'imported': True,
+    '_id': 'bf1b993c',
+    'abbreviation': 'PVF',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'cab8b360',
+        'id': 'fb085f7f',
         'sequences': list([
-          dict({
-            '_id': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-            'host': 'sweet cherry',
-            'isolate_id': 'cab8b360',
-            'otu_id': '6116cba1',
-            'reference': dict({
-              'id': 1,
-            }),
-            'segment': None,
-            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-          }),
         ]),
         'source_name': '8816-v2',
         'source_type': 'isolate',
       }),
     ]),
-    'last_indexed_version': 0,
+    'last_indexed_version': None,
     'lower_name': 'prunus virus f',
     'name': 'Prunus virus F',
     'reference': dict({
@@ -342,41 +315,40 @@
 # ---
 # name: test_patch_to_version_intermediate[current]
   dict({
-    '_id': '6116cba1',
-    'abbreviation': 'TST',
-    'imported': True,
+    '_id': 'bf1b993c',
+    'abbreviation': 'PVF',
     'isolates': list([
     ]),
-    'last_indexed_version': 0,
-    'lower_name': 'prunus virus f',
+    'last_indexed_version': None,
+    'lower_name': 'test virus',
     'name': 'Test Virus',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 1,
     }),
     'schema': list([
     ]),
     'verified': False,
-    'version': 3,
+    'version': 4,
   })
 # ---
 # name: test_patch_to_version_intermediate[patched]
   dict({
-    '_id': '6116cba1',
-    'abbreviation': 'TST',
-    'imported': True,
+    '_id': 'bf1b993c',
+    'abbreviation': 'PVF',
     'isolates': list([
       dict({
         'default': True,
-        'id': 'cab8b360',
+        'id': 'fb085f7f',
         'sequences': list([
           dict({
-            '_id': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
+            '_id': '7cf872dc',
+            'accession': 'KX269872',
+            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene',
             'host': 'sweet cherry',
-            'isolate_id': 'cab8b360',
-            'otu_id': '6116cba1',
+            'isolate_id': 'fb085f7f',
+            'otu_id': 'bf1b993c',
             'reference': dict({
-              'id': 'hxn167',
+              'id': 1,
             }),
             'segment': None,
             'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
@@ -386,15 +358,15 @@
         'source_type': 'isolate',
       }),
     ]),
-    'last_indexed_version': 0,
+    'last_indexed_version': None,
     'lower_name': 'prunus virus f',
-    'name': 'Test Virus',
+    'name': 'Prunus virus F',
     'reference': dict({
-      'id': 'hxn167',
+      'id': 1,
     }),
     'schema': list([
     ]),
-    'verified': False,
+    'verified': True,
     'version': 2,
   })
 # ---

--- a/tests/history/test_db.py
+++ b/tests/history/test_db.py
@@ -346,15 +346,15 @@ class TestGetMostRecentChange:
 @pytest.mark.parametrize("remove", [True, False])
 async def test_patch_to_version(
     remove: bool,
-    create_mock_history,
+    build_otu_history,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
-    await create_mock_history(remove=remove)
+    otu_id = await build_otu_history(remove=remove)
 
     current, patched = await virtool.history.db.patch_to_version(
         pg,
-        "6116cba1",
+        otu_id,
         1,
     )
 
@@ -392,18 +392,18 @@ def test_stamp_reference():
 
 
 async def test_patch_to_version_intermediate(
-    create_mock_history,
+    build_otu_history,
     pg: AsyncEngine,
     snapshot: SnapshotAssertion,
 ):
     """Patching to an intermediate version unwinds only the changes above it, stopping
     at the first change at or below the target version.
     """
-    await create_mock_history(remove=False)
+    otu_id = await build_otu_history(remove=False)
 
     current, patched = await virtool.history.db.patch_to_version(
         pg,
-        "6116cba1",
+        otu_id,
         2,
     )
 
@@ -423,7 +423,7 @@ class TestPatchOTUsToVersions:
     async def test_same_otu_at_two_versions(
         self,
         remove: bool,
-        create_mock_history,
+        build_otu_history,
         pg: AsyncEngine,
     ):
         """An OTU patched to two versions at once resolves as each version does alone.
@@ -432,9 +432,9 @@ class TestPatchOTUsToVersions:
         its OTUs is being patched to, so the specifier bound for the higher version is
         handed rows reaching past its own target that it must not revert.
         """
-        await create_mock_history(remove=remove)
+        otu_id = await build_otu_history(remove=remove)
 
-        specifiers = [("6116cba1", 1), ("6116cba1", 2)]
+        specifiers = [(otu_id, 1), (otu_id, 2)]
 
         patched_otus = await virtool.history.db.patch_otus_to_versions(pg, specifiers)
 

--- a/tests/otus/__snapshots__/test_api.ambr
+++ b/tests/otus/__snapshots__/test_api.ambr
@@ -1156,33 +1156,21 @@
 # name: TestEdit.test_no_change[0-data0][json]
   dict({
     'abbreviation': 'PVF',
-    'id': '6116cba1',
+    'id': 'bf1b993c',
     'isolates': list([
-      dict({
-        'default': True,
-        'id': 'cab8b360',
-        'sequences': list([
-          dict({
-            'accession': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-            'host': 'sweet cherry',
-            'id': 'abcd1234',
-            'remote': None,
-            'segment': None,
-            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-          }),
-        ]),
-        'source_name': '8816-v2',
-        'source_type': 'isolate',
-      }),
     ]),
-    'issues': None,
-    'last_indexed_version': 0,
+    'issues': dict({
+      'empty_isolate': False,
+      'empty_otu': True,
+      'empty_sequence': False,
+      'isolate_inconsistency': False,
+    }),
+    'last_indexed_version': None,
     'most_recent_change': dict({
       'created_at': '2015-10-06T20:00:00Z',
-      'description': 'Edited Prunus virus E',
-      'id': '6116cba1.0',
-      'method_name': 'edit',
+      'description': 'Created Prunus virus F (PVF)',
+      'id': 'bf1b993c.0',
+      'method_name': 'create',
       'user': dict({
         'handle': 'leeashley',
         'id': 1,
@@ -1204,33 +1192,21 @@
 # name: TestEdit.test_no_change[0-data1][json]
   dict({
     'abbreviation': 'PVF',
-    'id': '6116cba1',
+    'id': 'bf1b993c',
     'isolates': list([
-      dict({
-        'default': True,
-        'id': 'cab8b360',
-        'sequences': list([
-          dict({
-            'accession': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-            'host': 'sweet cherry',
-            'id': 'abcd1234',
-            'remote': None,
-            'segment': None,
-            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-          }),
-        ]),
-        'source_name': '8816-v2',
-        'source_type': 'isolate',
-      }),
     ]),
-    'issues': None,
-    'last_indexed_version': 0,
+    'issues': dict({
+      'empty_isolate': False,
+      'empty_otu': True,
+      'empty_sequence': False,
+      'isolate_inconsistency': False,
+    }),
+    'last_indexed_version': None,
     'most_recent_change': dict({
       'created_at': '2015-10-06T20:00:00Z',
-      'description': 'Edited Prunus virus E',
-      'id': '6116cba1.0',
-      'method_name': 'edit',
+      'description': 'Created Prunus virus F (PVF)',
+      'id': 'bf1b993c.0',
+      'method_name': 'create',
       'user': dict({
         'handle': 'leeashley',
         'id': 1,
@@ -1252,32 +1228,20 @@
 # name: TestEdit.test_no_change[1-data2][json]
   dict({
     'abbreviation': 'PVF2',
-    'id': '6116cba1',
+    'id': 'bf1b993c',
     'isolates': list([
-      dict({
-        'default': True,
-        'id': 'cab8b360',
-        'sequences': list([
-          dict({
-            'accession': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-            'host': 'sweet cherry',
-            'id': 'abcd1234',
-            'remote': None,
-            'segment': None,
-            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-          }),
-        ]),
-        'source_name': '8816-v2',
-        'source_type': 'isolate',
-      }),
     ]),
-    'issues': None,
-    'last_indexed_version': 0,
+    'issues': dict({
+      'empty_isolate': False,
+      'empty_otu': True,
+      'empty_sequence': False,
+      'isolate_inconsistency': False,
+    }),
+    'last_indexed_version': None,
     'most_recent_change': dict({
       'created_at': '2015-10-06T20:00:00Z',
       'description': 'Changed name to Prunus virus F and changed abbreviation to PVF2 and modified schema',
-      'id': '6116cba1.1',
+      'id': 'bf1b993c.1',
       'method_name': 'edit',
       'user': dict({
         'handle': 'leeashley',
@@ -1293,39 +1257,27 @@
     'remote': None,
     'schema': list([
     ]),
-    'verified': True,
+    'verified': False,
     'version': 1,
   })
 # ---
 # name: TestEdit.test_no_change[1-data3][json]
   dict({
     'abbreviation': 'PVF',
-    'id': '6116cba1',
+    'id': 'bf1b993c',
     'isolates': list([
-      dict({
-        'default': True,
-        'id': 'cab8b360',
-        'sequences': list([
-          dict({
-            'accession': 'KX269872',
-            'definition': 'Prunus virus F isolate 8816-s2 segment RNA2 polyprotein 2 gene, complete cds.',
-            'host': 'sweet cherry',
-            'id': 'abcd1234',
-            'remote': None,
-            'segment': None,
-            'sequence': 'TGTTTAAGAGATTAAACAACCGCTTTC',
-          }),
-        ]),
-        'source_name': '8816-v2',
-        'source_type': 'isolate',
-      }),
     ]),
-    'issues': None,
-    'last_indexed_version': 0,
+    'issues': dict({
+      'empty_isolate': False,
+      'empty_otu': True,
+      'empty_sequence': False,
+      'isolate_inconsistency': False,
+    }),
+    'last_indexed_version': None,
     'most_recent_change': dict({
       'created_at': '2015-10-06T20:00:00Z',
       'description': 'Changed name to Prunus virus G and changed abbreviation to PVF and modified schema',
-      'id': '6116cba1.1',
+      'id': 'bf1b993c.1',
       'method_name': 'edit',
       'user': dict({
         'handle': 'leeashley',
@@ -1341,7 +1293,7 @@
     'remote': None,
     'schema': list([
     ]),
-    'verified': True,
+    'verified': False,
     'version': 1,
   })
 # ---

--- a/tests/otus/test_api.py
+++ b/tests/otus/test_api.py
@@ -12,7 +12,6 @@ from tests.fixtures.response import RespIs
 from virtool.data.errors import ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
-from virtool.history.db import legacy_history_values
 from virtool.history.sql import SQLLegacyHistory
 from virtool.models.enums import HistoryMethod, Molecule, Permission
 from virtool.mongo.core import Mongo
@@ -276,30 +275,26 @@ class TestEdit:
         self,
         change_count: int,
         data: dict,
-        insert_otu,
+        data_layer: DataLayer,
         pg: AsyncEngine,
         spawn_client: ClientSpawner,
         snapshot: SnapshotAssertion,
-        test_change,
-        test_otu,
-        test_sequence,
+        static_time: StaticTime,
     ):
         client = await spawn_client(
             authenticated=True,
             permissions=[Permission.create_ref],
         )
 
-        change = {**test_change, "user": {"id": client.user.id}, "_id": "6116cba1.0"}
-
         reference = await create_reference(client)
 
-        await insert_otu(test_otu, reference["id"], [test_sequence])
+        otu = await data_layer.otus.create(
+            reference["id"],
+            CreateOTURequest(name="Prunus virus F", abbreviation="PVF"),
+            client.user.id,
+        )
 
-        async with AsyncSession(pg) as session:
-            session.add(SQLLegacyHistory(**legacy_history_values(change)))
-            await session.commit()
-
-        resp = await client.patch(f"/otus/{test_otu['_id']}", data)
+        resp = await client.patch(f"/otus/{otu.id}", data)
 
         assert resp.status == HTTPStatus.OK
 

--- a/tests/otus/test_db.py
+++ b/tests/otus/test_db.py
@@ -7,7 +7,6 @@ from tests.fixtures.otus import IMPORTED_CREATED_AT
 from virtool.api.custom_json import dump_string, loads
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
-from virtool.history.sql import SQLLegacyHistory
 from virtool.models.enums import Molecule
 from virtool.mongo.core import Mongo
 from virtool.otus.db import (
@@ -343,51 +342,22 @@ class TestFindModifiedCount:
     versions.
     """
 
-    async def _add_history(
-        self,
-        pg: AsyncEngine,
-        user_id: int,
-        created_at,
-        rows: list[tuple[str, str, str]],
-    ) -> None:
-        async with AsyncSession(pg) as session:
-            session.add_all(
-                SQLLegacyHistory(
-                    legacy_id=f"{otu}.{otu_version}",
-                    created_at=created_at,
-                    description="",
-                    method_name="edit",
-                    user_id=user_id,
-                    otu=otu,
-                    otu_name=otu_name,
-                    otu_version=otu_version,
-                    reference="reference",
-                    index=None,
-                    index_version=None,
-                )
-                for otu, otu_name, otu_version in rows
-            )
-            await session.commit()
-
     async def test_shared_name_counted_separately(
         self,
-        fake,
-        mongo: Mongo,
+        data_layer: DataLayer,
+        fake: DataFaker,
         pg: AsyncEngine,
-        static_time,
     ):
         """Two OTUs that share a name count as two modifications, not one."""
         user = await fake.users.create()
+        reference = await fake.references.create(user=user)
 
-        await self._add_history(
-            pg,
-            user.id,
-            static_time.datetime,
-            [
-                ("first_otu", "Shared Name", "0"),
-                ("second_otu", "Shared Name", "0"),
-            ],
-        )
+        for abbreviation in ("SNA", "SNB"):
+            await data_layer.otus.create(
+                reference.id,
+                CreateOTURequest(name="Shared Name", abbreviation=abbreviation),
+                user.id,
+            )
 
         data = await find(pg, None, 1, 25, None)
 
@@ -395,22 +365,24 @@ class TestFindModifiedCount:
 
     async def test_renamed_otu_counted_once(
         self,
-        fake,
-        mongo: Mongo,
+        data_layer: DataLayer,
+        fake: DataFaker,
         pg: AsyncEngine,
-        static_time,
     ):
         """One OTU renamed across versions counts as a single modification."""
         user = await fake.users.create()
+        reference = await fake.references.create(user=user)
 
-        await self._add_history(
-            pg,
+        otu = await data_layer.otus.create(
+            reference.id,
+            CreateOTURequest(name="Old Name", abbreviation="ON"),
             user.id,
-            static_time.datetime,
-            [
-                ("renamed_otu", "Old Name", "0"),
-                ("renamed_otu", "New Name", "1"),
-            ],
+        )
+
+        await data_layer.otus.update(
+            otu.id,
+            UpdateOTURequest(name="New Name"),
+            user.id,
         )
 
         data = await find(pg, None, 1, 25, None)


### PR DESCRIPTION
## Summary
- Replace the hand-seeded `create_mock_history` fixture and OTU-domain history builders with real data-layer OTU mutations, so tests exercise the same change-record producer as production.
- Keep direct history seeding only where mutations can't produce the shape (index-scoped rows).