### PR TITLE
fix: align progress indicators across list items

### DIFF
--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -76,12 +76,14 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 					user={user.handle}
 					time={createdAt}
 				/>
-				<div className="flex justify-end items-center gap-2">
+				<div className="flex h-10 justify-end items-center gap-2">
 					{!ready && (
-						<ProgressCircle
-							progress={job?.progress ?? 0}
-							state={job?.state ?? "pending"}
-						/>
+						<span className="flex size-10 items-center justify-center">
+							<ProgressCircle
+								progress={job?.progress ?? 0}
+								state={job?.state ?? "pending"}
+							/>
+						</span>
 					)}
 					{canDelete && (
 						<AnalysisItemRightIcon

--- a/apps/web/src/references/components/ReferenceItem.tsx
+++ b/apps/web/src/references/components/ReferenceItem.tsx
@@ -34,10 +34,12 @@ export function ReferenceItem({ onClone, reference }: ReferenceItemProps) {
 
 	if (activeTask && !activeTask.complete) {
 		end = (
-			<ProgressCircle
-				progress={activeTask.progress || 0}
-				state={activeTask.complete ? "succeeded" : "running"}
-			/>
+			<span className="flex size-10 items-center justify-center">
+				<ProgressCircle
+					progress={activeTask.progress || 0}
+					state={activeTask.complete ? "succeeded" : "running"}
+				/>
+			</span>
 		);
 	} else if (archived) {
 		end = (


### PR DESCRIPTION
## Summary
- align analysis progress circles with job-list end icons
- give reference progress circles the same centered 40px slot