### PR TITLE
feat: add server sqlite index support

### DIFF
--- a/assets/alembic/versions/af827765c1d5_replace_indextype_enum_with_text_check.py
+++ b/assets/alembic/versions/af827765c1d5_replace_indextype_enum_with_text_check.py
@@ -1,0 +1,47 @@
+"""replace indextype enum with text check
+
+Revision ID: af827765c1d5
+Revises: 06d0b71c37c3
+Create Date: 2026-07-29 00:56:17.601196+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "af827765c1d5"
+down_revision = "06d0b71c37c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE index_files ALTER COLUMN type TYPE text USING type::text",
+    )
+
+    op.execute("DROP TYPE indextype")
+
+    op.create_check_constraint(
+        "ck_index_files_type",
+        "index_files",
+        "type IN ('json', 'fasta', 'bowtie2', 'sqlite')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_index_files_type", "index_files", type_="check")
+
+    op.execute(
+        "CREATE TYPE indextype AS ENUM ('json', 'fasta', 'bowtie2')",
+    )
+
+    op.execute(
+        "UPDATE index_files SET type = NULL "
+        "WHERE type NOT IN ('json', 'fasta', 'bowtie2')",
+    )
+
+    op.execute(
+        "ALTER TABLE index_files ALTER COLUMN type TYPE indextype "
+        "USING type::indextype",
+    )

--- a/tests/fixtures/workflow_api/__init__.py
+++ b/tests/fixtures/workflow_api/__init__.py
@@ -19,6 +19,7 @@ async def api_server(
     aiohttp_server,
     example_path: Path,
     read_file_from_multipart,
+    tmp_path: Path,
     workflow_data: WorkflowData,
 ) -> TestServer:
     app = Application()
@@ -26,7 +27,11 @@ async def api_server(
     for route in (
         create_analyses_routes(workflow_data, example_path, read_file_from_multipart),
         create_hmms_routes(workflow_data, example_path),
-        create_indexes_routes(workflow_data, example_path),
+        create_indexes_routes(
+            workflow_data,
+            example_path,
+            tmp_path / "workflow-api-index.sqlite",
+        ),
         create_jobs_routes(workflow_data),
         create_samples_routes(workflow_data, example_path, read_file_from_multipart),
         create_subtractions_routes(

--- a/tests/fixtures/workflow_api/indexes.py
+++ b/tests/fixtures/workflow_api/indexes.py
@@ -8,16 +8,19 @@ from tests.fixtures.workflow_api.utils import (
     custom_dumps,
     generate_not_found,
 )
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.indexes.db import (
     JOB_INDEX_FILE_NAMES,
     REFERENCE_JSON_V2_FILE_NAME,
 )
+from virtool.workflow.data.index_sqlite import create_index_sqlite
 from virtool.workflow.pytest_plugin.data import WorkflowData
 
 
 def create_indexes_routes(
     data: WorkflowData,
     example_path: Path,
+    index_sqlite_path: Path,
 ) -> RouteTableDef:
     with gzip.open(
         example_path / "indexes" / "reference.json.gz",
@@ -27,7 +30,7 @@ def create_indexes_routes(
 
     reference_json_v2["_id"] = data.index.reference.id
     reference_json_v2["name"] = data.index.reference.name
-    reference_json_v2 = gzip.compress(json.dumps(reference_json_v2).encode())
+    compressed_reference_json_v2 = gzip.compress(json.dumps(reference_json_v2).encode())
 
     routes = RouteTableDef()
 
@@ -67,7 +70,35 @@ def create_indexes_routes(
 
                 if filename == REFERENCE_JSON_V2_FILE_NAME:
                     return Response(
-                        body=reference_json_v2,
+                        body=compressed_reference_json_v2,
+                        headers={
+                            "Content-Disposition": (
+                                f"attachment; filename='{filename}'"
+                            ),
+                            "Content-Type": "application/octet-stream",
+                        },
+                    )
+
+                if filename == INDEX_SQLITE_FILE_NAME:
+                    reference = {
+                        "_id": data.index.reference.id,
+                        "created_at": reference_json_v2["created_at"],
+                        "data_type": reference_json_v2["data_type"],
+                        "name": data.index.reference.name,
+                        "organism": reference_json_v2["organism"],
+                    }
+                    otus = [
+                        {
+                            **otu,
+                            "version": data.index.manifest[otu["_id"]],
+                        }
+                        for otu in reference_json_v2["otus"]
+                    ]
+
+                    await create_index_sqlite(index_sqlite_path, reference, otus)
+
+                    return FileResponse(
+                        index_sqlite_path,
                         headers={
                             "Content-Disposition": (
                                 f"attachment; filename='{filename}'"

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -10,10 +10,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
-from tests.fixtures.client import JobClientSpawner
+from tests.fixtures.client import ClientSpawner, JobClientSpawner
 from tests.fixtures.response import RespIs
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.indexes.utils import compose_index_file_key
 from virtool.storage.protocol import StorageBackend
@@ -277,3 +278,72 @@ async def test_download(
         assert response.status == status
         if response.status == HTTPStatus.OK:
             assert await response.read() == expected_bytes
+
+
+async def _seed_downloadable_sqlite(
+    fake: DataFaker,
+    memory_storage: StorageBackend,
+    pg: AsyncEngine,
+) -> tuple[int, bytes]:
+    user = await fake.users.create()
+    reference = await fake.references.create(user=user)
+    index = await fake.indexes.create(reference, user)
+    expected = b"server-produced SQLite index"
+
+    async with AsyncSession(pg) as session:
+        storage_key = await session.scalar(
+            select(SQLIndex.storage_key).where(SQLIndex.id == index.id),
+        )
+
+        session.add(
+            SQLIndexFile(
+                name=INDEX_SQLITE_FILE_NAME,
+                index=str(index.id),
+                index_id=index.id,
+                type="sqlite",
+                size=len(expected),
+            ),
+        )
+        await session.commit()
+
+    async def stream():
+        yield expected
+
+    await memory_storage.write(
+        compose_index_file_key(storage_key, INDEX_SQLITE_FILE_NAME),
+        stream(),
+    )
+
+    return index.id, expected
+
+
+async def test_download_sqlite_for_jobs(
+    fake: DataFaker,
+    memory_storage: StorageBackend,
+    pg: AsyncEngine,
+    spawn_job_client: JobClientSpawner,
+):
+    """The jobs download route serves a recorded SQLite index file."""
+    client = await spawn_job_client(authenticated=True)
+    index_id, expected = await _seed_downloadable_sqlite(fake, memory_storage, pg)
+
+    response = await client.get(f"/indexes/{index_id}/files/{INDEX_SQLITE_FILE_NAME}")
+
+    assert response.status == HTTPStatus.OK
+    assert await response.read() == expected
+
+
+async def test_download_sqlite_for_authenticated_user(
+    fake: DataFaker,
+    memory_storage: StorageBackend,
+    pg: AsyncEngine,
+    spawn_client: ClientSpawner,
+):
+    """The authenticated route serves a recorded SQLite index file."""
+    client = await spawn_client(authenticated=True, administrator=True)
+    index_id, expected = await _seed_downloadable_sqlite(fake, memory_storage, pg)
+
+    response = await client.get(f"/indexes/{index_id}/files/{INDEX_SQLITE_FILE_NAME}")
+
+    assert response.status == HTTPStatus.OK
+    assert await response.read() == expected

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -8,7 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 import virtool.indexes.db
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.indexes.db import (
+    INDEX_FILE_NAMES,
+    JOB_INDEX_FILE_NAMES,
     IndexCountsTransform,
     attach_files,
     iter_patched_otus,
@@ -18,6 +21,12 @@ from virtool.indexes.db import (
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.otus.sql import SQLOTU
 from virtool.utils import timestamp
+
+
+def test_sqlite_file_contract():
+    """SQLite is downloadable but not classified as a legacy job artifact."""
+    assert INDEX_SQLITE_FILE_NAME in INDEX_FILE_NAMES
+    assert INDEX_SQLITE_FILE_NAME not in JOB_INDEX_FILE_NAMES
 
 
 async def _seed_index(pg: AsyncEngine, fake: DataFaker, legacy_id: str) -> int:

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -897,5 +897,12 @@
       'name': 'cascade sample label and subtraction links',
       'revision': '06d0b71c37c3',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 129,
+      'name': 'replace indextype enum with text check',
+      'revision': 'af827765c1d5',
+    }),
   ])
 # ---

--- a/tests/migration/test_replace_indextype_enum.py
+++ b/tests/migration/test_replace_indextype_enum.py
@@ -1,0 +1,100 @@
+"""Tests for replacing the index file type enum with constrained text."""
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+
+import alembic.command
+import alembic.config
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from virtool.migration.ctx import MigrationContext
+
+PREVIOUS_REVISION = "06d0b71c37c3"
+REVISION = "af827765c1d5"
+
+
+def _downgrade(revision: str) -> None:
+    alembic.command.downgrade(
+        alembic.config.Config(Path(__file__).parent.parent.parent / "alembic.ini"),
+        revision,
+    )
+
+
+async def test_replaces_indextype_with_constrained_text(
+    apply_alembic: Callable,
+    ctx: MigrationContext,
+):
+    await asyncio.to_thread(apply_alembic, PREVIOUS_REVISION)
+    await asyncio.to_thread(apply_alembic, REVISION)
+
+    async with AsyncSession(ctx.pg) as session:
+        column = (
+            await session.execute(
+                text("""
+                    SELECT data_type, udt_name
+                    FROM information_schema.columns
+                    WHERE table_name = 'index_files' AND column_name = 'type'
+                """),
+            )
+        ).one()
+        enum_type = await session.scalar(text("SELECT to_regtype('indextype')"))
+        constraint = await session.scalar(
+            text("""
+                SELECT pg_get_constraintdef(oid)
+                FROM pg_constraint
+                WHERE conname = 'ck_index_files_type'
+            """),
+        )
+
+    assert column == ("text", "text")
+    assert enum_type is None
+    assert constraint is not None
+    assert all(value in constraint for value in ("json", "fasta", "bowtie2", "sqlite"))
+
+
+async def test_rejects_unknown_index_file_type(
+    apply_alembic: Callable,
+    ctx: MigrationContext,
+):
+    await asyncio.to_thread(apply_alembic, PREVIOUS_REVISION)
+    await asyncio.to_thread(apply_alembic, REVISION)
+
+    with pytest.raises(IntegrityError, match="ck_index_files_type"):
+        async with AsyncSession(ctx.pg) as session:
+            await session.execute(
+                text("""
+                    INSERT INTO index_files (index, index_id, name, type, size)
+                    VALUES ('missing', 1, 'invalid', 'invalid', 0)
+                """),
+            )
+            await session.commit()
+
+
+async def test_downgrade_recreates_indextype(
+    apply_alembic: Callable,
+    ctx: MigrationContext,
+):
+    await asyncio.to_thread(apply_alembic, REVISION)
+    await asyncio.to_thread(_downgrade, PREVIOUS_REVISION)
+    await ctx.pg.dispose()
+
+    async with AsyncSession(ctx.pg) as session:
+        column_type = await session.scalar(
+            text("""
+                SELECT udt_name
+                FROM information_schema.columns
+                WHERE table_name = 'index_files' AND column_name = 'type'
+            """),
+        )
+        enum_values = (
+            await session.scalars(
+                text("SELECT unnest(enum_range(NULL::indextype))::text"),
+            )
+        ).all()
+
+    assert column_type == "indextype"
+    assert enum_values == ["json", "fasta", "bowtie2"]

--- a/tests/workflow/data/test_index_sqlite.py
+++ b/tests/workflow/data/test_index_sqlite.py
@@ -5,8 +5,8 @@ from threading import get_ident
 
 from sqlalchemy import select
 
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.workflow.data.index_sqlite import (
-    INDEX_SQLITE_FILE_NAME,
     connect_index_sqlite,
     create_index_sqlite,
     isolates_table,

--- a/tests/workflow/data/test_indexes.py
+++ b/tests/workflow/data/test_indexes.py
@@ -4,9 +4,9 @@ from threading import get_ident
 import pytest
 from pyfixtures import FixtureScope
 
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.indexes.db import REFERENCE_JSON_V2_FILE_NAME
 from virtool.indexes.models import IndexFile
-from virtool.workflow.data.index_sqlite import INDEX_SQLITE_FILE_NAME
 from virtool.workflow.data.indexes import (
     WFIndex,
     _read_json,
@@ -162,6 +162,22 @@ def _set_reference_json_v2_index_data(workflow_data: WorkflowData) -> None:
             type="json",
         )
     ]
+
+
+def _set_sqlite_index_data(workflow_data: WorkflowData) -> None:
+    _set_reference_json_v2_index_data(workflow_data)
+    workflow_data.index.files.append(
+        IndexFile(
+            download_url=(
+                f"/indexes/{workflow_data.index.id}/files/{INDEX_SQLITE_FILE_NAME}"
+            ),
+            id=2,
+            index=workflow_data.index.id,
+            name=INDEX_SQLITE_FILE_NAME,
+            size=100,
+            type="sqlite",
+        )
+    )
 
 
 def test_shape_reference_json_metadata_preserves_required_values():
@@ -556,6 +572,33 @@ class TestIndex:
             "8f6riell",
             "ixnaodb8",
         }
+
+    async def test_sqlite_ok(
+        self,
+        mocker,
+        scope: FixtureScope,
+        work_path: Path,
+        workflow_data: WorkflowData,
+    ):
+        """Server SQLite is downloaded and loaded without JSON conversion."""
+        _set_sqlite_index_data(workflow_data)
+        create_index_sqlite = mocker.patch(
+            "virtool.workflow.data.indexes.create_index_sqlite"
+        )
+
+        index: WFIndex = await scope.instantiate_by_key("index")
+
+        index_path = work_path / "indexes" / str(workflow_data.analysis.index.id)
+
+        assert {path.name for path in index_path.iterdir()} == {INDEX_SQLITE_FILE_NAME}
+        assert index.id == workflow_data.analysis.index.id
+        assert (await index.get_reference_metadata())["id"] == str(
+            workflow_data.index.reference.id
+        )
+        assert sorted([otu["version"] async for otu in index.iter_otus()]) == sorted(
+            workflow_data.index.manifest.values()
+        )
+        create_index_sqlite.assert_not_called()
 
     async def test_write_fasta(
         self,

--- a/virtool/indexes/constants.py
+++ b/virtool/indexes/constants.py
@@ -1,0 +1,3 @@
+"""Constants for index file contracts."""
+
+INDEX_SQLITE_FILE_NAME = "virtool-index-sqlite-v1.sqlite"

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -28,6 +28,7 @@ from virtool.data.topg import (
 )
 from virtool.data.transforms import AbstractTransform
 from virtool.history.sql import SQLLegacyHistory
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.otus.sql import SQLOTU
 from virtool.references.sql import SQLReference
@@ -54,7 +55,11 @@ JOB_INDEX_FILE_NAMES = (
     "reference.rev.2.bt2",
 )
 
-INDEX_FILE_NAMES = (*JOB_INDEX_FILE_NAMES, REFERENCE_JSON_V2_FILE_NAME)
+INDEX_FILE_NAMES = (
+    *JOB_INDEX_FILE_NAMES,
+    REFERENCE_JSON_V2_FILE_NAME,
+    INDEX_SQLITE_FILE_NAME,
+)
 
 
 class IndexCountsTransform(AbstractTransform):

--- a/virtool/indexes/sql.py
+++ b/virtool/indexes/sql.py
@@ -6,7 +6,6 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     DateTime,
-    Enum,
     ForeignKey,
     Identity,
     Integer,
@@ -72,6 +71,10 @@ class IndexType(str, SQLEnum):
     json = "json"
     fasta = "fasta"
     bowtie2 = "bowtie2"
+    sqlite = "sqlite"
+
+
+_ALLOWED_INDEX_TYPES = ", ".join(repr(value) for value in IndexType.to_list())
 
 
 class SQLIndexFile(Base):
@@ -91,6 +94,10 @@ class SQLIndexFile(Base):
     __tablename__ = "index_files"
     __table_args__ = (
         UniqueConstraint("index_id", "name", name="index_files_index_id_name_key"),
+        CheckConstraint(
+            f"type IN ({_ALLOWED_INDEX_TYPES})",
+            name="ck_index_files_type",
+        ),
     )
 
     id = Column(Integer, primary_key=True)
@@ -101,5 +108,5 @@ class SQLIndexFile(Base):
         ForeignKey("indexes.id", ondelete="CASCADE"),
         nullable=False,
     )
-    type = Column(Enum(IndexType))
+    type = Column(String)
     size = Column(BigInteger)

--- a/virtool/workflow/data/index_sqlite.py
+++ b/virtool/workflow/data/index_sqlite.py
@@ -28,7 +28,6 @@ from virtool.api.custom_json import datetime_to_isoformat
 
 INDEX_SQLITE_FORMAT = "virtool-index-sqlite"
 INDEX_SQLITE_FORMAT_VERSION = "1"
-INDEX_SQLITE_FILE_NAME = f"{INDEX_SQLITE_FORMAT}-v{INDEX_SQLITE_FORMAT_VERSION}.sqlite"
 
 index_sqlite_metadata = MetaData()
 

--- a/virtool/workflow/data/indexes.py
+++ b/virtool/workflow/data/indexes.py
@@ -22,12 +22,12 @@ from sqlalchemy.sql.elements import ColumnElement
 from structlog import get_logger
 
 from virtool.analyses.models import Analysis
+from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
 from virtool.indexes.db import REFERENCE_JSON_V2_FILE_NAME
 from virtool.indexes.models import Index
 from virtool.utils import decompress_file
 from virtool.workflow.client import WorkflowAPIClient
 from virtool.workflow.data.index_sqlite import (
-    INDEX_SQLITE_FILE_NAME,
     _get_id,
     connect_index_sqlite,
     create_index_sqlite,
@@ -507,6 +507,18 @@ async def index(
     await asyncio.to_thread(index_work_path.mkdir, parents=True, exist_ok=True)
 
     log.info("created index directory")
+
+    if any(file.name == INDEX_SQLITE_FILE_NAME for file in index_.files):
+        index_sqlite_path = index_work_path / INDEX_SQLITE_FILE_NAME
+
+        await _api.get_file(
+            f"/indexes/{id_}/files/{INDEX_SQLITE_FILE_NAME}",
+            index_sqlite_path,
+        )
+
+        log.info("loaded server index sqlite")
+
+        return WFIndex.load(id_, index_sqlite_path)
 
     if any(file.name == REFERENCE_JSON_V2_FILE_NAME for file in index_.files):
         compressed_reference_json_path = index_work_path / REFERENCE_JSON_V2_FILE_NAME


### PR DESCRIPTION
- Allow the server to persist and serve SQLite index artifacts with a portable text-backed type constraint.
- Prefer server-produced SQLite indexes in workflows while retaining legacy JSON conversion as a fallback.