### PR TITLE
feat: give samples and subtractions immutable storage keys

### DIFF
--- a/assets/alembic/versions/5b86749d13eb_add_storage_key_to_samples_and_.py
+++ b/assets/alembic/versions/5b86749d13eb_add_storage_key_to_samples_and_.py
@@ -1,0 +1,36 @@
+"""add storage_key to samples and subtractions
+
+Revision ID: 5b86749d13eb
+Revises: c976a55c3382
+Create Date: 2026-07-21 22:35:19.530859+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5b86749d13eb"
+down_revision = "c976a55c3382"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Give samples and subtractions an immutable, recorded storage prefix instead
+    # of deriving one from database identity on every read. Backfilling with each
+    # row's current prefix (``legacy_id`` where present, ``id`` otherwise) reproduces
+    # exactly the key its objects already live under, so no object has to move.
+    for table in ("legacy_samples", "subtractions"):
+        op.add_column(table, sa.Column("storage_key", sa.String(), nullable=True))
+        op.execute(
+            f"UPDATE {table} SET storage_key = COALESCE(legacy_id, id::text)"  # noqa: S608
+        )
+        op.alter_column(table, "storage_key", nullable=False)
+        op.create_unique_constraint(f"uq_{table}_storage_key", table, ["storage_key"])
+
+
+def downgrade() -> None:
+    for table in ("legacy_samples", "subtractions"):
+        op.drop_constraint(f"uq_{table}_storage_key", table, type_="unique")
+        op.drop_column(table, "storage_key")

--- a/tests/alembic/test_5b86749d13eb_add_storage_key_to_samples_and_subtractions.py
+++ b/tests/alembic/test_5b86749d13eb_add_storage_key_to_samples_and_subtractions.py
@@ -1,0 +1,83 @@
+import asyncio
+from collections.abc import Callable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from virtool.utils import timestamp
+
+
+async def _seed_sample(session: AsyncSession, legacy_id: str | None) -> int:
+    result = await session.execute(
+        text("""
+            INSERT INTO legacy_samples (
+                legacy_id, name, host, isolate, locale, notes, library_type,
+                format, created_at, paired, ready, hold, is_legacy, all_read,
+                all_write, group_read, group_write
+            )
+            VALUES (
+                :legacy_id, 'Sample', '', '', '', '', 'normal',
+                'fastq', :now, false, true, false, false, false,
+                false, false, false
+            )
+            RETURNING id
+        """),
+        {"legacy_id": legacy_id, "now": timestamp()},
+    )
+
+    return result.scalar_one()
+
+
+async def _seed_subtraction(session: AsyncSession, legacy_id: str | None) -> int:
+    result = await session.execute(
+        text("""
+            INSERT INTO subtractions (legacy_id, name, nickname, created_at,
+                                      deleted, ready)
+            VALUES (:legacy_id, 'Subtraction', '', :now, false, true)
+            RETURNING id
+        """),
+        {"legacy_id": legacy_id, "now": timestamp()},
+    )
+
+    return result.scalar_one()
+
+
+async def test_upgrade(apply_alembic: Callable, migration_pg: AsyncEngine):
+    """Backfilled ``storage_key`` reproduces each row's current storage prefix.
+
+    A migrated row is keyed by its legacy Mongo slug; a natively created row (no
+    ``legacy_id``) is keyed by its integer primary key. Recording exactly that value
+    is what lets existing objects stay where they are.
+    """
+    await asyncio.to_thread(apply_alembic, "c976a55c3382")
+
+    async with AsyncSession(migration_pg) as session:
+        migrated_sample = await _seed_sample(session, "sample_legacy")
+        native_sample = await _seed_sample(session, None)
+        migrated_subtraction = await _seed_subtraction(session, "sub_legacy")
+        native_subtraction = await _seed_subtraction(session, None)
+        await session.commit()
+
+    await asyncio.to_thread(apply_alembic, "5b86749d13eb")
+
+    async with AsyncSession(migration_pg) as session:
+        samples = (
+            await session.execute(
+                text("SELECT id, storage_key FROM legacy_samples ORDER BY id"),
+            )
+        ).all()
+
+        subtractions = (
+            await session.execute(
+                text("SELECT id, storage_key FROM subtractions ORDER BY id"),
+            )
+        ).all()
+
+    assert samples == [
+        (migrated_sample, "sample_legacy"),
+        (native_sample, str(native_sample)),
+    ]
+    assert subtractions == [
+        (migrated_subtraction, "sub_legacy"),
+        (native_subtraction, str(native_subtraction)),
+    ]

--- a/tests/fixtures/subtractions.py
+++ b/tests/fixtures/subtractions.py
@@ -12,6 +12,7 @@ async def test_subtraction_files(pg) -> int:
     async with AsyncSession(pg) as session:
         subtraction = SQLSubtraction(
             legacy_id="foo",
+            storage_key="foo",
             name="Foo",
             created_at=datetime(2015, 10, 6, 20, 0, 0),
             ready=True,

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -214,6 +214,7 @@ class TestCreatePostgres:
         async with AsyncSession(pg) as session:
             sample = SQLLegacySample(
                 legacy_id="sample_123",
+                storage_key="sample_123",
                 name="Sample 123",
                 library_type="normal",
                 created_at=arrow.utcnow().naive,
@@ -314,6 +315,7 @@ class TestCreatePostgres:
         async with AsyncSession(pg) as session:
             subtraction = SQLSubtraction(
                 legacy_id="sub_789",
+                storage_key="sub_789",
                 name="Subtraction 789",
                 created_at=arrow.utcnow().naive,
                 user_id=user.id,

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -890,5 +890,12 @@
       'name': 'drop legacy_history index_version',
       'revision': 'c976a55c3382',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 128,
+      'name': 'add storage_key to samples and subtractions',
+      'revision': '5b86749d13eb',
+    }),
   ])
 # ---

--- a/tests/samples/__snapshots__/test_api.ambr
+++ b/tests/samples/__snapshots__/test_api.ambr
@@ -4418,7 +4418,6 @@
     'id': 1,
     'name': 'small.fq.gz',
     'name_on_disk': 'small.fq.gz',
-    'sample': '1',
     'sample_id': 1,
     'size': 723988,
     'type': 'fastq',

--- a/tests/samples/test_api.py
+++ b/tests/samples/test_api.py
@@ -25,7 +25,8 @@ from virtool.pg.utils import get_row_by_id
 from virtool.references.models import Reference
 from virtool.samples.models import Sample
 from virtool.samples.oas import UpdateSampleRequest
-from virtool.samples.utils import sample_file_key, sample_storage_id
+from virtool.samples.sql import SQLLegacySample
+from virtool.samples.utils import sample_file_key
 from virtool.settings.oas import UpdateSettingsRequest
 from virtool.subtractions.pg import SQLSubtraction
 from virtool.uploads.sql import SQLUpload
@@ -1205,6 +1206,7 @@ class TestAnalyze:
             session.add(
                 SQLSubtraction(
                     legacy_id="subtraction_1",
+                    storage_key="subtraction_1",
                     name="Subtraction 1",
                     created_at=datetime(2015, 10, 6, 20, 0, 0),
                     ready=True,
@@ -1403,7 +1405,14 @@ class TestUploadArtifact:
         resp = await self._post(client, path, "fastq", sample.id)
 
         assert resp.status == 201
-        assert await resp.json() == snapshot
+
+        body = await resp.json()
+
+        # ``sample`` is the parent sample's opaque storage key, a random 32-character
+        # UUID for a natively created sample. Exclude it from the snapshot.
+        assert len(body.pop("sample")) == 32
+
+        assert body == snapshot
 
         download = await client.get(f"/samples/{sample.id}/artifacts/small.fq.gz")
 
@@ -1736,6 +1745,7 @@ class TestDownloadReads:
         self,
         fake: DataFaker,
         memory_storage,
+        pg: AsyncEngine,
         spawn_client: ClientSpawner,
         spawn_job_client: JobClientSpawner,
     ):
@@ -1748,9 +1758,11 @@ class TestDownloadReads:
         user = await fake.users.create()
         sample = await fake.samples.create(user, ready=True)
 
+        storage_key = (await get_row_by_id(pg, SQLLegacySample, sample.id)).storage_key
+
         file_name = "reads_1.fq.gz"
         await memory_storage.delete(
-            sample_file_key(sample_storage_id(sample.id, None), file_name),
+            sample_file_key(storage_key, file_name),
         )
 
         client = await spawn_client(authenticated=True)
@@ -1829,6 +1841,7 @@ class TestDownloadArtifact:
         example_path: Path,
         fake: DataFaker,
         memory_storage,
+        pg: AsyncEngine,
         spawn_job_client: JobClientSpawner,
     ):
         """An artifact row that resolves but whose blob is missing is a server-side
@@ -1843,8 +1856,10 @@ class TestDownloadArtifact:
         client = await spawn_job_client(authenticated=True)
         await self._upload_artifact(client, example_path, sample.id)
 
+        storage_key = (await get_row_by_id(pg, SQLLegacySample, sample.id)).storage_key
+
         await memory_storage.delete(
-            sample_file_key(sample_storage_id(sample.id, None), "fastqc.txt"),
+            sample_file_key(storage_key, "fastqc.txt"),
         )
 
         resp = await client.get(f"/samples/{sample.id}/artifacts/fastqc.txt")

--- a/tests/samples/test_data.py
+++ b/tests/samples/test_data.py
@@ -164,7 +164,7 @@ class TestCreate:
             )
 
         assert [(row.sample, row.upload_id, row.index) for row in sample_uploads] == [
-            (str(legacy.id), upload.id, 0),
+            (legacy.storage_key, upload.id, 0),
         ]
 
         # Samples created natively in Postgres have no Mongo id to carry.
@@ -396,7 +396,7 @@ class TestFinalize:
         mocker.patch.object(
             data_layer.samples,
             "_resolve_ids",
-            return_value=(999999, "gone"),
+            return_value=(999999, "gone", "gone"),
         )
 
         with pytest.raises(ResourceNotFoundError):
@@ -1269,13 +1269,15 @@ class TestDelete:
         user = await fake.users.create()
         sample = await fake.samples.create(user, paired=True, ready=True)
 
-        assert (await get_row_by_id(pg, SQLLegacySample, sample.id)).legacy_id is None
+        row = await get_row_by_id(pg, SQLLegacySample, sample.id)
+        assert row.legacy_id is None
 
-        prefix = sample_prefix(str(sample.id))
+        storage_key = row.storage_key
+        prefix = sample_prefix(storage_key)
 
         assert [obj.key async for obj in memory_storage.list(prefix)] == [
-            sample_file_key(str(sample.id), "reads_1.fq.gz"),
-            sample_file_key(str(sample.id), "reads_2.fq.gz"),
+            sample_file_key(storage_key, "reads_1.fq.gz"),
+            sample_file_key(storage_key, "reads_2.fq.gz"),
         ]
 
         await data_layer.samples.delete(sample.id)

--- a/tests/subtractions/test_api.py
+++ b/tests/subtractions/test_api.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy.assertion import SnapshotAssertion
 
@@ -11,7 +11,8 @@ from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
 from virtool.models.enums import Permission
 from virtool.samples.oas import UpdateSampleRequest
-from virtool.subtractions.pg import SQLSubtractionFile
+from virtool.subtractions.pg import SQLSubtraction, SQLSubtractionFile
+from virtool.subtractions.utils import subtraction_prefix
 from virtool.uploads.sql import UploadType
 
 
@@ -588,6 +589,7 @@ class TestDownloadSubtractionFile:
         self,
         fake: DataFaker,
         memory_storage,
+        pg: AsyncEngine,
         spawn_job_client: JobClientSpawner,
     ):
         """Test that a 500 response is returned when a file has a database entry but
@@ -605,7 +607,14 @@ class TestDownloadSubtractionFile:
         )
         subtraction = await fake.subtractions.create(user=user, upload=upload)
 
-        async for obj in memory_storage.list(f"subtractions/{subtraction.id}/"):
+        async with AsyncSession(pg) as session:
+            storage_key = await session.scalar(
+                select(SQLSubtraction.storage_key).where(
+                    SQLSubtraction.id == subtraction.id,
+                ),
+            )
+
+        async for obj in memory_storage.list(subtraction_prefix(storage_key)):
             await memory_storage.delete(obj.key)
 
         bowtie_resp = await client.get(

--- a/tests/subtractions/test_data.py
+++ b/tests/subtractions/test_data.py
@@ -231,7 +231,13 @@ async def test_finalize(
             )
         ).scalar_one()
 
-    assert row.to_dict() == snapshot_recent(name="pg")
+    pg_row = row.to_dict()
+
+    # A natively created subtraction gets a freshly minted 32-character UUID storage
+    # key. Its value is random, so exclude it from the snapshot and assert its shape.
+    assert len(pg_row.pop("storage_key")) == 32
+
+    assert pg_row == snapshot_recent(name="pg")
     assert row.legacy_id is None
 
 

--- a/tests/subtractions/test_files.py
+++ b/tests/subtractions/test_files.py
@@ -16,6 +16,7 @@ async def test_create_subtraction_files(snapshot, tmp_path, pg: AsyncEngine):
     async with AsyncSession(pg) as session:
         subtraction = SQLSubtraction(
             legacy_id="foo",
+            storage_key="foo",
             name="Foo",
             created_at=datetime(2023, 1, 1),
         )

--- a/virtool/fake/next.py
+++ b/virtool/fake/next.py
@@ -48,7 +48,8 @@ from virtool.references.tasks import CloneReferenceTask
 from virtool.samples.files import create_reads_file
 from virtool.samples.models import Sample
 from virtool.samples.oas import CreateSampleRequest
-from virtool.samples.utils import sample_file_key, sample_storage_id
+from virtool.samples.sql import SQLLegacySample
+from virtool.samples.utils import sample_file_key
 from virtool.storage.protocol import STORAGE_CHUNK_SIZE, StorageBackend
 from virtool.subtractions.models import Subtraction
 from virtool.subtractions.oas import (
@@ -756,14 +757,21 @@ class SamplesFakerDomain(DataFakerDomain):
         if not ready:
             return sample
 
-        storage_id = sample_storage_id(sample.id, None)
+        async with AsyncSession(self._pg) as session:
+            storage_key = (
+                await session.execute(
+                    select(SQLLegacySample.storage_key).where(
+                        SQLLegacySample.id == sample.id,
+                    ),
+                )
+            ).scalar_one()
 
         filenames = ["reads_1.fq.gz", "reads_2.fq.gz"] if paired else ["reads_1.fq.gz"]
 
         for filename in filenames:
             file_path = example_path / "sample" / filename
 
-            await copy_reads_file(self._storage, file_path, filename, storage_id)
+            await copy_reads_file(self._storage, file_path, filename, storage_key)
 
             await create_reads_file(
                 self._pg,
@@ -771,7 +779,7 @@ class SamplesFakerDomain(DataFakerDomain):
                 filename,
                 filename,
                 sample.id,
-                storage_id,
+                storage_key,
             )
 
         # A real finalized sample has a completed creation job. Mark this

--- a/virtool/samples/data.py
+++ b/virtool/samples/data.py
@@ -1,6 +1,7 @@
 """The sample data layer domain."""
 
 import math
+import uuid
 from asyncio import CancelledError, gather
 from collections import defaultdict
 from collections.abc import AsyncGenerator, AsyncIterator
@@ -70,7 +71,6 @@ from virtool.samples.utils import (
     has_sample_right,
     sample_file_key,
     sample_prefix,
-    sample_storage_id,
 )
 from virtool.storage.cleanup import delete_prefix
 from virtool.storage.protocol import StorageBackend
@@ -170,20 +170,27 @@ class SamplesData(DataLayerDomain):
         self._pg = pg
         self._storage = storage
 
-    async def _resolve_ids(self, sample_id: int | str) -> tuple[int, str | None] | None:
-        """Resolve a sample's integer primary key and legacy Mongo id from either form.
+    async def _resolve_ids(
+        self, sample_id: int | str
+    ) -> tuple[int, str | None, str] | None:
+        """Resolve a sample's primary key, legacy Mongo id, and storage key.
 
-        Accepts the outward-facing integer id or the legacy Mongo string. Samples
-        migrated from Mongo keep their ``legacy_id`` as their storage key for life;
-        samples created natively in Postgres have none and are keyed by primary key.
+        Accepts the outward-facing integer id or the legacy Mongo string. The
+        ``storage_key`` is the immutable prefix the sample's objects live under; it
+        is recorded on the row rather than derived from the id.
 
         :param sample_id: the integer primary key or legacy string id of the sample
-        :return: the row's ``(id, legacy_id)``, or ``None`` if no sample matches
+        :return: the row's ``(id, legacy_id, storage_key)``, or ``None`` if no sample
+            matches
         """
         async with AsyncSession(self._pg) as session:
             return (
                 await session.execute(
-                    select(SQLLegacySample.id, SQLLegacySample.legacy_id).where(
+                    select(
+                        SQLLegacySample.id,
+                        SQLLegacySample.legacy_id,
+                        SQLLegacySample.storage_key,
+                    ).where(
                         compose_legacy_id_single_expression(SQLLegacySample, sample_id),
                     ),
                 )
@@ -481,6 +488,7 @@ class SamplesData(DataLayerDomain):
                 paired=len(uploads) == 2,
                 quality=None,
                 ready=False,
+                storage_key=uuid.uuid4().hex,
                 user_id=user_id,
             )
 
@@ -488,6 +496,7 @@ class SamplesData(DataLayerDomain):
             await pg_session.flush()
 
             sample_pk = sample.id
+            storage_key = sample.storage_key
 
             self._add_legacy_sample_join_rows(
                 pg_session,
@@ -499,7 +508,7 @@ class SamplesData(DataLayerDomain):
             for index, upload in enumerate(uploads):
                 pg_session.add(
                     SQLSampleUpload(
-                        sample=sample_storage_id(sample_pk, None),
+                        sample=storage_key,
                         sample_id=sample_pk,
                         upload_id=upload["id"],
                         index=index,
@@ -525,7 +534,7 @@ class SamplesData(DataLayerDomain):
         if resolved is None:
             raise ResourceNotFoundError
 
-        sample_pk, legacy_id = resolved
+        sample_pk, _, storage_key = resolved
 
         sample = await self.get(sample_id)
 
@@ -559,7 +568,7 @@ class SamplesData(DataLayerDomain):
                 delete(SQLSampleUpload).where(
                     or_(
                         SQLSampleUpload.sample_id == sample_pk,
-                        SQLSampleUpload.sample == legacy_id,
+                        SQLSampleUpload.sample == storage_key,
                     ),
                 ),
             )
@@ -567,7 +576,7 @@ class SamplesData(DataLayerDomain):
                 delete(SQLSampleArtifact).where(
                     or_(
                         SQLSampleArtifact.sample_id == sample_pk,
-                        SQLSampleArtifact.sample == legacy_id,
+                        SQLSampleArtifact.sample == storage_key,
                     ),
                 ),
             )
@@ -575,7 +584,7 @@ class SamplesData(DataLayerDomain):
                 delete(SQLSampleReads).where(
                     or_(
                         SQLSampleReads.sample_id == sample_pk,
-                        SQLSampleReads.sample == legacy_id,
+                        SQLSampleReads.sample == storage_key,
                     ),
                 ),
             )
@@ -591,7 +600,7 @@ class SamplesData(DataLayerDomain):
             await pg_session.commit()
 
         for key, failure in await delete_prefix(
-            self._storage, sample_prefix(sample_storage_id(sample_pk, legacy_id))
+            self._storage, sample_prefix(storage_key)
         ):
             logger.error(
                 "storage cleanup failed; file orphaned",
@@ -619,7 +628,7 @@ class SamplesData(DataLayerDomain):
         if resolved is None:
             raise ResourceNotFoundError
 
-        sample_pk, _ = resolved
+        sample_pk, _, _ = resolved
 
         async with AsyncSession(self._pg) as pg_session:
             ready = (
@@ -691,7 +700,7 @@ class SamplesData(DataLayerDomain):
         if resolved is None:
             raise ResourceNotFoundError
 
-        sample_pk, _ = resolved
+        sample_pk, _, _ = resolved
 
         data = data.dict(exclude_unset=True)
 
@@ -779,7 +788,7 @@ class SamplesData(DataLayerDomain):
         if resolved is None:
             raise ResourceNotFoundError
 
-        sample_pk, _ = resolved
+        sample_pk, _, _ = resolved
 
         group_id = None
 
@@ -907,8 +916,7 @@ class SamplesData(DataLayerDomain):
         if artifact_type and artifact_type not in ArtifactType.to_list():
             raise ResourceConflictError("Unsupported sample artifact type")
 
-        sample_pk, legacy_id = resolved
-        storage_id = sample_storage_id(sample_pk, legacy_id)
+        sample_pk, _, storage_key = resolved
 
         try:
             artifact = await create_artifact_file(
@@ -916,7 +924,7 @@ class SamplesData(DataLayerDomain):
                 filename,
                 filename,
                 sample_pk,
-                storage_id,
+                storage_key,
                 artifact_type,
             )
         except exc.IntegrityError:
@@ -924,7 +932,7 @@ class SamplesData(DataLayerDomain):
                 "Artifact file has already been uploaded for this sample",
             )
 
-        key = sample_file_key(storage_id, filename)
+        key = sample_file_key(storage_key, filename)
 
         try:
             size = await self._storage.write(key, chunker)
@@ -952,10 +960,9 @@ class SamplesData(DataLayerDomain):
         if resolved is None:
             raise ResourceNotFoundError
 
-        sample_pk, legacy_id = resolved
-        storage_id = sample_storage_id(sample_pk, legacy_id)
+        sample_pk, _, storage_key = resolved
 
-        key = sample_file_key(storage_id, filename)
+        key = sample_file_key(storage_key, filename)
 
         first = await anext(chunker, None)
 
@@ -978,7 +985,7 @@ class SamplesData(DataLayerDomain):
                 filename,
                 filename,
                 sample_pk,
-                storage_id,
+                storage_key,
                 upload_id=upload_id,
             )
         except exc.IntegrityError:

--- a/virtool/samples/sql.py
+++ b/virtool/samples/sql.py
@@ -102,6 +102,13 @@ class SQLLegacySample(Base):
     become the ``legacy_sample_labels`` and ``legacy_sample_subtractions`` join
     tables rather than array columns. ``quality`` is stored as JSONB and never
     queried.
+
+    ``storage_key`` is the immutable prefix a sample's objects live under
+    (``samples/{storage_key}/``). It is recorded, never derived: backfilled rows
+    hold their legacy id slug or old integer prefix, and natively created samples
+    hold a freshly minted UUID. Recording rather than deriving it means the prefix
+    survives any future change to how identities are formatted without moving a
+    single object.
     """
 
     __tablename__ = "legacy_samples"
@@ -127,6 +134,7 @@ class SQLLegacySample(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
     legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    storage_key: Mapped[str] = mapped_column(unique=True)
     name: Mapped[str]
     host: Mapped[str] = mapped_column(default="")
     isolate: Mapped[str] = mapped_column(default="")

--- a/virtool/samples/utils.py
+++ b/virtool/samples/utils.py
@@ -128,19 +128,6 @@ def bad_labels_response(labels: list[int]) -> Response:
     )
 
 
-def sample_storage_id(sample_id: int, legacy_id: str | None) -> str:
-    """Get the identifier a sample's storage objects are keyed under.
-
-    A sample keeps a single storage prefix for its whole life: its Mongo ``_id`` if
-    it has one, and its integer primary key otherwise. Samples created natively in
-    Postgres have no ``legacy_id`` and are keyed by primary key from the start.
-
-    Deleting a sample removes its prefix in one operation, so a sample whose files
-    were split across two prefixes would have half of them orphaned.
-    """
-    return legacy_id or str(sample_id)
-
-
 def sample_file_key(storage_id: str, filename: str) -> str:
     return f"samples/{storage_id}/{filename}"
 

--- a/virtool/subtractions/data.py
+++ b/virtool/subtractions/data.py
@@ -1,4 +1,5 @@
 import math
+import uuid
 from asyncio import CancelledError
 from collections.abc import AsyncGenerator
 
@@ -173,6 +174,7 @@ class SubtractionsData(DataLayerDomain):
         async with AsyncSession(self._pg) as session:
             subtraction = SQLSubtraction(
                 legacy_id=None,
+                storage_key=uuid.uuid4().hex,
                 name=data.name,
                 nickname=data.nickname,
                 count=None,
@@ -203,26 +205,26 @@ class SubtractionsData(DataLayerDomain):
         return await self.get(new_subtraction_id)
 
     async def _resolve_storage_id(self, subtraction_id: int) -> str:
-        """Return the storage-key identifier for a subtraction.
+        """Return the immutable storage-key prefix for a subtraction.
 
-        Pre-migration subtractions store files under their legacy Mongo slug; ones
-        created natively in Postgres (``legacy_id`` is NULL) store under the integer
-        id. Raises ResourceNotFoundError if no subtraction matches.
+        The ``storage_key`` is recorded on the row rather than derived from the id:
+        migrated subtractions hold their legacy Mongo slug, natively created ones
+        hold a UUID. Raises ResourceNotFoundError if no subtraction matches.
         """
         async with AsyncSession(self._pg) as session:
-            row = (
+            storage_key = (
                 await session.execute(
-                    select(SQLSubtraction.id, SQLSubtraction.legacy_id).where(
+                    select(SQLSubtraction.storage_key).where(
                         SQLSubtraction.id == subtraction_id,
                         SQLSubtraction.deleted.is_(False),
                     ),
                 )
-            ).one_or_none()
+            ).scalar_one_or_none()
 
-        if row is None:
+        if storage_key is None:
             raise ResourceNotFoundError
 
-        return row.legacy_id or str(row.id)
+        return storage_key
 
     async def get(self, subtraction_id: int) -> Subtraction:
         """Get a subtraction by its id."""
@@ -299,8 +301,7 @@ class SubtractionsData(DataLayerDomain):
             row = (
                 await pg_session.execute(
                     select(
-                        SQLSubtraction.id,
-                        SQLSubtraction.legacy_id,
+                        SQLSubtraction.storage_key,
                         SQLSubtraction.deleted,
                     ).where(SQLSubtraction.id == subtraction_id),
                 )
@@ -309,7 +310,7 @@ class SubtractionsData(DataLayerDomain):
             if row is None or row.deleted:
                 raise ResourceNotFoundError
 
-            storage_id = row.legacy_id or str(row.id)
+            storage_id = row.storage_key
 
             result = await pg_session.execute(
                 update(SQLSubtraction)

--- a/virtool/subtractions/pg.py
+++ b/virtool/subtractions/pg.py
@@ -39,6 +39,11 @@ class SQLSubtraction(Base):
     natively in Postgres can omit it, matching the convention on ``analyses``,
     ``jobs``, ``users``, and ``groups``. The Mongo ``space`` field is
     intentionally dropped.
+
+    ``storage_key`` is the immutable prefix a subtraction's objects live under
+    (``subtractions/{storage_key}/``). It is recorded, never derived: backfilled
+    rows hold their legacy id slug or old integer prefix, and natively created
+    subtractions hold a freshly minted UUID.
     """
 
     __tablename__ = "subtractions"
@@ -46,6 +51,7 @@ class SQLSubtraction(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
     legacy_id: Mapped[str | None] = mapped_column(unique=True)
+    storage_key: Mapped[str] = mapped_column(unique=True)
     name: Mapped[str]
     nickname: Mapped[str] = mapped_column(default="")
     count: Mapped[int | None]


### PR DESCRIPTION
## Summary
- Add a `storage_key` column to samples and subtractions, recorded on the row instead of derived from `legacy_id`/integer id on every read
- Backfill existing rows with their current storage prefix so no objects move; new rows mint a UUID
- Decouples object-storage prefixes from identifier formatting, so future id changes can't move or orphan files