### PR TITLE
ci: stop publishing the ts- workflow image tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,11 +190,11 @@ jobs:
                       target: tasks
                       workspace: apps/tasks
                       area: Tasks
-                    - image: ts-create-sample
+                    - image: create-sample
                       target: create-sample
                       workspace: apps/create-sample
                       area: Create Sample
-                    - image: ts-create-subtraction
+                    - image: create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction
                       area: Create Subtraction
@@ -214,8 +214,7 @@ jobs:
                   # have each matrix leg overwrite the last one's cache.
                   cache-from: type=gha,scope=${{ matrix.image }}
                   cache-to: type=gha,mode=max,scope=${{ matrix.image }}
-    # Also published by `release-ghcr` as `ghcr.io/virtool/ts-pathoscope` and
-    # `ghcr.io/virtool/pathoscope`.
+    # Also published by `release-ghcr` as `ghcr.io/virtool/pathoscope`.
     build-pathoscope:
         name: Pathoscope / Build
         runs-on: ubuntu-24.04
@@ -332,8 +331,7 @@ jobs:
     # -------------------------------------------------------------------------
     # NuVs (apps/nuvs)
     # -------------------------------------------------------------------------
-    # Also published by `release-ghcr` as `ghcr.io/virtool/ts-nuvs` and
-    # `ghcr.io/virtool/nuvs`.
+    # Also published by `release-ghcr` as `ghcr.io/virtool/nuvs`.
     #
     # The 45-minute timeout is longer than pathoscope's 30: this image compiles
     # SPAdes from source, which is the single most expensive thing either
@@ -610,47 +608,32 @@ jobs:
                       target: tasks
                       workspace: apps/tasks
                       images: ghcr.io/virtool/tasks
-                    # These four also publish their bare, unprefixed name
-                    # (e.g. `ghcr.io/virtool/create-sample`). That name
-                    # previously came from a separate legacy repository
-                    # shipping the Python workflow of the same name; this
-                    # release now supersedes it, so both tags point at the
-                    # TS-based image.
-                    - image: ts-create-sample
+                    # These four names previously came from separate legacy
+                    # repositories shipping the Python workflow of the same
+                    # name; this repository's release supersedes them.
+                    - image: create-sample
                       target: create-sample
                       workspace: apps/create-sample
-                      images: |
-                          ghcr.io/virtool/ts-create-sample
-                          ghcr.io/virtool/create-sample
-                    - image: ts-create-subtraction
+                      images: ghcr.io/virtool/create-sample
+                    - image: create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction
-                      images: |
-                          ghcr.io/virtool/ts-create-subtraction
-                          ghcr.io/virtool/create-subtraction
-                    # cache-scope overrides matrix.image: build-pathoscope and
-                    # build-nuvs write their gha cache under the bare
-                    # `pathoscope` / `nuvs` scope (matching pathoscope-test's
-                    # bowtie2 scope too), not `ts-pathoscope` / `ts-nuvs`. A
-                    # release that read matrix.image here would miss those
-                    # caches and rebuild the Rust crate, the bioinformatics
-                    # tools and SPAdes from scratch inside this job's shared
-                    # 20-minute timeout, instead of reusing what the
-                    # 45/60-minute build jobs already produced.
-                    - image: ts-pathoscope
+                      images: ghcr.io/virtool/create-subtraction
+                    # These two read their gha cache under the same scope
+                    # build-pathoscope and build-nuvs write it to (matching
+                    # pathoscope-test's bowtie2 scope too), so the release
+                    # reuses what those 45/60-minute jobs already produced
+                    # rather than rebuilding the Rust crate, the
+                    # bioinformatics tools and SPAdes from scratch inside this
+                    # job's shared 20-minute timeout.
+                    - image: pathoscope
                       target: pathoscope
                       workspace: apps/pathoscope
-                      images: |
-                          ghcr.io/virtool/ts-pathoscope
-                          ghcr.io/virtool/pathoscope
-                      cache-scope: pathoscope
-                    - image: ts-nuvs
+                      images: ghcr.io/virtool/pathoscope
+                    - image: nuvs
                       target: nuvs
                       workspace: apps/nuvs
-                      images: |
-                          ghcr.io/virtool/ts-nuvs
-                          ghcr.io/virtool/nuvs
-                      cache-scope: nuvs
+                      images: ghcr.io/virtool/nuvs
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -682,7 +665,7 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   target: ${{ matrix.target }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha,scope=${{ matrix.cache-scope || matrix.image }}
-                  cache-to: type=gha,mode=max,scope=${{ matrix.cache-scope || matrix.image }}
+                  cache-from: type=gha,scope=${{ matrix.image }}
+                  cache-to: type=gha,mode=max,scope=${{ matrix.image }}
                   secrets: |
                       sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -248,7 +248,7 @@ COPY --from=seqkit /tools/seqkit/2.13.0/seqkit /usr/local/bin/
 COPY --from=build-create-subtraction /prod/create-subtraction ./
 CMD ["node", "dist/index.mjs"]
 
-# The create-sample workflow, published as ghcr.io/virtool/ts-create-sample. It
+# The create-sample workflow, published as ghcr.io/virtool/create-sample. It
 # turns a user's uploaded FASTQ files into a sample an analysis can run against.
 FROM base AS build-create-sample
 COPY apps/create-sample ./apps/create-sample
@@ -303,7 +303,7 @@ COPY --from=pathoscope-builder /build/target/release/pathoscope-core /usr/local/
 COPY --from=build-pathoscope /prod/pathoscope ./
 CMD ["node", "dist/index.mjs"]
 
-# The NuVs workflow, published as ghcr.io/virtool/ts-nuvs. It finds viruses the
+# The NuVs workflow, published as ghcr.io/virtool/nuvs. It finds viruses the
 # reference does not describe, by discarding reads that map to a known OTU or a
 # subtraction, assembling what is left with SPAdes and searching the contigs
 # for viral motifs with HMMER.

--- a/Tiltfile
+++ b/Tiltfile
@@ -15,16 +15,11 @@ SERVICE_TARGETS = [
 # start when something claims work, so nothing is waiting on a rebuild — and an
 # automatic one would rebuild a large image on every edit. Deploy them from the
 # Tilt UI.
-#
-# All four images publish on release, but `ts-nuvs` has no registry package
-# until the first release that carries it and `ts-pathoscope:latest` is a
-# tools-only leftover with no workflow code in it, so build those two locally
-# meanwhile with `tilt up -- --nuvs`.
 WORKFLOW_TARGETS = [
-    ('create-sample', 'ghcr.io/virtool/ts-create-sample'),
-    ('create-subtraction', 'ghcr.io/virtool/ts-create-subtraction'),
-    ('nuvs', 'ghcr.io/virtool/ts-nuvs'),
-    ('pathoscope', 'ghcr.io/virtool/ts-pathoscope'),
+    ('create-sample', 'ghcr.io/virtool/create-sample'),
+    ('create-subtraction', 'ghcr.io/virtool/create-subtraction'),
+    ('nuvs', 'ghcr.io/virtool/nuvs'),
+    ('pathoscope', 'ghcr.io/virtool/pathoscope'),
 ]
 
 config.define_bool('web', usage='live edit web')

--- a/apps/create-sample/README.md
+++ b/apps/create-sample/README.md
@@ -1,6 +1,6 @@
 # @virtool/create-sample
 
-Image: `ghcr.io/virtool/ts-create-sample`.
+Image: `ghcr.io/virtool/create-sample`.
 
 Turns a user's uploaded FASTQ files into a sample an analysis can run against:
 measures their quality, normalizes them to `reads_1.fq.gz` and

--- a/apps/create-subtraction/README.md
+++ b/apps/create-subtraction/README.md
@@ -1,6 +1,6 @@
 # @virtool/create-subtraction
 
-Image: `ghcr.io/virtool/ts-create-subtraction`.
+Image: `ghcr.io/virtool/create-subtraction`.
 
 Computes GC and sequence count for a subtraction and commits it's 
 FASTA to object storage.

--- a/apps/create-subtraction/README.md
+++ b/apps/create-subtraction/README.md
@@ -2,7 +2,7 @@
 
 Image: `ghcr.io/virtool/create-subtraction`.
 
-Computes GC and sequence count for a subtraction and commits it's 
+Computes GC and sequence count for a subtraction and commits its
 FASTA to object storage.
 
 Two steps, `compute_gc_and_count` and `finalize`, and one external tool,

--- a/apps/jobs-api/src/jobs/handlers.test.ts
+++ b/apps/jobs-api/src/jobs/handlers.test.ts
@@ -85,7 +85,7 @@ function claimBody() {
 		runnerId: "runner-1",
 		mem: 4,
 		cpu: 2,
-		image: "ghcr.io/virtool/ts-pathoscope:1.0.0",
+		image: "ghcr.io/virtool/pathoscope:1.0.0",
 		runtimeVersion: "1.2.3",
 		workflowVersion: "4.5.6",
 		steps: STEPS,
@@ -234,7 +234,7 @@ describe("handleClaimJob", () => {
 			runnerId: "runner-1",
 			mem: 4,
 			cpu: 2,
-			image: "ghcr.io/virtool/ts-pathoscope:1.0.0",
+			image: "ghcr.io/virtool/pathoscope:1.0.0",
 			runtimeVersion: "1.2.3",
 			workflowVersion: "4.5.6",
 		});
@@ -252,7 +252,7 @@ describe("handleClaimJob", () => {
 			runner_id: "runner-1",
 			mem: 4,
 			cpu: 2,
-			image: "ghcr.io/virtool/ts-pathoscope:1.0.0",
+			image: "ghcr.io/virtool/pathoscope:1.0.0",
 			runtime_version: "1.2.3",
 			workflow_version: "4.5.6",
 		});

--- a/apps/nuvs/README.md
+++ b/apps/nuvs/README.md
@@ -5,7 +5,7 @@ describe: it discards every read that maps to a known OTU or to a
 subtraction, assembles what is left with SPAdes, and searches the contigs for
 viral motifs with HMMER.
 
-Image: `ghcr.io/virtool/ts-nuvs`. Ten steps, five external tools — `skewer`,
+Image: `ghcr.io/virtool/nuvs`. Ten steps, five external tools — `skewer`,
 `bowtie2`, SPAdes, `hmmpress` and `hmmscan`.
 
 ## Building the image

--- a/apps/pathoscope/README.md
+++ b/apps/pathoscope/README.md
@@ -6,7 +6,7 @@ against one representative per OTU to find candidates, rebuilds an index
 carrying every isolate of just those OTUs, maps again, drops reads that belong
 to the host, and reassigns the reads that matched more than one isolate.
 
-Image: `ghcr.io/virtool/ts-pathoscope`. Eight steps, four external
+Image: `ghcr.io/virtool/pathoscope`. Eight steps, four external
 tools — `bowtie2`, `cd-hit-est`, `pigz`, `samtools` — and `pathoscope-core`,
 which it drives **as a subprocess**; there is no FFI here and adding one is out
 of scope by decision.

--- a/apps/pathoscope/README.md
+++ b/apps/pathoscope/README.md
@@ -62,13 +62,12 @@ docker run --rm vt-tool-bowtie2 head -1 /tools/bowtie2/2.5.4/bowtie2-build
 
 `Pathoscope / Build` compiles the image on every run and `release-ghcr`
 publishes it on release, alongside `virtool/workflow-pathoscope`'s
-`ghcr.io/virtool/pathoscope`. The names differ, so the cluster picks one by the
-image it pulls and neither stream overwrites the other.
+`ghcr.io/virtool/pathoscope`. Both publishers use the same image name, so each
+release can overwrite the tag published by the other repository.
 
-Its release-matrix entry carries `cache-scope: pathoscope`, because the build
-job writes its gha cache under that bare scope rather than under the image
-name. Without the override the release would rebuild the Rust crate and every
-tool stage from scratch inside a 20-minute timeout.
+Its release-matrix image name is also the `pathoscope` cache scope used by the
+build job. This lets the release reuse the Rust crate and tool stages instead
+of rebuilding them from scratch inside a 20-minute timeout.
 
 ## Configuration
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -79,10 +79,10 @@ stage named after the target. Pass a flag to turn one on:
 | `--web` | `ghcr.io/virtool/web` | `dev` |
 | `--jobs-api` | `ghcr.io/virtool/jobs-api` | `jobs-api` |
 | `--tasks` | `ghcr.io/virtool/tasks` | `tasks` |
-| `--create-sample` | `ghcr.io/virtool/ts-create-sample` | `create-sample` |
-| `--create-subtraction` | `ghcr.io/virtool/ts-create-subtraction` | `create-subtraction` |
-| `--nuvs` | `ghcr.io/virtool/ts-nuvs` | `nuvs` |
-| `--pathoscope` | `ghcr.io/virtool/ts-pathoscope` | `pathoscope` |
+| `--create-sample` | `ghcr.io/virtool/create-sample` | `create-sample` |
+| `--create-subtraction` | `ghcr.io/virtool/create-subtraction` | `create-subtraction` |
+| `--nuvs` | `ghcr.io/virtool/nuvs` | `nuvs` |
+| `--pathoscope` | `ghcr.io/virtool/pathoscope` | `pathoscope` |
 
 Flags combine: `tilt up -- --web --jobs-api`.
 
@@ -104,13 +104,6 @@ the newest release each time it starts and no tag is ever committed. While
 migrations temporarily live in `ghcr.io/virtool/tasks`, the migration Job runs
 the tasks image's Drizzle migrator and follows the same tag or local Tilt build
 as the tasks Deployment.
-
-`ts-nuvs` and `ts-pathoscope` publish on release like the other two, but
-neither has a usable `latest` until the first release that carries them:
-`ts-nuvs` has no registry package at all, and `ts-pathoscope:latest` is the
-leftover of a short-lived publish job and carries the tools with no workflow
-code. Until then, run those two under `--nuvs` / `--pathoscope`, which build
-the image locally.
 
 ## Labels
 

--- a/dev/manifests/workflows/create-sample.yaml
+++ b/dev/manifests/workflows/create-sample.yaml
@@ -19,7 +19,7 @@ spec:
       spec:
         containers:
           - name: workflow-create-sample
-            image: ghcr.io/virtool/ts-create-sample:latest
+            image: ghcr.io/virtool/create-sample:latest
             env:
               - name: VT_PROC
                 value: "2"

--- a/dev/manifests/workflows/create-subtraction.yaml
+++ b/dev/manifests/workflows/create-subtraction.yaml
@@ -19,7 +19,7 @@ spec:
       spec:
         containers:
           - name: workflow-create-subtraction
-            image: ghcr.io/virtool/ts-create-subtraction:latest
+            image: ghcr.io/virtool/create-subtraction:latest
             env:
               - name: VT_PROC
                 value: "2"

--- a/dev/manifests/workflows/nuvs.yaml
+++ b/dev/manifests/workflows/nuvs.yaml
@@ -1,7 +1,3 @@
-# `ghcr.io/virtool/ts-nuvs` is published on release, but no tag of this name
-# exists in the registry until the first release that carries it. Run this
-# ScaledJob under `tilt up -- --nuvs` meanwhile, which builds the image
-# locally. The same holds for pathoscope.
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -23,7 +19,7 @@ spec:
       spec:
         containers:
           - name: workflow-nuvs
-            image: ghcr.io/virtool/ts-nuvs:latest
+            image: ghcr.io/virtool/nuvs:latest
             # VT_MEM is the cap SPAdes is given, so it moves with the memory
             # limit below rather than being sized independently — a value above
             # the limit is an OOMKill rather than a slower assembly.

--- a/dev/manifests/workflows/pathoscope.yaml
+++ b/dev/manifests/workflows/pathoscope.yaml
@@ -1,8 +1,3 @@
-# `ghcr.io/virtool/ts-pathoscope` is published on release. The `:latest` tag
-# below resolves today regardless, but it is the leftover of a short-lived
-# publish job from before the port landed and carries the tools with no
-# workflow code — so until a release has run since publishing was restored,
-# use `tilt up -- --pathoscope`, which builds the image locally.
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -24,7 +19,7 @@ spec:
       spec:
         containers:
           - name: workflow-pathoscope
-            image: ghcr.io/virtool/ts-pathoscope:latest
+            image: ghcr.io/virtool/pathoscope:latest
             env:
               - name: VT_MEM
                 value: "6"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,30 +11,27 @@ jobs. `release-ghcr` publishes all seven targets on every release.
 | `dist` | `ghcr.io/virtool/web` | `build` |
 | `jobs-api` | `ghcr.io/virtool/jobs-api` | `build` |
 | `tasks` | `ghcr.io/virtool/tasks` | `build` |
-| `create-sample` | `ghcr.io/virtool/ts-create-sample`, `ghcr.io/virtool/create-sample` | `build` |
-| `create-subtraction` | `ghcr.io/virtool/ts-create-subtraction`, `ghcr.io/virtool/create-subtraction` | `build` |
-| `pathoscope` | `ghcr.io/virtool/ts-pathoscope`, `ghcr.io/virtool/pathoscope` | `build-pathoscope` |
-| `nuvs` | `ghcr.io/virtool/ts-nuvs`, `ghcr.io/virtool/nuvs` | `build-nuvs` |
+| `create-sample` | `ghcr.io/virtool/create-sample` | `build` |
+| `create-subtraction` | `ghcr.io/virtool/create-subtraction` | `build` |
+| `pathoscope` | `ghcr.io/virtool/pathoscope` | `build-pathoscope` |
+| `nuvs` | `ghcr.io/virtool/nuvs` | `build-nuvs` |
 
 `dist` retains its name because tooling outside this repository targets it.
 
-The four workflow images publish under both their `ts-` prefixed name and
-their bare, unprefixed name (e.g. `ghcr.io/virtool/pathoscope`). The bare name
-previously came from separate legacy repositories shipping the Python
-workflow of the same name; this repository's release now supersedes those, so
-both tags point at the same TS-based image. The `ts-` prefix is kept
-alongside the bare name only so an existing deployment pinned to it keeps
-pulling the same tag.
+The four workflow images publish under their bare, unprefixed names. Those
+names previously came from separate legacy repositories shipping the Python
+workflow of the same name; this repository's release supersedes them. The
+`ts-` prefixed variants were a transitional second tag during the TypeScript
+port and are no longer published; their existing tags stay in the registry
+but never move again.
 
 Adding an image requires a Dockerfile target and a release-matrix entry. For
 the five targets in `build`, keep its matrix entry in step with
-`release-ghcr`. Pathoscope and Nuvs instead use the dedicated build jobs above
-and release entries whose `cache-scope` values are `pathoscope` and `nuvs`.
-Those overrides reuse the caches populated by the long build jobs rather than
-rebuilding the Rust crate, bioinformatics tools, or SPAdes inside the shared
-20-minute release timeout. Give a workflow image's release entry both its
-`ts-` prefixed and bare `images:` names as a multi-line list, matching the
-existing four.
+`release-ghcr`. Pathoscope and Nuvs instead use the dedicated build jobs
+above, and their `matrix.image` values must match the cache scopes those jobs
+write, so the release reuses the caches they populated rather than rebuilding
+the Rust crate, bioinformatics tools, or SPAdes inside the shared 20-minute
+release timeout.
 
 Build one image locally by naming its target:
 

--- a/packages/data/src/jobs/data.test.ts
+++ b/packages/data/src/jobs/data.test.ts
@@ -428,7 +428,7 @@ const CLAIM: StoredJobClaim = {
 	runner_id: "dead-runner",
 	mem: 8,
 	cpu: 2,
-	image: "ghcr.io/virtool/ts-nuvs:0.0.0",
+	image: "ghcr.io/virtool/nuvs:0.0.0",
 	runtime_version: "1.0.0",
 	workflow_version: "0.0.0",
 };

--- a/packages/pathoscope-core/README.md
+++ b/packages/pathoscope-core/README.md
@@ -147,16 +147,14 @@ every Rust edit. Add a line there when a new TypeScript package appears.
 ## The image build
 
 The root `Dockerfile`'s `pathoscope` target builds
-`ghcr.io/virtool/ts-pathoscope`. The crate is compiled in the same Dockerfile as
+`ghcr.io/virtool/pathoscope`. The crate is compiled in the same Dockerfile as
 its only consumer, so there is no second release stream to coordinate and no
 window in which the workflow and its core disagree.
 
 The `Pathoscope / Build` job compiles the Dockerfile on every run and
-`release-ghcr` pushes it on release. `virtool/workflow-pathoscope` still
-releases the pathoscope workflow too, but it publishes
-`ghcr.io/virtool/pathoscope` while this Dockerfile targets
-`ghcr.io/virtool/ts-pathoscope` — the cluster picks one by the image it pulls,
-and neither stream overwrites the other.
+`release-ghcr` pushes it on release. `ghcr.io/virtool/pathoscope` previously
+came from `virtool/workflow-pathoscope`, which shipped the Python workflow
+under that name; this repository's release supersedes it and owns the name now.
 
 **The crate is built on `rust:1.97-bookworm`.** The runtime copies binaries from
 the tool stages in the same file, which are built on `debian:bookworm`, so the

--- a/packages/workflow/src/config.test.ts
+++ b/packages/workflow/src/config.test.ts
@@ -31,7 +31,7 @@ describe("parseWorkflowRunConfig", () => {
 				VT_PROC: "8",
 				VT_TIMEOUT: "60",
 				VT_SENTRY_DSN: "https://key@sentry.example/1",
-				VT_IMAGE: "ghcr.io/virtool/ts-pathoscope:1.2.3",
+				VT_IMAGE: "ghcr.io/virtool/pathoscope:1.2.3",
 			}),
 		);
 
@@ -43,7 +43,7 @@ describe("parseWorkflowRunConfig", () => {
 			workPath: "/work",
 			timeout: 60,
 			sentryDsn: "https://key@sentry.example/1",
-			image: "ghcr.io/virtool/ts-pathoscope:1.2.3",
+			image: "ghcr.io/virtool/pathoscope:1.2.3",
 			storage: {
 				kind: "s3",
 				bucket: "virtool",
@@ -89,9 +89,9 @@ describe("parseWorkflowRunConfig", () => {
 		],
 		[
 			"VT_IMAGE",
-			"ghcr.io/virtool/ts-nuvs:2.0.0",
+			"ghcr.io/virtool/nuvs:2.0.0",
 			"image",
-			"ghcr.io/virtool/ts-nuvs:2.0.0",
+			"ghcr.io/virtool/nuvs:2.0.0",
 		],
 	])("resolves %s from its _FILE variant", (key, written, field, expected) => {
 		const env = minimalEnv({ [`${key}_FILE`]: writeSecret(written) });

--- a/packages/workflow/src/testing/builders.ts
+++ b/packages/workflow/src/testing/builders.ts
@@ -139,7 +139,7 @@ export function createFakeJobClaim(
 		runnerId: `runner-${random.hex(8)}`,
 		mem: 8,
 		cpu: 2,
-		image: "ghcr.io/virtool/ts-create-subtraction:1.0.0",
+		image: "ghcr.io/virtool/create-subtraction:1.0.0",
 		runtimeVersion: "1.0.0",
 		workflowVersion: "1.0.0",
 		...overrides,

--- a/packages/workflow/src/testing/jobsApi/server.test.ts
+++ b/packages/workflow/src/testing/jobsApi/server.test.ts
@@ -35,7 +35,7 @@ const CLAIM_REQUEST = {
 	runnerId: "runner-1",
 	mem: 8,
 	cpu: 2,
-	image: "ghcr.io/virtool/ts-create-subtraction:1.0.0",
+	image: "ghcr.io/virtool/create-subtraction:1.0.0",
 	runtimeVersion: "1.0.0",
 	workflowVersion: "1.0.0",
 	steps: [


### PR DESCRIPTION
## Summary
- `release-ghcr` now publishes each workflow image under one bare name (`create-sample`, `create-subtraction`, `pathoscope`, `nuvs`). The `ts-` prefix was a transitional second tag for the TypeScript port; existing `ts-` tags stay in the registry but never move again.
- Dropping the prefix from the `matrix.image` cache keys made the `cache-scope` override for pathoscope and nuvs redundant, so the release entries read `matrix.image` directly and still reuse the caches the long build jobs populate.
- Pointed the Tiltfile, dev manifests, docs, READMEs, and test fixtures at the bare names, and removed the "no usable `latest` yet, build locally" caveats — all four bare tags already resolve to the same digest as their `ts-` counterparts.