### PR TITLE
fix: record a changed BLAST envelope instead of retrying until expiry

### DIFF
--- a/packages/data/src/blast/data.test.ts
+++ b/packages/data/src/blast/data.test.ts
@@ -416,6 +416,31 @@ describe("sweepBlasts", () => {
 			);
 		});
 
+		it("records a changed result envelope as an error rather than backing off", async () => {
+			const analysisId = await seedAnalysis();
+			const blastId = await seedBlast(analysisId, {
+				rid: "RID001",
+				interval: 3,
+			});
+
+			const { program, ...report } = REPORT.BlastOutput2.report;
+
+			void program;
+
+			stubNcbi({
+				check: () => new Response("Status=READY"),
+				result: (rid) => zipResponse(rid, { BlastOutput2: { report } }),
+			});
+
+			await sweepBlasts(db, testLogger);
+
+			expect(await readBlast(blastId)).toMatchObject({
+				error: "BLAST result report has no program",
+				interval: 3,
+				ready: false,
+			});
+		});
+
 		it("backs off rather than recording an error when the fetch is refused", async () => {
 			const analysisId = await seedAnalysis();
 			const blastId = await seedBlast(analysisId, {

--- a/packages/data/src/blast/data.ts
+++ b/packages/data/src/blast/data.ts
@@ -327,15 +327,16 @@ async function readCheckValues(
 			result: formatBlastContent(await fetchBlastResult(row.rid, signal)),
 		};
 	} catch (err) {
-		/* Only bytes that are not a readable result stop here — that condition
-		   will not clear, so the row records it and stops asking. A refusal or a
-		   deadline is thrown on to the caller's backoff instead, being exactly
-		   what a later attempt might settle.
+		/* Only a result NCBI has already sent stops here — bytes that are not a
+		   zip of JSON, or an envelope whose shape has changed. Neither condition
+		   clears, so the row records it and stops asking; retrying would
+		   re-fetch the same bytes every pass until the row expired half an hour
+		   later, reporting a timeout for a fault that was visible on the first
+		   attempt. A refusal or a deadline is thrown on to the caller's backoff
+		   instead, being exactly what a later attempt might settle.
 
-		   An envelope whose shape has changed lands in the backoff too, and will
-		   fail identically every pass until the row expires. A shape change is
-		   not something a later attempt can settle, so such rows are abandoned
-		   rather than recorded as a readable result. */
+		   The message recorded is the parse failure's own, so the panel names
+		   the key that went missing rather than saying only that something did. */
 		if (err instanceof BlastResultUnreadableError) {
 			return { ...values, error: err.message };
 		}

--- a/packages/data/src/blast/data.ts
+++ b/packages/data/src/blast/data.ts
@@ -327,13 +327,10 @@ async function readCheckValues(
 			result: formatBlastContent(await fetchBlastResult(row.rid, signal)),
 		};
 	} catch (err) {
-		/* Only a result NCBI has already sent stops here — bytes that are not a
-		   zip of JSON, or an envelope whose shape has changed. Neither condition
-		   clears, so the row records it and stops asking; retrying would
-		   re-fetch the same bytes every pass until the row expired half an hour
-		   later, reporting a timeout for a fault that was visible on the first
-		   attempt. A refusal or a deadline is thrown on to the caller's backoff
-		   instead, being exactly what a later attempt might settle.
+		/* A result that arrived but cannot be read stops here and is recorded on
+		   the row; a refusal or a deadline is thrown on to the caller's backoff
+		   instead, being exactly what a later attempt might settle. See
+		   BlastResultUnreadableError for why the two are routed differently.
 
 		   The message recorded is the parse failure's own, so the panel names
 		   the key that went missing rather than saying only that something did. */

--- a/packages/data/src/blast/ncbi.test.ts
+++ b/packages/data/src/blast/ncbi.test.ts
@@ -370,19 +370,39 @@ describe("formatBlastContent", () => {
 		expect(formatBlastContent(unmasked).masking).toBeNull();
 	});
 
-	it("throws on a hit whose HSP has lost a field", async () => {
+	it("throws an unreadable error on a hit whose HSP has lost a field", async () => {
 		const damaged = structuredClone(raw);
 
 		damaged.BlastOutput2.report.results.search.hits[0].hsps[0] = {
 			score: 600,
 		} as unknown as (typeof raw.BlastOutput2.report.results.search.hits)[0]["hsps"][0];
 
-		expect(() => formatBlastContent(damaged)).toThrow(NcbiBlastError);
+		expect(() => formatBlastContent(damaged)).toThrow(
+			BlastResultUnreadableError,
+		);
 	});
 
-	it("throws on a result carrying more than one query", async () => {
+	it("throws an unreadable error on a result carrying more than one query", async () => {
 		expect(() =>
 			formatBlastContent({ BlastOutput2: { report: {}, extra: {} } }),
-		).toThrow(NcbiBlastError);
+		).toThrow(BlastResultUnreadableError);
+	});
+
+	it("throws an unreadable rather than a transient error on a missing envelope key", async () => {
+		const { program, ...report } = raw.BlastOutput2.report;
+
+		void program;
+
+		const error = (() => {
+			try {
+				formatBlastContent({ BlastOutput2: { report } });
+			} catch (err) {
+				return err;
+			}
+		})();
+
+		expect(error).toBeInstanceOf(BlastResultUnreadableError);
+		expect(error).not.toBeInstanceOf(NcbiBlastError);
+		expect((error as Error).message).toBe("BLAST result report has no program");
 	});
 });

--- a/packages/data/src/blast/ncbi.ts
+++ b/packages/data/src/blast/ncbi.ts
@@ -55,21 +55,26 @@ const SUBMIT_PARAMS = {
 };
 
 /**
- * Thrown when NCBI could not be reached, or answered something this side
- * cannot use.
+ * Thrown when NCBI could not be reached, or refused an exchange.
  *
  * Transient by assumption: the sweep backs the row off and tries again on a
  * later pass rather than recording anything on it. A condition that will not
- * clear on its own is written to the row's `error` column instead.
+ * clear on its own is {@link BlastResultUnreadableError} instead, and is
+ * written to the row's `error` column.
  */
 export class NcbiBlastError extends AppError {}
 
 /**
- * Thrown when a result arrived but could not be unpacked into JSON.
+ * Thrown when a result arrived but this side cannot make a stored result of
+ * it — bytes that are not a zip of JSON, or JSON whose envelope is not the
+ * shape {@link formatBlastContent} reduces.
  *
- * Distinct from {@link NcbiBlastError} because it is *not* transient — the
- * bytes NCBI holds for that RID will not become a zip on the next attempt — so
- * the sweep records it on the row and stops asking.
+ * Distinct from {@link NcbiBlastError} because it is *not* transient. The
+ * bytes NCBI holds for that RID will not become a zip on the next attempt, and
+ * an envelope NCBI has changed the shape of will not change back, so re-asking
+ * only reproduces the same failure every pass until the row expires half an
+ * hour later — telling the user the search timed out rather than what actually
+ * broke. The sweep records this on the row and stops asking.
  */
 export class BlastResultUnreadableError extends AppError {}
 
@@ -296,7 +301,7 @@ export async function fetchBlastResult(
 
 function readObject(value: JsonValue | undefined, path: string): JsonObject {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) {
-		throw new NcbiBlastError(`BLAST result has no ${path} object`);
+		throw new BlastResultUnreadableError(`BLAST result has no ${path} object`);
 	}
 
 	return value;
@@ -304,7 +309,7 @@ function readObject(value: JsonValue | undefined, path: string): JsonObject {
 
 function readArray(value: JsonValue | undefined, path: string): JsonValue[] {
 	if (!Array.isArray(value)) {
-		throw new NcbiBlastError(`BLAST result has no ${path} array`);
+		throw new BlastResultUnreadableError(`BLAST result has no ${path} array`);
 	}
 
 	return value;
@@ -312,9 +317,9 @@ function readArray(value: JsonValue | undefined, path: string): JsonValue[] {
 
 /**
  * Read a key that must be present, so a result that has lost it is a shape
- * change rather than a hit with a blank field. Failing here backs the row off
- * and leaves it for the next pass; defaulting it would store a result the SPA
- * renders as a real, empty answer.
+ * change rather than a hit with a blank field. Failing here records the row as
+ * unreadable; defaulting it would store a result the SPA renders as a real,
+ * empty answer.
  */
 function readRequired(
 	object: JsonObject,
@@ -324,7 +329,7 @@ function readRequired(
 	const value = object[key];
 
 	if (value === undefined) {
-		throw new NcbiBlastError(`BLAST result ${path} has no ${key}`);
+		throw new BlastResultUnreadableError(`BLAST result ${path} has no ${key}`);
 	}
 
 	return value;
@@ -382,13 +387,18 @@ function formatBlastHit(hit: JsonObject, path: string): JsonObject {
  * `masking` is the one key that may be absent; every other key is required and
  * throws when missing.
  *
+ * **Every throw here is a {@link BlastResultUnreadableError}, not an
+ * {@link NcbiBlastError}.** A missing key means NCBI has changed the shape it
+ * sends, which no later attempt settles, so the row records the failure and
+ * stops rather than re-fetching the same bytes until it expires.
+ *
  * The two single-key assertions are what rejects a multi-query result:
  * `HITLIST_SIZE` bounds the hits per query but nothing bounds the queries, and
  * a zip member carrying two would otherwise have its second silently dropped.
  */
 export function formatBlastContent(raw: JsonObject): JsonObject {
 	if (Object.keys(raw).length !== 1) {
-		throw new NcbiBlastError(
+		throw new BlastResultUnreadableError(
 			`Unexpected BLAST result count ${Object.keys(raw).length} returned`,
 		);
 	}
@@ -396,7 +406,7 @@ export function formatBlastContent(raw: JsonObject): JsonObject {
 	const outputs = readObject(raw.BlastOutput2, "BlastOutput2");
 
 	if (Object.keys(outputs).length !== 1) {
-		throw new NcbiBlastError(
+		throw new BlastResultUnreadableError(
 			`Unexpected BLAST result count ${Object.keys(outputs).length} returned`,
 		);
 	}


### PR DESCRIPTION
## Summary
- Envelope shape failures in `formatBlastContent` threw `NcbiBlastError`, which the sweep treats as transient. A result NCBI had already sent was re-fetched every pass for thirty minutes and then reported to the user as a timeout rather than the fault that was visible on the first attempt.
- Those throws are now `BlastResultUnreadableError`, so `readCheckValues` records the failure on the row and stops asking. The error classes' docs move with them: `NcbiBlastError` is now reached-or-refused, `BlastResultUnreadableError` covers both unreadable bytes and a changed shape.
- The row records the parse failure's own message, so the panel names the key that went missing.

Closes VIR-3002.