### PR TITLE
fix: scope the sample list total to what the caller may read

### DIFF
--- a/packages/contracts/src/search.ts
+++ b/packages/contracts/src/search.ts
@@ -2,9 +2,15 @@
  * The paginated search-result envelope returned by every server-function-backed
  * list. A domain carrying extra summary fields — a ready count, per-state job
  * counts — intersects this rather than restating the five.
+ *
+ * Both counts are scoped to what the caller may read. `totalCount` then counts
+ * everything in that scope, while `foundCount` also applies the narrowing
+ * filters the caller asked for, so a list can tell "you have none" apart from
+ * "your filters matched none". A domain with no narrowing filters reports the
+ * same number twice.
  */
 export type SearchResult = {
-	/** The number of items found */
+	/** The number of readable items matching the caller's filters */
 	foundCount: number;
 
 	/** The current page number */
@@ -16,6 +22,6 @@ export type SearchResult = {
 	/** The number of items per page */
 	perPage: number;
 
-	/** The total number of items */
+	/** The number of readable items before the caller's filters */
 	totalCount: number;
 };

--- a/packages/data/src/analyses/data.test.ts
+++ b/packages/data/src/analyses/data.test.ts
@@ -246,6 +246,7 @@ describe("findAnalyses", () => {
 
 		expect(result.items.map((item) => item.id)).toEqual([wanted]);
 		expect(result.foundCount).toBe(1);
+		expect(result.totalCount).toBe(2);
 	});
 
 	it("names the parent sample of each analysis", async () => {
@@ -273,6 +274,7 @@ describe("findAnalyses", () => {
 
 		expect(result.items.map((item) => item.id)).toEqual([wanted]);
 		expect(result.foundCount).toBe(1);
+		expect(result.totalCount).toBe(2);
 	});
 
 	it("intersects a userId with the caller's readable samples", async () => {
@@ -292,6 +294,7 @@ describe("findAnalyses", () => {
 
 		expect(result.items.map((item) => item.id)).toEqual([readable]);
 		expect(result.foundCount).toBe(1);
+		expect(result.totalCount).toBe(1);
 	});
 
 	it("orders by created_at descending, then id descending", async () => {

--- a/packages/data/src/analyses/data.ts
+++ b/packages/data/src/analyses/data.ts
@@ -354,7 +354,7 @@ export async function findAnalyses(
 
 	return {
 		foundCount,
-		// Both counts are the scoped one: `totalCount` is not an unscoped total.
+		// Every filter here scopes rather than narrows, so the two counts agree.
 		totalCount: foundCount,
 		page: options.page,
 		perPage: options.perPage,

--- a/packages/data/src/analyses/data.ts
+++ b/packages/data/src/analyses/data.ts
@@ -296,25 +296,24 @@ export async function findAnalyses(
 	options: FindAnalysesOptions,
 	actor: SampleActor,
 ): Promise<AnalysisSearchResult> {
-	const filters: SQL[] = [];
-
 	const readable = analysisReadableFilter(db, actor);
-	if (readable) {
-		filters.push(readable);
-	}
+	const narrowing: SQL[] = [];
 
 	if (options.sampleId !== undefined) {
-		filters.push(eq(analyses.sample_id, options.sampleId));
+		narrowing.push(eq(analyses.sample_id, options.sampleId));
 	}
 
 	if (options.userId !== undefined) {
-		filters.push(eq(analyses.user_id, options.userId));
+		narrowing.push(eq(analyses.user_id, options.userId));
 	}
 
-	const where = filters.length > 0 ? and(...filters) : undefined;
+	const where = narrowing.length > 0 ? and(readable, ...narrowing) : readable;
 
-	const [foundRows, rows] = await Promise.all([
-		db.select({ value: count() }).from(analyses).where(where),
+	const [totalRows, foundRows, rows] = await Promise.all([
+		db.select({ value: count() }).from(analyses).where(readable),
+		narrowing.length > 0
+			? db.select({ value: count() }).from(analyses).where(where)
+			: undefined,
 		// The index, reference and owner are one-to-one, so they join onto the
 		// analysis row. The index join is an outer join so an analysis whose index
 		// cannot be resolved surfaces loudly in `mapMinimal` rather than silently
@@ -338,7 +337,8 @@ export async function findAnalyses(
 			.limit(options.perPage),
 	]);
 
-	const foundCount = foundRows[0]?.value ?? 0;
+	const totalCount = totalRows[0]?.value ?? 0;
+	const foundCount = foundRows ? (foundRows[0]?.value ?? 0) : totalCount;
 
 	const analysisIds = rows.map((row) => row.id);
 	const jobIds = [
@@ -354,8 +354,7 @@ export async function findAnalyses(
 
 	return {
 		foundCount,
-		// Every filter here scopes rather than narrows, so the two counts agree.
-		totalCount: foundCount,
+		totalCount,
 		page: options.page,
 		perPage: options.perPage,
 		pageCount: foundCount ? Math.ceil(foundCount / options.perPage) : 0,

--- a/packages/data/src/samples/data.test.ts
+++ b/packages/data/src/samples/data.test.ts
@@ -265,13 +265,24 @@ describe("findSamples", () => {
 		expect(result.items).toHaveLength(2);
 	});
 
-	it("reports the unscoped total but the scoped found count", async () => {
+	it("leaves samples the caller cannot read out of both counts", async () => {
 		await seedSample({ user_id: ownerId, name: "Mine" });
 		const stranger = await seedUser(db, { handle: "stranger" });
 		await seedSample({ user_id: stranger, name: "Theirs" });
 
 		const actor = await resolveSampleActor(db, ownerId);
 		const result = await findSamples(db, options, actor);
+
+		expect(result.totalCount).toBe(1);
+		expect(result.foundCount).toBe(1);
+	});
+
+	it("narrows the found count by the search term, leaving totalCount whole", async () => {
+		await seedSample({ user_id: ownerId, name: "Apple" });
+		await seedSample({ user_id: ownerId, name: "Banana" });
+
+		const actor = await resolveSampleActor(db, ownerId);
+		const result = await findSamples(db, { ...options, term: "app" }, actor);
 
 		expect(result.totalCount).toBe(2);
 		expect(result.foundCount).toBe(1);

--- a/packages/data/src/samples/data.ts
+++ b/packages/data/src/samples/data.ts
@@ -589,23 +589,20 @@ export async function findSamples(
 	options: FindSamplesOptions,
 	actor: SampleActor,
 ): Promise<SampleSearchResult> {
-	const filters: SQL[] = [];
+	const baseFilter = sampleReadableFilter(actor);
 
-	const readable = sampleReadableFilter(actor);
-	if (readable) {
-		filters.push(readable);
-	}
+	const narrowing: SQL[] = [];
 
 	if (options.term) {
-		filters.push(ilike(legacySamples.name, `%${escapeLike(options.term)}%`));
+		narrowing.push(ilike(legacySamples.name, `%${escapeLike(options.term)}%`));
 	}
 
 	if (options.users.length > 0) {
-		filters.push(inArray(legacySamples.user_id, options.users));
+		narrowing.push(inArray(legacySamples.user_id, options.users));
 	}
 
 	if (options.labels.length > 0) {
-		filters.push(
+		narrowing.push(
 			inArray(
 				legacySamples.id,
 				db
@@ -618,16 +615,19 @@ export async function findSamples(
 
 	const workflowFilter = composeWorkflowFilter(db, options.workflows);
 	if (workflowFilter) {
-		filters.push(workflowFilter);
+		narrowing.push(workflowFilter);
 	}
 
-	const where = filters.length > 0 ? and(...filters) : undefined;
+	const where =
+		narrowing.length > 0 ? and(baseFilter, ...narrowing) : baseFilter;
 
 	const [totalRows, foundRows, rows] = await Promise.all([
-		// `total_count` is the unscoped grand total of samples, not the count
-		// visible to the caller.
-		db.select({ value: count() }).from(legacySamples),
-		db.select({ value: count() }).from(legacySamples).where(where),
+		db.select({ value: count() }).from(legacySamples).where(baseFilter),
+		// Without a narrowing filter the found count equals the total count, so
+		// skip the redundant query and reuse totalCount below.
+		narrowing.length > 0
+			? db.select({ value: count() }).from(legacySamples).where(where)
+			: undefined,
 		// The owner joins onto the sample row; the collection relationships fan
 		// out below, batched by the page's sample ids.
 		db
@@ -641,7 +641,7 @@ export async function findSamples(
 	]);
 
 	const totalCount = totalRows[0]?.value ?? 0;
-	const foundCount = foundRows[0]?.value ?? 0;
+	const foundCount = foundRows ? (foundRows[0]?.value ?? 0) : totalCount;
 
 	const sampleIds = rows.map(({ sample }) => sample.id);
 	const jobIds = [


### PR DESCRIPTION
## Summary

- `findSamples` counted every sample on the instance for `totalCount`, ignoring the readable filter that already scopes `foundCount` and the page itself, so a non-admin caller learned how many samples existed outside their permissions. The readable filter is now split from the narrowing ones (term, users, labels, workflows) and applied to the total query, matching `findReferences` and the other list endpoints.
- `totalCount` meant a scoped count on analyses and an unscoped grand total on samples (VIR-3005). Both were pinned for wire compatibility with an implementation that no longer exists. The rule the other ten endpoints already follow is now stated once on `SearchResult`: both counts are scoped to what the caller may read, and `foundCount` additionally applies the caller's filters.
- Analyses is unchanged. Its filters only scope, never narrow, so its two counts genuinely agree; the comment calling that an exception was corrected.

Admins see no change, since the readable filter is empty for them. No UI reads `samples.totalCount`, so the effect is limited to direct API consumers.