### PR TITLE
ci: fix semantic-release after the move to virtool/virtool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,6 +563,11 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v7
+              with:
+                  # semantic-release resolves the last release from the tags
+                  # reachable from the branch; the default shallow checkout has
+                  # none, and it would publish 1.0.0 over the live series.
+                  fetch-depth: 0
             - name: Setup
               uses: ./.github/actions/setup
             - name: Run semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -23,6 +23,6 @@
          }
     ]
   ],
-  "repositoryUrl": "https://github.com/virtool/virtool-ui.git",
+  "repositoryUrl": "https://github.com/virtool/virtool.git",
   "tagFormat": "${version}"
 }


### PR DESCRIPTION
## Summary
- `.releaserc` still named `virtool-ui`, so every release since the move talked to the old repo — one run failed with `EGITNOPERMISSION` pushing there, and the rest exited 0 reporting main "behind the remote one". That leaves `release-tag`'s `git-tag` output empty, which skips `release-ghcr`, so no image has been published since the cutover.
- `release-tag`'s checkout was the default shallow one. semantic-release resolves the last release from the tags reachable from the branch and a depth-1 fetch has none, so once it could reach the right repo it would have published `1.0.0` over the live series.
- **Still outstanding:** no tag from either series (7.x or 41.x) is an ancestor of `main`, so a baseline tag has to land before the next `feat`/`fix` — otherwise the first cut off this pipeline is `1.0.0` regardless of these fixes.