### PR TITLE
feat: screen pathoscope references with cd-hit representatives

### DIFF
--- a/apps/pathoscope/README.md
+++ b/apps/pathoscope/README.md
@@ -2,9 +2,10 @@
 
 The pathoscope workflow executor. Pathoscope quantifies known viruses in a
 sample: it collapses redundant isolates out of the reference, maps the sample
-against one representative per OTU to find candidates, rebuilds an index
-carrying every isolate of just those OTUs, maps again, drops reads that belong
-to the host, and reassigns the reads that matched more than one isolate.
+against CD-HIT-EST representatives from every OTU and declared segment to find
+candidates, rebuilds an index carrying every collapsed isolate of just those
+OTUs, maps again, drops reads that belong to the host, and reassigns the reads
+that matched more than one isolate.
 
 Image: `ghcr.io/virtool/ts-pathoscope`. Eight steps, four external
 tools — `bowtie2`, `cd-hit-est`, `pigz`, `samtools` — and `pathoscope-core`,

--- a/apps/pathoscope/src/cacheParams.test.ts
+++ b/apps/pathoscope/src/cacheParams.test.ts
@@ -1,21 +1,19 @@
 import {
 	buildMappingIndexCacheParams,
 	deriveCacheKey,
-	type RunSubprocess,
 } from "@virtool/workflow";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
 	buildCollapsedReferenceCacheParams,
-	getCdHitEstVersion,
-	REFERENCE_INDEX_EXTRA_PARAMS,
+	buildReferenceIndexExtraParams,
 	WORKFLOW_NAME,
 } from "./cacheParams";
 
 /**
- * The keys these namespaces are pinned to, recorded from blobs already in the
- * bucket rather than reasoned out from the serialization: the SHA-256 of the
- * params rendered as JSON with keys sorted, no whitespace around the
- * separators, and every non-ASCII character escaped.
+ * The keys these namespaces are pinned to: the SHA-256 of the params rendered
+ * as JSON with keys sorted, no whitespace around the separators, and every
+ * non-ASCII character escaped. `oldReference` is the default-isolate artifact
+ * key that the representative policy must never reuse.
  *
  * `collapsed` is the key the shared `collapsed_reference` namespace uses. It is
  * pinned as the key this workflow's forked params must **not** derive.
@@ -26,41 +24,17 @@ import {
  * asks for.
  */
 const PINNED_KEYS = {
-	reference: "da4654a3a9c96981cc6a071c99d2a0caf03012b9d0b98931963e3601173af66e",
+	reference: "5155d708b76b8f17b701fd46dd79163070794849b90c439b4e0d91fa306c9d96",
+	oldReference:
+		"da4654a3a9c96981cc6a071c99d2a0caf03012b9d0b98931963e3601173af66e",
 	subtraction:
 		"77cc01d7028d9d87fadc9d091a590577359ceedcb1a5a8a1d95911f46f7b9aea",
 	collapsed: "3d4bbf0d92c5e39a0f72f394cc2c40eb6cb2add959e3491e9b8d922d43a9b5ec",
 };
 
 const TOOL_VERSION = "2.5.4";
+const CD_HIT_EST_VERSION = "4.8.1";
 const WORKFLOW_VERSION = "5.2.1";
-
-function subprocessWriting(
-	lines: readonly string[],
-	{
-		stream = "stdout",
-		fails = false,
-	}: { stream?: "stdout" | "stderr"; fails?: boolean } = {},
-): RunSubprocess {
-	return vi.fn(async (options) => {
-		for (const line of lines) {
-			await options[stream]?.(line);
-		}
-
-		if (fails) {
-			throw new Error("subprocess exited 1");
-		}
-
-		return {
-			command: options.command,
-			exitCode: 0,
-			signal: null,
-			cancelled: false,
-			stderrTail: [],
-			durationMs: 1,
-		};
-	});
-}
 
 // The params themselves are the runtime's — every workflow that builds a bowtie2
 // index derives them the same way. What is pinned here is that *this* workflow's
@@ -69,7 +43,7 @@ function subprocessWriting(
 describe("the shared mapping index namespaces", () => {
 	it("derives the pinned key for a reference mapping index", () => {
 		const params = buildMappingIndexCacheParams({
-			extra: REFERENCE_INDEX_EXTRA_PARAMS,
+			extra: buildReferenceIndexExtraParams(CD_HIT_EST_VERSION),
 			indexKind: "reference_mapping_index",
 			parentId: 42,
 			toolVersion: TOOL_VERSION,
@@ -78,6 +52,18 @@ describe("the shared mapping index namespaces", () => {
 		});
 
 		expect(deriveCacheKey(params)).toBe(PINNED_KEYS.reference);
+		expect(deriveCacheKey(params)).not.toBe(PINNED_KEYS.oldReference);
+		expect(params).toMatchObject({
+			selection: "cd_hit_est_representatives",
+			selection_coverage: "none",
+			selection_identity: "0.80",
+			selection_minimum_length: "9",
+			selection_policy_version: "otu-segment-v1",
+			selection_source: "full_source_reference",
+			selection_tool: "cd-hit-est",
+			selection_tool_version: CD_HIT_EST_VERSION,
+			selection_word_size: "5",
+		});
 	});
 
 	it("derives the pinned key for a subtraction mapping index", () => {
@@ -116,40 +102,13 @@ describe("buildCollapsedReferenceCacheParams", () => {
 
 		const { impl, ...withoutDiscriminator } = params;
 
-		expect(impl).toBeDefined();
+		expect(impl).toBe("typescript-v2");
 		// Removing it lands back on the shared namespace's key, which is what makes
 		// the fork the discriminator's doing rather than an accident of some other
 		// field.
 		expect(deriveCacheKey(withoutDiscriminator)).toBe(PINNED_KEYS.collapsed);
-	});
-});
-
-describe("getCdHitEstVersion", () => {
-	// `cd-hit-est -h` prints its help text and exits 1. There is no --version
-	// flag, so the failure is expected and the output is parsed anyway.
-	it("parses the version out of a run that exits non-zero", async () => {
-		const runSubprocess = subprocessWriting(
-			["\t\t====== CD-HIT version 4.8.1 (built on Jan 1 2024) ======", ""],
-			{ fails: true },
+		expect(deriveCacheKey(params)).not.toBe(
+			deriveCacheKey({ ...params, impl: "typescript-v1" }),
 		);
-
-		await expect(getCdHitEstVersion(runSubprocess)).resolves.toBe("4.8.1");
-	});
-
-	it("reads the banner from stderr as well as stdout", async () => {
-		const runSubprocess = subprocessWriting(
-			["====== CD-HIT version 4.8.1 ======"],
-			{ stream: "stderr", fails: true },
-		);
-
-		await expect(getCdHitEstVersion(runSubprocess)).resolves.toBe("4.8.1");
-	});
-
-	// A missing binary produces no matching line, and the failure names the
-	// version parse rather than the exit code.
-	it("throws when the output carries no version", async () => {
-		await expect(
-			getCdHitEstVersion(subprocessWriting([], { fails: true })),
-		).rejects.toThrow("Could not parse cd-hit-est version");
 	});
 });

--- a/apps/pathoscope/src/cacheParams.ts
+++ b/apps/pathoscope/src/cacheParams.ts
@@ -16,7 +16,7 @@
  *   than anything declared here. Their artifact is a bowtie2 index, which
  *   `bowtie2-build` produces identically whoever ran it, so this side
  *   contributes only {@link WORKFLOW_NAME} and
- *   {@link REFERENCE_INDEX_EXTRA_PARAMS} — what the index was built from.
+ *   {@link buildReferenceIndexExtraParams} — what the index was built from.
  * - `collapsed_reference` is **forked**, deliberately, and is this workflow's
  *   alone. Its artifact is a SQLite index *this code* writes, and a collapsed
  *   index from the shared namespace is not interchangeable with it.
@@ -28,10 +28,10 @@
 
 import {
 	type CacheParams,
-	matchToolVersion,
-	type RunSubprocess,
+	CD_HIT_EST_TOOL,
+	REFERENCE_REPRESENTATIVE_POLICY,
 } from "@virtool/workflow";
-import { CD_HIT_EST_IDENTITY, CD_HIT_EST_TOOL } from "./reference/collapse";
+import { CD_HIT_EST_IDENTITY } from "./reference/collapse";
 
 export const WORKFLOW_NAME = "pathoscope";
 
@@ -43,7 +43,7 @@ export const WORKFLOW_NAME = "pathoscope";
  * serialization differs and so does the SHA-256 over it. Bump the value if the
  * collapsed artifact's content ever changes shape; do not remove it.
  */
-const COLLAPSE_IMPL = "typescript-v1";
+const COLLAPSE_IMPL = "typescript-v2";
 
 /** Params for the forked `collapsed_reference` namespace. */
 export function buildCollapsedReferenceCacheParams({
@@ -72,50 +72,22 @@ export function buildCollapsedReferenceCacheParams({
  * What this workflow's reference mapping index adds, describing the FASTA it was
  * built from.
  *
- * Pathoscope maps against a *collapsed* reference, so its index is built from
- * different bytes than one built straight off the artifact's default isolates.
- * These fields are what keep the two out of each other's namespace.
+ * Pathoscope maps against representatives selected from the full source
+ * reference. These fields keep that policy out of every older or differently
+ * selected mapping-index namespace.
  */
-export const REFERENCE_INDEX_EXTRA_PARAMS = {
-	collapse_identity: CD_HIT_EST_IDENTITY,
-	selection: "default_isolates",
-	source: "collapsed_reference",
-};
-
-/**
- * Read `cd-hit-est`'s version.
- *
- * **`cd-hit-est -h` prints its help text and exits 1**, so the subprocess
- * failure is caught and the output parsed anyway. There is no `--version` flag
- * to use instead. Both streams are collected because the tool has moved the
- * banner between them across releases.
- *
- * @throws {WorkflowError} when the output carries no recognisable version.
- */
-export async function getCdHitEstVersion(
-	runSubprocess: RunSubprocess,
-): Promise<string> {
-	const lines: string[] = [];
-
-	const collect = (line: string) => {
-		lines.push(line);
+export function buildReferenceIndexExtraParams(
+	toolVersion: string,
+): Record<string, string> {
+	return {
+		selection: "cd_hit_est_representatives",
+		selection_coverage: REFERENCE_REPRESENTATIVE_POLICY.coverage,
+		selection_identity: REFERENCE_REPRESENTATIVE_POLICY.identity,
+		selection_minimum_length: REFERENCE_REPRESENTATIVE_POLICY.minimumLength,
+		selection_policy_version: REFERENCE_REPRESENTATIVE_POLICY.version,
+		selection_source: "full_source_reference",
+		selection_tool: CD_HIT_EST_TOOL,
+		selection_tool_version: toolVersion,
+		selection_word_size: REFERENCE_REPRESENTATIVE_POLICY.wordSize,
 	};
-
-	try {
-		await runSubprocess({
-			command: [CD_HIT_EST_TOOL, "-h"],
-			stdout: collect,
-			stderr: collect,
-		});
-	} catch {
-		// Expected: the help text is the output and exit 1 is how it ends. A tool
-		// that is genuinely absent produces no matching line and fails below,
-		// naming the version parse rather than the exit code.
-	}
-
-	return matchToolVersion(
-		/\bCD-HIT\s+version\s+(\S+)/,
-		lines,
-		"Could not parse cd-hit-est version",
-	);
 }

--- a/apps/pathoscope/src/paths.ts
+++ b/apps/pathoscope/src/paths.ts
@@ -49,16 +49,16 @@ export type PathoscopePaths = {
 	/** The directory archived into the collapsed-reference cache */
 	collapsedReferenceDir: string;
 
-	/** The bowtie2 index prefix over the collapsed default isolates */
-	referenceIndexPrefix: string;
+	/** The bowtie2 index prefix over full-source reference representatives */
+	representativeIndexPrefix: string;
 
 	subtraction: (subtractionId: number) => SubtractionPaths;
 
 	/** Every sequence of every candidate OTU */
-	isolateFasta: string;
+	candidateOtuFasta: string;
 
-	/** The bowtie2 index prefix over {@link isolateFasta} */
-	isolateIndexPrefix: string;
+	/** The bowtie2 index prefix over {@link candidateOtuFasta} */
+	candidateOtuIndexPrefix: string;
 
 	/** Reads that aligned to an isolate, written by `bowtie2 --al` */
 	isolateFastq: string;
@@ -118,7 +118,7 @@ export function workPaths(workPath: string): PathoscopePaths {
 		),
 		collapsedReferenceDir: join(workPath, "collapsed_reference"),
 
-		referenceIndexPrefix: join(workPath, "reference_index", "reference"),
+		representativeIndexPrefix: join(workPath, "reference_index", "reference"),
 
 		subtraction: (subtractionId) => {
 			const dir = join(workPath, "subtraction_indexes", String(subtractionId));
@@ -139,8 +139,8 @@ export function workPaths(workPath: string): PathoscopePaths {
 		},
 
 		isolatesDir,
-		isolateFasta: join(isolatesDir, "isolate_index.fa"),
-		isolateIndexPrefix: join(isolatesDir, "isolates"),
+		candidateOtuFasta: join(isolatesDir, "isolate_index.fa"),
+		candidateOtuIndexPrefix: join(isolatesDir, "isolates"),
 		isolateFastq: join(isolatesDir, "isolate_mapped.fq"),
 		isolateBam: join(isolatesDir, "to_isolates.bam"),
 

--- a/apps/pathoscope/src/reference/collapse.test.ts
+++ b/apps/pathoscope/src/reference/collapse.test.ts
@@ -242,9 +242,8 @@ describe("collapseOtu", () => {
 		]);
 	});
 
-	// Iteration order decides which duplicate survives, and the default isolate
-	// is kept whatever its position.
-	it("keeps a default isolate that duplicates an earlier one", async () => {
+	// Iteration order alone decides which duplicate survives.
+	it("does not prefer a default isolate that duplicates an earlier one", async () => {
 		const otu = createOtu([
 			createIsolate("iso_1", [createSequence("seq_1")]),
 			createIsolate("iso_2", [createSequence("seq_2")], true),
@@ -252,10 +251,7 @@ describe("collapseOtu", () => {
 
 		const result = await collapseOtu(otu, await tempDir(), collapseTo("seq_1"));
 
-		expect(result.otu.isolates.map((isolate) => isolate.id)).toEqual([
-			"iso_1",
-			"iso_2",
-		]);
+		expect(result.otu.isolates.map((isolate) => isolate.id)).toEqual(["iso_1"]);
 	});
 
 	it("runs one cd-hit-est per segment, named after the OTU and segment", async () => {

--- a/apps/pathoscope/src/reference/collapse.ts
+++ b/apps/pathoscope/src/reference/collapse.ts
@@ -24,12 +24,10 @@ import type {
 	IndexOtuSequence,
 	WorkflowIndex,
 } from "@virtool/sqlite";
-import type { RunSubprocess } from "@virtool/workflow";
+import { CD_HIT_EST_TOOL, type RunSubprocess } from "@virtool/workflow";
 import { parseCdHitClusters } from "./clusters";
 
-export const CD_HIT_EST_TOOL = "cd-hit-est";
-
-/** The identity threshold every cd-hit-est run in this workflow uses. */
+/** The identity threshold the isolate-collapse runs use. */
 export const CD_HIT_EST_IDENTITY = "0.99";
 
 /** What collapsing did to one OTU. */
@@ -259,12 +257,6 @@ export async function collapseOtu(
 		limit,
 	);
 
-	const defaultSequenceIds = new Set(
-		otu.isolates
-			.filter((isolate) => isolate.default)
-			.flatMap((isolate) => isolate.sequences.map((sequence) => sequence.id)),
-	);
-
 	const seenRepresentativeSets = new Set<string>();
 	const collapsedIsolates: IndexOtuIsolate[] = [];
 
@@ -275,14 +267,7 @@ export async function collapseOtu(
 
 		seenRepresentativeSets.add(key);
 
-		// A no-op, and deliberately kept for now: a sequence has exactly one parent
-		// isolate, so this is true precisely when `isolate.default` is. VIR-2938
-		// deletes it.
-		const containsDefaultSequence = isolate.sequences.some((sequence) =>
-			defaultSequenceIds.has(sequence.id),
-		);
-
-		if (isolate.default || containsDefaultSequence || firstForSet) {
+		if (firstForSet) {
 			collapsedIsolates.push(isolate);
 		}
 	}

--- a/apps/pathoscope/src/state.ts
+++ b/apps/pathoscope/src/state.ts
@@ -8,15 +8,15 @@
 /** Cross-step scratch for one pathoscope run. */
 export type PathoscopeState = {
 	/**
-	 * The reference sequences the sample's reads mapped to.
+	 * The OTUs owning reference representatives the sample's reads mapped to.
 	 *
-	 * Empty until `map_default_isolates` fills it, and **an empty set after that
+	 * Empty until `map_representatives` fills it, and **an empty list after that
 	 * step is a legitimate outcome**: the sample carries nothing this reference
 	 * knows about. Four later steps short-circuit on it, because `bowtie2-build`
 	 * exits 1 on an empty FASTA and every step after that has no index to map
 	 * against.
 	 */
-	candidateSequenceIds: string[];
+	candidateOtuIds: string[];
 
 	/**
 	 * Reads dropped for aligning at least as well to a subtraction, accumulated
@@ -26,5 +26,5 @@ export type PathoscopeState = {
 };
 
 export function createPathoscopeState(): PathoscopeState {
-	return { candidateSequenceIds: [], subtractedCount: 0 };
+	return { candidateOtuIds: [], subtractedCount: 0 };
 }

--- a/apps/pathoscope/src/steps/collapseReference.ts
+++ b/apps/pathoscope/src/steps/collapseReference.ts
@@ -2,12 +2,13 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { Logger } from "@virtool/logger";
 import { createIndexArtifact, openWorkflowIndex } from "@virtool/sqlite";
-import { deriveCacheKey, type RunSubprocess } from "@virtool/workflow";
-import { cacheFor } from "../cache";
 import {
-	buildCollapsedReferenceCacheParams,
+	deriveCacheKey,
 	getCdHitEstVersion,
-} from "../cacheParams";
+	type RunSubprocess,
+} from "@virtool/workflow";
+import { cacheFor } from "../cache";
+import { buildCollapsedReferenceCacheParams } from "../cacheParams";
 import { type PathoscopePaths, workPaths } from "../paths";
 import {
 	collapseOtus,

--- a/apps/pathoscope/src/steps/collapseReference.ts
+++ b/apps/pathoscope/src/steps/collapseReference.ts
@@ -29,7 +29,9 @@ import type { PathoscopeStep } from "./types";
  */
 export const collapseReferenceStep: PathoscopeStep = {
 	id: "collapse_reference",
-	description: "Ensure a cd-hit-est collapsed reference index exists locally.",
+	name: "Remove Redundant Isolates",
+	description:
+		"Remove nearly identical virus isolates before detailed read matching.",
 	async run(context) {
 		const { data, logger, proc, runSubprocess, workPath } = context;
 		const paths = workPaths(workPath);

--- a/apps/pathoscope/src/steps/createIndexes.test.ts
+++ b/apps/pathoscope/src/steps/createIndexes.test.ts
@@ -422,7 +422,10 @@ describe("createRepresentativeIndexStep", () => {
 		expect(state.cacheRegistrations).toEqual([]);
 
 		await expect(
-			readFile(join(dirname(paths.representativeIndexPrefix), SHARD_NAME), "utf8"),
+			readFile(
+				join(dirname(paths.representativeIndexPrefix), SHARD_NAME),
+				"utf8",
+			),
 		).resolves.toBe("cached shard");
 	});
 

--- a/apps/pathoscope/src/steps/createIndexes.test.ts
+++ b/apps/pathoscope/src/steps/createIndexes.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rm,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { createIndexArtifact, type IndexOtu } from "@virtool/sqlite";
@@ -15,22 +22,24 @@ import {
 	createFakeJobsApiClient,
 	createFakeSubprocessRunner,
 	createJobsApiState,
+	createRecordingLogger,
 	createTestStorage,
 	createTestWorkPath,
 } from "@virtool/workflow/testing";
 import { describe, expect, it, onTestFinished } from "vitest";
-import { REFERENCE_INDEX_EXTRA_PARAMS, WORKFLOW_NAME } from "../cacheParams";
+import { buildReferenceIndexExtraParams, WORKFLOW_NAME } from "../cacheParams";
 import type { PathoscopeData } from "../context";
 import { workPaths } from "../paths";
 import type { PathoscopeState } from "../state";
 import { APP_VERSION } from "../version";
 import {
-	createReferenceIndexStep,
+	createRepresentativeIndexStep,
 	createSubtractionIndexStep,
 } from "./createIndexes";
 
 const BOWTIE2_BUILD = "bowtie2-build";
 const BOWTIE2_BUILD_VERSION = "2.4.4";
+const CD_HIT_EST_VERSION = "4.8.1";
 const INDEX_ID = 7;
 const SHARD_NAME = "reference.1.bt2";
 const SUBTRACTION_ID = 9;
@@ -51,7 +60,7 @@ const OTU: IndexOtu = {
 					host: null,
 					id: "seq_default",
 					segment: null,
-					sequence: "ACGTACGT",
+					sequence: "ACGTACGTACGT",
 				},
 			],
 			source_name: "A",
@@ -67,7 +76,7 @@ const OTU: IndexOtu = {
 					host: null,
 					id: "seq_other",
 					segment: null,
-					sequence: "TTTT",
+					sequence: "TTTTTTTTTTTT",
 				},
 			],
 			source_name: "B",
@@ -82,7 +91,7 @@ const OTU: IndexOtu = {
 
 function referenceIndexCacheParams(): CacheParams {
 	return buildMappingIndexCacheParams({
-		extra: REFERENCE_INDEX_EXTRA_PARAMS,
+		extra: buildReferenceIndexExtraParams(CD_HIT_EST_VERSION),
 		indexKind: "reference_mapping_index",
 		parentId: INDEX_ID,
 		toolVersion: BOWTIE2_BUILD_VERSION,
@@ -117,19 +126,60 @@ async function createHarness() {
 	const client = createFakeJobsApiClient(state);
 	const testStorage = createTestStorage();
 	const { storage } = testStorage;
+	const recordingLogger = createRecordingLogger();
 
 	const runner = createFakeSubprocessRunner();
 
 	runner.register([BOWTIE2_BUILD, "--version"], {
 		stdout: [`${BOWTIE2_BUILD} version ${BOWTIE2_BUILD_VERSION}`],
 	});
+	runner.register(["cd-hit-est", "-h"], {
+		exitCode: 1,
+		stderr: [`====== CD-HIT version ${CD_HIT_EST_VERSION} ======`],
+	});
 
 	const builtFastas: string[] = [];
+	const cdHitCommands: Array<readonly string[]> = [];
+	let shouldFailCdHit = false;
 
 	const runSubprocess: RunSubprocess = async (
 		options: RunSubprocessOptions,
 	) => {
 		const [tool, flag, , fastaPath, indexPrefix] = options.command;
+
+		if (tool === "cd-hit-est" && flag !== "-h") {
+			cdHitCommands.push(options.command);
+
+			if (shouldFailCdHit) {
+				throw new Error("cd-hit-est failed");
+			}
+
+			const input = await readFile(options.command[2] ?? "", "utf8");
+			const ids = [...input.matchAll(/^>(.+)$/gm)].map(
+				(match) => match[1] ?? "",
+			);
+			const representative = ids.at(-1) ?? "";
+			const cluster = [
+				">Cluster 0",
+				...ids.map((id, index) =>
+					id === representative
+						? `${index}\t12nt, >${id}... *`
+						: `${index}\t12nt, >${id}... at +/80.00%`,
+				),
+				"",
+			].join("\n");
+
+			await writeFile(`${options.command[4]}.clstr`, cluster);
+
+			return {
+				cancelled: false,
+				command: options.command,
+				durationMs: 1,
+				exitCode: 0,
+				signal: null,
+				stderrTail: [],
+			};
+		}
 
 		if (tool === BOWTIE2_BUILD && flag !== "--version") {
 			builtFastas.push(await readFile(fastaPath ?? "", "utf8"));
@@ -143,20 +193,25 @@ async function createHarness() {
 	};
 
 	const pathoscopeState: PathoscopeState = {
-		candidateSequenceIds: [],
+		candidateOtuIds: [],
 		subtractedCount: 0,
 	};
 
 	return {
 		builtFastas,
+		cdHitCommands,
 		client,
 		paths,
 		pathoscopeState,
+		recordingLogger,
 		runSubprocess,
 		state,
 		storage,
 		testStorage,
 		workPath,
+		failCdHit() {
+			shouldFailCdHit = true;
+		},
 
 		/**
 		 * Register a built index under the key a run derives.
@@ -190,8 +245,15 @@ async function createHarness() {
 
 async function setup() {
 	const harness = await createHarness();
-	const { client, paths, pathoscopeState, runSubprocess, storage, workPath } =
-		harness;
+	const {
+		client,
+		paths,
+		pathoscopeState,
+		recordingLogger,
+		runSubprocess,
+		storage,
+		workPath,
+	} = harness;
 
 	const data: PathoscopeData = {
 		analysisId: 1,
@@ -209,9 +271,10 @@ async function setup() {
 		...harness,
 
 		run() {
-			return createReferenceIndexStep.run(
+			return createRepresentativeIndexStep.run(
 				createFakeContext(data, pathoscopeState, {
 					client,
+					logger: recordingLogger.logger,
 					runSubprocess,
 					storage,
 					workPath,
@@ -219,11 +282,11 @@ async function setup() {
 			);
 		},
 
-		/** Write a collapsed reference for the step to read default isolates from. */
-		async writeCollapsedReference() {
-			await mkdir(dirname(paths.collapsedReference), { recursive: true });
+		/** Write the full source reference used for representative selection. */
+		async writeSourceReference() {
+			await mkdir(dirname(data.index.path), { recursive: true });
 
-			await createIndexArtifact(paths.collapsedReference, null, [OTU]);
+			await createIndexArtifact(data.index.path, null, [OTU]);
 		},
 
 		seedCachedIndex(directoryName = "reference_index") {
@@ -243,6 +306,7 @@ async function setupSubtraction() {
 		client,
 		paths,
 		pathoscopeState,
+		recordingLogger,
 		runSubprocess,
 		storage,
 		testStorage,
@@ -282,6 +346,7 @@ async function setupSubtraction() {
 			return createSubtractionIndexStep.run(
 				createFakeContext(data, pathoscopeState, {
 					client,
+					logger: recordingLogger.logger,
 					runSubprocess,
 					storage,
 					workPath,
@@ -299,43 +364,90 @@ async function setupSubtraction() {
 	};
 }
 
-describe("createReferenceIndexStep", () => {
+describe("createRepresentativeIndexStep", () => {
 	it("writes the reference fasta and caches the index on a miss", async () => {
-		const { builtFastas, paths, run, state, writeCollapsedReference } =
-			await setup();
+		const {
+			builtFastas,
+			cdHitCommands,
+			paths,
+			recordingLogger,
+			run,
+			state,
+			writeSourceReference,
+		} = await setup();
 
-		await writeCollapsedReference();
+		await writeSourceReference();
 
 		await run();
 
-		expect(builtFastas).toEqual([">seq_default\nACGTACGT\n"]);
+		expect(builtFastas).toEqual([">seq_other\nTTTTTTTTTTTT\n"]);
+		expect(cdHitCommands).toHaveLength(1);
+		expect(
+			recordingLogger
+				.records()
+				.find(
+					(record) => record.msg === "assembled representative reference fasta",
+				),
+		).toMatchObject({
+			baseCount: 12,
+			durationMs: expect.any(Number),
+			fastaBytes: 24,
+			groupCount: 1,
+			representativeCount: 1,
+		});
 
 		expect(state.cacheRegistrations.map(({ key }) => key)).toEqual([
 			deriveCacheKey(referenceIndexCacheParams()),
 		]);
 
 		await expect(
-			readFile(`${paths.referenceIndexPrefix}.1.bt2`, "utf8"),
+			readFile(`${paths.representativeIndexPrefix}.1.bt2`, "utf8"),
 		).resolves.toBe("built shard");
 	});
 
-	// The collapsed reference is deliberately absent: assembling the FASTA has to
+	// The source reference is deliberately absent: assembling the FASTA has to
 	// open it, and `openWorkflowIndex` throws on a missing artifact. So a run that
-	// restores the index cannot have scanned the reference to write a file it
+	// restores the index cannot have scanned or clustered the reference to write a file it
 	// then deletes unread.
 	it("writes no reference fasta on a cache hit", async () => {
-		const { builtFastas, paths, run, seedCachedIndex, state } = await setup();
+		const { builtFastas, cdHitCommands, paths, run, seedCachedIndex, state } =
+			await setup();
 
 		await seedCachedIndex();
 
 		await run();
 
 		expect(builtFastas).toEqual([]);
+		expect(cdHitCommands).toEqual([]);
 		expect(state.cacheRegistrations).toEqual([]);
 
 		await expect(
-			readFile(join(dirname(paths.referenceIndexPrefix), SHARD_NAME), "utf8"),
+			readFile(join(dirname(paths.representativeIndexPrefix), SHARD_NAME), "utf8"),
 		).resolves.toBe("cached shard");
+	});
+
+	it("does not build or cache an index when representative preparation fails", async () => {
+		const {
+			builtFastas,
+			failCdHit,
+			run,
+			state,
+			workPath,
+			writeSourceReference,
+		} = await setup();
+
+		await writeSourceReference();
+		failCdHit();
+
+		await expect(run()).rejects.toThrow("cd-hit-est failed");
+
+		expect(builtFastas).toEqual([]);
+		expect(state.cacheRegistrations).toEqual([]);
+		expect(
+			(await readdir(workPath)).filter((name) =>
+				name.startsWith("reference-fasta-"),
+			),
+		).toEqual([]);
 	});
 
 	// The namespace is shared, so a blob can have been archived from a directory
@@ -348,7 +460,7 @@ describe("createReferenceIndexStep", () => {
 		await seedCachedIndex("reference-index");
 
 		await expect(run()).rejects.toThrow(
-			`restored to ${join(workPath, "reference-index")}, not ${dirname(paths.referenceIndexPrefix)}`,
+			`restored to ${join(workPath, "reference-index")}, not ${dirname(paths.representativeIndexPrefix)}`,
 		);
 
 		expect(builtFastas).toEqual([]);

--- a/apps/pathoscope/src/steps/createIndexes.ts
+++ b/apps/pathoscope/src/steps/createIndexes.ts
@@ -25,7 +25,9 @@ import type { PathoscopeStep } from "./types";
  */
 export const createRepresentativeIndexStep: PathoscopeStep = {
 	id: "create_representative_index",
-	description: "Ensure the representative Bowtie2 index exists locally.",
+	name: "Prepare Screening Reference",
+	description:
+		"Select a small set of reference sequences for quickly finding possible viruses.",
 	async run(context) {
 		const { data, logger, proc, runSubprocess, workPath } = context;
 		const paths = workPaths(workPath);
@@ -161,7 +163,9 @@ async function writeRepresentativeFasta({
  */
 export const createSubtractionIndexStep: PathoscopeStep = {
 	id: "create_subtraction_index",
-	description: "Ensure subtraction Bowtie2 indexes exist locally.",
+	name: "Prepare Host References",
+	description:
+		"Build the search data used later to remove reads from the sample's host.",
 	async run(context) {
 		const { data, logger, proc, runSubprocess, storage, workPath } = context;
 		const paths = workPaths(workPath);

--- a/apps/pathoscope/src/steps/createIndexes.ts
+++ b/apps/pathoscope/src/steps/createIndexes.ts
@@ -1,14 +1,17 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rename, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import type { Logger } from "@virtool/logger";
 import { openWorkflowIndex, writeFasta } from "@virtool/sqlite";
 import {
 	type BuildContextInput,
 	createMappingIndex,
 	downloadToPath,
+	getCdHitEstVersion,
+	selectReferenceRepresentatives,
 } from "@virtool/workflow";
 import { cacheFor } from "../cache";
-import { REFERENCE_INDEX_EXTRA_PARAMS, WORKFLOW_NAME } from "../cacheParams";
+import { buildReferenceIndexExtraParams, WORKFLOW_NAME } from "../cacheParams";
 import { workPaths } from "../paths";
 import { APP_VERSION } from "../version";
 import type { PathoscopeStep } from "./types";
@@ -16,16 +19,17 @@ import type { PathoscopeStep } from "./types";
 /**
  * Build the bowtie2 index the candidate search maps against.
  *
- * Only the collapsed reference's **default isolates** go into it. The point of
- * this pass is to find which OTUs are present at all, and one representative per
- * OTU answers that far more cheaply than every isolate would.
+ * CD-HIT-EST representatives selected from every source OTU and declared
+ * segment go into it. The point of this pass is to find which OTUs are present
+ * without paying to map against every source sequence.
  */
-export const createReferenceIndexStep: PathoscopeStep = {
-	id: "create_reference_index",
-	description: "Ensure the reference Bowtie2 index exists locally.",
+export const createRepresentativeIndexStep: PathoscopeStep = {
+	id: "create_representative_index",
+	description: "Ensure the representative Bowtie2 index exists locally.",
 	async run(context) {
 		const { data, logger, proc, runSubprocess, workPath } = context;
 		const paths = workPaths(workPath);
+		const cdHitEstVersion = await getCdHitEstVersion(runSubprocess);
 
 		// The FASTA is an input to `bowtie2-build` and nothing reads it again, so
 		// it is staged and removed rather than left in the work path.
@@ -35,18 +39,21 @@ export const createReferenceIndexStep: PathoscopeStep = {
 		try {
 			await createMappingIndex({
 				cache: cacheFor(context),
-				extraParams: REFERENCE_INDEX_EXTRA_PARAMS,
+				extraParams: buildReferenceIndexExtraParams(cdHitEstVersion),
 				fastaPath,
 				indexKind: "reference_mapping_index",
-				indexPrefix: paths.referenceIndexPrefix,
+				indexPrefix: paths.representativeIndexPrefix,
 				logger,
 				parentId: data.index.id,
 				prepareFasta: () =>
-					writeDefaultIsolateFasta({
+					writeRepresentativeFasta({
 						fastaPath,
 						indexId: data.index.id,
-						indexPath: paths.collapsedReference,
+						indexPath: data.index.path,
 						logger,
+						proc,
+						runSubprocess,
+						scratchPath: temp,
 					}),
 				proc,
 				runSubprocess,
@@ -60,36 +67,85 @@ export const createReferenceIndexStep: PathoscopeStep = {
 };
 
 /**
- * Write the collapsed reference's default isolates as one FASTA.
+ * Write source-reference CD-HIT-EST representatives as one FASTA.
  *
  * Handed to {@link createMappingIndex} as a producer rather than run before it:
  * the `reference_mapping_index` namespace is shared, so a hit is the common
- * outcome and the whole collapsed reference would otherwise be scanned into a
+ * outcome and the whole source reference would otherwise be scanned into a
  * file nothing then reads.
  */
-async function writeDefaultIsolateFasta({
+async function writeRepresentativeFasta({
 	fastaPath,
 	indexId,
 	indexPath,
 	logger,
+	proc,
+	runSubprocess,
+	scratchPath,
 }: {
 	fastaPath: string;
 	indexId: number;
 	indexPath: string;
 	logger: Logger;
+	proc: number;
+	runSubprocess: BuildContextInput["runSubprocess"];
+	scratchPath: string;
 }): Promise<void> {
 	const source = openWorkflowIndex({ id: indexId, path: indexPath });
+	const partialPath = `${fastaPath}.partial`;
+	const startedAt = performance.now();
+	let baseCount = 0;
+	let groupCount = 0;
+	let representativeCount = 0;
+	let previousOtuId: string | null = null;
+	let previousSegment: string | null = null;
+	let hasPreviousGroup = false;
 
-	try {
-		// Streamed from SQLite straight to disk. The sequence order is the index
-		// reader's, which decides the FASTA order and so every SAM line mapped
-		// against the built index.
-		await writeFasta(fastaPath, source.iterDefaultSequences());
-	} finally {
-		source.close();
+	async function* tallyRepresentatives() {
+		for await (const representative of selectReferenceRepresentatives({
+			concurrency: proc,
+			otus: source.iterOtus(),
+			runSubprocess,
+			scratchPath,
+		})) {
+			if (
+				!hasPreviousGroup ||
+				representative.otuId !== previousOtuId ||
+				representative.groupSegment !== previousSegment
+			) {
+				groupCount += 1;
+				previousOtuId = representative.otuId;
+				previousSegment = representative.groupSegment;
+				hasPreviousGroup = true;
+			}
+
+			representativeCount += 1;
+			baseCount += representative.sequence.length;
+
+			yield representative;
+		}
 	}
 
-	logger.info({ fastaPath }, "assembled default reference fasta");
+	try {
+		await writeFasta(partialPath, tallyRepresentatives());
+		await rename(partialPath, fastaPath);
+
+		const { size: fastaBytes } = await stat(fastaPath);
+
+		logger.info(
+			{
+				baseCount,
+				durationMs: Math.round(performance.now() - startedAt),
+				fastaBytes,
+				groupCount,
+				representativeCount,
+			},
+			"assembled representative reference fasta",
+		);
+	} finally {
+		source.close();
+		await rm(partialPath, { force: true });
+	}
 }
 
 /**

--- a/apps/pathoscope/src/steps/eliminateSubtraction.test.ts
+++ b/apps/pathoscope/src/steps/eliminateSubtraction.test.ts
@@ -166,7 +166,7 @@ async function runStep(
 	};
 
 	const state: PathoscopeState = {
-		candidateSequenceIds: ["seq_a"],
+		candidateOtuIds: ["otu_a"],
 		subtractedCount: 0,
 	};
 

--- a/apps/pathoscope/src/steps/eliminateSubtraction.ts
+++ b/apps/pathoscope/src/steps/eliminateSubtraction.ts
@@ -19,7 +19,7 @@ export const eliminateSubtractionStep: PathoscopeStep = {
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
-		if (state.candidateSequenceIds.length === 0) {
+		if (state.candidateOtuIds.length === 0) {
 			logger.info("no candidate otus; nothing to subtract");
 
 			return;

--- a/apps/pathoscope/src/steps/eliminateSubtraction.ts
+++ b/apps/pathoscope/src/steps/eliminateSubtraction.ts
@@ -14,8 +14,8 @@ import type { PathoscopeStep } from "./types";
  */
 export const eliminateSubtractionStep: PathoscopeStep = {
 	id: "eliminate_subtraction",
-	description:
-		"Remove reads that map better to a subtraction than to a reference.",
+	name: "Remove Host Reads",
+	description: "Remove reads belonging to the sample's host.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 

--- a/apps/pathoscope/src/steps/mapping.test.ts
+++ b/apps/pathoscope/src/steps/mapping.test.ts
@@ -1,4 +1,6 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { createIndexArtifact, type IndexOtu } from "@virtool/sqlite";
 import type { RunSubprocess, RunSubprocessOptions } from "@virtool/workflow";
 import {
 	createFakeContext,
@@ -8,9 +10,95 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import type { PathoscopeData } from "../context";
 import { workPaths } from "../paths";
 import type { PathoscopeState } from "../state";
-import { mapIsolatesStep } from "./mapping";
+import {
+	buildCandidateOtuIndexStep,
+	mapIsolatesStep,
+	mapRepresentativesStep,
+} from "./mapping";
 
 const PIPEFAIL_PREFIX = "set -o pipefail; ";
+
+function createOtu(id: string, sequenceIds: readonly string[]): IndexOtu {
+	return {
+		abbreviation: id,
+		id,
+		isolates: [
+			{
+				default: true,
+				id: `${id}_isolate`,
+				sequences: sequenceIds.map((sequenceId) => ({
+					accession: sequenceId,
+					definition: sequenceId,
+					host: null,
+					id: sequenceId,
+					segment: null,
+					sequence: "ACGTACGTACGT",
+				})),
+				source_name: id,
+				source_type: "isolate",
+			},
+		],
+		name: id,
+		schema: [],
+		taxid: null,
+		version: 1,
+	};
+}
+
+describe("mapRepresentativesStep", () => {
+	it("stores the distinct OTUs owning candidate representative sequences", async () => {
+		const { path: workPath, cleanup } = await createTestWorkPath();
+		onTestFinished(cleanup);
+
+		const paths = workPaths(workPath);
+		const sourcePath = paths.sourceIndex(1);
+
+		await mkdir(join(workPath, "indexes", "1"), { recursive: true });
+		await createIndexArtifact(sourcePath, null, [
+			createOtu("otu_z", ["seq_a", "seq_b"]),
+			createOtu("otu_a", ["seq_c"]),
+		]);
+
+		const runSubprocess: RunSubprocess = async (options) => {
+			const outputIndex = options.command.indexOf("--output");
+
+			await writeFile(
+				options.command[outputIndex + 1] ?? "",
+				JSON.stringify(["seq_a", "seq_b", "seq_c"]),
+			);
+
+			return {
+				cancelled: false,
+				command: options.command,
+				durationMs: 1,
+				exitCode: 0,
+				signal: null,
+				stderrTail: [],
+			};
+		};
+		const data: PathoscopeData = {
+			analysisId: 1,
+			index: {
+				id: 1,
+				path: sourcePath,
+				storageKey: "indexes/1/source",
+			},
+			pScoreCutoff: 0.01,
+			reads: [],
+			subtractions: [],
+		};
+		const state: PathoscopeState = {
+			candidateOtuIds: [],
+			subtractedCount: 0,
+		};
+
+		await mapRepresentativesStep.run(
+			createFakeContext(data, state, { runSubprocess, workPath }),
+		);
+
+		expect(state.candidateOtuIds).toEqual(["otu_a", "otu_z"]);
+	});
+});
 
 /**
  * Run the isolate mapping step, capturing the bash pipeline it composes.
@@ -57,7 +145,7 @@ async function runStep(readNames: readonly string[]) {
 	};
 
 	const state: PathoscopeState = {
-		candidateSequenceIds: ["seq_a"],
+		candidateOtuIds: ["otu_a"],
 		subtractedCount: 0,
 	};
 
@@ -81,7 +169,7 @@ describe("mapIsolatesStep", () => {
 		const { paths, script } = await runStep(["reads_1.fq.gz"]);
 
 		expect(script).toContain(`--al '${paths.isolateFastq}'`);
-		expect(script).toContain(`-x '${paths.isolateIndexPrefix}'`);
+		expect(script).toContain(`-x '${paths.candidateOtuIndexPrefix}'`);
 		expect(script).toContain(`-o '${paths.isolateBam}'`);
 	});
 
@@ -119,7 +207,7 @@ describe("mapIsolatesStep", () => {
 		};
 
 		const state: PathoscopeState = {
-			candidateSequenceIds: [],
+			candidateOtuIds: [],
 			subtractedCount: 0,
 		};
 
@@ -132,5 +220,108 @@ describe("mapIsolatesStep", () => {
 				createFakeContext(data, state, { workPath, runSubprocess }),
 			),
 		).resolves.toBeUndefined();
+	});
+});
+
+describe("buildCandidateOtuIndexStep", () => {
+	it("writes candidate OTUs from the collapsed reference", async () => {
+		const { path: workPath, cleanup } = await createTestWorkPath();
+		onTestFinished(cleanup);
+
+		const paths = workPaths(workPath);
+		const sourcePath = paths.sourceIndex(1);
+		const sourceOtu: IndexOtu = {
+			abbreviation: "TMV",
+			id: "otu_1",
+			isolates: [
+				{
+					default: true,
+					id: "isolate_survivor",
+					sequences: [
+						{
+							accession: "AC_1",
+							definition: "Surviving sequence",
+							host: null,
+							id: "seq_survivor",
+							segment: null,
+							sequence: "ACGTACGTACGT",
+						},
+					],
+					source_name: "survivor",
+					source_type: "isolate",
+				},
+				{
+					default: false,
+					id: "isolate_removed",
+					sequences: [
+						{
+							accession: "AC_2",
+							definition: "Removed representative",
+							host: null,
+							id: "seq_removed",
+							segment: null,
+							sequence: "ACGTACGTACGA",
+						},
+					],
+					source_name: "removed",
+					source_type: "isolate",
+				},
+			],
+			name: "Tobacco mosaic virus",
+			schema: [],
+			taxid: 12242,
+			version: 3,
+		};
+		const collapsedOtu: IndexOtu = {
+			...sourceOtu,
+			isolates: [sourceOtu.isolates[0] as IndexOtu["isolates"][number]],
+		};
+
+		await mkdir(paths.collapsedReferenceDir, { recursive: true });
+		await createIndexArtifact(paths.collapsedReference, null, [collapsedOtu]);
+
+		const commands: Array<readonly string[]> = [];
+		const runSubprocess: RunSubprocess = async (options) => {
+			commands.push(options.command);
+
+			return {
+				cancelled: false,
+				command: options.command,
+				durationMs: 1,
+				exitCode: 0,
+				signal: null,
+				stderrTail: [],
+			};
+		};
+		const data: PathoscopeData = {
+			analysisId: 1,
+			index: {
+				id: 1,
+				path: sourcePath,
+				storageKey: "indexes/1/source",
+			},
+			pScoreCutoff: 0.01,
+			reads: [],
+			subtractions: [],
+		};
+		const state: PathoscopeState = {
+			candidateOtuIds: ["otu_1"],
+			subtractedCount: 0,
+		};
+
+		await buildCandidateOtuIndexStep.run(
+			createFakeContext(data, state, { runSubprocess, workPath }),
+		);
+
+		await expect(readFile(paths.candidateOtuFasta, "utf8")).resolves.toBe(
+			">seq_survivor\nACGTACGTACGT\n",
+		);
+		expect(commands[0]).toEqual([
+			"bowtie2-build",
+			"--threads",
+			"2",
+			paths.candidateOtuFasta,
+			paths.candidateOtuIndexPrefix,
+		]);
 	});
 });

--- a/apps/pathoscope/src/steps/mapping.ts
+++ b/apps/pathoscope/src/steps/mapping.ts
@@ -10,80 +10,96 @@ import type { PathoscopeStep } from "./types";
  * Find the OTUs the sample's reads could plausibly belong to.
  *
  * `pathoscope-core` drives bowtie2 itself here and streams the SAM as it comes,
- * so a full alignment against every default isolate never lands on disk and
+ * so a full alignment against every source sequence never lands on disk and
  * never enters this process.
  */
-export const mapDefaultIsolatesStep: PathoscopeStep = {
-	id: "map_default_isolates",
+export const mapRepresentativesStep: PathoscopeStep = {
+	id: "map_representatives",
 	description:
-		"Map sample reads to all default isolates to identify candidate OTUs.",
+		"Map sample reads to reference representatives to identify candidate OTUs.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
-		state.candidateSequenceIds = await findCandidateSequenceIds(
+		const candidateSequenceIds = await findCandidateSequenceIds(
 			{ runSubprocess, outputPath: paths.coreResults("candidates") },
 			{
-				indexPrefix: paths.referenceIndexPrefix,
+				indexPrefix: paths.representativeIndexPrefix,
 				pScoreCutoff: data.pScoreCutoff,
 				proc,
 				readPaths: data.reads.map((read) => read.path),
 			},
 		);
 
+		const source = openWorkflowIndex({
+			id: data.index.id,
+			path: data.index.path,
+		});
+
+		try {
+			const otuRefs =
+				await source.getOtuRefsBySequenceIds(candidateSequenceIds);
+
+			state.candidateOtuIds = [
+				...new Set(Object.values(otuRefs).map((otuRef) => otuRef.id)),
+			].sort();
+		} finally {
+			source.close();
+		}
+
 		logger.info(
-			{ count: state.candidateSequenceIds.length },
-			"found candidate sequences",
+			{ count: state.candidateOtuIds.length },
+			"found candidate otus",
 		);
 	},
 };
 
 /**
- * Build a second index holding **every** isolate of every candidate OTU.
+ * Build a second index holding every surviving isolate of every candidate OTU.
  *
  * The first pass narrowed the reference to a handful of OTUs; this one restores
  * the isolate-level detail for just those, which is what makes an isolate-level
  * result affordable.
  */
-export const buildIsolateIndexStep: PathoscopeStep = {
-	id: "build_isolate_index",
+export const buildCandidateOtuIndexStep: PathoscopeStep = {
+	id: "build_candidate_otu_index",
 	description:
-		"Build a mapping index containing all isolates of candidate OTUs.",
+		"Build a mapping index containing surviving isolates of candidate OTUs.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
 		// `bowtie2-build` exits 1 on an empty FASTA, and every step after this one
 		// short-circuits on the same condition.
-		if (state.candidateSequenceIds.length === 0) {
+		if (state.candidateOtuIds.length === 0) {
 			logger.info("no candidate otus; skipping isolate index");
 
 			return;
 		}
 
-		const index = openWorkflowIndex({
+		const collapsed = openWorkflowIndex({
 			id: data.index.id,
 			path: paths.collapsedReference,
 		});
 
 		try {
-			const otuRefs = await index.getOtuRefsBySequenceIds(
-				state.candidateSequenceIds,
-			);
-
-			const otuIds = new Set(Object.values(otuRefs).map((otuRef) => otuRef.id));
-
 			await mkdir(paths.isolatesDir, { recursive: true });
 
-			await writeFasta(paths.isolateFasta, index.iterOtuSequences(otuIds));
+			await writeFasta(
+				paths.candidateOtuFasta,
+				collapsed.iterOtuSequences(state.candidateOtuIds),
+			);
 
-			logger.info({ otuCount: otuIds.size }, "wrote isolate fasta");
+			logger.info(
+				{ otuCount: state.candidateOtuIds.length },
+				"wrote isolate fasta",
+			);
 		} finally {
-			index.close();
+			collapsed.close();
 		}
 
 		await buildBowtie2Index(
 			runSubprocess,
-			paths.isolateFasta,
-			paths.isolateIndexPrefix,
+			paths.candidateOtuFasta,
+			paths.candidateOtuIndexPrefix,
 			proc,
 		);
 	},
@@ -102,11 +118,11 @@ export const buildIsolateIndexStep: PathoscopeStep = {
  */
 export const mapIsolatesStep: PathoscopeStep = {
 	id: "map_isolates",
-	description: "Map sample reads to the all isolate index.",
+	description: "Map sample reads to the candidate isolate index.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
-		if (state.candidateSequenceIds.length === 0) {
+		if (state.candidateOtuIds.length === 0) {
 			logger.info("no candidate otus; skipping isolate mapping");
 
 			return;
@@ -127,7 +143,7 @@ export const mapIsolatesStep: PathoscopeStep = {
 			"-L 15",
 			"-k 100",
 			`--al ${quote(paths.isolateFastq)}`,
-			`-x ${quote(paths.isolateIndexPrefix)}`,
+			`-x ${quote(paths.candidateOtuIndexPrefix)}`,
 			`-U ${reads}`,
 		].join(" ");
 

--- a/apps/pathoscope/src/steps/mapping.ts
+++ b/apps/pathoscope/src/steps/mapping.ts
@@ -15,8 +15,9 @@ import type { PathoscopeStep } from "./types";
  */
 export const mapRepresentativesStep: PathoscopeStep = {
 	id: "map_representatives",
+	name: "Find Possible Viruses",
 	description:
-		"Map sample reads to reference representatives to identify candidate OTUs.",
+		"Compare sample reads with the screening reference to identify viruses for detailed analysis.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
@@ -62,8 +63,9 @@ export const mapRepresentativesStep: PathoscopeStep = {
  */
 export const buildCandidateOtuIndexStep: PathoscopeStep = {
 	id: "build_candidate_otu_index",
+	name: "Prepare Detailed Reference",
 	description:
-		"Build a mapping index containing surviving isolates of candidate OTUs.",
+		"Build a reference containing the remaining isolates for the possible viruses.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
@@ -118,7 +120,9 @@ export const buildCandidateOtuIndexStep: PathoscopeStep = {
  */
 export const mapIsolatesStep: PathoscopeStep = {
 	id: "map_isolates",
-	description: "Map sample reads to the candidate isolate index.",
+	name: "Match Reads in Detail",
+	description:
+		"Compare sample reads with the possible viruses at isolate level.",
 	async run({ data, logger, proc, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 

--- a/apps/pathoscope/src/steps/reassignment.ts
+++ b/apps/pathoscope/src/steps/reassignment.ts
@@ -22,7 +22,9 @@ const COVERAGE_PLACES = 3;
  */
 export const reassignmentStep: PathoscopeStep = {
 	id: "reassignment",
-	description: "Run the Pathoscope reassignment algorithm.",
+	name: "Estimate Virus Abundance",
+	description:
+		"Assign reads that match multiple isolates and calculate the final results.",
 	async run({ client, data, logger, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 

--- a/apps/pathoscope/src/steps/reassignment.ts
+++ b/apps/pathoscope/src/steps/reassignment.ts
@@ -26,7 +26,7 @@ export const reassignmentStep: PathoscopeStep = {
 	async run({ client, data, logger, runSubprocess, state, workPath }) {
 		const paths = workPaths(workPath);
 
-		if (state.candidateSequenceIds.length === 0) {
+		if (state.candidateOtuIds.length === 0) {
 			logger.info("no candidate otus found; uploading empty result");
 
 			await finalize(client, data.analysisId, {

--- a/apps/pathoscope/src/workflow.test.ts
+++ b/apps/pathoscope/src/workflow.test.ts
@@ -4,14 +4,37 @@ import { pathoscopeWorkflow } from "./workflow";
 describe("pathoscopeWorkflow", () => {
 	it("declares representative mapping as the candidate-screen step", () => {
 		expect(pathoscopeWorkflow.steps.map(({ id }) => id)).toEqual([
-			"collapse_reference",
 			"create_representative_index",
 			"create_subtraction_index",
 			"map_representatives",
+			"collapse_reference",
 			"build_candidate_otu_index",
 			"map_isolates",
 			"eliminate_subtraction",
 			"reassignment",
+		]);
+	});
+
+	it("distinguishes screening reduction from isolate deduplication", () => {
+		expect(
+			pathoscopeWorkflow.steps
+				.filter(({ id }) =>
+					["create_representative_index", "collapse_reference"].includes(id),
+				)
+				.map(({ description, id, name }) => ({ description, id, name })),
+		).toEqual([
+			{
+				description:
+					"Select a small set of reference sequences for quickly finding possible viruses.",
+				id: "create_representative_index",
+				name: "Prepare Screening Reference",
+			},
+			{
+				description:
+					"Remove nearly identical virus isolates before detailed read matching.",
+				id: "collapse_reference",
+				name: "Remove Redundant Isolates",
+			},
 		]);
 	});
 });

--- a/apps/pathoscope/src/workflow.test.ts
+++ b/apps/pathoscope/src/workflow.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { pathoscopeWorkflow } from "./workflow";
+
+describe("pathoscopeWorkflow", () => {
+	it("declares representative mapping as the candidate-screen step", () => {
+		expect(pathoscopeWorkflow.steps.map(({ id }) => id)).toEqual([
+			"collapse_reference",
+			"create_representative_index",
+			"create_subtraction_index",
+			"map_representatives",
+			"build_candidate_otu_index",
+			"map_isolates",
+			"eliminate_subtraction",
+			"reassignment",
+		]);
+	});
+});

--- a/apps/pathoscope/src/workflow.ts
+++ b/apps/pathoscope/src/workflow.ts
@@ -2,10 +2,10 @@
  * The pathoscope workflow: eight steps, four external tools and the Rust core.
  *
  * Pathoscope quantifies known viruses in a sample. It collapses redundant
- * isolates out of the reference, maps the sample against one representative per
- * OTU to find candidates, rebuilds an index carrying every isolate of just those
- * OTUs, maps again, drops reads that belong to the host, and finally reassigns
- * the reads that matched more than one isolate.
+ * isolates out of the reference, maps the sample against full-source
+ * representatives to find candidates, rebuilds an index carrying every
+ * collapsed isolate of just those OTUs, maps again, drops reads that belong to
+ * the host, and finally reassigns the reads that matched more than one isolate.
  *
  * Step ids are `snake_case`. The jobs API stores them in the `jobs.steps`
  * column and the UI renders them, so renaming one changes what users see, on
@@ -21,14 +21,14 @@ import { buildPathoscopeContext } from "./context";
 import { createPathoscopeState } from "./state";
 import { collapseReferenceStep } from "./steps/collapseReference";
 import {
-	createReferenceIndexStep,
+	createRepresentativeIndexStep,
 	createSubtractionIndexStep,
 } from "./steps/createIndexes";
 import { eliminateSubtractionStep } from "./steps/eliminateSubtraction";
 import {
-	buildIsolateIndexStep,
-	mapDefaultIsolatesStep,
+	buildCandidateOtuIndexStep,
 	mapIsolatesStep,
+	mapRepresentativesStep,
 } from "./steps/mapping";
 import { reassignmentStep } from "./steps/reassignment";
 
@@ -38,10 +38,10 @@ export const pathoscopeWorkflow = defineWorkflow({
 	createState: createPathoscopeState,
 	steps: [
 		collapseReferenceStep,
-		createReferenceIndexStep,
+		createRepresentativeIndexStep,
 		createSubtractionIndexStep,
-		mapDefaultIsolatesStep,
-		buildIsolateIndexStep,
+		mapRepresentativesStep,
+		buildCandidateOtuIndexStep,
 		mapIsolatesStep,
 		eliminateSubtractionStep,
 		reassignmentStep,

--- a/apps/pathoscope/src/workflow.ts
+++ b/apps/pathoscope/src/workflow.ts
@@ -1,11 +1,11 @@
 /**
  * The pathoscope workflow: eight steps, four external tools and the Rust core.
  *
- * Pathoscope quantifies known viruses in a sample. It collapses redundant
- * isolates out of the reference, maps the sample against full-source
- * representatives to find candidates, rebuilds an index carrying every
- * collapsed isolate of just those OTUs, maps again, drops reads that belong to
- * the host, and finally reassigns the reads that matched more than one isolate.
+ * Pathoscope quantifies known viruses in a sample. It maps the sample against
+ * full-source representatives to find candidates, collapses redundant isolates
+ * out of the reference, rebuilds an index carrying every surviving isolate of
+ * just those OTUs, maps again, drops reads that belong to the host, and finally
+ * reassigns the reads that matched more than one isolate.
  *
  * Step ids are `snake_case`. The jobs API stores them in the `jobs.steps`
  * column and the UI renders them, so renaming one changes what users see, on
@@ -37,10 +37,10 @@ export const pathoscopeWorkflow = defineWorkflow({
 	buildContext: buildPathoscopeContext,
 	createState: createPathoscopeState,
 	steps: [
-		collapseReferenceStep,
 		createRepresentativeIndexStep,
 		createSubtractionIndexStep,
 		mapRepresentativesStep,
+		collapseReferenceStep,
 		buildCandidateOtuIndexStep,
 		mapIsolatesStep,
 		eliminateSubtractionStep,

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -46,6 +46,19 @@ Run every external tool through `context.runSubprocess`:
 - the child runs in a process group so cancellation kills descendants;
 - cancellation sends `SIGTERM`, then `SIGKILL` after five seconds.
 
+### Reference representatives
+
+`selectReferenceRepresentatives()` streams full-reference OTUs and runs one
+single-threaded `cd-hit-est` process per OTU and declared segment. Its exported
+policy fixes global identity at `0.80`, word size at `5`, minimum length at `9`,
+and uses no coverage controls. Callers provide the scratch path, subprocess
+runner, and concurrency bound; the selector yields original sequence records in
+deterministic group and cluster order and removes its temporary files on every
+exit path.
+
+Invalid grouping, malformed or incomplete cluster output, and subprocess
+failure reject selection. There is no default-sequence or all-sequence fallback.
+
 `createRunSubprocess()` logs `ESRCH` and `EPIPE` from a signal racing process
 exit at debug level. An ordinary tool exit with code 15 is a failure; only a
 cancellation-driven kill resolves with `cancelled: true`.

--- a/packages/workflow/src/app.test.ts
+++ b/packages/workflow/src/app.test.ts
@@ -182,7 +182,7 @@ describe("a successful run", () => {
 		server = await startTestServer(createHandler({}));
 
 		const { code } = await run(
-			createWorkflow([step("prepare"), step("map_default_isolates")]),
+			createWorkflow([step("prepare"), step("map_representatives")]),
 		);
 
 		expect(code).toBe(EXIT_OK);
@@ -193,7 +193,7 @@ describe("a successful run", () => {
 
 		expect(paths).toContain(`POST /jobs/${JOB_ID}/steps/prepare/start`);
 		expect(paths).toContain(
-			`POST /jobs/${JOB_ID}/steps/map_default_isolates/start`,
+			`POST /jobs/${JOB_ID}/steps/map_representatives/start`,
 		);
 		expect(paths).toContain(`POST /jobs/${JOB_ID}/finish`);
 	});
@@ -201,11 +201,11 @@ describe("a successful run", () => {
 	it("reports the step's id rather than its display name", async () => {
 		server = await startTestServer(createHandler({}));
 
-		await run(createWorkflow([step("map_default_isolates")]));
+		await run(createWorkflow([step("map_representatives")]));
 
 		expect(
 			server.requests.some((request) =>
-				request.path.includes("/steps/Map Default Isolates/"),
+				request.path.includes("/steps/Map Representatives/"),
 			),
 		).toBe(false);
 	});

--- a/packages/workflow/src/client/client.test.ts
+++ b/packages/workflow/src/client/client.test.ts
@@ -116,7 +116,7 @@ describe("paths", () => {
 
 		await client.getJob();
 		await client.ping();
-		await client.startStep("map_default_isolates");
+		await client.startStep("map_representatives");
 		await client.finish();
 
 		expect(
@@ -124,7 +124,7 @@ describe("paths", () => {
 		).toEqual([
 			"GET /jobs/17",
 			"PUT /jobs/17/ping",
-			"POST /jobs/17/steps/map_default_isolates/start",
+			"POST /jobs/17/steps/map_representatives/start",
 			"POST /jobs/17/finish",
 		]);
 	});

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -11,6 +11,7 @@ export * from "./files/transfer";
 export * from "./lifecycle/claim";
 export * from "./lifecycle/ping";
 export * from "./mapping/mappingIndex";
+export * from "./reference/representatives";
 export * from "./run";
 export * from "./serializable";
 export * from "./step";

--- a/packages/workflow/src/lifecycle/claim.test.ts
+++ b/packages/workflow/src/lifecycle/claim.test.ts
@@ -18,7 +18,11 @@ const REQUEST: CreateJobClaimRequest = {
 	runtimeVersion: "1.2.3",
 	workflowVersion: "4.5.6",
 	steps: [
-		{ id: "map_default_isolates", name: "Map Default", description: "d" },
+		{
+			id: "map_representatives",
+			name: "Map Representatives",
+			description: "d",
+		},
 	],
 };
 

--- a/packages/workflow/src/reference/representatives.test.ts
+++ b/packages/workflow/src/reference/representatives.test.ts
@@ -1,0 +1,424 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { describe, expect, it, onTestFinished } from "vitest";
+import type { RunSubprocess, RunSubprocessOptions } from "../subprocess/types";
+import {
+	getCdHitEstVersion,
+	REFERENCE_REPRESENTATIVE_POLICY,
+	type RepresentativeInputOtu,
+	type RepresentativeInputSequence,
+	selectReferenceRepresentatives,
+} from "./representatives";
+
+type TestSequence = RepresentativeInputSequence & {
+	accession: string;
+};
+
+type TestRunner = RunSubprocess & {
+	commands: readonly (readonly string[])[];
+	inputs: readonly string[];
+	maxActive: () => number;
+};
+
+function sequence(id: string, segment: string | null = null): TestSequence {
+	return {
+		accession: `AC_${id}`,
+		id,
+		segment,
+		sequence: "ACGTACGTACGT",
+	};
+}
+
+function otu(
+	id: string,
+	sequences: TestSequence[],
+	schema: string[] = [],
+): RepresentativeInputOtu<TestSequence> {
+	return {
+		id,
+		isolates: [{ sequences }],
+		schema: schema.map((name) => ({ name })),
+	};
+}
+
+async function* otus(
+	values: readonly RepresentativeInputOtu<TestSequence>[],
+): AsyncGenerator<RepresentativeInputOtu<TestSequence>> {
+	yield* values;
+}
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+	const collected: T[] = [];
+
+	for await (const value of values) {
+		collected.push(value);
+	}
+
+	return collected;
+}
+
+async function scratchPath(): Promise<string> {
+	const path = await mkdtemp(join(tmpdir(), "workflow-representatives-test-"));
+
+	onTestFinished(async () => {
+		await rm(path, { force: true, recursive: true });
+	});
+
+	return path;
+}
+
+function result(command: readonly string[]) {
+	return {
+		cancelled: false,
+		command,
+		durationMs: 1,
+		exitCode: 0,
+		signal: null,
+		stderrTail: [],
+	};
+}
+
+function createRunner(
+	clusters: (input: string, callIndex: number) => string,
+	options: { delayMs?: number; failAt?: number } = {},
+): TestRunner {
+	const commands: Array<readonly string[]> = [];
+	const inputs: string[] = [];
+	let active = 0;
+	let maximumActive = 0;
+
+	const run: RunSubprocess = async (runOptions: RunSubprocessOptions) => {
+		const callIndex = commands.length;
+		commands.push(runOptions.command);
+
+		const inputPath = runOptions.command[2] ?? "";
+		const outputPath = runOptions.command[4] ?? "";
+		const input = await readFile(inputPath, "utf8");
+		inputs.push(input);
+
+		active += 1;
+		maximumActive = Math.max(maximumActive, active);
+
+		try {
+			if (options.delayMs !== undefined) {
+				await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+			}
+
+			if (options.failAt === callIndex) {
+				throw new Error("cd-hit-est failed");
+			}
+
+			await writeFile(`${outputPath}.clstr`, clusters(input, callIndex));
+
+			return result(runOptions.command);
+		} finally {
+			active -= 1;
+		}
+	};
+
+	return Object.assign(run, {
+		commands,
+		inputs,
+		maxActive() {
+			return maximumActive;
+		},
+	});
+}
+
+function singletonClusters(input: string): string {
+	const ids = [...input.matchAll(/^>(.+)$/gm)].map((match) => match[1] ?? "");
+
+	return ids
+		.map((id, index) => `>Cluster ${index}\n0\t12nt, >${id}... *\n`)
+		.join("");
+}
+
+describe("selectReferenceRepresentatives", () => {
+	it("groups in schema order, ignores defaults, and preserves source metadata", async () => {
+		const path = await scratchPath();
+		const isolate = {
+			get default(): never {
+				throw new Error("read default");
+			},
+			sequences: [
+				sequence("seq_a1", "A"),
+				sequence("seq_b1", "B"),
+				sequence("seq_a2", "A"),
+			],
+		};
+		const source: RepresentativeInputOtu<TestSequence>[] = [
+			{
+				id: "otu_segmented",
+				isolates: [isolate],
+				schema: [{ name: "B" }, { name: "A" }],
+			},
+			otu("otu_unsegmented", [sequence("seq_u1")]),
+		];
+		const runner = createRunner((_input, callIndex) => {
+			if (callIndex === 1) {
+				return [
+					">Cluster 0",
+					"0\t12nt, >seq_a1... at +/80.00%",
+					"1\t12nt, >seq_a2... *",
+					"",
+				].join("\n");
+			}
+
+			return singletonClusters(_input);
+		});
+
+		const representatives = await collect(
+			selectReferenceRepresentatives({
+				concurrency: 1,
+				otus: otus(source),
+				runSubprocess: runner,
+				scratchPath: path,
+			}),
+		);
+
+		expect(representatives.map(({ id }) => id)).toEqual([
+			"seq_b1",
+			"seq_a2",
+			"seq_u1",
+		]);
+		expect(representatives[1]).toMatchObject({
+			accession: "AC_seq_a2",
+			groupSegment: "A",
+			otuId: "otu_segmented",
+		});
+		expect(runner.inputs).toEqual([
+			">seq_b1\nACGTACGTACGT\n",
+			">seq_a1\nACGTACGTACGT\n>seq_a2\nACGTACGTACGT\n",
+			">seq_u1\nACGTACGTACGT\n",
+		]);
+		expect(await readdir(path)).toEqual([]);
+	});
+
+	it("passes the exact policy arguments once per group", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(singletonClusters);
+
+		await collect(
+			selectReferenceRepresentatives({
+				concurrency: 1,
+				otus: otus([otu("otu_1", [sequence("seq_1")])]),
+				runSubprocess: runner,
+				scratchPath: path,
+			}),
+		);
+
+		expect(runner.commands).toHaveLength(1);
+		expect(runner.commands[0]?.slice(5)).toEqual([
+			"-c",
+			"0.80",
+			"-n",
+			"5",
+			"-l",
+			"9",
+			"-T",
+			"1",
+			"-M",
+			"0",
+			"-d",
+			"0",
+		]);
+		expect(REFERENCE_REPRESENTATIVE_POLICY.coverage).toBe("none");
+	});
+
+	it("names scratch files with OTU and segment context", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(singletonClusters);
+
+		await collect(
+			selectReferenceRepresentatives({
+				concurrency: 1,
+				otus: otus([
+					otu("otu/1", [sequence("seq_1", "RNA A/1")], ["RNA A/1"]),
+					otu("otu_2", [sequence("seq_2")]),
+				]),
+				runSubprocess: runner,
+				scratchPath: path,
+			}),
+		);
+
+		expect(
+			runner.commands.map((command) => [
+				basename(command[2] ?? ""),
+				basename(command[4] ?? ""),
+			]),
+		).toEqual([
+			["otu_1_RNA_A_1_00000000.fa", "otu_1_RNA_A_1_00000000.cdhit"],
+			["otu_2_unsegmented_00000001.fa", "otu_2_unsegmented_00000001.cdhit"],
+		]);
+		expect(await readdir(path)).toEqual([]);
+	});
+
+	it("emits one original sequence for every returned cluster", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(() =>
+			[
+				">Cluster 0",
+				"0\t12nt, >seq_1... at +/80.00%",
+				"1\t12nt, >seq_2... *",
+				">Cluster 1",
+				"0\t12nt, >seq_3... *",
+				"",
+			].join("\n"),
+		);
+
+		const representatives = await collect(
+			selectReferenceRepresentatives({
+				concurrency: 1,
+				otus: otus([
+					otu("otu_1", [
+						sequence("seq_1"),
+						sequence("seq_2"),
+						sequence("seq_3"),
+					]),
+				]),
+				runSubprocess: runner,
+				scratchPath: path,
+			}),
+		);
+
+		expect(representatives.map(({ id }) => id)).toEqual(["seq_2", "seq_3"]);
+		expect(representatives.map(({ accession }) => accession)).toEqual([
+			"AC_seq_2",
+			"AC_seq_3",
+		]);
+	});
+
+	it("bounds concurrent subprocesses and cleans scratch files", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(singletonClusters, { delayMs: 5 });
+
+		await collect(
+			selectReferenceRepresentatives({
+				concurrency: 2,
+				otus: otus(
+					Array.from({ length: 5 }, (_, index) =>
+						otu(`otu_${index}`, [sequence(`seq_${index}`)]),
+					),
+				),
+				runSubprocess: runner,
+				scratchPath: path,
+			}),
+		);
+
+		expect(runner.maxActive()).toBe(2);
+		expect(await readdir(path)).toEqual([]);
+	});
+
+	it("rejects malformed grouping without running cd-hit-est", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(singletonClusters);
+
+		await expect(
+			collect(
+				selectReferenceRepresentatives({
+					concurrency: 1,
+					otus: otus([
+						otu("otu_1", [sequence("seq_1", "undeclared")], ["declared"]),
+					]),
+					runSubprocess: runner,
+					scratchPath: path,
+				}),
+			),
+		).rejects.toThrow("undeclared segment");
+
+		expect(runner.commands).toEqual([]);
+		expect(await readdir(path)).toEqual([]);
+	});
+
+	it("rejects a reference with no groups", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(singletonClusters);
+
+		await expect(
+			collect(
+				selectReferenceRepresentatives({
+					concurrency: 1,
+					otus: otus([]),
+					runSubprocess: runner,
+					scratchPath: path,
+				}),
+			),
+		).rejects.toThrow("Reference contains no OTU/segment groups");
+
+		expect(await readdir(path)).toEqual([]);
+	});
+
+	it.each([
+		[
+			"malformed parser output",
+			() => "not a cluster file\n",
+			/Could not parse/,
+		],
+		[
+			"incomplete cluster output",
+			() => ">Cluster 0\n0\t12nt, >seq_1... *\n",
+			/omits sequence seq_2/,
+		],
+	])("propagates %s and cleans scratch", async (_name, clusters, error) => {
+		const path = await scratchPath();
+		const runner = createRunner(clusters);
+
+		await expect(
+			collect(
+				selectReferenceRepresentatives({
+					concurrency: 1,
+					otus: otus([otu("otu_1", [sequence("seq_1"), sequence("seq_2")])]),
+					runSubprocess: runner,
+					scratchPath: path,
+				}),
+			),
+		).rejects.toThrow(error);
+
+		expect(await readdir(path)).toEqual([]);
+	});
+
+	it("propagates subprocess failure after all active groups settle", async () => {
+		const path = await scratchPath();
+		const runner = createRunner(singletonClusters, { delayMs: 5, failAt: 0 });
+
+		await expect(
+			collect(
+				selectReferenceRepresentatives({
+					concurrency: 2,
+					otus: otus([
+						otu("otu_1", [sequence("seq_1")]),
+						otu("otu_2", [sequence("seq_2")]),
+					]),
+					runSubprocess: runner,
+					scratchPath: path,
+				}),
+			),
+		).rejects.toThrow("cd-hit-est failed");
+
+		expect(runner.commands).toHaveLength(2);
+		expect(await readdir(path)).toEqual([]);
+	});
+});
+
+describe("getCdHitEstVersion", () => {
+	it("parses the version banner from a failing help invocation", async () => {
+		const runSubprocess: RunSubprocess = async (options) => {
+			await options.stderr?.("====== CD-HIT version 4.8.1 ======");
+			throw new Error("help exited 1");
+		};
+
+		await expect(getCdHitEstVersion(runSubprocess)).resolves.toBe("4.8.1");
+	});
+
+	it("rejects help output without a version", async () => {
+		const runSubprocess: RunSubprocess = async (options) => {
+			await options.stdout?.("nothing here");
+			return result(options.command);
+		};
+
+		await expect(getCdHitEstVersion(runSubprocess)).rejects.toThrow(
+			"Could not parse cd-hit-est version",
+		);
+	});
+});

--- a/packages/workflow/src/reference/representatives.ts
+++ b/packages/workflow/src/reference/representatives.ts
@@ -1,0 +1,436 @@
+import { createReadStream } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import type { RunSubprocess } from "../subprocess/types";
+import { matchToolVersion } from "../subprocess/version";
+
+/** The CD-HIT-EST executable used for reference representative selection. */
+export const CD_HIT_EST_TOOL = "cd-hit-est";
+
+/** The fixed representative-selection policy shared by workflow consumers. */
+export const REFERENCE_REPRESENTATIVE_POLICY = {
+	coverage: "none",
+	identity: "0.80",
+	minimumLength: "9",
+	tool: CD_HIT_EST_TOOL,
+	version: "otu-segment-v1",
+	wordSize: "5",
+} as const;
+
+/** A sequence accepted by the representative selector. */
+export type RepresentativeInputSequence = {
+	id: string;
+	segment: string | null;
+	sequence: string;
+};
+
+/** An OTU accepted by the representative selector. */
+export type RepresentativeInputOtu<
+	TSequence extends RepresentativeInputSequence = RepresentativeInputSequence,
+> = {
+	id: string;
+	isolates: readonly { sequences: readonly TSequence[] }[];
+	schema: readonly { name: string }[];
+};
+
+/** An original source sequence selected as a CD-HIT-EST representative. */
+export type ReferenceRepresentative<
+	TSequence extends RepresentativeInputSequence = RepresentativeInputSequence,
+> = TSequence & {
+	groupSegment: string | null;
+	otuId: string;
+};
+
+/** Options for streaming reference representative selection. */
+export type SelectReferenceRepresentativesOptions<
+	TSequence extends RepresentativeInputSequence,
+> = {
+	concurrency: number;
+	otus: AsyncIterable<RepresentativeInputOtu<TSequence>>;
+	runSubprocess: RunSubprocess;
+	scratchPath: string;
+};
+
+type SequenceGroup<TSequence extends RepresentativeInputSequence> = {
+	index: number;
+	otuId: string;
+	segment: string | null;
+	sequences: TSequence[];
+};
+
+type ParsedClusters = {
+	members: Set<string>;
+	representatives: string[];
+};
+
+function getSafeFilenamePart(value: string, fallback: string): string {
+	const part = value.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64);
+
+	return part === "" ? fallback : part;
+}
+
+function getGroupStem<TSequence extends RepresentativeInputSequence>(
+	group: SequenceGroup<TSequence>,
+): string {
+	const otu = getSafeFilenamePart(group.otuId, "otu");
+	const segment =
+		group.segment === null
+			? "unsegmented"
+			: getSafeFilenamePart(group.segment, "segment");
+	const index = String(group.index).padStart(8, "0");
+
+	return `${otu}_${segment}_${index}`;
+}
+
+/** Read `cd-hit-est`'s version from its non-zero help invocation. */
+export async function getCdHitEstVersion(
+	runSubprocess: RunSubprocess,
+): Promise<string> {
+	const lines: string[] = [];
+
+	function collect(line: string): void {
+		lines.push(line);
+	}
+
+	try {
+		await runSubprocess({
+			command: [CD_HIT_EST_TOOL, "-h"],
+			stderr: collect,
+			stdout: collect,
+		});
+	} catch {
+		// cd-hit-est prints its version banner from `-h` and exits non-zero.
+	}
+
+	return matchToolVersion(
+		/\bCD-HIT\s+version\s+(\S+)/,
+		lines,
+		"Could not parse cd-hit-est version",
+	);
+}
+
+function groupOtu<TSequence extends RepresentativeInputSequence>(
+	otu: RepresentativeInputOtu<TSequence>,
+): Array<Omit<SequenceGroup<TSequence>, "index">> {
+	const sequences = otu.isolates.flatMap((isolate) => isolate.sequences);
+
+	if (otu.schema.length === 0) {
+		if (sequences.length === 0) {
+			throw new Error(`Unsegmented OTU ${otu.id} has no sequences`);
+		}
+
+		for (const sequence of sequences) {
+			if (sequence.segment !== null && sequence.segment !== "") {
+				throw new Error(
+					`Sequence ${sequence.id} of unsegmented OTU ${otu.id} declares segment ${sequence.segment}`,
+				);
+			}
+		}
+
+		return [{ otuId: otu.id, segment: null, sequences }];
+	}
+
+	const segments = otu.schema.map(({ name }) => name);
+	const groups = new Map<string, TSequence[]>();
+
+	for (const segment of segments) {
+		if (segment === "" || groups.has(segment)) {
+			throw new Error(`OTU ${otu.id} has an invalid segment schema`);
+		}
+
+		groups.set(segment, []);
+	}
+
+	for (const sequence of sequences) {
+		const group = groups.get(sequence.segment ?? "");
+
+		if (group === undefined) {
+			throw new Error(
+				`Sequence ${sequence.id} of OTU ${otu.id} has undeclared segment ${String(sequence.segment)}`,
+			);
+		}
+
+		group.push(sequence);
+	}
+
+	return [...groups].map(([segment, groupedSequences]) => {
+		if (groupedSequences.length === 0) {
+			throw new Error(`OTU ${otu.id} segment ${segment} has no sequences`);
+		}
+
+		return { otuId: otu.id, segment, sequences: groupedSequences };
+	});
+}
+
+async function* iterateGroups<TSequence extends RepresentativeInputSequence>(
+	otus: AsyncIterable<RepresentativeInputOtu<TSequence>>,
+): AsyncGenerator<SequenceGroup<TSequence>> {
+	let index = 0;
+
+	for await (const otu of otus) {
+		for (const group of groupOtu(otu)) {
+			yield { ...group, index };
+			index += 1;
+		}
+	}
+}
+
+function flushCluster(
+	members: string[],
+	representative: string | null,
+	parsed: ParsedClusters,
+): void {
+	if (members.length === 0 || representative === null) {
+		throw new Error("CD-HIT cluster is incomplete");
+	}
+
+	parsed.representatives.push(representative);
+
+	for (const member of members) {
+		if (parsed.members.has(member)) {
+			throw new Error(`CD-HIT output repeats sequence ${member}`);
+		}
+
+		parsed.members.add(member);
+	}
+}
+
+async function parseClusters(path: string): Promise<ParsedClusters> {
+	const parsed: ParsedClusters = {
+		members: new Set(),
+		representatives: [],
+	};
+
+	let hasCluster = false;
+	let members: string[] = [];
+	let representative: string | null = null;
+
+	const lines = createInterface({
+		crlfDelay: Number.POSITIVE_INFINITY,
+		input: createReadStream(path),
+	});
+
+	for await (const rawLine of lines) {
+		const line = rawLine.trim();
+
+		if (line === "") {
+			continue;
+		}
+
+		const header = /^>Cluster\s+\d+$/.exec(line);
+
+		if (header !== null) {
+			if (hasCluster) {
+				flushCluster(members, representative, parsed);
+			}
+
+			hasCluster = true;
+			members = [];
+			representative = null;
+			continue;
+		}
+
+		const member = /^\d+\s+\d+nt,\s+>(.+)\.\.\.\s+(.+)$/.exec(line);
+
+		if (!hasCluster || member === null) {
+			throw new Error(`Could not parse CD-HIT cluster line: ${rawLine}`);
+		}
+
+		const sequenceId = member[1] ?? "";
+		const suffix = member[2] ?? "";
+
+		if (sequenceId === "" || (suffix !== "*" && !suffix.startsWith("at "))) {
+			throw new Error(`Could not parse CD-HIT cluster line: ${rawLine}`);
+		}
+
+		members.push(sequenceId);
+
+		if (suffix === "*") {
+			if (representative !== null) {
+				throw new Error("CD-HIT cluster has two representatives");
+			}
+
+			representative = sequenceId;
+		}
+	}
+
+	if (hasCluster) {
+		flushCluster(members, representative, parsed);
+	}
+
+	if (parsed.representatives.length === 0) {
+		throw new Error("CD-HIT output contains no clusters");
+	}
+
+	return parsed;
+}
+
+async function selectGroup<TSequence extends RepresentativeInputSequence>(
+	group: SequenceGroup<TSequence>,
+	tempPath: string,
+	runSubprocess: RunSubprocess,
+): Promise<Array<ReferenceRepresentative<TSequence>>> {
+	const stem = getGroupStem(group);
+	const inputPath = join(tempPath, `${stem}.fa`);
+	const outputPath = join(tempPath, `${stem}.cdhit`);
+	const clusterPath = `${outputPath}.clstr`;
+	const sequencesById = new Map<string, TSequence>();
+
+	for (const sequence of group.sequences) {
+		if (sequence.id === "" || /\s/.test(sequence.id)) {
+			throw new Error(
+				`Sequence id ${JSON.stringify(sequence.id)} is not FASTA-safe`,
+			);
+		}
+
+		if (sequencesById.has(sequence.id)) {
+			throw new Error(`OTU ${group.otuId} repeats sequence id ${sequence.id}`);
+		}
+
+		sequencesById.set(sequence.id, sequence);
+	}
+
+	try {
+		await writeFile(
+			inputPath,
+			group.sequences
+				.map((sequence) => `>${sequence.id}\n${sequence.sequence}\n`)
+				.join(""),
+		);
+
+		await runSubprocess({
+			command: [
+				REFERENCE_REPRESENTATIVE_POLICY.tool,
+				"-i",
+				inputPath,
+				"-o",
+				outputPath,
+				"-c",
+				REFERENCE_REPRESENTATIVE_POLICY.identity,
+				"-n",
+				REFERENCE_REPRESENTATIVE_POLICY.wordSize,
+				"-l",
+				REFERENCE_REPRESENTATIVE_POLICY.minimumLength,
+				"-T",
+				"1",
+				"-M",
+				"0",
+				"-d",
+				"0",
+			],
+		});
+
+		const parsed = await parseClusters(clusterPath);
+
+		for (const member of parsed.members) {
+			if (!sequencesById.has(member)) {
+				throw new Error(`CD-HIT output contains unknown sequence ${member}`);
+			}
+		}
+
+		for (const sequenceId of sequencesById.keys()) {
+			if (!parsed.members.has(sequenceId)) {
+				throw new Error(`CD-HIT output omits sequence ${sequenceId}`);
+			}
+		}
+
+		return parsed.representatives.map((sequenceId) => {
+			const sequence = sequencesById.get(sequenceId);
+
+			if (sequence === undefined) {
+				throw new Error(
+					`CD-HIT representative ${sequenceId} is absent from the source group`,
+				);
+			}
+
+			return {
+				...sequence,
+				groupSegment: group.segment,
+				otuId: group.otuId,
+			};
+		});
+	} finally {
+		await Promise.all([
+			rm(inputPath, { force: true }),
+			rm(outputPath, { force: true }),
+			rm(clusterPath, { force: true }),
+		]);
+	}
+}
+
+async function selectRepresentativesForBatch<
+	TSequence extends RepresentativeInputSequence,
+>(
+	batch: readonly SequenceGroup<TSequence>[],
+	tempPath: string,
+	runSubprocess: RunSubprocess,
+): Promise<Array<Array<ReferenceRepresentative<TSequence>>>> {
+	const settled = await Promise.allSettled(
+		batch.map((group) => selectGroup(group, tempPath, runSubprocess)),
+	);
+
+	return settled.map((result) => {
+		if (result.status === "rejected") {
+			throw result.reason;
+		}
+
+		return result.value;
+	});
+}
+
+/** Stream one original representative sequence from every CD-HIT-EST cluster. */
+export async function* selectReferenceRepresentatives<
+	TSequence extends RepresentativeInputSequence,
+>({
+	concurrency,
+	otus,
+	runSubprocess,
+	scratchPath,
+}: SelectReferenceRepresentativesOptions<TSequence>): AsyncGenerator<
+	ReferenceRepresentative<TSequence>
+> {
+	if (!Number.isInteger(concurrency) || concurrency < 1) {
+		throw new Error("Representative selection concurrency must be positive");
+	}
+
+	const tempPath = await mkdtemp(join(scratchPath, "representatives-"));
+
+	try {
+		let batch: SequenceGroup<TSequence>[] = [];
+		let groupCount = 0;
+
+		for await (const group of iterateGroups(otus)) {
+			groupCount += 1;
+			batch.push(group);
+
+			if (batch.length === concurrency) {
+				for (const representatives of await selectRepresentativesForBatch(
+					batch,
+					tempPath,
+					runSubprocess,
+				)) {
+					yield* representatives;
+				}
+
+				batch = [];
+			}
+		}
+
+		if (batch.length > 0) {
+			for (const representatives of await selectRepresentativesForBatch(
+				batch,
+				tempPath,
+				runSubprocess,
+			)) {
+				yield* representatives;
+			}
+		}
+
+		if (groupCount === 0) {
+			throw new Error("Reference contains no OTU/segment groups");
+		}
+	} finally {
+		await rm(tempPath, { force: true, recursive: true });
+	}
+}

--- a/packages/workflow/src/step.test.ts
+++ b/packages/workflow/src/step.test.ts
@@ -7,8 +7,8 @@ type State = { hits: number };
 
 function makeStep(overrides: Partial<WorkflowStep<Data, State>> = {}) {
 	return {
-		id: "map_default_isolates",
-		description: "Map reads to the default isolates.",
+		id: "map_representatives",
+		description: "Map reads to reference representatives.",
 		run: async () => {},
 		...overrides,
 	};
@@ -31,15 +31,15 @@ describe("defineWorkflow", () => {
 		]);
 
 		expect(workflow.steps.map((step) => step.name)).toEqual([
-			"Map Default Isolates",
+			"Map Representatives",
 			"Write Report",
 		]);
 	});
 
 	it("keeps an explicit display name", () => {
-		const workflow = define([makeStep({ name: "Map to Default Isolates" })]);
+		const workflow = define([makeStep({ name: "Map to Representatives" })]);
 
-		expect(workflow.steps[0]?.name).toBe("Map to Default Isolates");
+		expect(workflow.steps[0]?.name).toBe("Map to Representatives");
 	});
 
 	// The display name is what the UI shows, so it has to come out of the id
@@ -72,8 +72,8 @@ describe("defineWorkflow", () => {
 	});
 
 	it.each([
-		["MapDefaultIsolates", "camel or pascal case"],
-		["map-default-isolates", "kebab case"],
+		["MapRepresentatives", "camel or pascal case"],
+		["map-representatives", "kebab case"],
 		["2_map_isolates", "a leading digit"],
 		["map isolates", "a space"],
 		["", "an empty string"],
@@ -89,7 +89,7 @@ describe("defineWorkflow", () => {
 
 		expect(() => define(steps)).toThrow(WorkflowDefinitionError);
 		expect(() => define(steps)).toThrow(
-			/pathoscope step "map_default_isolates" has an id already used/,
+			/pathoscope step "map_representatives" has an id already used/,
 		);
 	});
 
@@ -101,7 +101,7 @@ describe("defineWorkflow", () => {
 			WorkflowDefinitionError,
 		);
 		expect(() => define([makeStep({ description })])).toThrow(
-			/pathoscope step "map_default_isolates" has an empty description/,
+			/pathoscope step "map_representatives" has an empty description/,
 		);
 	});
 });

--- a/packages/workflow/src/step.ts
+++ b/packages/workflow/src/step.ts
@@ -64,7 +64,7 @@ export type Workflow<TData, TState> = Omit<
 /**
  * Title-case an id.
  *
- * `map_default_isolates` becomes `Map Default Isolates`, which is the label the
+ * `map_representatives` becomes `Map Representatives`, which is the label the
  * UI shows. Every letter whose predecessor is not a letter is uppercased, which
  * is why this matches on the boundary rather than splitting on spaces.
  */


### PR DESCRIPTION
Replace Pathoscope's default screening behavior with CD-HIT representative selection. This reduces redundant reference sequences before screening while preserving the existing workflow integration.