### PR TITLE
feat: send an instance NCBI API key with GenBank requests

### DIFF
--- a/apps/jobs-api/src/settings/handlers.test.ts
+++ b/apps/jobs-api/src/settings/handlers.test.ts
@@ -1,3 +1,4 @@
+import { WorkflowSettings } from "@virtool/contracts";
 import { seedUser } from "@virtool/data/auth/test/fixtures";
 import type { Db } from "@virtool/data/db/pg";
 import { jobs } from "@virtool/data/db/schema/jobs";
@@ -39,6 +40,16 @@ beforeEach(async () => {
 	deps = { db };
 });
 
+/**
+ * `DEFAULT_SETTINGS` as the wire carries it.
+ *
+ * The stored row and the wire shape no longer agree field for field —
+ * `ncbiApiKey` is a credential the handler does not serve — so the expectation
+ * is taken through the contract, which strips what does not belong on the wire,
+ * rather than from the data layer's constant.
+ */
+const DEFAULT_WORKFLOW_SETTINGS = WorkflowSettings.parse(DEFAULT_SETTINGS);
+
 function get(authenticated = true): Request {
 	return new Request("https://jobs.virtool.test/settings", {
 		headers: authenticated ? { authorization: `Basic ${credential}` } : {},
@@ -58,7 +69,7 @@ describe("handleGetSettings", () => {
 
 		expect(response.status).toBe(200);
 		expect(await response.json()).toEqual({
-			...DEFAULT_SETTINGS,
+			...DEFAULT_WORKFLOW_SETTINGS,
 			sampleAllWrite: true,
 			minimumPasswordLength: 12,
 		});
@@ -71,8 +82,26 @@ describe("handleGetSettings", () => {
 		const response = await handleGetSettings(deps, get());
 
 		expect(response.status).toBe(200);
-		expect(await response.json()).toEqual(DEFAULT_SETTINGS);
+		expect(await response.json()).toEqual(DEFAULT_WORKFLOW_SETTINGS);
 		expect(await db.select().from(settings)).toHaveLength(1);
+	});
+
+	// The NCBI API key is a credential. `toWorkflowSettings` names the fields it
+	// serves rather than spreading the row, so it cannot pick one up by accident
+	// — this holds that mapping to it.
+	it("never serves the NCBI API key", async () => {
+		await db.insert(settings).values({
+			id: 1,
+			...DEFAULT_SETTINGS,
+			ncbiApiKey: "secret-key",
+		});
+
+		const response = await handleGetSettings(deps, get());
+
+		const body = await response.json();
+
+		expect(body).not.toHaveProperty("ncbiApiKey");
+		expect(JSON.stringify(body)).not.toContain("secret-key");
 	});
 
 	it("refuses an unauthenticated request", async () => {

--- a/apps/web/src/administration/components/NcbiApiKey.tsx
+++ b/apps/web/src/administration/components/NcbiApiKey.tsx
@@ -1,0 +1,109 @@
+import { useFetchSettings, useUpdateSettings } from "@administration/queries";
+import BoxGroup from "@base/BoxGroup";
+import BoxGroupSection from "@base/BoxGroupSection";
+import Button from "@base/Button";
+import InputError from "@base/InputError";
+import InputGroup from "@base/InputGroup";
+import InputLabel from "@base/InputLabel";
+import InputPassword from "@base/InputPassword";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
+import SaveButton from "@base/SaveButton";
+import SectionHeader from "@base/SectionHeader";
+import { useForm } from "react-hook-form";
+
+type NcbiApiKeyFormValues = {
+	ncbiApiKey: string;
+};
+
+/**
+ * Set or clear the instance's NCBI API key.
+ *
+ * The key raises the rate limit NCBI applies to the deployment's GenBank
+ * lookups from three requests a second to ten.
+ *
+ * **The field starts empty however the setting is stored.** The server reports
+ * only whether a key is configured, never the key itself, so there is nothing
+ * to fill it in with — saving replaces whatever is stored and clearing removes
+ * it.
+ */
+export default function NcbiApiKey() {
+	const { data, isPending, isError } = useFetchSettings();
+	const mutation = useUpdateSettings();
+
+	const {
+		formState: { errors },
+		handleSubmit,
+		register,
+		reset,
+	} = useForm<NcbiApiKeyFormValues>({ defaultValues: { ncbiApiKey: "" } });
+
+	if (isError && !data) {
+		return <QueryError noun="settings" />;
+	}
+
+	if (isPending) {
+		return <LoadingPlaceholder />;
+	}
+
+	function save({ ncbiApiKey }: NcbiApiKeyFormValues) {
+		mutation.mutate(
+			{ ncbiApiKey: ncbiApiKey.trim() },
+			{ onSuccess: () => reset() },
+		);
+	}
+
+	return (
+		<section>
+			<SectionHeader>
+				<h2>NCBI API Key</h2>
+				<p>
+					Raise the rate limit NCBI applies to this instance when it looks up
+					GenBank records.
+				</p>
+			</SectionHeader>
+			<BoxGroup>
+				<BoxGroupSection>
+					<form onSubmit={handleSubmit(save)}>
+						<InputGroup>
+							<InputLabel htmlFor="ncbiApiKey">API Key</InputLabel>
+							<InputPassword
+								id="ncbiApiKey"
+								aria-describedby="ncbiApiKey-error"
+								aria-invalid={Boolean(errors.ncbiApiKey) || undefined}
+								autoComplete="off"
+								placeholder={
+									data.hasNcbiApiKey
+										? "A key is configured"
+										: "No key configured"
+								}
+								{...register("ncbiApiKey", {
+									required: "An API key is required.",
+								})}
+							/>
+							<InputError id="ncbiApiKey-error">
+								{errors.ncbiApiKey?.message}
+							</InputError>
+						</InputGroup>
+						<div className="flex justify-end gap-2">
+							{data.hasNcbiApiKey ? (
+								<Button
+									onClick={() => {
+										mutation.mutate(
+											{ ncbiApiKey: "" },
+											{ onSuccess: () => reset() },
+										);
+									}}
+									type="button"
+								>
+									Remove
+								</Button>
+							) : null}
+							<SaveButton />
+						</div>
+					</form>
+				</BoxGroupSection>
+			</BoxGroup>
+		</section>
+	);
+}

--- a/apps/web/src/administration/components/ServerSettings.tsx
+++ b/apps/web/src/administration/components/ServerSettings.tsx
@@ -1,10 +1,12 @@
 import ContainerNarrow from "@base/ContainerNarrow";
 import Banners from "./Banners";
+import NcbiApiKey from "./NcbiApiKey";
 
 export default function ServerSettings() {
 	return (
 		<ContainerNarrow>
 			<Banners />
+			<NcbiApiKey />
 		</ContainerNarrow>
 	);
 }

--- a/apps/web/src/administration/components/__tests__/NcbiApiKey.test.tsx
+++ b/apps/web/src/administration/components/__tests__/NcbiApiKey.test.tsx
@@ -1,0 +1,70 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createFakeSettings } from "@tests/fake/administrator";
+import { mockSettingsStore } from "@tests/server-fn/settings";
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+
+const { default: NcbiApiKey } = await import("../NcbiApiKey");
+
+describe("<NcbiApiKey>", () => {
+	it("saves a typed key and clears the field", async () => {
+		const { updateSettings } = mockSettingsStore(
+			createFakeSettings({ hasNcbiApiKey: false }),
+		);
+
+		renderWithProviders(<NcbiApiKey />);
+
+		const input = await screen.findByLabelText("API Key");
+		await userEvent.type(input, "  secret-key  ");
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(updateSettings).toHaveBeenCalledWith({
+				data: { ncbiApiKey: "secret-key" },
+			});
+		});
+
+		await waitFor(() => expect(input).toHaveValue(""));
+	});
+
+	it("refuses to save an empty field", async () => {
+		const { updateSettings } = mockSettingsStore(
+			createFakeSettings({ hasNcbiApiKey: false }),
+		);
+
+		renderWithProviders(<NcbiApiKey />);
+
+		await userEvent.click(await screen.findByRole("button", { name: "Save" }));
+
+		expect(await screen.findByText("An API key is required.")).toBeVisible();
+		expect(updateSettings).not.toHaveBeenCalled();
+	});
+
+	it("offers to remove a configured key", async () => {
+		const { updateSettings } = mockSettingsStore(
+			createFakeSettings({ hasNcbiApiKey: true }),
+		);
+
+		renderWithProviders(<NcbiApiKey />);
+
+		await userEvent.click(
+			await screen.findByRole("button", { name: "Remove" }),
+		);
+
+		await waitFor(() => {
+			expect(updateSettings).toHaveBeenCalledWith({ data: { ncbiApiKey: "" } });
+		});
+	});
+
+	it("offers no removal when no key is configured", async () => {
+		mockSettingsStore(createFakeSettings({ hasNcbiApiKey: false }));
+
+		renderWithProviders(<NcbiApiKey />);
+
+		expect(await screen.findByLabelText("API Key")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Remove" }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/administration/components/__tests__/NcbiApiKey.test.tsx
+++ b/apps/web/src/administration/components/__tests__/NcbiApiKey.test.tsx
@@ -1,13 +1,63 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeSettings } from "@tests/fake/administrator";
-import { mockSettingsStore } from "@tests/server-fn/settings";
+import {
+	mockSettingsStore,
+	settingsServerFnMocks,
+} from "@tests/server-fn/settings";
 import { renderWithProviders } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 
 const { default: NcbiApiKey } = await import("../NcbiApiKey");
 
 describe("<NcbiApiKey>", () => {
+	// The field is empty whichever way the setting is stored, so the placeholder
+	// is the only thing telling an administrator whether one is already set.
+	it("says a key is configured when one is", async () => {
+		mockSettingsStore(createFakeSettings({ hasNcbiApiKey: true }));
+
+		renderWithProviders(<NcbiApiKey />);
+
+		expect(await screen.findByLabelText("API Key")).toHaveAttribute(
+			"placeholder",
+			"A key is configured",
+		);
+	});
+
+	it("says no key is configured when none is", async () => {
+		mockSettingsStore(createFakeSettings({ hasNcbiApiKey: false }));
+
+		renderWithProviders(<NcbiApiKey />);
+
+		expect(await screen.findByLabelText("API Key")).toHaveAttribute(
+			"placeholder",
+			"No key configured",
+		);
+	});
+
+	it("shows a loader while the settings are pending", () => {
+		settingsServerFnMocks.getSettingsFn.mockReturnValue(
+			new Promise(() => undefined),
+		);
+
+		renderWithProviders(<NcbiApiKey />);
+
+		expect(screen.getByRole("status", { name: "loading" })).toBeInTheDocument();
+		expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+	});
+
+	// A `settings` role is what `getSettingsFn` demands, but the route itself only
+	// gates on `users`, so a lesser administrator reaching it is refused here.
+	it("shows an error when the settings cannot be read", async () => {
+		settingsServerFnMocks.getSettingsFn.mockRejectedValue(
+			new Error("Forbidden"),
+		);
+
+		renderWithProviders(<NcbiApiKey />);
+
+		expect(await screen.findByText(/couldn't load settings/i)).toBeVisible();
+	});
+
 	it("saves a typed key and clears the field", async () => {
 		const { updateSettings } = mockSettingsStore(
 			createFakeSettings({ hasNcbiApiKey: false }),

--- a/apps/web/src/administration/queries.ts
+++ b/apps/web/src/administration/queries.ts
@@ -12,7 +12,7 @@ import {
 	useQueryClient,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import type { Settings } from "./types";
+import type { Settings } from "@virtool/contracts";
 
 /** Fields that can be changed when updating the server settings */
 export type SettingsUpdate = {

--- a/apps/web/src/administration/queries.ts
+++ b/apps/web/src/administration/queries.ts
@@ -19,6 +19,8 @@ export type SettingsUpdate = {
 	defaultSourceTypes?: string[];
 	enableSentry?: boolean;
 	minimumPasswordLength?: number;
+	/** A new NCBI API key, or `""` to clear the configured one. */
+	ncbiApiKey?: string;
 	sampleAllRead?: boolean;
 	sampleAllWrite?: boolean;
 	sampleGroup?: string;
@@ -34,6 +36,18 @@ export function settingsQueryOptions() {
 		queryKey: settingsQueryKeys.all(),
 		queryFn: () => getSettingsFn(),
 	});
+}
+
+/**
+ * Fetch the API settings without suspending.
+ *
+ * For components on routes that do not prefetch the settings, and for the
+ * settings route itself, which any `users` administrator can reach but only a
+ * `settings` administrator may read — so the query has to be allowed to fail
+ * beside the parts of the view that do render.
+ */
+export function useFetchSettings() {
+	return useQuery(settingsQueryOptions());
 }
 
 /**

--- a/apps/web/src/administration/types.ts
+++ b/apps/web/src/administration/types.ts
@@ -14,11 +14,16 @@ export type AdministratorRole = {
 };
 
 /**
- * Instance-wide settings
+ * Instance-wide settings, as the server publishes them.
+ *
+ * The NCBI API key is a credential and never crosses the wire. Only
+ * `hasNcbiApiKey` says whether one is configured; the form writes a new key or
+ * clears it, and cannot read the stored one back.
  */
 export type Settings = {
 	defaultSourceTypes: string[];
 	enableSentry: boolean;
+	hasNcbiApiKey: boolean;
 	minimumPasswordLength: number;
 	sampleAllRead: boolean;
 	sampleAllWrite: boolean;

--- a/apps/web/src/administration/types.ts
+++ b/apps/web/src/administration/types.ts
@@ -12,22 +12,3 @@ export type AdministratorRole = {
 	id: AdministratorRoleName;
 	name: string;
 };
-
-/**
- * Instance-wide settings, as the server publishes them.
- *
- * The NCBI API key is a credential and never crosses the wire. Only
- * `hasNcbiApiKey` says whether one is configured; the form writes a new key or
- * clears it, and cannot read the stored one back.
- */
-export type Settings = {
-	defaultSourceTypes: string[];
-	enableSentry: boolean;
-	hasNcbiApiKey: boolean;
-	minimumPasswordLength: number;
-	sampleAllRead: boolean;
-	sampleAllWrite: boolean;
-	sampleGroup: string;
-	sampleGroupRead: boolean;
-	sampleGroupWrite: boolean;
-};

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -1,5 +1,5 @@
 import { settingsQueryKeys } from "@administration/keys";
-import type { Settings } from "@administration/types";
+
 import { referenceQueryKeys } from "@references/keys";
 import {
 	addReferenceGroupFn,
@@ -31,6 +31,7 @@ import type {
 	ReferenceSearchResult,
 	ReferenceUpdateRequest,
 	ReferenceUser,
+	Settings,
 } from "@virtool/contracts";
 import { useState } from "react";
 

--- a/apps/web/src/samples/components/SampleRights.tsx
+++ b/apps/web/src/samples/components/SampleRights.tsx
@@ -1,11 +1,11 @@
 import { useUpdateSettings } from "@administration/queries";
-import type { Settings } from "@administration/types";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import { SelectBox, SelectBoxItem } from "@base/SelectBox";
+import type { Settings } from "@virtool/contracts";
 import RightsSelect from "./RightsSelect";
 
 type SampleRightsProps = {

--- a/apps/web/src/server/genbank/functions.ts
+++ b/apps/web/src/server/genbank/functions.ts
@@ -4,8 +4,10 @@ import {
 	GenbankUnreachableError,
 	getGenbank,
 } from "@virtool/data/genbank/data";
+import { getSettings } from "@virtool/data/settings/data";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
+import { db } from "../composition";
 import { ClientError } from "../errors";
 import { logger } from "../logger";
 
@@ -33,15 +35,22 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
  * Look a sequence up in GenBank by accession, so the sequence form can fill
  * itself in.
  *
- * A pure outbound proxy — nothing here touches the database. It stays behind a
- * session because an open endpoint would let anyone use the deployment as an
- * unmetered NCBI relay under Virtool's `tool` and `email` identifiers.
+ * The one database read is the instance's NCBI API key, which raises the rate
+ * limit NCBI applies to the deployment. It is read here rather than in
+ * `getGenbank` so the data layer carries no settings dependency, and it is
+ * handed straight to the request without being logged or returned.
+ *
+ * It stays behind a session because an open endpoint would let anyone use the
+ * deployment as an unmetered NCBI relay under Virtool's `tool` and `email`
+ * identifiers — and, now, its API key.
  */
 export const getGenbankFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(accessionSchema)
 	.handler(async ({ data }) => {
-		const record = await getGenbank(logger, data.accession).catch(
+		const { ncbiApiKey } = await getSettings(db);
+
+		const record = await getGenbank(logger, data.accession, ncbiApiKey).catch(
 			rethrowAsHttp,
 		);
 

--- a/apps/web/src/server/settings/functions.test.ts
+++ b/apps/web/src/server/settings/functions.test.ts
@@ -103,6 +103,26 @@ describe("getSettings", () => {
 			sampleGroup: "force_choice",
 		});
 	});
+
+	it("reports the NCBI API key as a flag and never sends the key", async () => {
+		await signIn(db, getRequest, { administratorRole: "settings" });
+		await seedSettings(db, { ncbiApiKey: "secret-key" });
+
+		const published = await call("getSettingsFn");
+
+		expect(published).toMatchObject({ hasNcbiApiKey: true });
+		expect(published).not.toHaveProperty("ncbiApiKey");
+		expect(JSON.stringify(published)).not.toContain("secret-key");
+	});
+
+	it("reports no NCBI API key when the stored one is empty", async () => {
+		await signIn(db, getRequest, { administratorRole: "settings" });
+		await seedSettings(db, { ncbiApiKey: "" });
+
+		await expect(call("getSettingsFn")).resolves.toMatchObject({
+			hasNcbiApiKey: false,
+		});
+	});
 });
 
 describe("updateSettings", () => {
@@ -150,5 +170,39 @@ describe("updateSettings", () => {
 	it("rejects an empty patch", async () => {
 		await signIn(db, getRequest, { administratorRole: "settings" });
 		await expect(call("updateSettingsFn", {})).rejects.toThrow();
+	});
+
+	it("stores an NCBI API key without echoing it back", async () => {
+		await signIn(db, getRequest, { administratorRole: "settings" });
+		await seedSettings(db);
+
+		const published = await call("updateSettingsFn", {
+			ncbiApiKey: "  secret-key  ",
+		});
+
+		expect(published).toMatchObject({ hasNcbiApiKey: true });
+		expect(JSON.stringify(published)).not.toContain("secret-key");
+
+		const [row] = await db.select().from(settings);
+		expect(row).toMatchObject({ ncbiApiKey: "secret-key" });
+	});
+
+	it("clears the NCBI API key when given an empty string", async () => {
+		await signIn(db, getRequest, { administratorRole: "settings" });
+		await seedSettings(db, { ncbiApiKey: "secret-key" });
+
+		await expect(
+			call("updateSettingsFn", { ncbiApiKey: "" }),
+		).resolves.toMatchObject({ hasNcbiApiKey: false });
+
+		const [row] = await db.select().from(settings);
+		expect(row).toMatchObject({ ncbiApiKey: "" });
+	});
+
+	it("rejects an NCBI API key longer than the column should hold", async () => {
+		await signIn(db, getRequest, { administratorRole: "settings" });
+		await expect(
+			call("updateSettingsFn", { ncbiApiKey: "a".repeat(129) }),
+		).rejects.toThrow();
 	});
 });

--- a/apps/web/src/server/settings/functions.ts
+++ b/apps/web/src/server/settings/functions.ts
@@ -1,11 +1,12 @@
 import { createServerFn } from "@tanstack/react-start";
 import {
 	type SampleGroup,
+	type Settings,
 	sampleGroups,
-} from "@virtool/data/db/schema/settings";
+} from "@virtool/contracts";
 import {
 	getSettings,
-	type Settings,
+	type Settings as StoredSettings,
 	updateSettings,
 } from "@virtool/data/settings/data";
 import { z } from "zod";
@@ -18,17 +19,6 @@ export type PasswordPolicy = {
 };
 
 /**
- * The instance settings as a client sees them.
- *
- * Every stored setting except the NCBI API key, which is a credential and is
- * reported only as whether one is configured. A client writes the key and never
- * reads it back.
- */
-export type PublicSettings = Omit<Settings, "ncbiApiKey"> & {
-	hasNcbiApiKey: boolean;
-};
-
-/**
  * Reduce the stored settings to what may cross the wire.
  *
  * Both settings functions answer any administrator holding the `settings` role,
@@ -36,7 +26,7 @@ export type PublicSettings = Omit<Settings, "ncbiApiKey"> & {
  * payload. Narrowing here rather than in the data layer keeps the redaction on
  * the transport boundary, where the row is published.
  */
-function toPublicSettings({ ncbiApiKey, ...rest }: Settings): PublicSettings {
+function toSettings({ ncbiApiKey, ...rest }: StoredSettings): Settings {
 	return { ...rest, hasNcbiApiKey: ncbiApiKey !== "" };
 }
 
@@ -93,15 +83,12 @@ const updateSettingsSchema = z
 
 export const getSettingsFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("settings")])
-	.handler(
-		async (): Promise<PublicSettings> =>
-			toPublicSettings(await getSettings(db)),
-	);
+	.handler(async (): Promise<Settings> => toSettings(await getSettings(db)));
 
 export const updateSettingsFn = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.validator(updateSettingsSchema)
 	.handler(
-		async ({ data }): Promise<PublicSettings> =>
-			toPublicSettings(await updateSettings(db, data)),
+		async ({ data }): Promise<Settings> =>
+			toSettings(await updateSettings(db, data)),
 	);

--- a/apps/web/src/server/settings/functions.ts
+++ b/apps/web/src/server/settings/functions.ts
@@ -18,6 +18,29 @@ export type PasswordPolicy = {
 };
 
 /**
+ * The instance settings as a client sees them.
+ *
+ * Every stored setting except the NCBI API key, which is a credential and is
+ * reported only as whether one is configured. A client writes the key and never
+ * reads it back.
+ */
+export type PublicSettings = Omit<Settings, "ncbiApiKey"> & {
+	hasNcbiApiKey: boolean;
+};
+
+/**
+ * Reduce the stored settings to what may cross the wire.
+ *
+ * Both settings functions answer any administrator holding the `settings` role,
+ * so returning the row as stored would put the NCBI API key in a browser
+ * payload. Narrowing here rather than in the data layer keeps the redaction on
+ * the transport boundary, where the row is published.
+ */
+function toPublicSettings({ ncbiApiKey, ...rest }: Settings): PublicSettings {
+	return { ...rest, hasNcbiApiKey: ncbiApiKey !== "" };
+}
+
+/**
  * Password policy server function. Unauthenticated by necessity — the
  * forced-reset and first-user forms both set a password before any session
  * exists, and they can only apply the configured minimum if they can read it.
@@ -33,11 +56,24 @@ export const getPasswordPolicyFn = createServerFn({ method: "GET" })
 		return { minimumPasswordLength };
 	});
 
+/**
+ * The longest NCBI API key accepted.
+ *
+ * NCBI issues a 36-character hexadecimal key today. The bound is generous
+ * rather than exact so a format change does not lock administrators out of
+ * saving one, and exists only to stop an unbounded string reaching the column.
+ */
+const MAX_NCBI_API_KEY_LENGTH = 128;
+
 const updateSettingsSchema = z
 	.object({
 		defaultSourceTypes: z.array(z.string()).optional(),
 		enableSentry: z.boolean().optional(),
 		minimumPasswordLength: z.number().int().min(1).optional(),
+		// Trimmed, so a pasted key carrying whitespace is stored as the key
+		// itself. Empty is how a key is cleared, and is what the request layer
+		// reads as unset.
+		ncbiApiKey: z.string().trim().max(MAX_NCBI_API_KEY_LENGTH).optional(),
 		sampleAllRead: z.boolean().optional(),
 		sampleAllWrite: z.boolean().optional(),
 		sampleGroup: z
@@ -57,9 +93,15 @@ const updateSettingsSchema = z
 
 export const getSettingsFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("settings")])
-	.handler(async (): Promise<Settings> => getSettings(db));
+	.handler(
+		async (): Promise<PublicSettings> =>
+			toPublicSettings(await getSettings(db)),
+	);
 
 export const updateSettingsFn = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.validator(updateSettingsSchema)
-	.handler(async ({ data }): Promise<Settings> => updateSettings(db, data));
+	.handler(
+		async ({ data }): Promise<PublicSettings> =>
+			toPublicSettings(await updateSettings(db, data)),
+	);

--- a/apps/web/src/tests/fake/administrator.ts
+++ b/apps/web/src/tests/fake/administrator.ts
@@ -1,5 +1,6 @@
-import type { AdministratorRole, Settings } from "@administration/types";
+import type { AdministratorRole } from "@administration/types";
 import { faker } from "@faker-js/faker";
+import type { Settings } from "@virtool/contracts";
 
 export const administratorRoles: AdministratorRole[] = [
 	{
@@ -31,7 +32,7 @@ export const administratorRoles: AdministratorRole[] = [
  * @param overrides - optional properties for creating fake settings with specific values
  */
 export function createFakeSettings(overrides?: Partial<Settings>): Settings {
-	const defaultSettings = {
+	const defaultSettings: Settings = {
 		defaultSourceTypes: [faker.word.noun({ strategy: "any-length" })],
 		enableSentry: faker.datatype.boolean(),
 		hasNcbiApiKey: false,

--- a/apps/web/src/tests/fake/administrator.ts
+++ b/apps/web/src/tests/fake/administrator.ts
@@ -34,6 +34,7 @@ export function createFakeSettings(overrides?: Partial<Settings>): Settings {
 	const defaultSettings = {
 		defaultSourceTypes: [faker.word.noun({ strategy: "any-length" })],
 		enableSentry: faker.datatype.boolean(),
+		hasNcbiApiKey: false,
 		minimumPasswordLength: 8,
 		sampleAllRead: faker.datatype.boolean(),
 		sampleAllWrite: faker.datatype.boolean(),

--- a/apps/web/src/tests/server-fn/settings.ts
+++ b/apps/web/src/tests/server-fn/settings.ts
@@ -1,5 +1,7 @@
-import type { Settings } from "@administration/types";
-import { DEFAULT_MINIMUM_PASSWORD_LENGTH } from "@virtool/contracts";
+import {
+	DEFAULT_MINIMUM_PASSWORD_LENGTH,
+	type Settings,
+} from "@virtool/contracts";
 import { type Mock, vi } from "vitest";
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -22,6 +22,7 @@ export * from "./references";
 export * from "./samples";
 export * from "./search";
 export * from "./sessions";
+export * from "./settings";
 export * from "./sse";
 export * from "./subtractions";
 export * from "./tasks";

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -1,0 +1,39 @@
+/**
+ * The group-access policies a newly created sample can be assigned.
+ *
+ * `settings.sample_group` is a `text` column closed by the
+ * `ck_settings_sample_group` CHECK constraint; this is the one declaration of
+ * what that constraint admits, imported by the schema mirror rather than
+ * restated there.
+ */
+export const sampleGroups = [
+	"none",
+	"force_choice",
+	"users_primary_group",
+] as const;
+
+/** The group-access policy applied to a newly created sample. */
+export type SampleGroup = (typeof sampleGroups)[number];
+
+/**
+ * The instance settings singleton, as an administration client reads it.
+ *
+ * Every stored setting except the NCBI API key, which is a credential:
+ * `hasNcbiApiKey` reports only whether one is configured, and the key itself
+ * never crosses the wire. A client writes a new key or clears it, and never
+ * reads one back. `apps/web`'s settings server functions do that narrowing.
+ *
+ * Distinct from {@link WorkflowSettings}, which is what the jobs API serves to
+ * a workflow and carries no NCBI field at all.
+ */
+export type Settings = {
+	defaultSourceTypes: string[];
+	enableSentry: boolean;
+	hasNcbiApiKey: boolean;
+	minimumPasswordLength: number;
+	sampleAllRead: boolean;
+	sampleAllWrite: boolean;
+	sampleGroup: SampleGroup;
+	sampleGroupRead: boolean;
+	sampleGroupWrite: boolean;
+};

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -190,6 +190,20 @@ module-scope client construction. The token has no version because this package
 cannot access the app-specific build versions used by `apps/web` and
 `apps/tasks`.
 
+### NCBI API key
+
+`getGenbank` takes the instance's NCBI API key as an argument and appends it as
+`api_key`, which raises the E-utilities rate limit from three requests a second
+to ten. An empty string means no key is configured and the parameter is omitted
+entirely; NCBI refuses a blank one rather than falling back to the anonymous
+tier.
+
+The key is stored in the `settings` row and read by the caller, not here, so
+this package takes no settings dependency for it. It is a credential: never log
+the request URL, and publish only whether a key is configured. `apps/web`'s
+settings server functions do that narrowing, and `ncbiApiKey` is in the shared
+logger's redaction paths.
+
 ## Task queue
 
 `src/tasks/data.ts` owns persistence for the Postgres task queue shared by task

--- a/packages/data/drizzle/0006_add_settings_ncbi_api_key.sql
+++ b/packages/data/drizzle/0006_add_settings_ncbi_api_key.sql
@@ -1,0 +1,6 @@
+-- The default is transient. `settings` already carries its singleton row, so a
+-- NOT NULL column cannot be added without one; and no column in this table has
+-- a server default — every value is written on insert from `DEFAULT_SETTINGS` —
+-- so the default is dropped again once the existing row has been filled.
+ALTER TABLE "settings" ADD COLUMN "ncbi_api_key" text NOT NULL DEFAULT '';--> statement-breakpoint
+ALTER TABLE "settings" ALTER COLUMN "ncbi_api_key" DROP DEFAULT;

--- a/packages/data/drizzle/meta/0006_snapshot.json
+++ b/packages/data/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,4190 @@
+{
+  "id": "96cd9a38-fe24-4344-98fa-d95d90a3907a",
+  "prevId": "243dc35d-e577-47ca-aeb5-5343ae93483f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analyses_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_analyses_sample": {
+          "name": "ix_analyses_sample",
+          "columns": [
+            {
+              "expression": "sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_analyses_sample_id_workflow": {
+          "name": "ix_analyses_sample_id_workflow",
+          "columns": [
+            {
+              "expression": "sample_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analyses_sample_id_fkey": {
+          "name": "analyses_sample_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_index_id_fkey": {
+          "name": "analyses_index_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_user_id_fkey": {
+          "name": "analyses_user_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_job_id_fkey": {
+          "name": "analyses_job_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analyses_legacy_id_key": {
+          "name": "analyses_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_files": {
+      "name": "analysis_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_files_analysis_id_fkey": {
+          "name": "analysis_files_analysis_id_fkey",
+          "tableFrom": "analysis_files",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_files_name_on_disk_key": {
+          "name": "analysis_files_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_analysis_files_storage_key": {
+          "name": "uq_analysis_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_analysis_files_format": {
+          "name": "ck_analysis_files_format",
+          "value": "\"analysis_files\".\"format\" in ('sam', 'bam', 'fasta', 'fastq', 'csv', 'tsv', 'json')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_subtractions": {
+      "name": "analysis_subtractions",
+      "schema": "",
+      "columns": {
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_analysis_subtractions_subtraction_id": {
+          "name": "ix_analysis_subtractions_subtraction_id",
+          "columns": [
+            {
+              "expression": "subtraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_subtractions_analysis_id_fkey": {
+          "name": "analysis_subtractions_analysis_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_subtractions_subtraction_id_fkey": {
+          "name": "analysis_subtractions_subtraction_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analysis_subtractions_pkey": {
+          "name": "analysis_subtractions_pkey",
+          "columns": [
+            "analysis_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nuvs_blast": {
+      "name": "nuvs_blast",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rid": {
+          "name": "rid",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nuvs_blast_analysis_id_fkey": {
+          "name": "nuvs_blast_analysis_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nuvs_blast_task_id_fkey": {
+          "name": "nuvs_blast_task_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nuvs_blast_analysis_id_sequence_index_key": {
+          "name": "nuvs_blast_analysis_id_sequence_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_id",
+            "sequence_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hashed": {
+          "name": "hashed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key": {
+          "name": "api_keys_hashed_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caches": {
+      "name": "caches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_caches_last_accessed_at_id": {
+          "name": "ix_caches_last_accessed_at_id",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cache_key": {
+          "name": "cache_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "caches_storage_key_key": {
+          "name": "caches_storage_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_name_unique": {
+          "name": "groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "groups_legacy_id_key": {
+          "name": "groups_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "primary_group_unique": {
+          "name": "primary_group_unique",
+          "columns": [
+            {
+              "expression": "primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_group_id_fkey": {
+          "name": "user_groups_group_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_user_id_fkey": {
+          "name": "user_groups_user_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_pkey": {
+          "name": "user_groups_pkey",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history": {
+      "name": "legacy_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu": {
+          "name": "otu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_name": {
+          "name": "otu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_version": {
+          "name": "otu_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_history_index": {
+          "name": "ix_legacy_history_index",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_index_id": {
+          "name": "ix_legacy_history_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_otu_otu_version": {
+          "name": "ix_legacy_history_otu_otu_version",
+          "columns": [
+            {
+              "expression": "otu",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "otu_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_reference": {
+          "name": "ix_legacy_history_reference",
+          "columns": [
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_reference_id": {
+          "name": "ix_legacy_history_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_user_id": {
+          "name": "ix_legacy_history_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_history_user_id_fkey": {
+          "name": "legacy_history_user_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_reference_id_fkey": {
+          "name": "legacy_history_reference_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_index_id_fkey": {
+          "name": "legacy_history_index_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_history_legacy_id_key": {
+          "name": "legacy_history_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history_diff": {
+      "name": "legacy_history_diff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_history_diff_history_id_fkey": {
+          "name": "legacy_history_diff_history_id_fkey",
+          "tableFrom": "legacy_history_diff",
+          "tableTo": "legacy_history",
+          "columnsFrom": [
+            "history_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "history_diffs_pkey": {
+          "name": "history_diffs_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "history_diffs_change_id_key": {
+          "name": "history_diffs_change_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_id"
+          ]
+        },
+        "legacy_history_diff_history_id_key": {
+          "name": "legacy_history_diff_history_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "history_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmms": {
+      "name": "hmms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hmms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster": {
+          "name": "cluster",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_entropy": {
+          "name": "mean_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_entropy": {
+          "name": "total_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "names": {
+          "name": "names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "families": {
+          "name": "families",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genera": {
+          "name": "genera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmms_legacy_id_key": {
+          "name": "hmms_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_hmm_status": {
+      "name": "legacy_hmm_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed": {
+          "name": "installed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updates": {
+          "name": "updates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_hmm_status_task_id_fkey": {
+          "name": "legacy_hmm_status_task_id_fkey",
+          "tableFrom": "legacy_hmm_status",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_legacy_hmm_status_singleton": {
+          "name": "ck_legacy_hmm_status_singleton",
+          "value": "\"legacy_hmm_status\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.index_files": {
+      "name": "index_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "index_files_index_id_fkey": {
+          "name": "index_files_index_id_fkey",
+          "tableFrom": "index_files",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_index_files_storage_key": {
+          "name": "uq_index_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "index_files_index_id_name_key": {
+          "name": "index_files_index_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_index_files_type": {
+          "name": "ck_index_files_type",
+          "value": "\"index_files\".\"type\" in ('json', 'fasta', 'bowtie2', 'sqlite')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.indexes": {
+      "name": "indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "indexes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otus_json_storage_key": {
+          "name": "otus_json_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "indexes_reference_id_fkey": {
+          "name": "indexes_reference_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_user_id_fkey": {
+          "name": "indexes_user_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_job_id_fkey": {
+          "name": "indexes_job_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_task_id_fkey": {
+          "name": "indexes_task_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "indexes_legacy_id_key": {
+          "name": "indexes_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "indexes_storage_key_key": {
+          "name": "indexes_storage_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "uq_indexes_otus_json_storage_key": {
+          "name": "uq_indexes_otus_json_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "otus_json_storage_key"
+          ]
+        },
+        "uq_indexes_reference_id_version": {
+          "name": "uq_indexes_reference_id_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_indexes_job_or_task": {
+          "name": "ck_indexes_job_or_task",
+          "value": "num_nonnulls(\"indexes\".\"job_id\", \"indexes\".\"task_id\") <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "acquired": {
+          "name": "acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claim": {
+          "name": "claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinged_at": {
+          "name": "pinged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_jobs_state_created_at": {
+          "name": "ix_jobs_state_created_at",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_user_id_state": {
+          "name": "ix_jobs_user_id_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_workflow_state": {
+          "name": "ix_jobs_workflow_state",
+          "columns": [
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_active": {
+          "name": "idx_jobs_active",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"state\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_user_id_fkey": {
+          "name": "jobs_user_id_fkey",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_legacy_id_key": {
+          "name": "jobs_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_jobs_state": {
+          "name": "ck_jobs_state",
+          "value": "\"jobs\".\"state\" in ('pending', 'running', 'cancelled', 'failed', 'succeeded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_name_key": {
+          "name": "labels_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_messages": {
+      "name": "instance_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "instance_messages_one_active": {
+          "name": "instance_messages_one_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"instance_messages\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instance_messages_user_id_fkey": {
+          "name": "instance_messages_user_id_fkey",
+          "tableFrom": "instance_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_instance_messages_color": {
+          "name": "ck_instance_messages_color",
+          "value": "\"instance_messages\".\"color\" in ('red', 'yellow', 'blue', 'purple', 'orange', 'grey')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.alembic_version": {
+      "name": "alembic_version",
+      "schema": "",
+      "columns": {
+        "version_num": {
+          "name": "version_num",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "alembic_version_pkc": {
+          "name": "alembic_version_pkc",
+          "columns": [
+            "version_num"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revisions": {
+      "name": "revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "revisions_revision_key": {
+          "name": "revisions_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "revision"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_otus": {
+      "name": "legacy_otus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_indexed_version": {
+          "name": "last_indexed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_legacy_otus_reference_id": {
+          "name": "ix_legacy_otus_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_otus_name_lower": {
+          "name": "legacy_otus_name_lower",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_otus_reference_id_fkey": {
+          "name": "legacy_otus_reference_id_fkey",
+          "tableFrom": "legacy_otus",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sequences": {
+      "name": "legacy_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_id": {
+          "name": "otu_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate_id": {
+          "name": "isolate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_sequences_otu_id": {
+          "name": "ix_legacy_sequences_otu_id",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_sequences_otu_id_position": {
+          "name": "ix_legacy_sequences_otu_id_position",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_sequences_otu_id_fkey": {
+          "name": "legacy_sequences_otu_id_fkey",
+          "tableFrom": "legacy_sequences",
+          "tableTo": "legacy_otus",
+          "columnsFrom": [
+            "otu_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_groups": {
+      "name": "legacy_reference_groups",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_groups_reference_id_fkey": {
+          "name": "legacy_reference_groups_reference_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_groups_group_id_fkey": {
+          "name": "legacy_reference_groups_group_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_groups_pkey": {
+          "name": "legacy_reference_groups_pkey",
+          "columns": [
+            "reference_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_users": {
+      "name": "legacy_reference_users",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_users_reference_id_fkey": {
+          "name": "legacy_reference_users_reference_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_users_user_id_fkey": {
+          "name": "legacy_reference_users_user_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_users_pkey": {
+          "name": "legacy_reference_users_pkey",
+          "columns": [
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_references": {
+      "name": "legacy_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_references_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organism": {
+          "name": "organism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restrict_source_types": {
+          "name": "restrict_source_types",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_types": {
+          "name": "source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloned_from_id": {
+          "name": "cloned_from_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_references_user_id_fkey": {
+          "name": "legacy_references_user_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_upload_id_fkey": {
+          "name": "legacy_references_upload_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_cloned_from_id_fkey": {
+          "name": "legacy_references_cloned_from_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "cloned_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_task_id_fkey": {
+          "name": "legacy_references_task_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_references_legacy_id_key": {
+          "name": "legacy_references_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_labels": {
+      "name": "legacy_sample_labels",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_labels_sample_id_fkey": {
+          "name": "legacy_sample_labels_sample_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_labels_label_id_fkey": {
+          "name": "legacy_sample_labels_label_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_labels_pkey": {
+          "name": "legacy_sample_labels_pkey",
+          "columns": [
+            "sample_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_subtractions": {
+      "name": "legacy_sample_subtractions",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_subtractions_sample_id_fkey": {
+          "name": "legacy_sample_subtractions_sample_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_subtractions_subtraction_id_fkey": {
+          "name": "legacy_sample_subtractions_subtraction_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_subtractions_pkey": {
+          "name": "legacy_sample_subtractions_pkey",
+          "columns": [
+            "sample_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_samples": {
+      "name": "legacy_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_samples_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate": {
+          "name": "isolate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_type": {
+          "name": "library_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paired": {
+          "name": "paired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold": {
+          "name": "hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_read": {
+          "name": "all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_write": {
+          "name": "all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_read": {
+          "name": "group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_write": {
+          "name": "group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_samples_all_read": {
+          "name": "ix_legacy_samples_all_read",
+          "columns": [
+            {
+              "expression": "all_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"all_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_id": {
+          "name": "ix_legacy_samples_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_read": {
+          "name": "ix_legacy_samples_group_read",
+          "columns": [
+            {
+              "expression": "group_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"group_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_user_id_created_at": {
+          "name": "ix_legacy_samples_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_samples_group_id_fkey": {
+          "name": "legacy_samples_group_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_user_id_fkey": {
+          "name": "legacy_samples_user_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_job_id_fkey": {
+          "name": "legacy_samples_job_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_samples_legacy_id_key": {
+          "name": "legacy_samples_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "legacy_samples_job_id_key": {
+          "name": "legacy_samples_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_reads": {
+      "name": "sample_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload": {
+          "name": "upload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_reads_sample_id_fkey": {
+          "name": "sample_reads_sample_id_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_reads_upload_fkey": {
+          "name": "sample_reads_upload_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_sample_reads_storage_key": {
+          "name": "uq_sample_reads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "sample_reads_sample_id_name_key": {
+          "name": "sample_reads_sample_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample_id",
+            "name"
+          ]
+        },
+        "sample_reads_sample_name_key": {
+          "name": "sample_reads_sample_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_uploads": {
+      "name": "sample_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sample_uploads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_uploads_sample_id_fkey": {
+          "name": "sample_uploads_sample_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_uploads_upload_id_fkey": {
+          "name": "sample_uploads_upload_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sample_uploads_upload_id_key": {
+          "name": "sample_uploads_upload_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_code": {
+          "name": "reset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_remember": {
+          "name": "reset_remember",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_session_id": {
+          "name": "idx_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_type": {
+          "name": "idx_sessions_type",
+          "columns": [
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_fkey": {
+          "name": "sessions_user_id_fkey",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_type_valid": {
+          "name": "session_type_valid",
+          "value": "\"sessions\".\"session_type\" in ('anonymous', 'authenticated', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_source_types": {
+          "name": "default_source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_api": {
+          "name": "enable_api",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_sentry": {
+          "name": "enable_sentry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimum_password_length": {
+          "name": "minimum_password_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ncbi_api_key": {
+          "name": "ncbi_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_read": {
+          "name": "sample_all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_write": {
+          "name": "sample_all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group": {
+          "name": "sample_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_read": {
+          "name": "sample_group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_write": {
+          "name": "sample_group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_settings_singleton": {
+          "name": "ck_settings_singleton",
+          "value": "\"settings\".\"id\" = 1"
+        },
+        "ck_settings_sample_group": {
+          "name": "ck_settings_sample_group",
+          "value": "\"settings\".\"sample_group\" in ('none', 'force_choice', 'users_primary_group')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtraction_files": {
+      "name": "subtraction_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtraction_files_subtraction_id_fkey": {
+          "name": "subtraction_files_subtraction_id_fkey",
+          "tableFrom": "subtraction_files",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_subtraction_files_storage_key": {
+          "name": "uq_subtraction_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "subtraction_files_subtraction_id_name_key": {
+          "name": "subtraction_files_subtraction_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subtraction_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_subtraction_files_type": {
+          "name": "ck_subtraction_files_type",
+          "value": "\"subtraction_files\".\"type\" in ('fasta', 'bowtie2')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtractions": {
+      "name": "subtractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subtractions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gc": {
+          "name": "gc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtractions_user_id_fkey": {
+          "name": "subtractions_user_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_job_id_fkey": {
+          "name": "subtractions_job_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_upload_id_fkey": {
+          "name": "subtractions_upload_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtractions_legacy_id_key": {
+          "name": "subtractions_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "subtractions_job_id_key": {
+          "name": "subtractions_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_active": {
+          "name": "idx_tasks_active",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"complete\" = false and \"tasks\".\"error\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_unacquired": {
+          "name": "idx_tasks_unacquired",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"acquired_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed": {
+          "name": "removed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploads_user_id_fkey": {
+          "name": "uploads_user_id_fkey",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uploads_name_on_disk_key": {
+          "name": "uploads_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_uploads_storage_key": {
+          "name": "uq_uploads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_uploads_type": {
+          "name": "ck_uploads_type",
+          "value": "\"uploads\".\"type\" in ('reference', 'reads', 'subtraction')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrator_role": {
+          "name": "administrator_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_reset": {
+          "name": "force_reset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_handle_lower_unique": {
+          "name": "users_handle_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_legacy_id_key": {
+          "name": "users_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "administrator_role_valid": {
+          "name": "administrator_role_valid",
+          "value": "\"users\".\"administrator_role\" in ('full', 'settings', 'users', 'base')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_results": {
+      "name": "analysis_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_results_analysis_id_key": {
+          "name": "analysis_results_analysis_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_analyses": {
+      "name": "job_analyses",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_analyses_job_id_fkey": {
+          "name": "job_analyses_job_id_fkey",
+          "tableFrom": "job_analyses",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "job_analyses_pkey": {
+          "name": "job_analyses_pkey",
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_indexes": {
+      "name": "job_indexes",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_indexes_job_id_fkey": {
+          "name": "job_indexes_job_id_fkey",
+          "tableFrom": "job_indexes",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "job_indexes_pkey": {
+          "name": "job_indexes_pkey",
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "resourcetype",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action": {
+      "name": "action",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete",
+        "modify",
+        "remove"
+      ]
+    },
+    "public.resourcetype": {
+      "name": "resourcetype",
+      "schema": "public",
+      "values": [
+        "app",
+        "group"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/data/drizzle/meta/_journal.json
+++ b/packages/data/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1787173426198,
       "tag": "0005_drop_analyses_reference",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787177564901,
+      "tag": "0006_add_settings_ncbi_api_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/data/src/db/schema/settings.ts
+++ b/packages/data/src/db/schema/settings.ts
@@ -6,6 +6,7 @@
 // than this file. `enable_api` is the one exception, for the reason given
 // below.
 
+import type { SampleGroup } from "@virtool/contracts";
 import { sql } from "drizzle-orm";
 import {
 	boolean,
@@ -15,16 +16,6 @@ import {
 	pgTable,
 	text,
 } from "drizzle-orm/pg-core";
-
-/** The group-access policies a newly created sample can be assigned. */
-export const sampleGroups = [
-	"none",
-	"force_choice",
-	"users_primary_group",
-] as const;
-
-/** The group-access policy applied to a newly created sample. */
-export type SampleGroup = (typeof sampleGroups)[number];
 
 export const settings = pgTable(
 	"settings",

--- a/packages/data/src/db/schema/settings.ts
+++ b/packages/data/src/db/schema/settings.ts
@@ -42,6 +42,11 @@ export const settings = pgTable(
 			.$defaultFn(() => false),
 		enableSentry: boolean("enable_sentry").notNull(),
 		minimumPasswordLength: integer("minimum_password_length").notNull(),
+		// A credential, unlike every other column here. It is never published to
+		// a client: `apps/web/src/server/settings/functions.ts` reduces it to a
+		// boolean at the transport boundary. Empty means unset, and the GenBank
+		// request layer omits `api_key` rather than sending a blank one.
+		ncbiApiKey: text("ncbi_api_key").notNull(),
 		sampleAllRead: boolean("sample_all_read").notNull(),
 		sampleAllWrite: boolean("sample_all_write").notNull(),
 		sampleGroup: text("sample_group").$type<SampleGroup>().notNull(),

--- a/packages/data/src/genbank/data.test.ts
+++ b/packages/data/src/genbank/data.test.ts
@@ -203,7 +203,7 @@ describe("getGenbank", () => {
 		it("calls the NCBI efetch endpoint with the documented parameters", async () => {
 			const fetchMock = mockFetch(HOST_RECORD);
 
-			await getGenbank(logger, "NC_045512");
+			await getGenbank(logger, "NC_045512", "");
 
 			expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -223,10 +223,43 @@ describe("getGenbank", () => {
 			});
 		});
 
+		it("sends the API key when one is configured", async () => {
+			const fetchMock = mockFetch(HOST_RECORD);
+
+			await getGenbank(logger, "NC_045512", "abc123");
+
+			expect(requestUrl(fetchMock).searchParams.get("api_key")).toBe("abc123");
+		});
+
+		// NCBI reads a blank `api_key` as a bad key and refuses the request, so an
+		// unconfigured instance has to omit the parameter rather than send it empty.
+		it("omits the API key when none is configured", async () => {
+			const fetchMock = mockFetch(HOST_RECORD);
+
+			await getGenbank(logger, "NC_045512", "");
+
+			expect(requestUrl(fetchMock).searchParams.has("api_key")).toBe(false);
+		});
+
+		it("keeps the API key out of the log when NCBI cannot be reached", async () => {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+			);
+
+			await expect(
+				getGenbank(logger, "NC_045512", "abc123"),
+			).rejects.toBeInstanceOf(GenbankUnreachableError);
+
+			expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(
+				"abc123",
+			);
+		});
+
 		it("identifies itself to NCBI with a User-Agent", async () => {
 			const fetchMock = mockFetch(HOST_RECORD);
 
-			await getGenbank(logger, "NC_045512");
+			await getGenbank(logger, "NC_045512", "");
 
 			const [, init] = firstCall(fetchMock.mock.calls) as [URL, RequestInit];
 
@@ -236,7 +269,7 @@ describe("getGenbank", () => {
 		it("encodes an accession that needs escaping", async () => {
 			const fetchMock = mockFetch(HOST_RECORD);
 
-			await getGenbank(logger, "NC_045512 2");
+			await getGenbank(logger, "NC_045512 2", "");
 
 			const url = requestUrl(fetchMock);
 
@@ -249,7 +282,7 @@ describe("getGenbank", () => {
 		it("parses a record whose source feature carries a host", async () => {
 			mockFetch(HOST_RECORD);
 
-			await expect(getGenbank(logger, "NC_045512")).resolves.toEqual({
+			await expect(getGenbank(logger, "NC_045512", "")).resolves.toEqual({
 				accession: "NC_045512.2",
 				definition:
 					"Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
@@ -263,7 +296,7 @@ describe("getGenbank", () => {
 		it("unwraps a multi-line definition and drops its trailing period", async () => {
 			mockFetch(LAB_HOST_RECORD);
 
-			const genbank = await getGenbank(logger, "AB000048");
+			const genbank = await getGenbank(logger, "AB000048", "");
 
 			expect(genbank?.definition).toBe(
 				"Feline panleukopenia virus gene for nonstructural protein 1, complete cds, isolate: 483",
@@ -273,7 +306,7 @@ describe("getGenbank", () => {
 		it("leaves a definition without a trailing period alone", async () => {
 			mockFetch(HOST_RECORD.replace("complete genome.", "complete genome"));
 
-			const genbank = await getGenbank(logger, "NC_045512");
+			const genbank = await getGenbank(logger, "NC_045512", "");
 
 			expect(genbank?.definition).toBe(
 				"Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
@@ -283,7 +316,7 @@ describe("getGenbank", () => {
 		it("drops only one trailing period", async () => {
 			mockFetch(HOST_RECORD.replace("complete genome.", "complete genome.."));
 
-			const genbank = await getGenbank(logger, "NC_045512");
+			const genbank = await getGenbank(logger, "NC_045512", "");
 
 			expect(genbank?.definition).toBe(
 				"Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome.",
@@ -293,7 +326,7 @@ describe("getGenbank", () => {
 		it("prefers the VERSION value over the ACCESSION value", async () => {
 			mockFetch(LAB_HOST_RECORD);
 
-			const genbank = await getGenbank(logger, "AB000048");
+			const genbank = await getGenbank(logger, "AB000048", "");
 
 			expect(genbank?.accession).toBe("AB000048.1");
 		});
@@ -306,7 +339,7 @@ describe("getGenbank", () => {
 				),
 			);
 
-			const genbank = await getGenbank(logger, "AB000048");
+			const genbank = await getGenbank(logger, "AB000048", "");
 
 			expect(genbank?.accession).toBe("AB000048.1");
 		});
@@ -314,7 +347,7 @@ describe("getGenbank", () => {
 		it("falls back to ACCESSION when there is no VERSION line", async () => {
 			mockFetch(NO_VERSION_RECORD);
 
-			const genbank = await getGenbank(logger, "ACCNUM01");
+			const genbank = await getGenbank(logger, "ACCNUM01", "");
 
 			expect(genbank?.accession).toBe("ACCNUM01");
 		});
@@ -322,7 +355,7 @@ describe("getGenbank", () => {
 		it("falls back to the LOCUS name when there is neither VERSION nor ACCESSION", async () => {
 			mockFetch(LOCUS_ONLY_RECORD);
 
-			const genbank = await getGenbank(logger, "LOCUSONLY");
+			const genbank = await getGenbank(logger, "LOCUSONLY", "");
 
 			expect(genbank?.accession).toBe("LOCUSONLY");
 		});
@@ -330,7 +363,7 @@ describe("getGenbank", () => {
 		it("upper-cases the lower-case ORIGIN block and drops its numbering", async () => {
 			mockFetch(WRAPPED_HOST_RECORD);
 
-			const genbank = await getGenbank(logger, "TEST0001");
+			const genbank = await getGenbank(logger, "TEST0001", "");
 
 			expect(genbank?.sequence).toBe("ACGTACGTACGTACGTACGTACGT");
 		});
@@ -343,7 +376,7 @@ describe("getGenbank", () => {
 				),
 			);
 
-			const genbank = await getGenbank(logger, "TEST0001");
+			const genbank = await getGenbank(logger, "TEST0001", "");
 
 			expect(genbank?.sequence).toBe("ACGTRYKNNNNNACGTACGTACGT");
 		});
@@ -351,7 +384,7 @@ describe("getGenbank", () => {
 		it("ignores a BASE COUNT line between the feature table and ORIGIN", async () => {
 			mockFetch(BASE_COUNT_RECORD);
 
-			const genbank = await getGenbank(logger, "TEST0005");
+			const genbank = await getGenbank(logger, "TEST0005", "");
 
 			expect(genbank?.host).toBe("Homo sapiens");
 			expect(genbank?.sequence).toBe("ACGTACGTACGTACGTACGTACGT");
@@ -360,7 +393,7 @@ describe("getGenbank", () => {
 		it("parses a record with carriage returns", async () => {
 			mockFetch(HOST_RECORD.replaceAll("\n", "\r\n"));
 
-			const genbank = await getGenbank(logger, "NC_045512");
+			const genbank = await getGenbank(logger, "NC_045512", "");
 
 			expect(genbank?.accession).toBe("NC_045512.2");
 			expect(genbank?.host).toBe("Homo sapiens");
@@ -370,7 +403,7 @@ describe("getGenbank", () => {
 		it("throws when a 200 response is not a GenBank record", async () => {
 			mockFetch("<html><body>Service unavailable</body></html>");
 
-			await expect(getGenbank(logger, "NC_045512")).rejects.toThrow(
+			await expect(getGenbank(logger, "NC_045512", "")).rejects.toThrow(
 				"Could not parse GenBank record",
 			);
 		});
@@ -380,7 +413,7 @@ describe("getGenbank", () => {
 		it("is empty when the source feature has none", async () => {
 			mockFetch(LAB_HOST_RECORD);
 
-			const genbank = await getGenbank(logger, "AB000048");
+			const genbank = await getGenbank(logger, "AB000048", "");
 
 			expect(genbank?.host).toBe("");
 		});
@@ -388,7 +421,7 @@ describe("getGenbank", () => {
 		it("does not match /lab_host", async () => {
 			mockFetch(LAB_HOST_RECORD);
 
-			const genbank = await getGenbank(logger, "AB000048");
+			const genbank = await getGenbank(logger, "AB000048", "");
 
 			expect(genbank?.host).not.toBe("Felis domesticus");
 		});
@@ -396,7 +429,7 @@ describe("getGenbank", () => {
 		it("joins a value wrapped over a continuation line with a single space", async () => {
 			mockFetch(WRAPPED_HOST_RECORD);
 
-			const genbank = await getGenbank(logger, "TEST0001");
+			const genbank = await getGenbank(logger, "TEST0001", "");
 
 			expect(genbank?.host).toBe(
 				"Solanum lycopersicum cultivar Moneymaker grown under glass",
@@ -406,7 +439,7 @@ describe("getGenbank", () => {
 		it("takes the last source feature when several carry a host", async () => {
 			mockFetch(TWO_SOURCES_BOTH_HOSTS);
 
-			const genbank = await getGenbank(logger, "TEST0002");
+			const genbank = await getGenbank(logger, "TEST0002", "");
 
 			expect(genbank?.host).toBe("Second host");
 		});
@@ -414,7 +447,7 @@ describe("getGenbank", () => {
 		it("is cleared when the last source feature carries no host", async () => {
 			mockFetch(TWO_SOURCES_LAST_HOSTLESS);
 
-			const genbank = await getGenbank(logger, "TEST0003");
+			const genbank = await getGenbank(logger, "TEST0003", "");
 
 			expect(genbank?.host).toBe("");
 		});
@@ -422,7 +455,7 @@ describe("getGenbank", () => {
 		it("unescapes doubled quotes", async () => {
 			mockFetch(ESCAPED_QUOTES_RECORD);
 
-			const genbank = await getGenbank(logger, "TEST0004");
+			const genbank = await getGenbank(logger, "TEST0004", "");
 
 			expect(genbank?.host).toBe('Homo "sapiens" here');
 		});
@@ -435,7 +468,7 @@ describe("getGenbank", () => {
 				),
 			);
 
-			const genbank = await getGenbank(logger, "TEST0001");
+			const genbank = await getGenbank(logger, "TEST0001", "");
 
 			expect(genbank?.host).toBe("");
 		});
@@ -448,7 +481,7 @@ describe("getGenbank", () => {
 				),
 			);
 
-			const genbank = await getGenbank(logger, "AB000048");
+			const genbank = await getGenbank(logger, "AB000048", "");
 
 			expect(genbank?.host).toBe("Felis domesticus");
 		});
@@ -458,13 +491,13 @@ describe("getGenbank", () => {
 		it("returns null when NCBI cannot retrieve the sequence", async () => {
 			mockFetch("Error: Failed to retrieve sequence: NOPE00000\n", 400);
 
-			await expect(getGenbank(logger, "NOPE00000")).resolves.toBeNull();
+			await expect(getGenbank(logger, "NOPE00000", "")).resolves.toBeNull();
 		});
 
 		it("does not warn about an expected retrieval failure", async () => {
 			mockFetch("Error: Failed to retrieve sequence: NOPE00000\n", 400);
 
-			await getGenbank(logger, "NOPE00000");
+			await getGenbank(logger, "NOPE00000", "");
 
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
@@ -472,7 +505,7 @@ describe("getGenbank", () => {
 		it("warns about an unexpected non-200 response and returns null", async () => {
 			mockFetch("Bad gateway", 502);
 
-			await expect(getGenbank(logger, "NC_045512")).resolves.toBeNull();
+			await expect(getGenbank(logger, "NC_045512", "")).resolves.toBeNull();
 
 			expect(logger.warn).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -487,7 +520,7 @@ describe("getGenbank", () => {
 		it("truncates a long body before logging it", async () => {
 			mockFetch("x".repeat(5000), 500);
 
-			await getGenbank(logger, "NC_045512");
+			await getGenbank(logger, "NC_045512", "");
 
 			expect(firstCall(vi.mocked(logger.warn).mock.calls)[0]).toMatchObject({
 				body: "x".repeat(500),
@@ -500,7 +533,7 @@ describe("getGenbank", () => {
 				vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
 			);
 
-			await expect(getGenbank(logger, "NC_045512")).rejects.toThrow(
+			await expect(getGenbank(logger, "NC_045512", "")).rejects.toThrow(
 				GenbankUnreachableError,
 			);
 		});
@@ -511,7 +544,7 @@ describe("getGenbank", () => {
 				vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
 			);
 
-			await expect(getGenbank(logger, "NC_045512")).rejects.toThrow(
+			await expect(getGenbank(logger, "NC_045512", "")).rejects.toThrow(
 				"Could not reach NCBI",
 			);
 		});
@@ -522,7 +555,7 @@ describe("getGenbank", () => {
 				vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
 			);
 
-			await expect(getGenbank(logger, "NC_045512")).rejects.toMatchObject({
+			await expect(getGenbank(logger, "NC_045512", "")).rejects.toMatchObject({
 				name: "GenbankUnreachableError",
 			});
 		});

--- a/packages/data/src/genbank/data.ts
+++ b/packages/data/src/genbank/data.ts
@@ -265,10 +265,23 @@ function parseGenbank(text: string): Genbank {
  *
  * Returns `null` when NCBI has no such accession, and throws
  * `GenbankUnreachableError` when NCBI could not be reached.
+ *
+ * `apiKey` is the instance's NCBI API key, which raises the E-utilities rate
+ * limit from three requests a second to ten. It is passed in rather than read
+ * here so this module stays free of a settings read. An empty string means no
+ * key is configured, and `api_key` is left off the query string entirely — NCBI
+ * treats a blank one as a bad key and refuses the request rather than falling
+ * back to the anonymous tier.
+ *
+ * **The URL never reaches a log or an error message.** It carries the key, and
+ * nothing here has a scrubber in front of it: the two `logger.warn` calls below
+ * name the accession and the response, and `GenbankUnreachableError` carries a
+ * fixed string.
  */
 export async function getGenbank(
 	logger: Logger,
 	accession: string,
+	apiKey: string,
 ): Promise<Genbank | null> {
 	const url = new URL(FETCH_URL);
 
@@ -279,6 +292,7 @@ export async function getGenbank(
 		retmode: "text",
 		rettype: "gb",
 		tool: TOOL,
+		...(apiKey ? { api_key: apiKey } : {}),
 	}).toString();
 
 	let response: Response;

--- a/packages/data/src/settings/data.test.ts
+++ b/packages/data/src/settings/data.test.ts
@@ -145,6 +145,7 @@ describe("DEFAULT_SETTINGS", () => {
 			defaultSourceTypes: ["isolate", "strain"],
 			enableSentry: true,
 			minimumPasswordLength: 8,
+			ncbiApiKey: "",
 			sampleAllRead: true,
 			sampleAllWrite: false,
 			sampleGroup: "none",

--- a/packages/data/src/settings/data.ts
+++ b/packages/data/src/settings/data.ts
@@ -16,6 +16,14 @@ export type Settings = {
 	defaultSourceTypes: string[];
 	enableSentry: boolean;
 	minimumPasswordLength: number;
+	/**
+	 * The instance's NCBI API key, or `""` when none is configured.
+	 *
+	 * A credential, so it never leaves the server as-is —
+	 * `apps/web/src/server/settings/functions.ts` reduces it to a boolean before
+	 * publishing the row.
+	 */
+	ncbiApiKey: string;
 	sampleAllRead: boolean;
 	sampleAllWrite: boolean;
 	sampleGroup: SampleGroup;
@@ -33,6 +41,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	defaultSourceTypes: ["isolate", "strain"],
 	enableSentry: true,
 	minimumPasswordLength: DEFAULT_MINIMUM_PASSWORD_LENGTH,
+	ncbiApiKey: "",
 	sampleAllRead: true,
 	sampleAllWrite: false,
 	sampleGroup: "none",
@@ -45,6 +54,7 @@ function toSettings(row: SettingsRow): Settings {
 		defaultSourceTypes: row.defaultSourceTypes,
 		enableSentry: row.enableSentry,
 		minimumPasswordLength: row.minimumPasswordLength,
+		ncbiApiKey: row.ncbiApiKey,
 		sampleAllRead: row.sampleAllRead,
 		sampleAllWrite: row.sampleAllWrite,
 		sampleGroup: row.sampleGroup,

--- a/packages/data/src/settings/data.ts
+++ b/packages/data/src/settings/data.ts
@@ -1,9 +1,11 @@
-import { DEFAULT_MINIMUM_PASSWORD_LENGTH } from "@virtool/contracts";
+import {
+	DEFAULT_MINIMUM_PASSWORD_LENGTH,
+	type SampleGroup,
+} from "@virtool/contracts";
 import { eq } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { takeFirst, takeFirstOrThrow } from "../db/rows";
 import {
-	type SampleGroup,
 	type SettingsRow,
 	settings as settingsTable,
 } from "../db/schema/settings";

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -31,11 +31,12 @@ for the silent logger tests pass in its place.
 ## Redaction
 
 `DEFAULT_REDACT_PATHS` (`src/config.ts`) censors the obvious secret
-fields, this codebase's session-credential field names, and the
-`req.headers.*` / `headers.*` variants, matched one level deep as well as
-at the top. Pass `redact` to `createLogger` to merge in more paths for a
-feature that needs to censor something else. Redaction runs before any
-destination sees the record, including the Sentry stream below.
+fields, this codebase's session-credential and stored-credential field names
+(`ncbiApiKey` among them), and the `req.headers.*` / `headers.*` variants,
+matched one level deep as well as at the top. Pass `redact` to `createLogger`
+to merge in more paths for a feature that needs to censor something else.
+Redaction runs before any destination sees the record, including the Sentry
+stream below.
 
 ## Sentry forwarding
 

--- a/packages/logger/src/config.ts
+++ b/packages/logger/src/config.ts
@@ -34,7 +34,8 @@ export function resolveLevel(env: Env): LogLevel {
 /**
  * Keys redacted from log records by default. Covers the obvious secret-bearing
  * fields, the session-credential field names this codebase actually uses
- * (`sessionToken` / `session_token` / `tokenHash` / `resetCode`), and common
+ * (`sessionToken` / `session_token` / `tokenHash` / `resetCode` / `ncbiApiKey`),
+ * and common
  * HTTP shapes (`req.headers.authorization`, `headers.cookie`) so that incidental
  * request logging does not leak credentials. Redaction runs before any
  * destination — including the Sentry forwarding stream — sees the record.
@@ -49,6 +50,7 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = [
 	"session_token",
 	"tokenHash",
 	"resetCode",
+	"ncbiApiKey",
 	"*.password",
 	"*.token",
 	"*.secret",
@@ -58,6 +60,7 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = [
 	"*.session_token",
 	"*.tokenHash",
 	"*.resetCode",
+	"*.ncbiApiKey",
 	"req.headers.authorization",
 	"req.headers.cookie",
 	"headers.authorization",


### PR DESCRIPTION
## Summary

- Add an instance-wide NCBI API key to the application settings and send it as `api_key` on GenBank `efetch` requests, raising the E-utilities rate limit from three requests a second to ten. It is a setting rather than a `VT_` variable so an administrator can rotate it without a redeploy. An empty key is omitted from the query string entirely — NCBI refuses a blank one rather than falling back to the anonymous tier.
- Treat it as write-only, since it is the first credential to live in the `settings` row. The settings server functions narrow it away at the transport boundary: a client is told only whether a key is configured and can write a new one or clear it, but never reads the stored value back. `ncbiApiKey` also joins the shared logger's redaction paths, and the request URL is kept out of every log and error message.
- Migrate `settings` with a transient column default. The singleton row already exists, so a `NOT NULL` column cannot be added without one; the default is dropped again afterwards to match the table's convention that every value is written on insert from `DEFAULT_SETTINGS`.