### PR TITLE
refactor: drop the ts- runner-id scoping and unused lease sweep

### DIFF
--- a/apps/tasks/src/framework/progress.test.ts
+++ b/apps/tasks/src/framework/progress.test.ts
@@ -22,8 +22,8 @@ import {
 	roundHalfToEven,
 } from "./progress";
 
-const RUNNER_A = "ts-runner-a-1";
-const RUNNER_B = "ts-runner-b-2";
+const RUNNER_A = "runner-a-1";
+const RUNNER_B = "runner-b-2";
 
 /** Long enough that no test's debounce window closes on its own. */
 const NEVER_FIRES_MS = 60_000;

--- a/apps/tasks/src/framework/run.test.ts
+++ b/apps/tasks/src/framework/run.test.ts
@@ -23,7 +23,7 @@ import { acquireOrThrow, readTaskRow } from "../testing/tasks";
 import { defineTask, type TaskRegistry } from "./define";
 import { runTask } from "./run";
 
-const OTHER_RUNNER = "ts-runner-b-2";
+const OTHER_RUNNER = "runner-b-2";
 
 /** Long enough that no test's debounce window closes on its own. */
 const NEVER_FIRES_MS = 60_000;

--- a/apps/tasks/src/runner.test.ts
+++ b/apps/tasks/src/runner.test.ts
@@ -28,7 +28,7 @@ import type { TaskRunSample } from "./metrics/registry";
 import { createTaskRunner, dispatchTask, type TaskRunner } from "./runner";
 import { waitFor } from "./testing/waitFor";
 
-const RUNNER = "ts-runner-a-1";
+const RUNNER = "runner-a-1";
 
 const logger: Logger = createLogger({ name: "test", level: "silent" });
 
@@ -251,16 +251,10 @@ describe("createTaskRunner", () => {
 		}
 	});
 
-	// Reclaim is scoped to the `ts-` prefix, so a claim recorded under any other
-	// prefix is out of this runner's reach however old the lease is. Widening
-	// the scope is a decision, and this assertion is what stops a refactor
-	// making it quietly.
-	it("reclaims an expired ts- lease but not another prefix's", async () => {
+	it("reclaims the expired lease of a departed runner", async () => {
 		const ours = await createTask(db, "install_hmms");
-		const foreign = await createTask(db, "install_hmms");
 
-		await holdTask(ours, "ts-gone-1", TASK_LEASE_SECONDS + 60);
-		await holdTask(foreign, "somehost-4242", TASK_LEASE_SECONDS * 100);
+		await holdTask(ours, "gone-1", TASK_LEASE_SECONDS + 60);
 
 		const ran: number[] = [];
 
@@ -283,10 +277,6 @@ describe("createTaskRunner", () => {
 		}
 
 		expect(ran).toEqual([ours]);
-		expect(await readRow(foreign)).toMatchObject({
-			complete: false,
-			runner_id: "somehost-4242",
-		});
 	});
 
 	// Release converts an abandoned task from the full lease of dead time into

--- a/apps/tasks/src/testing/tasks.ts
+++ b/apps/tasks/src/testing/tasks.ts
@@ -3,14 +3,8 @@ import { type TaskRow, tasks } from "@virtool/data/db/schema/tasks";
 import { acquireTask, type ClaimedTask } from "@virtool/data/tasks/data";
 import { eq } from "drizzle-orm";
 
-/**
- * The runner id a task test claims under.
- *
- * The `ts-` prefix is load-bearing rather than decorative: reclaim and release
- * are scoped to it, so a test claiming under any other prefix exercises a path
- * no runner in the fleet takes.
- */
-export const TEST_RUNNER_ID = "ts-runner-a-1";
+/** The runner id a task test claims under. */
+export const TEST_RUNNER_ID = "runner-a-1";
 
 /**
  * Insert a queued row of `type` and return its id.

--- a/packages/data/src/tasks/data.test.ts
+++ b/packages/data/src/tasks/data.test.ts
@@ -1,3 +1,4 @@
+import { hostname } from "node:os";
 import { eq } from "drizzle-orm";
 import {
 	afterAll,
@@ -24,7 +25,6 @@ import {
 	readOldestQueuedTaskAges,
 	readTaskCounts,
 	readTaskQueueBounded,
-	reclaimExpiredLeases,
 	releaseRunnerClaims,
 	releaseTask,
 	renewLeases,
@@ -37,8 +37,8 @@ import {
 let database: TestDatabase;
 let db: Db;
 
-const RUNNER_A = "ts-runner-a-1";
-const RUNNER_B = "ts-runner-b-2";
+const RUNNER_A = "runner-a-1";
+const RUNNER_B = "runner-b-2";
 
 const ALL_TYPES = [
 	"clone_reference",
@@ -145,11 +145,10 @@ describe("getTasks", () => {
 });
 
 describe("buildRunnerId", () => {
-	it("marks the runner as this service's and names the process", () => {
+	it("names the host and the process", () => {
 		const runnerId = buildRunnerId();
 
-		expect(runnerId.startsWith("ts-")).toBe(true);
-		expect(runnerId.endsWith(`-${process.pid}`)).toBe(true);
+		expect(runnerId).toBe(`${hostname()}-${process.pid}`);
 	});
 });
 
@@ -282,20 +281,6 @@ describe("acquireTask", () => {
 		).resolves.toBeNull();
 
 		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_A });
-	});
-
-	it("never reclaims a task claimed outside our runner-id prefix", async () => {
-		// Reclaim reads a stale `acquired_at` as abandonment, so a claim nothing
-		// renews looks abandoned however live it is. The `ts-` scoping is the only
-		// thing keeping this side from pulling work out from under it.
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, "somehost-4242", TASK_LEASE_SECONDS * 100);
-
-		await expect(
-			acquireTask(db, { runnerId: RUNNER_B, allowedTypes: ["install_hmms"] }),
-		).resolves.toBeNull();
-
-		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
 	});
 
 	it("honours a shorter lease passed by the caller", async () => {
@@ -518,17 +503,6 @@ describe("releaseTask", () => {
 
 		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_B });
 	});
-
-	it("never releases a task claimed outside our runner-id prefix", async () => {
-		// The scope has to hold at the query, not at the caller: an unprefixed id
-		// reaching this argument would otherwise hand live work to our fleet.
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, "somehost-4242", 10);
-
-		await expect(releaseTask(db, taskId, "somehost-4242")).resolves.toBe(false);
-
-		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
-	});
 });
 
 describe("releaseRunnerClaims", () => {
@@ -558,70 +532,6 @@ describe("releaseRunnerClaims", () => {
 		await expect(releaseRunnerClaims(db, RUNNER_A)).resolves.toEqual([]);
 
 		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_A });
-	});
-
-	it("never releases the claims of a runner outside our prefix", async () => {
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, "somehost-4242", 10);
-
-		await expect(releaseRunnerClaims(db, "somehost-4242")).resolves.toEqual([]);
-
-		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
-	});
-});
-
-describe("reclaimExpiredLeases", () => {
-	it("takes back a lease that has run out", async () => {
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS + 60);
-
-		await expect(reclaimExpiredLeases(db)).resolves.toEqual([taskId]);
-
-		expect(await readRow(taskId)).toMatchObject({
-			acquired_at: null,
-			runner_id: null,
-		});
-	});
-
-	it("leaves a live lease alone", async () => {
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS - 60);
-
-		await expect(reclaimExpiredLeases(db)).resolves.toEqual([]);
-	});
-
-	it("never touches a task claimed outside our runner-id prefix", async () => {
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, "somehost-4242", TASK_LEASE_SECONDS * 100);
-
-		await expect(reclaimExpiredLeases(db)).resolves.toEqual([]);
-
-		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
-	});
-
-	it("leaves finished and failed tasks alone", async () => {
-		const completed = await createTask(db, "install_hmms");
-		const failed = await createTask(db, "clone_reference");
-
-		await holdTask(completed, RUNNER_A, TASK_LEASE_SECONDS + 60);
-		await holdTask(failed, RUNNER_A, TASK_LEASE_SECONDS + 60);
-
-		await db
-			.update(tasks)
-			.set({ complete: true })
-			.where(eq(tasks.id, completed));
-		await db.update(tasks).set({ error: "boom" }).where(eq(tasks.id, failed));
-
-		await expect(reclaimExpiredLeases(db)).resolves.toEqual([]);
-	});
-
-	it("honours a shorter lease passed by the caller", async () => {
-		const taskId = await createTask(db, "install_hmms");
-		await holdTask(taskId, RUNNER_A, 30);
-
-		await expect(
-			reclaimExpiredLeases(db, { leaseSeconds: 10 }),
-		).resolves.toEqual([taskId]);
 	});
 });
 
@@ -729,11 +639,8 @@ describe("frames", () => {
 		]);
 	});
 
-	it("publishes nothing for claiming, releasing or reclaiming", async () => {
+	it("publishes nothing for claiming or releasing", async () => {
 		const claimable = await createTask(db, "install_hmms");
-		const expired = await createTask(db, "clone_reference");
-
-		await holdTask(expired, RUNNER_B, TASK_LEASE_SECONDS + 60);
 
 		const frames = await collectFrames(database.client, async () => {
 			await acquireTask(db, {
@@ -743,7 +650,6 @@ describe("frames", () => {
 			await renewLeases(db, [claimable], RUNNER_A);
 			await releaseTask(db, claimable, RUNNER_A);
 			await releaseRunnerClaims(db, RUNNER_A);
-			await reclaimExpiredLeases(db);
 		});
 
 		expect(frames).toEqual([]);

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -13,7 +13,6 @@ import {
 	inArray,
 	isNotNull,
 	isNull,
-	like,
 	lt,
 	or,
 	type SQL,
@@ -295,20 +294,6 @@ export const TASK_LEASE_SECONDS = 300;
  */
 export const TASK_HEARTBEAT_SECONDS = 60;
 
-/**
- * Marks a `runner_id` as belonging to this service.
- *
- * Every query that takes work back off a runner is scoped to this prefix, so a
- * claim carrying any other id is never reclaimed and never released. Reclaim
- * reads a stale `acquired_at` as abandonment, which only holds for a runner
- * that renews it; a claim from anything that does not would look abandoned
- * while it was still live, and the reclaimer would pull work out from under it.
- * Scoping at the query level is what makes that enforceable rather than a note
- * in a runbook, which is why there is deliberately no configuration flag to
- * widen it.
- */
-const RUNNER_ID_PREFIX = "ts-";
-
 /** A task just claimed by a runner, with the lease it now holds. */
 export type ClaimedTask = {
 	id: number;
@@ -337,14 +322,13 @@ export type TaskProgressValues = {
 /**
  * Identify this process as a task runner.
  *
- * `{hostname}-{pid}`, prefixed to mark the row as this service's. The column is
- * `varchar(255)`, which a Kubernetes pod name and a pid cannot come close to
- * filling — and Postgres raises on overflow rather than truncating, so a
- * hostname that did would fail the claim loudly instead of minting an id that
- * collides with another runner's.
+ * `{hostname}-{pid}`. The column is `varchar(255)`, which a Kubernetes pod name
+ * and a pid cannot come close to filling — and Postgres raises on overflow
+ * rather than truncating, so a hostname that did would fail the claim loudly
+ * instead of minting an id that collides with another runner's.
  */
 export function buildRunnerId(): string {
-	return `${RUNNER_ID_PREFIX}${hostname()}-${process.pid}`;
+	return `${hostname()}-${process.pid}`;
 }
 
 /**
@@ -372,10 +356,7 @@ function isClaimable(
 		inArray(tasksTable.type, [...allowedTypes]),
 		or(
 			isNull(tasksTable.acquired_at),
-			and(
-				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
-				lt(tasksTable.acquired_at, secondsAgo(leaseSeconds)),
-			),
+			lt(tasksTable.acquired_at, secondsAgo(leaseSeconds)),
 		),
 	);
 }
@@ -604,10 +585,6 @@ async function writeHeldTask(
  * rather than letting it sit until the lease expires. Returns `false` when the
  * runner no longer holds the task.
  *
- * Scoped to {@link RUNNER_ID_PREFIX} like every other query that takes work off
- * a runner, so the scope holds however the id was obtained rather than only
- * when it came from {@link buildRunnerId}.
- *
  * Emits nothing. The task returns to exactly the state a client last saw it
  * in — nothing about the row that any view renders has changed.
  */
@@ -623,7 +600,6 @@ export async function releaseTask(
 			and(
 				eq(tasksTable.id, taskId),
 				eq(tasksTable.runner_id, runnerId),
-				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
 				eq(tasksTable.complete, false),
 			),
 		)
@@ -636,8 +612,8 @@ export async function releaseTask(
  * Give up every unfinished claim `runnerId` holds, and report which.
  *
  * The bulk form of {@link releaseTask}, for a runner draining on shutdown or
- * clearing whatever a previous incarnation left behind at startup. Scoped and
- * silent for the same reasons.
+ * clearing whatever a previous incarnation left behind at startup. Silent for
+ * the same reason.
  */
 export async function releaseRunnerClaims(
 	db: Db,
@@ -647,11 +623,7 @@ export async function releaseRunnerClaims(
 		.update(tasksTable)
 		.set({ acquired_at: null, runner_id: null })
 		.where(
-			and(
-				eq(tasksTable.runner_id, runnerId),
-				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
-				eq(tasksTable.complete, false),
-			),
+			and(eq(tasksTable.runner_id, runnerId), eq(tasksTable.complete, false)),
 		)
 		.returning({ id: tasksTable.id });
 
@@ -761,41 +733,4 @@ export function readTaskQueueBounded(
 		),
 		timeoutMs,
 	);
-}
-
-/**
- * Take back every claim held by one of our runners whose lease has run out, and
- * report which.
- *
- * {@link acquireTask} already reclaims as it claims, so a fleet that is
- * claiming heals itself without this. It ships as its own query for the case
- * where there is no claim to fold the sweep into: a fleet that has stopped
- * claiming cannot otherwise recover what a departed runner was mid-flight on.
- *
- * Scoped to {@link RUNNER_ID_PREFIX}: a claim carrying any other id is never
- * touched.
- *
- * Emits nothing. A reclaimed task is pending again, which is the state a client
- * last saw it in.
- */
-export async function reclaimExpiredLeases(
-	db: Db,
-	options: { leaseSeconds?: number } = {},
-): Promise<number[]> {
-	const leaseSeconds = options.leaseSeconds ?? TASK_LEASE_SECONDS;
-
-	const rows = await db
-		.update(tasksTable)
-		.set({ acquired_at: null, runner_id: null })
-		.where(
-			and(
-				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
-				lt(tasksTable.acquired_at, secondsAgo(leaseSeconds)),
-				eq(tasksTable.complete, false),
-				isNull(tasksTable.error),
-			),
-		)
-		.returning({ id: tasksTable.id });
-
-	return rows.map((row) => row.id);
 }


### PR DESCRIPTION
## Summary

- Every task claim is minted by `buildRunnerId()`, so each `LIKE 'ts-%'` term matched every row it saw. The constant and the four predicates built on it are gone; `buildRunnerId()` keeps `{hostname}-{pid}` for attribution.
- Deleted `reclaimExpiredLeases`, which had no callers and no `@public` tag. `acquireTask` reclaims inline on every poll, and a fleet that has stopped claiming has no process for a standalone sweep to run in.
- Retired the four tests seeding a bare `somehost-4242` id to guard a regression no production path could cause, and unprefixed the runner-id constants the queries had forced.

During a rolling restart, old pods still scope reclaim to `ts-%` while new pods mint bare ids, so an old pod won't reclaim a new pod's expired lease until the rollout finishes.

Closes VIR-2997