### PR TITLE
chore: run dev migrations from tasks image

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -67,9 +67,9 @@ k8s_resource("postgres", labels=['data'])
 k8s_yaml('dev/manifests/config.yaml')
 k8s_yaml('dev/manifests/ingress.yaml')
 
-# The migration Job runs the published `ghcr.io/virtool/virtool` image and is
-# never built here. Migrations are Python's, and the repository that used to
-# hold them as a live-edit target no longer exists.
+# The migration Job temporarily runs the tasks image's Drizzle migrator
+# entrypoint. It stays a separate Job so the long-lived tasks process only
+# starts after schema changes have been applied.
 k8s_yaml('dev/manifests/migration.yaml')
 
 # Anything in the build context that no sync below covers forces a full image
@@ -152,7 +152,7 @@ k8s_resource(
     'virtool-migration',
     labels=['virtool'],
     new_name="migration",
-    resource_deps=["azurite", "postgres"],
+    resource_deps=["azurite", "config", "postgres"],
     trigger_mode=TRIGGER_MODE_MANUAL
 )
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -93,17 +93,17 @@ from the Tilt UI when you want the build. A workflow's pods are one-shot and
 only start when something claims work, so nothing waits on a rebuild and an
 automatic one would rebuild a large image on every edit.
 
-There is no migration target. Migrations are Python's, and the migration Job
-runs the published `ghcr.io/virtool/virtool` image.
+There is no separate migration target. Migrations temporarily live in the
+`tasks` image, and the migration Job runs its `node dist/migrate.mjs`
+entrypoint.
 
 ## Images
 
 Every image this repository publishes is pinned to `latest`, so a pod picks up
-the newest release each time it starts and no tag is ever committed. The
-migration Job is the exception and stays pinned to an explicit
-`ghcr.io/virtool/virtool` release: it runs Python's image, which owns the
-schema, so an unrelated Python release must not migrate the dev database
-without someone choosing it.
+the newest release each time it starts and no tag is ever committed. While
+migrations temporarily live in `ghcr.io/virtool/tasks`, the migration Job runs
+the tasks image's Drizzle migrator and follows the same tag or local Tilt build
+as the tasks Deployment.
 
 `ts-nuvs` and `ts-pathoscope` publish on release like the other two, but
 neither has a usable `latest` until the first release that carries them:

--- a/dev/manifests/config.yaml
+++ b/dev/manifests/config.yaml
@@ -4,8 +4,8 @@
 # (`web`, `virtool`, `workflows`) render independently, so a generator would
 # produce three hash-suffixed copies instead of one shared object.
 #
-# The migration Job deliberately does not use this. It runs Python's image and
-# reads Python's variable names, so it keeps its own inline block.
+# The migration Job uses this too. Its tasks-image migrator reads
+# `VT_POSTGRES_URL` and ignores the storage settings.
 #
 # These are Azurite's well-known public dev credentials, not secrets.
 apiVersion: v1

--- a/dev/manifests/migration.yaml
+++ b/dev/manifests/migration.yaml
@@ -17,28 +17,12 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - image: ghcr.io/virtool/virtool:41.19.0
+        - image: ghcr.io/virtool/tasks:latest
           name: virtool-migration
-          command: ["virtool", "migration", "apply"]
-          env:
-            - name: VT_DATA_PATH
-              value: "/data"
-            - name: VT_DEV
-              value: "true"
-            - name: VT_HOST
-              value: "0.0.0.0"
-            - name: VT_POSTGRES_CONNECTION_STRING
-              value: "postgresql+asyncpg://virtool@postgres.default.svc.cluster.local?password=virtool"
-            - name: VT_STORAGE_BACKEND
-              value: "azure"
-            - name: VT_STORAGE_AZURE_ACCOUNT
-              value: "devstoreaccount1"
-            - name: VT_STORAGE_AZURE_CONTAINER
-              value: "virtool"
-            - name: VT_STORAGE_AZURE_ACCESS_KEY
-              value: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-            - name: VT_STORAGE_AZURE_ENDPOINT
-              value: "http://azurite.default.svc.cluster.local:10000/devstoreaccount1"
+          command: ["node", "dist/migrate.mjs"]
+          envFrom:
+            - configMapRef:
+                name: virtool-env
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
## Summary
- run the development migration Job through the tasks image Drizzle entrypoint
- share the development ConfigMap and align Tilt dependencies and documentation