### PR TITLE
feat(migration): delete orphaned bowtie2 subtraction files

### DIFF
--- a/assets/revisions/rev_22klaq3y66sm_delete_bowtie2_subtraction_files.py
+++ b/assets/revisions/rev_22klaq3y66sm_delete_bowtie2_subtraction_files.py
@@ -1,0 +1,80 @@
+"""delete bowtie2 subtraction files
+
+Subtractions no longer carry a Bowtie2 index. The create-subtraction workflow
+stopped building one, and no workflow downloads the ``.bt2`` files any more, so
+the six ``bowtie2`` rows every older subtraction owns name objects that nothing
+reads.
+
+The objects are deleted before the rows because the rows are the only record of
+them: a revision that dropped the rows first and then failed mid-sweep would
+leave the survivors unreachable. A failed delete raises for the same reason,
+which keeps the revision pending; ``delete`` is idempotent, so a re-run picks up
+where this one stopped.
+
+The ``fasta`` rows and their objects are left alone.
+
+Revision ID: 22klaq3y66sm
+Date: 2026-08-12 16:51:41.445075
+
+"""
+
+import arrow
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from virtool.migration import MigrationContext
+from virtool.storage.cleanup import delete_keys
+
+logger = get_logger("migration")
+
+# Revision identifiers.
+name = "delete bowtie2 subtraction files"
+created_at = arrow.get("2026-08-12 16:51:41.445075")
+revision_id = "22klaq3y66sm"
+
+alembic_down_revision = "b253add43d69"
+virtool_down_revision = None
+
+# Change this if an Alembic revision is required to run this migration.
+required_alembic_revision = None
+
+BOWTIE2_KEYS = text(
+    """
+    SELECT storage_key
+    FROM subtraction_files
+    WHERE type = 'bowtie2' AND storage_key IS NOT NULL
+    """,
+)
+
+DELETE_BOWTIE2_ROWS = text("DELETE FROM subtraction_files WHERE type = 'bowtie2'")
+
+
+async def upgrade(ctx: MigrationContext) -> None:
+    async with AsyncSession(ctx.pg) as session:
+        keys = list((await session.execute(BOWTIE2_KEYS)).scalars())
+
+    if keys:
+        logger.info("deleting bowtie2 subtraction objects", count=len(keys))
+
+        failures = await delete_keys(ctx.storage, keys)
+
+        if failures:
+            for key, failure in failures:
+                logger.error(
+                    "could not delete bowtie2 subtraction object",
+                    key=key,
+                    error=repr(failure),
+                )
+
+            raise RuntimeError(
+                f"Could not delete {len(failures)} of {len(keys)} bowtie2 "
+                f"subtraction objects. The rows are left in place so the sweep "
+                f"can be retried.",
+            )
+
+    async with AsyncSession(ctx.pg) as session:
+        result = await session.execute(DELETE_BOWTIE2_ROWS)
+        await session.commit()
+
+    logger.info("deleted bowtie2 subtraction file rows", count=result.rowcount)

--- a/assets/revisions/rev_22klaq3y66sm_delete_bowtie2_subtraction_files.py
+++ b/assets/revisions/rev_22klaq3y66sm_delete_bowtie2_subtraction_files.py
@@ -11,6 +11,13 @@ leave the survivors unreachable. A failed delete raises for the same reason,
 which keeps the revision pending; ``delete`` is idempotent, so a re-run picks up
 where this one stopped.
 
+Deletes are issued in batches. ``delete_keys`` starts every delete in the list
+it is given at once, and an installation with thousands of legacy subtractions
+carries six keys each, so handing it the whole sweep would open thousands of
+simultaneous requests to the object store. The first batch to report a failure
+stops the sweep rather than driving the remaining batches into a store that is
+evidently unhealthy.
+
 The ``fasta`` rows and their objects are left alone.
 
 Revision ID: 22klaq3y66sm
@@ -25,6 +32,7 @@ from structlog import get_logger
 
 from virtool.migration import MigrationContext
 from virtool.storage.cleanup import delete_keys
+from virtool.utils import chunk_list
 
 logger = get_logger("migration")
 
@@ -49,6 +57,9 @@ BOWTIE2_KEYS = text(
 
 DELETE_BOWTIE2_ROWS = text("DELETE FROM subtraction_files WHERE type = 'bowtie2'")
 
+BATCH_SIZE = 100
+"""The number of objects deleted concurrently."""
+
 
 async def upgrade(ctx: MigrationContext) -> None:
     async with AsyncSession(ctx.pg) as session:
@@ -57,21 +68,22 @@ async def upgrade(ctx: MigrationContext) -> None:
     if keys:
         logger.info("deleting bowtie2 subtraction objects", count=len(keys))
 
-        failures = await delete_keys(ctx.storage, keys)
+        for batch in chunk_list(keys, BATCH_SIZE):
+            failures = await delete_keys(ctx.storage, batch)
 
-        if failures:
-            for key, failure in failures:
-                logger.error(
-                    "could not delete bowtie2 subtraction object",
-                    key=key,
-                    error=repr(failure),
+            if failures:
+                for key, failure in failures:
+                    logger.error(
+                        "could not delete bowtie2 subtraction object",
+                        key=key,
+                        error=repr(failure),
+                    )
+
+                raise RuntimeError(
+                    f"Could not delete {len(failures)} of {len(batch)} bowtie2 "
+                    f"subtraction objects in a batch of the {len(keys)} to sweep. "
+                    f"The rows are left in place so the sweep can be retried.",
                 )
-
-            raise RuntimeError(
-                f"Could not delete {len(failures)} of {len(keys)} bowtie2 "
-                f"subtraction objects. The rows are left in place so the sweep "
-                f"can be retried.",
-            )
 
     async with AsyncSession(ctx.pg) as session:
         result = await session.execute(DELETE_BOWTIE2_ROWS)

--- a/tests/migration/__snapshots__/test_apply.ambr
+++ b/tests/migration/__snapshots__/test_apply.ambr
@@ -946,5 +946,12 @@
       'name': 'drop dormant sample artifacts table',
       'revision': 'b253add43d69',
     }),
+    dict({
+      'applied_at': datetime,
+      'created_at': datetime,
+      'id': 136,
+      'name': 'delete bowtie2 subtraction files',
+      'revision': '22klaq3y66sm',
+    }),
   ])
 # ---

--- a/tests/migration/test_delete_bowtie2_subtraction_files.py
+++ b/tests/migration/test_delete_bowtie2_subtraction_files.py
@@ -7,7 +7,10 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from assets.revisions.rev_22klaq3y66sm_delete_bowtie2_subtraction_files import upgrade
+from assets.revisions.rev_22klaq3y66sm_delete_bowtie2_subtraction_files import (
+    BATCH_SIZE,
+    upgrade,
+)
 from virtool.migration.ctx import MigrationContext
 from virtool.storage.errors import StorageError, StorageKeyNotFoundError
 
@@ -146,6 +149,34 @@ class TestDeleteBowtie2SubtractionFiles:
 
         assert await ctx.storage.size(fasta_key) == len(b"payload")
         assert await _list_file_names(ctx) == ["subtraction.fa.gz"]
+
+    async def test_sweep_spans_batches(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        """A sweep larger than one batch deletes every object and row."""
+        await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+
+        subtraction_id = await _insert_subtraction(ctx, "legacy")
+
+        keys = []
+
+        for i in range(BATCH_SIZE + 10):
+            name = f"subtraction.{i}.bt2"
+            key = f"subtractions/{subtraction_id}/{name}"
+            keys.append(key)
+
+            await _insert_file(ctx, subtraction_id, name, "bowtie2", key)
+            await _write(ctx, key)
+
+        await upgrade(ctx)
+
+        for key in keys:
+            with pytest.raises(StorageKeyNotFoundError):
+                await ctx.storage.size(key)
+
+        assert await _list_file_names(ctx) == []
 
     async def test_null_storage_key_is_skipped(
         self,

--- a/tests/migration/test_delete_bowtie2_subtraction_files.py
+++ b/tests/migration/test_delete_bowtie2_subtraction_files.py
@@ -1,0 +1,202 @@
+"""Tests for the ``delete bowtie2 subtraction files`` migration."""
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from assets.revisions.rev_22klaq3y66sm_delete_bowtie2_subtraction_files import upgrade
+from virtool.migration.ctx import MigrationContext
+from virtool.storage.errors import StorageError, StorageKeyNotFoundError
+
+ALEMBIC_REVISION = "b253add43d69"
+
+
+async def _write(ctx: MigrationContext, key: str) -> None:
+    async def _chunks():
+        yield b"payload"
+
+    await ctx.storage.write(key, _chunks())
+
+
+async def _insert_subtraction(ctx: MigrationContext, name: str) -> int:
+    async with AsyncSession(ctx.pg) as session:
+        subtraction_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO subtractions (name, nickname, created_at, deleted,
+                                              ready)
+                    VALUES (:name, '', now(), false, true)
+                    RETURNING id
+                    """,
+                ),
+                {"name": name},
+            )
+        ).scalar_one()
+
+        await session.commit()
+
+    return subtraction_id
+
+
+async def _insert_file(
+    ctx: MigrationContext,
+    subtraction_id: int,
+    name: str,
+    type_: str,
+    storage_key: str | None,
+) -> None:
+    async with AsyncSession(ctx.pg) as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO subtraction_files (subtraction_id, name, type, size,
+                                               storage_key)
+                VALUES (:subtraction_id, :name, :type, 100, :storage_key)
+                """,
+            ),
+            {
+                "subtraction_id": subtraction_id,
+                "name": name,
+                "type": type_,
+                "storage_key": storage_key,
+            },
+        )
+        await session.commit()
+
+
+async def _list_file_names(ctx: MigrationContext) -> list[str]:
+    async with AsyncSession(ctx.pg) as session:
+        return sorted(
+            (
+                await session.execute(
+                    text("SELECT name FROM subtraction_files"),
+                )
+            ).scalars(),
+        )
+
+
+class TestDeleteBowtie2SubtractionFiles:
+    async def test_bowtie2_files_are_deleted(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        """Every bowtie2 object and row is removed."""
+        await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+
+        subtraction_id = await _insert_subtraction(ctx, "legacy")
+
+        keys = []
+
+        for name in (
+            "subtraction.1.bt2",
+            "subtraction.2.bt2",
+            "subtraction.rev.1.bt2",
+        ):
+            key = f"subtractions/{subtraction_id}/{name}"
+            keys.append(key)
+
+            await _insert_file(ctx, subtraction_id, name, "bowtie2", key)
+            await _write(ctx, key)
+
+        await upgrade(ctx)
+
+        for key in keys:
+            with pytest.raises(StorageKeyNotFoundError):
+                await ctx.storage.size(key)
+
+        assert await _list_file_names(ctx) == []
+
+    async def test_fasta_file_is_kept(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        """The FASTA a subtraction is still read from survives the sweep."""
+        await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+
+        subtraction_id = await _insert_subtraction(ctx, "legacy")
+
+        fasta_key = f"subtractions/{subtraction_id}/subtraction.fa.gz"
+        bowtie2_key = f"subtractions/{subtraction_id}/subtraction.1.bt2"
+
+        await _insert_file(
+            ctx,
+            subtraction_id,
+            "subtraction.fa.gz",
+            "fasta",
+            fasta_key,
+        )
+        await _insert_file(
+            ctx,
+            subtraction_id,
+            "subtraction.1.bt2",
+            "bowtie2",
+            bowtie2_key,
+        )
+
+        await _write(ctx, fasta_key)
+        await _write(ctx, bowtie2_key)
+
+        await upgrade(ctx)
+
+        assert await ctx.storage.size(fasta_key) == len(b"payload")
+        assert await _list_file_names(ctx) == ["subtraction.fa.gz"]
+
+    async def test_null_storage_key_is_skipped(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+    ):
+        """A bowtie2 row that names no object is dropped without stopping the sweep."""
+        await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+
+        subtraction_id = await _insert_subtraction(ctx, "legacy")
+
+        key = f"subtractions/{subtraction_id}/subtraction.1.bt2"
+
+        await _insert_file(ctx, subtraction_id, "subtraction.2.bt2", "bowtie2", None)
+        await _insert_file(ctx, subtraction_id, "subtraction.1.bt2", "bowtie2", key)
+        await _write(ctx, key)
+
+        await upgrade(ctx)
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await ctx.storage.size(key)
+
+        assert await _list_file_names(ctx) == []
+
+    async def test_failed_delete_raises(
+        self,
+        ctx: MigrationContext,
+        apply_alembic: Callable,
+        mocker,
+    ):
+        """A storage error fails the revision and leaves the rows in place.
+
+        The rows are the only record of these objects, so dropping them after a
+        failed sweep would leave the survivors unreachable.
+        """
+        await asyncio.to_thread(apply_alembic, ALEMBIC_REVISION)
+
+        subtraction_id = await _insert_subtraction(ctx, "legacy")
+
+        key = f"subtractions/{subtraction_id}/subtraction.1.bt2"
+
+        await _insert_file(ctx, subtraction_id, "subtraction.1.bt2", "bowtie2", key)
+        await _write(ctx, key)
+
+        mocker.patch.object(
+            ctx.storage,
+            "delete",
+            side_effect=StorageError("bucket unreachable"),
+        )
+
+        with pytest.raises(RuntimeError, match="bowtie2 subtraction objects"):
+            await upgrade(ctx)
+
+        assert await _list_file_names(ctx) == ["subtraction.1.bt2"]


### PR DESCRIPTION
## Summary
- Deletes the `bowtie2`-type `subtraction_files` rows and their storage objects. They are orphaned now that the create-subtraction workflow no longer builds a Bowtie2 index and no workflow downloads the `.bt2` files.
- Objects are deleted before their rows, since the rows are the only record of them. Any storage failure raises so the revision stays pending and can be retried. `fasta` rows and objects are untouched.