### PR TITLE
refactor: drop the unreachable SSE unknown-domain branch

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -415,10 +415,9 @@ Postgres `client_events` channel; the route converts each event to the id-only
 normal API so authorization remains at the request boundary.
 
 Adding a domain requires all three of `SseDomainSchema`, `SseMessageSchema`,
-and `reactQueryHandler`'s `domains` record. A domain absent from the schemas is
-expected forward-compatible traffic and is dropped silently. A known domain
-whose operation or id type fails validation is contract drift and is reported
-to Sentry.
+and `reactQueryHandler`'s `domains` record. A frame that fails validation — an
+unknown domain, a bad operation, a wrong id type — is contract drift and is
+reported to Sentry.
 
 The handshake uses `requireAuthenticatedRequest`. While connected, the server
 rechecks the session on each keepalive interval and closes a revoked stream.

--- a/apps/web/src/app/sse/SseConnection.ts
+++ b/apps/web/src/app/sse/SseConnection.ts
@@ -2,7 +2,7 @@ import { useServerVersionStore } from "@app/serverVersion";
 import { endSession } from "@app/session";
 import * as Sentry from "@sentry/tanstackstart-react";
 import type { QueryClient } from "@tanstack/react-query";
-import { SseDomainSchema, SseMessageSchema } from "@virtool/contracts";
+import { SseMessageSchema } from "@virtool/contracts";
 import { reactQueryHandler } from "./reactQueryHandler";
 
 type ConnectionStatus =
@@ -33,16 +33,9 @@ export function init(queryClient: QueryClient): void {
 			return;
 		}
 
-		// Frames arrive for domains this client doesn't handle yet (otus,
-		// subtraction, and the rest). Those are expected forward-compatible
-		// traffic, not drift, so drop them silently. Only a frame for a domain we
-		// *do* handle that still fails to validate — a wrong id type, a bad
-		// operation — is worth reporting.
-		const domain = (data as { domain?: unknown } | null)?.domain;
-		if (!SseDomainSchema.safeParse(domain).success) {
-			return;
-		}
-
+		// One publisher, typed to the same enum this validates against, and a
+		// forced reload on redeploy: nothing can legitimately arrive that fails to
+		// parse, so every failure is drift worth reporting.
 		Sentry.captureException(parsed.error, {
 			tags: { sse: "message-validation" },
 		});

--- a/apps/web/src/app/sse/__tests__/SseConnection.test.ts
+++ b/apps/web/src/app/sse/__tests__/SseConnection.test.ts
@@ -212,22 +212,6 @@ describe("SseConnection", () => {
 		expect(captureException).not.toHaveBeenCalled();
 	});
 
-	it("drops frames for domains it does not handle without reporting them", async () => {
-		await establish();
-
-		// Frames arrive for domains the client has no query keys for yet; a frame
-		// for one of them must be ignored, not treated as a validation error worth
-		// a Sentry report.
-		openConnection().message({
-			domain: "subtraction",
-			operation: "update",
-			id: 4,
-		});
-
-		expect(handler).not.toHaveBeenCalled();
-		expect(captureException).not.toHaveBeenCalled();
-	});
-
 	it("reports a malformed frame for a domain it does handle", async () => {
 		await establish();
 


### PR DESCRIPTION
## Summary

- Remove the silent drop for SSE frames whose `domain` is absent from `SseDomainSchema`. It guarded against a second publisher emitting domains this client did not know; there is one publisher, `emit`, typed to the same enum the client validates against, so nothing reaches it.
- Delete its test, which only got there with `domain: "subtraction"` — singular, where the enum says `subtractions` — passing against a misspelling rather than anything the system can emit.
- Drop the README paragraph describing dropped frames as expected forward-compatible traffic. A frame that fails validation is now documented, and treated, as contract drift.

The one reachable case left was a tab holding a bundle predating a newly added domain. `UpdateToast` is moving to a forced reload, which closes it; until that lands, a deploy that adds a domain would report per frame from a stale tab.

The per-domain id-type tolerance beside it is untouched — ids genuinely arrive as both strings and integers depending on domain.

Closes VIR-3000.