### PR TITLE
fix: report created records beside the button and standardize transient feedback

### DIFF
--- a/apps/web/src/account/components/AccountPassword.tsx
+++ b/apps/web/src/account/components/AccountPassword.tsx
@@ -1,7 +1,9 @@
+import { useTimedReset } from "@app/hooks";
 import Alert from "@base/Alert";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
+import FadeOut from "@base/FadeOut";
 import InputContainer from "@base/InputContainer";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
@@ -45,12 +47,10 @@ export default function AccountPassword({
 	useEffect(() => {
 		if (mutation.isSuccess) {
 			reset();
-			const timer = setTimeout(() => {
-				mutation.reset();
-			}, 3000);
-			return () => clearTimeout(timer);
 		}
-	}, [mutation.isSuccess, reset, mutation.reset]);
+	}, [mutation.isSuccess, reset]);
+
+	useTimedReset(mutation.isSuccess, mutation.reset);
 
 	function onSubmit({ oldPassword, newPassword }: FormValues) {
 		mutation.mutate({ oldPassword, password: newPassword });
@@ -110,11 +110,13 @@ export default function AccountPassword({
 							</InputError>
 						</InputContainer>
 					</InputGroup>
-					{mutation.isSuccess && (
-						<Alert color="green" icon={Check}>
-							Password changed successfully
-						</Alert>
-					)}
+					<FadeOut role="status">
+						{mutation.isSuccess ? (
+							<Alert color="green" icon={Check}>
+								Password changed successfully
+							</Alert>
+						) : null}
+					</FadeOut>
 					<div className="flex items-center justify-between mb-4">
 						<span>
 							Last changed <RelativeTime time={lastPasswordChange} />

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -1,18 +1,11 @@
 import { useCompatibleIndexes, useSubtractionOptions } from "@analyses/hooks";
 import { useCreateAnalysis } from "@analyses/queries";
 import Button from "@base/Button";
+import CreatedCount from "@base/CreatedCount";
 import { DialogFooter } from "@base/Dialog";
 import InputError from "@base/InputError";
 import QueryError from "@base/QueryError";
 import Switch from "@base/Switch";
-import {
-	Toast,
-	ToastClose,
-	ToastDescription,
-	ToastProvider,
-	ToastTitle,
-	ToastViewport,
-} from "@base/Toast";
 import SubtractionSelector from "@subtraction/components/SubtractionSelector";
 import type { AnalysisWorkflow } from "@virtool/contracts";
 import { useState } from "react";
@@ -26,13 +19,6 @@ type CreateAnalysisFormValues = {
 	indexId: string;
 	subtractionIds: number[];
 	workflow: AnalysisWorkflow;
-};
-
-/** A dismissible confirmation shown after analyses are created with "Create more" on. */
-type CreatedAnalysis = {
-	id: number;
-	count: number;
-	workflow: string;
 };
 
 type CreateAnalysisFormProps = {
@@ -90,8 +76,7 @@ export default function CreateAnalysisForm({
 	} = useForm<CreateAnalysisFormValues>({ defaultValues });
 
 	const [createMore, setCreateMore] = useState(false);
-	const [createdAnalysis, setCreatedAnalysis] =
-		useState<CreatedAnalysis | null>(null);
+	const [createdCount, setCreatedCount] = useState(0);
 
 	if (isErrorIndexes || isErrorSubtractions) {
 		return <QueryError noun="analysis options" />;
@@ -132,13 +117,7 @@ export default function CreateAnalysisForm({
 		}
 
 		reset(defaultValues);
-		setCreatedAnalysis({
-			id: created[0]?.id ?? 0,
-			count: created.length,
-			workflow:
-				compatibleWorkflows.find((option) => option.id === workflow)?.name ??
-				workflow,
-		});
+		setCreatedCount((count) => count + created.length);
 	}
 
 	return (
@@ -204,6 +183,12 @@ export default function CreateAnalysisForm({
 				</div>
 
 				<div className="flex items-center gap-4">
+					<CreatedCount
+						count={createdCount}
+						onExpire={() => setCreatedCount(0)}
+						plural="analyses"
+						singular="analysis"
+					/>
 					<CreateAnalysisSummary
 						sampleCount={sampleCount}
 						indexCount={watch("indexId") ? 1 : 0}
@@ -213,31 +198,6 @@ export default function CreateAnalysisForm({
 					</Button>
 				</div>
 			</DialogFooter>
-
-			<ToastProvider>
-				{createdAnalysis && (
-					<Toast
-						key={createdAnalysis.id}
-						onOpenChange={(open) => {
-							if (!open) {
-								setCreatedAnalysis(null);
-							}
-						}}
-						open
-					>
-						<div>
-							<ToastTitle>
-								{createdAnalysis.count === 1
-									? "Analysis created"
-									: `${createdAnalysis.count} analyses created`}
-							</ToastTitle>
-							<ToastDescription>{createdAnalysis.workflow}</ToastDescription>
-						</div>
-						<ToastClose />
-					</Toast>
-				)}
-				<ToastViewport />
-			</ToastProvider>
 		</form>
 	);
 }

--- a/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
@@ -90,7 +90,7 @@ describe("<CreateAnalysisForm>", () => {
 		expect(createAnalysis).toHaveBeenCalled();
 	});
 
-	it("keeps the dialog open and shows a toast when 'Create more' is on", async () => {
+	it("keeps the dialog open and counts the created analysis when 'Create more' is on", async () => {
 		const { onClose, sample } = await renderForm();
 
 		const createAnalysis = mockCreateAnalysis(
@@ -103,7 +103,7 @@ describe("<CreateAnalysisForm>", () => {
 		await userEvent.click(screen.getByRole("switch", { name: "Create more" }));
 		await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
-		expect(await screen.findByText("Analysis created")).toBeInTheDocument();
+		expect(await screen.findByText("1 analysis created")).toBeInTheDocument();
 		expect(onClose).not.toHaveBeenCalled();
 		expect(screen.getByText("Select a reference")).toBeInTheDocument();
 		expect(createAnalysis).toHaveBeenCalled();

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeExport.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeExport.tsx
@@ -2,7 +2,7 @@ import { useAnalysisSearch } from "@analyses/components/AnalysisSearchContext";
 import { useSortAndFilterPathoscopeHits } from "@analyses/hooks";
 import type { FormattedPathoscopeAnalysis } from "@analyses/types";
 import { writeToClipboard } from "@app/clipboard";
-import { useIsSecureContext } from "@app/hooks";
+import { useIsSecureContext, useTimedReset } from "@app/hooks";
 import Dropdown from "@base/Dropdown";
 import DropdownButton from "@base/DropdownButton";
 import DropdownMenuContent from "@base/DropdownMenuContent";
@@ -16,7 +16,7 @@ import Tooltip from "@base/Tooltip";
 import * as Sentry from "@sentry/tanstackstart-react";
 import type { PathoscopeHit } from "@virtool/contracts";
 import { Check, ClipboardCopy, Download, FileSpreadsheet } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { collapsingLabel } from "./collapsingLabel";
 import {
 	formatPathoscopeHitsAsTsv,
@@ -65,15 +65,7 @@ export default function PathoscopeExport({ analysis }: PathoscopeExportProps) {
 
 	const [copied, setCopied] = useState(false);
 
-	useEffect(() => {
-		if (!copied) {
-			return;
-		}
-
-		const timeout = setTimeout(() => setCopied(false), 2000);
-
-		return () => clearTimeout(timeout);
-	}, [copied]);
+	useTimedReset(copied, () => setCopied(false));
 
 	// Only a resolved write flips the label, so a rejected one — a revoked
 	// permission, an unfocused document — cannot claim the table was copied.

--- a/apps/web/src/app/hooks.tsx
+++ b/apps/web/src/app/hooks.tsx
@@ -1,4 +1,5 @@
 import { readServerNow } from "@app/serverNow";
+import { TRANSIENT_HOLD_DURATION } from "@app/timing";
 import type { RefObject } from "react";
 import {
 	useEffect,
@@ -258,4 +259,32 @@ export function useElementSize<T extends HTMLElement>(): [
 	}, []);
 
 	return [ref, size];
+}
+
+/**
+ * Calls `onExpire` once `key` has been truthy for `delay`.
+ *
+ * A changed `key` restarts the wait, so repeating an action reads as new
+ * instead of inheriting what was left of the previous one's time.
+ */
+export function useTimedReset(
+	key: unknown,
+	onExpire: () => void,
+	delay: number = TRANSIENT_HOLD_DURATION,
+): void {
+	const onExpireRef = useRef(onExpire);
+
+	useEffect(() => {
+		onExpireRef.current = onExpire;
+	});
+
+	useEffect(() => {
+		if (!key) {
+			return;
+		}
+
+		const timeout = setTimeout(() => onExpireRef.current(), delay);
+
+		return () => clearTimeout(timeout);
+	}, [key, delay]);
 }

--- a/apps/web/src/app/timing.ts
+++ b/apps/web/src/app/timing.ts
@@ -1,0 +1,5 @@
+/** How long transient feedback holds before it clears. */
+export const TRANSIENT_HOLD_DURATION = 3000;
+
+/** How long transient feedback takes to fade out, matching `duration-300`. */
+export const TRANSIENT_FADE_DURATION = 300;

--- a/apps/web/src/base/CreatedCount.tsx
+++ b/apps/web/src/base/CreatedCount.tsx
@@ -1,12 +1,7 @@
 import { cn } from "@app/cn";
 import { pluralize } from "@app/format";
-import { useEffect, useRef, useState } from "react";
-
-/** How long the tally holds at full opacity before it starts fading. */
-const HOLD_DURATION = 5000;
-
-/** Matches the `duration-300` opacity transition below. */
-const FADE_DURATION = 300;
+import { useTimedReset } from "@app/hooks";
+import FadeOut from "@base/FadeOut";
 
 type CreatedCountProps = {
 	className?: string;
@@ -28,11 +23,6 @@ type CreatedCountProps = {
  * A running tally of the records a "create more" form has created, which fades
  * out once it has been on screen long enough. Creating again before it expires
  * bumps the count and restarts the hold.
- *
- * The element stays mounted while the count is zero so the live region exists
- * before the first message lands; a region added and filled in the same commit
- * is missed by some screen readers. The message outlives the count so the fade
- * has something to act on, and is dropped afterwards so the row reflows.
  */
 export default function CreatedCount({
 	className,
@@ -41,47 +31,11 @@ export default function CreatedCount({
 	plural,
 	singular,
 }: CreatedCountProps) {
-	const [message, setMessage] = useState("");
-	const onExpireRef = useRef(onExpire);
-
-	useEffect(() => {
-		onExpireRef.current = onExpire;
-	});
-
-	useEffect(() => {
-		if (count === 0) {
-			return;
-		}
-
-		setMessage(`${pluralize(count, singular, plural)} created`);
-
-		const timeout = setTimeout(() => onExpireRef.current(), HOLD_DURATION);
-
-		return () => clearTimeout(timeout);
-	}, [count, plural, singular]);
-
-	// Clocked rather than driven by `transitionend`, which never fires when the
-	// user has asked for reduced motion.
-	useEffect(() => {
-		if (count > 0 || message === "") {
-			return;
-		}
-
-		const timeout = setTimeout(() => setMessage(""), FADE_DURATION);
-
-		return () => clearTimeout(timeout);
-	}, [count, message]);
+	useTimedReset(count, onExpire);
 
 	return (
-		<p
-			className={cn(
-				"m-0 text-gray-600 transition-opacity duration-300",
-				count === 0 ? "opacity-0" : "opacity-100",
-				className,
-			)}
-			role="status"
-		>
-			{message}
-		</p>
+		<FadeOut className={cn("text-gray-600", className)} role="status">
+			{count > 0 ? `${pluralize(count, singular, plural)} created` : null}
+		</FadeOut>
 	);
 }

--- a/apps/web/src/base/CreatedCount.tsx
+++ b/apps/web/src/base/CreatedCount.tsx
@@ -1,0 +1,87 @@
+import { cn } from "@app/cn";
+import { pluralize } from "@app/format";
+import { useEffect, useRef, useState } from "react";
+
+/** How long the tally holds at full opacity before it starts fading. */
+const HOLD_DURATION = 5000;
+
+/** Matches the `duration-300` opacity transition below. */
+const FADE_DURATION = 300;
+
+type CreatedCountProps = {
+	className?: string;
+
+	/** How many records the form has created since the tally last cleared. */
+	count: number;
+
+	/** Clears `count` once the tally has been on screen long enough. */
+	onExpire: () => void;
+
+	/** The plural noun, for irregular nouns like "analyses". */
+	plural?: string;
+
+	/** The singular noun for the created record. */
+	singular: string;
+};
+
+/**
+ * A running tally of the records a "create more" form has created, which fades
+ * out once it has been on screen long enough. Creating again before it expires
+ * bumps the count and restarts the hold.
+ *
+ * The element stays mounted while the count is zero so the live region exists
+ * before the first message lands; a region added and filled in the same commit
+ * is missed by some screen readers. The message outlives the count so the fade
+ * has something to act on, and is dropped afterwards so the row reflows.
+ */
+export default function CreatedCount({
+	className,
+	count,
+	onExpire,
+	plural,
+	singular,
+}: CreatedCountProps) {
+	const [message, setMessage] = useState("");
+	const onExpireRef = useRef(onExpire);
+
+	useEffect(() => {
+		onExpireRef.current = onExpire;
+	});
+
+	useEffect(() => {
+		if (count === 0) {
+			return;
+		}
+
+		setMessage(`${pluralize(count, singular, plural)} created`);
+
+		const timeout = setTimeout(() => onExpireRef.current(), HOLD_DURATION);
+
+		return () => clearTimeout(timeout);
+	}, [count, plural, singular]);
+
+	// Clocked rather than driven by `transitionend`, which never fires when the
+	// user has asked for reduced motion.
+	useEffect(() => {
+		if (count > 0 || message === "") {
+			return;
+		}
+
+		const timeout = setTimeout(() => setMessage(""), FADE_DURATION);
+
+		return () => clearTimeout(timeout);
+	}, [count, message]);
+
+	return (
+		<p
+			className={cn(
+				"m-0 text-gray-600 transition-opacity duration-300",
+				count === 0 ? "opacity-0" : "opacity-100",
+				className,
+			)}
+			role="status"
+		>
+			{message}
+		</p>
+	);
+}

--- a/apps/web/src/base/FadeOut.tsx
+++ b/apps/web/src/base/FadeOut.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@app/cn";
+import { TRANSIENT_FADE_DURATION } from "@app/timing";
+import { type ReactNode, useEffect, useState } from "react";
+
+type FadeOutProps = {
+	/** The content to show. An empty value fades out whatever was last shown. */
+	children: ReactNode;
+
+	className?: string;
+
+	/** The live region role to announce the content under, if any. */
+	role?: "alert" | "status";
+};
+
+/**
+ * Shows its content and fades it out once `children` goes empty, holding the
+ * last content mounted until the fade finishes so the fade has something to
+ * act on. The content is dropped afterwards so the surrounding layout reflows.
+ *
+ * The wrapper stays mounted while empty so a live region exists before the
+ * first message lands; a region added and filled in the same commit is missed
+ * by some screen readers.
+ */
+export default function FadeOut({ children, className, role }: FadeOutProps) {
+	const [shown, setShown] = useState<ReactNode>(null);
+	const visible = Boolean(children);
+
+	useEffect(() => {
+		if (children) {
+			setShown(children);
+		}
+	}, [children]);
+
+	// Clocked rather than driven by `transitionend`, which never fires when the
+	// user has asked for reduced motion.
+	useEffect(() => {
+		if (visible) {
+			return;
+		}
+
+		const timeout = setTimeout(() => setShown(null), TRANSIENT_FADE_DURATION);
+
+		return () => clearTimeout(timeout);
+	}, [visible]);
+
+	return (
+		<div
+			className={cn(
+				"transition-opacity duration-300",
+				visible ? "opacity-100" : "opacity-0",
+				className,
+			)}
+			role={role}
+		>
+			{shown}
+		</div>
+	);
+}

--- a/apps/web/src/base/Toast.tsx
+++ b/apps/web/src/base/Toast.tsx
@@ -4,24 +4,38 @@ import { Toast as ToastPrimitive } from "radix-ui";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { buttonVariants } from "./buttonVariants";
 
-export const ToastProvider = ToastPrimitive.Provider;
+type ToastProviderProps = ComponentPropsWithoutRef<
+	typeof ToastPrimitive.Provider
+>;
+
+/**
+ * Provides the toast context. Toasts sit at the bottom-left of the screen, so
+ * they swipe left to dismiss.
+ */
+export function ToastProvider({
+	swipeDirection = "left",
+	...props
+}: ToastProviderProps) {
+	return <ToastPrimitive.Provider swipeDirection={swipeDirection} {...props} />;
+}
 
 type ToastViewportProps = {
 	className?: string;
 };
 
 /**
- * A fixed viewport that anchors toasts to the bottom-right of the screen and
- * stacks them vertically.
+ * A fixed viewport that anchors toasts to the bottom-left of the screen and
+ * stacks them vertically. Primary actions sit at the bottom-right of dialogs
+ * and forms, so toasts stay on the opposite side to avoid covering them.
  */
 export function ToastViewport({ className }: ToastViewportProps) {
 	return (
 		<ToastPrimitive.Viewport
 			className={cn(
-				"fixed bottom-0 right-0 z-toast",
+				"fixed bottom-0 left-0 z-toast",
 				"flex flex-col gap-2",
 				"m-0 p-6 w-full sm:max-w-md",
-				"list-none outline-none",
+				"list-none outline-none pointer-events-none",
 				className,
 			)}
 		/>

--- a/apps/web/src/base/Toast.tsx
+++ b/apps/web/src/base/Toast.tsx
@@ -3,39 +3,24 @@ import { Toast as ToastPrimitive } from "radix-ui";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { buttonVariants } from "./buttonVariants";
 
-type ToastProviderProps = ComponentPropsWithoutRef<
-	typeof ToastPrimitive.Provider
->;
-
-/**
- * Provides the toast context. Toasts sit at the top of the screen, so they
- * swipe up to dismiss.
- */
-export function ToastProvider({
-	swipeDirection = "up",
-	...props
-}: ToastProviderProps) {
-	return <ToastPrimitive.Provider swipeDirection={swipeDirection} {...props} />;
-}
+export const ToastProvider = ToastPrimitive.Provider;
 
 type ToastViewportProps = {
 	className?: string;
 };
 
 /**
- * A fixed viewport that anchors toasts to the top-centre of the screen and
- * stacks them vertically. Dialogs put their actions in a footer and the nav
- * puts its controls in the top corners, so the top centre is the one band
- * that stays clear of both.
+ * A fixed viewport that anchors toasts to the bottom-right of the screen and
+ * stacks them vertically.
  */
 export function ToastViewport({ className }: ToastViewportProps) {
 	return (
 		<ToastPrimitive.Viewport
 			className={cn(
-				"fixed top-0 inset-x-0 z-toast",
+				"fixed bottom-0 right-0 z-toast",
 				"flex flex-col gap-2",
-				"mx-auto my-0 p-6 w-full sm:max-w-md",
-				"list-none outline-none pointer-events-none",
+				"m-0 p-6 w-full sm:max-w-md",
+				"list-none outline-none",
 				className,
 			)}
 		/>
@@ -52,7 +37,7 @@ export function Toast({ className, ...props }: ToastProps) {
 	return (
 		<ToastPrimitive.Root
 			className={cn(
-				"data-[state=open]:animate-slideDownAndFade",
+				"data-[state=open]:animate-slideUpAndFade",
 				"bg-white border border-gray-200 rounded-md shadow-lg",
 				"flex items-center justify-between gap-4",
 				"p-4 pointer-events-auto",

--- a/apps/web/src/base/Toast.tsx
+++ b/apps/web/src/base/Toast.tsx
@@ -9,11 +9,11 @@ type ToastProviderProps = ComponentPropsWithoutRef<
 >;
 
 /**
- * Provides the toast context. Toasts sit at the bottom-left of the screen, so
- * they swipe left to dismiss.
+ * Provides the toast context. Toasts sit at the top of the screen, so they
+ * swipe up to dismiss.
  */
 export function ToastProvider({
-	swipeDirection = "left",
+	swipeDirection = "up",
 	...props
 }: ToastProviderProps) {
 	return <ToastPrimitive.Provider swipeDirection={swipeDirection} {...props} />;
@@ -24,17 +24,18 @@ type ToastViewportProps = {
 };
 
 /**
- * A fixed viewport that anchors toasts to the bottom-left of the screen and
- * stacks them vertically. Primary actions sit at the bottom-right of dialogs
- * and forms, so toasts stay on the opposite side to avoid covering them.
+ * A fixed viewport that anchors toasts to the top-centre of the screen and
+ * stacks them vertically. Dialogs put their actions in a footer and the nav
+ * puts its controls in the top corners, so the top centre is the one band
+ * that stays clear of both.
  */
 export function ToastViewport({ className }: ToastViewportProps) {
 	return (
 		<ToastPrimitive.Viewport
 			className={cn(
-				"fixed bottom-0 left-0 z-toast",
+				"fixed top-0 inset-x-0 z-toast",
 				"flex flex-col gap-2",
-				"m-0 p-6 w-full sm:max-w-md",
+				"mx-auto my-0 p-6 w-full sm:max-w-md",
 				"list-none outline-none pointer-events-none",
 				className,
 			)}
@@ -52,7 +53,7 @@ export function Toast({ className, ...props }: ToastProps) {
 	return (
 		<ToastPrimitive.Root
 			className={cn(
-				"data-[state=open]:animate-slideUpAndFade",
+				"data-[state=open]:animate-slideDownAndFade",
 				"bg-white border border-gray-200 rounded-md shadow-lg",
 				"flex items-center justify-between gap-4",
 				"p-4 pointer-events-auto",

--- a/apps/web/src/base/Toast.tsx
+++ b/apps/web/src/base/Toast.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@app/cn";
-import { X } from "lucide-react";
 import { Toast as ToastPrimitive } from "radix-ui";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { buttonVariants } from "./buttonVariants";
@@ -80,25 +79,6 @@ export function ToastTitle({ children, className }: ToastTitleProps) {
 	);
 }
 
-type ToastDescriptionProps = {
-	children: ReactNode;
-	className?: string;
-};
-
-/** A styled toast body for secondary detail beneath the title. */
-export function ToastDescription({
-	children,
-	className,
-}: ToastDescriptionProps) {
-	return (
-		<ToastPrimitive.Description
-			className={cn("text-gray-600 text-sm", className)}
-		>
-			{children}
-		</ToastPrimitive.Description>
-	);
-}
-
 type ToastActionProps = ComponentPropsWithoutRef<typeof ToastPrimitive.Action>;
 
 /**
@@ -114,24 +94,5 @@ export function ToastAction({ className, ...props }: ToastActionProps) {
 			)}
 			{...props}
 		/>
-	);
-}
-
-type ToastCloseProps = {
-	className?: string;
-};
-
-/** A styled dismiss button rendered in the corner of a toast. */
-export function ToastClose({ className }: ToastCloseProps) {
-	return (
-		<ToastPrimitive.Close
-			aria-label="Close"
-			className={cn(
-				"text-gray-500 hover:text-gray-600 cursor-pointer",
-				className,
-			)}
-		>
-			<X size={16} />
-		</ToastPrimitive.Close>
 	);
 }

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -6,6 +6,7 @@ import {
 	CollapsibleTrigger,
 } from "@base/Collapsible";
 import ContainerNarrow from "@base/ContainerNarrow";
+import CreatedCount from "@base/CreatedCount";
 import InputContainer from "@base/InputContainer";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
@@ -16,14 +17,6 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
 import Switch from "@base/Switch";
-import {
-	Toast,
-	ToastClose,
-	ToastDescription,
-	ToastProvider,
-	ToastTitle,
-	ToastViewport,
-} from "@base/Toast";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useListGroups } from "@groups/queries";
@@ -31,7 +24,7 @@ import { useCreateSample } from "@samples/queries";
 import { getCreateSampleRequest, getSampleNameFromReads } from "@samples/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { useInfiniteFindFiles } from "@uploads/queries";
-import type { Label, Sample } from "@virtool/contracts";
+import type { Label } from "@virtool/contracts";
 import { WandSparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -107,7 +100,7 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 
 	const [showMetadata, setShowMetadata] = useState(false);
 	const [createMore, setCreateMore] = useState(false);
-	const [createdSample, setCreatedSample] = useState<Sample | null>(null);
+	const [createdCount, setCreatedCount] = useState(0);
 
 	useEffect(() => {
 		setValue("group", String(account?.primaryGroup?.id ?? ""));
@@ -154,11 +147,11 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 
 	function onSubmit(values: FormValues) {
 		mutation.mutate(getCreateSampleRequest(values, values.readFiles), {
-			onSuccess: (sample) => {
+			onSuccess: () => {
 				clearForm();
 
 				if (createMore) {
-					setCreatedSample(sample);
+					setCreatedCount((count) => count + 1);
 					return;
 				}
 
@@ -315,38 +308,24 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 									</label>
 								</div>
 
-								<div className="flex gap-2">
-									<Button onClick={handleReset} type="button">
-										Reset Form
-									</Button>
-									<SaveButton />
+								<div className="flex items-center gap-4">
+									<CreatedCount
+										count={createdCount}
+										onExpire={() => setCreatedCount(0)}
+										singular="sample"
+									/>
+									<div className="flex gap-2">
+										<Button onClick={handleReset} type="button">
+											Reset Form
+										</Button>
+										<SaveButton />
+									</div>
 								</div>
 							</div>
 						</div>
 					</>
 				)}
 			</form>
-
-			<ToastProvider>
-				{createdSample && (
-					<Toast
-						key={createdSample.id}
-						onOpenChange={(open) => {
-							if (!open) {
-								setCreatedSample(null);
-							}
-						}}
-						open
-					>
-						<div>
-							<ToastTitle>Sample created</ToastTitle>
-							<ToastDescription>{createdSample.name}</ToastDescription>
-						</div>
-						<ToastClose />
-					</Toast>
-				)}
-				<ToastViewport />
-			</ToastProvider>
 		</ContainerNarrow>
 	);
 }

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -362,7 +362,7 @@ describe("<CreateSample>", () => {
 
 		await submitForm();
 
-		expect(await screen.findByText("Sample created")).toBeInTheDocument();
+		expect(await screen.findByText("1 sample created")).toBeInTheDocument();
 		expect(screen.getByLabelText("Name")).toHaveValue("");
 	});
 


### PR DESCRIPTION
## Summary
- Replace the "Analysis created" and "Sample created" toasts with an inline, fading tally (`CreatedCount`) next to the Create button, so repeat creation in the Analyze, Quick Analyze, and Create Sample dialogs no longer covers the button the user is about to click again.
- Extract the fade behaviour into a shared `FadeOut` primitive: it keeps the last content mounted through a clocked opacity transition (not `transitionend`, which never fires under reduced motion) and stays mounted while empty so a live region exists before the first message lands.
- Extract the shared hold/reset timer into a `useTimedReset` hook and a `TRANSIENT_HOLD_DURATION` / `TRANSIENT_FADE_DURATION` constant in `app/timing.ts`, then reuse both for the password-changed alert (`AccountPassword`) and the "Copied" state (`PathoscopeExport`), replacing three near-identical hand-rolled `setTimeout` effects.
- Remove `ToastDescription` and `ToastClose` from `base/Toast.tsx` now that nothing renders a dismissible toast with a description.