### PR TITLE
fix: keep sample user filters usable on large instances

### DIFF
--- a/apps/web/src/base/ScrollArea.tsx
+++ b/apps/web/src/base/ScrollArea.tsx
@@ -26,7 +26,11 @@ export default function ScrollArea({ children, className }: ScrollAreaProps) {
 				className,
 			)}
 		>
-			<ScrollAreaPrimitive.Viewport className={cn("w-full", "h-full rounded")}>
+			{/* `max-h-[inherit]` lets a root with a max height and no fixed height
+			    scroll instead of clipping: the viewport picks up the same cap. */}
+			<ScrollAreaPrimitive.Viewport
+				className={cn("w-full", "h-full max-h-[inherit] rounded")}
+			>
 				{children}
 			</ScrollAreaPrimitive.Viewport>
 			<ScrollAreaPrimitive.Scrollbar

--- a/apps/web/src/base/ScrollArea.tsx
+++ b/apps/web/src/base/ScrollArea.tsx
@@ -26,11 +26,7 @@ export default function ScrollArea({ children, className }: ScrollAreaProps) {
 				className,
 			)}
 		>
-			{/* `max-h-[inherit]` lets a root with a max height and no fixed height
-			    scroll instead of clipping: the viewport picks up the same cap. */}
-			<ScrollAreaPrimitive.Viewport
-				className={cn("w-full", "h-full max-h-[inherit] rounded")}
-			>
+			<ScrollAreaPrimitive.Viewport className={cn("w-full", "h-full rounded")}>
 				{children}
 			</ScrollAreaPrimitive.Viewport>
 			<ScrollAreaPrimitive.Scrollbar

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -502,6 +502,15 @@ describe("<SamplesList />", () => {
 				`${self.handle}You`,
 				at(users, 0).handle,
 			]);
+
+			const otherUsers = screen.getByTestId("other-users");
+			expect(otherUsers).not.toContainElement(at(items, 0));
+			expect(otherUsers).toContainElement(at(items, 1));
+			expect(otherUsers).toHaveClass(
+				"max-h-96",
+				"overflow-x-hidden",
+				"overflow-y-auto",
+			);
 		});
 
 		it("should narrow the user list as the search input is typed in", async () => {

--- a/apps/web/src/users/components/UserFilterMenu.tsx
+++ b/apps/web/src/users/components/UserFilterMenu.tsx
@@ -3,7 +3,6 @@ import { DropdownMenuSeparator } from "@base/Dropdown";
 import { FilterMenuCheckboxItem, FilterMenuContent } from "@base/Filter";
 import Input from "@base/Input";
 import QueryError from "@base/QueryError";
-import ScrollArea from "@base/ScrollArea";
 import { useListUsers } from "@users/queries";
 import type { UserNested } from "@virtool/contracts";
 import { useState } from "react";
@@ -75,17 +74,24 @@ export default function UserFilterMenu({
 			) : matches.length === 0 ? (
 				<p className="px-2 py-1.5 text-gray-500 text-sm">No users found.</p>
 			) : (
-				// Capped at twelve users so a large instance doesn't grow the menu
-				// past the viewport.
-				<ScrollArea className="mr-0 h-auto max-h-96 w-full rounded-none border-none">
+				<>
 					{self && (
 						<>
 							{renderUser(self, true)}
 							{others.length > 0 && <DropdownMenuSeparator />}
 						</>
 					)}
-					{others.map((user) => renderUser(user, false))}
-				</ScrollArea>
+					{others.length > 0 && (
+						// Capped at twelve users so a large instance doesn't grow the menu
+						// past the viewport.
+						<div
+							className="max-h-96 overflow-x-hidden overflow-y-auto"
+							data-testid="other-users"
+						>
+							{others.map((user) => renderUser(user, false))}
+						</div>
+					)}
+				</>
 			)}
 		</FilterMenuContent>
 	);

--- a/apps/web/src/users/components/UserFilterMenu.tsx
+++ b/apps/web/src/users/components/UserFilterMenu.tsx
@@ -3,6 +3,7 @@ import { DropdownMenuSeparator } from "@base/Dropdown";
 import { FilterMenuCheckboxItem, FilterMenuContent } from "@base/Filter";
 import Input from "@base/Input";
 import QueryError from "@base/QueryError";
+import ScrollArea from "@base/ScrollArea";
 import { useListUsers } from "@users/queries";
 import type { UserNested } from "@virtool/contracts";
 import { useState } from "react";
@@ -74,7 +75,9 @@ export default function UserFilterMenu({
 			) : matches.length === 0 ? (
 				<p className="px-2 py-1.5 text-gray-500 text-sm">No users found.</p>
 			) : (
-				<>
+				// Capped at twelve users so a large instance doesn't grow the menu
+				// past the viewport.
+				<ScrollArea className="mr-0 h-auto max-h-96 w-full rounded-none border-none">
 					{self && (
 						<>
 							{renderUser(self, true)}
@@ -82,7 +85,7 @@ export default function UserFilterMenu({
 						</>
 					)}
 					{others.map((user) => renderUser(user, false))}
-				</>
+				</ScrollArea>
 			)}
 		</FilterMenuContent>
 	);


### PR DESCRIPTION
## Summary
- keep the current user fixed above the scrollable user list
- cap vertical overflow and prevent horizontal scrolling
- cover the user-list layout with a regression test