### PR TITLE
feat: improve the job detail view

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .idea
+.agents
+.codex
 data
 # The Tilt/Minikube dev cluster. The Tiltfile builds these images with the repo
 # root as the context, and Tilt reads this file to decide what it watches — so

--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -36,6 +36,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 
 	const title = checkSupportedWorkflow(workflow) ? (
 		<Link
+			className="text-lg"
 			to="/samples/$sampleId/analyses/$analysisId"
 			params={{
 				sampleId: String(analysis.sample.id),
@@ -45,7 +46,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 			{getWorkflowDisplayName(workflow)}
 		</Link>
 	) : (
-		<div className="text-black [&_svg]:ml-1">
+		<div className="text-lg [&_svg]:ml-1">
 			{getWorkflowDisplayName(workflow)}
 			<span className="text-gray-500 text-sm ml-1 font-normal">
 				Workflow unavailable
@@ -67,11 +68,11 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 	const canDelete = state === undefined || isJobStateTerminal(state);
 
 	return (
-		<Box as="li" className="text-gray-600 mb-2.5">
+		<Box as="li" className="mb-2.5">
 			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
 				<div className="col-span-2">{title}</div>
 				<Attribution
-					className="col-span-2 text-sm font-normal"
+					className="col-span-2 font-normal"
 					user={user.handle}
 					time={createdAt}
 				/>

--- a/apps/web/src/app/__tests__/date.test.ts
+++ b/apps/web/src/app/__tests__/date.test.ts
@@ -1,0 +1,29 @@
+import { formatElapsed } from "@app/date";
+import { describe, expect, it } from "vitest";
+
+describe("formatElapsed()", () => {
+	it.each([
+		[0, "00:00:00"],
+		[1, "00:00:01"],
+		[59, "00:00:59"],
+		[60, "00:01:00"],
+		[3599, "00:59:59"],
+		[3600, "01:00:00"],
+	])("formats %i seconds as %s", (seconds, expected) => {
+		expect(formatElapsed(seconds)).toBe(expected);
+	});
+
+	// The figure is an elapsed duration rather than a time of day, so a job that
+	// ran past a day reads its real hour count.
+	it("does not wrap the hours at 24", () => {
+		expect(formatElapsed(129600)).toBe("36:00:00");
+	});
+
+	it("truncates a fractional second rather than rounding it up", () => {
+		expect(formatElapsed(59.9)).toBe("00:00:59");
+	});
+
+	it("clamps a negative duration to zero", () => {
+		expect(formatElapsed(-5)).toBe("00:00:00");
+	});
+});

--- a/apps/web/src/app/date.ts
+++ b/apps/web/src/app/date.ts
@@ -78,6 +78,24 @@ export function formatRoundedDuration(seconds: number): string {
 }
 
 /**
+ * Format a duration in seconds as a clock string (HH:MM:SS).
+ *
+ * Hours are not wrapped at 24: a job that ran for a day and a half reads
+ * `36:00:00`, because the figure is an elapsed duration rather than a time of
+ * day.
+ *
+ * @param seconds - the duration in seconds
+ * @returns a zero-padded clock string
+ */
+export function formatElapsed(seconds: number): string {
+	const total = Math.max(0, Math.floor(seconds));
+
+	return [Math.floor(total / 3600), Math.floor(total / 60) % 60, total % 60]
+		.map((part) => String(part).padStart(2, "0"))
+		.join(":");
+}
+
+/**
  * Add seconds to a date.
  *
  * @param date - the base date

--- a/apps/web/src/app/style.css
+++ b/apps/web/src/app/style.css
@@ -11,6 +11,7 @@
 		"Inter Variable", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 	--color-virtool: #387e7d;
 	--color-virtool-dark: #2a5e5d;
+	--color-muted: var(--color-gray-500);
 
 	/* Z-index scale. Portalled and fixed overlays share the root stacking
 	   context, so their order is decided here by named layer rather than

--- a/apps/web/src/jobs/components/AnalysisPeek.tsx
+++ b/apps/web/src/jobs/components/AnalysisPeek.tsx
@@ -1,15 +1,13 @@
-import { useCheckAdminRole } from "@administration/hooks";
-import { useGetAnalysis, useRemoveAnalysis } from "@analyses/queries";
+import { useGetAnalysis } from "@analyses/queries";
 import { getWorkflowDisplayName } from "@app/utils";
 import Attribution from "@base/Attribution";
 import Box from "@base/Box";
 import Icon from "@base/Icon";
-import IconButton from "@base/IconButton";
 import Link from "@base/Link";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SlashList from "@base/SlashList";
-import { Equal, EqualNot, Trash } from "lucide-react";
+import { Equal, EqualNot } from "lucide-react";
 
 type AnalysisPeekProps = {
 	/** The unique identifier of the analysis the job is producing */
@@ -20,14 +18,12 @@ type AnalysisPeekProps = {
  * The analysis a Pathoscope or NuVs job produces, shown on the job detail view.
  *
  * Apart from `AnalysisItem`, which it is otherwise shaped like, it shows no job
- * state — the job's own state and steps are on the same page — and offers
- * removal only while the analysis is unfinished, where a stuck or failed run is
- * worth clearing out.
+ * state and no remove button — the job's own state, steps and controls are on
+ * the same page, so repeating any of them here would be a second opinion about
+ * the same run.
  */
 export default function AnalysisPeek({ analysisId }: AnalysisPeekProps) {
 	const { data, isPending, isError } = useGetAnalysis(analysisId);
-	const { hasPermission: canModify } = useCheckAdminRole("users");
-	const onRemove = useRemoveAnalysis(analysisId);
 
 	if (isError && !data) {
 		return <QueryError noun="analysis" />;
@@ -37,22 +33,15 @@ export default function AnalysisPeek({ analysisId }: AnalysisPeekProps) {
 		return <LoadingPlaceholder className="mt-8 mb-8" />;
 	}
 
-	const {
-		createdAt,
-		index,
-		ready,
-		reference,
-		sample,
-		subtractions,
-		user,
-		workflow,
-	} = data;
+	const { createdAt, index, reference, sample, subtractions, user, workflow } =
+		data;
 
 	return (
-		<Box className="text-gray-600 mb-2.5">
+		<Box className="mb-2.5">
 			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
 				<div className="col-span-2">
 					<Link
+						className="text-lg"
 						to="/samples/$sampleId/analyses/$analysisId"
 						params={{
 							sampleId: String(sample.id),
@@ -63,20 +52,10 @@ export default function AnalysisPeek({ analysisId }: AnalysisPeekProps) {
 					</Link>
 				</div>
 				<Attribution
-					className="col-span-2 text-sm font-normal"
+					className="col-span-2 font-normal"
 					user={user.handle}
 					time={createdAt}
 				/>
-				<div className="flex justify-end items-center gap-2">
-					{!ready && canModify && (
-						<IconButton
-							IconComponent={Trash}
-							color="red"
-							tip="remove"
-							onClick={onRemove}
-						/>
-					)}
-				</div>
 			</div>
 			<div className="flex items-center mt-2.5">
 				<span className="inline-flex items-center mr-4 [&_i]:mr-1">

--- a/apps/web/src/jobs/components/AnalysisPeek.tsx
+++ b/apps/web/src/jobs/components/AnalysisPeek.tsx
@@ -1,0 +1,120 @@
+import { useCheckAdminRole } from "@administration/hooks";
+import { useGetAnalysis, useRemoveAnalysis } from "@analyses/queries";
+import { getWorkflowDisplayName } from "@app/utils";
+import Attribution from "@base/Attribution";
+import Box from "@base/Box";
+import Icon from "@base/Icon";
+import IconButton from "@base/IconButton";
+import Link from "@base/Link";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
+import SlashList from "@base/SlashList";
+import { Equal, EqualNot, Trash } from "lucide-react";
+
+type AnalysisPeekProps = {
+	/** The unique identifier of the analysis the job is producing */
+	analysisId: number;
+};
+
+/**
+ * The analysis a Pathoscope or NuVs job produces, shown on the job detail view.
+ *
+ * Apart from `AnalysisItem`, which it is otherwise shaped like, it shows no job
+ * state — the job's own state and steps are on the same page — and offers
+ * removal only while the analysis is unfinished, where a stuck or failed run is
+ * worth clearing out.
+ */
+export default function AnalysisPeek({ analysisId }: AnalysisPeekProps) {
+	const { data, isPending, isError } = useGetAnalysis(analysisId);
+	const { hasPermission: canModify } = useCheckAdminRole("users");
+	const onRemove = useRemoveAnalysis(analysisId);
+
+	if (isError && !data) {
+		return <QueryError noun="analysis" />;
+	}
+
+	if (isPending) {
+		return <LoadingPlaceholder className="mt-8 mb-8" />;
+	}
+
+	const {
+		createdAt,
+		index,
+		ready,
+		reference,
+		sample,
+		subtractions,
+		user,
+		workflow,
+	} = data;
+
+	return (
+		<Box className="text-gray-600 mb-2.5">
+			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
+				<div className="col-span-2">
+					<Link
+						to="/samples/$sampleId/analyses/$analysisId"
+						params={{
+							sampleId: String(sample.id),
+							analysisId: String(analysisId),
+						}}
+					>
+						{getWorkflowDisplayName(workflow)}
+					</Link>
+				</div>
+				<Attribution
+					className="col-span-2 text-sm font-normal"
+					user={user.handle}
+					time={createdAt}
+				/>
+				<div className="flex justify-end items-center gap-2">
+					{!ready && canModify && (
+						<IconButton
+							IconComponent={Trash}
+							color="red"
+							tip="remove"
+							onClick={onRemove}
+						/>
+					)}
+				</div>
+			</div>
+			<div className="flex items-center mt-2.5">
+				<span className="inline-flex items-center mr-4 [&_i]:mr-1">
+					<Equal size={18} />
+					<SlashList className="m-0">
+						<li>
+							<Link to="/refs/$refId" params={{ refId: String(reference.id) }}>
+								{reference.name}
+							</Link>
+						</li>
+						<li>
+							<Link
+								to="/refs/$refId/indexes/$indexId"
+								params={{
+									refId: String(reference.id),
+									indexId: String(index.id),
+								}}
+							>
+								Index {index.version}
+							</Link>
+						</li>
+					</SlashList>
+				</span>
+				{subtractions.map((subtraction) => (
+					<span
+						className="inline-flex items-center mr-4 [&_i]:mr-1"
+						key={subtraction.id}
+					>
+						<Icon icon={EqualNot} />
+						<Link
+							to="/subtractions/$subtractionId"
+							params={{ subtractionId: String(subtraction.id) }}
+						>
+							{subtraction.name}
+						</Link>
+					</span>
+				))}
+			</div>
+		</Box>
+	);
+}

--- a/apps/web/src/jobs/components/JobArgs.tsx
+++ b/apps/web/src/jobs/components/JobArgs.tsx
@@ -4,6 +4,8 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import type { ReactNode } from "react";
 import AnalysisPeek from "./AnalysisPeek";
+import SamplePeek from "./SamplePeek";
+import SubtractionPeek from "./SubtractionPeek";
 
 type JobArgsRowProps = {
 	/** What to display as the value of the argument */
@@ -73,44 +75,6 @@ function BuildIndexRows({ index_id, ref_id }: BuildIndexRowsProps) {
 	);
 }
 
-type CreateSampleRowsProps = {
-	/** the unique identifier of the sample being created*/
-	sample_id: string;
-};
-
-/** Rows showing important arguments when running an "create_sample" workflow. */
-function CreateSampleRows({ sample_id }: CreateSampleRowsProps) {
-	return (
-		<JobArgsRow title="Sample" description="Sample created by this job">
-			<Link to="/samples/$sampleId" params={{ sampleId: sample_id }}>
-				{sample_id}
-			</Link>
-		</JobArgsRow>
-	);
-}
-
-type CreateSubtractionRowsProps = {
-	/** the unique identifier of the created subtraction */
-	subtraction_id: string;
-};
-
-/** Rows showing important arguments when running a "create_subtraction" workflow. */
-function CreateSubtractionRows({ subtraction_id }: CreateSubtractionRowsProps) {
-	return (
-		<JobArgsRow
-			title="Subtraction"
-			description="Subtraction created by this job"
-		>
-			<Link
-				to="/subtractions/$subtractionId"
-				params={{ subtractionId: subtraction_id }}
-			>
-				{subtraction_id}
-			</Link>
-		</JobArgsRow>
-	);
-}
-
 type UnknownJobRows = {
 	/** The list of arguments used to run the job */
 	args: object;
@@ -139,22 +103,13 @@ type GenericJobArgsProps<workflowType, argsType> = {
 	args: argsType;
 };
 
-type JobArgsRowsProps =
-	| GenericJobArgsProps<"build_index", BuildIndexRowsProps>
-	| GenericJobArgsProps<"create_sample", CreateSampleRowsProps>
-	| GenericJobArgsProps<"create_subtraction", CreateSubtractionRowsProps>;
+type JobArgsRowsProps = GenericJobArgsProps<"build_index", BuildIndexRowsProps>;
 
 /**  The table rows containing arguments used to run a job. */
 function JobArgsRows({ workflow, args }: JobArgsRowsProps) {
 	switch (workflow) {
 		case "build_index":
 			return <BuildIndexRows {...args} />;
-
-		case "create_sample":
-			return <CreateSampleRows {...args} />;
-
-		case "create_subtraction":
-			return <CreateSubtractionRows {...args} />;
 
 		default:
 			return <UnknownJobRows args={args} />;
@@ -170,6 +125,14 @@ type JobArgsProps = {
 export default function JobArgs({ workflow, args }: JobArgsProps) {
 	if (workflow === "pathoscope" || workflow === "nuvs") {
 		return <AnalysisPeek analysisId={Number(args.analysis_id)} />;
+	}
+
+	if (workflow === "create_sample") {
+		return <SamplePeek sampleId={Number(args.sample_id)} />;
+	}
+
+	if (workflow === "create_subtraction") {
+		return <SubtractionPeek subtractionId={Number(args.subtraction_id)} />;
 	}
 
 	return (

--- a/apps/web/src/jobs/components/JobArgs.tsx
+++ b/apps/web/src/jobs/components/JobArgs.tsx
@@ -1,12 +1,9 @@
-import AnalysisItem from "@analyses/components/AnalysisItem";
-import { useGetAnalysis } from "@analyses/queries";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
-import QueryError from "@base/QueryError";
 import type { ReactNode } from "react";
+import AnalysisPeek from "./AnalysisPeek";
 
 type JobArgsRowProps = {
 	/** What to display as the value of the argument */
@@ -41,30 +38,6 @@ function JobArgsRow({
 			</div>
 			<div className="text-right">{children}</div>
 		</BoxGroupSection>
-	);
-}
-
-type AnalysisJobArgsProps = {
-	/** The unique identified of the created analysis  */
-	analysis_id: string;
-};
-
-/** The analysis created by a Pathoscope or NuVs job. */
-function AnalysisJobArgs({ analysis_id }: AnalysisJobArgsProps) {
-	const { data, isPending, isError } = useGetAnalysis(Number(analysis_id));
-
-	if (isError && !data) {
-		return <QueryError noun="analysis" />;
-	}
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder className="mt-8 mb-8" />;
-	}
-
-	return (
-		<ul className="list-none">
-			<AnalysisItem analysis={data} />
-		</ul>
 	);
 }
 
@@ -196,7 +169,7 @@ type JobArgsProps = {
 /** A table of arguments used to run a job. */
 export default function JobArgs({ workflow, args }: JobArgsProps) {
 	if (workflow === "pathoscope" || workflow === "nuvs") {
-		return <AnalysisJobArgs {...(args as AnalysisJobArgsProps)} />;
+		return <AnalysisPeek analysisId={Number(args.analysis_id)} />;
 	}
 
 	return (

--- a/apps/web/src/jobs/components/JobArgs.tsx
+++ b/apps/web/src/jobs/components/JobArgs.tsx
@@ -1,7 +1,11 @@
+import AnalysisItem from "@analyses/components/AnalysisItem";
+import { useGetAnalysis } from "@analyses/queries";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
-import BoxGroupTable from "@base/BoxGroupTable";
+import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import type { ReactNode } from "react";
 
 type JobArgsRowProps = {
@@ -11,46 +15,56 @@ type JobArgsRowProps = {
 	/** The name of the job argument */
 	title: string;
 
+	/** A short explanation of the argument */
+	description?: string;
+
 	/** An optional class name to apply to the row */
 	className?: string;
 };
 
-/** A single row of the job arguments table. */
-function JobArgsRow({ children, title, className }: JobArgsRowProps) {
+/** A single card showing a job argument. */
+function JobArgsRow({
+	children,
+	title,
+	description,
+	className,
+}: JobArgsRowProps) {
 	return (
-		<tr className={className}>
-			<th scope="row">{title}</th>
-			<td>{children}</td>
-		</tr>
+		<BoxGroupSection
+			className={`flex items-center justify-between gap-4 ${className ?? ""}`}
+		>
+			<div>
+				<span className="font-medium">{title}</span>
+				{description ? (
+					<p className="m-0 text-gray-500">{description}</p>
+				) : null}
+			</div>
+			<div className="text-right">{children}</div>
+		</BoxGroupSection>
 	);
 }
 
-type AnalysisRowsProps = {
-	/** The unique identified of the sample analysed */
-	sample_id: string;
-
+type AnalysisJobArgsProps = {
 	/** The unique identified of the created analysis  */
 	analysis_id: string;
 };
 
-/** Rows showing important arguments when running a sample analysis workflow */
-function AnalysisRows({ sample_id, analysis_id }: AnalysisRowsProps) {
+/** The analysis created by a Pathoscope or NuVs job. */
+function AnalysisJobArgs({ analysis_id }: AnalysisJobArgsProps) {
+	const { data, isPending, isError } = useGetAnalysis(Number(analysis_id));
+
+	if (isError && !data) {
+		return <QueryError noun="analysis" />;
+	}
+
+	if (isPending || !data) {
+		return <LoadingPlaceholder className="mt-8 mb-8" />;
+	}
+
 	return (
-		<>
-			<JobArgsRow title="Sample">
-				<Link to="/samples/$sampleId" params={{ sampleId: sample_id }}>
-					{sample_id}
-				</Link>
-			</JobArgsRow>
-			<JobArgsRow title="Analysis">
-				<Link
-					to="/samples/$sampleId/analyses/$analysisId"
-					params={{ sampleId: sample_id, analysisId: analysis_id }}
-				>
-					{analysis_id}
-				</Link>
-			</JobArgsRow>
-		</>
+		<ul className="list-none">
+			<AnalysisItem analysis={data} />
+		</ul>
 	);
 }
 
@@ -66,12 +80,15 @@ type BuildIndexRowsProps = {
 function BuildIndexRows({ index_id, ref_id }: BuildIndexRowsProps) {
 	return (
 		<>
-			<JobArgsRow title="Reference">
+			<JobArgsRow
+				title="Reference"
+				description="Reference used to build the index"
+			>
 				<Link to="/refs/$refId" params={{ refId: ref_id }}>
 					{ref_id}
 				</Link>
 			</JobArgsRow>
-			<JobArgsRow title="Index">
+			<JobArgsRow title="Index" description="Index built by this job">
 				<Link
 					to="/refs/$refId/indexes/$indexId"
 					params={{ refId: ref_id, indexId: index_id }}
@@ -91,7 +108,7 @@ type CreateSampleRowsProps = {
 /** Rows showing important arguments when running an "create_sample" workflow. */
 function CreateSampleRows({ sample_id }: CreateSampleRowsProps) {
 	return (
-		<JobArgsRow title="Sample">
+		<JobArgsRow title="Sample" description="Sample created by this job">
 			<Link to="/samples/$sampleId" params={{ sampleId: sample_id }}>
 				{sample_id}
 			</Link>
@@ -107,7 +124,10 @@ type CreateSubtractionRowsProps = {
 /** Rows showing important arguments when running a "create_subtraction" workflow. */
 function CreateSubtractionRows({ subtraction_id }: CreateSubtractionRowsProps) {
 	return (
-		<JobArgsRow title="Subtraction">
+		<JobArgsRow
+			title="Subtraction"
+			description="Subtraction created by this job"
+		>
 			<Link
 				to="/subtractions/$subtractionId"
 				params={{ subtractionId: subtraction_id }}
@@ -147,7 +167,6 @@ type GenericJobArgsProps<workflowType, argsType> = {
 };
 
 type JobArgsRowsProps =
-	| GenericJobArgsProps<"pathoscope" | "nuvs", AnalysisRowsProps>
 	| GenericJobArgsProps<"build_index", BuildIndexRowsProps>
 	| GenericJobArgsProps<"create_sample", CreateSampleRowsProps>
 	| GenericJobArgsProps<"create_subtraction", CreateSubtractionRowsProps>;
@@ -164,10 +183,6 @@ function JobArgsRows({ workflow, args }: JobArgsRowsProps) {
 		case "create_subtraction":
 			return <CreateSubtractionRows {...args} />;
 
-		case "nuvs":
-		case "pathoscope":
-			return <AnalysisRows {...args} />;
-
 		default:
 			return <UnknownJobRows args={args} />;
 	}
@@ -180,20 +195,19 @@ type JobArgsProps = {
 
 /** A table of arguments used to run a job. */
 export default function JobArgs({ workflow, args }: JobArgsProps) {
+	if (workflow === "pathoscope" || workflow === "nuvs") {
+		return <AnalysisJobArgs {...(args as AnalysisJobArgsProps)} />;
+	}
+
 	return (
 		<BoxGroup>
 			<BoxGroupHeader>
 				<h2>Arguments</h2>
 				<p>Run arguments that make this job unique.</p>
 			</BoxGroupHeader>
-			<BoxGroupTable>
-				<caption className="sr-only">Job arguments</caption>
-				<tbody>
-					{/* The API returns args as an untyped record; JobArgsRows narrows
-					    them per workflow. */}
-					<JobArgsRows {...({ workflow, args } as JobArgsRowsProps)} />
-				</tbody>
-			</BoxGroupTable>
+			{/* The API returns args as an untyped record; JobArgsRows narrows
+			    them per workflow. */}
+			<JobArgsRows {...({ workflow, args } as JobArgsRowsProps)} />
 		</BoxGroup>
 	);
 }

--- a/apps/web/src/jobs/components/JobDetail.tsx
+++ b/apps/web/src/jobs/components/JobDetail.tsx
@@ -85,7 +85,7 @@ export default function JobDetail() {
 		: data.args;
 
 	return (
-		<ContainerNarrow>
+		<ContainerNarrow className="pb-8">
 			<ViewHeader title={workflow}>
 				<ViewHeaderTitle>{workflow}</ViewHeaderTitle>
 				<ViewHeaderAttribution time={data.createdAt} user={data.user.handle} />

--- a/apps/web/src/jobs/components/JobDetail.tsx
+++ b/apps/web/src/jobs/components/JobDetail.tsx
@@ -1,51 +1,18 @@
 import { getErrorStatus } from "@app/queryErrors";
 import { getWorkflowDisplayName } from "@app/utils";
-import Alert from "@base/Alert";
 import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NotFound from "@base/NotFound";
-import RelativeTime, { useRelativeTime } from "@base/RelativeTime";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useFetchIndex } from "@indexes/queries";
 import { getRouteApi } from "@tanstack/react-router";
-import type { JobState } from "@virtool/contracts";
 import { useFetchJob } from "../queries";
 import JobArgs from "./JobArgs";
 import JobSteps from "./JobSteps";
 
 const routeApi = getRouteApi("/_authenticated/jobs/$jobId");
-
-function getAlertColor(
-	state: JobState,
-): "blue" | "green" | "orange" | "red" | "purple" {
-	switch (state) {
-		case "failed":
-			return "red";
-		case "pending":
-			return "purple";
-		case "running":
-			return "green";
-		case "succeeded":
-			return "blue";
-		case "cancelled":
-			return "orange";
-	}
-}
-
-function PendingJobAlert({ createdAt }: { createdAt: Date }) {
-	const pendingTime = useRelativeTime(createdAt, { addSuffix: false });
-
-	return (
-		<Alert color="purple">
-			<div>
-				<div>Job pending for {pendingTime}.</div>
-				<div className="mt-1">The job is waiting for an available runner.</div>
-			</div>
-		</Alert>
-	);
-}
 
 /**
  * The job detailed view
@@ -78,7 +45,6 @@ export default function JobDetail() {
 		return <LoadingPlaceholder />;
 	}
 
-	const color = getAlertColor(data.state);
 	const workflow = getWorkflowDisplayName(data.workflow);
 	const args = index
 		? { ...data.args, ref_id: String(index.reference.id) }
@@ -91,19 +57,6 @@ export default function JobDetail() {
 				<ViewHeaderAttribution time={data.createdAt} user={data.user.handle} />
 			</ViewHeader>
 			<JobArgs workflow={data.workflow} args={args} />
-			{data.state === "pending" ? (
-				<PendingJobAlert createdAt={data.createdAt} />
-			) : (
-				<Alert color={color}>
-					Job {data.state}
-					{data.finishedAt && (
-						<>
-							&nbsp;
-							<RelativeTime time={data.finishedAt} />
-						</>
-					)}
-				</Alert>
-			)}
 			<JobSteps
 				finishedAt={data.finishedAt}
 				state={data.state}

--- a/apps/web/src/jobs/components/JobDetail.tsx
+++ b/apps/web/src/jobs/components/JobDetail.tsx
@@ -104,7 +104,11 @@ export default function JobDetail() {
 					)}
 				</Alert>
 			)}
-			<JobSteps state={data.state} steps={data.steps} />
+			<JobSteps
+				finishedAt={data.finishedAt}
+				state={data.state}
+				steps={data.steps}
+			/>
 		</ContainerNarrow>
 	);
 }

--- a/apps/web/src/jobs/components/JobItem.tsx
+++ b/apps/web/src/jobs/components/JobItem.tsx
@@ -43,9 +43,9 @@ export default function JobItem({
 	workflow,
 }: JobItemProps) {
 	return (
-		<BoxGroupSection as={as} className="grid grid-cols-3 text-lg">
+		<BoxGroupSection as={as} className="grid grid-cols-3 items-center gap-x-4">
 			<Link
-				className="col-span-1 font-medium"
+				className="col-span-1 font-medium text-lg"
 				to="/jobs/$jobId"
 				params={{ jobId: String(id) }}
 			>

--- a/apps/web/src/jobs/components/JobStep.tsx
+++ b/apps/web/src/jobs/components/JobStep.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@app/cn";
-import { formatDate, formatRoundedDuration, formatTime } from "@app/date";
+import { formatDate, formatElapsed, formatTime } from "@app/date";
 import Markdown from "@base/Markdown";
 import { useHydrated } from "@tanstack/react-router";
 import type { JobState, JobStep } from "@virtool/contracts";
@@ -26,9 +26,7 @@ export default function JobStepItem({ endedAt, step, state }: JobStepProps) {
 	const elapsed =
 		endedAt === null || step.startedAt === null
 			? null
-			: formatRoundedDuration(
-					Math.max(0, endedAt - step.startedAt.getTime()) / 1000,
-				);
+			: formatElapsed(Math.max(0, endedAt - step.startedAt.getTime()) / 1000);
 
 	return (
 		<tr
@@ -62,14 +60,12 @@ export default function JobStepItem({ endedAt, step, state }: JobStepProps) {
 						className={cn({ invisible: !hydrated })}
 					>
 						{hydrated
-							? `${formatDate(step.startedAt)} ${formatTime(step.startedAt)}`
-							: "0000-00-00 00:00:00"}
+							? `${formatDate(step.startedAt)} at ${formatTime(step.startedAt)}`
+							: "0000-00-00 at 00:00:00"}
 					</time>
 				)}
 			</td>
-			<td className="px-4 py-3 align-top tabular-nums text-right text-sm">
-				{elapsed}
-			</td>
+			<td className="px-4 py-3 align-top tabular-nums text-sm">{elapsed}</td>
 		</tr>
 	);
 }

--- a/apps/web/src/jobs/components/JobStep.tsx
+++ b/apps/web/src/jobs/components/JobStep.tsx
@@ -1,14 +1,13 @@
 import { cn } from "@app/cn";
-import { formatDate, formatTime } from "@app/date";
-import Badge from "@base/Badge";
-import BoxGroupSection from "@base/BoxGroupSection";
+import { formatDate, formatRoundedDuration, formatTime } from "@app/date";
 import Markdown from "@base/Markdown";
 import { useHydrated } from "@tanstack/react-router";
 import type { JobState, JobStep } from "@virtool/contracts";
-import { Calendar, Clock } from "lucide-react";
+import { CircleDashed } from "lucide-react";
 import JobStateIcon from "./JobStateIcon";
 
 type JobStepProps = {
+	endedAt: number | null;
 	state: JobState;
 	step: JobStep;
 };
@@ -16,7 +15,7 @@ type JobStepProps = {
 /**
  * A condensed job step for use in a list of job steps
  */
-export default function JobStepItem({ step, state }: JobStepProps) {
+export default function JobStepItem({ endedAt, step, state }: JobStepProps) {
 	// Both formats read the local timezone, and the server renders in the
 	// container's zone rather than the viewer's, so it cannot produce the string
 	// the browser will. The value is held back until hydration instead of being
@@ -24,40 +23,48 @@ export default function JobStepItem({ step, state }: JobStepProps) {
 	// server's zone would stay on screen for good. The placeholder runs to the
 	// same character count as the real value, so nothing moves when it lands.
 	const hydrated = useHydrated();
+	const elapsed =
+		endedAt === null || step.startedAt === null
+			? null
+			: formatRoundedDuration(
+					Math.max(0, endedAt - step.startedAt.getTime()) / 1000,
+				);
 
 	return (
-		<BoxGroupSection className="flex gap-2 items-start">
-			<div className="items-center flex">
-				<JobStateIcon state={state} />
-			</div>
-
-			<div className="">
-				<h4 className="font-medium text-lg">{step.name}</h4>
-				<Markdown markdown={step.description} />
-
-				{step.startedAt && (
-					<div className="flex gap-4">
-						<Badge className="flex gap-1.5 items-center tabular-nums">
-							<Clock size={16} />
-							<time
-								dateTime={step.startedAt.toISOString()}
-								className={cn({ invisible: !hydrated })}
-							>
-								{hydrated ? formatTime(step.startedAt) : "00:00:00"}
-							</time>
-						</Badge>
-						<Badge className="flex gap-1.5 items-center tabular-nums">
-							<Calendar size={16} />
-							<time
-								dateTime={step.startedAt.toISOString()}
-								className={cn({ invisible: !hydrated })}
-							>
-								{hydrated ? formatDate(step.startedAt) : "0000-00-00"}
-							</time>
-						</Badge>
-					</div>
+		<tr
+			className={cn("border-gray-300 not-last:border-b", {
+				"text-muted": state === "pending",
+			})}
+		>
+			<td className="px-4 py-3 align-top">
+				{state === "pending" ? (
+					<CircleDashed className="stroke-current" size={16} />
+				) : (
+					<JobStateIcon state={state} />
 				)}
-			</div>
-		</BoxGroupSection>
+				<span className="sr-only">{state}</span>
+			</td>
+			<td className="px-4 py-3 align-top">
+				<div className="font-medium">{step.name}</div>
+				<div className="min-w-0">
+					<Markdown markdown={step.description} />
+				</div>
+			</td>
+			<td className="px-4 py-3 align-top tabular-nums text-sm">
+				{step.startedAt && (
+					<time
+						dateTime={step.startedAt.toISOString()}
+						className={cn({ invisible: !hydrated })}
+					>
+						{hydrated
+							? `${formatDate(step.startedAt)} ${formatTime(step.startedAt)}`
+							: "0000-00-00 00:00:00"}
+					</time>
+				)}
+			</td>
+			<td className="px-4 py-3 align-top tabular-nums text-right text-sm">
+				{elapsed}
+			</td>
+		</tr>
 	);
 }

--- a/apps/web/src/jobs/components/JobStep.tsx
+++ b/apps/web/src/jobs/components/JobStep.tsx
@@ -3,7 +3,7 @@ import { formatDate, formatRoundedDuration, formatTime } from "@app/date";
 import Markdown from "@base/Markdown";
 import { useHydrated } from "@tanstack/react-router";
 import type { JobState, JobStep } from "@virtool/contracts";
-import { CircleDashed } from "lucide-react";
+import { CircleDashed, LoaderCircle } from "lucide-react";
 import JobStateIcon from "./JobStateIcon";
 
 type JobStepProps = {
@@ -37,7 +37,12 @@ export default function JobStepItem({ endedAt, step, state }: JobStepProps) {
 			})}
 		>
 			<td className="px-4 py-3 align-top">
-				{state === "pending" ? (
+				{state === "running" ? (
+					<LoaderCircle
+						className="block origin-center animate-spin stroke-blue-600"
+						size={16}
+					/>
+				) : state === "pending" ? (
 					<CircleDashed className="stroke-current" size={16} />
 				) : (
 					<JobStateIcon state={state} />

--- a/apps/web/src/jobs/components/JobSteps.tsx
+++ b/apps/web/src/jobs/components/JobSteps.tsx
@@ -1,28 +1,62 @@
+import { useNow } from "@app/hooks";
 import BoxGroup from "@base/BoxGroup";
 import type { JobState, JobStep } from "@virtool/contracts";
 import JobStepItem from "./JobStep";
 
 type JobStepsProps = {
+	finishedAt: Date | null;
 	state: JobState;
 	steps: JobStep[] | null;
 };
 
-export default function JobSteps({ state, steps }: JobStepsProps) {
-	const startedSteps = steps?.filter((step) => step.startedAt !== null) ?? [];
+export default function JobSteps({ finishedAt, state, steps }: JobStepsProps) {
+	const now = useNow();
+	const claimedSteps = steps ?? [];
+	const lastStartedIndex = claimedSteps.findLastIndex(
+		(step) => step.startedAt !== null,
+	);
 
-	if (startedSteps.length === 0) {
+	if (claimedSteps.length === 0) {
 		return null;
 	}
 
 	return (
-		<BoxGroup>
-			{startedSteps.map((step, index) => (
-				<JobStepItem
-					key={step.id}
-					step={step}
-					state={index === startedSteps.length - 1 ? state : "succeeded"}
-				/>
-			))}
+		<BoxGroup className="overflow-hidden">
+			<table className="table-fixed w-full">
+				<thead>
+					<tr className="bg-gray-50 border-b border-gray-300 text-gray-600 text-sm">
+						<th className="px-4 py-3 w-12">
+							<span className="sr-only">Status</span>
+						</th>
+						<th className="font-medium px-4 py-3 text-left">Step</th>
+						<th className="font-medium px-4 py-3 text-left w-1/4">Started</th>
+						<th className="font-medium px-4 py-3 text-right w-1/4">Elapsed</th>
+					</tr>
+				</thead>
+				<tbody>
+					{claimedSteps.map((step, index) => {
+						const nextStartedAt = claimedSteps[index + 1]?.startedAt;
+						const endedAt = step.startedAt
+							? ((nextStartedAt ?? finishedAt)?.getTime() ?? now)
+							: null;
+						const stepState =
+							step.startedAt === null
+								? "pending"
+								: index === lastStartedIndex
+									? state
+									: "succeeded";
+
+						return (
+							<JobStepItem
+								endedAt={endedAt}
+								key={step.id}
+								step={step}
+								state={stepState}
+							/>
+						);
+					})}
+				</tbody>
+			</table>
 		</BoxGroup>
 	);
 }

--- a/apps/web/src/jobs/components/JobSteps.tsx
+++ b/apps/web/src/jobs/components/JobSteps.tsx
@@ -1,8 +1,49 @@
 import { useNow } from "@app/hooks";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
+import RelativeTime from "@base/RelativeTime";
 import type { JobState, JobStep } from "@virtool/contracts";
+import JobStateIcon from "./JobStateIcon";
 import JobStepItem from "./JobStep";
+
+const statusTitles: Record<JobState, string> = {
+	cancelled: "Cancelled",
+	failed: "Failed",
+	pending: "Waiting for a runner",
+	running: "Waiting for the first step",
+	succeeded: "Succeeded",
+};
+
+type JobStatusProps = {
+	finishedAt: Date | null;
+	state: JobState;
+};
+
+/**
+ * The job's own state, shown when no step has started and the step rows can
+ * therefore say nothing about it.
+ */
+function JobStatus({ finishedAt, state }: JobStatusProps) {
+	return (
+		<BoxGroupSection className="py-6">
+			<div className="flex gap-2 items-center">
+				<JobStateIcon state={state} />
+				<h2 className="font-medium text-base">{statusTitles[state]}</h2>
+			</div>
+			<p className="mt-1 mb-0 text-gray-600">
+				{state === "pending" ? (
+					"This job is queued. Its steps will appear when a runner claims it."
+				) : state === "running" ? (
+					"A runner has claimed this job. Its steps will appear as they start."
+				) : finishedAt ? (
+					<>
+						This job finished <RelativeTime time={finishedAt} />.
+					</>
+				) : null}
+			</p>
+		</BoxGroupSection>
+	);
+}
 
 type JobStepsProps = {
 	finishedAt: Date | null;
@@ -17,60 +58,48 @@ export default function JobSteps({ finishedAt, state, steps }: JobStepsProps) {
 		(step) => step.startedAt !== null,
 	);
 
-	if (claimedSteps.length === 0) {
-		if (state === "pending") {
-			return (
-				<BoxGroup>
-					<BoxGroupSection className="py-6">
-						<h2 className="font-medium text-base">Waiting for a runner</h2>
-						<p className="mt-1 mb-0 text-gray-600">
-							This job is queued. Its steps will appear when a runner claims it.
-						</p>
-					</BoxGroupSection>
-				</BoxGroup>
-			);
-		}
-
-		return null;
-	}
-
 	return (
 		<BoxGroup className="overflow-hidden">
-			<table className="table-fixed w-full">
-				<thead>
-					<tr className="bg-gray-50 border-b border-gray-300 text-gray-600 text-sm">
-						<th className="px-4 py-3 w-12">
-							<span className="sr-only">Status</span>
-						</th>
-						<th className="font-medium px-4 py-3 text-left">Step</th>
-						<th className="font-medium px-4 py-3 text-left w-1/5">Started</th>
-						<th className="font-medium px-4 py-3 text-left w-1/6">Elapsed</th>
-					</tr>
-				</thead>
-				<tbody>
-					{claimedSteps.map((step, index) => {
-						const nextStartedAt = claimedSteps[index + 1]?.startedAt;
-						const endedAt = step.startedAt
-							? ((nextStartedAt ?? finishedAt)?.getTime() ?? now)
-							: null;
-						const stepState =
-							step.startedAt === null
-								? "pending"
-								: index === lastStartedIndex
-									? state
-									: "succeeded";
+			{lastStartedIndex === -1 && (
+				<JobStatus finishedAt={finishedAt} state={state} />
+			)}
+			{claimedSteps.length > 0 && (
+				<table className="table-fixed w-full">
+					<thead>
+						<tr className="bg-gray-50 border-b border-gray-300 text-gray-600 text-sm">
+							<th className="px-4 py-3 w-12">
+								<span className="sr-only">Status</span>
+							</th>
+							<th className="font-medium px-4 py-3 text-left">Step</th>
+							<th className="font-medium px-4 py-3 text-left w-1/5">Started</th>
+							<th className="font-medium px-4 py-3 text-left w-1/6">Elapsed</th>
+						</tr>
+					</thead>
+					<tbody>
+						{claimedSteps.map((step, index) => {
+							const nextStartedAt = claimedSteps[index + 1]?.startedAt;
+							const endedAt = step.startedAt
+								? ((nextStartedAt ?? finishedAt)?.getTime() ?? now)
+								: null;
+							const stepState =
+								step.startedAt === null
+									? "pending"
+									: index === lastStartedIndex
+										? state
+										: "succeeded";
 
-						return (
-							<JobStepItem
-								endedAt={endedAt}
-								key={step.id}
-								step={step}
-								state={stepState}
-							/>
-						);
-					})}
-				</tbody>
-			</table>
+							return (
+								<JobStepItem
+									endedAt={endedAt}
+									key={step.id}
+									step={step}
+									state={stepState}
+								/>
+							);
+						})}
+					</tbody>
+				</table>
+			)}
 		</BoxGroup>
 	);
 }

--- a/apps/web/src/jobs/components/JobSteps.tsx
+++ b/apps/web/src/jobs/components/JobSteps.tsx
@@ -1,5 +1,6 @@
 import { useNow } from "@app/hooks";
 import BoxGroup from "@base/BoxGroup";
+import BoxGroupSection from "@base/BoxGroupSection";
 import type { JobState, JobStep } from "@virtool/contracts";
 import JobStepItem from "./JobStep";
 
@@ -17,6 +18,19 @@ export default function JobSteps({ finishedAt, state, steps }: JobStepsProps) {
 	);
 
 	if (claimedSteps.length === 0) {
+		if (state === "pending") {
+			return (
+				<BoxGroup>
+					<BoxGroupSection className="py-6">
+						<h2 className="font-medium text-base">Waiting for a runner</h2>
+						<p className="mt-1 mb-0 text-gray-600">
+							This job is queued. Its steps will appear when a runner claims it.
+						</p>
+					</BoxGroupSection>
+				</BoxGroup>
+			);
+		}
+
 		return null;
 	}
 

--- a/apps/web/src/jobs/components/JobSteps.tsx
+++ b/apps/web/src/jobs/components/JobSteps.tsx
@@ -8,17 +8,19 @@ type JobStepsProps = {
 };
 
 export default function JobSteps({ state, steps }: JobStepsProps) {
-	if (steps === null || steps.length === 0) {
+	const startedSteps = steps?.filter((step) => step.startedAt !== null) ?? [];
+
+	if (startedSteps.length === 0) {
 		return null;
 	}
 
 	return (
 		<BoxGroup>
-			{steps.map((step, index) => (
+			{startedSteps.map((step, index) => (
 				<JobStepItem
 					key={step.id}
 					step={step}
-					state={index === steps.length - 1 ? state : "succeeded"}
+					state={index === startedSteps.length - 1 ? state : "succeeded"}
 				/>
 			))}
 		</BoxGroup>

--- a/apps/web/src/jobs/components/JobSteps.tsx
+++ b/apps/web/src/jobs/components/JobSteps.tsx
@@ -43,8 +43,8 @@ export default function JobSteps({ finishedAt, state, steps }: JobStepsProps) {
 							<span className="sr-only">Status</span>
 						</th>
 						<th className="font-medium px-4 py-3 text-left">Step</th>
-						<th className="font-medium px-4 py-3 text-left w-1/4">Started</th>
-						<th className="font-medium px-4 py-3 text-right w-1/4">Elapsed</th>
+						<th className="font-medium px-4 py-3 text-left w-1/5">Started</th>
+						<th className="font-medium px-4 py-3 text-left w-1/6">Elapsed</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/apps/web/src/jobs/components/SamplePeek.tsx
+++ b/apps/web/src/jobs/components/SamplePeek.tsx
@@ -1,0 +1,53 @@
+import Attribution from "@base/Attribution";
+import Box from "@base/Box";
+import Link from "@base/Link";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
+import { useFetchSample } from "@samples/queries";
+
+type SamplePeekProps = {
+	/** The unique identifier of the sample the job is producing */
+	sampleId: number;
+};
+
+/**
+ * The sample a create_sample job produces, shown on the job detail view.
+ *
+ * Like `AnalysisPeek`, it shows no job state and no controls — the job's own
+ * state, steps and progress are on the same page, so repeating any of them here
+ * would be a second opinion about the same run.
+ */
+export default function SamplePeek({ sampleId }: SamplePeekProps) {
+	const { data, isPending, isError } = useFetchSample(sampleId);
+
+	if (isError && !data) {
+		return <QueryError noun="sample" />;
+	}
+
+	if (isPending) {
+		return <LoadingPlaceholder className="mt-8 mb-8" />;
+	}
+
+	const { createdAt, name, user } = data;
+
+	return (
+		<Box className="mb-2.5">
+			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
+				<div className="col-span-2">
+					<Link
+						className="text-lg"
+						to="/samples/$sampleId"
+						params={{ sampleId: String(sampleId) }}
+					>
+						{name}
+					</Link>
+				</div>
+				<Attribution
+					className="col-span-2 font-normal"
+					user={user.handle}
+					time={createdAt}
+				/>
+			</div>
+		</Box>
+	);
+}

--- a/apps/web/src/jobs/components/SubtractionPeek.tsx
+++ b/apps/web/src/jobs/components/SubtractionPeek.tsx
@@ -1,0 +1,60 @@
+import Box from "@base/Box";
+import Link from "@base/Link";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
+import { SubtractionAttribution } from "@subtraction/components/Attribution";
+import { useFetchSubtraction } from "@subtraction/queries";
+
+type SubtractionPeekProps = {
+	/** The unique identifier of the subtraction the job is producing */
+	subtractionId: number;
+};
+
+/**
+ * The subtraction a create_subtraction job produces, shown on the job detail
+ * view.
+ *
+ * Like `AnalysisPeek`, it shows no job state and no controls — the job's own
+ * state, steps and progress are on the same page, so repeating any of them here
+ * would be a second opinion about the same run.
+ */
+export default function SubtractionPeek({
+	subtractionId,
+}: SubtractionPeekProps) {
+	const { data, isPending, isError } = useFetchSubtraction(subtractionId);
+
+	if (isError && !data) {
+		return <QueryError noun="subtraction" />;
+	}
+
+	if (isPending) {
+		return <LoadingPlaceholder className="mt-8 mb-8" />;
+	}
+
+	const { createdAt, name, nickname, user } = data;
+
+	return (
+		<Box className="mb-2.5">
+			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
+				<div className="col-span-2">
+					<Link
+						className="text-lg"
+						to="/subtractions/$subtractionId"
+						params={{ subtractionId: String(subtractionId) }}
+					>
+						{name}
+					</Link>
+					{nickname && (
+						<span className="ml-2 font-normal text-gray-500">{nickname}</span>
+					)}
+				</div>
+				<div className="col-span-2 font-normal">
+					<SubtractionAttribution
+						handle={user?.handle ?? ""}
+						time={createdAt}
+					/>
+				</div>
+			</div>
+		</Box>
+	);
+}

--- a/apps/web/src/jobs/components/__tests__/AnalysisPeek.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/AnalysisPeek.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from "@testing-library/react";
+import { createFakeAccount } from "@tests/fake/account";
+import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import { analysisServerFnMocks } from "@tests/server-fn/analyses";
+import { mockGetAccount } from "@tests/server-fn/users";
+import { renderWithRouter } from "@tests/setup";
+import type { AnalysisMinimal } from "@virtool/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import AnalysisPeek from "../AnalysisPeek";
+
+describe("<AnalysisPeek />", () => {
+	beforeEach(() => {
+		mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+	});
+
+	async function renderPeek(overrides?: Partial<AnalysisMinimal>) {
+		const analysis = createFakeAnalysisMinimal({
+			id: 9254,
+			index: { id: 12, version: 3 },
+			reference: { id: 41, name: "Plant Viruses" },
+			sample: { id: 123, name: "Sample 123" },
+			subtractions: [
+				{ id: 5, name: "Arabidopsis", ready: true },
+				{ id: 6, name: "Malus", ready: true },
+			],
+			...overrides,
+		});
+
+		analysisServerFnMocks.getAnalysisFn.mockResolvedValue(analysis);
+
+		await renderWithRouter(<AnalysisPeek analysisId={analysis.id} />);
+
+		return analysis;
+	}
+
+	it("links to the analysis, reference, index and subtractions", async () => {
+		await renderPeek();
+
+		expect(
+			await screen.findByRole("link", { name: "Pathoscope" }),
+		).toHaveAttribute("href", "/samples/123/analyses/9254");
+		expect(screen.getByRole("link", { name: "Plant Viruses" })).toHaveAttribute(
+			"href",
+			"/refs/41",
+		);
+		expect(screen.getByRole("link", { name: "Index 3" })).toHaveAttribute(
+			"href",
+			"/refs/41/indexes/12",
+		);
+		expect(screen.getByRole("link", { name: "Arabidopsis" })).toHaveAttribute(
+			"href",
+			"/subtractions/5",
+		);
+		expect(screen.getByRole("link", { name: "Malus" })).toHaveAttribute(
+			"href",
+			"/subtractions/6",
+		);
+	});
+
+	// The job's own state and steps are on the same page, so the analysis has no
+	// business repeating them.
+	it("shows no job state", async () => {
+		await renderPeek({ ready: false });
+
+		await screen.findByRole("link", { name: "Pathoscope" });
+		expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+	});
+
+	it("offers removal while the analysis is unfinished", async () => {
+		await renderPeek({ ready: false });
+
+		expect(
+			await screen.findByRole("button", { name: "remove" }),
+		).toBeInTheDocument();
+	});
+
+	it("withholds removal once the analysis is complete", async () => {
+		await renderPeek({ ready: true });
+
+		await screen.findByRole("link", { name: "Pathoscope" });
+		await expect(
+			screen.findByRole("button", { name: "remove" }),
+		).rejects.toThrow();
+	});
+
+	it("withholds removal from a user who may not modify analyses", async () => {
+		mockGetAccount(createFakeAccount({ administratorRole: null }));
+
+		await renderPeek({ ready: false });
+
+		await screen.findByRole("link", { name: "Pathoscope" });
+		await expect(
+			screen.findByRole("button", { name: "remove" }),
+		).rejects.toThrow();
+	});
+});

--- a/apps/web/src/jobs/components/__tests__/AnalysisPeek.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/AnalysisPeek.test.tsx
@@ -66,31 +66,18 @@ describe("<AnalysisPeek />", () => {
 		expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
 	});
 
-	it("offers removal while the analysis is unfinished", async () => {
-		await renderPeek({ ready: false });
+	// The job detail view owns the controls for the run, so the analysis it
+	// produced offers none of its own — not to an administrator, and not while
+	// the analysis is unfinished.
+	it.each([
+		["unfinished", false],
+		["complete", true],
+	])("shows no remove button for an %s analysis", async (_, ready) => {
+		await renderPeek({ ready });
 
+		await screen.findByRole("link", { name: "Pathoscope" });
 		expect(
-			await screen.findByRole("button", { name: "remove" }),
-		).toBeInTheDocument();
-	});
-
-	it("withholds removal once the analysis is complete", async () => {
-		await renderPeek({ ready: true });
-
-		await screen.findByRole("link", { name: "Pathoscope" });
-		await expect(
-			screen.findByRole("button", { name: "remove" }),
-		).rejects.toThrow();
-	});
-
-	it("withholds removal from a user who may not modify analyses", async () => {
-		mockGetAccount(createFakeAccount({ administratorRole: null }));
-
-		await renderPeek({ ready: false });
-
-		await screen.findByRole("link", { name: "Pathoscope" });
-		await expect(
-			screen.findByRole("button", { name: "remove" }),
-		).rejects.toThrow();
+			screen.queryByRole("button", { name: "remove" }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
@@ -1,6 +1,10 @@
 import { screen } from "@testing-library/react";
 import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import { createFakeSample } from "@tests/fake/samples";
+import { createFakeSubtraction } from "@tests/fake/subtractions";
 import { analysisServerFnMocks } from "@tests/server-fn/analyses";
+import { mockGetSample } from "@tests/server-fn/samples";
+import { mockGetSubtraction } from "@tests/server-fn/subtractions";
 import { renderWithRouter } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 import JobArgs from "../JobArgs";
@@ -14,24 +18,14 @@ const workflows = [
 			{ name: "ref1", href: "/refs/ref1" },
 		],
 	},
-	{
-		workflow: "create_sample",
-		args: { sample_id: "smp1" },
-		links: [{ name: "smp1", href: "/samples/smp1" }],
-	},
-	{
-		workflow: "create_subtraction",
-		args: { subtraction_id: "sub1" },
-		links: [{ name: "sub1", href: "/subtractions/sub1" }],
-	},
 ];
 
 describe("<JobArgs />", () => {
 	it("should render basics correctly", async () => {
 		await renderWithRouter(
 			<JobArgs
-				workflow="create_sample"
-				args={{ sample_id: "test_sample_id" }}
+				workflow="build_index"
+				args={{ index_id: "41", ref_id: "ref1" }}
 			/>,
 		);
 
@@ -86,6 +80,33 @@ describe("<JobArgs />", () => {
 			expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
 		},
 	);
+
+	it("should render the sample for create_sample jobs", async () => {
+		mockGetSample(createFakeSample({ id: 123, name: "Foo" }));
+
+		await renderWithRouter(
+			<JobArgs workflow="create_sample" args={{ sample_id: "123" }} />,
+		);
+
+		expect(await screen.findByRole("link", { name: "Foo" })).toHaveAttribute(
+			"href",
+			"/samples/123",
+		);
+		expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
+	});
+
+	it("should render the subtraction for create_subtraction jobs", async () => {
+		mockGetSubtraction(createFakeSubtraction({ id: 5, name: "Arabidopsis" }));
+
+		await renderWithRouter(
+			<JobArgs workflow="create_subtraction" args={{ subtraction_id: "5" }} />,
+		);
+
+		expect(
+			await screen.findByRole("link", { name: "Arabidopsis" }),
+		).toHaveAttribute("href", "/subtractions/5");
+		expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
+	});
 
 	it("should render unknown workflows", async () => {
 		await renderWithRouter(

--- a/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
@@ -33,6 +33,12 @@ describe("<JobArgs />", () => {
 		expect(
 			screen.getByText("Run arguments that make this job unique."),
 		).toBeInTheDocument();
+		expect(screen.getByText("Reference")).toBeInTheDocument();
+		expect(
+			screen.getByText("Reference used to build the index"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Index")).toBeInTheDocument();
+		expect(screen.getByText("Index built by this job")).toBeInTheDocument();
 	});
 
 	it.each(workflows)(

--- a/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
@@ -1,4 +1,6 @@
 import { screen } from "@testing-library/react";
+import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import { analysisServerFnMocks } from "@tests/server-fn/analyses";
 import { renderWithRouter } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 import JobArgs from "../JobArgs";
@@ -21,22 +23,6 @@ const workflows = [
 		workflow: "create_subtraction",
 		args: { subtraction_id: "sub1" },
 		links: [{ name: "sub1", href: "/subtractions/sub1" }],
-	},
-	{
-		workflow: "pathoscope",
-		args: { sample_id: "smp1", analysis_id: "9254" },
-		links: [
-			{ name: "smp1", href: "/samples/smp1" },
-			{ name: "9254", href: "/samples/smp1/analyses/9254" },
-		],
-	},
-	{
-		workflow: "nuvs",
-		args: { sample_id: "smp1", analysis_id: "9254" },
-		links: [
-			{ name: "smp1", href: "/samples/smp1" },
-			{ name: "9254", href: "/samples/smp1/analyses/9254" },
-		],
 	},
 ];
 
@@ -72,6 +58,32 @@ describe("<JobArgs />", () => {
 				);
 			}
 			expect(screen.queryByText("extra_param")).not.toBeInTheDocument();
+		},
+	);
+
+	it.each<"pathoscope" | "nuvs">(["pathoscope", "nuvs"])(
+		"should render the analysis item for %s jobs",
+		async (workflow) => {
+			const analysis = createFakeAnalysisMinimal({
+				id: 9254,
+				sample: { id: 123, name: "Sample 123" },
+				workflow,
+			});
+			analysisServerFnMocks.getAnalysisFn.mockResolvedValue(analysis);
+
+			await renderWithRouter(
+				<JobArgs
+					workflow={workflow}
+					args={{ sample_id: "123", analysis_id: "9254" }}
+				/>,
+			);
+
+			expect(
+				await screen.findByRole("link", {
+					name: workflow === "pathoscope" ? "Pathoscope" : "Nuvs",
+				}),
+			).toHaveAttribute("href", "/samples/123/analyses/9254");
+			expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
 		},
 	);
 

--- a/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
@@ -127,4 +127,42 @@ describe("<JobSteps />", () => {
 		expect(container.querySelector("img")).toBeNull();
 		expect(screen.getByText(description)).toBeInTheDocument();
 	});
+
+	it("renders the terminal state when the job recorded no steps", () => {
+		renderWithProviders(
+			<JobSteps
+				finishedAt={new Date("2024-04-12T21:53:19.108000Z")}
+				state="succeeded"
+				steps={null}
+			/>,
+		);
+
+		expect(screen.getByText("Succeeded")).toBeInTheDocument();
+		expect(screen.getByText(/This job finished/)).toBeInTheDocument();
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+	});
+
+	it("renders the terminal state when the job failed before its first step", () => {
+		renderWithProviders(
+			<JobSteps
+				finishedAt={new Date("2024-04-12T21:53:19.108000Z")}
+				state="failed"
+				steps={[
+					{
+						id: "eliminate_otus",
+						name: "Eliminate OTUs",
+						description: "Mapping reads to the reference",
+						startedAt: null,
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Failed")).toBeInTheDocument();
+		expect(screen.getByText(/This job finished/)).toBeInTheDocument();
+		expect(screen.getByRole("table")).toBeInTheDocument();
+		expect(screen.getByText("Eliminate OTUs").closest("tr")).toHaveClass(
+			"text-muted",
+		);
+	});
 });

--- a/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
@@ -31,6 +31,47 @@ describe("<JobSteps />", () => {
 		expect(screen.getByText("Building search index")).toBeInTheDocument();
 	});
 
+	it("does not render steps that have not started", () => {
+		const { rerender } = renderWithProviders(
+			<JobSteps
+				state="running"
+				steps={[
+					{
+						id: "download_files",
+						name: "Download files",
+						description: "Downloading reference files",
+						startedAt: new Date("2024-04-12T21:50:19.108000Z"),
+					},
+					{
+						id: "build_index",
+						name: "Build index",
+						description: "Building search index",
+						startedAt: null,
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Download files")).toBeInTheDocument();
+		expect(screen.queryByText("Build index")).not.toBeInTheDocument();
+
+		rerender(
+			<JobSteps
+				state="pending"
+				steps={[
+					{
+						id: "download_files",
+						name: "Download files",
+						description: "Downloading reference files",
+						startedAt: null,
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText("Download files")).not.toBeInTheDocument();
+	});
+
 	it("should escape HTML in a step description", () => {
 		const description = `Downloading <img src="x" onerror="alert(1)"> files`;
 

--- a/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
@@ -4,6 +4,20 @@ import { renderWithProviders } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 
 describe("<JobSteps />", () => {
+	it("renders an informative box before the job is claimed", () => {
+		renderWithProviders(
+			<JobSteps finishedAt={null} state="pending" steps={null} />,
+		);
+
+		expect(screen.getByText("Waiting for a runner")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"This job is queued. Its steps will appear when a runner claims it.",
+			),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+	});
+
 	it("should render", () => {
 		renderWithProviders(
 			<JobSteps
@@ -39,6 +53,11 @@ describe("<JobSteps />", () => {
 		).toBeInTheDocument();
 		expect(screen.getByText("1 minute")).toBeInTheDocument();
 		expect(screen.getByText("2 minutes")).toBeInTheDocument();
+		const runningRow = screen.getByText("Build index").closest("tr");
+		expect(runningRow?.querySelector("svg")).toHaveClass(
+			"lucide-loader-circle",
+			"animate-spin",
+		);
 	});
 
 	it("renders claimed steps that have not started", () => {

--- a/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
@@ -7,6 +7,7 @@ describe("<JobSteps />", () => {
 	it("should render", () => {
 		renderWithProviders(
 			<JobSteps
+				finishedAt={new Date("2024-04-12T21:53:19.108000Z")}
 				state="running"
 				steps={[
 					{
@@ -29,11 +30,21 @@ describe("<JobSteps />", () => {
 		expect(screen.getByText("Downloading reference files")).toBeInTheDocument();
 		expect(screen.getByText("Build index")).toBeInTheDocument();
 		expect(screen.getByText("Building search index")).toBeInTheDocument();
+		expect(screen.getByRole("table")).toBeInTheDocument();
+		expect(
+			screen.getByRole("columnheader", { name: "Status" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("columnheader", { name: "Elapsed" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("1 minute")).toBeInTheDocument();
+		expect(screen.getByText("2 minutes")).toBeInTheDocument();
 	});
 
-	it("does not render steps that have not started", () => {
+	it("renders claimed steps that have not started", () => {
 		const { rerender } = renderWithProviders(
 			<JobSteps
+				finishedAt={null}
 				state="running"
 				steps={[
 					{
@@ -53,10 +64,14 @@ describe("<JobSteps />", () => {
 		);
 
 		expect(screen.getByText("Download files")).toBeInTheDocument();
-		expect(screen.queryByText("Build index")).not.toBeInTheDocument();
+		const pendingRow = screen.getByText("Build index").closest("tr");
+		expect(pendingRow).toHaveClass("text-muted");
+		expect(pendingRow?.querySelector("svg")).toHaveClass("stroke-current");
+		expect(screen.getByText("pending")).toBeInTheDocument();
 
 		rerender(
 			<JobSteps
+				finishedAt={null}
 				state="pending"
 				steps={[
 					{
@@ -69,7 +84,7 @@ describe("<JobSteps />", () => {
 			/>,
 		);
 
-		expect(screen.queryByText("Download files")).not.toBeInTheDocument();
+		expect(screen.getByText("Download files")).toBeInTheDocument();
 	});
 
 	it("should escape HTML in a step description", () => {
@@ -77,6 +92,7 @@ describe("<JobSteps />", () => {
 
 		const { container } = renderWithProviders(
 			<JobSteps
+				finishedAt={null}
 				state="running"
 				steps={[
 					{

--- a/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobSteps.test.tsx
@@ -51,8 +51,8 @@ describe("<JobSteps />", () => {
 		expect(
 			screen.getByRole("columnheader", { name: "Elapsed" }),
 		).toBeInTheDocument();
-		expect(screen.getByText("1 minute")).toBeInTheDocument();
-		expect(screen.getByText("2 minutes")).toBeInTheDocument();
+		expect(screen.getByText("00:01:00")).toBeInTheDocument();
+		expect(screen.getByText("00:02:00")).toBeInTheDocument();
 		const runningRow = screen.getByText("Build index").closest("tr");
 		expect(runningRow?.querySelector("svg")).toHaveClass(
 			"lucide-loader-circle",

--- a/apps/web/src/jobs/components/__tests__/SamplePeek.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/SamplePeek.test.tsx
@@ -1,0 +1,47 @@
+import { screen } from "@testing-library/react";
+import { createFakeAccount } from "@tests/fake/account";
+import { createFakeSample } from "@tests/fake/samples";
+import { mockGetSample } from "@tests/server-fn/samples";
+import { mockGetAccount } from "@tests/server-fn/users";
+import { renderWithRouter } from "@tests/setup";
+import type { Sample } from "@virtool/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import SamplePeek from "../SamplePeek";
+
+describe("<SamplePeek />", () => {
+	beforeEach(() => {
+		mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+	});
+
+	async function renderPeek(overrides?: Partial<Sample>) {
+		const sample = createFakeSample({
+			id: 123,
+			name: "Foo",
+			...overrides,
+		});
+
+		mockGetSample(sample);
+
+		await renderWithRouter(<SamplePeek sampleId={sample.id} />);
+
+		return sample;
+	}
+
+	it("links to the sample", async () => {
+		await renderPeek();
+
+		expect(await screen.findByRole("link", { name: "Foo" })).toHaveAttribute(
+			"href",
+			"/samples/123",
+		);
+	});
+
+	// The job's own state and steps are on the same page, so the sample has no
+	// business repeating them.
+	it("shows no job state", async () => {
+		await renderPeek({ ready: false });
+
+		await screen.findByRole("link", { name: "Foo" });
+		expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/jobs/components/__tests__/SubtractionPeek.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/SubtractionPeek.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from "@testing-library/react";
+import { createFakeAccount } from "@tests/fake/account";
+import { createFakeSubtraction } from "@tests/fake/subtractions";
+import { mockGetSubtraction } from "@tests/server-fn/subtractions";
+import { mockGetAccount } from "@tests/server-fn/users";
+import { renderWithRouter } from "@tests/setup";
+import type { Subtraction } from "@virtool/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import SubtractionPeek from "../SubtractionPeek";
+
+describe("<SubtractionPeek />", () => {
+	beforeEach(() => {
+		mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+	});
+
+	async function renderPeek(overrides?: Partial<Subtraction>) {
+		const subtraction = createFakeSubtraction({
+			id: 5,
+			name: "Arabidopsis",
+			nickname: "Thale cress",
+			...overrides,
+		});
+
+		mockGetSubtraction(subtraction);
+
+		await renderWithRouter(<SubtractionPeek subtractionId={subtraction.id} />);
+
+		return subtraction;
+	}
+
+	it("links to the subtraction and shows its nickname", async () => {
+		await renderPeek();
+
+		expect(
+			await screen.findByRole("link", { name: "Arabidopsis" }),
+		).toHaveAttribute("href", "/subtractions/5");
+		expect(screen.getByText("Thale cress")).toBeInTheDocument();
+	});
+
+	// The job's own state and steps are on the same page, so the subtraction has
+	// no business repeating them.
+	it("shows no job state", async () => {
+		await renderPeek({ ready: false });
+
+		await screen.findByRole("link", { name: "Arabidopsis" });
+		expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+	});
+});

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,7 @@
 	"ignoreExportsUsedInFile": true,
 	"ignoreDependencies": ["conventional-changelog-conventionalcommits"],
 	"ignoreWorkspaces": ["apps/site"],
-	"ignore": ["packages/pathoscope-core/**"],
+	"ignore": [".venv/**", "packages/pathoscope-core/**"],
 	"workspaces": {
 		"apps/web": {
 			"entry": [


### PR DESCRIPTION
## Summary
- Job steps now render as a table, with the start timestamp read as a date "at" a time and elapsed as an `HH:MM:SS` clock value from a new `formatElapsed` — `formatRoundedDuration` reported only the largest non-zero unit, so a step reading "2 minutes" could have run for anything up to three.
- Each workflow's output is shown as a peek — `AnalysisPeek`, `SamplePeek`, `SubtractionPeek` — carrying the resource's name, link and attribution instead of `AnalysisItem` (which repeats the job state the page already shows in full) or a bare id in an "Arguments" row. None of them shows job state or controls, which the page owns.
- Item title and attribution text styles align across the analysis, reference, sample and job items: size lives on the title link, and the containers handle layout only.