### PR TITLE
fix: butt the samples list against the sidebar like other lists

### DIFF
--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -248,7 +248,7 @@ export default function SamplesList({
 				setOpen={setOpenQuickAnalyze}
 				samples={quickAnalyzeTarget.samples}
 			/>
-			<div className="container mx-auto">
+			<div className="container">
 				<ViewHeader title="Samples">
 					<ViewHeaderTitle>Samples</ViewHeaderTitle>
 				</ViewHeader>


### PR DESCRIPTION
## Summary
- Drop `mx-auto` from the samples list container so it sits flush against the sidebar like the other list views, instead of centering with a gap.