### PR TITLE
feat: read latest reference build from postgres

### DIFF
--- a/tests/references/test_api.py
+++ b/tests/references/test_api.py
@@ -281,6 +281,42 @@ async def test_find_archived_invalid(spawn_client: ClientSpawner):
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
+async def test_find_attaches_latest_build(
+    fake: DataFaker,
+    spawn_client: ClientSpawner,
+):
+    """Each reference in the list carries its own highest-versioned ready build,
+    with the build user resolved.
+    """
+    client = await spawn_client(authenticated=True, administrator=True)
+
+    user = await fake.users.create()
+
+    expected_build_ids = {}
+    for _ in range(3):
+        reference = await fake.references.create(user=user)
+        await fake.indexes.create(reference, user, version=0, ready=True)
+        latest = await fake.indexes.create(reference, user, version=1, ready=True)
+        expected_build_ids[reference.id] = latest.id
+
+    resp = await client.get("/references/v1")
+
+    assert resp.status == HTTPStatus.OK
+
+    body = await resp.json()
+
+    assert {
+        document["id"]: document["latest_build"]["id"] for document in body["documents"]
+    } == expected_build_ids
+
+    for document in body["documents"]:
+        assert document["latest_build"]["version"] == 1
+        assert document["latest_build"]["user"] == {
+            "id": user.id,
+            "handle": user.handle,
+        }
+
+
 class TestGet:
     async def test_ok(
         self,

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -8,6 +9,7 @@ from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
+from virtool.references.db import get_latest_builds
 from virtool.references.oas import (
     CreateReferenceGroupRequest,
     CreateReferenceRequest,
@@ -17,6 +19,41 @@ from virtool.references.oas import (
 )
 from virtool.references.sql import SQLReference
 from virtool.tasks.sql import SQLTask
+
+
+class TestFind:
+    async def test_latest_build_batched_once(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        mocker: MockerFixture,
+    ):
+        """The list path resolves latest builds with a single batch call for the
+        whole page, not one call per reference.
+        """
+        user = await fake.users.create()
+
+        for _ in range(3):
+            reference = await fake.references.create(user=user)
+            await fake.indexes.create(reference, user, version=0, ready=True)
+
+        spy = mocker.patch(
+            "virtool.references.data.get_latest_builds",
+            wraps=get_latest_builds,
+        )
+
+        result = await data_layer.references.find(
+            find="",
+            user_id=user.id,
+            administrator=True,
+            groups=[],
+            page=1,
+            per_page=25,
+        )
+
+        assert len(result.documents) == 3
+        assert all(d.latest_build is not None for d in result.documents)
+        spy.assert_called_once()
 
 
 class TestCreate:

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -1,3 +1,14 @@
+"""Tests for the references data layer.
+
+``ReferencesData.find`` is intentionally not tested here. Its only production
+caller is the ``GET /references/v1`` handler, so it is exercised end-to-end in
+``test_api.py`` (see ``test_find`` and ``test_find_attaches_latest_build``)
+rather than duplicated against the data layer. As a general rule, when a
+data-layer method's sole production caller is a thin API handler, cover it at
+the API layer and skip the redundant data-layer test; reserve data-layer tests
+for logic that has no direct HTTP entry point of its own.
+"""
+
 import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -17,43 +28,6 @@ from virtool.references.oas import (
 )
 from virtool.references.sql import SQLReference
 from virtool.tasks.sql import SQLTask
-
-
-class TestFind:
-    async def test_attaches_latest_build_per_reference(
-        self,
-        data_layer: DataLayer,
-        fake: DataFaker,
-    ):
-        """Each reference on the page carries its own highest-versioned ready build,
-        with the build user resolved.
-        """
-        user = await fake.users.create()
-
-        expected_build_ids = {}
-        for _ in range(3):
-            reference = await fake.references.create(user=user)
-            await fake.indexes.create(reference, user, version=0, ready=True)
-            latest = await fake.indexes.create(reference, user, version=1, ready=True)
-            expected_build_ids[reference.id] = latest.id
-
-        result = await data_layer.references.find(
-            find="",
-            user_id=user.id,
-            administrator=True,
-            groups=[],
-            page=1,
-            per_page=25,
-        )
-
-        assert {
-            document.id: document.latest_build.id for document in result.documents
-        } == expected_build_ids
-
-        for document in result.documents:
-            assert document.latest_build.version == 1
-            assert document.latest_build.user.id == user.id
-            assert document.latest_build.user.handle == user.handle
 
 
 class TestCreate:

--- a/tests/references/test_data.py
+++ b/tests/references/test_data.py
@@ -1,5 +1,4 @@
 import pytest
-from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -9,7 +8,6 @@ from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.mongo.core import Mongo
-from virtool.references.db import get_latest_builds
 from virtool.references.oas import (
     CreateReferenceGroupRequest,
     CreateReferenceRequest,
@@ -22,25 +20,22 @@ from virtool.tasks.sql import SQLTask
 
 
 class TestFind:
-    async def test_latest_build_batched_once(
+    async def test_attaches_latest_build_per_reference(
         self,
         data_layer: DataLayer,
         fake: DataFaker,
-        mocker: MockerFixture,
     ):
-        """The list path resolves latest builds with a single batch call for the
-        whole page, not one call per reference.
+        """Each reference on the page carries its own highest-versioned ready build,
+        with the build user resolved.
         """
         user = await fake.users.create()
 
+        expected_build_ids = {}
         for _ in range(3):
             reference = await fake.references.create(user=user)
             await fake.indexes.create(reference, user, version=0, ready=True)
-
-        spy = mocker.patch(
-            "virtool.references.data.get_latest_builds",
-            wraps=get_latest_builds,
-        )
+            latest = await fake.indexes.create(reference, user, version=1, ready=True)
+            expected_build_ids[reference.id] = latest.id
 
         result = await data_layer.references.find(
             find="",
@@ -51,9 +46,14 @@ class TestFind:
             per_page=25,
         )
 
-        assert len(result.documents) == 3
-        assert all(d.latest_build is not None for d in result.documents)
-        spy.assert_called_once()
+        assert {
+            document.id: document.latest_build.id for document in result.documents
+        } == expected_build_ids
+
+        for document in result.documents:
+            assert document.latest_build.version == 1
+            assert document.latest_build.user.id == user.id
+            assert document.latest_build.user.handle == user.handle
 
 
 class TestCreate:

--- a/tests/references/test_db.py
+++ b/tests/references/test_db.py
@@ -19,6 +19,7 @@ from virtool.otus.sql import SQLOTU, SQLSequence
 from virtool.references.db import (
     compose_reference_ids_match,
     create_document,
+    get_latest_builds,
     get_manifest,
     get_reference_groups,
     populate_insert_only_reference,
@@ -526,6 +527,66 @@ async def test_create_manifest(fake: DataFaker, pg: AsyncEngine):
     await fake.otus.create(other_reference.id, user)
 
     assert await get_manifest(pg, reference.id) == {otu.id: otu.version for otu in otus}
+
+
+class TestGetLatestBuilds:
+    async def test_ok(self, fake: DataFaker, pg: AsyncEngine, static_time):
+        """Each reference maps to its highest-versioned ready build, resolved in a
+        single batch with the build user attached.
+        """
+        user = await fake.users.create()
+        reference_a = await fake.references.create(user=user)
+        reference_b = await fake.references.create(user=user)
+
+        await fake.indexes.create(reference_a, user, version=0, ready=True)
+        latest_a = await fake.indexes.create(reference_a, user, version=1, ready=True)
+        latest_b = await fake.indexes.create(reference_b, user, version=0, ready=True)
+
+        result = await get_latest_builds(pg, [reference_a.id, reference_b.id])
+
+        assert result == {
+            reference_a.id: {
+                "id": latest_a.id,
+                "created_at": static_time.datetime,
+                "version": 1,
+                "user": {"id": user.id, "handle": user.handle},
+            },
+            reference_b.id: {
+                "id": latest_b.id,
+                "created_at": static_time.datetime,
+                "version": 0,
+                "user": {"id": user.id, "handle": user.handle},
+            },
+        }
+
+    async def test_ignores_unready_builds(self, fake: DataFaker, pg: AsyncEngine):
+        """A newer unready build never wins over an older ready one."""
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+
+        ready = await fake.indexes.create(reference, user, version=0, ready=True)
+        await fake.indexes.create(reference, user, version=1, ready=False)
+
+        result = await get_latest_builds(pg, [reference.id])
+
+        assert result[reference.id]["id"] == ready.id
+        assert result[reference.id]["version"] == 0
+
+    async def test_none_without_ready_build(self, fake: DataFaker, pg: AsyncEngine):
+        """A reference with no ready build maps to ``None``."""
+        user = await fake.users.create()
+        with_unready = await fake.references.create(user=user)
+        without_index = await fake.references.create(user=user)
+
+        await fake.indexes.create(with_unready, user, version=0, ready=False)
+
+        result = await get_latest_builds(pg, [with_unready.id, without_index.id])
+
+        assert result == {with_unready.id: None, without_index.id: None}
+
+    async def test_empty(self, pg: AsyncEngine):
+        """An empty reference list issues no query and returns an empty mapping."""
+        assert await get_latest_builds(pg, []) == {}
 
 
 async def test_get_reference_groups(

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -45,7 +45,7 @@ from virtool.references.db import (
     compose_reference_id_match,
     get_cloned_from_lookup,
     get_contributors,
-    get_latest_build,
+    get_latest_builds,
     get_manifest,
     get_otu_count,
     get_reference_groups,
@@ -376,12 +376,14 @@ class ReferencesData(DataLayerDomain):
 
             cloned_from_lookup = await get_cloned_from_lookup(session, rows)
 
+        latest_builds = await get_latest_builds(self._pg, [row.id for row in rows])
+
         documents = [
             await processor(
-                self._mongo,
                 self._pg,
                 row,
                 cloned_from_lookup.get(row.cloned_from_id),
+                latest_builds[row.id],
             )
             for row in rows
         ]
@@ -544,14 +546,14 @@ class ReferencesData(DataLayerDomain):
 
         (
             contributors,
-            latest_build,
+            latest_builds,
             otu_count,
             groups,
             users,
             unbuilt_count,
         ) = await asyncio.gather(
             get_contributors(self._pg, row.id),
-            get_latest_build(self._mongo, self._pg, row.id),
+            get_latest_builds(self._pg, [row.id]),
             get_otu_count(self._pg, row.id),
             get_reference_groups(self._pg, row.id, row.created_at),
             get_reference_users(self._pg, row.id, row.created_at),
@@ -565,7 +567,7 @@ class ReferencesData(DataLayerDomain):
             "source_types": row.source_types,
             "contributors": contributors,
             "groups": groups,
-            "latest_build": latest_build,
+            "latest_build": latest_builds[row.id],
             "otu_count": otu_count,
             "unbuilt_change_count": unbuilt_count,
             "users": users,

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -4,7 +4,6 @@ import asyncio
 import datetime
 from typing import TYPE_CHECKING
 
-import pymongo
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
@@ -18,10 +17,10 @@ from virtool.data.topg import (
     compose_legacy_id_subquery,
     resolve_legacy_id,
 )
-from virtool.data.transforms import apply_transforms
 from virtool.groups.pg import SQLGroup
 from virtool.history.db import bulk_insert_history
 from virtool.history.sql import SQLLegacyHistory, SQLLegacyHistoryDiff
+from virtool.indexes.sql import SQLIndex
 from virtool.models.enums import HistoryMethod
 from virtool.otus.db import bulk_insert_otu_rows, bulk_insert_sequence_rows
 from virtool.otus.sql import SQLOTU
@@ -34,8 +33,7 @@ from virtool.references.sql import (
 from virtool.references.utils import reference_values
 from virtool.settings.models import Settings
 from virtool.types import Document
-from virtool.users.transforms import AttachUserTransform
-from virtool.utils import base_processor
+from virtool.users.pg import SQLUser
 
 if TYPE_CHECKING:
     from virtool.mongo.core import Mongo
@@ -183,21 +181,20 @@ async def get_cloned_from_lookup(
 
 
 async def processor(
-    mongo: "Mongo",
     pg: AsyncEngine,
     row: SQLReference,
     cloned_from: Document | None,
+    latest_build: Document | None,
 ) -> Document:
     """Process a reference row into the ``ReferenceMinimal`` document shape.
 
-    :param mongo: the application Mongo client
     :param pg: the application PostgreSQL engine
     :param row: the ``legacy_references`` row to process
     :param cloned_from: the resolved nested cloned-from doc, or ``None``
+    :param latest_build: the reference's latest ready build, or ``None``
     :return: the processed document
     """
-    latest_build, otu_count, unbuilt_count = await asyncio.gather(
-        get_latest_build(mongo, pg, row.id),
+    otu_count, unbuilt_count = await asyncio.gather(
         get_otu_count(pg, row.id),
         get_unbuilt_count(pg, row.id),
     )
@@ -277,8 +274,6 @@ async def get_reference_users(
     :return: a list of user data dictionaries
 
     """
-    from virtool.users.pg import SQLUser
-
     async with AsyncSession(pg) as session:
         rows = (
             await session.execute(
@@ -392,32 +387,60 @@ async def get_contributors(pg, ref_id: int | str) -> list[Document] | None:
     return await virtool.history.db.get_contributors(pg, reference_id=ref_id)
 
 
-async def get_latest_build(
-    mongo: "Mongo", pg: AsyncEngine, ref_id: int | str
-) -> Document | None:
-    """Return the latest index build for the ref.
+async def get_latest_builds(
+    pg: AsyncEngine, ref_ids: list[int]
+) -> dict[int, Document | None]:
+    """Return the latest ready index build for each reference.
 
-    :param mongo: the application database client
+    A single ``DISTINCT ON (reference_id)`` query selects one build per reference,
+    ordered by descending version so the newest build wins. The index primary key
+    breaks ties deterministically should two builds share a version. The build user
+    is resolved in the same statement by joining ``users``, so the batch costs one
+    query rather than a query plus a follow-up user lookup.
+
     :param pg: the application PostgreSQL engine
-    :param ref_id: the id of the ref to get the latest build for
-    :return: a subset of fields for the latest build
-
+    :param ref_ids: the reference primary keys to get latest builds for
+    :return: a mapping of each reference primary key to its latest build, or ``None``
     """
-    latest_build = await mongo.indexes.find_one(
-        {
-            "reference.id": await compose_reference_id_match(pg, ref_id),
-            "ready": True,
-        },
-        projection=["created_at", "version", "user"],
-        sort=[("version", pymongo.DESCENDING)],
-    )
+    result: dict[int, Document | None] = dict.fromkeys(ref_ids)
 
-    if latest_build:
-        return await apply_transforms(
-            base_processor(latest_build),
-            [AttachUserTransform(pg)],
-            pg,
-        )
+    if not ref_ids:
+        return result
+
+    async with AsyncSession(pg) as session:
+        rows = (
+            await session.execute(
+                select(
+                    SQLIndex.reference_id,
+                    SQLIndex.legacy_id,
+                    SQLIndex.version,
+                    SQLIndex.created_at,
+                    SQLUser.id.label("user_id"),
+                    SQLUser.handle,
+                )
+                .join(SQLUser, SQLUser.id == SQLIndex.user_id)
+                .where(
+                    SQLIndex.reference_id.in_(ref_ids),
+                    SQLIndex.ready.is_(True),
+                )
+                .distinct(SQLIndex.reference_id)
+                .order_by(
+                    SQLIndex.reference_id,
+                    SQLIndex.version.desc(),
+                    SQLIndex.id.desc(),
+                ),
+            )
+        ).all()
+
+    for row in rows:
+        result[row.reference_id] = {
+            "id": row.legacy_id,
+            "created_at": row.created_at,
+            "version": row.version,
+            "user": {"id": row.user_id, "handle": row.handle},
+        }
+
+    return result
 
 
 async def get_manifest(pg: AsyncEngine, ref_id: int | str) -> Document:


### PR DESCRIPTION
## Summary
- Resolve each reference's latest ready build from Postgres instead of Mongo, joining the build user in the same query.
- Batch latest-build lookups across a page of references into a single `DISTINCT ON` query instead of one per reference.