### PR TITLE
refactor: fold redundant data-layer reads into single queries

### DIFF
--- a/virtool/history/db.py
+++ b/virtool/history/db.py
@@ -537,8 +537,9 @@ async def get_contributors(
     """Return a list of contributors and their contribution count for a set of history.
 
     The set is scoped by ``reference_id`` or ``index_id``. Contribution counts are
-    aggregated in Postgres by ``user_id`` and joined to user handles. A change whose
-    user cannot be resolved is reported as the ``"Unknown User"`` fallback.
+    aggregated in Postgres per user, joining the change rows to their user handles in
+    a single query. ``SQLLegacyHistory.user_id`` is a non-null foreign key, so every
+    change resolves to a user and an inner join drops nothing.
 
     :param pg: the application PostgreSQL database object
     :param reference_id: restrict contributions to a single reference
@@ -563,32 +564,19 @@ async def get_contributors(
         )
 
     async with AsyncSession(pg) as session:
-        counts = (
+        rows = (
             await session.execute(
-                select(SQLLegacyHistory.user_id, func.count())
+                select(SQLUser.id, SQLUser.handle, func.count())
+                .join(SQLLegacyHistory, SQLLegacyHistory.user_id == SQLUser.id)
                 .where(*filters)
-                .group_by(SQLLegacyHistory.user_id)
-                .order_by(SQLLegacyHistory.user_id),
+                .group_by(SQLUser.id, SQLUser.handle)
+                .order_by(SQLUser.id),
             )
         ).all()
 
-        if not counts:
-            return []
-
-        users = {
-            row.id: {"id": row.id, "handle": row.handle}
-            for row in (
-                await session.execute(
-                    select(SQLUser.id, SQLUser.handle).where(
-                        SQLUser.id.in_([user_id for user_id, _ in counts]),
-                    ),
-                )
-            ).all()
-        }
-
     return [
-        {**users.get(user_id, {"id": -1, "handle": "Unknown User"}), "count": count}
-        for user_id, count in counts
+        {"id": user_id, "handle": handle, "count": count}
+        for user_id, handle, count in rows
     ]
 
 

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -347,20 +347,19 @@ class IndexData:
         async with AsyncSession(self._pg) as session:
             row = (
                 await session.execute(
-                    select(SQLIndexFile).where(
-                        SQLIndexFile.index_id
-                        == compose_legacy_id_subquery(SQLIndex, index_id),
+                    select(SQLIndexFile.size, SQLIndex.storage_key)
+                    .join(SQLIndex, SQLIndexFile.index_id == SQLIndex.id)
+                    .where(
+                        compose_legacy_id_single_expression(SQLIndex, index_id),
                         SQLIndexFile.name == filename,
                     ),
                 )
-            ).scalar()
+            ).first()
 
         if row is None:
             raise ResourceNotFoundError
 
-        storage_key = await self._resolve_storage_key(index_id)
-
-        key = compose_index_file_key(storage_key, filename)
+        key = compose_index_file_key(row.storage_key, filename)
 
         return self._storage.read(key), row.size
 

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -261,13 +261,21 @@ async def find(
             )
         order_by = [SQLIndex.created_at.desc(), SQLIndex.id.desc()]
 
+    # ``search_filters`` is always ``base_filters`` plus, at most, the archived
+    # constraint, so the found count is a filtered aggregate over the same scan the
+    # total count reads. Computing both in one query removes a duplicate round-trip.
+    found_count_column = (
+        func.count().filter(*search_filters) if search_filters else func.count()
+    )
+
     async with AsyncSession(pg) as session:
-        total_count = await session.scalar(
-            select(func.count()).select_from(SQLIndex).where(*base_filters),
-        )
-        found_count = await session.scalar(
-            select(func.count()).select_from(SQLIndex).where(*search_filters),
-        )
+        total_count, found_count = (
+            await session.execute(
+                select(func.count(), found_count_column)
+                .select_from(SQLIndex)
+                .where(*base_filters),
+            )
+        ).one()
         rows = (
             (
                 await session.execute(


### PR DESCRIPTION
## Summary

- Combine the history contributor count and user-handle lookups into one joined query instead of two round-trips.
- Resolve the index file's size and storage key in a single joined query instead of a separate storage-key lookup.
- Compute the index list's total and filtered counts in one aggregate query instead of two.