### PR TITLE
fix: keep spawning periodic tasks after a database error

### DIFF
--- a/tests/tasks/test_periodic.py
+++ b/tests/tasks/test_periodic.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 
 from virtool.tasks.periodic import PeriodicTaskSpawner
 from virtool.tasks.task import BaseTask
@@ -40,10 +41,15 @@ class TestPeriodicTaskSpawner:
         transient database error instead of leaving the deployment without
         periodic tasks until the next restart.
         """
+
+        async def create_periodic(task_class, interval):
+            if task_class is SweepTask:
+                raise ConnectionResetError("connection reset")
+
+            return mocker.Mock()
+
         tasks_datalayer = mocker.Mock()
-        tasks_datalayer.create_periodic = mocker.AsyncMock(
-            side_effect=[ConnectionResetError("connection reset"), mocker.Mock()],
-        )
+        tasks_datalayer.create_periodic = mocker.AsyncMock(side_effect=create_periodic)
 
         spawner = PeriodicTaskSpawner(tasks_datalayer)
 
@@ -66,3 +72,30 @@ class TestPeriodicTaskSpawner:
             mocker.call(SweepTask, 30),
             mocker.call(ReapTask, 600),
         ]
+
+    async def test_cancelled_while_spawning(self, mocker, log):
+        """Reach the shutdown path when cancelled mid-spawn.
+
+        ``CancelledError`` inherits from ``BaseException``, so the per-task handler
+        does not intercept it.
+        """
+
+        async def create_periodic(task_class, interval):
+            await asyncio.Event().wait()
+
+        tasks_datalayer = mocker.Mock()
+        tasks_datalayer.create_periodic = mocker.AsyncMock(side_effect=create_periodic)
+
+        spawner = PeriodicTaskSpawner(tasks_datalayer)
+
+        spawner_task = asyncio.create_task(spawner.run([(SweepTask, 30)]))
+
+        await asyncio.sleep(0.1)
+
+        spawner_task.cancel()
+
+        with suppress(asyncio.CancelledError):
+            await spawner_task
+
+        assert log.has("stopped periodic task spawner", level="info")
+        assert not log.has("failed to spawn periodic task")

--- a/tests/tasks/test_periodic.py
+++ b/tests/tasks/test_periodic.py
@@ -1,0 +1,68 @@
+import asyncio
+
+from virtool.tasks.periodic import PeriodicTaskSpawner
+from virtool.tasks.task import BaseTask
+
+
+class SweepTask(BaseTask):
+    name = "sweep_dummy"
+
+
+class ReapTask(BaseTask):
+    name = "reap_dummy"
+
+
+class TestPeriodicTaskSpawner:
+    async def test_spawns_each_task(self, mocker):
+        """Attempt to spawn every configured task on each cycle."""
+        tasks_datalayer = mocker.Mock()
+        tasks_datalayer.create_periodic = mocker.AsyncMock(return_value=mocker.Mock())
+
+        spawner = PeriodicTaskSpawner(tasks_datalayer)
+
+        spawner_task = asyncio.create_task(
+            spawner.run([(SweepTask, 30), (ReapTask, 600)]),
+        )
+
+        await asyncio.sleep(0.1)
+
+        spawner_task.cancel()
+
+        assert tasks_datalayer.create_periodic.call_args_list == [
+            mocker.call(SweepTask, 30),
+            mocker.call(ReapTask, 600),
+        ]
+
+    async def test_survives_spawn_failure(self, mocker, log):
+        """Keep spawning after one task fails to spawn.
+
+        The spawner is the only producer of periodic work, so it must outlive a
+        transient database error instead of leaving the deployment without
+        periodic tasks until the next restart.
+        """
+        tasks_datalayer = mocker.Mock()
+        tasks_datalayer.create_periodic = mocker.AsyncMock(
+            side_effect=[ConnectionResetError("connection reset"), mocker.Mock()],
+        )
+
+        spawner = PeriodicTaskSpawner(tasks_datalayer)
+
+        spawner_task = asyncio.create_task(
+            spawner.run([(SweepTask, 30), (ReapTask, 600)]),
+        )
+
+        await asyncio.sleep(0.1)
+
+        assert not spawner_task.done()
+
+        spawner_task.cancel()
+
+        assert log.has(
+            "failed to spawn periodic task",
+            level="error",
+            name="sweep_dummy",
+        )
+        assert tasks_datalayer.create_periodic.call_args_list == [
+            mocker.call(SweepTask, 30),
+            mocker.call(ReapTask, 600),
+        ]

--- a/tests/tasks/test_runner.py
+++ b/tests/tasks/test_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 
 from virtool.data.layer import DataLayer
 from virtool.tasks.registry import get_task_from_name
@@ -25,10 +26,33 @@ async def test_runner_picks_up_task(data_layer: DataLayer):
     # Cancel the runner task since CloneReferenceTask would run indefinitely
     runner_task.cancel()
 
-    try:
+    with suppress(asyncio.CancelledError):
         await runner_task
-    except asyncio.CancelledError:
-        pass
 
     # Since we cancelled while running, the task may not be complete
     # Just verify it was picked up correctly
+
+
+async def test_runner_survives_acquire_failure(data_layer: DataLayer, mocker, log):
+    """Keep polling after a failed acquisition.
+
+    A runner that dies on a transient database error leaves the queue unattended
+    until the next restart.
+    """
+    mocker.patch.object(
+        data_layer.tasks,
+        "acquire",
+        side_effect=ConnectionResetError("connection reset"),
+    )
+
+    runner_task = asyncio.create_task(TaskRunner(data_layer).run())
+
+    await asyncio.sleep(0.1)
+
+    assert not runner_task.done()
+    assert log.has("encountered error in task runner", level="error")
+
+    runner_task.cancel()
+
+    with suppress(asyncio.CancelledError):
+        await runner_task

--- a/tests/tasks/test_runner.py
+++ b/tests/tasks/test_runner.py
@@ -50,9 +50,68 @@ async def test_runner_survives_acquire_failure(data_layer: DataLayer, mocker, lo
     await asyncio.sleep(0.1)
 
     assert not runner_task.done()
-    assert log.has("encountered error in task runner", level="error")
+    assert log.has("encountered error acquiring task", level="error")
 
     runner_task.cancel()
 
     with suppress(asyncio.CancelledError):
         await runner_task
+
+
+async def test_runner_cancelled_while_acquiring(data_layer: DataLayer, mocker, log):
+    """Reach the shutdown path when cancelled during an acquisition.
+
+    ``CancelledError`` inherits from ``BaseException``, so the acquire handler does
+    not intercept it.
+    """
+
+    async def acquire(runner_id, allowed_types):
+        await asyncio.Event().wait()
+
+    mocker.patch.object(data_layer.tasks, "acquire", side_effect=acquire)
+
+    runner_task = asyncio.create_task(TaskRunner(data_layer).run())
+
+    await asyncio.sleep(0.1)
+
+    runner_task.cancel()
+
+    with suppress(asyncio.CancelledError):
+        await runner_task
+
+    assert log.has("received stop signal", level="info")
+    assert not log.has("encountered error acquiring task")
+
+
+async def test_runner_marks_failed_task_errored(
+    data_layer: DataLayer,
+    mocker,
+    log,
+):
+    """Mark an acquired task errored when it fails outside its own steps.
+
+    ``acquire`` only returns unacquired rows, so a task left acquired after a
+    failure would never be picked up again.
+    """
+    task = await data_layer.tasks.create(
+        get_task_from_name("clone_reference"),
+        {"user_id": "test_1"},
+    )
+
+    mocker.patch.object(
+        TaskRunner,
+        "_run_task",
+        side_effect=ConnectionResetError("connection reset"),
+    )
+
+    runner_task = asyncio.create_task(TaskRunner(data_layer).run())
+
+    await asyncio.sleep(0.1)
+
+    runner_task.cancel()
+
+    with suppress(asyncio.CancelledError):
+        await runner_task
+
+    assert log.has("encountered error running task", level="error", id=task.id)
+    assert "connection reset" in (await data_layer.tasks.get(task.id)).error

--- a/virtool/sentry.py
+++ b/virtool/sentry.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from structlog import get_logger
 
@@ -63,6 +64,7 @@ def configure_sentry(dsn: str, release: str) -> None:
             },
             integrations=[
                 AioHttpIntegration(),
+                AsyncioIntegration(),
                 LoggingIntegration(event_level=logging.WARNING, level=logging.INFO),
             ],
             release=release,

--- a/virtool/tasks/periodic.py
+++ b/virtool/tasks/periodic.py
@@ -18,6 +18,11 @@ class PeriodicTaskSpawner:
     async def run(self, tasks: list[tuple[type[BaseTask], int]]) -> None:
         """Run the periodic task spawner.
 
+        A failure to spawn one task is logged and skipped. The spawner is the only
+        thing that puts periodic work in the queue, so it must survive transient
+        database errors instead of leaving the deployment silently without periodic
+        tasks until the next restart.
+
         :param tasks: List of (task_class, interval_seconds) tuples
         """
         try:
@@ -27,9 +32,15 @@ class PeriodicTaskSpawner:
 
             while True:
                 for task_class, interval in tasks:
-                    task = await self._tasks_datalayer.create_periodic(
-                        task_class, interval
-                    )
+                    try:
+                        task = await self._tasks_datalayer.create_periodic(
+                            task_class, interval
+                        )
+                    except Exception:
+                        logger.exception(
+                            "failed to spawn periodic task", name=task_class.name
+                        )
+                        continue
 
                     if task is not None:
                         logger.info("spawned periodic task", name=task_class.name)

--- a/virtool/tasks/runner.py
+++ b/virtool/tasks/runner.py
@@ -9,10 +9,17 @@ from structlog import get_logger
 from virtool.data.errors import ResourceError
 from virtool.data.layer import DataLayer
 from virtool.tasks.models import Task
+from virtool.tasks.oas import UpdateTaskRequest
 from virtool.tasks.registry import get_available_task_names, get_task_from_name
 from virtool.tasks.task import BaseTask
 
 logger = get_logger("tasks")
+
+POLL_DELAY = 2
+"""The number of seconds to wait between polls when the queue is empty."""
+
+MAX_ACQUIRE_DELAY = 60
+"""The longest a runner will wait between retries after failing to acquire a task."""
 
 
 class TaskRunner:
@@ -37,7 +44,11 @@ class TaskRunner:
         Errors raised outside a task's own steps, such as a failed acquisition or a
         failure to load the task, are logged and skipped. The runner must keep
         polling instead of dying and leaving the queue unattended until the next
-        restart.
+        restart. Failed acquisitions back off so a database outage does not spin
+        the loop or flood the logs.
+
+        ``CancelledError`` inherits from ``BaseException``, so it passes through the
+        inner handlers to the shutdown path below.
         """
         logger.info(
             "started task runner",
@@ -45,21 +56,48 @@ class TaskRunner:
             supported_task_types=self._supported_task_types,
         )
 
+        delay = POLL_DELAY
+
         try:
             while True:
                 try:
                     task = await self._data.tasks.acquire(
                         self._runner_id, self._supported_task_types
                     )
-                    if task is not None:
-                        await self._run_task(task.id)
-                    else:
-                        await asyncio.sleep(2)
                 except Exception:
-                    logger.exception("encountered error in task runner")
-                    await asyncio.sleep(2)
+                    logger.exception("encountered error acquiring task", delay=delay)
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, MAX_ACQUIRE_DELAY)
+                    continue
+
+                delay = POLL_DELAY
+
+                if task is None:
+                    await asyncio.sleep(POLL_DELAY)
+                    continue
+
+                try:
+                    await self._run_task(task.id)
+                except Exception as e:
+                    logger.exception("encountered error running task", id=task.id)
+                    await self._fail_task(task.id, f"{type(e)}: {e!s}")
         except CancelledError:
             await self._shutdown()
+
+    async def _fail_task(self, task_id: int, error: str) -> None:
+        """Mark an acquired task as errored.
+
+        A task that fails outside its own steps is already acquired, and
+        :meth:`~virtool.tasks.data.TasksData.acquire` only returns unacquired rows.
+        Without this it would sit incomplete and unprocessable forever.
+
+        :param task_id: the ID of the task to mark
+        :param error: the error to record on the task
+        """
+        try:
+            await self._data.tasks.update(task_id, UpdateTaskRequest(error=error))
+        except Exception:
+            logger.exception("failed to mark task as errored", id=task_id)
 
     async def _run_task(self, task_id: int):
         """Run a task given a ``task_id``.

--- a/virtool/tasks/runner.py
+++ b/virtool/tasks/runner.py
@@ -33,6 +33,11 @@ class TaskRunner:
         The task runner polls PostgreSQL for available tasks and runs them.
         The runner will run until a stop signal is received. When a stop signal is
         received, the runner will wait for the current task to finish before exiting.
+
+        Errors raised outside a task's own steps, such as a failed acquisition or a
+        failure to load the task, are logged and skipped. The runner must keep
+        polling instead of dying and leaving the queue unattended until the next
+        restart.
         """
         logger.info(
             "started task runner",
@@ -42,12 +47,16 @@ class TaskRunner:
 
         try:
             while True:
-                task = await self._data.tasks.acquire(
-                    self._runner_id, self._supported_task_types
-                )
-                if task is not None:
-                    await self._run_task(task.id)
-                else:
+                try:
+                    task = await self._data.tasks.acquire(
+                        self._runner_id, self._supported_task_types
+                    )
+                    if task is not None:
+                        await self._run_task(task.id)
+                    else:
+                        await asyncio.sleep(2)
+                except Exception:
+                    logger.exception("encountered error in task runner")
                     await asyncio.sleep(2)
         except CancelledError:
             await self._shutdown()


### PR DESCRIPTION
## Summary

- The periodic task spawner and the task runner both caught only `CancelledError`, so any other exception — a transient Postgres error, a pool timeout — ended the loop for the life of the process. Both now log the failure and keep polling.
- The death was silent: the asyncio task is retained in `app["background_tasks"]`, so it is never garbage collected and asyncio never reports the unretrieved exception. Sentry had no `AsyncioIntegration` either, so nothing surfaced anywhere.
- Added `AsyncioIntegration` so a background task that does die is reported.