### PR TITLE
ci: publish workflow images under both ts- and bare tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,8 +214,8 @@ jobs:
                   # have each matrix leg overwrite the last one's cache.
                   cache-from: type=gha,scope=${{ matrix.image }}
                   cache-to: type=gha,mode=max,scope=${{ matrix.image }}
-    # Also published by `release-ghcr` as `ghcr.io/virtool/ts-pathoscope`,
-    # alongside `virtool/workflow-pathoscope`'s `ghcr.io/virtool/pathoscope`.
+    # Also published by `release-ghcr` as `ghcr.io/virtool/ts-pathoscope` and
+    # `ghcr.io/virtool/pathoscope`.
     build-pathoscope:
         name: Pathoscope / Build
         runs-on: ubuntu-24.04
@@ -332,8 +332,8 @@ jobs:
     # -------------------------------------------------------------------------
     # NuVs (apps/nuvs)
     # -------------------------------------------------------------------------
-    # Also published by `release-ghcr` as `ghcr.io/virtool/ts-nuvs`, alongside
-    # `virtool/workflow-nuvs`'s `ghcr.io/virtool/nuvs`.
+    # Also published by `release-ghcr` as `ghcr.io/virtool/ts-nuvs` and
+    # `ghcr.io/virtool/nuvs`.
     #
     # The 45-minute timeout is longer than pathoscope's 30: this image compiles
     # SPAdes from source, which is the single most expensive thing either
@@ -610,14 +610,24 @@ jobs:
                       target: tasks
                       workspace: apps/tasks
                       images: ghcr.io/virtool/tasks
+                    # These four also publish their bare, unprefixed name
+                    # (e.g. `ghcr.io/virtool/create-sample`). That name
+                    # previously came from a separate legacy repository
+                    # shipping the Python workflow of the same name; this
+                    # release now supersedes it, so both tags point at the
+                    # TS-based image.
                     - image: ts-create-sample
                       target: create-sample
                       workspace: apps/create-sample
-                      images: ghcr.io/virtool/ts-create-sample
+                      images: |
+                          ghcr.io/virtool/ts-create-sample
+                          ghcr.io/virtool/create-sample
                     - image: ts-create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction
-                      images: ghcr.io/virtool/ts-create-subtraction
+                      images: |
+                          ghcr.io/virtool/ts-create-subtraction
+                          ghcr.io/virtool/create-subtraction
                     # cache-scope overrides matrix.image: build-pathoscope and
                     # build-nuvs write their gha cache under the bare
                     # `pathoscope` / `nuvs` scope (matching pathoscope-test's
@@ -630,12 +640,16 @@ jobs:
                     - image: ts-pathoscope
                       target: pathoscope
                       workspace: apps/pathoscope
-                      images: ghcr.io/virtool/ts-pathoscope
+                      images: |
+                          ghcr.io/virtool/ts-pathoscope
+                          ghcr.io/virtool/pathoscope
                       cache-scope: pathoscope
                     - image: ts-nuvs
                       target: nuvs
                       workspace: apps/nuvs
-                      images: ghcr.io/virtool/ts-nuvs
+                      images: |
+                          ghcr.io/virtool/ts-nuvs
+                          ghcr.io/virtool/nuvs
                       cache-scope: nuvs
         steps:
             - name: Checkout

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,22 +6,25 @@ Every image ships from a target in the root `Dockerfile`. Five targets use the
 `build` job matrix; Pathoscope and Nuvs have separate, longer path-filtered
 jobs. `release-ghcr` publishes all seven targets on every release.
 
-| Target | Published image | Build job |
+| Target | Published image(s) | Build job |
 | --- | --- | --- |
 | `dist` | `ghcr.io/virtool/web` | `build` |
 | `jobs-api` | `ghcr.io/virtool/jobs-api` | `build` |
 | `tasks` | `ghcr.io/virtool/tasks` | `build` |
-| `create-sample` | `ghcr.io/virtool/ts-create-sample` | `build` |
-| `create-subtraction` | `ghcr.io/virtool/ts-create-subtraction` | `build` |
-| `pathoscope` | `ghcr.io/virtool/ts-pathoscope` | `build-pathoscope` |
-| `nuvs` | `ghcr.io/virtool/ts-nuvs` | `build-nuvs` |
+| `create-sample` | `ghcr.io/virtool/ts-create-sample`, `ghcr.io/virtool/create-sample` | `build` |
+| `create-subtraction` | `ghcr.io/virtool/ts-create-subtraction`, `ghcr.io/virtool/create-subtraction` | `build` |
+| `pathoscope` | `ghcr.io/virtool/ts-pathoscope`, `ghcr.io/virtool/pathoscope` | `build-pathoscope` |
+| `nuvs` | `ghcr.io/virtool/ts-nuvs`, `ghcr.io/virtool/nuvs` | `build-nuvs` |
 
 `dist` retains its name because tooling outside this repository targets it.
 
-The `ts-` prefix distinguishes these workflow images from the unprefixed names
-such as `ghcr.io/virtool/pathoscope` that earlier releases used. Nothing
-publishes the unprefixed names now, so the prefix is retained only so an
-existing deployment keeps pulling what it already pulls.
+The four workflow images publish under both their `ts-` prefixed name and
+their bare, unprefixed name (e.g. `ghcr.io/virtool/pathoscope`). The bare name
+previously came from separate legacy repositories shipping the Python
+workflow of the same name; this repository's release now supersedes those, so
+both tags point at the same TS-based image. The `ts-` prefix is kept
+alongside the bare name only so an existing deployment pinned to it keeps
+pulling the same tag.
 
 Adding an image requires a Dockerfile target and a release-matrix entry. For
 the five targets in `build`, keep its matrix entry in step with
@@ -29,7 +32,9 @@ the five targets in `build`, keep its matrix entry in step with
 and release entries whose `cache-scope` values are `pathoscope` and `nuvs`.
 Those overrides reuse the caches populated by the long build jobs rather than
 rebuilding the Rust crate, bioinformatics tools, or SPAdes inside the shared
-20-minute release timeout.
+20-minute release timeout. Give a workflow image's release entry both its
+`ts-` prefixed and bare `images:` names as a multi-line list, matching the
+existing four.
 
 Build one image locally by naming its target:
 


### PR DESCRIPTION
## Summary
- `release-ghcr` now publishes each of the four workflow images (`create-sample`, `create-subtraction`, `pathoscope`, `nuvs`) under both its `ts-` prefixed name and its bare, unprefixed name.
- Future workflow releases such as `virtool/create-sample` will ship the TS-based workflow instead of the legacy Python one, so the bare tag now needs to resolve to the same image as its `ts-` prefixed counterpart.
- Updated `docs/ci.md` and the relevant CI comments to describe the dual-tag publishing.