### PR TITLE
feat: spawn periodic tasks from the jobs api server

### DIFF
--- a/tests/jobs/test_main.py
+++ b/tests/jobs/test_main.py
@@ -1,0 +1,29 @@
+from tests.config.test_cls import build_server_config
+from virtool.app import create_app as create_api_app
+from virtool.jobs.main import create_app
+from virtool.shutdown import shutdown_scheduler
+from virtool.startup import startup_periodic_tasks
+
+
+class TestPeriodicTasks:
+    """The jobs API server owns periodic task spawning.
+
+    The public API server must not spawn periodic tasks so it can be scaled to
+    zero without stalling the task queue.
+    """
+
+    async def test_spawned_by_jobs_server(self):
+        app = await create_app(build_server_config())
+
+        assert startup_periodic_tasks in app.on_startup
+
+    async def test_not_spawned_by_api_server(self):
+        app = create_api_app(build_server_config())
+
+        assert startup_periodic_tasks not in app.on_startup
+
+
+async def test_background_tasks_cancelled_on_shutdown():
+    app = await create_app(build_server_config())
+
+    assert shutdown_scheduler in app.on_shutdown

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -2,7 +2,16 @@ import pytest
 from aiohttp.client import ClientSession, ClientTimeout
 
 from tests.config.test_cls import build_server_config
-from virtool.startup import startup_http_client_session, startup_storage
+from virtool.blast.task import BLASTSweepTask
+from virtool.caches.tasks import LRUCacheEvictionTask
+from virtool.hmm.tasks import HMMRefreshTask
+from virtool.jobs.tasks import JobsTimeoutTask
+from virtool.startup import (
+    startup_http_client_session,
+    startup_periodic_tasks,
+    startup_storage,
+)
+from virtool.uploads.tasks import ReapOrphanedUploadsTask
 
 
 @pytest.fixture
@@ -50,3 +59,35 @@ async def test_startup_storage(fake_app, mocker):
     await startup_storage(fake_app)
 
     assert fake_app["storage"] is backend
+
+
+class TestStartupPeriodicTasks:
+    async def test_spawner_started(self, fake_app, mocker):
+        fake_app["config"] = build_server_config(no_periodic_tasks=False)
+        fake_app["data"] = mocker.Mock()
+
+        spawner = mocker.patch("virtool.startup.PeriodicTaskSpawner").return_value
+        spawner.run = mocker.AsyncMock()
+
+        await startup_periodic_tasks(fake_app)
+
+        await fake_app["background_tasks"][0]
+
+        assert [task_class for task_class, _ in spawner.run.call_args.args[0]] == [
+            BLASTSweepTask,
+            HMMRefreshTask,
+            JobsTimeoutTask,
+            LRUCacheEvictionTask,
+            ReapOrphanedUploadsTask,
+        ]
+
+    async def test_disabled(self, fake_app, mocker):
+        fake_app["config"] = build_server_config(no_periodic_tasks=True)
+        fake_app["data"] = mocker.Mock()
+
+        spawner = mocker.patch("virtool.startup.PeriodicTaskSpawner")
+
+        await startup_periodic_tasks(fake_app)
+
+        spawner.assert_not_called()
+        assert "background_tasks" not in fake_app

--- a/virtool/app.py
+++ b/virtool/app.py
@@ -21,7 +21,6 @@ from virtool.startup import (
     startup_events,
     startup_executors,
     startup_http_client_session,
-    startup_periodic_tasks,
     startup_routes,
     startup_sentry,
     startup_settings,
@@ -62,7 +61,6 @@ def create_app(config: Config):
             startup_data,
             startup_settings,
             startup_sentry,
-            startup_periodic_tasks,
         ]
     )
 

--- a/virtool/cli.py
+++ b/virtool/cli.py
@@ -68,7 +68,6 @@ def server() -> None:
 @cache_storage_budget_option
 @dev_option
 @flags_option
-@no_periodic_tasks_option
 @no_revision_check_option
 @postgres_connection_string_option
 @real_ip_header_option
@@ -79,7 +78,7 @@ def start_api_server(**kwargs) -> None:
     configure_logging(bool(kwargs["sentry_dsn"]))
     logger.info("starting the public api service")
 
-    run_api_server(ServerConfig(**kwargs))
+    run_api_server(ServerConfig(**kwargs, no_periodic_tasks=True))
 
 
 @server.command("jobs")

--- a/virtool/jobs/main.py
+++ b/virtool/jobs/main.py
@@ -9,12 +9,18 @@ from virtool.caches.utils import CACHE_MAX_SIZE
 from virtool.config.cls import ServerConfig
 from virtool.flags import FeatureFlags, feature_flag_middleware
 from virtool.jobs.routes import startup_routes
+from virtool.shutdown import (
+    shutdown_executors,
+    shutdown_http_client,
+    shutdown_scheduler,
+)
 from virtool.startup import (
     startup_data,
     startup_databases,
     startup_events,
     startup_executors,
     startup_http_client_session,
+    startup_periodic_tasks,
     startup_sentry,
     startup_settings,
     startup_storage,
@@ -51,6 +57,15 @@ async def create_app(config: ServerConfig):
             startup_routes,
             startup_settings,
             startup_sentry,
+            startup_periodic_tasks,
+        ],
+    )
+
+    app.on_shutdown.extend(
+        [
+            shutdown_scheduler,
+            shutdown_http_client,
+            shutdown_executors,
         ],
     )
 

--- a/virtool/startup.py
+++ b/virtool/startup.py
@@ -150,7 +150,11 @@ async def startup_task_runner(app: App) -> None:
 
 
 async def startup_periodic_tasks(app: App) -> None:
-    """Start the periodic task spawner for API servers.
+    """Start the periodic task spawner for the jobs API server.
+
+    Spawning is deduplicated across replicas by a Postgres advisory lock in
+    :meth:`~virtool.tasks.data.TasksData.create_periodic`, so every jobs API
+    replica can safely run a spawner.
 
     :param app: the app object
     """


### PR DESCRIPTION
## Summary
- Move periodic task spawning to the jobs API server so it no longer depends on the public API server being up, allowing `web-api` to scale to zero without stalling job timeout reaping.
- Honour the `--no-periodic-tasks` flag on `server jobs`, where it was previously accepted but silently ignored, and drop it from `server api`.
- Wire the shutdown handlers the jobs server was missing entirely, so its background tasks, HTTP client, and executors are cleaned up on exit.