### PR TITLE
feat: support gzip-compressed sqlite reference artifacts

### DIFF
--- a/tests/fixtures/workflow_api/indexes.py
+++ b/tests/fixtures/workflow_api/indexes.py
@@ -12,7 +12,11 @@ from virtool.indexes.db import (
     JOB_INDEX_FILE_NAMES,
     REFERENCE_JSON_V2_FILE_NAME,
 )
-from virtool.references.sqlite import REFERENCE_SQLITE_FILE_NAME, SQLiteReference
+from virtool.references.sqlite import (
+    REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
+    SQLiteReference,
+)
 from virtool.workflow.pytest_plugin.data import WorkflowData
 
 
@@ -78,7 +82,10 @@ def create_indexes_routes(
                         },
                     )
 
-                if filename == REFERENCE_SQLITE_FILE_NAME:
+                if filename in {
+                    REFERENCE_SQLITE_FILE_NAME,
+                    REFERENCE_SQLITE_GZIP_FILE_NAME,
+                }:
                     reference = {
                         "_id": data.index.reference.id,
                         "created_at": reference_json_v2["created_at"],
@@ -103,6 +110,17 @@ def create_indexes_routes(
                         reference,
                         iter_otus(),
                     )
+
+                    if filename == REFERENCE_SQLITE_GZIP_FILE_NAME:
+                        return Response(
+                            body=gzip.compress(reference_sqlite_path.read_bytes()),
+                            headers={
+                                "Content-Disposition": (
+                                    f"attachment; filename='{filename}'"
+                                ),
+                                "Content-Type": "application/octet-stream",
+                            },
+                        )
 
                     return FileResponse(
                         reference_sqlite_path,

--- a/tests/indexes/test_api.py
+++ b/tests/indexes/test_api.py
@@ -15,7 +15,10 @@ from tests.fixtures.response import RespIs
 from virtool.fake.next import DataFaker
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
-from virtool.references.sqlite import REFERENCE_SQLITE_FILE_NAME
+from virtool.references.sqlite import (
+    REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
+)
 from virtool.storage.keys import mint_storage_key
 from virtool.storage.protocol import StorageBackend
 from virtool.workflow.pytest_plugin.utils import StaticTime
@@ -270,7 +273,7 @@ async def test_download(
 
     if status == HTTPStatus.OK:
         files_url += "reference.1.bt2"
-    elif status == 400:
+    else:
         files_url += "foo.bar"
 
     async with client.get(files_url) as response:
@@ -283,18 +286,19 @@ async def _seed_downloadable_sqlite_reference(
     fake: DataFaker,
     memory_storage: StorageBackend,
     pg: AsyncEngine,
+    filename: str,
 ) -> tuple[int, bytes]:
     user = await fake.users.create()
     reference = await fake.references.create(user=user)
     index = await fake.indexes.create(reference, user)
-    expected = b"server-produced SQLite reference"
+    expected = f"server-produced {filename}".encode()
 
     storage_key = mint_storage_key("indexes", index.id)
 
     async with AsyncSession(pg) as session:
         session.add(
             SQLIndexFile(
-                name=REFERENCE_SQLITE_FILE_NAME,
+                name=filename,
                 index=str(index.id),
                 index_id=index.id,
                 type="sqlite",
@@ -324,10 +328,34 @@ async def test_download_sqlite_reference_for_jobs(
         fake,
         memory_storage,
         pg,
+        REFERENCE_SQLITE_FILE_NAME,
     )
 
     response = await client.get(
         f"/indexes/{index_id}/files/{REFERENCE_SQLITE_FILE_NAME}"
+    )
+
+    assert response.status == HTTPStatus.OK
+    assert await response.read() == expected
+
+
+async def test_download_compressed_sqlite_reference_for_jobs(
+    fake: DataFaker,
+    memory_storage: StorageBackend,
+    pg: AsyncEngine,
+    spawn_job_client: JobClientSpawner,
+):
+    """The jobs route serves a recorded compressed SQLite reference file."""
+    client = await spawn_job_client(authenticated=True)
+    index_id, expected = await _seed_downloadable_sqlite_reference(
+        fake,
+        memory_storage,
+        pg,
+        REFERENCE_SQLITE_GZIP_FILE_NAME,
+    )
+
+    response = await client.get(
+        f"/indexes/{index_id}/files/{REFERENCE_SQLITE_GZIP_FILE_NAME}"
     )
 
     assert response.status == HTTPStatus.OK

--- a/tests/indexes/test_db.py
+++ b/tests/indexes/test_db.py
@@ -19,7 +19,10 @@ from virtool.indexes.db import (
 )
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.otus.sql import SQLOTU
-from virtool.references.sqlite import REFERENCE_SQLITE_FILE_NAME
+from virtool.references.sqlite import (
+    REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
+)
 from virtool.utils import timestamp
 
 
@@ -27,6 +30,8 @@ def test_sqlite_reference_file_contract():
     """SQLite is downloadable but not classified as a legacy job artifact."""
     assert REFERENCE_SQLITE_FILE_NAME in INDEX_FILE_NAMES
     assert REFERENCE_SQLITE_FILE_NAME not in JOB_INDEX_FILE_NAMES
+    assert REFERENCE_SQLITE_GZIP_FILE_NAME in INDEX_FILE_NAMES
+    assert REFERENCE_SQLITE_GZIP_FILE_NAME not in JOB_INDEX_FILE_NAMES
 
 
 async def _seed_index(pg: AsyncEngine, fake: DataFaker, legacy_id: str) -> int:

--- a/tests/references/test_sqlite.py
+++ b/tests/references/test_sqlite.py
@@ -1,19 +1,25 @@
 """Tests for SQLite reference artifacts."""
 
+import gzip
 from collections.abc import AsyncIterator, Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from threading import get_ident
 
 import pytest
 from sqlalchemy import create_engine, delete, insert, select, update
 from sqlalchemy.engine import URL, Connection
 
+from virtool.references import sqlite as sqlite_module
 from virtool.references.sqlite import (
     REFERENCE_SQLITE_FILE_NAME,
     REFERENCE_SQLITE_FORMAT,
     REFERENCE_SQLITE_FORMAT_VERSION,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
     SQLiteReference,
+    SQLiteReferenceDecompressionError,
     SQLiteReferenceReadError,
+    decompress_sqlite_reference,
     isolates_table,
     metadata_table,
     otu_schema_table,
@@ -38,6 +44,7 @@ def _connect_sqlite(path: Path) -> Iterator[Connection]:
 
 def test_reference_sqlite_file_name_is_versioned():
     assert REFERENCE_SQLITE_FILE_NAME == "reference-snapshot.v1.sqlite"
+    assert REFERENCE_SQLITE_GZIP_FILE_NAME == "reference-snapshot.v1.sqlite.gz"
 
 
 def _reference() -> dict:
@@ -184,6 +191,98 @@ async def test_sqlite_reference_round_trip(tmp_path: Path):
         "sequence_dna_b",
     ]
     assert [item["required"] for item in otus[0]["schema"]] == [True, True]
+
+
+class TestDecompressSQLiteReference:
+    async def test_streams_in_worker_thread_and_validates(
+        self,
+        mocker,
+        tmp_path: Path,
+    ):
+        event_loop_thread_id = get_ident()
+        decompression_thread_ids = []
+        sqlite_path = tmp_path / REFERENCE_SQLITE_FILE_NAME
+        compressed_path = tmp_path / REFERENCE_SQLITE_GZIP_FILE_NAME
+        await SQLiteReference.create(
+            sqlite_path,
+            _reference(),
+            _aiter([_otu()]),
+        )
+        compressed_path.write_bytes(gzip.compress(sqlite_path.read_bytes()))
+        sqlite_path.unlink()
+
+        original_decompress = sqlite_module._decompress_sqlite_reference
+
+        def decompress_in_thread(source_path: Path, target_path: Path) -> None:
+            decompression_thread_ids.append(get_ident())
+            original_decompress(source_path, target_path)
+
+        decompress_file = mocker.patch.object(
+            sqlite_module,
+            "decompress_file_with_gzip",
+            wraps=sqlite_module.decompress_file_with_gzip,
+        )
+        mocker.patch.object(
+            sqlite_module,
+            "_decompress_sqlite_reference",
+            side_effect=decompress_in_thread,
+        )
+
+        await decompress_sqlite_reference(
+            compressed_path,
+            sqlite_path,
+        )
+        sqlite_reference = SQLiteReference.load(sqlite_path)
+        await sqlite_reference.validate()
+
+        assert sqlite_reference.path == sqlite_path
+        assert await sqlite_reference.get_metadata() == {
+            "id": "reference",
+            "created_at": "2026-01-15T19:55:34.203324Z",
+            "data_type": "genome",
+            "name": "0.1.1",
+            "organism": "",
+        }
+        assert len(decompression_thread_ids) == 1
+        assert decompression_thread_ids[0] != event_loop_thread_id
+        decompress_file.assert_called_once_with(compressed_path, sqlite_path)
+
+    async def test_rejects_invalid_gzip(self, tmp_path: Path):
+        compressed_path = tmp_path / REFERENCE_SQLITE_GZIP_FILE_NAME
+        sqlite_path = tmp_path / REFERENCE_SQLITE_FILE_NAME
+        compressed_path.write_bytes(b"not gzip")
+
+        with pytest.raises(
+            SQLiteReferenceDecompressionError,
+            match="Could not decompress SQLite reference gzip",
+        ):
+            await decompress_sqlite_reference(compressed_path, sqlite_path)
+
+    async def test_rejects_truncated_gzip(self, tmp_path: Path):
+        compressed_path = tmp_path / REFERENCE_SQLITE_GZIP_FILE_NAME
+        sqlite_path = tmp_path / REFERENCE_SQLITE_FILE_NAME
+        compressed_path.write_bytes(gzip.compress(b"SQLite data")[:-4])
+
+        with pytest.raises(
+            SQLiteReferenceDecompressionError,
+            match="Could not decompress SQLite reference gzip",
+        ):
+            await decompress_sqlite_reference(compressed_path, sqlite_path)
+
+    async def test_distinguishes_invalid_sqlite_from_invalid_gzip(
+        self,
+        tmp_path: Path,
+    ):
+        compressed_path = tmp_path / REFERENCE_SQLITE_GZIP_FILE_NAME
+        sqlite_path = tmp_path / REFERENCE_SQLITE_FILE_NAME
+        compressed_path.write_bytes(gzip.compress(b"not a sqlite database"))
+
+        await decompress_sqlite_reference(compressed_path, sqlite_path)
+
+        with pytest.raises(SQLiteReferenceReadError):
+            await SQLiteReference.load(sqlite_path).validate()
+
+        assert sqlite_path.read_bytes() == b"not a sqlite database"
 
 
 class TestSQLiteReferenceSequences:

--- a/tests/references/test_tasks.py
+++ b/tests/references/test_tasks.py
@@ -23,6 +23,7 @@ from virtool.references.models import Reference
 from virtool.references.sql import SQLReference
 from virtool.references.sqlite import (
     REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
     SQLiteReference,
     otus_table,
     reference_table,
@@ -227,6 +228,16 @@ async def reference_sqlite_path(example_path: Path, tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def reference_sqlite_gzip_path(
+    reference_sqlite_path: Path,
+    tmp_path: Path,
+) -> Path:
+    compressed_path = tmp_path / REFERENCE_SQLITE_GZIP_FILE_NAME
+    compressed_path.write_bytes(gzip.compress(reference_sqlite_path.read_bytes()))
+    return compressed_path
+
+
+@pytest.fixture
 def assert_reference_not_populated(pg: AsyncEngine):
     async def assert_not_populated() -> None:
         async with AsyncSession(pg) as session:
@@ -342,6 +353,44 @@ async def test_import_reference_task_from_producer_named_sqlite(
     await assert_reference_populated()
 
 
+@pytest.mark.flaky(reruns=2)
+async def test_import_reference_task_from_compressed_sqlite(
+    assert_reference_populated,
+    data_layer: DataLayer,
+    memory_storage: StorageBackend,
+    mocker,
+    reference_sqlite_gzip_path: Path,
+    spawn_import_task,
+    static_time: StaticTime,
+):
+    _, task = await spawn_import_task(
+        upload_path=reference_sqlite_gzip_path,
+        upload_name="external-reference.v1.sqlite.gz",
+    )
+    compressed_data = reference_sqlite_gzip_path.read_bytes()
+    chunks = [
+        compressed_data[:100],
+        compressed_data[100:1000],
+        compressed_data[1000:],
+    ]
+    observed_sizes = []
+
+    async def read_in_chunks(_key: str):
+        for chunk in chunks:
+            observed_sizes.append(len(chunk))
+            yield chunk
+
+    mocker.patch.object(memory_storage, "read", new=read_in_chunks)
+
+    await (await ImportReferenceTask.from_task_id(data_layer, task.id)).run()
+
+    completed_task = await data_layer.tasks.get(task.id)
+    assert observed_sizes == [100, 900, len(compressed_data) - 1000]
+    assert completed_task.complete is True
+    assert completed_task.error is None
+    await assert_reference_populated()
+
+
 async def test_import_reference_task_streams_sqlite_to_scratch_space(
     data_layer: DataLayer,
     memory_storage: StorageBackend,
@@ -392,7 +441,8 @@ async def test_import_reference_task_rejects_unsupported_filename(
 
     completed_task = await data_layer.tasks.get(task.id)
     assert completed_task.error == (
-        "Unsupported reference file name; expected a .json.gz or .v1.sqlite suffix"
+        "Unsupported reference file name; expected a .json.gz or .v1.sqlite or "
+        ".v1.sqlite.gz suffix"
     )
     await assert_reference_not_populated()
 
@@ -431,6 +481,63 @@ async def test_import_reference_task_rejects_invalid_json(
     completed_task = await data_layer.tasks.get(task.id)
     assert completed_task.error is not None
     assert "Expecting property name" in completed_task.error
+    await assert_reference_not_populated()
+
+
+async def test_import_reference_task_rejects_invalid_sqlite_gzip(
+    assert_reference_not_populated,
+    data_layer: DataLayer,
+    mocker,
+    spawn_import_task,
+    tmp_path: Path,
+):
+    invalid_gzip_path = tmp_path / "invalid.v1.sqlite.gz"
+    invalid_gzip_path.write_bytes(b"not gzip")
+    reference, task = await spawn_import_task(
+        upload_path=invalid_gzip_path,
+        upload_name="invalid.v1.sqlite.gz",
+    )
+    logger_exception = mocker.patch("virtool.references.imports.logger.exception")
+
+    await (await ImportReferenceTask.from_task_id(data_layer, task.id)).run()
+
+    completed_task = await data_layer.tasks.get(task.id)
+    assert completed_task.error == (
+        "Invalid gzip-compressed SQLite reference file: could not decompress the "
+        "archive"
+    )
+    logger_exception.assert_called_once_with(
+        "could not decompress gzip-compressed SQLite reference file",
+        ref_id=reference.id,
+    )
+    await assert_reference_not_populated()
+
+
+async def test_import_reference_task_rejects_gzipped_invalid_sqlite(
+    assert_reference_not_populated,
+    data_layer: DataLayer,
+    mocker,
+    spawn_import_task,
+    tmp_path: Path,
+):
+    invalid_sqlite_path = tmp_path / "invalid.v1.sqlite.gz"
+    invalid_sqlite_path.write_bytes(gzip.compress(b"not a sqlite database"))
+    reference, task = await spawn_import_task(
+        upload_path=invalid_sqlite_path,
+        upload_name="invalid.v1.sqlite.gz",
+    )
+    logger_exception = mocker.patch("virtool.references.imports.logger.exception")
+
+    await (await ImportReferenceTask.from_task_id(data_layer, task.id)).run()
+
+    completed_task = await data_layer.tasks.get(task.id)
+    assert completed_task.error == (
+        "Invalid SQLite reference file: could not read the database"
+    )
+    logger_exception.assert_called_once_with(
+        "could not read SQLite reference database",
+        ref_id=reference.id,
+    )
     await assert_reference_not_populated()
 
 

--- a/tests/workflow/data/test_indexes.py
+++ b/tests/workflow/data/test_indexes.py
@@ -6,7 +6,10 @@ from pyfixtures import FixtureScope
 
 from virtool.indexes.db import REFERENCE_JSON_V2_FILE_NAME
 from virtool.indexes.models import IndexFile
-from virtool.references.sqlite import REFERENCE_SQLITE_FILE_NAME
+from virtool.references.sqlite import (
+    REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
+)
 from virtool.workflow.data.indexes import (
     INDEX_SQLITE_FILE_NAME,
     WFIndex,
@@ -166,6 +169,23 @@ def _set_sqlite_reference_data(workflow_data: WorkflowData) -> None:
             id=2,
             index=workflow_data.index.id,
             name=REFERENCE_SQLITE_FILE_NAME,
+            size=100,
+            type="sqlite",
+        )
+    )
+
+
+def _set_compressed_sqlite_reference_data(workflow_data: WorkflowData) -> None:
+    _set_sqlite_reference_data(workflow_data)
+    workflow_data.index.files.append(
+        IndexFile(
+            download_url=(
+                f"/indexes/{workflow_data.index.id}/files/"
+                f"{REFERENCE_SQLITE_GZIP_FILE_NAME}"
+            ),
+            id=3,
+            index=workflow_data.index.id,
+            name=REFERENCE_SQLITE_GZIP_FILE_NAME,
             size=100,
             type="sqlite",
         )
@@ -423,6 +443,38 @@ class TestIndex:
         assert sorted([otu["version"] async for otu in index.iter_otus()]) == sorted(
             workflow_data.index.manifest.values()
         )
+        create_workflow_index.assert_not_called()
+
+    async def test_compressed_sqlite_reference_is_preferred(
+        self,
+        mocker,
+        scope: FixtureScope,
+        tmp_path: Path,
+        work_path: Path,
+        workflow_data: WorkflowData,
+    ):
+        """Compressed SQLite is preferred and exposed decompressed to workflows."""
+        _set_compressed_sqlite_reference_data(workflow_data)
+        create_workflow_index = mocker.patch.object(WFIndex, "create")
+
+        index: WFIndex = await scope.instantiate_by_key("index")
+        fasta_path = tmp_path / "reference.fa"
+        await index.write_fasta(fasta_path, index.iter_default_sequences())
+
+        index_path = work_path / "indexes" / str(workflow_data.analysis.index.id)
+
+        assert {path.name for path in index_path.iterdir()} == {
+            REFERENCE_SQLITE_GZIP_FILE_NAME,
+            REFERENCE_SQLITE_FILE_NAME,
+        }
+        assert index.path == index_path / REFERENCE_SQLITE_FILE_NAME
+        assert (await index.get_reference_metadata())["id"] == str(
+            workflow_data.index.reference.id
+        )
+        assert sorted([otu["version"] async for otu in index.iter_otus()]) == sorted(
+            workflow_data.index.manifest.values()
+        )
+        assert fasta_path.read_text().startswith(">njbw70pe\n")
         create_workflow_index.assert_not_called()
 
     async def test_write_fasta(

--- a/virtool/indexes/db.py
+++ b/virtool/indexes/db.py
@@ -31,7 +31,10 @@ from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.otus.sql import SQLOTU
 from virtool.references.sql import SQLReference
-from virtool.references.sqlite import REFERENCE_SQLITE_FILE_NAME
+from virtool.references.sqlite import (
+    REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
+)
 from virtool.types import Document
 
 OTU_ID_CHUNK_SIZE = 500
@@ -59,6 +62,7 @@ INDEX_FILE_NAMES = (
     *JOB_INDEX_FILE_NAMES,
     REFERENCE_JSON_V2_FILE_NAME,
     REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
 )
 
 

--- a/virtool/references/data.py
+++ b/virtool/references/data.py
@@ -362,18 +362,19 @@ class ReferencesData(DataLayerDomain):
                 storage_key,
                 progress_handler,
             )
-        elif name_on_disk.endswith(".v1.sqlite"):
+        elif name_on_disk.endswith((".v1.sqlite", ".v1.sqlite.gz")):
             import_data = await load_sqlite_import(
                 self._storage,
                 storage_key,
                 temp_path,
                 progress_handler,
                 ref_id,
+                compressed=name_on_disk.endswith(".v1.sqlite.gz"),
             )
         else:
             await progress_handler.set_error(
                 "Unsupported reference file name; expected a .json.gz or "
-                ".v1.sqlite suffix"
+                ".v1.sqlite or .v1.sqlite.gz suffix"
             )
             return
 

--- a/virtool/references/imports.py
+++ b/virtool/references/imports.py
@@ -8,8 +8,11 @@ from structlog import get_logger
 
 from virtool.references.sqlite import (
     REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
     SQLiteReference,
+    SQLiteReferenceDecompressionError,
     SQLiteReferenceReadError,
+    decompress_sqlite_reference,
 )
 from virtool.references.utils import load_reference_from_storage
 from virtool.storage.protocol import StorageBackend
@@ -43,19 +46,41 @@ async def load_sqlite_import(
     temp_path: Path,
     progress_handler: AbstractProgressHandler,
     ref_id: int,
+    *,
+    compressed: bool,
 ) -> dict | None:
     """Load an uploaded SQLite reference."""
     sqlite_path = temp_path / REFERENCE_SQLITE_FILE_NAME
+    upload_path = (
+        temp_path / REFERENCE_SQLITE_GZIP_FILE_NAME if compressed else sqlite_path
+    )
 
     try:
-        async with aiofiles.open(sqlite_path, "wb") as handle:
+        async with aiofiles.open(upload_path, "wb") as handle:
             async for chunk in storage.read(key):
                 await handle.write(chunk)
 
+        if compressed:
+            await decompress_sqlite_reference(
+                upload_path,
+                sqlite_path,
+            )
+
         sqlite_reference = SQLiteReference.load(sqlite_path)
         await sqlite_reference.validate()
+
         reference = await sqlite_reference.get_metadata()
         otus = [otu async for otu in sqlite_reference.iter_otus()]
+    except SQLiteReferenceDecompressionError:
+        logger.exception(
+            "could not decompress gzip-compressed SQLite reference file",
+            ref_id=ref_id,
+        )
+        await progress_handler.set_error(
+            "Invalid gzip-compressed SQLite reference file: could not decompress "
+            "the archive"
+        )
+        return None
     except SQLiteReferenceReadError:
         logger.exception(
             "could not read SQLite reference database",

--- a/virtool/references/sqlite.py
+++ b/virtool/references/sqlite.py
@@ -1,5 +1,8 @@
 """Build and query portable SQLite reference artifacts."""
 
+import asyncio
+import gzip
+import zlib
 from collections.abc import (
     AsyncIterable,
     AsyncIterator,
@@ -38,7 +41,10 @@ from sqlalchemy.pool import ConnectionPoolEntry
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.elements import ColumnElement
 
+from virtool.utils import decompress_file_with_gzip
+
 REFERENCE_SQLITE_FILE_NAME = "reference-snapshot.v1.sqlite"
+REFERENCE_SQLITE_GZIP_FILE_NAME = f"{REFERENCE_SQLITE_FILE_NAME}.gz"
 REFERENCE_SQLITE_FORMAT = "virtool-reference-sqlite"
 REFERENCE_SQLITE_FORMAT_VERSION = "1"
 
@@ -49,6 +55,10 @@ reference_sqlite_metadata = MetaData()
 
 class SQLiteReferenceReadError(ValueError):
     """Raised when a SQLite reference database cannot be read."""
+
+
+class SQLiteReferenceDecompressionError(ValueError):
+    """Raised when a gzip-compressed SQLite reference cannot be decompressed."""
 
 
 class SQLiteReferenceWriteError(ValueError):
@@ -356,6 +366,26 @@ class SQLiteReference:
         except SQLAlchemyError as err:
             msg = "Could not read SQLite reference database"
             raise SQLiteReferenceReadError(msg) from err
+
+
+async def decompress_sqlite_reference(
+    source_path: Path,
+    target_path: Path,
+) -> None:
+    """Decompress a gzip-wrapped SQLite reference on disk."""
+    await asyncio.to_thread(
+        _decompress_sqlite_reference,
+        source_path,
+        target_path,
+    )
+
+
+def _decompress_sqlite_reference(source_path: Path, target_path: Path) -> None:
+    try:
+        decompress_file_with_gzip(source_path, target_path)
+    except (gzip.BadGzipFile, EOFError, zlib.error) as err:
+        msg = f"Could not decompress SQLite reference gzip: {err}"
+        raise SQLiteReferenceDecompressionError(msg) from err
 
 
 def _create_reference_sqlite_engine(path: Path) -> AsyncEngine:

--- a/virtool/workflow/data/indexes.py
+++ b/virtool/workflow/data/indexes.py
@@ -18,8 +18,10 @@ from virtool.indexes.db import REFERENCE_JSON_V2_FILE_NAME
 from virtool.indexes.models import Index
 from virtool.references.sqlite import (
     REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
     OTUSummary,
     SQLiteReference,
+    decompress_sqlite_reference,
 )
 from virtool.utils import decompress_file
 from virtool.workflow.client import WorkflowAPIClient
@@ -176,17 +178,40 @@ async def index(
 
     log.info("created index directory")
 
-    if any(file.name == REFERENCE_SQLITE_FILE_NAME for file in index_.files):
+    available_file_names = {file.name for file in index_.files}
+    sqlite_file_name = next(
+        (
+            file_name
+            for file_name in (
+                REFERENCE_SQLITE_GZIP_FILE_NAME,
+                REFERENCE_SQLITE_FILE_NAME,
+            )
+            if file_name in available_file_names
+        ),
+        None,
+    )
+
+    if sqlite_file_name is not None:
         reference_sqlite_path = index_work_path / REFERENCE_SQLITE_FILE_NAME
+        download_path = index_work_path / sqlite_file_name
 
         await _api.get_file(
-            f"/indexes/{id_}/files/{REFERENCE_SQLITE_FILE_NAME}",
-            reference_sqlite_path,
+            f"/indexes/{id_}/files/{sqlite_file_name}",
+            download_path,
         )
 
-        log.info("loaded server SQLite reference")
+        if sqlite_file_name == REFERENCE_SQLITE_GZIP_FILE_NAME:
+            await decompress_sqlite_reference(
+                download_path,
+                reference_sqlite_path,
+            )
 
-        return WFIndex.load(id_, reference_sqlite_path)
+        sqlite_reference = SQLiteReference.load(reference_sqlite_path)
+        await sqlite_reference.validate()
+
+        log.info("loaded server SQLite reference", filename=sqlite_file_name)
+
+        return WFIndex(id_, sqlite_reference)
 
     if any(file.name == REFERENCE_JSON_V2_FILE_NAME for file in index_.files):
         compressed_reference_json_path = index_work_path / REFERENCE_JSON_V2_FILE_NAME


### PR DESCRIPTION
- Accept and validate `.v1.sqlite.gz` reference imports with distinct decompression errors.
- Prefer compressed SQLite index artifacts and transparently decompress them for workflows.
- Expose compressed artifacts through index file contracts and job downloads.