### PR TITLE
ci: stop the accessibility job hanging on apt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,9 +401,26 @@ jobs:
               uses: actions/checkout@v7
             # hts-sys runs bindgen against htslib's headers and does not fall
             # back to pre-generated bindings, so libclang is required here just
-            # as it is in the image build.
+            # as it is in the image build. Unlike the accessibility job's
+            # Playwright libraries it cannot simply be dropped, so apt is
+            # bounded instead. The runner's mirrorlist puts
+            # azure.archive.ubuntu.com first; when that host goes unreachable
+            # apt retries it for every index against a two-minute default
+            # timeout before falling back to archive.ubuntu.com, which reads as
+            # a hang. Rewriting the mirrorlist skips the dead host outright and
+            # the acquire options cap what a merely slow one can cost, for the
+            # package downloads as well as the index fetch. The step timeout is
+            # the backstop for both.
             - name: Install libclang
-              run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev
+              timeout-minutes: 5
+              run: |
+                  if [ -f /etc/apt/apt-mirrors.txt ]; then
+                      sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
+                  fi
+                  printf 'Acquire::Retries "2";\nAcquire::http::Timeout "15";\nAcquire::https::Timeout "15";\n' \
+                      | sudo tee /etc/apt/apt.conf.d/99-ci-timeouts > /dev/null
+                  sudo apt-get update
+                  sudo apt-get install -y --no-install-recommends libclang-dev
             # The `candidates` golden vectors shell out to bowtie2. Without it
             # the harness skips them; VT_REQUIRE_BOWTIE2 below turns that skip
             # into a failure so CI can never quietly stop checking them. It is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,8 +280,30 @@ jobs:
               uses: actions/checkout@v7
             - name: Setup
               uses: ./.github/actions/setup
+            # Keyed on the Playwright version rather than the lockfile hash:
+            # the browser revision a release pins is this cache's only input, so
+            # an unrelated dependency bump must not throw the download away. No
+            # `restore-keys` either — a near-miss restore would seed the
+            # directory with a revision `install` then downloads past, leaving
+            # both in the cache.
+            - name: Resolve Playwright version
+              id: playwright
+              run: echo "version=$(pnpm --filter @virtool/web exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+            - name: Cache Playwright browsers
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+            # No `--with-deps`. It shells out to `apt-get update && apt-get
+            # install`, which carries no timeout of its own: when the runner's
+            # Azure mirror goes unreachable apt falls back to
+            # archive.ubuntu.com and stalls until the job timeout kills it. The
+            # ubuntu-24.04 image ships Chrome and Edge, so Chromium's shared
+            # libraries are already present. The step timeout below is a
+            # backstop for a slow CDN, not for apt.
             - name: Install Playwright Chromium
-              run: pnpm --filter @virtool/web exec playwright install --with-deps chromium
+              run: pnpm --filter @virtool/web exec playwright install chromium
+              timeout-minutes: 5
             - name: Test
               run: VT_TEST_WORKERS=$(nproc) pnpm --filter @virtool/web exec vitest run --project a11y
               env:


### PR DESCRIPTION
## Summary
- Drop `--with-deps` from the Playwright install in `Web / Accessibility`. It shells out to `apt-get update && apt-get install`, which has no timeout of its own, so an unreachable Azure mirror stalls the step until the job timeout kills it. The `ubuntu-24.04` image ships Chrome and Edge, so Chromium's shared libraries are already present.
- Cache `~/.cache/ms-playwright`, keyed on the resolved Playwright version rather than the lockfile hash so an unrelated dependency bump does not discard the browser download.
- Cap the install step at `timeout-minutes: 5` as a fail-fast backstop for a slow CDN.