### PR TITLE
feat: publish compressed sqlite artifacts for new indexes

### DIFF
--- a/tests/indexes/test_tasks.py
+++ b/tests/indexes/test_tasks.py
@@ -540,7 +540,7 @@ class TestCreateIndexTask:
         build = asyncio.create_task(
             self.data_layer.index.generate_task_index(self.index_id),
         )
-        await asyncio.wait_for(all_started.wait(), timeout=1)
+        await asyncio.wait_for(all_started.wait(), timeout=5)
         build.cancel()
 
         with pytest.raises(asyncio.CancelledError):

--- a/tests/indexes/test_tasks.py
+++ b/tests/indexes/test_tasks.py
@@ -1,25 +1,30 @@
 """Tests for task-backed index creation."""
 
-import gzip
-import json
+import asyncio
 from collections.abc import AsyncIterator
+from datetime import UTC
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from threading import get_ident
 
 import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+import virtool.indexes.data
+import virtool.indexes.db
 from virtool.data.errors import ResourceConflictError
 from virtool.data.layer import DataLayer
 from virtool.fake.next import DataFaker
-from virtool.indexes.db import REFERENCE_JSON_V2_FILE_NAME
 from virtool.indexes.sql import SQLIndex, SQLIndexFile
 from virtool.indexes.tasks import CreateIndexTask
 from virtool.otus.sql import SQLOTU
 from virtool.references.sqlite import (
     REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
     SQLiteReference,
+    decompress_sqlite_reference,
 )
 from virtool.storage.errors import StorageKeyNotFoundError
 from virtool.storage.keys import mint_storage_key
@@ -82,29 +87,33 @@ class TestCreateIndexTask:
                 await session.execute(
                     select(SQLIndexFile.name, SQLIndexFile.storage_key).where(
                         SQLIndexFile.index_id == self.index_id,
-                        SQLIndexFile.name.in_(
-                            (
-                                REFERENCE_JSON_V2_FILE_NAME,
-                                REFERENCE_SQLITE_FILE_NAME,
-                            )
-                        ),
                     ),
                 )
             ).all()
 
         return dict(rows)
 
-    async def test_writes_json_and_sqlite_reference_exports_and_finalizes(
+    @staticmethod
+    def _assert_temp_path_empty(temp_path: Path) -> None:
+        assert list(temp_path.iterdir()) == []
+
+    @staticmethod
+    def _use_temp_path(mocker: MockerFixture, temp_path: Path) -> None:
+        mocker.patch(
+            "virtool.indexes.data.TemporaryDirectory",
+            side_effect=lambda: TemporaryDirectory(dir=temp_path),
+        )
+
+    async def test_writes_compressed_sqlite_reference_and_finalizes(
         self,
         task_id: int,
         tmp_path: Path,
     ) -> None:
-        """The task writes equivalent JSON and SQLite reference exports."""
+        """The task publishes only a valid gzip-compressed SQLite reference."""
         await (await CreateIndexTask.from_task_id(self.data_layer, task_id)).run()
 
         file_keys = await self.reference_file_keys()
-        json_key = file_keys[REFERENCE_JSON_V2_FILE_NAME]
-        sqlite_key = file_keys[REFERENCE_SQLITE_FILE_NAME]
+        gzip_key = file_keys[REFERENCE_SQLITE_GZIP_FILE_NAME]
 
         keys = [
             info.key
@@ -113,42 +122,20 @@ class TestCreateIndexTask:
         assert set(keys) == set(file_keys.values())
 
         compressed = b"".join(
-            [chunk async for chunk in self.memory_storage.read(json_key)],
+            [chunk async for chunk in self.memory_storage.read(gzip_key)],
         )
         download, size = await self.data_layer.index.get_index_file(
             self.index_id,
-            REFERENCE_JSON_V2_FILE_NAME,
+            REFERENCE_SQLITE_GZIP_FILE_NAME,
         )
 
         assert b"".join([chunk async for chunk in download]) == compressed
         assert size == len(compressed)
 
-        decompressed = gzip.decompress(compressed)
-        reference_json = json.loads(decompressed)
-
-        assert reference_json["_id"] == self.reference.id
-        assert reference_json["data_type"] == "genome"
-        assert reference_json["name"] == self.reference.name
-        assert reference_json["organism"] == self.reference.organism == ""
-        assert reference_json["otus"][0]["_id"] == self.otu.id
-        assert reference_json["otus"][0]["version"] == self.manifest[self.otu.id]
-        assert reference_json["otus"][0]["isolates"][0]["id"] == self.otu.isolates[0].id
-
-        json_sequences = {
-            sequence["_id"]: sequence["sequence"]
-            for sequence in reference_json["otus"][0]["isolates"][0]["sequences"]
-        }
-        assert json_sequences == {
-            sequence.id: sequence.sequence
-            for sequence in self.otu.isolates[0].sequences
-        }
-        assert len(compressed) < len(decompressed)
-
-        sqlite_bytes = b"".join(
-            [chunk async for chunk in self.memory_storage.read(sqlite_key)],
-        )
+        gzip_path = tmp_path / REFERENCE_SQLITE_GZIP_FILE_NAME
         sqlite_path = tmp_path / REFERENCE_SQLITE_FILE_NAME
-        sqlite_path.write_bytes(sqlite_bytes)
+        gzip_path.write_bytes(compressed)
+        await decompress_sqlite_reference(gzip_path, sqlite_path)
         sqlite_reference = SQLiteReference.load(sqlite_path)
 
         await sqlite_reference.validate()
@@ -158,21 +145,24 @@ class TestCreateIndexTask:
 
         assert sqlite_metadata == {
             "id": str(self.reference.id),
-            "created_at": reference_json["created_at"],
-            "data_type": reference_json["data_type"],
-            "name": reference_json["name"],
-            "organism": reference_json["organism"],
+            "created_at": self.reference.created_at.replace(tzinfo=UTC)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "data_type": "genome",
+            "name": self.reference.name,
+            "organism": self.reference.organism,
         }
-        assert sqlite_otus[0]["id"] == reference_json["otus"][0]["_id"]
-        assert sqlite_otus[0]["version"] == reference_json["otus"][0]["version"]
-        assert (
-            sqlite_otus[0]["isolates"][0]["id"]
-            == (reference_json["otus"][0]["isolates"][0]["id"])
-        )
+        assert sqlite_otus[0]["id"] == self.otu.id
+        assert sqlite_otus[0]["version"] == self.manifest[self.otu.id]
+        assert sqlite_otus[0]["isolates"][0]["id"] == self.otu.isolates[0].id
         assert {
             sequence["id"]: sequence["sequence"]
             for sequence in sqlite_otus[0]["isolates"][0]["sequences"]
-        } == json_sequences
+        } == {
+            sequence.id: sequence.sequence
+            for sequence in self.otu.isolates[0].sequences
+        }
+        assert len(compressed) < sqlite_path.stat().st_size
 
         async with AsyncSession(self.pg) as session:
             rows = (
@@ -187,14 +177,9 @@ class TestCreateIndexTask:
 
         rows_by_name = {row.name: row for row in rows}
 
-        assert set(rows_by_name) == {
-            REFERENCE_JSON_V2_FILE_NAME,
-            REFERENCE_SQLITE_FILE_NAME,
-        }
-        assert rows_by_name[REFERENCE_JSON_V2_FILE_NAME].type == "json"
-        assert rows_by_name[REFERENCE_JSON_V2_FILE_NAME].size == len(compressed)
-        assert rows_by_name[REFERENCE_SQLITE_FILE_NAME].type == "sqlite"
-        assert rows_by_name[REFERENCE_SQLITE_FILE_NAME].size == len(sqlite_bytes)
+        assert set(rows_by_name) == {REFERENCE_SQLITE_GZIP_FILE_NAME}
+        assert rows_by_name[REFERENCE_SQLITE_GZIP_FILE_NAME].type == "sqlite"
+        assert rows_by_name[REFERENCE_SQLITE_GZIP_FILE_NAME].size == len(compressed)
 
         async with AsyncSession(self.pg) as session:
             index_row = await session.scalar(
@@ -226,6 +211,85 @@ class TestCreateIndexTask:
         assert task.complete is True
         assert task.error is None
         assert (await self.data_layer.index.get(self.index_id)).ready is True
+
+    async def test_streams_patched_otus_directly_to_sqlite_create(
+        self,
+        mocker: MockerFixture,
+        task_id: int,
+    ) -> None:
+        """Patched OTUs are not materialized before SQLite creation starts."""
+        original_iter_patched_otus = virtool.indexes.db.iter_patched_otus
+        original_create = SQLiteReference.create
+        create_started = False
+        produced_count = 0
+
+        async def iter_patched_otus(*args: object, **kwargs: object):
+            nonlocal produced_count
+
+            async for otu in original_iter_patched_otus(*args, **kwargs):
+                assert create_started
+                produced_count += 1
+                yield otu
+
+        async def create(
+            path: Path,
+            reference: dict,
+            otus: AsyncIterator[dict],
+        ) -> SQLiteReference:
+            nonlocal create_started
+            assert produced_count == 0
+            create_started = True
+            return await original_create(path, reference, otus)
+
+        mocker.patch(
+            "virtool.indexes.db.iter_patched_otus",
+            side_effect=iter_patched_otus,
+        )
+        mocker.patch.object(SQLiteReference, "create", side_effect=create)
+
+        await (await CreateIndexTask.from_task_id(self.data_layer, task_id)).run()
+
+        assert create_started is True
+        assert produced_count == len(self.manifest)
+
+    async def test_compresses_off_loop_and_uploads_multiple_chunks(
+        self,
+        mocker: MockerFixture,
+        task_id: int,
+    ) -> None:
+        """Compression is threaded and the completed gzip is streamed to storage."""
+        event_loop_thread_id = get_ident()
+        compression_thread_ids = []
+        uploaded_chunks = []
+        upload_chunk_size = 64
+        original_compress = virtool.indexes.data.compress_file_with_gzip
+        original_write = self.memory_storage.write
+
+        def compress(source_path: Path, target_path: Path) -> None:
+            compression_thread_ids.append(get_ident())
+            original_compress(source_path, target_path)
+
+        async def write(key: str, data: AsyncIterator[bytes]) -> int:
+            async def capture_chunks():
+                async for chunk in data:
+                    uploaded_chunks.append(chunk)
+                    yield chunk
+
+            return await original_write(key, capture_chunks())
+
+        mocker.patch("virtool.storage.file.STORAGE_CHUNK_SIZE", upload_chunk_size)
+        mocker.patch(
+            "virtool.indexes.data.compress_file_with_gzip",
+            side_effect=compress,
+        )
+        mocker.patch.object(self.memory_storage, "write", side_effect=write)
+
+        await (await CreateIndexTask.from_task_id(self.data_layer, task_id)).run()
+
+        assert len(compression_thread_ids) == 1
+        assert compression_thread_ids[0] != event_loop_thread_id
+        assert len(uploaded_chunks) > 1
+        assert all(len(chunk) <= upload_chunk_size for chunk in uploaded_chunks)
         keys = [
             info.key
             async for info in self.memory_storage.list(f"indexes/{self.index_id}/")
@@ -255,43 +319,29 @@ class TestCreateIndexTask:
         assert task.error is None
         assert (await self.data_layer.index.get(self.index_id)).ready is True
 
-    async def test_updates_existing_index_file_rows(self, task_id: int) -> None:
-        """Existing reference export rows are updated instead of duplicated.
+    async def test_updates_existing_gzip_index_file_row(self, task_id: int) -> None:
+        """A successful retry replaces an existing gzip artifact.
 
         Keys are minted per write, so the rebuild writes a new object rather than
-        overwriting the old ones. Superseded objects must be deleted or every retried
-        build leaks two.
+        overwriting the old one. Superseded objects are deleted only after success.
         """
-        superseded_keys = {
-            file_name: mint_storage_key("indexes", self.index_id)
-            for file_name in (
-                REFERENCE_JSON_V2_FILE_NAME,
-                REFERENCE_SQLITE_FILE_NAME,
-            )
-        }
+        superseded_key = mint_storage_key("indexes", self.index_id)
 
         async def _stream():
             yield b"stale"
 
-        for key in superseded_keys.values():
-            await self.memory_storage.write(key, _stream())
+        await self.memory_storage.write(superseded_key, _stream())
 
         async with AsyncSession(self.pg) as session:
-            session.add_all(
-                [
-                    SQLIndexFile(
-                        index=str(self.index_id),
-                        index_id=self.index_id,
-                        name=file_name,
-                        size=5,
-                        storage_key=superseded_keys[file_name],
-                        type=file_type,
-                    )
-                    for file_name, file_type in (
-                        (REFERENCE_JSON_V2_FILE_NAME, "json"),
-                        (REFERENCE_SQLITE_FILE_NAME, "sqlite"),
-                    )
-                ],
+            session.add(
+                SQLIndexFile(
+                    index=str(self.index_id),
+                    index_id=self.index_id,
+                    name=REFERENCE_SQLITE_GZIP_FILE_NAME,
+                    size=5,
+                    storage_key=superseded_key,
+                    type="sqlite",
+                ),
             )
             await session.commit()
 
@@ -310,23 +360,20 @@ class TestCreateIndexTask:
 
         rows_by_name = {row.name: row for row in rows}
 
-        assert set(rows_by_name) == {
-            REFERENCE_JSON_V2_FILE_NAME,
-            REFERENCE_SQLITE_FILE_NAME,
-        }
-        assert rows_by_name[REFERENCE_JSON_V2_FILE_NAME].type == "json"
-        assert rows_by_name[REFERENCE_JSON_V2_FILE_NAME].size > 1
-        assert rows_by_name[REFERENCE_SQLITE_FILE_NAME].type == "sqlite"
-        assert rows_by_name[REFERENCE_SQLITE_FILE_NAME].size > 1
+        assert set(rows_by_name) == {REFERENCE_SQLITE_GZIP_FILE_NAME}
+        row = rows_by_name[REFERENCE_SQLITE_GZIP_FILE_NAME]
+        assert row.type == "sqlite"
+        assert row.size > 1
+        assert row.storage_key != superseded_key
+        assert await self.memory_storage.size(row.storage_key) == row.size
 
-        for file_name, row in rows_by_name.items():
-            assert row.storage_key != superseded_keys[file_name]
-            assert await self.memory_storage.size(row.storage_key) == row.size
+        with pytest.raises(StorageKeyNotFoundError):
+            await self.memory_storage.size(superseded_key)
 
-            with pytest.raises(StorageKeyNotFoundError):
-                await self.memory_storage.size(superseded_keys[file_name])
-
-    async def test_rejects_regenerating_ready_index(self, task_id: int) -> None:
+    async def test_rejects_regenerating_ready_index(
+        self,
+        task_id: int,
+    ) -> None:
         """A completed task-backed index cannot be regenerated."""
         await (await CreateIndexTask.from_task_id(self.data_layer, task_id)).run()
 
@@ -406,24 +453,121 @@ class TestCreateIndexTask:
 
         assert rows == []
 
-    async def test_sqlite_upload_failure_cleans_up_both_artifacts(
+    async def test_validation_failure_removes_temporary_files(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """A validation failure removes the raw SQLite scratch file."""
+        await self._create_task_backed_index({})
+        self._use_temp_path(mocker, tmp_path)
+        failure_message = "failed to validate sqlite export"
+        mocker.patch.object(
+            SQLiteReference,
+            "validate",
+            side_effect=RuntimeError(failure_message),
+        )
+
+        with pytest.raises(RuntimeError, match=failure_message):
+            await self.data_layer.index.generate_task_index(self.index_id)
+
+        self._assert_temp_path_empty(tmp_path)
+        assert [
+            info.key
+            async for info in self.memory_storage.list(f"indexes/{self.index_id}/")
+        ] == []
+        assert (await self.data_layer.index.get(self.index_id)).ready is False
+
+    async def test_compression_failure_removes_temporary_files(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """A compression failure removes raw and partial gzip scratch files."""
+        await self._create_task_backed_index({})
+        self._use_temp_path(mocker, tmp_path)
+        failure_message = "failed to compress sqlite export"
+
+        def fail_compression(_source_path: Path, target_path: Path) -> None:
+            target_path.write_bytes(b"partial gzip")
+            raise RuntimeError(failure_message)
+
+        mocker.patch(
+            "virtool.indexes.data.compress_file_with_gzip",
+            side_effect=fail_compression,
+        )
+
+        with pytest.raises(RuntimeError, match=failure_message):
+            await self.data_layer.index.generate_task_index(self.index_id)
+
+        self._assert_temp_path_empty(tmp_path)
+        assert [
+            info.key
+            async for info in self.memory_storage.list(f"indexes/{self.index_id}/")
+        ] == []
+        assert (await self.data_layer.index.get(self.index_id)).ready is False
+
+    async def test_cancellation_removes_temporary_files(
+        self,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Cancellation stops patch producers and removes candidate state."""
+        manifest = {"pending_otu_a": 1, "pending_otu_b": 2, "pending_otu_c": 3}
+        await self._create_task_backed_index(manifest)
+        self._use_temp_path(mocker, tmp_path)
+        all_started = asyncio.Event()
+        started = []
+        cancelled = []
+
+        async def patch_to_version(_pg: object, otu_id: str, _version: int):
+            started.append(otu_id)
+
+            if len(started) == len(manifest):
+                all_started.set()
+
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.append(otu_id)
+                raise
+
+        mocker.patch(
+            "virtool.history.db.patch_to_version",
+            side_effect=patch_to_version,
+        )
+
+        build = asyncio.create_task(
+            self.data_layer.index.generate_task_index(self.index_id),
+        )
+        await asyncio.wait_for(all_started.wait(), timeout=1)
+        build.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await build
+
+        assert sorted(cancelled) == sorted(manifest)
+        self._assert_temp_path_empty(tmp_path)
+        assert [
+            info.key
+            async for info in self.memory_storage.list(f"indexes/{self.index_id}/")
+        ] == []
+        assert await self.reference_file_keys() == {}
+        assert (await self.data_layer.index.get(self.index_id)).ready is False
+
+    async def test_sqlite_upload_failure_cleans_up_artifact(
         self,
         mocker: MockerFixture,
         task_id: int,
     ) -> None:
-        """A failed SQLite upload removes the previously uploaded JSON export."""
-        write = self.memory_storage.write
+        """A failed gzip SQLite upload leaves no object or file row."""
         failure_message = "failed to upload sqlite export"
-        write_count = 0
 
-        async def fail_sqlite_upload(key: str, data: AsyncIterator[bytes]) -> int:
-            nonlocal write_count
-            write_count += 1
-
-            if write_count == 2:
-                raise RuntimeError(failure_message)
-
-            return await write(key, data)
+        async def fail_sqlite_upload(
+            _key: str,
+            _data: AsyncIterator[bytes],
+        ) -> int:
+            raise RuntimeError(failure_message)
 
         mocker.patch.object(
             self.memory_storage,
@@ -455,12 +599,12 @@ class TestCreateIndexTask:
         assert rows == []
         assert (await self.data_layer.index.get(self.index_id)).ready is False
 
-    async def test_finalization_failure_cleans_up_both_artifacts(
+    async def test_finalization_failure_cleans_up_artifact(
         self,
         mocker: MockerFixture,
         task_id: int,
     ) -> None:
-        """A finalization failure removes both stored exports and file rows."""
+        """A finalization failure removes the candidate object and file row."""
         failure_message = "failed to finalize index"
 
         async def update_last_indexed_versions(*_args: object):
@@ -506,3 +650,60 @@ class TestCreateIndexTask:
 
         index = await self.data_layer.index.get(self.index_id)
         assert index.ready is False
+
+    async def test_failed_replacement_preserves_existing_artifact_and_retries(
+        self,
+        mocker: MockerFixture,
+        task_id: int,
+    ) -> None:
+        """Failed finalization preserves the prior row and permits a clean retry."""
+        superseded_key = mint_storage_key("indexes", self.index_id)
+        existing_payload = b"existing gzip"
+
+        async def stream():
+            yield existing_payload
+
+        await self.memory_storage.write(superseded_key, stream())
+
+        async with AsyncSession(self.pg) as session:
+            session.add(
+                SQLIndexFile(
+                    index=str(self.index_id),
+                    index_id=self.index_id,
+                    name=REFERENCE_SQLITE_GZIP_FILE_NAME,
+                    size=len(existing_payload),
+                    storage_key=superseded_key,
+                    type="sqlite",
+                ),
+            )
+            await session.commit()
+
+        failure_message = "failed to finalize replacement"
+        finalization = mocker.patch(
+            "virtool.indexes.data.update_last_indexed_versions",
+            side_effect=RuntimeError(failure_message),
+        )
+
+        await (await CreateIndexTask.from_task_id(self.data_layer, task_id)).run()
+
+        assert await self.reference_file_keys() == {
+            REFERENCE_SQLITE_GZIP_FILE_NAME: superseded_key,
+        }
+        assert await self.memory_storage.size(superseded_key) == len(existing_payload)
+        assert [
+            info.key
+            async for info in self.memory_storage.list(f"indexes/{self.index_id}/")
+        ] == [superseded_key]
+        assert (await self.data_layer.index.get(self.index_id)).ready is False
+
+        mocker.stop(finalization)
+        await self.data_layer.index.generate_task_index(self.index_id)
+
+        replacement_key = (await self.reference_file_keys())[
+            REFERENCE_SQLITE_GZIP_FILE_NAME
+        ]
+        assert replacement_key != superseded_key
+        assert (await self.data_layer.index.get(self.index_id)).ready is True
+
+        with pytest.raises(StorageKeyNotFoundError):
+            await self.memory_storage.size(superseded_key)

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -1,6 +1,7 @@
 import asyncio
 import gzip
 from collections.abc import AsyncIterator
+from contextlib import aclosing
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -25,7 +26,6 @@ from virtool.data.transforms import apply_transforms
 from virtool.history.sql import SQLLegacyHistory
 from virtool.indexes.db import (
     INDEX_FILE_NAMES,
-    REFERENCE_JSON_V2_FILE_NAME,
     IndexCountsTransform,
     _row_to_document,
     update_last_indexed_versions,
@@ -36,6 +36,7 @@ from virtool.references.models import ReferenceNested
 from virtool.references.sql import SQLReference
 from virtool.references.sqlite import (
     REFERENCE_SQLITE_FILE_NAME,
+    REFERENCE_SQLITE_GZIP_FILE_NAME,
     SQLiteReference,
 )
 from virtool.references.transforms import (
@@ -48,6 +49,7 @@ from virtool.storage.file import read_file_chunks
 from virtool.storage.keys import mint_storage_key
 from virtool.storage.protocol import StorageBackend
 from virtool.users.transforms import AttachUserTransform
+from virtool.utils import compress_file_with_gzip
 
 logger = get_logger("indexes")
 
@@ -240,6 +242,8 @@ class IndexData:
         task created before the integer-id cutover carries the string in its context,
         so both must resolve for one release. ``compose_legacy_id_single_expression``
         routes either form to the integer primary key.
+
+        :param index_id: the task-backed index to generate
         """
         async with AsyncSession(self._pg) as session:
             index_row = (
@@ -285,74 +289,49 @@ class IndexData:
             "organism": reference_row.organism,
         }
 
-        file_names = (
-            REFERENCE_JSON_V2_FILE_NAME,
-            REFERENCE_SQLITE_FILE_NAME,
-        )
-        keys = {
-            file_name: mint_storage_key("indexes", index_row.id)
-            for file_name in file_names
-        }
-
-        patched_otus = [
-            otu
-            async for otu in virtool.indexes.db.iter_patched_otus(
-                self._pg,
-                index_row.manifest,
-            )
-        ]
-        compressed = await asyncio.to_thread(
-            gzip.compress,
-            dump_bytes({**reference, "otus": patched_otus}),
-        )
-
-        async def stream_json() -> AsyncIterator[bytes]:
-            yield compressed
+        storage_key = mint_storage_key("indexes", index_row.id)
 
         try:
-            # Storage cannot participate in the database transactions. A hard process
-            # exit can leave objects no row names, which the orphan sweep collects.
-            json_size = await self._storage.write(
-                keys[REFERENCE_JSON_V2_FILE_NAME],
-                stream_json(),
-            )
             with TemporaryDirectory() as temp_dir:
                 sqlite_path = Path(temp_dir) / REFERENCE_SQLITE_FILE_NAME
+                gzip_path = Path(temp_dir) / REFERENCE_SQLITE_GZIP_FILE_NAME
 
-                # reference-v2.json.gz still requires a materialized list. Pass
-                # iter_patched_otus directly once that compatibility artifact is
-                # removed.
-                async def iter_materialized_otus() -> AsyncIterator[dict]:
-                    for otu in patched_otus:
-                        yield otu
+                async with aclosing(
+                    virtool.indexes.db.iter_patched_otus(
+                        self._pg,
+                        index_row.manifest,
+                    ),
+                ) as patched_otus:
+                    sqlite_reference = await SQLiteReference.create(
+                        sqlite_path,
+                        reference,
+                        patched_otus,
+                    )
 
-                await SQLiteReference.create(
+                await sqlite_reference.validate()
+                await asyncio.to_thread(
+                    compress_file_with_gzip,
                     sqlite_path,
-                    reference,
-                    iter_materialized_otus(),
+                    gzip_path,
                 )
-                sqlite_size = await self._storage.write(
-                    keys[REFERENCE_SQLITE_FILE_NAME],
-                    read_file_chunks(sqlite_path),
+
+                # Storage cannot participate in the database transactions. A hard
+                # process exit can leave an object no row names, which the orphan sweep
+                # collects.
+                gzip_size = await self._storage.write(
+                    storage_key,
+                    read_file_chunks(gzip_path),
                 )
 
             async with AsyncSession(self._pg) as session:
-                index_files = []
-
-                for type_, file_name, size in (
-                    ("json", REFERENCE_JSON_V2_FILE_NAME, json_size),
-                    ("sqlite", REFERENCE_SQLITE_FILE_NAME, sqlite_size),
-                ):
-                    index_files.append(
-                        await virtool.indexes.db.upsert_index_file(
-                            session,
-                            index_id,
-                            type_,
-                            file_name,
-                            size,
-                            keys[file_name],
-                        )
-                    )
+                index_file = await virtool.indexes.db.upsert_index_file(
+                    session,
+                    index_id,
+                    "sqlite",
+                    REFERENCE_SQLITE_GZIP_FILE_NAME,
+                    gzip_size,
+                    storage_key,
+                )
 
                 await update_last_indexed_versions(reference_id, session)
 
@@ -364,15 +343,15 @@ class IndexData:
 
                 await session.commit()
         except BaseException:
-            for key in keys.values():
-                await self._storage.delete(key)
+            await self._storage.delete(storage_key)
 
             async with AsyncSession(self._pg) as session:
                 await session.execute(
                     delete(SQLIndexFile).where(
                         SQLIndexFile.index_id
                         == compose_legacy_id_subquery(SQLIndex, index_id),
-                        SQLIndexFile.name.in_(file_names),
+                        SQLIndexFile.name == REFERENCE_SQLITE_GZIP_FILE_NAME,
+                        SQLIndexFile.storage_key == storage_key,
                     ),
                 )
                 await session.commit()
@@ -381,16 +360,12 @@ class IndexData:
 
         # The new row is committed, so the superseded object is already an orphan.
         # Cleaning it up must not fail a build that otherwise succeeded.
-        replaced_storage_keys = [
-            index_file["replaced_storage_key"]
-            for index_file in index_files
-            if index_file["replaced_storage_key"] is not None
-        ]
+        replaced_storage_key = index_file["replaced_storage_key"]
 
-        if replaced_storage_keys:
+        if replaced_storage_key is not None:
             for orphan_key, exc in await delete_keys(
                 self._storage,
-                replaced_storage_keys,
+                [replaced_storage_key],
             ):
                 logger.error(
                     "storage cleanup failed; file orphaned",

--- a/virtool/indexes/data.py
+++ b/virtool/indexes/data.py
@@ -343,7 +343,13 @@ class IndexData:
 
                 await session.commit()
         except BaseException:
-            await self._storage.delete(storage_key)
+            for orphan_key, exc in await delete_keys(self._storage, [storage_key]):
+                logger.error(
+                    "storage cleanup failed; file orphaned",
+                    index_id=index_id,
+                    key=orphan_key,
+                    error=repr(exc),
+                )
 
             async with AsyncSession(self._pg) as session:
                 await session.execute(


### PR DESCRIPTION
Publish new task-backed index reference artifacts as a single gzip-compressed SQLite file.

- Validate SQLite before compression and stream the completed gzip to storage.
- Preserve cleanup and retry safety while retiring legacy JSON and raw SQLite publication.