### PR TITLE
refactor(migration): cascade sample label and subtraction link deletes

### DIFF
--- a/assets/alembic/versions/06d0b71c37c3_cascade_sample_label_and_subtraction_.py
+++ b/assets/alembic/versions/06d0b71c37c3_cascade_sample_label_and_subtraction_.py
@@ -1,0 +1,56 @@
+"""cascade sample label and subtraction links
+
+Add ``ON DELETE CASCADE`` to the ``sample_id`` foreign keys on the
+``legacy_sample_labels`` and ``legacy_sample_subtractions`` join tables so that
+deleting a sample removes its label and subtraction links at the database level.
+
+Both columns are the NOT NULL integer primary key of their join table and have
+no legacy-string fallback, so the cascade fully replaces the manual pre-deletes
+that ``SamplesData.delete`` previously issued purely to satisfy the constraint.
+
+Each foreign key is dropped and recreated in place with ``ondelete="CASCADE"``;
+downgrade restores the default ``NO ACTION`` behaviour.
+
+Revision ID: 06d0b71c37c3
+Revises: c976a55c3382
+Create Date: 2026-07-21 22:19:21.831964+00:00
+
+"""
+
+from alembic import op
+
+revision = "06d0b71c37c3"
+down_revision = "c976a55c3382"
+branch_labels = None
+depends_on = None
+
+
+_CASCADES = (
+    ("legacy_sample_labels", "legacy_sample_labels_sample_id_fkey"),
+    ("legacy_sample_subtractions", "legacy_sample_subtractions_sample_id_fkey"),
+)
+
+
+def upgrade() -> None:
+    for table, constraint in _CASCADES:
+        op.drop_constraint(constraint, table, type_="foreignkey")
+        op.create_foreign_key(
+            constraint,
+            table,
+            "legacy_samples",
+            ["sample_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    for table, constraint in _CASCADES:
+        op.drop_constraint(constraint, table, type_="foreignkey")
+        op.create_foreign_key(
+            constraint,
+            table,
+            "legacy_samples",
+            ["sample_id"],
+            ["id"],
+        )

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -890,5 +890,12 @@
       'name': 'drop legacy_history index_version',
       'revision': 'c976a55c3382',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 128,
+      'name': 'cascade sample label and subtraction links',
+      'revision': '06d0b71c37c3',
+    }),
   ])
 # ---

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -546,16 +546,6 @@ class SamplesData(DataLayerDomain):
             )
 
             await pg_session.execute(
-                delete(SQLLegacySampleLabel).where(
-                    SQLLegacySampleLabel.sample_id == sample_pk,
-                ),
-            )
-            await pg_session.execute(
-                delete(SQLLegacySampleSubtraction).where(
-                    SQLLegacySampleSubtraction.sample_id == sample_pk,
-                ),
-            )
-            await pg_session.execute(
                 delete(SQLSampleUpload).where(
                     or_(
                         SQLSampleUpload.sample_id == sample_pk,

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -155,7 +155,9 @@ class SQLLegacySampleLabel(Base):
     __tablename__ = "legacy_sample_labels"
 
     sample_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("legacy_samples.id"), primary_key=True
+        BigInteger,
+        ForeignKey("legacy_samples.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     label_id: Mapped[int] = mapped_column(ForeignKey("labels.id"), primary_key=True)
 
@@ -166,7 +168,9 @@ class SQLLegacySampleSubtraction(Base):
     __tablename__ = "legacy_sample_subtractions"
 
     sample_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("legacy_samples.id"), primary_key=True
+        BigInteger,
+        ForeignKey("legacy_samples.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     subtraction_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("subtractions.id"), primary_key=True


### PR DESCRIPTION
## Summary
- Add `ON DELETE CASCADE` to the `sample_id` foreign keys on `legacy_sample_labels` and `legacy_sample_subtractions`, so a sample's label and subtraction links are removed at the database level when the sample row is deleted.
- Drop the two manual pre-deletes in `SamplesData.delete` that only existed to satisfy the previous `NO ACTION` constraints. Both columns are NOT NULL integer PKs with no legacy-string fallback, so the cascade fully replaces them.
- The other sample child tables (`sample_uploads`, `sample_artifacts`, `sample_reads`) are left as-is: their delete still matches on the legacy `sample` string, so a `sample_id`-only cascade is not yet safe.