### PR TITLE
fix: prevent oversized cache uploads from failing jobs

### DIFF
--- a/tests/caches/test_utils.py
+++ b/tests/caches/test_utils.py
@@ -102,7 +102,10 @@ class TestReadCacheContentLength:
 
         with pytest.raises(
             APIRequestEntityTooLarge,
-            match=f"Cache payload exceeds maximum size of {CACHE_MAX_SIZE} bytes",
+            match=(
+                f"Cache payload of {CACHE_MAX_SIZE + 1} bytes exceeds maximum "
+                f"size of {CACHE_MAX_SIZE} bytes"
+            ),
         ):
             read_cache_content_length(req)
 
@@ -141,6 +144,6 @@ class TestCacheBodyChunker:
 
         with pytest.raises(
             APIRequestEntityTooLarge,
-            match="Cache payload exceeds maximum size of 5 bytes",
+            match="Cache payload of 6 bytes exceeds maximum size of 5 bytes",
         ):
             await anext(chunker)

--- a/tests/workflow/data/test_cache.py
+++ b/tests/workflow/data/test_cache.py
@@ -264,3 +264,28 @@ class TestWorkflowCachePut:
         assert (result.path / "nested" / "reference.2.bt2").read_bytes() == (
             b"nested-reference"
         )
+
+    async def test_too_large(
+        self,
+        cache_scope: FixtureScope,
+        log: StructuredLogCapture,
+        monkeypatch,
+        tmp_path: Path,
+        work_path: Path,
+    ):
+        """A payload the jobs API rejects as too large is skipped, not fatal."""
+        monkeypatch.setattr("virtool.caches.utils.CACHE_MAX_SIZE", 1)
+
+        key = "workflow-cache-too-large"
+        source = tmp_path / "index.1.bt2"
+        source.write_bytes(b"an index too large to cache")
+
+        workflow_cache: WorkflowCache = await cache_scope.instantiate_by_key("cache")
+        created = await workflow_cache.put(key, source)
+        target = tmp_path / "target"
+        result = await workflow_cache.get(key, target)
+
+        assert created is False
+        assert isinstance(result, CacheMiss)
+        assert not any((work_path / "caches").iterdir())
+        assert log.has("cache put skipped; payload too large", key=key)

--- a/virtool/caches/utils.py
+++ b/virtool/caches/utils.py
@@ -18,8 +18,14 @@ from aiohttp.web import Request
 from virtool.api.errors import APIBadRequest, APIRequestEntityTooLarge
 from virtool.storage.protocol import STORAGE_CHUNK_SIZE
 
-CACHE_MAX_SIZE = 10 * 1024**3
+CACHE_MAX_SIZE = 30 * 1024**3
 """Maximum cache payload size in bytes."""
+
+
+def _too_large_message(size: int) -> str:
+    return (
+        f"Cache payload of {size} bytes exceeds maximum size of {CACHE_MAX_SIZE} bytes"
+    )
 
 
 def canonicalize_params(params: dict[str, Any]) -> str:
@@ -59,9 +65,7 @@ def read_cache_content_length(req: Request) -> int:
         raise APIBadRequest("Content-Length header is required")
 
     if content_length > CACHE_MAX_SIZE:
-        raise APIRequestEntityTooLarge(
-            f"Cache payload exceeds maximum size of {CACHE_MAX_SIZE} bytes",
-        )
+        raise APIRequestEntityTooLarge(_too_large_message(content_length))
 
     return content_length
 
@@ -79,9 +83,7 @@ async def cache_body_chunker(
             raise APIBadRequest("Request body size exceeds Content-Length")
 
         if size > CACHE_MAX_SIZE:
-            raise APIRequestEntityTooLarge(
-                f"Cache payload exceeds maximum size of {CACHE_MAX_SIZE} bytes",
-            )
+            raise APIRequestEntityTooLarge(_too_large_message(size))
 
         yield chunk
 

--- a/virtool/workflow/api/utils.py
+++ b/virtool/workflow/api/utils.py
@@ -13,6 +13,7 @@ from virtool.workflow.errors import (
     JobsAPIConflictError,
     JobsAPIForbiddenError,
     JobsAPINotFoundError,
+    JobsAPIRequestEntityTooLargeError,
     JobsAPIServerError,
     JobsAPIUnauthorizedError,
 )
@@ -113,6 +114,7 @@ async def raise_exception_by_status_code(resp: ClientResponse) -> None:
     :raise JobsAPIForbidden: the response status code is 403
     :raise JobsAPINotFound: the response status code is 404
     :raise JobsAPIConflict: the response status code is 409
+    :raise JobsAPIRequestEntityTooLargeError: the response status code is 413
     :raise JobsAPIServerError: the response status code is 500
     """
     status_exception_map = {
@@ -121,6 +123,7 @@ async def raise_exception_by_status_code(resp: ClientResponse) -> None:
         403: JobsAPIForbiddenError,
         404: JobsAPINotFoundError,
         409: JobsAPIConflictError,
+        413: JobsAPIRequestEntityTooLargeError,
         500: JobsAPIServerError,
     }
 

--- a/virtool/workflow/data/cache.py
+++ b/virtool/workflow/data/cache.py
@@ -12,7 +12,10 @@ from virtool.workflow.data.tar import (
     extract_tar_to_dir,
     write_path_as_tar,
 )
-from virtool.workflow.errors import JobsAPINotFoundError
+from virtool.workflow.errors import (
+    JobsAPINotFoundError,
+    JobsAPIRequestEntityTooLargeError,
+)
 
 logger = get_logger("api")
 
@@ -61,7 +64,16 @@ class WorkflowCache:
         with TemporaryDirectory(dir=self._path) as temp_dir:
             archive_path = Path(temp_dir) / "cache.tar"
             await write_path_as_tar(source, archive_path)
-            created = await self._api.put_cache(key, archive_path, params)
+
+            try:
+                created = await self._api.put_cache(key, archive_path, params)
+            except JobsAPIRequestEntityTooLargeError:
+                logger.warning(
+                    "cache put skipped; payload too large",
+                    key=key,
+                    size=archive_path.stat().st_size,
+                )
+                return False
 
         logger.info("cache put", key=key, created=created)
         return created

--- a/virtool/workflow/errors.py
+++ b/virtool/workflow/errors.py
@@ -40,6 +40,15 @@ class JobsAPIConflictError(JobsAPIError):
     status = 409
 
 
+class JobsAPIRequestEntityTooLargeError(JobsAPIError):
+    """A ``413 Content Too Large`` response was received from the jobs API.
+
+    The request body exceeds the size the jobs API is willing to accept.
+    """
+
+    status = 413
+
+
 class JobsAPIServerError(JobsAPIError):
     """A ``500 Internal Server Error`` response was received from the jobs API."""
 


### PR DESCRIPTION
## Summary
- Raise the cache payload cap from 10 GiB to 30 GiB. A bowtie2 subtraction index tarball exceeded the old cap, and the jobs API's own `413` failed the whole pathoscope job (VIR-2954).
- Map `413` to a `JobsAPIRequestEntityTooLargeError` in the workflow client instead of raising a bare `ValueError`, and have `WorkflowCache.put` log and skip when the payload is rejected. Caching is an optimization, so a refused write no longer kills the run.
- Include the actual payload size in the `413` message — nothing recorded it before, so there was no way to tell how big the rejected index was.