### PR TITLE
feat: gzip workflow files with pigz across the pod's cores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,8 +245,6 @@ RUN pnpm --filter @virtool/create-subtraction build \
 FROM node:24-bookworm-slim AS create-subtraction
 WORKDIR /workflow
 
-# pigz gzips the source genome in `finalize`. See the note above the tool
-# stages for why it comes from apt rather than a stage of its own.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends pigz \
     && rm -rf /var/lib/apt/lists/* \
@@ -266,16 +264,11 @@ RUN pnpm --filter @virtool/create-sample build \
 FROM node:24-bookworm-slim AS create-sample
 WORKDIR /workflow
 
-# pigz is the one apt package, and it is here because `finalize` calls it — not
-# because a copied binary needs it. Nothing copied does: FastQC once forced a
-# JRE and the full `perl` into this image, being a Java program behind a Perl
-# launcher that opens with `use FindBin`, and `quality-core` replaced it with a
-# static binary that needs nothing the base does not already carry. Keep it
-# that way.
-#
-# `finalize` gzips the normalized reads, which is this image's longest step on
-# its largest files. See the note above the tool stages for why pigz comes from
-# apt rather than a stage of its own.
+# pigz is here because `finalize` calls it, not because a copied binary needs
+# it. Nothing copied does: FastQC once forced a JRE and the full `perl` into
+# this image — a Java program behind a Perl launcher that opens with
+# `use FindBin` — and `quality-core` replaced it with a static binary that needs
+# nothing the base does not already carry. Keep it that way.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends pigz \
     && rm -rf /var/lib/apt/lists/* \
@@ -384,8 +377,7 @@ WORKDIR /workflow
 # binaries. Dropping either leaves an image whose steps fail at exec with no
 # clue why.
 #
-# pigz is the odd one out: a tool this workflow calls itself, to gzip the
-# assembly and the ORFs and to gunzip a subtraction genome.
+# pigz is the odd one out: a tool the steps call, not a library.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libbz2-1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN ./configure --prefix /tools/hmmer/3.3.2 \
 
 # There is deliberately no `pigz` stage. The only source for its tarball is
 # zlib.net, which goes down often enough to hang every build queued behind it,
-# so the stages that want pigz install Debian's package instead. Nothing here
+# so every workflow stage installs Debian's package instead. Nothing here
 # depends on its exact output bytes — checksums are taken over decompressed
 # content — so 2.6 rather than 2.8 costs nothing.
 
@@ -244,6 +244,14 @@ RUN pnpm --filter @virtool/create-subtraction build \
 
 FROM node:24-bookworm-slim AS create-subtraction
 WORKDIR /workflow
+
+# pigz gzips the source genome in `finalize`. See the note above the tool
+# stages for why it comes from apt rather than a stage of its own.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pigz \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
 COPY --from=seqkit /tools/seqkit/2.13.0/seqkit /usr/local/bin/
 COPY --from=build-create-subtraction /prod/create-subtraction ./
 CMD ["node", "dist/index.mjs"]
@@ -258,10 +266,21 @@ RUN pnpm --filter @virtool/create-sample build \
 FROM node:24-bookworm-slim AS create-sample
 WORKDIR /workflow
 
-# There is deliberately no apt layer here. FastQC forced a JRE and the full
-# `perl` into this image — it is a Java program behind a Perl launcher that
-# opens with `use FindBin` — and `quality-core` replaced it with one static
-# binary that needs nothing the base does not already carry.
+# pigz is the one apt package, and it is here because `finalize` calls it — not
+# because a copied binary needs it. Nothing copied does: FastQC once forced a
+# JRE and the full `perl` into this image, being a Java program behind a Perl
+# launcher that opens with `use FindBin`, and `quality-core` replaced it with a
+# static binary that needs nothing the base does not already carry. Keep it
+# that way.
+#
+# `finalize` gzips the normalized reads, which is this image's longest step on
+# its largest files. See the note above the tool stages for why pigz comes from
+# apt rather than a stage of its own.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pigz \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
 COPY --from=quality-builder /build/target/release/quality-core /usr/local/bin/
 
 COPY --from=build-create-sample /prod/create-sample ./
@@ -364,11 +383,15 @@ WORKDIR /workflow
 # `bowtie2-build` one and `spades.py`, which drives the compiled assembler
 # binaries. Dropping either leaves an image whose steps fail at exec with no
 # clue why.
+#
+# pigz is the odd one out: a tool this workflow calls itself, to gzip the
+# assembly and the ORFs and to gunzip a subtraction genome.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libbz2-1.0 \
         libgomp1 \
         perl \
+        pigz \
         python3 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
@@ -378,9 +401,6 @@ COPY --from=skewer /tools/skewer/0.2.2/ /usr/local/bin/
 COPY --from=hmmer /tools/hmmer/3.3.2/ /opt/hmmer/
 COPY --from=spades /build/spades /opt/spades
 
-# There is deliberately no pigz. `@virtool/workflow`'s gzip helpers are
-# `node:zlib` in-process, and checksums are taken over decompressed content,
-# so nothing depends on pigz's output.
 ENV PATH="/opt/hmmer/bin:/opt/spades/bin:${PATH}"
 
 COPY --from=build-nuvs /prod/nuvs ./

--- a/apps/create-sample/README.md
+++ b/apps/create-sample/README.md
@@ -6,14 +6,15 @@ Turns a user's uploaded FASTQ files into a sample an analysis can run against:
 measures their quality, normalizes them to `reads_1.fq.gz` and
 `reads_2.fq.gz`, and commits them to object storage.
 
-Two steps, `run_fastqc` and `finalize`, and one external binary,
+Two steps, `run_fastqc` and `finalize`, and two external binaries:
 [`quality-core`](../../packages/quality-core/README.md) — a Rust crate in this
-repo rather than a third-party tool.
+repo rather than a third-party tool — and `pigz`, which `finalize` uses to gzip
+the normalized reads across the pod's whole core allocation.
 
 ## Building the image
 
 The root Dockerfile uses cargo-chef to build `quality-core`, then copies its
-single binary into the runtime stage:
+single binary into the runtime stage, whose only apt package is `pigz`:
 
 ```console
 docker build --target create-sample .

--- a/apps/create-sample/README.md
+++ b/apps/create-sample/README.md
@@ -6,15 +6,14 @@ Turns a user's uploaded FASTQ files into a sample an analysis can run against:
 measures their quality, normalizes them to `reads_1.fq.gz` and
 `reads_2.fq.gz`, and commits them to object storage.
 
-Two steps, `run_fastqc` and `finalize`, and two external binaries:
+Two steps, `run_fastqc` and `finalize`, and two external binaries: `pigz` and
 [`quality-core`](../../packages/quality-core/README.md) — a Rust crate in this
-repo rather than a third-party tool — and `pigz`, which `finalize` uses to gzip
-the normalized reads across the pod's whole core allocation.
+repo rather than a third-party tool.
 
 ## Building the image
 
 The root Dockerfile uses cargo-chef to build `quality-core`, then copies its
-single binary into the runtime stage, whose only apt package is `pigz`:
+single binary into the runtime stage, which installs `pigz` from apt:
 
 ```console
 docker build --target create-sample .

--- a/apps/create-sample/src/steps/finalize.ts
+++ b/apps/create-sample/src/steps/finalize.ts
@@ -1,12 +1,11 @@
 import { mkdir, rename } from "node:fs/promises";
 import { dirname } from "node:path";
-import { compressFile } from "@virtool/archive/compression";
 import type {
 	FinalizeSampleRequest,
 	SampleReadManifest,
 } from "@virtool/contracts";
 import { mintStorageKey } from "@virtool/storage";
-import { uploadFromPath } from "@virtool/workflow";
+import { gzipFile, uploadFromPath } from "@virtool/workflow";
 import { readsFileName } from "../paths";
 import type { CreateSampleStep } from "./types";
 
@@ -40,7 +39,7 @@ import type { CreateSampleStep } from "./types";
 export const finalizeStep: CreateSampleStep = {
 	id: "finalize",
 	description: "Upload the normalized reads and finalize the sample.",
-	async run({ client, data, logger, state, storage }) {
+	async run({ client, data, logger, proc, runSubprocess, state, storage }) {
 		const { quality } = state;
 
 		// `run_fastqc` fills this. Reaching finalize without it means the run is
@@ -67,7 +66,12 @@ export const finalizeStep: CreateSampleStep = {
 			if (gzipped) {
 				await rename(read.upload, read.normalized);
 			} else {
-				await compressFile(read.upload, read.normalized);
+				await gzipFile({
+					proc,
+					runSubprocess,
+					source: read.upload,
+					target: read.normalized,
+				});
 			}
 
 			const storageKey = mintStorageKey("samples", data.sampleId);

--- a/apps/create-subtraction/README.md
+++ b/apps/create-subtraction/README.md
@@ -5,13 +5,13 @@ Image: `ghcr.io/virtool/create-subtraction`.
 Computes GC and sequence count for a subtraction and commits its
 FASTA to object storage.
 
-Two steps, `compute_gc_and_count` and `finalize`, and one external tool,
-`seqkit`.
+Two steps, `compute_gc_and_count` and `finalize`, and two external tools:
+`seqkit`, and `pigz` for gzipping the genome in `finalize`.
 
 ## Building the image
 
 The root Dockerfile builds SeqKit in its own stage and copies its binary into
-this app's runtime stage:
+this app's runtime stage, which installs `pigz` from apt:
 
 ```console
 docker build --target create-subtraction .

--- a/apps/create-subtraction/README.md
+++ b/apps/create-subtraction/README.md
@@ -5,8 +5,8 @@ Image: `ghcr.io/virtool/create-subtraction`.
 Computes GC and sequence count for a subtraction and commits its
 FASTA to object storage.
 
-Two steps, `compute_gc_and_count` and `finalize`, and two external tools:
-`seqkit`, and `pigz` for gzipping the genome in `finalize`.
+Two steps, `compute_gc_and_count` and `finalize`, and two external tools,
+`seqkit` and `pigz`.
 
 ## Building the image
 

--- a/apps/create-subtraction/src/steps/finalize.ts
+++ b/apps/create-subtraction/src/steps/finalize.ts
@@ -1,10 +1,9 @@
-import { compressFile } from "@virtool/archive/compression";
 import type {
 	FinalizeSubtractionRequest,
 	SubtractionFileManifest,
 } from "@virtool/contracts";
 import { mintStorageKey } from "@virtool/storage";
-import { uploadFromPath } from "@virtool/workflow";
+import { gzipFile, uploadFromPath } from "@virtool/workflow";
 import type { CreateSubtractionStep } from "./types";
 
 /**
@@ -43,7 +42,7 @@ const FASTA_NAME = "subtraction.fa.gz";
 export const finalizeStep: CreateSubtractionStep = {
 	id: "finalize",
 	description: "Upload the compressed genome and finalize the subtraction.",
-	async run({ client, data, logger, state, storage }) {
+	async run({ client, data, logger, proc, runSubprocess, state, storage }) {
 		const { count, gc } = state;
 
 		// `compute_gc_and_count` fills both. Reaching finalize without them means
@@ -57,7 +56,12 @@ export const finalizeStep: CreateSubtractionStep = {
 		if (!data.uploadIsGzipped) {
 			path = data.paths.compressedFasta;
 
-			await compressFile(data.paths.upload, path);
+			await gzipFile({
+				proc,
+				runSubprocess,
+				source: data.paths.upload,
+				target: path,
+			});
 		}
 
 		const storageKey = mintStorageKey("subtractions", data.subtractionId);

--- a/apps/nuvs/README.md
+++ b/apps/nuvs/README.md
@@ -6,8 +6,7 @@ subtraction, assembles what is left with SPAdes, and searches the contigs for
 viral motifs with HMMER.
 
 Image: `ghcr.io/virtool/nuvs`. Ten steps, six external tools — `skewer`,
-`bowtie2`, SPAdes, `hmmpress`, `hmmscan` and `pigz`, which gzips the assembly
-and the ORFs and gunzips a subtraction genome.
+`bowtie2`, SPAdes, `hmmpress`, `hmmscan` and `pigz`.
 
 ## Building the image
 

--- a/apps/nuvs/README.md
+++ b/apps/nuvs/README.md
@@ -5,16 +5,17 @@ describe: it discards every read that maps to a known OTU or to a
 subtraction, assembles what is left with SPAdes, and searches the contigs for
 viral motifs with HMMER.
 
-Image: `ghcr.io/virtool/nuvs`. Ten steps, five external tools — `skewer`,
-`bowtie2`, SPAdes, `hmmpress` and `hmmscan`.
+Image: `ghcr.io/virtool/nuvs`. Ten steps, six external tools — `skewer`,
+`bowtie2`, SPAdes, `hmmpress`, `hmmscan` and `pigz`, which gzips the assembly
+and the ORFs and gunzips a subtraction genome.
 
 ## Building the image
 
 The root Dockerfile builds each external tool in an independent stage. SPAdes
 4.2.0 is compiled from source because it has no binary release suitable for
 the runtime base. The runtime installs Perl for the Bowtie 2 wrapper, Python
-for `bowtie2-build` and `spades.py`, and the shared libraries required by the
-copied binaries.
+for `bowtie2-build` and `spades.py`, `pigz`, and the shared libraries required
+by the copied binaries.
 
 ```console
 docker build --target nuvs .

--- a/apps/nuvs/package.json
+++ b/apps/nuvs/package.json
@@ -19,7 +19,6 @@
 		"@azure/identity": "^4.13.1",
 		"@azure/storage-blob": "^12.33.0",
 		"@sentry/node": "^10.70.0",
-		"@virtool/archive": "workspace:*",
 		"@virtool/bio": "workspace:*",
 		"@virtool/contracts": "workspace:*",
 		"@virtool/sqlite": "workspace:*",

--- a/apps/nuvs/src/steps/assemble.ts
+++ b/apps/nuvs/src/steps/assemble.ts
@@ -1,4 +1,4 @@
-import { compressFile } from "@virtool/archive/compression";
+import { gzipFile } from "@virtool/workflow";
 import { workPaths } from "../paths";
 import type { NuvsStep } from "./types";
 
@@ -67,7 +67,12 @@ export const assembleStep: NuvsStep = {
 			},
 		});
 
-		await compressFile(paths.spadesScaffolds, paths.compressedAssembly);
+		await gzipFile({
+			proc,
+			runSubprocess,
+			source: paths.spadesScaffolds,
+			target: paths.compressedAssembly,
+		});
 
 		logger.info(
 			{ assemblyPath: paths.compressedAssembly, kmerLengths },

--- a/apps/nuvs/src/steps/createIndexes.ts
+++ b/apps/nuvs/src/steps/createIndexes.ts
@@ -1,7 +1,10 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { decompressFile } from "@virtool/archive/compression";
-import { createMappingIndex, downloadToPath } from "@virtool/workflow";
+import {
+	createMappingIndex,
+	downloadToPath,
+	gunzipFile,
+} from "@virtool/workflow";
 import { cacheFor } from "../cache";
 import {
 	REFERENCE_INDEX_EXTRA_PARAMS,
@@ -97,7 +100,12 @@ export const createSubtractionIndexesStep: NuvsStep = {
 							subtraction.path,
 						);
 
-						await decompressFile(subtraction.path, fastaPath);
+						await gunzipFile({
+							proc,
+							runSubprocess,
+							source: subtraction.path,
+							target: fastaPath,
+						});
 
 						logger.info(
 							{ fastaPath, subtractionId: subtraction.id },

--- a/apps/nuvs/src/steps/fixtures.ts
+++ b/apps/nuvs/src/steps/fixtures.ts
@@ -63,9 +63,7 @@ export async function setupStep({
 	const paths = workPaths(workPath);
 	const runSubprocess = createFakeSubprocessRunner();
 
-	// This runner replaces the one `createFakeContext` would have built, and
-	// with it the pigz that builder registers. Three steps here gzip or gunzip
-	// a file and then read it back.
+	// This runner replaces the one `createFakeContext` builds, and its pigz.
 	registerFakePigz(runSubprocess);
 	const jobsApiState = createJobsApiState();
 	const client = createFakeJobsApiClient(jobsApiState);

--- a/apps/nuvs/src/steps/fixtures.ts
+++ b/apps/nuvs/src/steps/fixtures.ts
@@ -20,6 +20,7 @@ import {
 	createJobsApiState,
 	createTestStorage,
 	createTestWorkPath,
+	registerFakePigz,
 } from "@virtool/workflow/testing";
 import { onTestFinished } from "vitest";
 import type { NuvsData, NuvsSubtraction } from "../context";
@@ -61,6 +62,11 @@ export async function setupStep({
 
 	const paths = workPaths(workPath);
 	const runSubprocess = createFakeSubprocessRunner();
+
+	// This runner replaces the one `createFakeContext` would have built, and
+	// with it the pigz that builder registers. Three steps here gzip or gunzip
+	// a file and then read it back.
+	registerFakePigz(runSubprocess);
 	const jobsApiState = createJobsApiState();
 	const client = createFakeJobsApiClient(jobsApiState);
 	const testStorage = createTestStorage();

--- a/apps/nuvs/src/steps/processAssembly.ts
+++ b/apps/nuvs/src/steps/processAssembly.ts
@@ -1,8 +1,8 @@
 import { createWriteStream } from "node:fs";
 import { rename } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
-import { compressFile } from "@virtool/archive/compression";
 import { findOrfs, parseFastaLines } from "@virtool/bio";
+import { gzipFile } from "@virtool/workflow";
 import { workPaths } from "../paths";
 import { readLines } from "../sequences";
 import type { NuvsRawContig } from "../state";
@@ -36,7 +36,7 @@ const MINIMUM_CONTIG_LENGTH = 300;
 export const processAssemblyStep: NuvsStep = {
 	id: "process_assembly",
 	description: "Find ORFs in the assembled contigs.",
-	async run({ logger, state, workPath }) {
+	async run({ logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
 		// `assemble` has already compressed the scaffolds under their original
@@ -72,7 +72,12 @@ export const processAssemblyStep: NuvsStep = {
 
 		await writeOrfsFasta(paths.orfsFasta, contigs);
 
-		await compressFile(paths.orfsFasta, paths.compressedOrfs);
+		await gzipFile({
+			proc,
+			runSubprocess,
+			source: paths.orfsFasta,
+			target: paths.compressedOrfs,
+		});
 
 		state.hits = contigs;
 

--- a/packages/archive/README.md
+++ b/packages/archive/README.md
@@ -3,10 +3,10 @@
 Tar, gzip and zip, for anything in the monorepo that reads or writes an archive.
 
 Framework-agnostic and dependency-light: `tar-stream` and `fflate` plus
-`node:zlib`, no database, no object storage, no logger, and no tool that has to
-be on `PATH`. It is imported by `@virtool/workflow` (cache archives), by the
-workflow apps (unpacking archives and reading gzip magic), by `@virtool/tasks`
-(the HMM release archive) and by `@virtool/data` (the NCBI BLAST result zip).
+`node:zlib`, no database, no object storage, no logger. It is imported by
+`@virtool/workflow` (cache archives), by the workflow apps (reading gzip magic),
+by `@virtool/tasks` (the HMM release archive) and by `@virtool/data` (the NCBI
+BLAST result zip).
 
 ## Exports
 
@@ -61,15 +61,10 @@ would stay inside the destination.
 
 ## Gzip
 
-`compressFile` compresses in-process, single threaded. Checksums are taken over
-decompressed content, so the gzip bytes need not be reproducible and nothing
-compares them against another compressor's.
-
-**Workflow steps do not use it.** They gzip several gigabytes at a time in a pod
-sized with `VT_PROC` cores, so they call `gzipFile()` and `gunzipFile()` from
-`@virtool/workflow`, which shell out to `pigz`. Those need a tool on `PATH` and
-a core count, and this package promises neither — which is why they live there
-and not here. Server-side callers run in pods with no `pigz` and stay on these.
+`compressFile` compresses in-process: checksums are taken over decompressed
+content, so the gzip bytes need not be reproducible. Workflow steps gzip
+gigabytes at a time and use `gzipFile` from `@virtool/workflow` instead, which
+runs `pigz`.
 
 `decompressGzipToFile` takes an `AsyncIterable<Uint8Array>` so object-storage
 callers can inflate directly into a destination without buffering or retaining

--- a/packages/archive/README.md
+++ b/packages/archive/README.md
@@ -3,10 +3,10 @@
 Tar, gzip and zip, for anything in the monorepo that reads or writes an archive.
 
 Framework-agnostic and dependency-light: `tar-stream` and `fflate` plus
-`node:zlib`, no database, no object storage, no logger. It is imported by
-`@virtool/workflow` (cache archives), by the workflow apps (gzipping reads and
-assemblies), by `@virtool/tasks` (the HMM release archive) and by
-`@virtool/data` (the NCBI BLAST result zip).
+`node:zlib`, no database, no object storage, no logger, and no tool that has to
+be on `PATH`. It is imported by `@virtool/workflow` (cache archives), by the
+workflow apps (unpacking archives and reading gzip magic), by `@virtool/tasks`
+(the HMM release archive) and by `@virtool/data` (the NCBI BLAST result zip).
 
 ## Exports
 
@@ -61,8 +61,15 @@ would stay inside the destination.
 
 ## Gzip
 
-`compressFile` compresses in-process: checksums are taken over decompressed
-content, so the gzip bytes need not be reproducible.
+`compressFile` compresses in-process, single threaded. Checksums are taken over
+decompressed content, so the gzip bytes need not be reproducible and nothing
+compares them against another compressor's.
+
+**Workflow steps do not use it.** They gzip several gigabytes at a time in a pod
+sized with `VT_PROC` cores, so they call `gzipFile()` and `gunzipFile()` from
+`@virtool/workflow`, which shell out to `pigz`. Those need a tool on `PATH` and
+a core count, and this package promises neither — which is why they live there
+and not here. Server-side callers run in pods with no `pigz` and stay on these.
 
 `decompressGzipToFile` takes an `AsyncIterable<Uint8Array>` so object-storage
 callers can inflate directly into a destination without buffering or retaining

--- a/packages/archive/src/compression.ts
+++ b/packages/archive/src/compression.ts
@@ -1,10 +1,14 @@
 /**
  * Gzip helpers.
  *
- * Compression runs in-process rather than shelling out to a parallel gzip:
- * checksums are taken over *decompressed* content, so the gzip bytes need not
- * be reproducible and there is nothing to gain from matching another
- * compressor.
+ * In-process and single threaded. Checksums are taken over *decompressed*
+ * content, so the gzip bytes need not be reproducible and there is nothing to
+ * gain from matching another compressor.
+ *
+ * Workflow steps gzip gigabytes at a time on a pod sized with `VT_PROC` cores
+ * and use `gzipFile` and `gunzipFile` from `@virtool/workflow` instead, which
+ * shell out to `pigz`. They live there rather than here because they need a
+ * tool on `PATH` and a core count, and this package promises neither.
  */
 
 import { createReadStream, createWriteStream } from "node:fs";

--- a/packages/archive/src/compression.ts
+++ b/packages/archive/src/compression.ts
@@ -1,14 +1,10 @@
 /**
  * Gzip helpers.
  *
- * In-process and single threaded. Checksums are taken over *decompressed*
- * content, so the gzip bytes need not be reproducible and there is nothing to
- * gain from matching another compressor.
- *
- * Workflow steps gzip gigabytes at a time on a pod sized with `VT_PROC` cores
- * and use `gzipFile` and `gunzipFile` from `@virtool/workflow` instead, which
- * shell out to `pigz`. They live there rather than here because they need a
- * tool on `PATH` and a core count, and this package promises neither.
+ * Compression runs in-process: checksums are taken over *decompressed* content,
+ * so the gzip bytes need not be reproducible and there is nothing to gain from
+ * matching another compressor. Workflow steps use `@virtool/workflow`'s
+ * `gzipFile`, which runs `pigz` across the pod's cores.
  */
 
 import { createReadStream, createWriteStream } from "node:fs";

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -69,9 +69,6 @@ ownership boundary between this package and `@virtool/jobs-api`.
 - Pass one `StorageBackend` into the run context. Tests use `MemoryStorage`.
 - Transfer files with `downloadToPath()` and `uploadFromPath()`; never buffer
   workflow files in memory.
-- Gzip a file on the work path with `gzipFile()` and `gunzipFile()`, passing the
-  context's `proc` and `runSubprocess`. Both shell out to `pigz`, which every
-  workflow image installs; there is no fallback.
 - Read storage keys from API records. Mint output keys with `mintStorageKey()`
   and send them back in the finalize manifest; never derive them from row IDs.
 - `createWorkflowCache()` stores an uncompressed tar containing one top-level
@@ -90,14 +87,8 @@ by code point, `,` and `:` separators, and every character outside
 `float()`, and do not change the frozen golden fixtures to match what the
 implementation currently produces.
 
-Tar belongs to `@virtool/archive`, and so does in-process gzip; this package
-re-exports neither. `gzipFile()` and `gunzipFile()` are not re-exports — they
-are the parallel counterparts of `compressFile()` and `decompressFile()`, and
-they live here because they need a tool on `PATH` and a core count, neither of
-which `@virtool/archive` promises. A pod is sized with `VT_PROC` cores and these
-files run to several gigabytes, so gzipping a sample's reads on one core leaves
-the rest of the allocation idle for minutes. Server-side callers, which run in
-pods with no `pigz`, keep the `@virtool/archive` functions.
+Tar and gzip operations belong to `@virtool/archive`; this package does not
+re-export them.
 
 ## Configuration
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -69,6 +69,9 @@ ownership boundary between this package and `@virtool/jobs-api`.
 - Pass one `StorageBackend` into the run context. Tests use `MemoryStorage`.
 - Transfer files with `downloadToPath()` and `uploadFromPath()`; never buffer
   workflow files in memory.
+- Gzip a file on the work path with `gzipFile()` and `gunzipFile()`, passing the
+  context's `proc` and `runSubprocess`. Both shell out to `pigz`, which every
+  workflow image installs; there is no fallback.
 - Read storage keys from API records. Mint output keys with `mintStorageKey()`
   and send them back in the finalize manifest; never derive them from row IDs.
 - `createWorkflowCache()` stores an uncompressed tar containing one top-level
@@ -87,8 +90,14 @@ by code point, `,` and `:` separators, and every character outside
 `float()`, and do not change the frozen golden fixtures to match what the
 implementation currently produces.
 
-Tar and gzip operations belong to `@virtool/archive`; this package does not
-re-export them.
+Tar belongs to `@virtool/archive`, and so does in-process gzip; this package
+re-exports neither. `gzipFile()` and `gunzipFile()` are not re-exports — they
+are the parallel counterparts of `compressFile()` and `decompressFile()`, and
+they live here because they need a tool on `PATH` and a core count, neither of
+which `@virtool/archive` promises. A pod is sized with `VT_PROC` cores and these
+files run to several gigabytes, so gzipping a sample's reads on one core leaves
+the rest of the allocation idle for minutes. Server-side callers, which run in
+pods with no `pigz`, keep the `@virtool/archive` functions.
 
 ## Configuration
 

--- a/packages/workflow/TESTING.md
+++ b/packages/workflow/TESTING.md
@@ -327,31 +327,6 @@ try {
 If the runner ever grows an `okExitCodes` option this changes — and it changes
 there, not here.
 
-### `pigz` is faked by actually gzipping
-
-An exit code is the whole of what most tools mean to a test, but not for one
-whose point is the file it leaves behind. `gzipFile()` and `gunzipFile()` shell
-out to `pigz`, and a step that gzips its output is almost always tested by
-reading that output back — against a runner that reports success and writes
-nothing, every such assertion becomes one about a file that is not there.
-
-So `registerFakePigz(run)` registers a response whose `effect` performs a real
-`node:zlib` round trip into the command's `stdoutFile`:
-
-```ts
-const run = createFakeSubprocessRunner();
-
-registerFakePigz(run);
-```
-
-`createFakeBuildContextInput` already does this to the runner it builds, because
-a fake context stands for a workflow image and every one of those carries pigz.
-**A test that supplies its own `runSubprocess` replaces that runner and loses
-it**, so register it again — `apps/nuvs/src/steps/fixtures.ts` is the example.
-
-`effect` is not pigz-specific: it is the hook for any tool whose test double has
-to leave a file behind.
-
 ## Storage: keys are minted and handed back
 
 Storage is faked at the **backend**, not at HTTP. `MemoryStorage` already

--- a/packages/workflow/TESTING.md
+++ b/packages/workflow/TESTING.md
@@ -327,6 +327,31 @@ try {
 If the runner ever grows an `okExitCodes` option this changes — and it changes
 there, not here.
 
+### `pigz` is faked by actually gzipping
+
+An exit code is the whole of what most tools mean to a test, but not for one
+whose point is the file it leaves behind. `gzipFile()` and `gunzipFile()` shell
+out to `pigz`, and a step that gzips its output is almost always tested by
+reading that output back — against a runner that reports success and writes
+nothing, every such assertion becomes one about a file that is not there.
+
+So `registerFakePigz(run)` registers a response whose `effect` performs a real
+`node:zlib` round trip into the command's `stdoutFile`:
+
+```ts
+const run = createFakeSubprocessRunner();
+
+registerFakePigz(run);
+```
+
+`createFakeBuildContextInput` already does this to the runner it builds, because
+a fake context stands for a workflow image and every one of those carries pigz.
+**A test that supplies its own `runSubprocess` replaces that runner and loses
+it**, so register it again — `apps/nuvs/src/steps/fixtures.ts` is the example.
+
+`effect` is not pigz-specific: it is the hook for any tool whose test double has
+to leave a file behind.
+
 ## Storage: keys are minted and handed back
 
 Storage is faked at the **backend**, not at HTTP. `MemoryStorage` already

--- a/packages/workflow/src/files/gzip.test.ts
+++ b/packages/workflow/src/files/gzip.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+	createFakeSubprocessRunner,
+	type FakeSubprocessRunner,
+	registerFakePigz,
+} from "../testing";
+import { gunzipFile, gzipFile } from "./gzip";
+
+const CONTENTS = ">contig_0\nACGTACGTACGT\n";
+
+async function setup(): Promise<{
+	dir: string;
+	runSubprocess: FakeSubprocessRunner;
+}> {
+	const dir = await mkdtemp(join(tmpdir(), "workflow-gzip-"));
+	const runSubprocess = createFakeSubprocessRunner();
+
+	registerFakePigz(runSubprocess);
+
+	return { dir, runSubprocess };
+}
+
+describe("gzipFile", () => {
+	it("runs pigz with the run's core count and the target as its stdout", async () => {
+		const { dir, runSubprocess } = await setup();
+		const source = join(dir, "source.fa");
+
+		await writeFile(source, CONTENTS);
+
+		const target = join(dir, "nested", "source.fa.gz");
+
+		await gzipFile({ proc: 6, runSubprocess, source, target });
+
+		expect(runSubprocess.calls()[0]).toMatchObject({
+			command: ["pigz", "-p", "6", "-c", source],
+			stdoutFile: target,
+		});
+
+		// The nested directory is the assertion: pigz would fail on a target
+		// whose parent does not exist, and every caller passes one it made up.
+		expect(gunzipSync(await readFile(target)).toString("utf8")).toBe(CONTENTS);
+	});
+});
+
+describe("gunzipFile", () => {
+	it("runs pigz in decompress mode and leaves the source in place", async () => {
+		const { dir, runSubprocess } = await setup();
+		const source = join(dir, "genome.fa.gz");
+
+		await writeFile(source, gzipSync(Buffer.from(CONTENTS)));
+
+		const target = join(dir, "genome.fa");
+
+		await gunzipFile({ proc: 2, runSubprocess, source, target });
+
+		expect(runSubprocess.calls()[0]).toMatchObject({
+			command: ["pigz", "-p", "2", "-d", "-c", source],
+			stdoutFile: target,
+		});
+
+		await expect(readFile(target, "utf8")).resolves.toBe(CONTENTS);
+		await expect(readFile(source)).resolves.toBeDefined();
+	});
+});

--- a/packages/workflow/src/files/gzip.test.ts
+++ b/packages/workflow/src/files/gzip.test.ts
@@ -40,8 +40,8 @@ describe("gzipFile", () => {
 			stdoutFile: target,
 		});
 
-		// The nested directory is the assertion: pigz would fail on a target
-		// whose parent does not exist, and every caller passes one it made up.
+		// The nested target directory is half the assertion: pigz would fail on a
+		// parent that does not exist.
 		expect(gunzipSync(await readFile(target)).toString("utf8")).toBe(CONTENTS);
 	});
 });

--- a/packages/workflow/src/files/gzip.ts
+++ b/packages/workflow/src/files/gzip.ts
@@ -1,0 +1,61 @@
+/**
+ * Gzip through `pigz`.
+ *
+ * `@virtool/archive`'s `compressFile` is `node:zlib` in-process and single
+ * threaded. A pod is sized with `VT_PROC` cores and the files here run to
+ * several gigabytes, so gzipping a sample's reads on one of them leaves the
+ * rest of the allocation idle for minutes.
+ *
+ * These live here rather than in `@virtool/archive` because they need a tool
+ * on `PATH` and a core count, and that package promises neither. Every workflow
+ * image installs `pigz`; there is no fallback, so a missing one fails the step
+ * with `SubprocessSpawnError` rather than quietly running at a seventh of the
+ * speed.
+ *
+ * `pigz -d` is barely parallel — inflating a gzip stream is inherently serial
+ * and the extra threads only overlap reads, writes and the CRC — but it is
+ * still the faster of the two and keeps one tool doing both directions.
+ */
+
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { RunSubprocess } from "../subprocess/types";
+
+/** What {@link gzipFile} and {@link gunzipFile} are told about one file. */
+export type GzipFileOptions = {
+	/** The run's core allocation, passed to `pigz -p`. */
+	proc: number;
+	runSubprocess: RunSubprocess;
+	source: string;
+	/** Overwritten if it exists. Its parent directory is created first. */
+	target: string;
+};
+
+/** Gzip `source` to `target` with `pigz`, leaving `source` in place. */
+export async function gzipFile(options: GzipFileOptions): Promise<void> {
+	await run(options, ["-c"]);
+}
+
+/** Gunzip `source` to `target` with `pigz`, leaving `source` in place. */
+export async function gunzipFile(options: GzipFileOptions): Promise<void> {
+	await run(options, ["-d", "-c"]);
+}
+
+/**
+ * Run `pigz` one way or the other.
+ *
+ * `-c` and a redirected stdout rather than pigz's in-place mode, which names
+ * its own output next to the input and would leave every caller renaming a
+ * file across whatever directories it chose.
+ */
+async function run(
+	{ proc, runSubprocess, source, target }: GzipFileOptions,
+	mode: readonly string[],
+): Promise<void> {
+	await mkdir(dirname(target), { recursive: true });
+
+	await runSubprocess({
+		command: ["pigz", "-p", String(proc), ...mode, source],
+		stdoutFile: target,
+	});
+}

--- a/packages/workflow/src/files/gzip.ts
+++ b/packages/workflow/src/files/gzip.ts
@@ -1,20 +1,9 @@
 /**
- * Gzip through `pigz`.
+ * Gzip through `pigz`, which every workflow image installs.
  *
- * `@virtool/archive`'s `compressFile` is `node:zlib` in-process and single
- * threaded. A pod is sized with `VT_PROC` cores and the files here run to
- * several gigabytes, so gzipping a sample's reads on one of them leaves the
- * rest of the allocation idle for minutes.
- *
- * These live here rather than in `@virtool/archive` because they need a tool
- * on `PATH` and a core count, and that package promises neither. Every workflow
- * image installs `pigz`; there is no fallback, so a missing one fails the step
- * with `SubprocessSpawnError` rather than quietly running at a seventh of the
- * speed.
- *
- * `pigz -d` is barely parallel — inflating a gzip stream is inherently serial
- * and the extra threads only overlap reads, writes and the CRC — but it is
- * still the faster of the two and keeps one tool doing both directions.
+ * `@virtool/archive`'s in-process helpers are single threaded, and these files
+ * run to several gigabytes on a pod sized with `VT_PROC` cores. They are here
+ * rather than there because they need a tool on `PATH` and a core count.
  */
 
 import { mkdir } from "node:fs/promises";
@@ -41,13 +30,8 @@ export async function gunzipFile(options: GzipFileOptions): Promise<void> {
 	await run(options, ["-d", "-c"]);
 }
 
-/**
- * Run `pigz` one way or the other.
- *
- * `-c` and a redirected stdout rather than pigz's in-place mode, which names
- * its own output next to the input and would leave every caller renaming a
- * file across whatever directories it chose.
- */
+// `-c` rather than pigz's in-place mode, which names its own output next to the
+// input and would leave every caller renaming a file.
 async function run(
 	{ proc, runSubprocess, source, target }: GzipFileOptions,
 	mode: readonly string[],

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -7,6 +7,7 @@ export * from "./client/retry";
 export * from "./config";
 export * from "./context";
 export * from "./errors";
+export * from "./files/gzip";
 export * from "./files/transfer";
 export * from "./lifecycle/claim";
 export * from "./lifecycle/ping";

--- a/packages/workflow/src/subprocess/execa.test.ts
+++ b/packages/workflow/src/subprocess/execa.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WorkflowError } from "../errors";
 import { createRecordingLogger } from "../testing";
 import { createRunSubprocess } from "./execa";
 import {
@@ -200,6 +201,36 @@ describe("createRunSubprocess", () => {
 		});
 
 		expect(seen).toEqual(["first", "second", "third"]);
+	});
+
+	it("writes stdout to the file given, truncating what was there", async () => {
+		const path = await script(
+			"stdoutFile",
+			'process.stdout.write("kept\\nbytes\\n");',
+		);
+
+		const target = join(scriptDir, "redirected.txt");
+
+		await writeFile(target, "a".repeat(4096));
+
+		const { runSubprocess } = createRunner();
+
+		await runSubprocess({ command: node(path), stdoutFile: target });
+
+		await expect(readFile(target, "utf8")).resolves.toBe("kept\nbytes\n");
+	});
+
+	it("refuses to both read stdout and redirect it to a file", async () => {
+		const path = await script("bothStdout", 'process.stdout.write("x");');
+		const { runSubprocess } = createRunner();
+
+		await expect(
+			runSubprocess({
+				command: node(path),
+				stdout: () => {},
+				stdoutFile: join(scriptDir, "unused.txt"),
+			}),
+		).rejects.toThrow(WorkflowError);
 	});
 
 	it("throws and kills the tree when a line exceeds the cap", async () => {

--- a/packages/workflow/src/subprocess/execa.ts
+++ b/packages/workflow/src/subprocess/execa.ts
@@ -43,6 +43,7 @@ export function createRunSubprocess({
 		cwd,
 		env,
 		stdout,
+		stdoutFile,
 		stderr,
 		maxLineBytes = DEFAULT_MAX_LINE_BYTES,
 	}) {
@@ -50,6 +51,12 @@ export function createRunSubprocess({
 
 		if (file === undefined) {
 			throw new WorkflowError("refusing to run an empty command");
+		}
+
+		if (stdout && stdoutFile !== undefined) {
+			throw new WorkflowError(
+				"refusing to both read stdout and redirect it to a file",
+			);
 		}
 
 		logger.info({ command }, "running subprocess");
@@ -76,8 +83,14 @@ export function createRunSubprocess({
 			stdin: "ignore",
 			// Not piped at all without a handler: an unread pipe is a buffer
 			// that fills, and a tool writing a SAM stream to stdout would fill
-			// it fast.
-			stdout: stdout ? "pipe" : "ignore",
+			// it fast. `stdoutFile` skips this process entirely — execa opens
+			// the file and hands the subprocess the descriptor.
+			stdout:
+				stdoutFile !== undefined
+					? { file: stdoutFile }
+					: stdout
+						? "pipe"
+						: "ignore",
 			stderr: "pipe",
 			// Every outcome is mapped below, and a rejection here would carry
 			// none of the stderr tail.

--- a/packages/workflow/src/subprocess/execa.ts
+++ b/packages/workflow/src/subprocess/execa.ts
@@ -83,8 +83,8 @@ export function createRunSubprocess({
 			stdin: "ignore",
 			// Not piped at all without a handler: an unread pipe is a buffer
 			// that fills, and a tool writing a SAM stream to stdout would fill
-			// it fast. `stdoutFile` skips this process entirely — execa opens
-			// the file and hands the subprocess the descriptor.
+			// it fast. `stdoutFile` hands the subprocess a descriptor instead,
+			// so the bytes never reach this process.
 			stdout:
 				stdoutFile !== undefined
 					? { file: stdoutFile }

--- a/packages/workflow/src/subprocess/types.ts
+++ b/packages/workflow/src/subprocess/types.ts
@@ -26,14 +26,11 @@ export type RunSubprocessOptions = {
 	 */
 	stdout?: LineHandler;
 	/**
-	 * Write stdout straight to this file, truncating it first.
+	 * Write stdout straight to this file, truncating it first. Mutually
+	 * exclusive with `stdout`.
 	 *
-	 * For a tool whose stdout is bytes rather than lines — `pigz -c` and
-	 * nothing else so far. The line splitter would have to buffer a gigabyte of
-	 * gzip looking for a newline that may never come, so the descriptor is
-	 * handed to the subprocess and this process never sees the stream.
-	 *
-	 * Mutually exclusive with `stdout`.
+	 * For a tool whose stdout is bytes rather than lines: the splitter would
+	 * buffer a gigabyte of gzip looking for a newline that never comes.
 	 */
 	stdoutFile?: string;
 	/** Called for each line of stderr, after it is logged. */

--- a/packages/workflow/src/subprocess/types.ts
+++ b/packages/workflow/src/subprocess/types.ts
@@ -25,6 +25,17 @@ export type RunSubprocessOptions = {
 	 * reads.
 	 */
 	stdout?: LineHandler;
+	/**
+	 * Write stdout straight to this file, truncating it first.
+	 *
+	 * For a tool whose stdout is bytes rather than lines — `pigz -c` and
+	 * nothing else so far. The line splitter would have to buffer a gigabyte of
+	 * gzip looking for a newline that may never come, so the descriptor is
+	 * handed to the subprocess and this process never sees the stream.
+	 *
+	 * Mutually exclusive with `stdout`.
+	 */
+	stdoutFile?: string;
 	/** Called for each line of stderr, after it is logged. */
 	stderr?: LineHandler;
 	/**

--- a/packages/workflow/src/testing/context.ts
+++ b/packages/workflow/src/testing/context.ts
@@ -16,6 +16,7 @@ import {
 	type WorkflowContext,
 } from "../context";
 import type { Workflow } from "../step";
+import { registerFakePigz } from "./gzip";
 import { createRecordingLogger } from "./logger";
 import { createFakeSubprocessRunner } from "./subprocess";
 
@@ -53,6 +54,13 @@ export function createUnreachableJobsApiClient(
 export function createFakeBuildContextInput(
 	overrides: Partial<BuildContextInput> = {},
 ): BuildContextInput {
+	const runSubprocess = createFakeSubprocessRunner();
+
+	// A fake context stands for a workflow image, and every one of those carries
+	// pigz. A runner that reported success and wrote nothing would leave any
+	// step that gzips its output asserting against an empty file.
+	registerFakePigz(runSubprocess);
+
 	return {
 		job: createFakeRunJob(),
 		workPath: "/tmp/workflow-test",
@@ -61,7 +69,7 @@ export function createFakeBuildContextInput(
 		logger: createRecordingLogger().logger,
 		signal: new AbortController().signal,
 		client: createUnreachableJobsApiClient(),
-		runSubprocess: createFakeSubprocessRunner(),
+		runSubprocess,
 		// An empty bucket rather than a refusing one: storage is faked at the
 		// backend, so a test that reads a key it never seeded gets the
 		// `StorageKeyNotFoundError` production would give it. Pass the

--- a/packages/workflow/src/testing/context.ts
+++ b/packages/workflow/src/testing/context.ts
@@ -56,9 +56,7 @@ export function createFakeBuildContextInput(
 ): BuildContextInput {
 	const runSubprocess = createFakeSubprocessRunner();
 
-	// A fake context stands for a workflow image, and every one of those carries
-	// pigz. A runner that reported success and wrote nothing would leave any
-	// step that gzips its output asserting against an empty file.
+	// A fake context stands for a workflow image, and every one carries pigz.
 	registerFakePigz(runSubprocess);
 
 	return {

--- a/packages/workflow/src/testing/gzip.ts
+++ b/packages/workflow/src/testing/gzip.ts
@@ -1,0 +1,47 @@
+/**
+ * A `pigz` that does not spawn.
+ *
+ * `gzipFile` and `gunzipFile` shell out, and a step that gzips its output is
+ * almost always tested by reading that output back. The default fake runner
+ * reports a silent success and writes nothing, which turns every such
+ * assertion into one about an empty file, so this stands in a real `node:zlib`
+ * round trip instead.
+ *
+ * It is registered on the runner `createFakeBuildContextInput` builds, because
+ * every workflow image carries `pigz` and a fake context stands for one of
+ * those. Register it by hand on a runner a test supplies itself.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { gunzip, gzip } from "node:zlib";
+import type { RunSubprocessOptions } from "../subprocess/types";
+import type { FakeSubprocessRunner } from "./subprocess";
+
+const gunzipAsync = promisify(gunzip);
+const gzipAsync = promisify(gzip);
+
+/** Teach `runner` to answer `pigz` by actually compressing the file. */
+export function registerFakePigz(runner: FakeSubprocessRunner): void {
+	runner.register("pigz", { effect: runFakePigz });
+}
+
+async function runFakePigz({
+	command,
+	stdoutFile,
+}: RunSubprocessOptions): Promise<void> {
+	const source = command.at(-1);
+
+	if (source === undefined || stdoutFile === undefined) {
+		throw new Error(`Fake pigz cannot run \`${command.join(" ")}\``);
+	}
+
+	const contents = await readFile(source);
+
+	await writeFile(
+		stdoutFile,
+		command.includes("-d")
+			? await gunzipAsync(contents)
+			: await gzipAsync(contents),
+	);
+}

--- a/packages/workflow/src/testing/gzip.ts
+++ b/packages/workflow/src/testing/gzip.ts
@@ -1,15 +1,9 @@
 /**
  * A `pigz` that does not spawn.
  *
- * `gzipFile` and `gunzipFile` shell out, and a step that gzips its output is
- * almost always tested by reading that output back. The default fake runner
- * reports a silent success and writes nothing, which turns every such
- * assertion into one about an empty file, so this stands in a real `node:zlib`
- * round trip instead.
- *
- * It is registered on the runner `createFakeBuildContextInput` builds, because
- * every workflow image carries `pigz` and a fake context stands for one of
- * those. Register it by hand on a runner a test supplies itself.
+ * `gzipFile` shells out, and a step that gzips its output is almost always
+ * tested by reading that output back — against a runner that writes nothing,
+ * every such assertion is about a file that is not there.
  */
 
 import { readFile, writeFile } from "node:fs/promises";

--- a/packages/workflow/src/testing/index.ts
+++ b/packages/workflow/src/testing/index.ts
@@ -17,6 +17,7 @@
 export * from "./builders";
 export * from "./checksum";
 export * from "./context";
+export * from "./gzip";
 export * from "./http";
 export * from "./jobsApi/fake";
 export * from "./jobsApi/routes";

--- a/packages/workflow/src/testing/subprocess.ts
+++ b/packages/workflow/src/testing/subprocess.ts
@@ -59,6 +59,15 @@ export type FakeSubprocessResponse = {
 	cancelled?: boolean;
 	/** Reported on the result. Defaults to 0. */
 	durationMs?: number;
+	/**
+	 * Runs in place of the tool itself, once the command is matched and before
+	 * any output is delivered.
+	 *
+	 * For the tools whose whole point is a file they leave behind: a step that
+	 * reads one back cannot be tested against a fake that only reports an exit
+	 * code. See {@link registerFakePigz}.
+	 */
+	effect?: (options: RunSubprocessOptions) => void | Promise<void>;
 };
 
 /** Decides whether a registration applies to a command. */
@@ -139,6 +148,8 @@ export function createFakeSubprocessRunner(
 		if (response.spawnError !== undefined) {
 			throw new SubprocessSpawnError(command, response.spawnError);
 		}
+
+		await response.effect?.(options);
 
 		// Handlers are awaited before the next line, matching the backpressure the
 		// real runner applies. A step whose handler throws must fail here too.

--- a/packages/workflow/src/testing/subprocess.ts
+++ b/packages/workflow/src/testing/subprocess.ts
@@ -60,12 +60,10 @@ export type FakeSubprocessResponse = {
 	/** Reported on the result. Defaults to 0. */
 	durationMs?: number;
 	/**
-	 * Runs in place of the tool itself, once the command is matched and before
-	 * any output is delivered.
+	 * Runs in place of the tool, before any output is delivered.
 	 *
-	 * For the tools whose whole point is a file they leave behind: a step that
-	 * reads one back cannot be tested against a fake that only reports an exit
-	 * code. See {@link registerFakePigz}.
+	 * For a tool whose whole point is the file it leaves behind. See
+	 * `registerFakePigz`.
 	 */
 	effect?: (options: RunSubprocessOptions) => void | Promise<void>;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       '@sentry/node':
         specifier: ^10.70.0
         version: 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
-      '@virtool/archive':
-        specifier: workspace:*
-        version: link:../../packages/archive
       '@virtool/bio':
         specifier: workspace:*
         version: link:../../packages/bio


### PR DESCRIPTION
## Summary

- Workflow pods are sized with `VT_PROC` cores but every gzip ran single-threaded through `node:zlib`. The largest of them — a sample's normalized reads in create-sample's `finalize` — is gigabyte-scale and left the rest of the allocation idle for minutes. `gzipFile()` and `gunzipFile()` in `@virtool/workflow` now shell out to `pigz`, which the `create-sample`, `create-subtraction` and `nuvs` images install alongside pathoscope's. All five workflow call sites move over; `@virtool/data`'s snapshot runs in a pod with no `pigz` and keeps `compressFile`.
- They live in `@virtool/workflow` rather than `@virtool/archive` because they need a tool on `PATH` and a core count, and that package promises neither. There is no fallback — a missing `pigz` is a broken image and fails the step rather than quietly running at a seventh of the speed.
- `runSubprocess` gains `stdoutFile`, so a tool whose stdout is bytes rather than lines writes straight to a file instead of buffering a gigabyte of gzip in the line splitter. In tests `registerFakePigz()` stands in a real `node:zlib` round trip, via a general `effect` hook for any tool double that has to leave a file behind.