### PR TITLE
feat: stop downloading bowtie2 files into workflow containers

### DIFF
--- a/tests/workflow/data/test_subtractions.py
+++ b/tests/workflow/data/test_subtractions.py
@@ -47,7 +47,7 @@ class TestSubtractions:
         workflow_data: WorkflowData,
     ):
         """Test that the subtractions fixture matches the expected data and writes the
-        subtraction data files to the work path.
+        subtraction FASTA to the work path.
         """
         workflow_data.job.args["analysis_id"] = workflow_data.analysis.id
 
@@ -59,14 +59,35 @@ class TestSubtractions:
 
         subtraction = subtractions[0]
 
-        for subtraction_file in subtraction.files:
-            assert filecmp.cmp(
-                subtraction.path / subtraction_file.name,
-                example_path
-                / "subtractions"
-                / "arabidopsis_thaliana"
-                / subtraction_file.name,
-            )
+        assert filecmp.cmp(
+            subtraction.fasta_path,
+            example_path
+            / "subtractions"
+            / "arabidopsis_thaliana"
+            / "subtraction.fa.gz",
+        )
+
+    async def test_bowtie2_files_not_downloaded(
+        self,
+        scope: FixtureScope,
+        workflow_data: WorkflowData,
+    ):
+        """Test that Bowtie2 index files listed on the subtraction are not pulled into
+        the work path.
+
+        Subtractions created before the Bowtie2 build was dropped still list their index
+        files, so the fixture must filter to the FASTA explicitly.
+        """
+        workflow_data.job.args["analysis_id"] = workflow_data.analysis.id
+
+        subtractions: list[WFSubtraction] = await scope.instantiate_by_key(
+            "subtractions",
+        )
+
+        subtraction = subtractions[0]
+
+        assert [f.name for f in subtraction.files] == list(SUBTRACTION_FILENAMES)
+        assert [p.name for p in subtraction.path.iterdir()] == ["subtraction.fa.gz"]
 
 
 class TestNewSubtraction:

--- a/virtool/workflow/data/subtractions.py
+++ b/virtool/workflow/data/subtractions.py
@@ -25,15 +25,19 @@ logger = get_logger("api")
 class WFSubtraction:
     """A Virtool subtraction that has been loaded into the workflow environment.
 
-    The subtraction files are downloaded to the workflow's local work path so they can
-    be used for analysis.
+    The subtraction FASTA is downloaded to the workflow's local work path so it can be
+    used for analysis.
     """
 
     id: int
     """The unique ID for the subtraction."""
 
     files: list[SubtractionFile]
-    """The files associated with the subtraction."""
+    """The files associated with the subtraction.
+
+    Only the FASTA is downloaded into the workflow. Older subtractions still list
+    Bowtie2 index files here, but they are not available in ``path``.
+    """
 
     gc: NucleotideComposition
     """The nucleotide composition of the subtraction."""
@@ -48,30 +52,13 @@ class WFSubtraction:
     """
     The path to the subtraction directory.
 
-    The subtraction directory contains the FASTA and Bowtie2 files for the subtraction.
+    The subtraction directory contains the gzipped FASTA file for the subtraction.
     """
 
     @property
     def fasta_path(self) -> Path:
         """The path to the gzipped FASTA file for the subtraction."""
         return self.path / "subtraction.fa.gz"
-
-    @property
-    def bowtie2_index_path(self) -> Path:
-        """The path to Bowtie2 prefix in the running workflow's work_path
-
-        For example, ``/work/subtractions/<id>/subtraction`` refers to the Bowtie2
-        index that comprises the files:
-
-        - ``/work/subtractions/<id>/subtraction.1.bt2``
-        - ``/work/subtractions/<id>/subtraction.2.bt2``
-        - ``/work/subtractions/<id>/subtraction.3.bt2``
-        - ``/work/subtractions/<id>/subtraction.4.bt2``
-        - ``/work/subtractions/<id>/subtraction.rev.1.bt2``
-        - ``/work/subtractions/<id>/subtraction.rev.2.bt2``
-
-        """
-        return self.path / "subtraction"
 
 
 @dataclass
@@ -148,13 +135,12 @@ async def subtractions(
     # Do this in a separate loop in case fetching the JSON fails. This prevents
     # expensive and unnecessary file downloads.
     for subtraction in subtractions_:
-        logger.info("downloading subtraction files", id=subtraction.id)
+        logger.info("downloading subtraction fasta", id=subtraction.id)
 
-        for subtraction_file in subtraction.files:
-            await _api.get_file(
-                f"/subtractions/{subtraction.id}/files/{subtraction_file.name}",
-                subtraction.path / subtraction_file.name,
-            )
+        await _api.get_file(
+            f"/subtractions/{subtraction.id}/files/subtraction.fa.gz",
+            subtraction.fasta_path,
+        )
 
     return subtractions_
 
@@ -211,14 +197,7 @@ async def new_subtraction(
     async def upload(path: Path):
         """Upload a file relating to this subtraction.
 
-        Filenames must be one of:
-            - subtraction.fa.gz
-            - subtraction.1.bt2
-            - subtraction.2.bt2
-            - subtraction.3.bt2
-            - subtraction.4.bt2
-            - subtraction.rev.1.bt2
-            - subtraction.rev.2.bt2
+        The filename must be ``subtraction.fa.gz``.
 
         :param path: The path to the file
 


### PR DESCRIPTION
## Summary

- The `subtractions` fixture downloaded every file listed on a subtraction. No workflow uses the bowtie2 index files — pathoscope and nuvs build their own mapping indexes from the FASTA — so this was gigabytes of pointless transfer into every analysis container for large genomes. It now fetches `subtraction.fa.gz` explicitly, rather than iterating `subtraction.files`, so it stays correct for subtractions that still list their six bowtie2 rows.
- Removes `WFSubtraction.bowtie2_index_path` and corrects the docstrings that enumerated the bowtie2 filenames. This is a breaking change to the workflow SDK, but nothing in the first-party workflows uses the property.

Closes VIR-2945.