### PR TITLE
fix(migration): serve current hmm annotations to workflows

### DIFF
--- a/assets/revisions/rev_8kt397kdecbe_delete_stale_hmm_annotations_blob.py
+++ b/assets/revisions/rev_8kt397kdecbe_delete_stale_hmm_annotations_blob.py
@@ -1,0 +1,34 @@
+"""delete stale hmm annotations blob
+
+The gzipped HMM annotations file served to workflows is derived data cached in
+object storage. Annotations are now identified by their Postgres integer id
+instead of the legacy Mongo string, but a blob generated before that switch is
+still cached and served verbatim, so the ``hmms`` workflow fixture fails to
+parse it.
+
+Deleting the object makes the next download regenerate it from Postgres.
+
+Revision ID: 8kt397kdecbe
+Date: 2026-08-05 23:07:48.393734
+
+"""
+
+import arrow
+
+from virtool.hmm.data import HMM_ANNOTATIONS_KEY
+from virtool.migration import MigrationContext
+
+# Revision identifiers.
+name = "delete stale hmm annotations blob"
+created_at = arrow.get("2026-08-05 23:07:48.393734")
+revision_id = "8kt397kdecbe"
+
+alembic_down_revision = "0cbbc3b23245"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+
+async def upgrade(ctx: MigrationContext):
+    await ctx.storage.delete(HMM_ANNOTATIONS_KEY)

--- a/tests/fixtures/migration.py
+++ b/tests/fixtures/migration.py
@@ -104,11 +104,18 @@ def migration_config(
     """A :class:`MigrationConfig` instance that plugs into test instances of backing
     services.
 
+    The storage fields point at the Garage service from ``docker-compose.yml`` so
+    that revisions applied through :func:`virtool.migration.apply.apply`, which
+    builds its own backend from this config, reach a real bucket.
     """
     return MigrationConfig(
         postgres_connection_string=migration_pg_connection_string,
         storage_backend="s3",
-        storage_s3_bucket="test",
+        storage_s3_bucket=os.environ["VT_TEST_S3_BUCKET"],
+        storage_s3_endpoint=os.environ["VT_TEST_S3_ENDPOINT"],
+        storage_s3_region=os.environ["VT_TEST_S3_REGION"],
+        storage_s3_access_key_id=os.environ["VT_TEST_S3_ACCESS_KEY_ID"],
+        storage_s3_secret_access_key=os.environ["VT_TEST_S3_SECRET_ACCESS_KEY"],
     )
 
 

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -9,6 +9,7 @@ from virtool.data.errors import ResourceNotFoundError
 from virtool.hmm.data import HMM_ANNOTATIONS_KEY, HMM_PROFILES_KEY, HmmsData
 from virtool.hmm.releases import GetReleaseError
 from virtool.hmm.sql import SQLHMM, SQLHMMStatus
+from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.object import ObjectProvider
 from virtool.tasks.progress import AbstractProgressHandler
 
@@ -233,6 +234,36 @@ class TestInstall:
         assert await _drain(data_layer.hmms._storage.read(HMM_PROFILES_KEY)) == (
             b"PROFILE-BYTES"
         )
+
+    async def test_clears_cached_annotations(self, data_layer, pg):
+        """An install drops the cached annotations blob it invalidates.
+
+        The blob is derived from the annotation rows. Serving one generated
+        before an install would describe the previous HMM dataset.
+        """
+        await _seed_status(
+            pg,
+            updates=[{"id": 1, "ready": False, "name": "v0.2.1"}],
+        )
+
+        async def _previous_annotations():
+            yield b"PREVIOUS-ANNOTATIONS"
+
+        await data_layer.hmms._storage.write(
+            HMM_ANNOTATIONS_KEY,
+            _previous_annotations(),
+        )
+
+        await data_layer.hmms.install(
+            [ANNOTATION],
+            RELEASE,
+            7,
+            _NullProgressHandler(),
+            _profile_bytes(),
+        )
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await data_layer.hmms._storage.size(HMM_ANNOTATIONS_KEY)
 
     async def test_profile_write_failure_rolls_back(self, data_layer, mocker, pg):
         """A storage failure rolls back the Postgres writes."""

--- a/tests/hmm/test_data.py
+++ b/tests/hmm/test_data.py
@@ -265,6 +265,46 @@ class TestInstall:
         with pytest.raises(StorageKeyNotFoundError):
             await data_layer.hmms._storage.size(HMM_ANNOTATIONS_KEY)
 
+    async def test_failed_install_keeps_cached_annotations(
+        self, data_layer, mocker, pg
+    ):
+        """A failed install leaves the cached annotations blob in place.
+
+        The rows it describes are rolled back, so it is still accurate. The
+        invalidation is tied to a successful commit rather than to the attempt.
+        """
+        await _seed_status(
+            pg,
+            updates=[{"id": 1, "ready": False, "name": "v0.2.1"}],
+        )
+
+        async def _previous_annotations():
+            yield b"PREVIOUS-ANNOTATIONS"
+
+        await data_layer.hmms._storage.write(
+            HMM_ANNOTATIONS_KEY,
+            _previous_annotations(),
+        )
+
+        mocker.patch.object(
+            data_layer.hmms._storage,
+            "write",
+            side_effect=RuntimeError("storage is down"),
+        )
+
+        with pytest.raises(RuntimeError):
+            await data_layer.hmms.install(
+                [ANNOTATION],
+                RELEASE,
+                7,
+                _NullProgressHandler(),
+                _profile_bytes(),
+            )
+
+        assert await _drain(
+            data_layer.hmms._storage.read(HMM_ANNOTATIONS_KEY),
+        ) == (b"PREVIOUS-ANNOTATIONS")
+
     async def test_profile_write_failure_rolls_back(self, data_layer, mocker, pg):
         """A storage failure rolls back the Postgres writes."""
         await _seed_status(

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -925,5 +925,12 @@
       'name': 'add storage keys to file tables',
       'revision': '0cbbc3b23245',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 133,
+      'name': 'delete stale hmm annotations blob',
+      'revision': '8kt397kdecbe',
+    }),
   ])
 # ---

--- a/tests/migration/test_delete_stale_hmm_annotations_blob.py
+++ b/tests/migration/test_delete_stale_hmm_annotations_blob.py
@@ -1,0 +1,22 @@
+"""Tests for the ``delete stale hmm annotations blob`` migration."""
+
+import pytest
+
+from assets.revisions.rev_8kt397kdecbe_delete_stale_hmm_annotations_blob import upgrade
+from virtool.hmm.data import HMM_ANNOTATIONS_KEY
+from virtool.migration.ctx import MigrationContext
+from virtool.storage.errors import StorageKeyNotFoundError
+
+
+async def test_deletes_cached_annotations(ctx: MigrationContext):
+    """The cached annotations blob is removed so it regenerates from Postgres."""
+
+    async def _stale():
+        yield b'[{"id": "p9gtlz0d", "cluster": 10}]'
+
+    await ctx.storage.write(HMM_ANNOTATIONS_KEY, _stale())
+
+    await upgrade(ctx)
+
+    with pytest.raises(StorageKeyNotFoundError):
+        await ctx.storage.size(HMM_ANNOTATIONS_KEY)

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -128,6 +128,11 @@ class HmmsData(DataLayerDomain):
                 wrote_profiles = True
                 await self._storage.write(HMM_PROFILES_KEY, profile_data)
 
+                # The cached annotations blob describes the annotation rows this
+                # install replaces. Drop it before the commit so it can never
+                # outlive them; a rollback only costs a regeneration.
+                await self._storage.delete(HMM_ANNOTATIONS_KEY)
+
                 await session.commit()
         except Exception:
             # Clean up the profiles blob on any failure from the write attempt

--- a/virtool/hmm/data.py
+++ b/virtool/hmm/data.py
@@ -128,11 +128,6 @@ class HmmsData(DataLayerDomain):
                 wrote_profiles = True
                 await self._storage.write(HMM_PROFILES_KEY, profile_data)
 
-                # The cached annotations blob describes the annotation rows this
-                # install replaces. Drop it before the commit so it can never
-                # outlive them; a rollback only costs a regeneration.
-                await self._storage.delete(HMM_ANNOTATIONS_KEY)
-
                 await session.commit()
         except Exception:
             # Clean up the profiles blob on any failure from the write attempt
@@ -146,6 +141,15 @@ class HmmsData(DataLayerDomain):
             if wrote_profiles:
                 await self._storage.delete(HMM_PROFILES_KEY)
             raise
+
+        # The cached annotations blob describes the rows this install replaced.
+        # Drop it only once the new rows are committed: deleting any earlier
+        # lets a concurrent ``download_annotations`` regenerate it from the
+        # pre-install rows, leaving a stale blob paired with the new profiles
+        # and no further invalidation to clear it. This runs outside the block
+        # above so a delete failure cannot trip the profiles cleanup, which
+        # would destroy the profiles of an install that already committed.
+        await self._storage.delete(HMM_ANNOTATIONS_KEY)
 
     async def download_profiles(self) -> tuple[AsyncIterator[bytes], int]:
         try:


### PR DESCRIPTION
## Summary

- The gzipped HMM annotations file is cached in object storage and served verbatim, but nothing invalidated it when annotations switched from Mongo string ids to Postgres integer ids. Workflows kept receiving the stale blob and failed to bind the `hmms` fixture (VIR-2927).
- A revision deletes the object so it regenerates from Postgres, and installing HMMs now drops it rather than letting it outlive the rows it describes.
- `migration_config` now points at the Garage service from `docker-compose.yml`; `apply()` builds its own storage backend, so revisions that touch storage need a reachable bucket.