### PR TITLE
fix(migration): allow analyses and index files to be created without legacy ids

### DIFF
--- a/assets/alembic/versions/9cea546d2cd3_make_legacy_analyses_and_index_files_.py
+++ b/assets/alembic/versions/9cea546d2cd3_make_legacy_analyses_and_index_files_.py
@@ -6,9 +6,30 @@ replaced. They are still ``NOT NULL`` with no default, so any writer that omits
 them — the TypeScript server's Drizzle mirror does — is rejected by Postgres.
 
 Relax all three to nullable. They are not dropped yet: ``analyses.reference`` is
-still read as a fallback when ``reference_id`` is ``NULL``, and no backfill has
-populated ``analyses.reference_id`` for existing rows. The columns are dropped in
-a later cleanup revision.
+still read as a fallback when ``reference_id`` is ``NULL``. The columns are
+dropped in a later cleanup revision.
+
+That ``NOT NULL`` was incidentally guaranteeing that every analysis names its
+reference and its index in one form or the other. Dropping it alone would let a
+writer that omits both the legacy string and the foreign key insert a row that
+cannot be read back, so each side gets a replacement guarantee:
+
+- ``index_id`` becomes ``NOT NULL``. The backfill in ``rev_bn8b4pzfvokk`` raises
+  rather than leaving a row unresolved, so every existing row already has one;
+  a tripwire refuses the upgrade if that is not true. Together with the existing
+  foreign key this makes an analysis's index always resolvable.
+- ``reference_id`` cannot be tightened the same way because no backfill has
+  populated it, so the ``ck_analyses_reference_present`` check constraint carries
+  the weaker invariant instead: legacy rows satisfy it through the string, rows
+  written against the foreign key satisfy it through the integer. It is replaced
+  by ``NOT NULL`` once ``reference_id`` is backfilled.
+
+``index_files`` needs no equivalent because ``index_id`` is already ``NOT NULL``
+there, set by ``f61c6dbf7ff6``.
+
+Downgrade restores the ``NOT NULL`` string columns and therefore fails once any
+row has been written without them. That is intended: there is no correct value to
+backfill, and fabricating one would corrupt the reference and index linkage.
 
 Revision ID: 9cea546d2cd3
 Revises: af827765c1d5
@@ -24,14 +45,42 @@ down_revision = "af827765c1d5"
 branch_labels = None
 depends_on = None
 
+COUNT_NULL_INDEX_ID_SQL = """
+SELECT COUNT(*) FROM analyses WHERE index_id IS NULL
+"""
+
 
 def upgrade() -> None:
     op.alter_column("analyses", "reference", existing_type=sa.String(), nullable=True)
     op.alter_column("analyses", "index", existing_type=sa.String(), nullable=True)
     op.alter_column("index_files", "index", existing_type=sa.String(), nullable=True)
 
+    null_count = op.get_bind().execute(sa.text(COUNT_NULL_INDEX_ID_SQL)).scalar()
+
+    if null_count:
+        msg = (
+            f"{null_count} analyses row(s) have NULL index_id; refusing to set NOT NULL"
+        )
+        raise RuntimeError(msg)
+
+    op.alter_column(
+        "analyses", "index_id", existing_type=sa.BigInteger(), nullable=False
+    )
+
+    op.create_check_constraint(
+        "ck_analyses_reference_present",
+        "analyses",
+        "num_nonnulls(reference, reference_id) >= 1",
+    )
+
 
 def downgrade() -> None:
+    op.drop_constraint("ck_analyses_reference_present", "analyses", type_="check")
+
+    op.alter_column(
+        "analyses", "index_id", existing_type=sa.BigInteger(), nullable=True
+    )
+
     op.alter_column("index_files", "index", existing_type=sa.String(), nullable=False)
     op.alter_column("analyses", "index", existing_type=sa.String(), nullable=False)
     op.alter_column("analyses", "reference", existing_type=sa.String(), nullable=False)

--- a/assets/alembic/versions/9cea546d2cd3_make_legacy_analyses_and_index_files_.py
+++ b/assets/alembic/versions/9cea546d2cd3_make_legacy_analyses_and_index_files_.py
@@ -1,0 +1,37 @@
+"""make legacy analyses and index_files columns nullable
+
+``analyses.reference``, ``analyses.index`` and ``index_files.index`` hold the
+legacy Mongo strings that the ``reference_id`` and ``index_id`` foreign keys
+replaced. They are still ``NOT NULL`` with no default, so any writer that omits
+them — the TypeScript server's Drizzle mirror does — is rejected by Postgres.
+
+Relax all three to nullable. They are not dropped yet: ``analyses.reference`` is
+still read as a fallback when ``reference_id`` is ``NULL``, and no backfill has
+populated ``analyses.reference_id`` for existing rows. The columns are dropped in
+a later cleanup revision.
+
+Revision ID: 9cea546d2cd3
+Revises: af827765c1d5
+Create Date: 2026-07-31 18:03:46.042189+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9cea546d2cd3"
+down_revision = "af827765c1d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("analyses", "reference", existing_type=sa.String(), nullable=True)
+    op.alter_column("analyses", "index", existing_type=sa.String(), nullable=True)
+    op.alter_column("index_files", "index", existing_type=sa.String(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("index_files", "index", existing_type=sa.String(), nullable=False)
+    op.alter_column("analyses", "index", existing_type=sa.String(), nullable=False)
+    op.alter_column("analyses", "reference", existing_type=sa.String(), nullable=False)

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -260,6 +260,42 @@ async def test_get_not_modified(
         await data_layer.analyses.get(analysis_id, row.updated_at)
 
 
+async def test_get_analysis_written_without_legacy_columns(
+    data_layer: DataLayer,
+    pg: AsyncEngine,
+    setup_sample: SampleSetup,
+):
+    """An analysis inserted with only the integer foreign keys — the shape written by
+    writers that have moved off the legacy Mongo strings — is accepted by Postgres and
+    reads back with its reference and index resolved.
+    """
+    async with AsyncSession(pg) as session:
+        analysis = SQLAnalysis(
+            created_at=timestamp(),
+            updated_at=timestamp(),
+            workflow="nuvs",
+            ready=False,
+            sample=str(setup_sample.sample_id),
+            sample_id=setup_sample.sample_id,
+            reference_id=setup_sample.reference_id,
+            index_id=setup_sample.index_id,
+            user_id=setup_sample.user_id,
+        )
+
+        session.add(analysis)
+        await session.flush()
+
+        analysis_id = analysis.id
+
+        await session.commit()
+
+    fetched = await data_layer.analyses.get(analysis_id)
+
+    assert fetched.id == analysis_id
+    assert fetched.reference.id == setup_sample.reference_id
+    assert fetched.index.id == setup_sample.index_id
+
+
 async def test_get_raises_on_unresolvable_index(
     data_layer: DataLayer,
     pg: AsyncEngine,

--- a/tests/analyses/test_data.py
+++ b/tests/analyses/test_data.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 from unittest.mock import ANY, AsyncMock
 
 import pytest
-from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from syrupy import SnapshotAssertion
 
@@ -289,6 +289,11 @@ async def test_get_analysis_written_without_legacy_columns(
 
         await session.commit()
 
+    row = await get_row(pg, SQLAnalysis, ("id", analysis_id))
+
+    assert row.reference is None
+    assert row.index is None
+
     fetched = await data_layer.analyses.get(analysis_id)
 
     assert fetched.id == analysis_id
@@ -296,31 +301,54 @@ async def test_get_analysis_written_without_legacy_columns(
     assert fetched.index.id == setup_sample.index_id
 
 
-async def test_get_raises_on_unresolvable_index(
-    data_layer: DataLayer,
+async def test_analysis_without_reference_or_reference_id_is_rejected(
     pg: AsyncEngine,
     setup_sample: SampleSetup,
-    subtraction_ids: dict[str, int],
 ):
-    """An analysis whose ``index_id`` does not resolve to a build raises loudly instead
-    of returning a versionless index.
+    """An analysis naming its reference neither by the legacy string nor by the foreign
+    key is rejected, rather than stored as a row that cannot be read back.
     """
-    analysis_id = await seed_setup_analysis(
-        pg,
-        setup_sample,
-        [subtraction_ids["subtraction_1"]],
-    )
-
     async with AsyncSession(pg) as session:
-        await session.execute(
-            update(SQLAnalysis)
-            .where(SQLAnalysis.id == analysis_id)
-            .values(index_id=None),
+        session.add(
+            SQLAnalysis(
+                created_at=timestamp(),
+                updated_at=timestamp(),
+                workflow="nuvs",
+                ready=False,
+                sample=str(setup_sample.sample_id),
+                sample_id=setup_sample.sample_id,
+                index_id=setup_sample.index_id,
+                user_id=setup_sample.user_id,
+            ),
         )
-        await session.commit()
 
-    with pytest.raises(ValueError, match="Index not found for analysis"):
-        await data_layer.analyses.get(analysis_id)
+        with pytest.raises(IntegrityError, match="ck_analyses_reference_present"):
+            await session.commit()
+
+
+async def test_analysis_without_index_id_is_rejected(
+    pg: AsyncEngine,
+    setup_sample: SampleSetup,
+):
+    """An analysis that does not name its index by the foreign key is rejected, rather
+    than stored as a row whose index cannot be resolved.
+    """
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLAnalysis(
+                created_at=timestamp(),
+                updated_at=timestamp(),
+                workflow="nuvs",
+                ready=False,
+                sample=str(setup_sample.sample_id),
+                sample_id=setup_sample.sample_id,
+                reference_id=setup_sample.reference_id,
+                user_id=setup_sample.user_id,
+            ),
+        )
+
+        with pytest.raises(IntegrityError, match="index_id"):
+            await session.commit()
 
 
 async def test_upload_file(

--- a/tests/analyses/test_utils.py
+++ b/tests/analyses/test_utils.py
@@ -4,6 +4,7 @@ from syrupy import SnapshotAssertion
 
 import virtool.analyses.files
 import virtool.analyses.utils
+from tests.fixtures.analysis import seed_index
 from virtool.analyses.sql import SQLAnalysis
 from virtool.analyses.utils import analysis_file_key
 from virtool.users.pg import SQLUser
@@ -38,6 +39,7 @@ async def test_attach_analysis_files(
             sample="sample",
             reference="reference",
             index="index",
+            index_id=await seed_index(session, 1),
             user_id=1,
         )
 

--- a/tests/blast/test_data.py
+++ b/tests/blast/test_data.py
@@ -7,6 +7,7 @@ from aiohttp import ClientSession
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from tests.fixtures.analysis import seed_index
 from virtool.analyses.sql import SQLAnalysis
 from virtool.blast.data import TIMEOUT, BLASTData
 from virtool.blast.sql import SQLNuVsBlast
@@ -69,6 +70,8 @@ async def analysis_ids(pg: AsyncEngine, static_time) -> dict[str, int]:
         )
         await session.flush()
 
+        index_id = await seed_index(session, 1)
+
         nuvs = SQLAnalysis(
             legacy_id="analysis",
             created_at=OLD_TIME,
@@ -79,6 +82,7 @@ async def analysis_ids(pg: AsyncEngine, static_time) -> dict[str, int]:
             sample="sample",
             reference="reference",
             index="index",
+            index_id=index_id,
             user_id=1,
         )
         other = SQLAnalysis(
@@ -91,6 +95,7 @@ async def analysis_ids(pg: AsyncEngine, static_time) -> dict[str, int]:
             sample="sample",
             reference="reference",
             index="index",
+            index_id=index_id,
             user_id=1,
         )
 

--- a/tests/fixtures/analysis.py
+++ b/tests/fixtures/analysis.py
@@ -10,6 +10,47 @@ from virtool.indexes.sql import SQLIndex
 from virtool.references.sql import SQLReference
 from virtool.samples.sql import SQLLegacySample
 from virtool.subtractions.pg import SQLSubtraction
+from virtool.utils import timestamp
+
+
+async def seed_index(
+    session: AsyncSession,
+    user_id: int,
+    legacy_id: str = "index",
+) -> int:
+    """Seed an ``indexes`` row and its ``legacy_references`` parent, returning its id.
+
+    Every analysis must name a resolvable index through the ``index_id`` foreign key.
+    Tests whose subject is not the index itself use this to satisfy that key without
+    restating the reference and index setup.
+
+    The caller is responsible for flushing or committing.
+    """
+    reference = SQLReference(
+        legacy_id=f"ref_{legacy_id}",
+        name="Plant Viruses",
+        description="",
+        created_at=timestamp(),
+        source_types=[],
+        user_id=user_id,
+    )
+    session.add(reference)
+    await session.flush()
+
+    index = SQLIndex(
+        legacy_id=legacy_id,
+        version=0,
+        created_at=timestamp(),
+        manifest={},
+        ready=True,
+        storage_key=legacy_id,
+        reference_id=reference.id,
+        user_id=user_id,
+    )
+    session.add(index)
+    await session.flush()
+
+    return index.id
 
 
 async def seed_analysis(pg: AsyncEngine, document: dict) -> int:

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -551,6 +551,31 @@ async def test_upsert_index_file_updates_existing_row(fake: DataFaker, pg: Async
     assert len(rows) == 1
 
 
+async def test_index_file_row_omitting_legacy_index(fake: DataFaker, pg: AsyncEngine):
+    """An index file inserted with only ``index_id`` — the shape written by writers that
+    have moved off the legacy Mongo string — is accepted by Postgres.
+    """
+    index_pk = await _seed_index(pg, fake, "migrated")
+
+    async with AsyncSession(pg) as session:
+        session.add(
+            SQLIndexFile(
+                index_id=index_pk,
+                name="reference.json.gz",
+                size=9000,
+                type="json",
+            ),
+        )
+        await session.commit()
+
+    async with AsyncSession(pg) as session:
+        row = (
+            await session.execute(select(SQLIndexFile).filter_by(index_id=index_pk))
+        ).scalar_one()
+
+    assert row.index is None
+
+
 class TestUpdateLastIndexedVersions:
     async def test_stamps_postgres(
         self,

--- a/tests/jobs/test_data.py
+++ b/tests/jobs/test_data.py
@@ -3,6 +3,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from tests.fixtures.analysis import seed_index
 from virtool.analyses.sql import SQLAnalysis
 from virtool.data.errors import ResourceConflictError, ResourceNotFoundError
 from virtool.data.events import (
@@ -351,6 +352,7 @@ class TestCreatePostgres:
                 sample="sample_abc",
                 reference="ref_abc",
                 index="index_abc",
+                index_id=await seed_index(session, user.id, "index_abc"),
                 user_id=user.id,
                 job_id=job.id,
             )

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -904,5 +904,12 @@
       'name': 'replace indextype enum with text check',
       'revision': 'af827765c1d5',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 130,
+      'name': 'make legacy analyses and index_files columns nullable',
+      'revision': '9cea546d2cd3',
+    }),
   ])
 # ---

--- a/tests/migration/test_backfill_analyses_index_ids.py
+++ b/tests/migration/test_backfill_analyses_index_ids.py
@@ -111,16 +111,25 @@ async def _fetch_index_id(ctx: MigrationContext, analysis_id: int) -> int | None
         ).scalar_one()
 
 
+NULLABLE_INDEX_ID_REVISION = "af827765c1d5"
+"""The last Alembic revision at which ``analyses.index_id`` is still nullable.
+
+``9cea546d2cd3`` sets it ``NOT NULL``, so from that point on there is no row for this
+backfill to fill. Any deployment where it still has work to do is at or below this
+revision, which makes it the schema to exercise the backfill against.
+"""
+
+
 @pytest.fixture
-async def _at_head(apply_alembic: Callable) -> None:
-    await asyncio.to_thread(apply_alembic, "head")
+async def _nullable_index_id(apply_alembic: Callable) -> None:
+    await asyncio.to_thread(apply_alembic, NULLABLE_INDEX_ID_REVISION)
 
 
 class TestBackfill:
     async def test_index_id_resolved_from_legacy_string(
         self,
         ctx: MigrationContext,
-        _at_head: None,
+        _nullable_index_id: None,
     ):
         """The backfill fills ``index_id`` from ``indexes.legacy_id``."""
         async with AsyncSession(ctx.pg) as session:
@@ -137,7 +146,7 @@ class TestBackfill:
     async def test_idempotent(
         self,
         ctx: MigrationContext,
-        _at_head: None,
+        _nullable_index_id: None,
     ):
         """A second run matches no rows and leaves ``index_id`` unchanged."""
         async with AsyncSession(ctx.pg) as session:
@@ -155,7 +164,7 @@ class TestBackfill:
     async def test_tripwire_raises_on_unresolved_index(
         self,
         ctx: MigrationContext,
-        _at_head: None,
+        _nullable_index_id: None,
     ):
         """An ``index`` string that matches no ``indexes`` row raises loudly, naming
         the unresolved value, rather than leaving ``index_id`` NULL.

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -53,7 +53,6 @@ FIND_COLUMNS = (
     SQLAnalysis.sample_id,
     SQLAnalysis.reference,
     SQLAnalysis.reference_id,
-    SQLAnalysis.index,
     SQLAnalysis.index_id,
     SQLAnalysis.user_id,
     SQLAnalysis.job_id,
@@ -95,7 +94,7 @@ def _row_to_document(row, *, include_results: bool) -> dict:
     that must surface loudly.
     """
     if row.index_pg_id is None:
-        raise ValueError(f"Index not found for analysis {row.id}: {row.index}")
+        raise ValueError(f"Index not found for analysis {row.id}: {row.index_id}")
 
     document = {
         "id": row.id,

--- a/virtool/analyses/data.py
+++ b/virtool/analyses/data.py
@@ -69,9 +69,9 @@ INDEX_COLUMNS = (
 """The joined ``SQLIndex`` columns that supply the nested ``{id, version}``.
 
 The version is not stored on ``analyses``, so it is read from ``indexes`` via the
-``analyses.index_id`` foreign key. Selected through an outer join so an analysis whose
-index cannot be resolved survives the query and raises loudly in ``_row_to_document``
-rather than silently dropping from a list.
+``analyses.index_id`` foreign key. An inner join is safe: ``index_id`` is ``NOT NULL``
+and a foreign key, so every analysis has exactly one matching build and none can be
+dropped from a result by the join.
 """
 
 
@@ -89,13 +89,8 @@ def _row_to_document(row, *, include_results: bool) -> dict:
     ``AttachReferenceTransform`` resolves either form.
 
     The nested index is read from the joined ``SQLIndex`` columns. Its outward id is the
-    integer primary key: indexes are addressed publicly by their Postgres id. A ``NULL``
-    join means ``index_id`` did not resolve to a build, which is a data-integrity failure
-    that must surface loudly.
+    integer primary key: indexes are addressed publicly by their Postgres id.
     """
-    if row.index_pg_id is None:
-        raise ValueError(f"Index not found for analysis {row.id}: {row.index_id}")
-
     document = {
         "id": row.id,
         "legacy_id": row.legacy_id,
@@ -161,7 +156,7 @@ class AnalysisData(DataLayerDomain):
             row = (
                 await session.execute(
                     select(*FIND_COLUMNS, SQLAnalysis.results, *INDEX_COLUMNS)
-                    .outerjoin(SQLIndex, SQLAnalysis.index_id == SQLIndex.id)
+                    .join(SQLIndex, SQLAnalysis.index_id == SQLIndex.id)
                     .where(
                         compose_legacy_id_single_expression(SQLAnalysis, analysis_id),
                     ),

--- a/virtool/analyses/sql.py
+++ b/virtool/analyses/sql.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     BigInteger,
+    CheckConstraint,
     Column,
     DateTime,
     Enum,
@@ -43,10 +44,23 @@ class SQLAnalysis(Base):
       rows the ``reference_id`` backfill has not reached. The bare columns are
       dropped in a later cleanup revision.
 
+    ``index_id`` is ``NOT NULL``, so an analysis's index is always resolvable
+    through the foreign key. ``reference_id`` cannot be tightened the same way
+    until it is backfilled, so ``ck_analyses_reference_present`` holds the weaker
+    invariant that a reference is named either by the legacy string or by the
+    foreign key. Without it a writer that omits both would insert a row that
+    cannot be read back.
+
     The Mongo ``space`` field is intentionally dropped.
     """
 
     __tablename__ = "analyses"
+    __table_args__ = (
+        CheckConstraint(
+            "num_nonnulls(reference, reference_id) >= 1",
+            name="ck_analyses_reference_present",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(always=True), primary_key=True)
     legacy_id: Mapped[str | None] = mapped_column(unique=True)
@@ -68,11 +82,7 @@ class SQLAnalysis(Base):
         nullable=True,
     )
     index: Mapped[str | None]
-    index_id: Mapped[int | None] = mapped_column(
-        BigInteger,
-        ForeignKey("indexes.id"),
-        nullable=True,
-    )
+    index_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("indexes.id"))
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     job_id: Mapped[int | None] = mapped_column(ForeignKey("jobs.id"), nullable=True)
 

--- a/virtool/analyses/sql.py
+++ b/virtool/analyses/sql.py
@@ -38,7 +38,10 @@ class SQLAnalysis(Base):
     - ``sample``, ``reference`` and ``index`` are mid-migration: the legacy Mongo
       string is retained alongside the new
       ``sample_id``/``reference_id``/``index_id`` foreign key while readers move
-      over. The bare columns are dropped in a later cleanup revision.
+      over. ``reference`` and ``index`` are nullable because writers that key off
+      the foreign keys omit them; ``reference`` is still read as a fallback on
+      rows the ``reference_id`` backfill has not reached. The bare columns are
+      dropped in a later cleanup revision.
 
     The Mongo ``space`` field is intentionally dropped.
     """
@@ -58,13 +61,13 @@ class SQLAnalysis(Base):
         ForeignKey("legacy_samples.id"),
         nullable=True,
     )
-    reference: Mapped[str]
+    reference: Mapped[str | None]
     reference_id: Mapped[int | None] = mapped_column(
         BigInteger,
         ForeignKey("legacy_references.id"),
         nullable=True,
     )
-    index: Mapped[str]
+    index: Mapped[str | None]
     index_id: Mapped[int | None] = mapped_column(
         BigInteger,
         ForeignKey("indexes.id"),

--- a/virtool/indexes/sql.py
+++ b/virtool/indexes/sql.py
@@ -81,10 +81,11 @@ class SQLIndexFile(Base):
     """SQL model to store new index files.
 
     ``index`` is mid-migration: the legacy Mongo string is retained alongside the
-    new ``index_id`` foreign key while readers move over. The bare ``index``
-    column is dropped in a later cleanup revision. Uniqueness is now keyed on the
-    integer ``(index_id, name)``; the legacy ``(index, name)`` constraint is
-    dropped by the finalize revision.
+    new ``index_id`` foreign key while readers move over. It is nullable because
+    writers that key off ``index_id`` omit it, and nothing reads it. The bare
+    ``index`` column is dropped in a later cleanup revision. Uniqueness is now
+    keyed on the integer ``(index_id, name)``; the legacy ``(index, name)``
+    constraint is dropped by the finalize revision.
 
     ``index_id`` cascades on delete: files belong to their index, so deleting the
     index (a hard delete, unlike the subtraction soft delete) removes its file
@@ -102,7 +103,7 @@ class SQLIndexFile(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
-    index = Column(String, nullable=False)
+    index = Column(String, nullable=True)
     index_id = Column(
         BigInteger,
         ForeignKey("indexes.id", ondelete="CASCADE"),


### PR DESCRIPTION
## Summary

- `analyses.reference`, `analyses.index` and `index_files.index` hold the legacy Mongo strings that the `reference_id` and `index_id` foreign keys replaced, but were still `NOT NULL` with no default. Any writer that keys off the foreign keys and omits them was rejected by Postgres. A new Alembic revision relaxes all three to nullable.
- That `NOT NULL` was incidentally guaranteeing every analysis names its index and reference, so the same revision replaces the guarantee: `analyses.index_id` becomes `NOT NULL` behind a tripwire, and `ck_analyses_reference_present` carries the weaker invariant for `reference_id`, which has no backfill yet and so must stay nullable.
- With `index_id` `NOT NULL` plus its existing foreign key the index join can no longer miss, so `AnalysisData.get` uses an inner join and its unreachable `ValueError` guard is gone.

Closes VIR-2907.