### PR TITLE
feat: key index file storage by storage_key

### DIFF
--- a/tests/indexes/test_data.py
+++ b/tests/indexes/test_data.py
@@ -1,12 +1,13 @@
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from virtool.data.errors import ResourceError
+from virtool.data.errors import ResourceError, ResourceNotFoundError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
+from virtool.indexes.utils import compose_index_file_key
 from virtool.mongo.core import Mongo
 from virtool.otus.sql import SQLOTU
 
@@ -280,3 +281,54 @@ class TestDelete:
             )
 
         assert remaining == 0
+
+
+class TestResolveStorageKey:
+    async def test_matches_legacy_id_at_landing(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+    ):
+        """At landing every migrated index carries ``storage_key == legacy_id``, so the
+        composed object path is byte-identical to keying by the index id.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        index = await fake.indexes.create(reference, user, manifest={}, version=2)
+
+        storage_key = await data_layer.index._resolve_storage_key(index.id)
+
+        assert storage_key == index.id
+        assert (
+            compose_index_file_key(storage_key, "otus.json.gz")
+            == f"indexes/{index.id}/otus.json.gz"
+        )
+
+    async def test_uses_storage_key_column(
+        self,
+        data_layer: DataLayer,
+        fake: DataFaker,
+        pg: AsyncEngine,
+    ):
+        """The resolver reads ``storage_key``, so a native UUID key addresses storage
+        independently of the public index id.
+        """
+        user = await fake.users.create()
+        reference = await fake.references.create(user=user)
+        index = await fake.indexes.create(reference, user, manifest={}, version=2)
+
+        async with AsyncSession(pg) as session:
+            await session.execute(
+                update(SQLIndex)
+                .where(SQLIndex.legacy_id == index.id)
+                .values(storage_key="a-native-uuid-key"),
+            )
+            await session.commit()
+
+        assert (
+            await data_layer.index._resolve_storage_key(index.id) == "a-native-uuid-key"
+        )
+
+    async def test_not_found(self, data_layer: DataLayer):
+        with pytest.raises(ResourceNotFoundError):
+            await data_layer.index._resolve_storage_key("missing")

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -21,7 +21,6 @@ from virtool.data.events import Operation, emit, emits
 from virtool.data.topg import (
     compose_legacy_id_single_expression,
     compose_legacy_id_subquery,
-    resolve_legacy_id,
     retry_both_transactions,
 )
 from virtool.data.transforms import apply_transforms
@@ -90,6 +89,28 @@ class IndexData:
         self._mongo = mongo
         self._pg = pg
         self._storage = storage
+
+    async def _resolve_storage_key(self, index_id: str) -> str:
+        """Return the object-storage key slug for an index.
+
+        Migrated indexes store their files under the legacy Mongo id; indexes
+        created natively in Postgres store under a minted UUID. Both live in the
+        load-bearing ``storage_key`` column, which cannot be derived from the
+        public index id. Raises ResourceNotFoundError if no index matches.
+        """
+        async with AsyncSession(self._pg) as session:
+            storage_key = (
+                await session.execute(
+                    select(SQLIndex.storage_key).where(
+                        compose_legacy_id_single_expression(SQLIndex, index_id),
+                    ),
+                )
+            ).scalar_one_or_none()
+
+        if storage_key is None:
+            raise ResourceNotFoundError
+
+        return storage_key
 
     async def find(
         self,
@@ -223,18 +244,20 @@ class IndexData:
         :return: an async iterator of bytes and the size
         """
         async with AsyncSession(self._pg) as session:
-            manifest = (
+            row = (
                 await session.execute(
-                    select(SQLIndex.manifest).where(
+                    select(SQLIndex.manifest, SQLIndex.storage_key).where(
                         compose_legacy_id_single_expression(SQLIndex, index_id),
                     ),
                 )
-            ).scalar_one_or_none()
+            ).one_or_none()
 
-        if manifest is None:
+        if row is None:
             raise ResourceNotFoundError()
 
-        key = compose_index_file_key(index_id, "otus.json.gz")
+        manifest = row.manifest
+
+        key = compose_index_file_key(row.storage_key, "otus.json.gz")
 
         try:
             size = await self._storage.size(key)
@@ -274,15 +297,21 @@ class IndexData:
         :return: the index file
         """
         async with AsyncSession(self._pg) as session:
-            index_pg_id = await resolve_legacy_id(session, SQLIndex, index_id)
+            index_row = (
+                await session.execute(
+                    select(SQLIndex.id, SQLIndex.storage_key).where(
+                        compose_legacy_id_single_expression(SQLIndex, index_id),
+                    ),
+                )
+            ).one_or_none()
 
-            if index_pg_id is None:
+            if index_row is None:
                 raise ResourceNotFoundError
 
             index_file = SQLIndexFile(
                 name=name,
                 index=index_id,
-                index_id=index_pg_id,
+                index_id=index_row.id,
                 type=file_type,
             )
 
@@ -293,7 +322,7 @@ class IndexData:
             except IntegrityError:
                 raise ResourceConflictError()
 
-            key = compose_index_file_key(index_id, name)
+            key = compose_index_file_key(index_row.storage_key, name)
 
             size = await self._storage.write(
                 key,
@@ -335,7 +364,9 @@ class IndexData:
         if row is None:
             raise ResourceNotFoundError
 
-        key = compose_index_file_key(index_id, filename)
+        storage_key = await self._resolve_storage_key(index_id)
+
+        key = compose_index_file_key(storage_key, filename)
 
         return self._storage.read(key), row.size
 
@@ -462,7 +493,9 @@ class IndexData:
             dump_bytes({**reference, "otus": patched_otus}),
         )
 
-        key = compose_index_file_key(index_id, file_name)
+        storage_key = await self._resolve_storage_key(index_id)
+
+        key = compose_index_file_key(storage_key, file_name)
 
         async def stream():
             yield compressed
@@ -563,6 +596,8 @@ class IndexData:
         if not index:
             raise ResourceNotFoundError
 
+        storage_key = await self._resolve_storage_key(index_id)
+
         async def remove(mongo_session, pg_session) -> None:
             delete_result = await self._mongo.indexes.delete_one(
                 {"_id": index_id},
@@ -585,7 +620,7 @@ class IndexData:
         await retry_both_transactions(self._mongo, self._pg, remove)
 
         for key, exc in await delete_prefix(
-            self._storage, compose_index_prefix(index_id)
+            self._storage, compose_index_prefix(storage_key)
         ):
             logger.error(
                 "storage cleanup failed; file orphaned",

--- a/virtool/indexes/utils.py
+++ b/virtool/indexes/utils.py
@@ -14,9 +14,9 @@ def check_index_file_type(file_name: str) -> str:
     return "bowtie2"
 
 
-def compose_index_file_key(index_id: str, filename: str) -> str:
-    return f"indexes/{index_id}/{filename}"
+def compose_index_file_key(storage_key: str, filename: str) -> str:
+    return f"indexes/{storage_key}/{filename}"
 
 
-def compose_index_prefix(index_id: str) -> str:
-    return f"indexes/{index_id}/"
+def compose_index_prefix(storage_key: str) -> str:
+    return f"indexes/{storage_key}/"

--- a/virtool/references/db.py
+++ b/virtool/references/db.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import datetime
-from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,9 +33,6 @@ from virtool.references.utils import reference_values
 from virtool.settings.models import Settings
 from virtool.types import Document
 from virtool.users.pg import SQLUser
-
-if TYPE_CHECKING:
-    from virtool.mongo.core import Mongo
 
 
 async def compose_reference_id_match(pg: AsyncEngine, ref_id: int | str) -> dict:


### PR DESCRIPTION
## Summary

- Compose object-storage keys for index files from a new `storage_key` column instead of the public index id, so the id can later change (e.g. string→integer) without migrating stored objects.
- Update `compose_index_file_key`/`compose_index_prefix` to take `storage_key`, and resolve it via a new `IndexData._resolve_storage_key` helper across the read, write, and delete paths.
- `storage_key` equals `legacy_id` at landing, so stored object paths are byte-identical today.