### PR TITLE
refactor: resolve build_index jobs via the index job foreign key

### DIFF
--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -26,7 +26,7 @@ from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import JOB_INDEX_FILE_NAMES
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.indexes.utils import check_index_file_type, compose_index_file_key
-from virtool.jobs.pg import SQLJob, SQLJobIndex
+from virtool.jobs.pg import SQLJob
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 from virtool.otus.sql import SQLOTU
@@ -445,7 +445,6 @@ class TestCreate:
             assert history is not None
             assert (history.index, history.index_version) == (index["_id"], "0")
             assert await session.scalar(select(SQLJob.id)) is None
-            assert await session.scalar(select(SQLJobIndex.job_id)) is None
 
         m_create_manifest.assert_called_with(ANY, reference["id"])
 

--- a/tests/jobs/__snapshots__/test_data.ambr
+++ b/tests/jobs/__snapshots__/test_data.ambr
@@ -21,7 +21,6 @@
 # name: test_create
   dict({
     'args': dict({
-      'index_id': 'foo',
     }),
     'claim': None,
     'claimed_at': None,

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -12,6 +12,7 @@ from virtool.data.events import (
 )
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
+from virtool.indexes.sql import SQLIndex
 from virtool.jobs.data import JobsData
 from virtool.jobs.models import (
     CreateJobClaimRequest,
@@ -251,6 +252,7 @@ class TestCreatePostgres:
         self,
         jobs_data: JobsData,
         fake: DataFaker,
+        pg: AsyncEngine,
     ):
         """``get`` resolves the index id from the index linked by job_id.
 
@@ -266,9 +268,38 @@ class TestCreatePostgres:
 
         index = await fake.indexes.create(reference, user, job=job)
 
+        async with AsyncSession(pg) as session:
+            sql_index = (
+                await session.execute(
+                    select(SQLIndex).where(SQLIndex.job_id == job.id),
+                )
+            ).scalar_one()
+
         fetched_job = await jobs_data.get(job.id)
 
-        assert fetched_job.args == {"index_id": index.id}
+        # The argument is the index's legacy string id, not its integer primary
+        # key, matching what the retired ``job_indexes`` table stored.
+        assert fetched_job.args == {"index_id": sql_index.legacy_id}
+        assert sql_index.legacy_id == index.id
+
+    async def test_index_id_absent_without_index(
+        self,
+        jobs_data: JobsData,
+        fake: DataFaker,
+    ):
+        """``get`` omits ``index_id`` when no index links the build_index job.
+
+        ``indexes.job_id`` is nullable, so a historical build whose job was deleted
+        leaves nothing to resolve on the reverse join. The argument disappears
+        entirely rather than resolving to ``None``.
+        """
+        user = await fake.users.create()
+
+        job = await jobs_data.create("build_index", {}, user.id, 0)
+
+        fetched_job = await jobs_data.get(job.id)
+
+        assert fetched_job.args == {}
 
     async def test_subtraction_id_resolved_from_subtraction(
         self,

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -23,7 +23,6 @@ from virtool.jobs.models import (
 )
 from virtool.jobs.pg import (
     SQLJob,
-    SQLJobIndex,
 )
 from virtool.samples.sql import SQLLegacySample
 from virtool.subtractions.pg import SQLSubtraction
@@ -55,7 +54,7 @@ async def test_create(
 
     user = await fake.users.create()
 
-    job = await jobs_data.create("build_index", {"index_id": "foo"}, user.id, 0)
+    job = await jobs_data.create("build_index", {}, user.id, 0)
 
     assert job == snapshot
 
@@ -248,37 +247,28 @@ class TestCreatePostgres:
 
         assert fetched_job.args == {"sample_id": sample.id}
 
-    async def test_index_join_table(
+    async def test_index_id_resolved_from_index(
         self,
         jobs_data: JobsData,
         fake: DataFaker,
-        pg: AsyncEngine,
     ):
-        """Test that build_index jobs write to job_indexes join table."""
+        """``get`` resolves the index id from the index linked by job_id.
+
+        A build_index job no longer writes a ``job_indexes`` link row; its
+        ``index_id`` argument is reconstructed from the reverse ``indexes.job_id``
+        foreign key and exposed as the index's legacy id, byte-identical to what the
+        retired join table stored.
+        """
         user = await fake.users.create()
+        reference = await fake.references.create(user)
 
-        job = await jobs_data.create(
-            "build_index",
-            {"index_id": "index_456"},
-            user.id,
-            0,
-        )
+        job = await jobs_data.create("build_index", {}, user.id, 0)
 
-        async with AsyncSession(pg) as session:
-            sql_job = (
-                await session.execute(
-                    select(SQLJob).where(SQLJob.id == job.id),
-                )
-            ).scalar()
+        index = await fake.indexes.create(reference, user, job=job)
 
-            job_index = (
-                await session.execute(
-                    select(SQLJobIndex).where(SQLJobIndex.job_id == sql_job.id),
-                )
-            ).scalar()
+        fetched_job = await jobs_data.get(job.id)
 
-        assert job_index is not None
-        assert job_index.index_id == "index_456"
+        assert fetched_job.args == {"index_id": index.id}
 
     async def test_subtraction_id_resolved_from_subtraction(
         self,

--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -17,7 +17,7 @@ from virtool.data.layer import DataLayer
 from virtool.data.topg import both_transactions
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
-from virtool.jobs.pg import SQLJob, SQLJobIndex
+from virtool.jobs.pg import SQLJob
 from virtool.models.enums import Permission
 from virtool.mongo.core import Mongo
 from virtool.otus.oas import (
@@ -973,7 +973,6 @@ class TestCreateIndex:
             assert history is not None
             assert (history.index, history.index_version) == (index["_id"], "0")
             assert await session.scalar(select(SQLJob.id)) is None
-            assert await session.scalar(select(SQLJobIndex.job_id)) is None
 
         m_create_manifest.assert_called_with(ANY, reference["id"])
 

--- a/virtool/jobs/data.py
+++ b/virtool/jobs/data.py
@@ -11,6 +11,7 @@ from virtool.analyses.sql import SQLAnalysis
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import Operation, emit, emits
 from virtool.data.transforms import apply_transforms
+from virtool.indexes.sql import SQLIndex
 from virtool.jobs.models import (
     CreateJobClaimRequest,
     Job,
@@ -27,7 +28,6 @@ from virtool.jobs.models import (
 )
 from virtool.jobs.pg import (
     SQLJob,
-    SQLJobIndex,
 )
 from virtool.jobs.utils import compute_progress
 from virtool.samples.sql import SQLLegacySample
@@ -215,9 +215,6 @@ class JobsData:
         session.add(sql_job)
         await session.flush()
 
-        if workflow == "build_index" and "index_id" in job_args:
-            session.add(SQLJobIndex(job_id=sql_job.id, index_id=job_args["index_id"]))
-
         return sql_job.id
 
     @emits(Operation.CREATE)
@@ -253,13 +250,13 @@ class JobsData:
                     SQLJob,
                     SQLUser,
                     SQLLegacySample.id.label("sample_id"),
-                    SQLJobIndex.index_id,
+                    SQLIndex.legacy_id.label("index_id"),
                     SQLSubtraction.id.label("subtraction_id"),
                     SQLAnalysis.id.label("analysis_id"),
                 )
                 .join(SQLUser, SQLJob.user_id == SQLUser.id)
                 .outerjoin(SQLLegacySample, SQLLegacySample.job_id == SQLJob.id)
-                .outerjoin(SQLJobIndex, SQLJob.id == SQLJobIndex.job_id)
+                .outerjoin(SQLIndex, SQLIndex.job_id == SQLJob.id)
                 .outerjoin(SQLSubtraction, SQLSubtraction.job_id == SQLJob.id)
                 .outerjoin(SQLAnalysis, SQLAnalysis.job_id == SQLJob.id)
                 .where(SQLJob.id == job_id),
@@ -273,7 +270,10 @@ class JobsData:
 
         # The create_sample job's sample is resolved through the reverse
         # ``legacy_samples.job_id`` foreign key rather than a ``job_samples`` link
-        # row.
+        # row. The build_index job's index is likewise resolved through the reverse
+        # ``indexes.job_id`` foreign key rather than a ``job_indexes`` link row; its
+        # ``index_id`` argument is the index's legacy id, byte-identical to what the
+        # retired join table stored.
         args = {
             field: value
             for field, value in (

--- a/virtool/jobs/pg.py
+++ b/virtool/jobs/pg.py
@@ -83,6 +83,14 @@ class SQLJobAnalysis(Base):
 
 
 class SQLJobIndex(Base):
+    """Links a job to the index it built.
+
+    No longer written: the index references its job directly via
+    ``indexes.job_id``, and ``JobsData.get`` resolves the index through that
+    reverse foreign key. The model and ``job_indexes`` table are retained pending
+    their drop in VIR-2394.
+    """
+
     __tablename__ = "job_indexes"
 
     job_id: Mapped[int] = mapped_column(ForeignKey("jobs.id"), primary_key=True)


### PR DESCRIPTION
## Summary
- Stop writing to the `job_indexes` join table when creating `build_index` jobs — `indexes.job_id` already captures the same link.
- Reconstruct a `build_index` job's `index_id` argument by joining on the reverse `indexes.job_id` foreign key instead of reading `job_indexes`.
- Keep the `SQLJobIndex` model and `job_indexes` table for now, docstringed as pending removal (VIR-2394), until the cutover is proven stable.