### PR TITLE
feat: make uploaded files easier to scan and sort

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -319,6 +319,13 @@ do not render at Tailwind's documented pixel values:
 | `md:` | 768px | 672px |
 | `2xl:` | 1536px | 1344px |
 
+`@base/Table` and `@base/BoxGroupTable` take a `variant`. `keyValue`, the
+default, is the detail-panel shape: a narrow first column of row labels, ruled
+off and top-aligned. `data` is a list of records, where the first column is a
+field like any other. Give a `data` table sortable columns with
+`@base/SortableHead`, which owns the `aria-sort` and direction-arrow rules and
+leaves the sort state to the caller.
+
 Size anything that holds text in `rem`; reserve pixels for graphics without
 text. If an API requires a number, express it as a rem multiple and resolve it
 with `useRootFontSize` from `@app/hooks`. Known exceptions are the virtualized

--- a/apps/web/src/base/BoxGroupTable.tsx
+++ b/apps/web/src/base/BoxGroupTable.tsx
@@ -1,10 +1,11 @@
 import { cn } from "@app/cn";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import Table from "./Table";
 
 type BoxGroupTableProps = {
 	children: ReactNode;
 	className?: string;
+	variant?: ComponentProps<typeof Table>["variant"];
 };
 
 /**
@@ -13,6 +14,7 @@ type BoxGroupTableProps = {
 export default function BoxGroupTable({
 	children,
 	className,
+	variant,
 }: BoxGroupTableProps) {
 	return (
 		<Table
@@ -26,6 +28,7 @@ export default function BoxGroupTable({
 				"[&_td]:py-2 [&_th]:py-2",
 				className,
 			)}
+			variant={variant}
 		>
 			{children}
 		</Table>

--- a/apps/web/src/base/ContainerNarrow.tsx
+++ b/apps/web/src/base/ContainerNarrow.tsx
@@ -14,7 +14,7 @@ export default function ContainerNarrow({
 	className,
 }: ContainerNarrowProps) {
 	return (
-		<div className={cn("flex-grow", "flex-shrink-0", "max-w-6xl", className)}>
+		<div className={cn("flex-grow", "flex-shrink-0", "max-w-7xl", className)}>
 			{children}
 		</div>
 	);

--- a/apps/web/src/base/SortableHead.tsx
+++ b/apps/web/src/base/SortableHead.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@app/cn";
 import type { SortDirection } from "@virtool/contracts";
-import { ArrowDown, ArrowUp } from "lucide-react";
+import { ChevronDown, ChevronsUpDown, ChevronUp } from "lucide-react";
 import type { ReactNode } from "react";
 import Icon from "./Icon";
 
@@ -67,14 +67,18 @@ export default function SortableHead<T extends string>({
 				type="button"
 			>
 				{children}
-				{active && (
-					<span aria-hidden>
-						<Icon
-							className="size-4"
-							icon={direction === "ascending" ? ArrowUp : ArrowDown}
-						/>
-					</span>
-				)}
+				<span aria-hidden className="flex items-center">
+					<Icon
+						className="size-4"
+						icon={
+							active
+								? direction === "ascending"
+									? ChevronUp
+									: ChevronDown
+								: ChevronsUpDown
+						}
+					/>
+				</span>
 			</button>
 		</th>
 	);

--- a/apps/web/src/base/SortableHead.tsx
+++ b/apps/web/src/base/SortableHead.tsx
@@ -1,0 +1,81 @@
+import { cn } from "@app/cn";
+import type { SortDirection } from "@virtool/contracts";
+import { ArrowDown, ArrowUp } from "lucide-react";
+import type { ReactNode } from "react";
+import Icon from "./Icon";
+
+type SortableHeadProps<T extends string> = {
+	/** The column label */
+	children: ReactNode;
+
+	className?: string;
+
+	/** The direction the list is currently ordered in */
+	direction: SortDirection;
+
+	/** The column this header sorts by */
+	field: T;
+
+	/** Called with this header's field when it is clicked */
+	onSort: (field: T) => void;
+
+	/** The column the list is currently sorted by, if any */
+	sort: T | undefined;
+};
+
+/**
+ * A column header that sorts the table by its column.
+ *
+ * Clicking an inactive header sorts by it; clicking the active one again
+ * reverses the direction. The caller owns the sort state and decides what each
+ * click does with it — this only reports which column was asked for.
+ *
+ * `aria-sort` sits on the `<th>` and carries the direction for the active
+ * column only, so assistive technology announces one sorted column rather than
+ * a table sorted every which way. The direction arrow follows the same rule and
+ * is decorative: `aria-sort` already says everything it does.
+ */
+export default function SortableHead<T extends string>({
+	children,
+	className,
+	direction,
+	field,
+	onSort,
+	sort,
+}: SortableHeadProps<T>) {
+	const active = sort === field;
+
+	return (
+		<th
+			aria-sort={active ? direction : "none"}
+			className={className}
+			scope="col"
+		>
+			<button
+				className={cn(
+					"cursor-pointer",
+					"flex",
+					"gap-1",
+					"items-center",
+					"rounded-sm",
+					"hover:text-gray-900",
+					"focus-visible:outline-2",
+					"focus-visible:outline-offset-2",
+					"focus-visible:outline-cyan-600",
+				)}
+				onClick={() => onSort(field)}
+				type="button"
+			>
+				{children}
+				{active && (
+					<span aria-hidden>
+						<Icon
+							className="size-4"
+							icon={direction === "ascending" ? ArrowUp : ArrowDown}
+						/>
+					</span>
+				)}
+			</button>
+		</th>
+	);
+}

--- a/apps/web/src/base/Table.tsx
+++ b/apps/web/src/base/Table.tsx
@@ -1,15 +1,30 @@
 import { cn } from "@app/cn";
 import type { ReactNode } from "react";
 
+/**
+ * How a table lays its columns out.
+ *
+ * `keyValue` is the detail-panel shape: a narrow first column of row labels,
+ * ruled off from the values beside it and aligned to the top so a tall value
+ * does not float its label. `data` is a list of records, where the first column
+ * is a field like any other.
+ */
+type TableVariant = "data" | "keyValue";
+
 type TableProps = {
 	children: ReactNode;
 	className?: string;
+	variant?: TableVariant;
 };
 
 /**
  * Replacement for the HTML table element
  */
-export default function Table({ children, className }: TableProps) {
+export default function Table({
+	children,
+	className,
+	variant = "keyValue",
+}: TableProps) {
 	return (
 		<table
 			className={cn(
@@ -23,12 +38,15 @@ export default function Table({ children, className }: TableProps) {
 				"[&_tr]:border-b",
 				"[&_tr]:border-gray-200",
 				"[&_tr:last-child]:border-b-0",
-				"[&_th:first-child]:w-1/5",
-				"[&_td,&_th]:align-top",
-				"[&_td:first-child]:border-r",
-				"[&_td:first-child]:border-gray-200",
-				"[&_th:first-child]:border-r",
-				"[&_th:first-child]:border-gray-200",
+				variant === "keyValue" && [
+					"[&_th:first-child]:w-1/5",
+					"[&_td,&_th]:align-top",
+					"[&_td:first-child]:border-r",
+					"[&_td:first-child]:border-gray-200",
+					"[&_th:first-child]:border-r",
+					"[&_th:first-child]:border-gray-200",
+				],
+				variant === "data" && ["[&_td,&_th]:align-middle"],
 				className,
 			)}
 		>

--- a/apps/web/src/base/__tests__/SortableHead.test.tsx
+++ b/apps/web/src/base/__tests__/SortableHead.test.tsx
@@ -1,0 +1,128 @@
+import SortableHead from "@base/SortableHead";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@tests/setup";
+import type { SortDirection } from "@virtool/contracts";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+type Field = "name" | "size";
+
+type HeadersProps = {
+	direction?: SortDirection;
+	onSort?: (field: Field) => void;
+	sort: Field | undefined;
+};
+
+function Headers({
+	direction = "ascending",
+	onSort = vi.fn(),
+	sort,
+}: HeadersProps) {
+	return (
+		<table>
+			<thead>
+				<tr>
+					<SortableHead
+						direction={direction}
+						field="name"
+						onSort={onSort}
+						sort={sort}
+					>
+						Name
+					</SortableHead>
+					<SortableHead
+						direction={direction}
+						field="size"
+						onSort={onSort}
+						sort={sort}
+					>
+						Size
+					</SortableHead>
+				</tr>
+			</thead>
+		</table>
+	);
+}
+
+/** A table whose sort state responds to its headers, as a caller's would. */
+function HeadersEnvironment() {
+	const [sort, setSort] = useState<Field | undefined>(undefined);
+	const [direction, setDirection] = useState<SortDirection>("descending");
+
+	function handleSort(field: Field) {
+		setDirection(
+			sort === field && direction === "ascending" ? "descending" : "ascending",
+		);
+		setSort(field);
+	}
+
+	return <Headers direction={direction} onSort={handleSort} sort={sort} />;
+}
+
+describe("<SortableHead />", () => {
+	it("marks only the active column as sorted", () => {
+		renderWithProviders(<Headers direction="ascending" sort="name" />);
+
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"ascending",
+		);
+		expect(screen.getByRole("columnheader", { name: "Size" })).toHaveAttribute(
+			"aria-sort",
+			"none",
+		);
+	});
+
+	it("carries the direction of the active column", () => {
+		renderWithProviders(<Headers direction="descending" sort="size" />);
+
+		expect(screen.getByRole("columnheader", { name: "Size" })).toHaveAttribute(
+			"aria-sort",
+			"descending",
+		);
+	});
+
+	it("leaves every column unsorted when there is no active column", () => {
+		renderWithProviders(<Headers sort={undefined} />);
+
+		for (const name of ["Name", "Size"]) {
+			expect(screen.getByRole("columnheader", { name })).toHaveAttribute(
+				"aria-sort",
+				"none",
+			);
+		}
+	});
+
+	it("reports its own field when clicked", async () => {
+		const onSort = vi.fn();
+
+		renderWithProviders(<Headers onSort={onSort} sort="name" />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Size" }));
+
+		expect(onSort).toHaveBeenCalledWith("size");
+	});
+
+	it("sorts by a new column, then reverses it on the next click", async () => {
+		renderWithProviders(<HeadersEnvironment />);
+
+		const name = () => screen.getByRole("columnheader", { name: "Name" });
+
+		expect(name()).toHaveAttribute("aria-sort", "none");
+
+		await userEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(name()).toHaveAttribute("aria-sort", "ascending");
+
+		await userEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(name()).toHaveAttribute("aria-sort", "descending");
+	});
+
+	// The arrow only ever describes the column it sits in, and `aria-sort`
+	// already announces that, so it must not reach the accessible name.
+	it("keeps the direction arrow out of the header's accessible name", () => {
+		renderWithProviders(<Headers direction="ascending" sort="name" />);
+
+		expect(screen.getByRole("button", { name: "Name" })).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/routes/_authenticated/samples/files.tsx
+++ b/apps/web/src/routes/_authenticated/samples/files.tsx
@@ -1,19 +1,26 @@
-import { type Paginated, paginated } from "@app/pagination";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import { useFetchLabels } from "@labels/queries";
 import SampleFileManager from "@samples/components/SampleFileManager";
 import type { SearchSchemaInput } from "@tanstack/react-router";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
+import {
+	UPLOADS_SEARCH_DEFAULTS,
+	type UploadsSearch,
+	uploadsSearch,
+} from "@uploads/search";
 
 function validateSampleFilesSearch(
-	input: Partial<Paginated> & SearchSchemaInput,
-): Paginated {
-	return paginated(input);
+	input: Partial<UploadsSearch> & SearchSchemaInput,
+): UploadsSearch {
+	return uploadsSearch(input);
 }
 
 export const Route = createFileRoute("/_authenticated/samples/files")({
 	validateSearch: validateSampleFilesSearch,
+	// `validateSearch` puts every default back on the way in, so dropping them on
+	// the way out keeps a shared link down to the params its sender changed.
+	search: { middlewares: [stripSearchParams(UPLOADS_SEARCH_DEFAULTS)] },
 	component: SampleFilesRoute,
 });
 
@@ -32,9 +39,14 @@ function SampleFilesRoute() {
 
 	return (
 		<SampleFileManager
+			direction={search.direction}
 			labels={labels}
 			page={search.page}
 			setPage={(page) => navigate({ search: { ...search, page } })}
+			setSort={(sort, direction) =>
+				navigate({ search: { ...search, direction, page: 1, sort } })
+			}
+			sort={search.sort}
 		/>
 	);
 }

--- a/apps/web/src/routes/_authenticated/subtractions/files.tsx
+++ b/apps/web/src/routes/_authenticated/subtractions/files.tsx
@@ -1,16 +1,23 @@
-import { type Paginated, paginated } from "@app/pagination";
 import { SubtractionFileManager } from "@subtraction/components/SubtractionFileManager";
 import type { SearchSchemaInput } from "@tanstack/react-router";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
+import {
+	UPLOADS_SEARCH_DEFAULTS,
+	type UploadsSearch,
+	uploadsSearch,
+} from "@uploads/search";
 
 function validateSubtractionFilesSearch(
-	input: Partial<Paginated> & SearchSchemaInput,
-): Paginated {
-	return paginated(input);
+	input: Partial<UploadsSearch> & SearchSchemaInput,
+): UploadsSearch {
+	return uploadsSearch(input);
 }
 
 export const Route = createFileRoute("/_authenticated/subtractions/files")({
 	validateSearch: validateSubtractionFilesSearch,
+	// `validateSearch` puts every default back on the way in, so dropping them on
+	// the way out keeps a shared link down to the params its sender changed.
+	search: { middlewares: [stripSearchParams(UPLOADS_SEARCH_DEFAULTS)] },
 	component: SubtractionFilesRoute,
 });
 
@@ -20,8 +27,13 @@ function SubtractionFilesRoute() {
 
 	return (
 		<SubtractionFileManager
+			direction={search.direction}
 			page={search.page}
 			setPage={(page) => navigate({ search: { ...search, page } })}
+			setSort={(sort, direction) =>
+				navigate({ search: { ...search, direction, page: 1, sort } })
+			}
+			sort={search.sort}
 		/>
 	);
 }

--- a/apps/web/src/samples/components/SampleFileManager.tsx
+++ b/apps/web/src/samples/components/SampleFileManager.tsx
@@ -1,19 +1,25 @@
 import { useCheckAdminRoleOrPermission } from "@administration/hooks";
 import ContainerNarrow from "@base/ContainerNarrow";
 import { FileManager } from "@uploads/components/FileManager";
-import type { Label } from "@virtool/contracts";
+import type { Label, SortDirection, UploadSortField } from "@virtool/contracts";
 import CreateSampleFromFile from "./Create/CreateSampleFromFile";
 
 type SampleFileManagerProps = {
+	direction: SortDirection;
 	labels: Label[];
 	page: number;
 	setPage: (page: number) => void;
+	setSort: (sort: UploadSortField, direction: SortDirection) => void;
+	sort?: UploadSortField;
 };
 
 export default function SampleFileManager({
+	direction,
 	labels,
 	page,
 	setPage,
+	setSort,
+	sort,
 }: SampleFileManagerProps) {
 	const { hasPermission: canCreate } =
 		useCheckAdminRoleOrPermission("create_sample");
@@ -25,6 +31,7 @@ export default function SampleFileManager({
 					"application/gzip": [".fasta.gz", ".fa.gz", ".fastq.gz", ".fq.gz"],
 					"text/plain": [".fasta", ".fa", ".fastq", ".fq"],
 				}}
+				direction={direction}
 				fileType="reads"
 				page={page}
 				hint="Supports plain or gzipped FASTA and FASTQ"
@@ -41,6 +48,8 @@ export default function SampleFileManager({
 						: undefined
 				}
 				setPage={setPage}
+				setSort={setSort}
+				sort={sort}
 			/>
 		</ContainerNarrow>
 	);

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -135,6 +135,57 @@ describe("findUploads", () => {
 
 		expect(result.items.map((upload) => upload.name)).toEqual(["reads.fq.gz"]);
 	});
+
+	it("orders by the requested column and direction", async () => {
+		const userId = await signIn(null);
+		await seedUpload(userId, { name: "beta.fq.gz" });
+		await seedUpload(userId, { name: "alpha.fq.gz" });
+
+		const result = (await call("findUploadsFn", {
+			page: 1,
+			perPage: 25,
+			sort: "name",
+			direction: "ascending",
+		})) as { items: { name: string }[] };
+
+		expect(result.items.map((upload) => upload.name)).toEqual([
+			"alpha.fq.gz",
+			"beta.fq.gz",
+		]);
+	});
+
+	// A direction on its own has nothing to order by, so it must not disturb the
+	// default newest-first ordering.
+	it("keeps the default order when a direction arrives without a column", async () => {
+		const userId = await signIn(null);
+		await seedUpload(userId, {
+			name: "older.fq.gz",
+			createdAt: new Date("2022-01-01T00:00:00Z"),
+		});
+		await seedUpload(userId, {
+			name: "newer.fq.gz",
+			createdAt: new Date("2022-02-01T00:00:00Z"),
+		});
+
+		const result = (await call("findUploadsFn", {
+			page: 1,
+			perPage: 25,
+			direction: "ascending",
+		})) as { items: { name: string }[] };
+
+		expect(result.items.map((upload) => upload.name)).toEqual([
+			"newer.fq.gz",
+			"older.fq.gz",
+		]);
+	});
+
+	it("rejects a column it does not sort by", async () => {
+		await signIn(null);
+
+		await expect(
+			call("findUploadsFn", { page: 1, perPage: 25, sort: "nameOnDisk" }),
+		).rejects.toThrow();
+	});
 });
 
 describe("deleteUpload", () => {

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -1,6 +1,10 @@
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
-import { UPLOAD_TYPES } from "@virtool/contracts";
+import {
+	SORT_DIRECTIONS,
+	UPLOAD_SORT_FIELDS,
+	UPLOAD_TYPES,
+} from "@virtool/contracts";
 import {
 	deleteUpload,
 	findUploads,
@@ -24,6 +28,10 @@ const findUploadsSchema = z
 		page: pageSchema,
 		perPage: perPageSchema,
 		user: rowIdSchema.optional(),
+		// A direction without a column has nothing to order by, so the pair is
+		// taken together: no column means the default newest-first ordering.
+		sort: z.enum(UPLOAD_SORT_FIELDS).optional(),
+		direction: z.enum(SORT_DIRECTIONS).default("descending"),
 	})
 	.optional();
 
@@ -57,6 +65,7 @@ export const findUploadsFn = createServerFn({ method: "GET" })
 			data?.page ?? 1,
 			data?.perPage ?? 25,
 			data?.user,
+			data?.sort ? { direction: data.direction, field: data.sort } : undefined,
 		),
 	);
 

--- a/apps/web/src/subtraction/components/SubtractionFileManager.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileManager.tsx
@@ -1,16 +1,23 @@
 import { FileManager } from "@uploads/components/FileManager";
+import type { SortDirection, UploadSortField } from "@virtool/contracts";
 
 type SubtractionFileManagerProps = {
+	direction?: SortDirection;
 	page?: number;
 	setPage?: (page: number) => void;
+	setSort?: (sort: UploadSortField, direction: SortDirection) => void;
+	sort?: UploadSortField;
 };
 
 /**
  * Displays a list of subtraction uploads with functionality to upload/delete uploads
  */
 export function SubtractionFileManager({
+	direction,
 	page = 1,
 	setPage = () => {},
+	setSort,
+	sort,
 }: SubtractionFileManagerProps) {
 	return (
 		<FileManager
@@ -18,11 +25,14 @@ export function SubtractionFileManager({
 				"application/gzip": [".fasta.gz", ".fa.gz"],
 				"application/text": [".fasta", ".fa"],
 			}}
+			direction={direction}
 			fileType="subtraction"
 			page={page}
 			hint="Supports plain or gzipped FASTA"
 			regex={/\.(?:fa|fasta)(?:\.gz|\.gzip)?$/}
 			setPage={setPage}
+			setSort={setSort}
+			sort={sort}
 		/>
 	);
 }

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -3,6 +3,7 @@ import { checkAdminRoleOrPermissionsFromAccount } from "@administration/utils";
 import Alert from "@base/Alert";
 import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
+import BoxGroupTable from "@base/BoxGroupTable";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
@@ -11,7 +12,12 @@ import { useListSelection } from "@base/useListSelection";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
-import type { Upload, UploadType } from "@virtool/contracts";
+import type {
+	SortDirection,
+	Upload,
+	UploadSortField,
+	UploadType,
+} from "@virtool/contracts";
 import { capitalize } from "es-toolkit";
 import { AlertCircle, FileUp } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
@@ -21,10 +27,14 @@ import { upload } from "../uploader";
 import { UploadBar } from "./UploadBar";
 import UploadItem from "./UploadItem";
 import UploadListHeader from "./UploadListHeader";
+import UploadTableHead from "./UploadTableHead";
 
 export type FileManagerProps = {
 	/* The MIME-types and extensions to accept. */
 	accept: Accept;
+
+	/* The direction the sorted column is ordered in. */
+	direction?: SortDirection;
 
 	/* The type of file accepted. */
 	fileType: UploadType;
@@ -42,16 +52,24 @@ export type FileManagerProps = {
 	renderItemAction?: (upload: Upload, uploads: Upload[]) => ReactNode;
 
 	setPage?: (page: number) => void;
+
+	setSort?: (sort: UploadSortField, direction: SortDirection) => void;
+
+	/* The column the list is sorted by, or undefined for newest first. */
+	sort?: UploadSortField;
 };
 
 export function FileManager({
 	accept,
+	direction = "descending",
 	fileType,
 	hint,
 	page = 1,
 	regex,
 	renderItemAction,
 	setPage = () => {},
+	setSort = () => {},
+	sort,
 }: FileManagerProps) {
 	const {
 		data: account,
@@ -62,7 +80,7 @@ export function FileManager({
 		data: files,
 		isPending: isPendingFiles,
 		isError: isErrorFiles,
-	} = useListFiles(fileType, page, 25);
+	} = useListFiles(fileType, page, 25, sort, direction);
 
 	// The uploads themselves are held, not just their ids, so a selection made on
 	// one page survives paging away from it.
@@ -104,6 +122,15 @@ export function FileManager({
 	function handleDelete() {
 		deleteFiles({ ids: selection.selected.map((item) => item.id) });
 		selection.clear();
+	}
+
+	// A column already sorted by reverses; a new one starts ascending, so the
+	// first click on any header moves the list somewhere it visibly wasn't.
+	function handleSort(field: UploadSortField) {
+		setSort(
+			field,
+			sort === field && direction === "ascending" ? "descending" : "ascending",
+		);
 	}
 
 	return (
@@ -156,33 +183,45 @@ export function FileManager({
 						{canDelete && (
 							<UploadListHeader
 								canDelete={canDelete}
-								checked={selection.getVisibleState(files.items)}
 								found={files.foundCount}
 								onDelete={handleDelete}
-								onSelectAll={() => selection.toggleVisible(files.items)}
 								selectedCount={selection.selected.length}
 							/>
 						)}
-						<ul className="list-none">
-							{files.items.map((item) => (
-								<UploadItem
-									{...item}
-									action={renderItemAction?.(item, files.items)}
-									canDelete={canDelete}
-									checked={selection.isSelected(item)}
-									key={item.id}
-									onSelect={
-										canDelete
-											? (event: MouseEvent<HTMLButtonElement>) =>
-													selection.select(item, {
-														shiftKey: event.shiftKey,
-														visibleItems: files.items,
-													})
-											: undefined
-									}
-								/>
-							))}
-						</ul>
+						<BoxGroupTable variant="data">
+							<caption className="sr-only">{title}</caption>
+							<UploadTableHead
+								checked={selection.getVisibleState(files.items)}
+								direction={direction}
+								onSelectAll={
+									canDelete
+										? () => selection.toggleVisible(files.items)
+										: undefined
+								}
+								onSort={handleSort}
+								sort={sort}
+							/>
+							<tbody>
+								{files.items.map((item) => (
+									<UploadItem
+										{...item}
+										action={renderItemAction?.(item, files.items)}
+										canDelete={canDelete}
+										checked={selection.isSelected(item)}
+										key={item.id}
+										onSelect={
+											canDelete
+												? (event: MouseEvent<HTMLButtonElement>) =>
+														selection.select(item, {
+															shiftKey: event.shiftKey,
+															visibleItems: files.items,
+														})
+												: undefined
+										}
+									/>
+								))}
+							</tbody>
+						</BoxGroupTable>
 					</BoxGroup>
 				</Pagination>
 			)}

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -188,7 +188,7 @@ export function FileManager({
 								selectedCount={selection.selected.length}
 							/>
 						)}
-						<BoxGroupTable variant="data">
+						<BoxGroupTable className="table-fixed" variant="data">
 							<caption className="sr-only">{title}</caption>
 							<UploadTableHead
 								checked={selection.getVisibleState(files.items)}

--- a/apps/web/src/uploads/components/UploadItem.tsx
+++ b/apps/web/src/uploads/components/UploadItem.tsx
@@ -59,7 +59,7 @@ export default function UploadItem({
 					/>
 				</td>
 			)}
-			<td className="font-medium">{name}</td>
+			<td className="break-all font-medium">{name}</td>
 			<td>
 				{user === null ? (
 					"Retrieved"

--- a/apps/web/src/uploads/components/UploadItem.tsx
+++ b/apps/web/src/uploads/components/UploadItem.tsx
@@ -1,9 +1,8 @@
 import { byteSize } from "@app/format";
-import Attribution from "@base/Attribution";
-import BoxGroupSection from "@base/BoxGroupSection";
 import Checkbox from "@base/Checkbox";
 import IconButton from "@base/IconButton";
 import IconLink from "@base/IconLink";
+import InitialIcon from "@base/InitialIcon";
 import RelativeTime from "@base/RelativeTime";
 import type { UserNested } from "@virtool/contracts";
 import { Download, Trash } from "lucide-react";
@@ -16,81 +15,90 @@ export type UploadItemProps = {
 	canDelete: boolean;
 	/** Whether the file is selected. */
 	checked?: boolean;
+
+	/** When the file was created, or null for a row that predates the column */
+	createdAt: Date | null;
+
 	id: number;
 	name: string;
 	/** Selects the file. Omitting it hides the checkbox. */
 	onSelect?: (event: MouseEvent<HTMLButtonElement>) => void;
 	size: number;
 
-	/** When the file was uploaded, or null for a row that predates the column */
-	uploadedAt: Date | null;
-
 	user: UserNested | null;
 };
 
+/**
+ * A file in the upload table.
+ *
+ * A file with no user was retrieved by Virtool rather than uploaded by anyone,
+ * so its user cell says so instead of naming an account.
+ */
 export default function UploadItem({
 	action,
 	canDelete,
 	checked = false,
+	createdAt,
 	id,
 	name,
 	onSelect,
 	size,
-	uploadedAt,
 	user,
 }: UploadItemProps) {
 	const { mutate: handleRemove } = useDeleteFile();
 
 	return (
-		<BoxGroupSection as="li">
-			<div className="flex items-center gap-4">
-				{onSelect && (
+		<tr>
+			{onSelect && (
+				<td className="w-px">
 					<Checkbox
 						ariaLabel={`Select ${name}`}
 						checked={checked}
 						id={`UploadCheckbox${id}`}
 						onClick={onSelect}
 					/>
-				)}
-				<div className="grid grid-cols-3 grow min-w-0">
-					<div className="flex font-medium items-center text-lg">{name}</div>
-					<div className="flex">
-						{user === null ? (
-							<span>
-								Retrieved <RelativeTime time={uploadedAt} />
-							</span>
-						) : (
-							<Attribution
-								time={uploadedAt}
-								user={user.handle}
-								verb="uploaded"
-							/>
-						)}
-					</div>
-					<div className="flex font-medium items-center gap-6 justify-end text-lg">
-						<div>{byteSize(size, true)}</div>
-						<span className="flex items-center gap-1">
-							{action}
-							<IconLink
-								ariaLabel={`Download ${name}`}
-								color="gray"
-								download={name}
-								href={`/uploads/${id}`}
-								IconComponent={Download}
-								tip="download"
-							/>
-							{canDelete && (
-								<IconButton
-									color="red"
-									IconComponent={Trash}
-									tip="remove"
-									onClick={() => handleRemove({ id })}
-								/>
-							)}
+				</td>
+			)}
+			<td className="font-medium">{name}</td>
+			<td>
+				{user === null ? (
+					"Retrieved"
+				) : (
+					<span className="inline-flex items-center gap-2">
+						{/* Decorative: the handle it draws is already the cell's text, and
+						    `InitialIcon` labels itself with it. */}
+						<span aria-hidden>
+							<InitialIcon size="md" handle={user.handle} />
 						</span>
-					</div>
-				</div>
-			</div>
-		</BoxGroupSection>
+						{user.handle}
+					</span>
+				)}
+			</td>
+			<td className="whitespace-nowrap">
+				<RelativeTime time={createdAt} />
+			</td>
+			<td className="whitespace-nowrap">{byteSize(size, true)}</td>
+			<td className="w-px">
+				<span className="flex items-center gap-1 justify-end">
+					{action}
+					<IconLink
+						ariaLabel={`Download ${name}`}
+						color="gray"
+						download={name}
+						href={`/uploads/${id}`}
+						IconComponent={Download}
+						tip="download"
+					/>
+					{canDelete && (
+						<IconButton
+							color="red"
+							IconComponent={Trash}
+							tip="remove"
+							onClick={() => handleRemove({ id })}
+						/>
+					)}
+				</span>
+			</td>
+		</tr>
 	);
 }

--- a/apps/web/src/uploads/components/UploadListHeader.tsx
+++ b/apps/web/src/uploads/components/UploadListHeader.tsx
@@ -28,7 +28,7 @@ export default function UploadListHeader({
 	selectedCount,
 }: UploadListHeaderProps) {
 	return (
-		<BoxGroupSection className="flex items-center gap-4 h-14 py-0 text-sm font-medium text-gray-600">
+		<BoxGroupSection className="flex items-center gap-4 h-14 py-0 bg-gray-50 text-sm font-medium text-gray-600">
 			<span>
 				{selectedCount
 					? `${selectedCount} selected`

--- a/apps/web/src/uploads/components/UploadListHeader.tsx
+++ b/apps/web/src/uploads/components/UploadListHeader.tsx
@@ -1,6 +1,5 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import Button from "@base/Button";
-import Checkbox from "@base/Checkbox";
 import Icon from "@base/Icon";
 import { Trash } from "lucide-react";
 
@@ -8,42 +7,28 @@ type UploadListHeaderProps = {
 	/** Whether the files can be deleted, which the Delete action requires */
 	canDelete: boolean;
 
-	/** Whether every, some, or no file on the page is selected */
-	checked: boolean | "indeterminate";
-
 	/** The number of files of this type */
 	found: number;
 
 	/** Callback to delete every selected file */
 	onDelete: () => void;
 
-	/** Callback to select or deselect every file on the page */
-	onSelectAll: () => void;
-
 	/** The number of selected files, which the actions apply to */
 	selectedCount: number;
 };
 
 /**
- * The header for the file list. Shows the file count until files are selected,
+ * The bar above the file table. Shows the file count until files are selected,
  * then swaps in the actions that apply to the selection.
  */
 export default function UploadListHeader({
 	canDelete,
-	checked,
 	found,
 	onDelete,
-	onSelectAll,
 	selectedCount,
 }: UploadListHeaderProps) {
 	return (
-		<BoxGroupSection className="flex items-center gap-4 bg-gray-50 h-14 py-0 text-sm font-medium text-gray-600">
-			<Checkbox
-				ariaLabel="Select all files"
-				checked={checked}
-				id="UploadSelectAll"
-				onClick={onSelectAll}
-			/>
+		<BoxGroupSection className="flex items-center gap-4 h-14 py-0 text-sm font-medium text-gray-600">
 			<span>
 				{selectedCount
 					? `${selectedCount} selected`

--- a/apps/web/src/uploads/components/UploadTableHead.tsx
+++ b/apps/web/src/uploads/components/UploadTableHead.tsx
@@ -38,7 +38,7 @@ export default function UploadTableHead({
 		<thead className="bg-gray-50 text-sm text-gray-600">
 			<tr>
 				{onSelectAll && (
-					<th className="w-px" scope="col">
+					<th className="w-12" scope="col">
 						<span className="sr-only">Select</span>
 						<Checkbox
 							ariaLabel="Select all files"
@@ -57,6 +57,7 @@ export default function UploadTableHead({
 					Name
 				</SortableHead>
 				<SortableHead
+					className="w-48"
 					direction={direction}
 					field="user"
 					onSort={onSort}
@@ -65,6 +66,7 @@ export default function UploadTableHead({
 					User
 				</SortableHead>
 				<SortableHead
+					className="w-48"
 					direction={direction}
 					field="createdAt"
 					onSort={onSort}
@@ -73,6 +75,7 @@ export default function UploadTableHead({
 					Created At
 				</SortableHead>
 				<SortableHead
+					className="w-48"
 					direction={direction}
 					field="size"
 					onSort={onSort}
@@ -80,7 +83,7 @@ export default function UploadTableHead({
 				>
 					Size
 				</SortableHead>
-				<th className="w-px" scope="col">
+				<th className="w-32" scope="col">
 					<span className="sr-only">Actions</span>
 				</th>
 			</tr>

--- a/apps/web/src/uploads/components/UploadTableHead.tsx
+++ b/apps/web/src/uploads/components/UploadTableHead.tsx
@@ -35,7 +35,7 @@ export default function UploadTableHead({
 	sort,
 }: UploadTableHeadProps) {
 	return (
-		<thead className="bg-gray-50 text-sm text-gray-600">
+		<thead className="bg-white text-sm text-gray-600">
 			<tr>
 				{onSelectAll && (
 					<th className="w-12" scope="col">
@@ -72,7 +72,7 @@ export default function UploadTableHead({
 					onSort={onSort}
 					sort={sort}
 				>
-					Created At
+					Created
 				</SortableHead>
 				<SortableHead
 					className="w-48"

--- a/apps/web/src/uploads/components/UploadTableHead.tsx
+++ b/apps/web/src/uploads/components/UploadTableHead.tsx
@@ -1,0 +1,89 @@
+import Checkbox from "@base/Checkbox";
+import SortableHead from "@base/SortableHead";
+import type { SortDirection, UploadSortField } from "@virtool/contracts";
+
+type UploadTableHeadProps = {
+	/** Whether every, some, or no file on the page is selected */
+	checked: boolean | "indeterminate";
+
+	/** The direction the sorted column is ordered in */
+	direction: SortDirection;
+
+	/** Callback to sort by a column, or to reverse the column already sorted by */
+	onSort: (field: UploadSortField) => void;
+
+	/** Callback to select or deselect every file on the page. Omitting it hides
+	 * the selection column. */
+	onSelectAll?: () => void;
+
+	/** The column the list is sorted by, if any */
+	sort: UploadSortField | undefined;
+};
+
+/**
+ * The column headers for the upload table.
+ *
+ * The selection and action columns carry no visible label, so each is named for
+ * assistive technology instead of leaving a header cell empty. The select-all
+ * checkbox names its own cell.
+ */
+export default function UploadTableHead({
+	checked,
+	direction,
+	onSelectAll,
+	onSort,
+	sort,
+}: UploadTableHeadProps) {
+	return (
+		<thead className="bg-gray-50 text-sm text-gray-600">
+			<tr>
+				{onSelectAll && (
+					<th className="w-px" scope="col">
+						<span className="sr-only">Select</span>
+						<Checkbox
+							ariaLabel="Select all files"
+							checked={checked}
+							id="UploadSelectAll"
+							onClick={onSelectAll}
+						/>
+					</th>
+				)}
+				<SortableHead
+					direction={direction}
+					field="name"
+					onSort={onSort}
+					sort={sort}
+				>
+					Name
+				</SortableHead>
+				<SortableHead
+					direction={direction}
+					field="user"
+					onSort={onSort}
+					sort={sort}
+				>
+					User
+				</SortableHead>
+				<SortableHead
+					direction={direction}
+					field="createdAt"
+					onSort={onSort}
+					sort={sort}
+				>
+					Created At
+				</SortableHead>
+				<SortableHead
+					direction={direction}
+					field="size"
+					onSort={onSort}
+					sort={sort}
+				>
+					Size
+				</SortableHead>
+				<th className="w-px" scope="col">
+					<span className="sr-only">Actions</span>
+				</th>
+			</tr>
+		</thead>
+	);
+}

--- a/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
@@ -124,7 +124,7 @@ describe("<FileManager>", () => {
 				"Select",
 				"Name",
 				"User",
-				"Created At",
+				"Created",
 				"Size",
 				"Actions",
 			]);

--- a/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
@@ -111,6 +111,106 @@ describe("<FileManager>", () => {
 		expect(screen.getByText("Drag files here to upload")).toBeInTheDocument();
 	});
 
+	describe("table", () => {
+		it("should label every column, including the ones with no visible header", async () => {
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			mockFindUploads([createFakeFile({ name: "one.fq.gz" })]);
+
+			await renderWithRouter(<FileManager {...props} />, path);
+
+			const headers = await screen.findAllByRole("columnheader");
+
+			expect(headers.map((header) => header.textContent)).toEqual([
+				"Select",
+				"Name",
+				"User",
+				"Created At",
+				"Size",
+				"Actions",
+			]);
+		});
+
+		it("should sort by an unsorted column ascending", async () => {
+			const setSort = vi.fn();
+
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			mockFindUploads([createFakeFile({ name: "one.fq.gz" })]);
+
+			await renderWithRouter(
+				<FileManager {...props} setSort={setSort} />,
+				path,
+			);
+
+			await userEvent.click(
+				await screen.findByRole("button", { name: "Name" }),
+			);
+
+			expect(setSort).toHaveBeenCalledWith("name", "ascending");
+		});
+
+		it("should reverse the column already sorted by", async () => {
+			const setSort = vi.fn();
+
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			mockFindUploads([createFakeFile({ name: "one.fq.gz" })]);
+
+			await renderWithRouter(
+				<FileManager
+					{...props}
+					direction="ascending"
+					setSort={setSort}
+					sort="name"
+				/>,
+				path,
+			);
+
+			await userEvent.click(
+				await screen.findByRole("button", { name: "Name" }),
+			);
+
+			expect(setSort).toHaveBeenCalledWith("name", "descending");
+		});
+
+		it("should request the sorted column from the server", async () => {
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			const findUploads = mockFindUploads([
+				createFakeFile({ name: "one.fq.gz" }),
+			]);
+
+			await renderWithRouter(
+				<FileManager {...props} direction="ascending" sort="size" />,
+				path,
+			);
+
+			await waitFor(() => {
+				expect(findUploads).toHaveBeenCalledWith({
+					data: expect.objectContaining({
+						direction: "ascending",
+						sort: "size",
+					}),
+				});
+			});
+		});
+
+		it("should request the default order when no column is sorted by", async () => {
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			const findUploads = mockFindUploads([
+				createFakeFile({ name: "one.fq.gz" }),
+			]);
+
+			await renderWithRouter(<FileManager {...props} />, path);
+
+			await waitFor(() => {
+				expect(findUploads).toHaveBeenCalledWith({
+					data: expect.objectContaining({
+						sort: undefined,
+						direction: "descending",
+					}),
+				});
+			});
+		});
+	});
+
 	describe("selection", () => {
 		it("should delete every selected file", async () => {
 			const first = createFakeFile({ name: "one.fq.gz" });

--- a/apps/web/src/uploads/components/__tests__/UploadItem.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/UploadItem.test.tsx
@@ -7,43 +7,54 @@ import UploadItem, { type UploadItemProps } from "../UploadItem.js";
 
 vi.mock("@administration/utils.ts");
 
+// A row is a `<tr>`, which only renders inside a table.
+function renderItem(props: UploadItemProps) {
+	return renderWithProviders(
+		<table>
+			<tbody>
+				<UploadItem {...props} />
+			</tbody>
+		</table>,
+	);
+}
+
 describe("<UploadItem />", () => {
 	let props: UploadItemProps;
 
 	beforeEach(() => {
 		props = {
 			canDelete: true,
+			createdAt: new Date("2018-02-14T17:12:00.000000Z"),
 			id: 1,
 			name: "foo.fa",
 			size: 10,
-			uploadedAt: new Date("2018-02-14T17:12:00.000000Z"),
 			user: { id: 1, handle: "bill" },
 		};
 	});
 
 	it("should render", () => {
 		const user = { id: 1, handle: "bill" };
-		renderWithProviders(<UploadItem {...props} user={user} />);
+		renderItem({ ...props, user });
 
-		expect(screen.getByText(new RegExp(user.handle))).toBeInTheDocument();
-		expect(screen.getByText(new RegExp(props.name))).toBeInTheDocument();
+		expect(screen.getByRole("cell", { name: user.handle })).toBeInTheDocument();
+		expect(screen.getByRole("cell", { name: props.name })).toBeInTheDocument();
 		expect(screen.getByText("10.0 B")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "remove" })).toBeInTheDocument();
 	});
 
-	it("should render when [user=null]", () => {
+	it("should name the file as retrieved when [user=null]", () => {
 		props.user = null;
 
-		renderWithProviders(<UploadItem {...props} />);
+		renderItem(props);
 
-		expect(screen.getByText(/Retrieved/)).toBeInTheDocument();
-		expect(screen.getByText(new RegExp(props.name))).toBeInTheDocument();
+		expect(screen.getByRole("cell", { name: "Retrieved" })).toBeInTheDocument();
+		expect(screen.getByRole("cell", { name: props.name })).toBeInTheDocument();
 		expect(screen.getByText("10.0 B")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "remove" })).toBeInTheDocument();
 	});
 
 	it("should link to the download route, named after the file", () => {
-		renderWithProviders(<UploadItem {...props} />);
+		renderItem(props);
 
 		const link = screen.getByRole("link", { name: `Download ${props.name}` });
 
@@ -56,7 +67,7 @@ describe("<UploadItem />", () => {
 	it("should render the download link when [canDelete=false]", () => {
 		props.canDelete = false;
 
-		renderWithProviders(<UploadItem {...props} />);
+		renderItem(props);
 
 		expect(
 			screen.getByRole("link", { name: `Download ${props.name}` }),
@@ -68,7 +79,7 @@ describe("<UploadItem />", () => {
 
 	it("should have [props.onRemove] called when trash icon clicked", async () => {
 		uploadServerFnMocks.deleteUploadFn.mockResolvedValue(null);
-		renderWithProviders(<UploadItem {...props} />);
+		renderItem(props);
 
 		await userEvent.click(screen.getByRole("button", { name: "remove" }));
 

--- a/apps/web/src/uploads/queries.ts
+++ b/apps/web/src/uploads/queries.ts
@@ -7,12 +7,26 @@ import {
 	useQueryClient,
 } from "@tanstack/react-query";
 import { fileQueryKeys } from "@uploads/keys";
-import type { UploadSearchResult, UploadType } from "@virtool/contracts";
+import type {
+	SortDirection,
+	UploadSearchResult,
+	UploadSortField,
+	UploadType,
+} from "@virtool/contracts";
 
-export function useListFiles(type: UploadType, page: number, perPage: number) {
+export function useListFiles(
+	type: UploadType,
+	page: number,
+	perPage: number,
+	sort: UploadSortField | undefined,
+	direction: SortDirection,
+) {
 	return useQuery<UploadSearchResult>({
-		queryKey: fileQueryKeys.list([type, page, perPage]),
-		queryFn: () => findUploadsFn({ data: { uploadType: type, page, perPage } }),
+		queryKey: fileQueryKeys.list([type, page, perPage, sort, direction]),
+		queryFn: () =>
+			findUploadsFn({
+				data: { uploadType: type, page, perPage, sort, direction },
+			}),
 		placeholderData: keepPreviousData,
 	});
 }

--- a/apps/web/src/uploads/search.ts
+++ b/apps/web/src/uploads/search.ts
@@ -1,0 +1,49 @@
+import { type Paginated, paginated } from "@app/pagination";
+import { oneOf, oneOfOptional } from "@app/searchParams";
+import {
+	SORT_DIRECTIONS,
+	type SortDirection,
+	UPLOAD_SORT_FIELDS,
+	type UploadSortField,
+} from "@virtool/contracts";
+
+/**
+ * The params an uploads list route resolves for itself, and so strips from the
+ * URL on the way out.
+ */
+export const UPLOADS_SEARCH_DEFAULTS = {
+	direction: "descending",
+	page: 1,
+} as const;
+
+/** The search params a route listing uploads takes. */
+export type UploadsSearch = Paginated & {
+	/** The direction the sorted column is ordered in */
+	direction: SortDirection;
+
+	/** The column the list is sorted by, or undefined for the default order */
+	sort?: UploadSortField;
+};
+
+/**
+ * Coerce the search params an uploads list route accepts.
+ *
+ * The direction stands on its own so a link can carry one without a column, but
+ * the server ignores it until a column is chosen — the default ordering is
+ * newest first either way.
+ */
+export function uploadsSearch(input: {
+	direction?: unknown;
+	page?: unknown;
+	sort?: unknown;
+}): UploadsSearch {
+	return {
+		...paginated(input),
+		direction: oneOf(
+			input.direction,
+			SORT_DIRECTIONS,
+			UPLOADS_SEARCH_DEFAULTS.direction,
+		),
+		sort: oneOfOptional(input.sort, UPLOAD_SORT_FIELDS),
+	};
+}

--- a/packages/contracts/src/search.ts
+++ b/packages/contracts/src/search.ts
@@ -19,3 +19,12 @@ export type SearchResult = {
 	/** The total number of items */
 	totalCount: number;
 };
+
+/**
+ * The directions a sorted list can be ordered in. The members match the values
+ * `aria-sort` takes, so a sortable column header can pass one straight through.
+ */
+export const SORT_DIRECTIONS = ["ascending", "descending"] as const;
+
+/** The direction a sorted list is ordered in. */
+export type SortDirection = (typeof SORT_DIRECTIONS)[number];

--- a/packages/contracts/src/uploads.ts
+++ b/packages/contracts/src/uploads.ts
@@ -1,6 +1,17 @@
 import type { SearchResult } from "./search";
 import type { UserNested } from "./users";
 
+/** The columns an upload list can be sorted by. */
+export const UPLOAD_SORT_FIELDS = [
+	"createdAt",
+	"name",
+	"size",
+	"user",
+] as const;
+
+/** A column an upload list can be sorted by. */
+export type UploadSortField = (typeof UPLOAD_SORT_FIELDS)[number];
+
 /** The kinds of file that can be uploaded. */
 export const UPLOAD_TYPES = ["reference", "reads", "subtraction"] as const;
 

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -189,6 +189,83 @@ describe("findUploads", () => {
 		expect(result.items).toHaveLength(1);
 		expect(result.items[0]?.user).toEqual({ id: alice, handle: "alice" });
 	});
+
+	describe("sorting", () => {
+		async function seedSortable() {
+			const bob = await seedUser(db, { handle: "bob" });
+			const alice = await seedUser(db, { handle: "alice" });
+
+			await seedUpload(bob, {
+				name: "beta.fq.gz",
+				size: 30,
+				createdAt: new Date("2022-02-01T00:00:00Z"),
+			});
+			await seedUpload(alice, {
+				name: "alpha.fq.gz",
+				size: 10,
+				createdAt: new Date("2022-03-01T00:00:00Z"),
+			});
+			await seedUpload(bob, {
+				name: "gamma.fq.gz",
+				size: 20,
+				createdAt: new Date("2022-01-01T00:00:00Z"),
+			});
+		}
+
+		it.each([
+			["name", "ascending", ["alpha.fq.gz", "beta.fq.gz", "gamma.fq.gz"]],
+			["name", "descending", ["gamma.fq.gz", "beta.fq.gz", "alpha.fq.gz"]],
+			["size", "ascending", ["alpha.fq.gz", "gamma.fq.gz", "beta.fq.gz"]],
+			["size", "descending", ["beta.fq.gz", "gamma.fq.gz", "alpha.fq.gz"]],
+			["createdAt", "ascending", ["gamma.fq.gz", "beta.fq.gz", "alpha.fq.gz"]],
+			["createdAt", "descending", ["alpha.fq.gz", "beta.fq.gz", "gamma.fq.gz"]],
+			// alice uploaded only alpha; bob's two files follow, ordered by the id
+			// tiebreak rather than left to the planner.
+			["user", "ascending", ["alpha.fq.gz", "beta.fq.gz", "gamma.fq.gz"]],
+			["user", "descending", ["gamma.fq.gz", "beta.fq.gz", "alpha.fq.gz"]],
+		] as const)("orders by %s %s", async (field, direction, expected) => {
+			await seedSortable();
+
+			const result = await findUploads(db, undefined, 1, 25, undefined, {
+				direction,
+				field,
+			});
+
+			expect(result.items.map((upload) => upload.name)).toEqual(expected);
+		});
+
+		it("defaults to newest first when no column is given", async () => {
+			await seedSortable();
+
+			const result = await findUploads(db, undefined, 1, 25);
+
+			expect(result.items.map((upload) => upload.name)).toEqual([
+				"alpha.fq.gz",
+				"beta.fq.gz",
+				"gamma.fq.gz",
+			]);
+		});
+
+		// Offset pagination over a tied ordering can repeat or skip rows between
+		// pages, so the primary key breaks every tie.
+		it("pages through tied values without repeating or skipping a row", async () => {
+			const userId = await seedUser(db);
+			const tied = new Date("2022-01-01T00:00:00Z");
+
+			for (const name of ["one", "two", "three", "four"]) {
+				await seedUpload(userId, { name, size: 5, createdAt: tied });
+			}
+
+			const sort = { direction: "ascending", field: "size" } as const;
+
+			const first = await findUploads(db, undefined, 1, 2, undefined, sort);
+			const second = await findUploads(db, undefined, 2, 2, undefined, sort);
+
+			const ids = [...first.items, ...second.items].map((upload) => upload.id);
+
+			expect(new Set(ids).size).toBe(4);
+		});
+	});
 });
 
 describe("deleteUpload", () => {

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -1,6 +1,8 @@
 import type {
+	SortDirection,
 	Upload,
 	UploadSearchResult,
+	UploadSortField,
 	UploadType,
 	UserNested,
 } from "@virtool/contracts";
@@ -67,12 +69,40 @@ async function fetchUser(
 	return row ?? null;
 }
 
+/** Which column an upload list is ordered by, and in which direction. */
+export type UploadSort = {
+	direction: SortDirection;
+	field: UploadSortField;
+};
+
+const SORT_COLUMNS = {
+	createdAt: uploadsTable.createdAt,
+	name: uploadsTable.name,
+	size: uploadsTable.size,
+	user: usersTable.handle,
+} as const;
+
+/**
+ * The `ORDER BY` an upload list takes, defaulting to newest first.
+ *
+ * Every sortable column has ties — two files of the same size, two uploads made
+ * in the same second — and offset pagination over a tied ordering can repeat or
+ * skip rows between pages. The primary key breaks them, so the order is total.
+ */
+function buildOrderBy(sort: UploadSort | undefined) {
+	const order = sort?.direction === "ascending" ? asc : desc;
+	const column = sort ? SORT_COLUMNS[sort.field] : uploadsTable.createdAt;
+
+	return [order(column), order(uploadsTable.id)];
+}
+
 export async function findUploads(
 	db: DbOrTx,
 	uploadType: UploadType | undefined,
 	page: number,
 	perPage: number,
 	userId?: number,
+	sort?: UploadSort,
 ): Promise<UploadSearchResult> {
 	// A visible upload is finished, not deleted, and not held for a sample that
 	// is mid-creation.
@@ -109,7 +139,7 @@ export async function findUploads(
 			.from(uploadsTable)
 			.leftJoin(usersTable, eq(usersTable.id, uploadsTable.userId))
 			.where(and(...filters))
-			.orderBy(desc(uploadsTable.createdAt))
+			.orderBy(...buildOrderBy(sort))
 			.limit(perPage)
 			.offset(skip),
 	]);


### PR DESCRIPTION
## Summary
- replace upload list rows with an accessible, stable-width data table
- add URL-backed sorting for name, user, creation time, and size
- apply deterministic server-side ordering with test coverage across data and UI layers