### PR TITLE
feat: upload large files directly to blob storage in chunks

### DIFF
--- a/apps/internal/src/run/tasks/reap-orphaned-uploads.ts
+++ b/apps/internal/src/run/tasks/reap-orphaned-uploads.ts
@@ -1,8 +1,4 @@
-import {
-	ORPHAN_AGE_SECONDS,
-	reapOrphanedUploads,
-	reapStalePendingUploads,
-} from "@virtool/data/uploads/data";
+import { ORPHAN_AGE_SECONDS, reapUploads } from "@virtool/data/uploads/data";
 import { z } from "zod";
 import { defineTask } from "../framework/define";
 import type { TaskContext } from "./registry";
@@ -31,10 +27,11 @@ export const reapOrphanedUploadsTask = defineTask<typeof payload, TaskContext>({
 	steps: ["reap"],
 	async run({ ctx, helpers, logger, signal }) {
 		await helpers.runStep("reap", async (report) => {
-			const { found, deleted } = await reapOrphanedUploads(
+			const orphaned = await reapUploads(
 				ctx.db,
 				ctx.storage,
 				logger,
+				"orphaned",
 				ORPHAN_AGE_SECONDS,
 				async (percent) => {
 					report(percent / 100);
@@ -42,17 +39,22 @@ export const reapOrphanedUploadsTask = defineTask<typeof payload, TaskContext>({
 				signal,
 			);
 
-			if (found > 0) {
-				logger.info({ found, deleted }, "reaped orphaned reserved uploads");
+			if (orphaned.found > 0) {
+				logger.info(
+					{ found: orphaned.found, deleted: orphaned.deleted },
+					"reaped orphaned reserved uploads",
+				);
 			}
 
 			// Chunked uploads reserved but never finalized leave unfinished rows the
 			// reserved sweep above does not match. Clear those in the same run.
-			const stale = await reapStalePendingUploads(
+			const stale = await reapUploads(
 				ctx.db,
 				ctx.storage,
 				logger,
+				"stale",
 				ORPHAN_AGE_SECONDS,
+				undefined,
 				signal,
 			);
 

--- a/apps/internal/src/run/tasks/reap-orphaned-uploads.ts
+++ b/apps/internal/src/run/tasks/reap-orphaned-uploads.ts
@@ -1,6 +1,7 @@
 import {
 	ORPHAN_AGE_SECONDS,
 	reapOrphanedUploads,
+	reapStalePendingUploads,
 } from "@virtool/data/uploads/data";
 import { z } from "zod";
 import { defineTask } from "../framework/define";
@@ -43,6 +44,23 @@ export const reapOrphanedUploadsTask = defineTask<typeof payload, TaskContext>({
 
 			if (found > 0) {
 				logger.info({ found, deleted }, "reaped orphaned reserved uploads");
+			}
+
+			// Chunked uploads reserved but never finalized leave unfinished rows the
+			// reserved sweep above does not match. Clear those in the same run.
+			const stale = await reapStalePendingUploads(
+				ctx.db,
+				ctx.storage,
+				logger,
+				ORPHAN_AGE_SECONDS,
+				signal,
+			);
+
+			if (stale.found > 0) {
+				logger.info(
+					{ found: stale.found, deleted: stale.deleted },
+					"reaped stale pending uploads",
+				);
 			}
 		});
 	},

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -408,6 +408,15 @@ or explicit whitelist first, then use that row's `storage_key`; never construct
 a key from URL parameters. Use the row's display name for
 `Content-Disposition`.
 
+Large uploads can go direct-to-blob instead of through the `POST /uploads`
+route. `initUploadFn` owns the choice so the client never carries the flag:
+with `VT_UPLOADS_CHUNKED` set and an Azure backend that can presign, it reserves
+the upload and returns a write SAS the client PUTs 4 MB blocks to (`@uploads/chunkedUpload`),
+then commits with a Put Block List and calls `finalizeChunkedUploadFn`;
+`cancelChunkedUploadFn` drops an abandoned reservation. Otherwise it returns
+`proxied` and the client streams through the raw `/uploads` route, which stays
+the fallback and the rollback path — unset the flag to revert.
+
 ### Server push
 
 Server-pushed cache invalidations arrive through the authenticated `/events`

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -411,9 +411,12 @@ a key from URL parameters. Use the row's display name for
 Large uploads can go direct-to-blob instead of through the `POST /uploads`
 route. `initUploadFn` owns the choice so the client never carries the flag:
 with `VT_UPLOADS_CHUNKED` set and an Azure backend that can presign, it reserves
-the upload and returns a write SAS the client PUTs 4 MB blocks to (`@uploads/chunkedUpload`),
-then commits with a Put Block List and calls `finalizeChunkedUploadFn`;
-`cancelChunkedUploadFn` drops an abandoned reservation. Otherwise it returns
+the upload — recording the file size the client declares at init — and returns a
+write SAS the client PUTs 4 MB blocks to (`@uploads/chunkedUpload`), then commits
+with a Put Block List and calls `finalizeChunkedUploadFn`. Finalize records the
+stored object's size only when it matches the declared size, so an empty or
+partial block list is rejected rather than recorded as ready; `cancelChunkedUploadFn`
+drops an abandoned or rejected reservation. Otherwise it returns
 `proxied` and the client streams through the raw `/uploads` route, which stays
 the fallback and the rollback path — unset the flag to revert.
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -410,15 +410,17 @@ a key from URL parameters. Use the row's display name for
 
 Large uploads can go direct-to-blob instead of through the `POST /uploads`
 route. `initUploadFn` owns the choice so the client never carries the flag:
-with `VT_UPLOADS_CHUNKED` set and an Azure backend that can presign, it reserves
-the upload — recording the file size the client declares at init — and returns a
-write SAS the client PUTs 4 MB blocks to (`@uploads/chunkedUpload`), then commits
-with a Put Block List and calls `finalizeChunkedUploadFn`. Finalize records the
-stored object's size only when it matches the declared size, so an empty or
-partial block list is rejected rather than recorded as ready; `cancelChunkedUploadFn`
-drops an abandoned or rejected reservation. Otherwise it returns
-`proxied` and the client streams through the raw `/uploads` route, which stays
-the fallback and the rollback path — unset the flag to revert.
+with `VT_UPLOADS_CHUNKED` enabled and an Azure backend that can presign, it
+reserves the upload — recording the file size the client declares at init — and
+returns a write SAS the client PUTs blocks to (`@uploads/chunkedUpload`), then
+commits with a Put Block List and calls `finalizeChunkedUploadFn`. Blocks start
+at 4 MiB and grow in 4 MiB increments when necessary to keep the upload within
+Azure's 50,000-block limit. Finalize records the stored object's size only when
+it matches the declared size, so an empty or partial block list is rejected
+rather than recorded as ready; `cancelChunkedUploadFn` drops an abandoned or
+rejected reservation. Otherwise it returns `proxied` and the client streams
+through the raw `/uploads` route, which stays the fallback and the rollback path
+— disable the flag to revert.
 
 ### Server push
 
@@ -518,7 +520,9 @@ whitespace is trimmed, and an empty value is treated as unset.
 | `VT_STORAGE_AZURE_ACCESS_KEY` | String | Unset | Set an Azure account key; leave unset to use managed identity. |
 | `VT_STORAGE_AZURE_ENDPOINT` | URL string | Unset | Override the Azure Blob endpoint. |
 | `VT_STORAGE_AZURE_DOWNLOAD_URL` | URL origin | Unset | Rehost redirected Azure downloads on a public origin, such as `https://files.virtool.ca`. Applies only in `redirect` download mode. |
+| `VT_STORAGE_AZURE_UPLOAD_URL` | URL origin | Unset | Rehost presigned Azure uploads on a public origin, such as a Front Door route to a private storage account. Falls back to `VT_STORAGE_AZURE_DOWNLOAD_URL`, then the Azure Blob endpoint. |
 | `VT_STORAGE_DOWNLOAD_MODE` | `stream` \| `redirect` | `stream` | Serve file downloads by streaming the bytes through this server, or by 302-redirecting to a short-lived presigned storage URL. `redirect` falls back to streaming when the backend cannot presign. |
+| `VT_UPLOADS_CHUNKED` | `0` \| `1` \| `true` \| `false` \| `yes` \| `no` | Unset (`false`) | Enable direct-to-blob chunked uploads when the storage backend can presign them. Unset or disable it to use the proxied upload route. |
 
 The build and test tooling reads one additional variable. It is not a runtime
 server setting and has no `_FILE` variant.

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -27,6 +27,14 @@ export type ServerConfig = {
 	 * streaming when the backend cannot presign.
 	 */
 	downloadMode: "stream" | "redirect";
+	/**
+	 * The global feature flag for chunked direct-to-blob uploads. When set — and
+	 * the storage backend can presign uploads — the client uploads files to
+	 * storage in blocks instead of streaming them through this server. Unset
+	 * keeps every upload on the proxied `POST /uploads` route, which is the
+	 * rollback path.
+	 */
+	uploadsChunked: boolean;
 };
 
 const ServerEnv = z.object({
@@ -67,11 +75,30 @@ const ServerEnv = z.object({
 		(value) => (value === "" ? undefined : value),
 		z.string().url().optional(),
 	),
+	// The Front Door origin chunked uploads PUT their blocks to. As with the
+	// download URL, a malformed value would reach `new URL()` at upload time, so
+	// validate it at startup.
+	VT_STORAGE_AZURE_UPLOAD_URL: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.string().url().optional(),
+	),
 	// Unset — or empty, which deployment tooling injects — keeps downloads
 	// streaming through this server.
 	VT_STORAGE_DOWNLOAD_MODE: z.preprocess(
 		(value) => (value === "" ? undefined : value),
 		z.enum(["stream", "redirect"]).default("stream"),
+	),
+	// The chunked-upload feature flag. `1`, `true`, or `yes` turns it on; unset —
+	// or empty, which deployment tooling injects — leaves it off, so an upgrade
+	// never switches upload paths by surprise. Rollback is unsetting it.
+	VT_UPLOADS_CHUNKED: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z
+			.enum(["0", "1", "true", "false", "yes", "no"])
+			.optional()
+			.transform(
+				(value) => value === "1" || value === "true" || value === "yes",
+			),
 	),
 });
 
@@ -84,6 +111,7 @@ const ServerEnvSchema = ServerEnv.transform((raw, ctx) => ({
 	sentryDsn: raw.VT_SENTRY_DSN,
 	storage: buildStorage(raw, ctx),
 	downloadMode: raw.VT_STORAGE_DOWNLOAD_MODE,
+	uploadsChunked: raw.VT_UPLOADS_CHUNKED,
 }));
 
 // Unset and empty are the same thing for storage variables. Deployment tooling
@@ -177,6 +205,7 @@ function buildStorage(raw: StorageEnv, ctx: z.RefinementCtx): StorageConfig {
 		accessKey: present(raw.VT_STORAGE_AZURE_ACCESS_KEY),
 		endpoint: present(raw.VT_STORAGE_AZURE_ENDPOINT),
 		downloadUrl: present(raw.VT_STORAGE_AZURE_DOWNLOAD_URL),
+		uploadUrl: present(raw.VT_STORAGE_AZURE_UPLOAD_URL),
 	};
 }
 

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -293,6 +293,20 @@ describe("initUpload", () => {
 			expect.objectContaining({ expiresIn: expect.any(Number) }),
 		);
 	});
+
+	it("drops the reservation when presigning fails", async () => {
+		testConfig.uploadsChunked = true;
+		presignUpload.mockRejectedValue(new Error("presign failed"));
+		await signIn("full");
+
+		await expect(
+			call("initUploadFn", { name: "reads.fq.gz", type: "reads", size: 4096 }),
+		).rejects.toThrow("presign failed");
+
+		const rows = await db.select().from(uploadsTable);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.removed).toBe(true);
+	});
 });
 
 describe("finalizeChunkedUpload", () => {

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -10,6 +10,7 @@ import {
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
 import { MemoryStorage } from "@virtool/storage";
+import { eq } from "drizzle-orm";
 import {
 	afterAll,
 	beforeAll,
@@ -20,6 +21,10 @@ import {
 	vi,
 } from "vitest";
 import { callServerFn, type SplitServerFnModule } from "../test/serverFn";
+
+async function* bodyOf(text: string): AsyncIterable<Uint8Array> {
+	yield new TextEncoder().encode(text);
+}
 
 const getRequest = vi.fn();
 const setResponseStatus = vi.fn();
@@ -51,7 +56,15 @@ vi.mock("@virtool/data/events/emit", () => ({
 	emit: vi.fn(),
 }));
 
+vi.mock("../config", () => ({ config: testConfig }));
+
 const storage = new MemoryStorage();
+const presignUpload = vi.fn();
+(storage as unknown as { presignUpload: unknown }).presignUpload =
+	presignUpload;
+
+// Mutable so a test can flip the chunked-upload flag; reset in `beforeEach`.
+const testConfig = { uploadsChunked: false };
 
 const handlers = (await import(
 	"./functions.ts?tss-serverfn-split"
@@ -76,6 +89,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	vi.clearAllMocks();
+	testConfig.uploadsChunked = false;
 	cookieHeader = "";
 	await db.delete(uploadsTable);
 	await db.delete(sessions);
@@ -226,5 +240,102 @@ describe("deleteUpload", () => {
 			"Upload is reserved and in use.",
 		);
 		expect(setResponseStatus).toHaveBeenCalledWith(409);
+	});
+});
+
+describe("initUpload", () => {
+	it("refuses a user without the upload_file permission", async () => {
+		await signIn(null);
+
+		await expect(
+			call("initUploadFn", { name: "reads.fq.gz", type: "reads" }),
+		).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	it("returns proxied and reserves no row when chunked is off", async () => {
+		await signIn("full");
+
+		const result = await call("initUploadFn", {
+			name: "reads.fq.gz",
+			type: "reads",
+		});
+
+		expect(result).toEqual({ mode: "proxied" });
+		expect(await db.select().from(uploadsTable)).toHaveLength(0);
+		expect(presignUpload).not.toHaveBeenCalled();
+	});
+
+	it("reserves an unfinished row and returns the SAS when chunked is on", async () => {
+		testConfig.uploadsChunked = true;
+		presignUpload.mockResolvedValue("https://fd/c/blob?sig=x");
+		const userId = await signIn("full");
+
+		const result = (await call("initUploadFn", {
+			name: "reads.fq.gz",
+			type: "reads",
+		})) as { mode: string; uploadId: number; url: string; blockSize: number };
+
+		expect(result.mode).toBe("chunked");
+		expect(result.url).toBe("https://fd/c/blob?sig=x");
+		expect(result.blockSize).toBeGreaterThan(0);
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, result.uploadId));
+		expect(row?.ready).toBe(false);
+		expect(row?.userId).toBe(userId);
+		expect(presignUpload).toHaveBeenCalledWith(
+			row?.storageKey,
+			expect.objectContaining({ expiresIn: expect.any(Number) }),
+		);
+	});
+});
+
+describe("finalizeChunkedUpload", () => {
+	it("marks the caller's upload ready from the stored size", async () => {
+		const userId = await signIn("full");
+		const upload = await seedUpload(userId, {
+			ready: false,
+			storageKey: "uploads/finalize",
+		});
+		await storage.write("uploads/finalize", bodyOf("hello"));
+
+		const result = (await call("finalizeChunkedUploadFn", {
+			id: upload.id,
+		})) as { ready: boolean; size: number };
+
+		expect(result).toMatchObject({ ready: true, size: 5 });
+	});
+
+	it("maps an upload whose bytes never arrived to a 409", async () => {
+		const userId = await signIn("full");
+		const upload = await seedUpload(userId, {
+			ready: false,
+			storageKey: "uploads/missing",
+		});
+
+		await expect(
+			call("finalizeChunkedUploadFn", { id: upload.id }),
+		).rejects.toThrow("Upload is not complete.");
+		expect(setResponseStatus).toHaveBeenCalledWith(409);
+	});
+});
+
+describe("cancelChunkedUpload", () => {
+	it("soft-deletes the caller's unfinished upload", async () => {
+		const userId = await signIn("full");
+		const upload = await seedUpload(userId, {
+			ready: false,
+			storageKey: "uploads/cancel",
+		});
+
+		await call("cancelChunkedUploadFn", { id: upload.id });
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, upload.id));
+		expect(row?.removed).toBe(true);
 	});
 });

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -279,7 +279,7 @@ describe("initUpload", () => {
 
 		expect(result.mode).toBe("chunked");
 		expect(result.url).toBe("https://fd/c/blob?sig=x");
-		expect(result.blockSize).toBeGreaterThan(0);
+		expect(result.blockSize).toBe(4 * 1024 * 1024);
 
 		const [row] = await db
 			.select()
@@ -292,6 +292,32 @@ describe("initUpload", () => {
 			row?.storageKey,
 			expect.objectContaining({ expiresIn: expect.any(Number) }),
 		);
+	});
+
+	it("increases the block size for files that need more than 50,000 blocks", async () => {
+		testConfig.uploadsChunked = true;
+		presignUpload.mockResolvedValue("https://fd/c/blob?sig=x");
+		await signIn("full");
+
+		const result = (await call("initUploadFn", {
+			name: "reads.fq.gz",
+			type: "reads",
+			size: 4 * 1024 * 1024 * 50_000 + 1,
+		})) as { blockSize: number };
+
+		expect(result.blockSize).toBe(8 * 1024 * 1024);
+	});
+
+	it("rejects files larger than Azure's maximum block blob size", async () => {
+		await signIn("full");
+
+		await expect(
+			call("initUploadFn", {
+				name: "reads.fq.gz",
+				type: "reads",
+				size: 4_000 * 1024 * 1024 * 50_000 + 1,
+			}),
+		).rejects.toThrow();
 	});
 
 	it("drops the reservation when presigning fails", async () => {

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -248,7 +248,7 @@ describe("initUpload", () => {
 		await signIn(null);
 
 		await expect(
-			call("initUploadFn", { name: "reads.fq.gz", type: "reads" }),
+			call("initUploadFn", { name: "reads.fq.gz", type: "reads", size: 5 }),
 		).rejects.toBeInstanceOf(ForbiddenError);
 	});
 
@@ -258,6 +258,7 @@ describe("initUpload", () => {
 		const result = await call("initUploadFn", {
 			name: "reads.fq.gz",
 			type: "reads",
+			size: 5,
 		});
 
 		expect(result).toEqual({ mode: "proxied" });
@@ -273,6 +274,7 @@ describe("initUpload", () => {
 		const result = (await call("initUploadFn", {
 			name: "reads.fq.gz",
 			type: "reads",
+			size: 4096,
 		})) as { mode: string; uploadId: number; url: string; blockSize: number };
 
 		expect(result.mode).toBe("chunked");
@@ -285,6 +287,7 @@ describe("initUpload", () => {
 			.where(eq(uploadsTable.id, result.uploadId));
 		expect(row?.ready).toBe(false);
 		expect(row?.userId).toBe(userId);
+		expect(row?.expectedSize).toBe(4096);
 		expect(presignUpload).toHaveBeenCalledWith(
 			row?.storageKey,
 			expect.objectContaining({ expiresIn: expect.any(Number) }),
@@ -318,6 +321,21 @@ describe("finalizeChunkedUpload", () => {
 		await expect(
 			call("finalizeChunkedUploadFn", { id: upload.id }),
 		).rejects.toThrow("Upload is not complete.");
+		expect(setResponseStatus).toHaveBeenCalledWith(409);
+	});
+
+	it("maps a commit that does not match the declared size to a 409", async () => {
+		const userId = await signIn("full");
+		const upload = await seedUpload(userId, {
+			ready: false,
+			storageKey: "uploads/short",
+			expectedSize: 5,
+		});
+		await storage.write("uploads/short", bodyOf("hi"));
+
+		await expect(
+			call("finalizeChunkedUploadFn", { id: upload.id }),
+		).rejects.toThrow("Upload size does not match the declared size.");
 		expect(setResponseStatus).toHaveBeenCalledWith(409);
 	});
 });

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -29,6 +29,10 @@ import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 // the write SAS lives in hours where a download redirect lives in minutes.
 const UPLOAD_SAS_TTL_SECONDS = 6 * 60 * 60;
 
+const AZURE_MAX_BLOCK_COUNT = 50_000;
+const AZURE_MAX_BLOCK_SIZE = 4_000 * 1024 * 1024;
+const AZURE_MAX_BLOB_SIZE = AZURE_MAX_BLOCK_COUNT * AZURE_MAX_BLOCK_SIZE;
+
 // The upload endpoint itself is not a server function — it streams a multi-GB
 // request body and is posted to with XMLHttpRequest so the client can report
 // progress. It lives in the `/uploads` route (`@server/uploads/upload`).
@@ -104,10 +108,17 @@ const initUploadSchema = z.object({
 	name: z.string().min(1),
 	type: z.enum(UPLOAD_TYPES),
 	// The file's byte length, locked here so finalize can reject a commit that
-	// does not land exactly this many bytes. `Number.MAX_SAFE_INTEGER` is the
-	// `bigint mode: "number"` ceiling the size column stores against.
-	size: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+	// does not land exactly this many bytes.
+	size: z.number().int().nonnegative().max(AZURE_MAX_BLOB_SIZE),
 });
+
+function getUploadBlockSize(size: number): number {
+	const minimumBlockSize = Math.ceil(size / AZURE_MAX_BLOCK_COUNT);
+	return Math.max(
+		STORAGE_CHUNK_SIZE,
+		Math.ceil(minimumBlockSize / STORAGE_CHUNK_SIZE) * STORAGE_CHUNK_SIZE,
+	);
+}
 
 /**
  * Begin an upload, deciding whether it goes direct-to-blob or through this
@@ -163,7 +174,7 @@ export const initUploadFn = createServerFn({ method: "POST" })
 			mode: "chunked" as const,
 			uploadId: upload.id,
 			url,
-			blockSize: STORAGE_CHUNK_SIZE,
+			blockSize: getUploadBlockSize(data.size),
 		};
 	});
 

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -6,17 +6,27 @@ import {
 	UPLOAD_TYPES,
 } from "@virtool/contracts";
 import {
+	cancelPendingUpload,
+	createPendingUpload,
 	deleteUpload,
+	finalizePendingUpload,
 	findUploads,
+	UploadIncompleteError,
 	UploadNotFoundError,
 	UploadReservedError,
 } from "@virtool/data/uploads/data";
+import { STORAGE_CHUNK_SIZE } from "@virtool/storage";
 import { z } from "zod";
 import { authenticated, permission } from "../auth/policy";
 import { db, storage } from "../composition";
+import { config } from "../config";
 import { ClientError } from "../errors";
 import { logger } from "../logger";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
+
+// A chunked upload can run for a long time across hundreds of block writes, so
+// the write SAS lives in hours where a download redirect lives in minutes.
+const UPLOAD_SAS_TTL_SECONDS = 6 * 60 * 60;
 
 // The upload endpoint itself is not a server function — it streams a multi-GB
 // request body and is posted to with XMLHttpRequest so the client can report
@@ -52,6 +62,10 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		setResponseStatus(409);
 		throw new ClientError("Upload is reserved and in use.");
 	}
+	if (err instanceof UploadIncompleteError) {
+		setResponseStatus(409);
+		throw new ClientError("Upload is not complete.");
+	}
 	throw err;
 });
 
@@ -75,6 +89,90 @@ export const deleteUploadFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		try {
 			await deleteUpload(db, storage, logger, data.id);
+			return null;
+		} catch (err) {
+			return rethrowAsHttp(err);
+		}
+	});
+
+const initUploadSchema = z.object({
+	name: z.string().min(1),
+	type: z.enum(UPLOAD_TYPES),
+});
+
+/**
+ * Begin an upload, deciding whether it goes direct-to-blob or through this
+ * server.
+ *
+ * The server owns the choice so the client never carries the feature flag:
+ * when chunked uploads are enabled and the backend can presign, this reserves
+ * the upload and returns the write SAS the client PUTs its blocks to; otherwise
+ * it returns `proxied` and the client falls back to the `POST /uploads` route.
+ * A `proxied` result reserves nothing — that route creates its own row.
+ *
+ * `blockSize` is the block size the client cuts the file into. After committing
+ * the block list the client calls {@link finalizeChunkedUploadFn}.
+ */
+export const initUploadFn = createServerFn({ method: "POST" })
+	.middleware([permission("upload_file")])
+	.validator(initUploadSchema)
+	.handler(async ({ data, context }) => {
+		const presignUpload = storage.presignUpload;
+
+		if (!config.uploadsChunked || !presignUpload) {
+			return { mode: "proxied" as const };
+		}
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: data.name,
+			type: data.type,
+			userId: context.session.userId,
+		});
+
+		return {
+			mode: "chunked" as const,
+			uploadId: upload.id,
+			url: await presignUpload(storageKey, {
+				expiresIn: UPLOAD_SAS_TTL_SECONDS,
+			}),
+			blockSize: STORAGE_CHUNK_SIZE,
+		};
+	});
+
+/**
+ * Finalize a chunked upload once its blocks are committed, returning the upload.
+ */
+export const finalizeChunkedUploadFn = createServerFn({ method: "POST" })
+	.middleware([permission("upload_file")])
+	.validator(uploadIdSchema)
+	.handler(async ({ data, context }) => {
+		try {
+			return await finalizePendingUpload(
+				db,
+				storage,
+				data.id,
+				context.session.userId,
+			);
+		} catch (err) {
+			return rethrowAsHttp(err);
+		}
+	});
+
+/**
+ * Cancel a chunked upload that was reserved but never finalized.
+ */
+export const cancelChunkedUploadFn = createServerFn({ method: "POST" })
+	.middleware([permission("upload_file")])
+	.validator(uploadIdSchema)
+	.handler(async ({ data, context }) => {
+		try {
+			await cancelPendingUpload(
+				db,
+				storage,
+				logger,
+				data.id,
+				context.session.userId,
+			);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -139,12 +139,30 @@ export const initUploadFn = createServerFn({ method: "POST" })
 			expectedSize: data.size,
 		});
 
+		// The reservation is written before the SAS is minted, so a presign failure
+		// would leave an unfinished row for the reaper to clear 30 days on. Drop it
+		// now; a failed cancel changes nothing the caller sees over the presign
+		// error already surfacing.
+		let url: string;
+		try {
+			url = await presignUpload(storageKey, {
+				expiresIn: UPLOAD_SAS_TTL_SECONDS,
+			});
+		} catch (err) {
+			await cancelPendingUpload(
+				db,
+				storage,
+				logger,
+				upload.id,
+				context.session.userId,
+			).catch(() => {});
+			throw err;
+		}
+
 		return {
 			mode: "chunked" as const,
 			uploadId: upload.id,
-			url: await presignUpload(storageKey, {
-				expiresIn: UPLOAD_SAS_TTL_SECONDS,
-			}),
+			url,
 			blockSize: STORAGE_CHUNK_SIZE,
 		};
 	});

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -14,6 +14,7 @@ import {
 	UploadIncompleteError,
 	UploadNotFoundError,
 	UploadReservedError,
+	UploadSizeMismatchError,
 } from "@virtool/data/uploads/data";
 import { STORAGE_CHUNK_SIZE } from "@virtool/storage";
 import { z } from "zod";
@@ -66,6 +67,10 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		setResponseStatus(409);
 		throw new ClientError("Upload is not complete.");
 	}
+	if (err instanceof UploadSizeMismatchError) {
+		setResponseStatus(409);
+		throw new ClientError("Upload size does not match the declared size.");
+	}
 	throw err;
 });
 
@@ -98,6 +103,10 @@ export const deleteUploadFn = createServerFn({ method: "POST" })
 const initUploadSchema = z.object({
 	name: z.string().min(1),
 	type: z.enum(UPLOAD_TYPES),
+	// The file's byte length, locked here so finalize can reject a commit that
+	// does not land exactly this many bytes. `Number.MAX_SAFE_INTEGER` is the
+	// `bigint mode: "number"` ceiling the size column stores against.
+	size: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
 });
 
 /**
@@ -127,6 +136,7 @@ export const initUploadFn = createServerFn({ method: "POST" })
 			name: data.name,
 			type: data.type,
 			userId: context.session.userId,
+			expectedSize: data.size,
 		});
 
 		return {

--- a/apps/web/src/tests/server-fn/uploads.ts
+++ b/apps/web/src/tests/server-fn/uploads.ts
@@ -11,8 +11,11 @@ import { type Mock, vi } from "vitest";
  * exercise uploading mock `@uploads/uploader` directly.
  */
 export const uploadServerFnMocks = {
+	cancelChunkedUploadFn: vi.fn(),
 	deleteUploadFn: vi.fn(),
+	finalizeChunkedUploadFn: vi.fn(),
 	findUploadsFn: vi.fn(),
+	initUploadFn: vi.fn(),
 };
 
 /** Sets up findUploads to resolve with a single page of the given uploads. */

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -172,6 +172,8 @@ beforeEach(() => {
 		referenceServerFnMocks.updateReferenceGroupFn,
 		referenceServerFnMocks.removeReferenceUserFn,
 		referenceServerFnMocks.removeReferenceGroupFn,
+		uploadServerFnMocks.finalizeChunkedUploadFn,
+		uploadServerFnMocks.cancelChunkedUploadFn,
 		sampleServerFnMocks.createSampleFn,
 		sampleServerFnMocks.updateSampleFn,
 		sampleServerFnMocks.deleteSampleFn,
@@ -200,6 +202,12 @@ beforeEach(() => {
 	// the fallback minimum in tests that mean to assert the configured one.
 	settingsServerFnMocks.getPasswordPolicyFn.mockReset();
 	mockGetPasswordPolicy();
+
+	// Every upload begins by asking the server which transport to take. Default
+	// to the proxied path so a test that just exercises uploading does not have
+	// to stub it; tests for the chunked path override this.
+	uploadServerFnMocks.initUploadFn.mockReset();
+	uploadServerFnMocks.initUploadFn.mockResolvedValue({ mode: "proxied" });
 });
 
 process.env.TZ = "UTC";

--- a/apps/web/src/uploads/__tests__/chunkedUpload.test.ts
+++ b/apps/web/src/uploads/__tests__/chunkedUpload.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadServerFnMocks } from "../../tests/server-fn/uploads";
+import { type ChunkedInit, uploadBlocks } from "../chunkedUpload";
+
+// The status a request settles with, chosen from its URL so a test can fail
+// just the block PUTs while the commit and everything else succeed.
+let statusFor: (url: string) => number;
+
+// Every request the run made, in creation order.
+let requests: MockXhr[];
+
+// A mock XHR that settles itself on the next microtask, so the concurrent block
+// uploads run to completion without a test driving each one by hand.
+class MockXhr {
+	status = 0;
+	responseText = "";
+	method = "";
+	url = "";
+	body: unknown;
+	aborted = false;
+	upload = new EventTarget();
+	private events = new EventTarget();
+
+	constructor() {
+		requests.push(this);
+	}
+
+	open(method: string, url: string): void {
+		this.method = method;
+		this.url = url;
+	}
+
+	setRequestHeader(): void {}
+
+	send(body: unknown): void {
+		this.body = body;
+		queueMicrotask(() => {
+			if (this.aborted) {
+				return;
+			}
+			this.status = statusFor(this.url);
+			this.events.dispatchEvent(new Event("load"));
+		});
+	}
+
+	addEventListener(type: string, listener: EventListener): void {
+		this.events.addEventListener(type, listener);
+	}
+
+	abort(): void {
+		this.aborted = true;
+		this.events.dispatchEvent(new Event("abort"));
+	}
+}
+
+function init(overrides: Partial<ChunkedInit> = {}): ChunkedInit {
+	return {
+		uploadId: 7,
+		url: "https://fd/c/blob?sig=x",
+		blockSize: 4,
+		...overrides,
+	};
+}
+
+function blockRequests(): MockXhr[] {
+	return requests.filter((request) => request.url.includes("comp=block&"));
+}
+
+function blockListRequest(): MockXhr | undefined {
+	return requests.find((request) => request.url.includes("comp=blocklist"));
+}
+
+beforeEach(() => {
+	requests = [];
+	statusFor = () => 201;
+	vi.stubGlobal("XMLHttpRequest", function XMLHttpRequestStub() {
+		return new MockXhr();
+	});
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("uploadBlocks", () => {
+	it("stages each block, commits the list in order, and finalizes", async () => {
+		const upload = { id: 7, name: "reads.fq.gz" };
+		uploadServerFnMocks.finalizeChunkedUploadFn.mockResolvedValue(upload);
+
+		// 10 bytes at a 4-byte block size is three blocks: 4, 4, 2.
+		const file = new File(["0123456789"], "reads.fq.gz");
+
+		await expect(uploadBlocks(init(), file)).resolves.toBe(upload);
+
+		expect(blockRequests()).toHaveLength(3);
+		for (const request of blockRequests()) {
+			expect(request.method).toBe("PUT");
+			expect(request.body).toBeInstanceOf(Blob);
+		}
+
+		const commit = blockListRequest();
+		expect(commit?.body).toContain(`<Latest>${btoa("000000")}</Latest>`);
+		expect(commit?.body).toContain(`<Latest>${btoa("000001")}</Latest>`);
+		expect(commit?.body).toContain(`<Latest>${btoa("000002")}</Latest>`);
+
+		expect(uploadServerFnMocks.finalizeChunkedUploadFn).toHaveBeenCalledWith({
+			data: { id: 7 },
+		});
+	});
+
+	it("commits an empty block list for a zero-byte file", async () => {
+		uploadServerFnMocks.finalizeChunkedUploadFn.mockResolvedValue({ id: 7 });
+
+		await uploadBlocks(init(), new File([], "empty.fq.gz"));
+
+		expect(blockRequests()).toHaveLength(0);
+		expect(blockListRequest()?.body).toBe(
+			'<?xml version="1.0" encoding="utf-8"?><BlockList></BlockList>',
+		);
+	});
+
+	it("cancels the reservation and rejects when a block fails", async () => {
+		statusFor = (url) => (url.includes("comp=block&") ? 500 : 201);
+		uploadServerFnMocks.cancelChunkedUploadFn.mockResolvedValue(null);
+
+		const file = new File(["0123456789"], "reads.fq.gz");
+
+		await expect(uploadBlocks(init(), file)).rejects.toThrow(
+			"Block upload failed (500).",
+		);
+
+		expect(uploadServerFnMocks.cancelChunkedUploadFn).toHaveBeenCalledWith({
+			data: { id: 7 },
+		});
+		expect(uploadServerFnMocks.finalizeChunkedUploadFn).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/uploads/__tests__/uploader.test.ts
+++ b/apps/web/src/uploads/__tests__/uploader.test.ts
@@ -185,6 +185,9 @@ describe("upload lifecycle", () => {
 
 	it("records the server's message when an upload fails", async () => {
 		upload(file(), "reads");
+		// The upload asks the server which transport to take before it posts, so
+		// the request the mock XHR stands in for is not made until that resolves.
+		await flush();
 		xhr.emitLoad(
 			422,
 			JSON.stringify({ message: "A valid `name` is required." }),
@@ -199,6 +202,7 @@ describe("upload lifecycle", () => {
 
 	it("marks an upload completed on success, keeping it until dismissed", async () => {
 		upload(file(), "reads");
+		await flush();
 		xhr.emitLoad(201, JSON.stringify({ id: 1 }));
 		await flush();
 
@@ -228,6 +232,7 @@ describe("upload lifecycle", () => {
 	it("retries a failed upload in place with the same file", async () => {
 		upload(file(), "reads");
 		const localId = currentId();
+		await flush();
 		xhr.emitLoad(500, "Server Error");
 		await flush();
 
@@ -242,6 +247,7 @@ describe("upload lifecycle", () => {
 			progress: 0,
 		});
 
+		await flush();
 		expect(xhr.body).toBeInstanceOf(File);
 
 		xhr.emitLoad(201, JSON.stringify({ id: 1 }));

--- a/apps/web/src/uploads/chunkedUpload.ts
+++ b/apps/web/src/uploads/chunkedUpload.ts
@@ -1,0 +1,262 @@
+/**
+ * Upload a file directly to blob storage in blocks, bypassing this server.
+ *
+ * The server mints a write SAS for one blob key; the browser then PUTs the file
+ * to that URL as a sequence of Azure "Put Block" calls and commits them with a
+ * "Put Block List", so a multi-GB upload is hundreds of short requests rather
+ * than one 40-minute stream. Front Door's idle timeout never trips, and no
+ * bytes pass through the Node process. The server is told when the blocks are
+ * committed so it can record the upload as ready.
+ *
+ * The decision to take this path, and the SAS itself, come from `initUploadFn`;
+ * this module runs the block upload the server handed it. Blocks are PUT with
+ * `XMLHttpRequest`, not `fetch`, for the same reason `postUpload` is: only XHR
+ * reports upload progress, and the file is sliced so each request streams a
+ * `Blob` from disk without buffering it in JS.
+ */
+import {
+	cancelChunkedUploadFn,
+	finalizeChunkedUploadFn,
+} from "@server/uploads/functions";
+import type { Upload } from "@virtool/contracts";
+import type { UploadProgress } from "./uploader";
+
+/** What `initUploadFn` hands back to run a chunked upload. */
+export type ChunkedInit = {
+	uploadId: number;
+	url: string;
+	blockSize: number;
+};
+
+/** How many blocks are PUT at once. */
+const BLOCK_CONCURRENCY = 4;
+
+/** How many times a single block PUT is retried before the upload fails. */
+const BLOCK_MAX_ATTEMPTS = 3;
+
+/**
+ * The block id for the block at `index`.
+ *
+ * Azure requires every block id of a blob to be the same length before base64
+ * encoding, so the index is zero-padded to a fixed width. Six digits allow
+ * enough blocks to cover any file this accepts.
+ */
+function blockId(index: number): string {
+	return btoa(String(index).padStart(6, "0"));
+}
+
+/** The Put Block List body committing `count` blocks in order. */
+function blockListBody(count: number): string {
+	const blocks = Array.from(
+		{ length: count },
+		(_, index) => `<Latest>${blockId(index)}</Latest>`,
+	).join("");
+
+	return `<?xml version="1.0" encoding="utf-8"?><BlockList>${blocks}</BlockList>`;
+}
+
+/**
+ * PUT one block of the blob, reporting how many of its bytes have been sent.
+ *
+ * Retries a network error or a 5xx a few times, since an upload is hundreds of
+ * these and a single transient failure should not sink it. A 4xx is fatal — the
+ * SAS has lapsed or the request is malformed — so it is not retried.
+ */
+function putBlock(
+	url: string,
+	index: number,
+	body: Blob,
+	onBlockProgress: (loaded: number) => void,
+	signal: AbortSignal | undefined,
+	attempt = 1,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("Upload aborted.", "AbortError"));
+			return;
+		}
+
+		const xhr = new XMLHttpRequest();
+		const blockUrl = `${url}&comp=block&blockid=${encodeURIComponent(blockId(index))}`;
+		xhr.open("PUT", blockUrl);
+
+		function onAbort() {
+			xhr.abort();
+		}
+		signal?.addEventListener("abort", onAbort);
+
+		function settle(action: () => void) {
+			signal?.removeEventListener("abort", onAbort);
+			action();
+		}
+
+		xhr.upload.addEventListener("progress", (event) => {
+			if (event.lengthComputable) {
+				onBlockProgress(event.loaded);
+			}
+		});
+
+		xhr.addEventListener("load", () => {
+			if (xhr.status >= 200 && xhr.status < 300) {
+				settle(() => {
+					onBlockProgress(body.size);
+					resolve();
+				});
+			} else if (xhr.status >= 500 && attempt < BLOCK_MAX_ATTEMPTS) {
+				settle(() =>
+					resolve(
+						putBlock(url, index, body, onBlockProgress, signal, attempt + 1),
+					),
+				);
+			} else {
+				settle(() => reject(new Error(`Block upload failed (${xhr.status}).`)));
+			}
+		});
+
+		xhr.addEventListener("error", () => {
+			if (attempt < BLOCK_MAX_ATTEMPTS) {
+				settle(() =>
+					resolve(
+						putBlock(url, index, body, onBlockProgress, signal, attempt + 1),
+					),
+				);
+			} else {
+				settle(() => reject(new Error("Block upload failed.")));
+			}
+		});
+
+		xhr.addEventListener("abort", () =>
+			settle(() => reject(new DOMException("Upload aborted.", "AbortError"))),
+		);
+
+		xhr.send(body);
+	});
+}
+
+/** Commit the staged blocks into the finished blob. */
+function putBlockList(
+	url: string,
+	count: number,
+	contentType: string,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("Upload aborted.", "AbortError"));
+			return;
+		}
+
+		const xhr = new XMLHttpRequest();
+		xhr.open("PUT", `${url}&comp=blocklist`);
+		xhr.setRequestHeader("content-type", "application/xml");
+		xhr.setRequestHeader(
+			"x-ms-blob-content-type",
+			contentType || "application/octet-stream",
+		);
+
+		function onAbort() {
+			xhr.abort();
+		}
+		signal?.addEventListener("abort", onAbort);
+
+		function settle(action: () => void) {
+			signal?.removeEventListener("abort", onAbort);
+			action();
+		}
+
+		xhr.addEventListener("load", () => {
+			if (xhr.status >= 200 && xhr.status < 300) {
+				settle(resolve);
+			} else {
+				settle(() =>
+					reject(new Error(`Commit failed with status ${xhr.status}.`)),
+				);
+			}
+		});
+		xhr.addEventListener("error", () =>
+			settle(() => reject(new Error("Commit failed."))),
+		);
+		xhr.addEventListener("abort", () =>
+			settle(() => reject(new DOMException("Upload aborted.", "AbortError"))),
+		);
+
+		xhr.send(blockListBody(count));
+	});
+}
+
+/**
+ * Stage every block, PUTting up to {@link BLOCK_CONCURRENCY} at once and summing
+ * their progress across the whole file.
+ */
+async function stageBlocks(
+	url: string,
+	file: File,
+	blockSize: number,
+	blockCount: number,
+	onProgress: ((progress: UploadProgress) => void) | undefined,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	const loaded = new Array<number>(blockCount).fill(0);
+
+	function report(index: number, value: number) {
+		loaded[index] = value;
+		if (onProgress) {
+			const total = loaded.reduce((sum, bytes) => sum + bytes, 0);
+			onProgress({
+				loaded: total,
+				total: file.size,
+				percent: file.size > 0 ? Math.round((total / file.size) * 100) : 100,
+			});
+		}
+	}
+
+	let next = 0;
+
+	async function worker() {
+		while (true) {
+			const index = next++;
+			if (index >= blockCount) {
+				return;
+			}
+
+			const start = index * blockSize;
+			const body = file.slice(start, Math.min(start + blockSize, file.size));
+
+			await putBlock(url, index, body, (value) => report(index, value), signal);
+		}
+	}
+
+	await Promise.all(
+		Array.from({ length: Math.min(BLOCK_CONCURRENCY, blockCount) }, worker),
+	);
+}
+
+/**
+ * Run the chunked upload the server reserved, returning the finished upload.
+ *
+ * On any failure — including an abort — the reserved upload is cancelled
+ * best-effort so it does not linger for the reaper, then the original error is
+ * surfaced.
+ */
+export async function uploadBlocks(
+	init: ChunkedInit,
+	file: File,
+	onProgress?: (progress: UploadProgress) => void,
+	signal?: AbortSignal,
+): Promise<Upload> {
+	const { uploadId, url, blockSize } = init;
+
+	try {
+		const blockCount = Math.ceil(file.size / blockSize);
+
+		await stageBlocks(url, file, blockSize, blockCount, onProgress, signal);
+		await putBlockList(url, blockCount, file.type, signal);
+
+		return await finalizeChunkedUploadFn({ data: { id: uploadId } });
+	} catch (error) {
+		// Drop the reservation so it is not left for the reaper. The upload has
+		// already failed, so a failed cancel changes nothing worth surfacing.
+		await cancelChunkedUploadFn({ data: { id: uploadId } }).catch(() => {});
+		throw error;
+	}
+}

--- a/apps/web/src/uploads/chunkedUpload.ts
+++ b/apps/web/src/uploads/chunkedUpload.ts
@@ -196,17 +196,46 @@ async function stageBlocks(
 	onProgress: ((progress: UploadProgress) => void) | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<void> {
+	// Each block's highest reported byte count, and their running sum. A running
+	// sum is kept by delta rather than re-reduced on every progress event, which
+	// for the many-thousand-block files this path exists to serve would be
+	// quadratic. A block's value never decreases: a retry's fresh request reports
+	// from zero, and taking that literally would jump the total backward, so a
+	// lower value is ignored until the retry climbs past where it left off.
 	const loaded = new Array<number>(blockCount).fill(0);
+	let total = 0;
 
 	function report(index: number, value: number) {
+		const previous = loaded[index] ?? 0;
+		if (value <= previous) {
+			return;
+		}
+		total += value - previous;
 		loaded[index] = value;
 		if (onProgress) {
-			const total = loaded.reduce((sum, bytes) => sum + bytes, 0);
 			onProgress({
 				loaded: total,
 				total: file.size,
 				percent: file.size > 0 ? Math.round((total / file.size) * 100) : 100,
 			});
+		}
+	}
+
+	// A block that fails permanently must stop its siblings: the other in-flight
+	// PUTs would otherwise keep streaming to storage after the upload has already
+	// failed, and race the cancel that drops the reservation. This controller
+	// aborts them, and an external abort is chained into it.
+	const controller = new AbortController();
+
+	function onExternalAbort() {
+		controller.abort();
+	}
+
+	if (signal) {
+		if (signal.aborted) {
+			controller.abort();
+		} else {
+			signal.addEventListener("abort", onExternalAbort);
 		}
 	}
 
@@ -222,13 +251,28 @@ async function stageBlocks(
 			const start = index * blockSize;
 			const body = file.slice(start, Math.min(start + blockSize, file.size));
 
-			await putBlock(url, index, body, (value) => report(index, value), signal);
+			try {
+				await putBlock(
+					url,
+					index,
+					body,
+					(value) => report(index, value),
+					controller.signal,
+				);
+			} catch (error) {
+				controller.abort();
+				throw error;
+			}
 		}
 	}
 
-	await Promise.all(
-		Array.from({ length: Math.min(BLOCK_CONCURRENCY, blockCount) }, worker),
-	);
+	try {
+		await Promise.all(
+			Array.from({ length: Math.min(BLOCK_CONCURRENCY, blockCount) }, worker),
+		);
+	} finally {
+		signal?.removeEventListener("abort", onExternalAbort);
+	}
 }
 
 /**
@@ -251,6 +295,13 @@ export async function uploadBlocks(
 
 		await stageBlocks(url, file, blockSize, blockCount, onProgress, signal);
 		await putBlockList(url, blockCount, file.type, signal);
+
+		// The server marks the row ready and cannot un-mark it, so once finalize is
+		// dispatched a cancel can no longer take the upload back. Check here, the
+		// last point it is still a droppable reservation: a cancel up to now throws
+		// and the catch cancels the reservation, keeping the finalized upload out of
+		// a list the user believes they cancelled.
+		signal?.throwIfAborted();
 
 		return await finalizeChunkedUploadFn({ data: { id: uploadId } });
 	} catch (error) {

--- a/apps/web/src/uploads/uploader.ts
+++ b/apps/web/src/uploads/uploader.ts
@@ -182,6 +182,14 @@ export function postUpload(
 	signal?: AbortSignal,
 ): Promise<Upload> {
 	return new Promise((resolve, reject) => {
+		// An already-aborted signal never fires `abort`, so a cancel that lands
+		// while `initUploadFn` is still choosing the transport would otherwise let
+		// the XHR send the whole file after the upload has left the UI.
+		if (signal?.aborted) {
+			reject(new Error("Upload aborted."));
+			return;
+		}
+
 		const xhr = new XMLHttpRequest();
 		const query = `?name=${encodeURIComponent(name)}&type=${fileType}`;
 		xhr.open("POST", `/uploads${query}`);

--- a/apps/web/src/uploads/uploader.ts
+++ b/apps/web/src/uploads/uploader.ts
@@ -2,9 +2,11 @@
  * Initiate and track uploads using Zustand.
  */
 import { createRandomString } from "@app/utils";
+import { initUploadFn } from "@server/uploads/functions";
 import type { Upload, UploadType } from "@virtool/contracts";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
+import { uploadBlocks } from "./chunkedUpload";
 import type { UploadInProgress } from "./types";
 
 const SAMPLE_INTERVAL_MS = 500;
@@ -221,7 +223,32 @@ const tracked = new Map<
 >();
 
 /**
- * Post one tracked file, wiring its progress and outcome into the store.
+ * Post one file, taking whichever transport the server chooses.
+ *
+ * `initUploadFn` decides between the direct-to-blob and proxied paths — the
+ * client never carries the feature flag — and, for a chunked upload, hands back
+ * the write SAS to run it. A proxied result falls back to the `POST /uploads`
+ * route, which reserves its own row.
+ */
+async function performUpload(
+	file: File,
+	fileType: UploadType,
+	onProgress: (progress: UploadProgress) => void,
+	signal: AbortSignal,
+): Promise<Upload> {
+	const init = await initUploadFn({
+		data: { name: file.name, type: fileType },
+	});
+
+	if (init.mode === "chunked") {
+		return uploadBlocks(init, file, onProgress, signal);
+	}
+
+	return postUpload(file, file.name, fileType, onProgress, signal);
+}
+
+/**
+ * Run one tracked file, wiring its progress and outcome into the store.
  *
  * An aborted request is left to `cancelUpload`, which has already removed the
  * upload; any other rejection surfaces its message on the failed upload.
@@ -230,9 +257,8 @@ function runUpload(localId: string, file: File, fileType: UploadType): void {
 	const controller = new AbortController();
 	tracked.set(localId, { controller, file, fileType });
 
-	postUpload(
+	performUpload(
 		file,
-		file.name,
 		fileType,
 		({ loaded, percent }) => {
 			useUploaderStore.getState().setProgress(localId, loaded, percent);

--- a/apps/web/src/uploads/uploader.ts
+++ b/apps/web/src/uploads/uploader.ts
@@ -237,7 +237,7 @@ async function performUpload(
 	signal: AbortSignal,
 ): Promise<Upload> {
 	const init = await initUploadFn({
-		data: { name: file.name, type: fileType },
+		data: { name: file.name, type: fileType, size: file.size },
 	});
 
 	if (init.mode === "chunked") {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -59,12 +59,15 @@ There is no prefix-based cleanup. Objects that were written without a key
 being recorded remain for a future orphan sweep.
 
 A chunked upload reserves an `uploads` row up front with `createPendingUpload`
-(`ready: false`, invisible to every list) and records the key its bytes will
-land at. The client writes the bytes straight to storage and calls
+(`ready: false`, invisible to every list) and records both the key its bytes
+will land at and the `expected_size` the client declared, locked before any
+bytes are staged. The client writes the bytes straight to storage and calls
 `finalizePendingUpload`, which reads the real size from storage — a missing
-object means the commit never happened — and flips the row ready. `cancelPendingUpload`
-drops a reservation the client abandons; `reapStalePendingUploads` sweeps any it
-never cancelled, alongside the reserved-upload sweep.
+object means the commit never happened, and a size other than `expected_size`
+means an empty or partial block list was committed — and flips the row ready
+only when the object matches. `cancelPendingUpload` drops a reservation the
+client abandons; `reapStalePendingUploads` sweeps any it never cancelled,
+alongside the reserved-upload sweep.
 
 ### Keys
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -45,6 +45,18 @@ Other failures throw `StorageError`. Both errors come from
 `lastModified` across backends or depend on it for ordering because its source
 differs between real buckets and `MemoryStorage`.
 
+### Pending uploads
+
+A chunked upload reserves an `uploads` row with `createPendingUpload` before
+any bytes are staged. The row records the storage key and declared
+`expected_size`, and remains `ready: false` so it is excluded from upload lists
+and downloads.
+
+After writing directly to storage, the client calls `finalizePendingUpload`.
+Finalization reads the stored size and marks the row ready only when it matches
+`expected_size`; a missing object or size mismatch leaves the row unfinished.
+`cancelPendingUpload` removes an unfinished reservation the client abandons.
+
 ### Cleanup
 
 Pass storage into data functions that remove stored objects. The argument
@@ -58,16 +70,8 @@ deleting their rows, including child keys removed by database cascades.
 There is no prefix-based cleanup. Objects that were written without a key
 being recorded remain for a future orphan sweep.
 
-A chunked upload reserves an `uploads` row up front with `createPendingUpload`
-(`ready: false`, invisible to every list) and records both the key its bytes
-will land at and the `expected_size` the client declared, locked before any
-bytes are staged. The client writes the bytes straight to storage and calls
-`finalizePendingUpload`, which reads the real size from storage — a missing
-object means the commit never happened, and a size other than `expected_size`
-means an empty or partial block list was committed — and flips the row ready
-only when the object matches. `cancelPendingUpload` drops a reservation the
-client abandons; `reapUploads` sweeps any it never cancelled, in a `stale` pass
-alongside the `orphaned` reserved-upload pass.
+`reapUploads` removes unfinished chunked uploads that clients never finalized
+or cancelled in a `stale` pass alongside the `orphaned` reserved-upload pass.
 
 ### Keys
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -58,6 +58,14 @@ deleting their rows, including child keys removed by database cascades.
 There is no prefix-based cleanup. Objects that were written without a key
 being recorded remain for a future orphan sweep.
 
+A chunked upload reserves an `uploads` row up front with `createPendingUpload`
+(`ready: false`, invisible to every list) and records the key its bytes will
+land at. The client writes the bytes straight to storage and calls
+`finalizePendingUpload`, which reads the real size from storage — a missing
+object means the commit never happened — and flips the row ready. `cancelPendingUpload`
+drops a reservation the client abandons; `reapStalePendingUploads` sweeps any it
+never cancelled, alongside the reserved-upload sweep.
+
 ### Keys
 
 Storage keys are recorded, never reconstructed. Every read path uses the full

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -66,8 +66,8 @@ bytes are staged. The client writes the bytes straight to storage and calls
 object means the commit never happened, and a size other than `expected_size`
 means an empty or partial block list was committed — and flips the row ready
 only when the object matches. `cancelPendingUpload` drops a reservation the
-client abandons; `reapStalePendingUploads` sweeps any it never cancelled,
-alongside the reserved-upload sweep.
+client abandons; `reapUploads` sweeps any it never cancelled, in a `stale` pass
+alongside the `orphaned` reserved-upload pass.
 
 ### Keys
 

--- a/packages/data/drizzle/0016_add_uploads_expected_size.sql
+++ b/packages/data/drizzle/0016_add_uploads_expected_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "uploads" ADD COLUMN "expected_size" bigint;

--- a/packages/data/drizzle/meta/0016_snapshot.json
+++ b/packages/data/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,4021 @@
+{
+  "id": "b00b943d-d626-4dd2-bbca-5f0e8b13cae3",
+  "prevId": "2c983900-12c9-40a7-96c6-6984556b0b4f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analyses_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_version": {
+          "name": "workflow_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_analyses_sample_id_workflow": {
+          "name": "ix_analyses_sample_id_workflow",
+          "columns": [
+            {
+              "expression": "sample_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analyses_sample_id_fkey": {
+          "name": "analyses_sample_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_index_id_fkey": {
+          "name": "analyses_index_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_user_id_fkey": {
+          "name": "analyses_user_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_job_id_fkey": {
+          "name": "analyses_job_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analyses_legacy_id_key": {
+          "name": "analyses_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_files": {
+      "name": "analysis_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_files_analysis_id_fkey": {
+          "name": "analysis_files_analysis_id_fkey",
+          "tableFrom": "analysis_files",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_files_name_on_disk_key": {
+          "name": "analysis_files_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_analysis_files_storage_key": {
+          "name": "uq_analysis_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_analysis_files_format": {
+          "name": "ck_analysis_files_format",
+          "value": "\"analysis_files\".\"format\" in ('sam', 'bam', 'fasta', 'fastq', 'csv', 'tsv', 'json')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_subtractions": {
+      "name": "analysis_subtractions",
+      "schema": "",
+      "columns": {
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_analysis_subtractions_subtraction_id": {
+          "name": "ix_analysis_subtractions_subtraction_id",
+          "columns": [
+            {
+              "expression": "subtraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_subtractions_analysis_id_fkey": {
+          "name": "analysis_subtractions_analysis_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_subtractions_subtraction_id_fkey": {
+          "name": "analysis_subtractions_subtraction_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analysis_subtractions_pkey": {
+          "name": "analysis_subtractions_pkey",
+          "columns": [
+            "analysis_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nuvs_blast": {
+      "name": "nuvs_blast",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "nuvs_blast_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rid": {
+          "name": "rid",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nuvs_blast_analysis_id_fkey": {
+          "name": "nuvs_blast_analysis_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nuvs_blast_task_id_fkey": {
+          "name": "nuvs_blast_task_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nuvs_blast_analysis_id_sequence_index_key": {
+          "name": "nuvs_blast_analysis_id_sequence_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_id",
+            "sequence_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "api_keys_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "hashed": {
+          "name": "hashed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key": {
+          "name": "api_keys_hashed_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banners": {
+      "name": "banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "banners_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banners_one_active": {
+          "name": "banners_one_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"banners\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banners_user_id_fkey": {
+          "name": "banners_user_id_fkey",
+          "tableFrom": "banners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_banners_color": {
+          "name": "ck_banners_color",
+          "value": "\"banners\".\"color\" in ('red', 'yellow', 'blue', 'purple', 'orange', 'grey')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.caches": {
+      "name": "caches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "caches_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_caches_last_accessed_at_id": {
+          "name": "ix_caches_last_accessed_at_id",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cache_key": {
+          "name": "cache_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "caches_storage_key_key": {
+          "name": "caches_storage_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_name_unique": {
+          "name": "groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "groups_legacy_id_key": {
+          "name": "groups_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "primary_group_unique": {
+          "name": "primary_group_unique",
+          "columns": [
+            {
+              "expression": "primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_group_id_fkey": {
+          "name": "user_groups_group_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_user_id_fkey": {
+          "name": "user_groups_user_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_pkey": {
+          "name": "user_groups_pkey",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history": {
+      "name": "legacy_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu": {
+          "name": "otu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_name": {
+          "name": "otu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_version": {
+          "name": "otu_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_history_index_id": {
+          "name": "ix_legacy_history_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_otu_otu_version": {
+          "name": "ix_legacy_history_otu_otu_version",
+          "columns": [
+            {
+              "expression": "otu",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "otu_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_reference_id": {
+          "name": "ix_legacy_history_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_user_id": {
+          "name": "ix_legacy_history_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_history_user_id_fkey": {
+          "name": "legacy_history_user_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_reference_id_fkey": {
+          "name": "legacy_history_reference_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_index_id_fkey": {
+          "name": "legacy_history_index_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_history_legacy_id_key": {
+          "name": "legacy_history_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history_diff": {
+      "name": "legacy_history_diff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_history_diff_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_history_diff_history_id_fkey": {
+          "name": "legacy_history_diff_history_id_fkey",
+          "tableFrom": "legacy_history_diff",
+          "tableTo": "legacy_history",
+          "columnsFrom": [
+            "history_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "history_diffs_pkey": {
+          "name": "history_diffs_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "history_diffs_change_id_key": {
+          "name": "history_diffs_change_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_id"
+          ]
+        },
+        "legacy_history_diff_history_id_key": {
+          "name": "legacy_history_diff_history_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "history_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmms": {
+      "name": "hmms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hmms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster": {
+          "name": "cluster",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_entropy": {
+          "name": "mean_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_entropy": {
+          "name": "total_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "names": {
+          "name": "names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "families": {
+          "name": "families",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genera": {
+          "name": "genera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmms_legacy_id_key": {
+          "name": "hmms_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_hmm_status": {
+      "name": "legacy_hmm_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed": {
+          "name": "installed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updates": {
+          "name": "updates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_hmm_status_task_id_fkey": {
+          "name": "legacy_hmm_status_task_id_fkey",
+          "tableFrom": "legacy_hmm_status",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_legacy_hmm_status_singleton": {
+          "name": "ck_legacy_hmm_status_singleton",
+          "value": "\"legacy_hmm_status\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.index_files": {
+      "name": "index_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "index_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "index_files_index_id_fkey": {
+          "name": "index_files_index_id_fkey",
+          "tableFrom": "index_files",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_index_files_storage_key": {
+          "name": "uq_index_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "index_files_index_id_name_key": {
+          "name": "index_files_index_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_index_files_type": {
+          "name": "ck_index_files_type",
+          "value": "\"index_files\".\"type\" in ('json', 'fasta', 'bowtie2', 'sqlite')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.indexes": {
+      "name": "indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "indexes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otus_json_storage_key": {
+          "name": "otus_json_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "indexes_reference_id_fkey": {
+          "name": "indexes_reference_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_user_id_fkey": {
+          "name": "indexes_user_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_job_id_fkey": {
+          "name": "indexes_job_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_task_id_fkey": {
+          "name": "indexes_task_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "indexes_legacy_id_key": {
+          "name": "indexes_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "uq_indexes_otus_json_storage_key": {
+          "name": "uq_indexes_otus_json_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "otus_json_storage_key"
+          ]
+        },
+        "uq_indexes_reference_id_version": {
+          "name": "uq_indexes_reference_id_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_indexes_job_or_task": {
+          "name": "ck_indexes_job_or_task",
+          "value": "num_nonnulls(\"indexes\".\"job_id\", \"indexes\".\"task_id\") <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "acquired": {
+          "name": "acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claim": {
+          "name": "claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinged_at": {
+          "name": "pinged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_jobs_state_created_at": {
+          "name": "ix_jobs_state_created_at",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_user_id_state": {
+          "name": "ix_jobs_user_id_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_workflow_state": {
+          "name": "ix_jobs_workflow_state",
+          "columns": [
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_active": {
+          "name": "idx_jobs_active",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"state\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_user_id_fkey": {
+          "name": "jobs_user_id_fkey",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_legacy_id_key": {
+          "name": "jobs_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_jobs_state": {
+          "name": "ck_jobs_state",
+          "value": "\"jobs\".\"state\" in ('pending', 'running', 'cancelled', 'failed', 'succeeded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "labels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_name_key": {
+          "name": "labels_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_otus": {
+      "name": "legacy_otus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_indexed_version": {
+          "name": "last_indexed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_legacy_otus_reference_id": {
+          "name": "ix_legacy_otus_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_otus_name_lower": {
+          "name": "legacy_otus_name_lower",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_otus_reference_id_fkey": {
+          "name": "legacy_otus_reference_id_fkey",
+          "tableFrom": "legacy_otus",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sequences": {
+      "name": "legacy_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_id": {
+          "name": "otu_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate_id": {
+          "name": "isolate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_sequences_otu_id": {
+          "name": "ix_legacy_sequences_otu_id",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_sequences_otu_id_position": {
+          "name": "ix_legacy_sequences_otu_id_position",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_sequences_otu_id_fkey": {
+          "name": "legacy_sequences_otu_id_fkey",
+          "tableFrom": "legacy_sequences",
+          "tableTo": "legacy_otus",
+          "columnsFrom": [
+            "otu_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_groups": {
+      "name": "legacy_reference_groups",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_groups_reference_id_fkey": {
+          "name": "legacy_reference_groups_reference_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_groups_group_id_fkey": {
+          "name": "legacy_reference_groups_group_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_groups_pkey": {
+          "name": "legacy_reference_groups_pkey",
+          "columns": [
+            "reference_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_users": {
+      "name": "legacy_reference_users",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_users_reference_id_fkey": {
+          "name": "legacy_reference_users_reference_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_users_user_id_fkey": {
+          "name": "legacy_reference_users_user_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_users_pkey": {
+          "name": "legacy_reference_users_pkey",
+          "columns": [
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_references": {
+      "name": "legacy_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_references_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organism": {
+          "name": "organism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restrict_source_types": {
+          "name": "restrict_source_types",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_types": {
+          "name": "source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloned_from_id": {
+          "name": "cloned_from_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_references_user_id_fkey": {
+          "name": "legacy_references_user_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_upload_id_fkey": {
+          "name": "legacy_references_upload_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_cloned_from_id_fkey": {
+          "name": "legacy_references_cloned_from_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "cloned_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_task_id_fkey": {
+          "name": "legacy_references_task_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_references_legacy_id_key": {
+          "name": "legacy_references_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_labels": {
+      "name": "legacy_sample_labels",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_labels_sample_id_fkey": {
+          "name": "legacy_sample_labels_sample_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_labels_label_id_fkey": {
+          "name": "legacy_sample_labels_label_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_labels_pkey": {
+          "name": "legacy_sample_labels_pkey",
+          "columns": [
+            "sample_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_subtractions": {
+      "name": "legacy_sample_subtractions",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_subtractions_sample_id_fkey": {
+          "name": "legacy_sample_subtractions_sample_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_subtractions_subtraction_id_fkey": {
+          "name": "legacy_sample_subtractions_subtraction_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_subtractions_pkey": {
+          "name": "legacy_sample_subtractions_pkey",
+          "columns": [
+            "sample_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_samples": {
+      "name": "legacy_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_samples_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate": {
+          "name": "isolate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_type": {
+          "name": "library_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paired": {
+          "name": "paired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold": {
+          "name": "hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_read": {
+          "name": "all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_write": {
+          "name": "all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_read": {
+          "name": "group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_write": {
+          "name": "group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_samples_all_read": {
+          "name": "ix_legacy_samples_all_read",
+          "columns": [
+            {
+              "expression": "all_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"all_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_id": {
+          "name": "ix_legacy_samples_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_read": {
+          "name": "ix_legacy_samples_group_read",
+          "columns": [
+            {
+              "expression": "group_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"group_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_user_id_created_at": {
+          "name": "ix_legacy_samples_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_samples_group_id_fkey": {
+          "name": "legacy_samples_group_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_user_id_fkey": {
+          "name": "legacy_samples_user_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_job_id_fkey": {
+          "name": "legacy_samples_job_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_samples_legacy_id_key": {
+          "name": "legacy_samples_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "legacy_samples_job_id_key": {
+          "name": "legacy_samples_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_reads": {
+      "name": "sample_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sample_reads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload": {
+          "name": "upload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_reads_sample_id_fkey": {
+          "name": "sample_reads_sample_id_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_reads_upload_fkey": {
+          "name": "sample_reads_upload_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_sample_reads_storage_key": {
+          "name": "uq_sample_reads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "sample_reads_sample_id_name_key": {
+          "name": "sample_reads_sample_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample_id",
+            "name"
+          ]
+        },
+        "sample_reads_sample_name_key": {
+          "name": "sample_reads_sample_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_uploads": {
+      "name": "sample_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sample_uploads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_uploads_sample_id_fkey": {
+          "name": "sample_uploads_sample_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_uploads_upload_id_fkey": {
+          "name": "sample_uploads_upload_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sample_uploads_upload_id_key": {
+          "name": "sample_uploads_upload_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sessions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_code": {
+          "name": "reset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_remember": {
+          "name": "reset_remember",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_session_id": {
+          "name": "idx_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_type": {
+          "name": "idx_sessions_type",
+          "columns": [
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_fkey": {
+          "name": "sessions_user_id_fkey",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_type_valid": {
+          "name": "session_type_valid",
+          "value": "\"sessions\".\"session_type\" in ('anonymous', 'authenticated', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cache_storage_budget": {
+          "name": "cache_storage_budget",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_types": {
+          "name": "default_source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_sentry": {
+          "name": "enable_sentry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimum_password_length": {
+          "name": "minimum_password_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ncbi_api_key": {
+          "name": "ncbi_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_read": {
+          "name": "sample_all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_write": {
+          "name": "sample_all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group": {
+          "name": "sample_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_read": {
+          "name": "sample_group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_write": {
+          "name": "sample_group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_settings_singleton": {
+          "name": "ck_settings_singleton",
+          "value": "\"settings\".\"id\" = 1"
+        },
+        "ck_settings_cache_storage_budget": {
+          "name": "ck_settings_cache_storage_budget",
+          "value": "\"settings\".\"cache_storage_budget\" > 0"
+        },
+        "ck_settings_sample_group": {
+          "name": "ck_settings_sample_group",
+          "value": "\"settings\".\"sample_group\" in ('none', 'force_choice', 'users_primary_group')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtraction_files": {
+      "name": "subtraction_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subtraction_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtraction_files_subtraction_id_fkey": {
+          "name": "subtraction_files_subtraction_id_fkey",
+          "tableFrom": "subtraction_files",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_subtraction_files_storage_key": {
+          "name": "uq_subtraction_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "subtraction_files_subtraction_id_name_key": {
+          "name": "subtraction_files_subtraction_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subtraction_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_subtraction_files_type": {
+          "name": "ck_subtraction_files_type",
+          "value": "\"subtraction_files\".\"type\" in ('fasta', 'bowtie2')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtractions": {
+      "name": "subtractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subtractions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gc": {
+          "name": "gc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtractions_user_id_fkey": {
+          "name": "subtractions_user_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_job_id_fkey": {
+          "name": "subtractions_job_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_upload_id_fkey": {
+          "name": "subtractions_upload_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtractions_legacy_id_key": {
+          "name": "subtractions_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "subtractions_job_id_key": {
+          "name": "subtractions_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tasks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_active": {
+          "name": "idx_tasks_active",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"complete\" = false and \"tasks\".\"error\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_unacquired": {
+          "name": "idx_tasks_unacquired",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"acquired_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "uploads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed": {
+          "name": "removed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_size": {
+          "name": "expected_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploads_user_id_fkey": {
+          "name": "uploads_user_id_fkey",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uploads_name_on_disk_key": {
+          "name": "uploads_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_uploads_storage_key": {
+          "name": "uq_uploads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_uploads_type": {
+          "name": "ck_uploads_type",
+          "value": "\"uploads\".\"type\" in ('reference', 'reads', 'subtraction')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrator_role": {
+          "name": "administrator_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_reset": {
+          "name": "force_reset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_handle_lower_unique": {
+          "name": "users_handle_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_legacy_id_key": {
+          "name": "users_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "administrator_role_valid": {
+          "name": "administrator_role_valid",
+          "value": "\"users\".\"administrator_role\" in ('full', 'settings', 'users', 'base')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/data/drizzle/meta/_journal.json
+++ b/packages/data/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1787757523999,
       "tag": "0015_add_analyses_workflow_version",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1787766173203,
+      "tag": "0016_add_uploads_expected_size",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/data/src/db/schema/uploads.ts
+++ b/packages/data/src/db/schema/uploads.ts
@@ -35,6 +35,11 @@ export const uploads = pgTable(
 		// Read sizes routinely exceed 2 GiB, past the range of a 32-bit integer,
 		// hence `bigint`. `mode: "number"` is safe up to 2^53.
 		size: bigint("size", { mode: "number" }),
+		// The byte length the client declared at init for a chunked upload, locked
+		// before any bytes are staged. Finalize records the storage object's size
+		// only when it equals this, so a partial or empty block list cannot be
+		// recorded as ready. Null on rows that never went through the chunked path.
+		expectedSize: bigint("expected_size", { mode: "number" }),
 		// The upload's complete object-storage key. Nullable because it was
 		// backfilled from `name_on_disk`, which is itself nullable: a row without one
 		// names no retrievable object.

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -26,6 +26,7 @@ import {
 	deleteUpload,
 	finalizePendingUpload,
 	findUploads,
+	getUploadFile,
 	ORPHAN_AGE_SECONDS,
 	reapUploads,
 	UploadIncompleteError,
@@ -144,6 +145,30 @@ describe("createUpload", () => {
 
 		const rows = await db.select().from(uploadsTable);
 		expect(rows).toHaveLength(0);
+	});
+});
+
+describe("getUploadFile", () => {
+	it("returns the file for a ready upload", async () => {
+		const userId = await seedUser(db);
+		const upload = await seedUpload(userId, {
+			name: "external.fa.gz",
+			storageKey: "uploads/ready",
+		});
+
+		await expect(getUploadFile(db, upload.id)).resolves.toEqual({
+			key: "uploads/ready",
+			name: "external.fa.gz",
+		});
+	});
+
+	it("returns null for pending and removed uploads", async () => {
+		const userId = await seedUser(db);
+		const pending = await seedUpload(userId, { ready: false });
+		const removed = await seedUpload(userId, { removed: true });
+
+		await expect(getUploadFile(db, pending.id)).resolves.toBeNull();
+		await expect(getUploadFile(db, removed.id)).resolves.toBeNull();
 	});
 });
 
@@ -770,6 +795,38 @@ describe("finalizePendingUpload", () => {
 
 		expect(again).toMatchObject({ ready: true, size: 5 });
 	});
+
+	it("does not finalize an upload removed while its object is inspected", async () => {
+		const userId = await seedUser(db);
+		const storage = new MemoryStorage();
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+			expectedSize: 5,
+		});
+		await storage.write(storageKey, bodyOf("hello"));
+
+		const size = storage.size.bind(storage);
+		storage.size = vi.fn(async (key: string): Promise<number> => {
+			const result = await size(key);
+			await db
+				.update(uploadsTable)
+				.set({ removed: true, removedAt: new Date() })
+				.where(eq(uploadsTable.id, upload.id));
+			return result;
+		});
+
+		await expect(
+			finalizePendingUpload(db, storage, upload.id, userId),
+		).rejects.toBeInstanceOf(UploadNotFoundError);
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, upload.id));
+		expect(row).toMatchObject({ ready: false, removed: true });
+	});
 });
 
 describe("cancelPendingUpload", () => {
@@ -797,17 +854,17 @@ describe("cancelPendingUpload", () => {
 
 	it("does not cancel a finalized upload", async () => {
 		const userId = await seedUser(db);
-		const ready = await seedUpload(userId, { ready: true });
+		const storage = new MemoryStorage();
+		const ready = await seedUpload(userId, {
+			ready: true,
+			storageKey: "uploads/finalized",
+		});
+		await storage.write("uploads/finalized", bodyOf("hello"));
 
 		await expect(
-			cancelPendingUpload(
-				db,
-				new MemoryStorage(),
-				testLogger,
-				ready.id,
-				userId,
-			),
+			cancelPendingUpload(db, storage, testLogger, ready.id, userId),
 		).rejects.toBeInstanceOf(UploadNotFoundError);
+		expect(await storage.size("uploads/finalized")).toBe(5);
 	});
 
 	it("does not cancel another user's upload", async () => {

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -27,8 +27,7 @@ import {
 	finalizePendingUpload,
 	findUploads,
 	ORPHAN_AGE_SECONDS,
-	reapOrphanedUploads,
-	reapStalePendingUploads,
+	reapUploads,
 	UploadIncompleteError,
 	UploadNotFoundError,
 	UploadReservedError,
@@ -343,7 +342,7 @@ describe("deleteUpload", () => {
 	});
 });
 
-describe("reapOrphanedUploads", () => {
+describe("reapUploads (orphaned)", () => {
 	// A minute-wide window rather than production's thirty days, which is what
 	// the age being an argument buys.
 	const WINDOW_SECONDS = 60;
@@ -393,10 +392,11 @@ describe("reapOrphanedUploads", () => {
 		onProgress?: (percent: number) => Promise<void>,
 		backend: MemoryStorage = storage,
 	) {
-		return reapOrphanedUploads(
+		return reapUploads(
 			db,
 			backend,
 			testLogger,
+			"orphaned",
 			WINDOW_SECONDS,
 			onProgress,
 		);
@@ -832,7 +832,7 @@ describe("cancelPendingUpload", () => {
 	});
 });
 
-describe("reapStalePendingUploads", () => {
+describe("reapUploads (stale)", () => {
 	const WINDOW_SECONDS = 60;
 
 	function secondsAgoDate(seconds: number): Date {
@@ -860,7 +860,7 @@ describe("reapStalePendingUploads", () => {
 		});
 
 		await expect(
-			reapStalePendingUploads(db, storage, testLogger, WINDOW_SECONDS),
+			reapUploads(db, storage, testLogger, "stale", WINDOW_SECONDS),
 		).resolves.toEqual({ found: 1, deleted: 1 });
 
 		const [staleRow] = await db

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -20,11 +20,16 @@ import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import { createEmitter } from "../events/emit";
 import { testLogger } from "../test/logger";
 import {
+	cancelPendingUpload,
+	createPendingUpload,
 	createUpload,
 	deleteUpload,
+	finalizePendingUpload,
 	findUploads,
 	ORPHAN_AGE_SECONDS,
 	reapOrphanedUploads,
+	reapStalePendingUploads,
+	UploadIncompleteError,
 	UploadNotFoundError,
 	UploadReservedError,
 } from "./data";
@@ -622,5 +627,226 @@ describe("reapOrphanedUploads", () => {
 
 		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
 		expect(notify).not.toHaveBeenCalled();
+	});
+});
+
+describe("createPendingUpload", () => {
+	it("inserts an unfinished row that no list shows, minting its key", async () => {
+		const userId = await seedUser(db, { handle: "bob" });
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+		});
+
+		expect(upload).toMatchObject({
+			name: "reads.fq.gz",
+			type: "reads",
+			ready: false,
+			removed: false,
+			reserved: false,
+			user: { id: userId, handle: "bob" },
+		});
+		expect(storageKey).toMatch(/^uploads\/[0-9a-f]{32}$/);
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, upload.id));
+		expect(row?.ready).toBe(false);
+		expect(row?.storageKey).toBe(storageKey);
+
+		const list = await findUploads(db, "reads", 1, 25);
+		expect(list.items).toHaveLength(0);
+	});
+});
+
+describe("finalizePendingUpload", () => {
+	it("records the storage size and marks the row ready", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedUser(db);
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+		});
+		await storage.write(storageKey, bodyOf("hello"));
+
+		const finalized = await finalizePendingUpload(
+			db,
+			storage,
+			upload.id,
+			userId,
+		);
+
+		expect(finalized).toMatchObject({ ready: true, size: 5 });
+
+		const list = await findUploads(db, "reads", 1, 25);
+		expect(list.items).toHaveLength(1);
+	});
+
+	it("throws when the object was never committed, leaving the row unfinished", async () => {
+		const userId = await seedUser(db);
+		const { upload } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+		});
+
+		await expect(
+			finalizePendingUpload(db, new MemoryStorage(), upload.id, userId),
+		).rejects.toBeInstanceOf(UploadIncompleteError);
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, upload.id));
+		expect(row?.ready).toBe(false);
+	});
+
+	it("does not finalize another user's upload", async () => {
+		const storage = new MemoryStorage();
+		const owner = await seedUser(db, { handle: "owner" });
+		const other = await seedUser(db, { handle: "other" });
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId: owner,
+		});
+		await storage.write(storageKey, bodyOf("hello"));
+
+		await expect(
+			finalizePendingUpload(db, storage, upload.id, other),
+		).rejects.toBeInstanceOf(UploadNotFoundError);
+	});
+
+	it("is idempotent for an already finalized upload", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedUser(db);
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+		});
+		await storage.write(storageKey, bodyOf("hello"));
+
+		await finalizePendingUpload(db, storage, upload.id, userId);
+		const again = await finalizePendingUpload(db, storage, upload.id, userId);
+
+		expect(again).toMatchObject({ ready: true, size: 5 });
+	});
+});
+
+describe("cancelPendingUpload", () => {
+	it("soft-deletes the unfinished row and drops its object", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedUser(db);
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+		});
+		await storage.write(storageKey, bodyOf("hello"));
+
+		await cancelPendingUpload(db, storage, testLogger, upload.id, userId);
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, upload.id));
+		expect(row?.removed).toBe(true);
+		await expect(storage.size(storageKey)).rejects.toThrow();
+	});
+
+	it("does not cancel a finalized upload", async () => {
+		const userId = await seedUser(db);
+		const ready = await seedUpload(userId, { ready: true });
+
+		await expect(
+			cancelPendingUpload(
+				db,
+				new MemoryStorage(),
+				testLogger,
+				ready.id,
+				userId,
+			),
+		).rejects.toBeInstanceOf(UploadNotFoundError);
+	});
+
+	it("does not cancel another user's upload", async () => {
+		const owner = await seedUser(db, { handle: "owner" });
+		const other = await seedUser(db, { handle: "other" });
+		const { upload } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId: owner,
+		});
+
+		await expect(
+			cancelPendingUpload(
+				db,
+				new MemoryStorage(),
+				testLogger,
+				upload.id,
+				other,
+			),
+		).rejects.toBeInstanceOf(UploadNotFoundError);
+	});
+});
+
+describe("reapStalePendingUploads", () => {
+	const WINDOW_SECONDS = 60;
+
+	function secondsAgoDate(seconds: number): Date {
+		return new Date(Date.now() - seconds * 1000);
+	}
+
+	it("reaps unfinished rows past the cutoff, sparing recent and ready ones", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedUser(db);
+
+		const stale = await seedUpload(userId, {
+			ready: false,
+			createdAt: secondsAgoDate(WINDOW_SECONDS * 2),
+			storageKey: "uploads/stale",
+		});
+		await storage.write("uploads/stale", bodyOf("reads"));
+
+		const recent = await seedUpload(userId, {
+			ready: false,
+			createdAt: new Date(),
+		});
+		const ready = await seedUpload(userId, {
+			ready: true,
+			createdAt: secondsAgoDate(WINDOW_SECONDS * 2),
+		});
+
+		await expect(
+			reapStalePendingUploads(db, storage, testLogger, WINDOW_SECONDS),
+		).resolves.toEqual({ found: 1, deleted: 1 });
+
+		const [staleRow] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, stale.id));
+		expect(staleRow?.removed).toBe(true);
+		await expect(storage.size("uploads/stale")).rejects.toThrow();
+
+		const [recentRow] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, recent.id));
+		expect(recentRow?.removed).toBe(false);
+
+		const [readyRow] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, ready.id));
+		expect(readyRow?.removed).toBe(false);
 	});
 });

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -32,6 +32,7 @@ import {
 	UploadIncompleteError,
 	UploadNotFoundError,
 	UploadReservedError,
+	UploadSizeMismatchError,
 } from "./data";
 
 let database: TestDatabase;
@@ -638,6 +639,7 @@ describe("createPendingUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId,
+			expectedSize: 5,
 		});
 
 		expect(upload).toMatchObject({
@@ -656,6 +658,7 @@ describe("createPendingUpload", () => {
 			.where(eq(uploadsTable.id, upload.id));
 		expect(row?.ready).toBe(false);
 		expect(row?.storageKey).toBe(storageKey);
+		expect(row?.expectedSize).toBe(5);
 
 		const list = await findUploads(db, "reads", 1, 25);
 		expect(list.items).toHaveLength(0);
@@ -671,6 +674,7 @@ describe("finalizePendingUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId,
+			expectedSize: 5,
 		});
 		await storage.write(storageKey, bodyOf("hello"));
 
@@ -687,12 +691,37 @@ describe("finalizePendingUpload", () => {
 		expect(list.items).toHaveLength(1);
 	});
 
+	it("rejects a commit whose size differs from the declared size, leaving the row unfinished", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedUser(db);
+
+		const { upload, storageKey } = await createPendingUpload(db, {
+			name: "reads.fq.gz",
+			type: "reads",
+			userId,
+			expectedSize: 5,
+		});
+		// A partial block list: fewer bytes land than the client declared at init.
+		await storage.write(storageKey, bodyOf("hi"));
+
+		await expect(
+			finalizePendingUpload(db, storage, upload.id, userId),
+		).rejects.toBeInstanceOf(UploadSizeMismatchError);
+
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, upload.id));
+		expect(row?.ready).toBe(false);
+	});
+
 	it("throws when the object was never committed, leaving the row unfinished", async () => {
 		const userId = await seedUser(db);
 		const { upload } = await createPendingUpload(db, {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId,
+			expectedSize: 5,
 		});
 
 		await expect(
@@ -715,6 +744,7 @@ describe("finalizePendingUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId: owner,
+			expectedSize: 5,
 		});
 		await storage.write(storageKey, bodyOf("hello"));
 
@@ -731,6 +761,7 @@ describe("finalizePendingUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId,
+			expectedSize: 5,
 		});
 		await storage.write(storageKey, bodyOf("hello"));
 
@@ -750,6 +781,7 @@ describe("cancelPendingUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId,
+			expectedSize: 5,
 		});
 		await storage.write(storageKey, bodyOf("hello"));
 
@@ -785,6 +817,7 @@ describe("cancelPendingUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			userId: owner,
+			expectedSize: 5,
 		});
 
 		await expect(

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -345,13 +345,27 @@ export async function finalizePendingUpload(
 		throw new UploadSizeMismatchError();
 	}
 
-	const finalized = takeFirstOrThrow(
-		await db
-			.update(uploadsTable)
-			.set({ ready: true, size, uploadedAt: new Date() })
-			.where(eq(uploadsTable.id, uploadId))
-			.returning(),
-	);
+	// Conditional on the row still being unfinished so two overlapping finalizes
+	// cannot both stamp it and both emit. The loser matches no row here and falls
+	// through to return the winner's already-finished row unchanged.
+	const [finalized] = await db
+		.update(uploadsTable)
+		.set({ ready: true, size, uploadedAt: new Date() })
+		.where(and(eq(uploadsTable.id, uploadId), eq(uploadsTable.ready, false)))
+		.returning();
+
+	if (finalized === undefined) {
+		const [current] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, uploadId));
+
+		if (!current) {
+			throw new UploadNotFoundError();
+		}
+
+		return toUpload(current, await fetchUser(db, current.userId));
+	}
 
 	await emit("uploads", finalized.id, "create");
 

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -408,74 +408,6 @@ export async function cancelPendingUpload(
 	}
 }
 
-/**
- * Delete chunked uploads reserved long ago that were never finalized.
- *
- * A reservation whose client never committed its block list, or never called
- * finalize, leaves an unfinished row that no list shows. The cutoff is far
- * longer than any real upload takes, so an in-flight upload is never swept.
- * Azure expires uncommitted blocks on its own after a week; this clears the row
- * and any object a stalled commit did land.
- */
-export async function reapStalePendingUploads(
-	db: Db,
-	storage: StorageBackend,
-	logger: Logger,
-	olderThanSeconds: number,
-	signal?: AbortSignal,
-): Promise<ReapResult> {
-	const stale = await db
-		.select({ id: uploadsTable.id })
-		.from(uploadsTable)
-		.where(
-			and(
-				eq(uploadsTable.ready, false),
-				eq(uploadsTable.removed, false),
-				lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
-			),
-		)
-		.orderBy(asc(uploadsTable.id));
-
-	const found = stale.length;
-
-	if (found === 0) {
-		return { found, deleted: 0 };
-	}
-
-	let deleted = 0;
-
-	for (const upload of stale) {
-		signal?.throwIfAborted();
-
-		const [reaped] = await db
-			.update(uploadsTable)
-			.set({ removed: true, removedAt: nowUtc() })
-			.where(
-				and(eq(uploadsTable.id, upload.id), eq(uploadsTable.removed, false)),
-			)
-			.returning({ storageKey: uploadsTable.storageKey });
-
-		if (reaped === undefined) {
-			continue;
-		}
-
-		deleted += 1;
-
-		if (reaped.storageKey) {
-			try {
-				await storage.delete(reaped.storageKey);
-			} catch (err) {
-				logger.warn(
-					{ err, uploadId: upload.id, storageKey: reaped.storageKey },
-					"failed to delete stale upload object; object orphaned",
-				);
-			}
-		}
-	}
-
-	return { found, deleted };
-}
-
 /** The storage key of an upload's bytes, with the name to download them as. */
 export type UploadFile = {
 	key: string;
@@ -631,26 +563,42 @@ export async function deleteUpload(
 	await emit("uploads", uploadId, "delete");
 }
 
-/** What one sweep of {@link reapOrphanedUploads} selected and what it removed. */
+/** What one sweep of {@link reapUploads} selected and what it removed. */
 export type ReapResult = {
-	/** Orphans the predicate selected. */
+	/** Rows the predicate selected. */
 	found: number;
-	/** Orphans this run flipped to `removed`. */
+	/** Rows this run flipped to `removed`. */
 	deleted: number;
 };
 
 /**
- * Delete reserved uploads that no sample claims.
+ * Which abandoned uploads a {@link reapUploads} sweep targets.
+ *
+ * - `orphaned`: a `reserved` upload no live sample claims — a sample creation
+ *   that never finished.
+ * - `stale`: an unfinished (`ready = false`) chunked reservation whose client
+ *   never committed its block list or never called finalize.
+ */
+export type ReapKind = "orphaned" | "stale";
+
+/**
+ * Delete abandoned uploads of one {@link ReapKind}, dropping their objects.
  *
  * The row goes before the object, unlike cache eviction: this is a soft delete,
  * so a refused delete leaves a row that still names the bytes. It emits no
- * frame, where `deleteUpload` does — every row it touches is `reserved`, which
- * `findUploads` filters out, so no client list held one.
+ * frame, where `deleteUpload` does — every row it touches is either `reserved`
+ * or `ready = false`, both of which `findUploads` filters out, so no client
+ * list held one.
+ *
+ * The cutoff is far longer than any real upload or sample creation takes, so an
+ * in-flight one is never swept. Azure expires uncommitted blocks on its own
+ * after a week; this clears the row and any object a stalled commit did land.
  */
-export async function reapOrphanedUploads(
+export async function reapUploads(
 	db: Db,
 	storage: StorageBackend,
 	logger: Logger,
+	kind: ReapKind,
 	olderThanSeconds: number,
 	onProgress?: (percent: number) => Promise<void>,
 	signal?: AbortSignal,
@@ -658,43 +606,50 @@ export async function reapOrphanedUploads(
 	/* The cutoff is Postgres's clock, not a bound `Date`, so the sweep selects
 	   against the same instant it stamps `removed_at` with. A NULL `created_at`
 	   is never selected. */
-	const orphans = await db
+	const predicate =
+		kind === "stale"
+			? and(
+					eq(uploadsTable.ready, false),
+					eq(uploadsTable.removed, false),
+					lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
+				)
+			: and(
+					eq(uploadsTable.reserved, true),
+					eq(uploadsTable.removed, false),
+					lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
+					notExists(
+						db
+							.select({ id: sampleReads.id })
+							.from(sampleReads)
+							.where(eq(sampleReads.upload, uploadsTable.id)),
+					),
+					/* `sample_reads` alone is not enough: those rows are written at
+					   finalize, so a sample that is still running looks exactly like an
+					   abandoned creation and has its inputs reaped out from under the
+					   workflow. The cutoff cannot rescue it — it measures the age of the
+					   upload rather than of the reservation, so an upload that sat in a
+					   user's list for a month is reapable the moment it is reserved.
+
+					   A `sample_uploads` row means a live sample claims the upload:
+					   `createSample` writes it in the transaction that reserves, and
+					   `deleteSample` clears it in the transaction that releases. What is
+					   left — a reservation no sample row names — is what this sweep is
+					   for. */
+					notExists(
+						db
+							.select({ id: sampleUploads.id })
+							.from(sampleUploads)
+							.where(eq(sampleUploads.upload_id, uploadsTable.id)),
+					),
+				);
+
+	const candidates = await db
 		.select({ id: uploadsTable.id })
 		.from(uploadsTable)
-		.where(
-			and(
-				eq(uploadsTable.reserved, true),
-				eq(uploadsTable.removed, false),
-				lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
-				notExists(
-					db
-						.select({ id: sampleReads.id })
-						.from(sampleReads)
-						.where(eq(sampleReads.upload, uploadsTable.id)),
-				),
-				/* `sample_reads` alone is not enough: those rows are written at
-				   finalize, so a sample that is still running looks exactly like an
-				   abandoned creation and has its inputs reaped out from under the
-				   workflow. The cutoff cannot rescue it — it measures the age of the
-				   upload rather than of the reservation, so an upload that sat in a
-				   user's list for a month is reapable the moment it is reserved.
-
-				   A `sample_uploads` row means a live sample claims the upload:
-				   `createSample` writes it in the transaction that reserves, and
-				   `deleteSample` clears it in the transaction that releases. What is
-				   left — a reservation no sample row names — is what this sweep is
-				   for. */
-				notExists(
-					db
-						.select({ id: sampleUploads.id })
-						.from(sampleUploads)
-						.where(eq(sampleUploads.upload_id, uploadsTable.id)),
-				),
-			),
-		)
+		.where(predicate)
 		.orderBy(asc(uploadsTable.id));
 
-	const found = orphans.length;
+	const found = candidates.length;
 
 	if (found === 0) {
 		return { found, deleted: 0 };
@@ -702,20 +657,21 @@ export async function reapOrphanedUploads(
 
 	let deleted = 0;
 
-	for (const [index, orphan] of orphans.entries()) {
+	for (const [index, candidate] of candidates.entries()) {
 		signal?.throwIfAborted();
 
 		/* Release and soft-delete in one statement. Never split these: releasing
 		   the batch and then looping an ordinary delete means anything
 		   interrupting that loop leaves the rest `reserved = false, removed =
-		   false` — which no later sweep matches, its predicate being
-		   `reserved = true`, and which no list shows. The guard is also what makes
-		   a reclaimed run a no-op against a sweep that committed. */
+		   false` — which the `orphaned` predicate no longer matches and which no
+		   list shows. The guard is also what makes a reclaimed run a no-op against
+		   a sweep that committed. `reserved` is already false on a `stale` row, so
+		   clearing it there is a harmless no-op. */
 		const [reaped] = await db
 			.update(uploadsTable)
 			.set({ reserved: false, removed: true, removedAt: nowUtc() })
 			.where(
-				and(eq(uploadsTable.id, orphan.id), eq(uploadsTable.removed, false)),
+				and(eq(uploadsTable.id, candidate.id), eq(uploadsTable.removed, false)),
 			)
 			.returning({ storageKey: uploadsTable.storageKey });
 
@@ -733,7 +689,7 @@ export async function reapOrphanedUploads(
 				await storage.delete(reaped.storageKey);
 			} catch (err) {
 				logger.warn(
-					{ err, uploadId: orphan.id, storageKey: reaped.storageKey },
+					{ err, uploadId: candidate.id, storageKey: reaped.storageKey },
 					"failed to delete reaped upload object; object orphaned",
 				);
 			}
@@ -741,7 +697,7 @@ export async function reapOrphanedUploads(
 			// Predates keys being recorded, as in `deleteUpload`. A composed key
 			// could reach another row's bytes.
 			logger.warn(
-				{ uploadId: orphan.id },
+				{ uploadId: candidate.id },
 				"reaped upload has no storage_key to delete",
 			);
 		}

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -345,13 +345,18 @@ export async function finalizePendingUpload(
 		throw new UploadSizeMismatchError();
 	}
 
-	// Conditional on the row still being unfinished so two overlapping finalizes
-	// cannot both stamp it and both emit. The loser matches no row here and falls
-	// through to return the winner's already-finished row unchanged.
+	// Conditional on the row still being active and unfinished so cancellation,
+	// reaping, and overlapping finalizes cannot race this transition.
 	const [finalized] = await db
 		.update(uploadsTable)
 		.set({ ready: true, size, uploadedAt: new Date() })
-		.where(and(eq(uploadsTable.id, uploadId), eq(uploadsTable.ready, false)))
+		.where(
+			and(
+				eq(uploadsTable.id, uploadId),
+				eq(uploadsTable.ready, false),
+				eq(uploadsTable.removed, false),
+			),
+		)
 		.returning();
 
 	if (finalized === undefined) {
@@ -360,11 +365,20 @@ export async function finalizePendingUpload(
 			.from(uploadsTable)
 			.where(eq(uploadsTable.id, uploadId));
 
-		if (!current) {
+		if (
+			!current ||
+			current.removed ||
+			current.userId !== userId ||
+			!current.storageKey
+		) {
 			throw new UploadNotFoundError();
 		}
 
-		return toUpload(current, await fetchUser(db, current.userId));
+		if (current.ready) {
+			return toUpload(current, await fetchUser(db, current.userId));
+		}
+
+		throw new UploadNotFoundError();
 	}
 
 	await emit("uploads", finalized.id, "create");
@@ -396,13 +410,25 @@ export async function cancelPendingUpload(
 		throw new UploadNotFoundError();
 	}
 
-	await db
+	const [cancelled] = await db
 		.update(uploadsTable)
 		.set({ removed: true, removedAt: new Date() })
-		.where(eq(uploadsTable.id, uploadId));
+		.where(
+			and(
+				eq(uploadsTable.id, uploadId),
+				eq(uploadsTable.userId, userId),
+				eq(uploadsTable.ready, false),
+				eq(uploadsTable.removed, false),
+			),
+		)
+		.returning({ storageKey: uploadsTable.storageKey });
 
-	if (row.storageKey) {
-		await storage.delete(row.storageKey);
+	if (cancelled === undefined) {
+		throw new UploadNotFoundError();
+	}
+
+	if (cancelled.storageKey) {
+		await storage.delete(cancelled.storageKey);
 	} else {
 		logger.warn({ uploadId }, "cancelled upload has no storage_key to delete");
 	}
@@ -420,7 +446,7 @@ export type UploadFile = {
  *
  * `storage_key` locates the object and `name` is what the user chose and what
  * the download is named. Both columns are nullable at the database level, so a
- * row missing either has no downloadable file.
+ * row missing either or not yet ready has no downloadable file.
  */
 export async function getUploadFile(
 	db: DbOrTx,
@@ -429,7 +455,13 @@ export async function getUploadFile(
 	const [row] = await db
 		.select({ name: uploadsTable.name, storageKey: uploadsTable.storageKey })
 		.from(uploadsTable)
-		.where(and(eq(uploadsTable.id, uploadId), eq(uploadsTable.removed, false)))
+		.where(
+			and(
+				eq(uploadsTable.id, uploadId),
+				eq(uploadsTable.ready, true),
+				eq(uploadsTable.removed, false),
+			),
+		)
 		.limit(1);
 
 	if (!row?.name || !row.storageKey) {

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -53,6 +53,17 @@ export class UploadReservedError extends AppError {}
  */
 export class UploadIncompleteError extends AppError {}
 
+/**
+ * Thrown when a finalized chunked upload's storage object is not the size the
+ * client declared at init.
+ *
+ * The declared size is locked on the row before any bytes are staged, so a
+ * client that commits an empty or partial block list finalizes an object whose
+ * size differs from it and is rejected rather than recorded as ready over a
+ * truncated file. The row is left unfinished; the client cancels it.
+ */
+export class UploadSizeMismatchError extends AppError {}
+
 function toUpload(row: UploadRow, user: UserNested | null): Upload {
 	return {
 		id: row.id,
@@ -222,6 +233,12 @@ export type PendingUploadValues = {
 	name: string;
 	type: UploadType;
 	userId: number;
+	/**
+	 * The file's byte length as the client reports it at init. Recorded on the
+	 * row and checked against the storage object at finalize, so the size the
+	 * upload commits to cannot be moved after the bytes are staged.
+	 */
+	expectedSize: number;
 };
 
 /** A reserved chunked upload and the storage key its bytes belong at. */
@@ -255,6 +272,7 @@ export async function createPendingUpload(
 			.insert(uploadsTable)
 			.values({
 				createdAt: now,
+				expectedSize: values.expectedSize,
 				name: values.name,
 				nameOnDisk,
 				ready: false,
@@ -281,6 +299,12 @@ export async function createPendingUpload(
  * probe which ids exist. The recorded size comes from storage, never the
  * client, and a missing object means the block list was never committed —
  * {@link UploadIncompleteError} — leaving the row unfinished for a retry.
+ *
+ * The storage object's size must equal the size the client declared at init and
+ * this row recorded; an empty or partial block list commits a smaller object
+ * and is rejected with {@link UploadSizeMismatchError} rather than recorded as
+ * ready over a truncated file. The row is left unfinished for the client to
+ * cancel.
  *
  * Idempotent: a row already finalized is returned unchanged, so a retried
  * finalize after a dropped response does not double-emit or re-stamp it.
@@ -312,6 +336,13 @@ export async function finalizePendingUpload(
 			throw new UploadIncompleteError();
 		}
 		throw err;
+	}
+
+	// The declared size is null only on rows that never took the chunked path,
+	// which never reach finalize; when present it is the contract the committed
+	// object must meet.
+	if (row.expectedSize !== null && size !== row.expectedSize) {
+		throw new UploadSizeMismatchError();
 	}
 
 	const finalized = takeFirstOrThrow(

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -8,7 +8,7 @@ import type {
 } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
-import { mintRootStorageKey } from "@virtool/storage";
+import { mintRootStorageKey, StorageKeyNotFoundError } from "@virtool/storage";
 import { and, asc, count, desc, eq, inArray, lt, notExists } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
@@ -43,6 +43,15 @@ export class UploadNotFoundError extends AppError {}
 
 /** Thrown when a reserved upload is deleted while still in use. */
 export class UploadReservedError extends AppError {}
+
+/**
+ * Thrown when a chunked upload is finalized before its bytes reached storage.
+ *
+ * The client commits the block list directly to storage and then asks the
+ * server to finalize; if no object is there, the commit never happened and the
+ * row stays unfinished rather than being marked ready over nothing.
+ */
+export class UploadIncompleteError extends AppError {}
 
 function toUpload(row: UploadRow, user: UserNested | null): Upload {
 	return {
@@ -206,6 +215,220 @@ export async function createUpload(
 	await emit("uploads", row.id, "create");
 
 	return toUpload(row, await fetchUser(db, row.userId));
+}
+
+/** Fields needed to reserve a chunked upload before its bytes exist. */
+export type PendingUploadValues = {
+	name: string;
+	type: UploadType;
+	userId: number;
+};
+
+/** A reserved chunked upload and the storage key its bytes belong at. */
+export type PendingUpload = {
+	upload: Upload;
+	storageKey: string;
+};
+
+/**
+ * Reserve a chunked upload, minting the storage key its bytes will land at.
+ *
+ * Unlike {@link createUpload}, no bytes flow through this server: the client
+ * writes them straight to storage under {@link PendingUpload.storageKey} and
+ * calls {@link finalizePendingUpload} afterwards. The row is written `ready:
+ * false`, so no list shows it and no frame is emitted until it is finalized.
+ *
+ * The key is recorded on the row so finalize can locate the bytes and confirm
+ * they arrived. The row is also what a later finalize checks ownership against,
+ * which is why the reservation is persisted rather than the key just handed out.
+ */
+export async function createPendingUpload(
+	db: DbOrTx,
+	values: PendingUploadValues,
+): Promise<PendingUpload> {
+	const now = new Date();
+	const nameOnDisk = `${crypto.randomUUID()}-${values.name}`;
+	const storageKey = mintRootStorageKey("uploads");
+
+	const row = takeFirstOrThrow(
+		await db
+			.insert(uploadsTable)
+			.values({
+				createdAt: now,
+				name: values.name,
+				nameOnDisk,
+				ready: false,
+				removed: false,
+				reserved: false,
+				storageKey,
+				type: values.type,
+				userId: values.userId,
+			})
+			.returning(),
+	);
+
+	return {
+		upload: toUpload(row, await fetchUser(db, row.userId)),
+		storageKey,
+	};
+}
+
+/**
+ * Finalize a chunked upload once its bytes are committed to storage.
+ *
+ * The row must belong to `userId` and still be unfinished; a mismatch reads as
+ * {@link UploadNotFoundError}, so one user cannot finalize another's upload or
+ * probe which ids exist. The recorded size comes from storage, never the
+ * client, and a missing object means the block list was never committed —
+ * {@link UploadIncompleteError} — leaving the row unfinished for a retry.
+ *
+ * Idempotent: a row already finalized is returned unchanged, so a retried
+ * finalize after a dropped response does not double-emit or re-stamp it.
+ */
+export async function finalizePendingUpload(
+	db: DbOrTx,
+	storage: StorageBackend,
+	uploadId: number,
+	userId: number,
+): Promise<Upload> {
+	const [row] = await db
+		.select()
+		.from(uploadsTable)
+		.where(eq(uploadsTable.id, uploadId));
+
+	if (!row || row.removed || row.userId !== userId || !row.storageKey) {
+		throw new UploadNotFoundError();
+	}
+
+	if (row.ready) {
+		return toUpload(row, await fetchUser(db, row.userId));
+	}
+
+	let size: number;
+	try {
+		size = await storage.size(row.storageKey);
+	} catch (err) {
+		if (err instanceof StorageKeyNotFoundError) {
+			throw new UploadIncompleteError();
+		}
+		throw err;
+	}
+
+	const finalized = takeFirstOrThrow(
+		await db
+			.update(uploadsTable)
+			.set({ ready: true, size, uploadedAt: new Date() })
+			.where(eq(uploadsTable.id, uploadId))
+			.returning(),
+	);
+
+	await emit("uploads", finalized.id, "create");
+
+	return toUpload(finalized, await fetchUser(db, finalized.userId));
+}
+
+/**
+ * Cancel a chunked upload that was reserved but never finalized.
+ *
+ * Only the owner's own unfinished reservation is cancellable; anything else —
+ * another user's row, a finalized upload, an already-removed one — reads as
+ * {@link UploadNotFoundError}. The row is soft-deleted and its object dropped.
+ * No frame is emitted, since an unfinished upload was never in any list.
+ */
+export async function cancelPendingUpload(
+	db: DbOrTx,
+	storage: StorageBackend,
+	logger: Logger,
+	uploadId: number,
+	userId: number,
+): Promise<void> {
+	const [row] = await db
+		.select()
+		.from(uploadsTable)
+		.where(eq(uploadsTable.id, uploadId));
+
+	if (!row || row.removed || row.userId !== userId || row.ready) {
+		throw new UploadNotFoundError();
+	}
+
+	await db
+		.update(uploadsTable)
+		.set({ removed: true, removedAt: new Date() })
+		.where(eq(uploadsTable.id, uploadId));
+
+	if (row.storageKey) {
+		await storage.delete(row.storageKey);
+	} else {
+		logger.warn({ uploadId }, "cancelled upload has no storage_key to delete");
+	}
+}
+
+/**
+ * Delete chunked uploads reserved long ago that were never finalized.
+ *
+ * A reservation whose client never committed its block list, or never called
+ * finalize, leaves an unfinished row that no list shows. The cutoff is far
+ * longer than any real upload takes, so an in-flight upload is never swept.
+ * Azure expires uncommitted blocks on its own after a week; this clears the row
+ * and any object a stalled commit did land.
+ */
+export async function reapStalePendingUploads(
+	db: Db,
+	storage: StorageBackend,
+	logger: Logger,
+	olderThanSeconds: number,
+	signal?: AbortSignal,
+): Promise<ReapResult> {
+	const stale = await db
+		.select({ id: uploadsTable.id })
+		.from(uploadsTable)
+		.where(
+			and(
+				eq(uploadsTable.ready, false),
+				eq(uploadsTable.removed, false),
+				lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
+			),
+		)
+		.orderBy(asc(uploadsTable.id));
+
+	const found = stale.length;
+
+	if (found === 0) {
+		return { found, deleted: 0 };
+	}
+
+	let deleted = 0;
+
+	for (const upload of stale) {
+		signal?.throwIfAborted();
+
+		const [reaped] = await db
+			.update(uploadsTable)
+			.set({ removed: true, removedAt: nowUtc() })
+			.where(
+				and(eq(uploadsTable.id, upload.id), eq(uploadsTable.removed, false)),
+			)
+			.returning({ storageKey: uploadsTable.storageKey });
+
+		if (reaped === undefined) {
+			continue;
+		}
+
+		deleted += 1;
+
+		if (reaped.storageKey) {
+			try {
+				await storage.delete(reaped.storageKey);
+			} catch (err) {
+				logger.warn(
+					{ err, uploadId: upload.id, storageKey: reaped.storageKey },
+					"failed to delete stale upload object; object orphaned",
+				);
+			}
+		}
+	}
+
+	return { found, deleted };
 }
 
 /** The storage key of an upload's bytes, with the name to download them as. */

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -19,6 +19,24 @@ the browser and the filename has to come from the URL.
 - **`MemoryStorage`** leaves the method undefined, and a caller falls back to
   streaming.
 
+## Presigned uploads
+
+`StorageBackend.presignUpload` is an optional capability that mints a
+short-lived, write-only URL a browser uploads an object to directly, chunk by
+chunk. The URL grants only create and write on one key; the client appends the
+Azure Block Blob query parameters (`comp=block`, `comp=blocklist`) itself and
+commits the blocks with a Put Block List. This turns a multi-gigabyte upload
+into hundreds of short requests rather than one long stream, so no idle-timeout
+proxy in the path trips and no bytes pass through the server.
+
+- **Azure** signs the write SAS with the same user-delegation key as the
+  download SAS (`cw` permissions). `uploadUrl` rehosts the URL on the Front Door
+  origin that fronts the private storage account, falling back to `downloadUrl`
+  and then the blob endpoint.
+- **S3** and **`MemoryStorage`** leave the method undefined — chunked direct
+  upload is an Azure capability — and a caller falls back to the proxied upload
+  route.
+
 ## Testing
 
 The `unit` Vitest project covers behavior testable with `MemoryStorage`. The

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -30,9 +30,9 @@ into hundreds of short requests rather than one long stream, so no idle-timeout
 proxy in the path trips and no bytes pass through the server.
 
 - **Azure** signs the write SAS with the same user-delegation key as the
-  download SAS (`cw` permissions). `uploadUrl` rehosts the URL on the Front Door
-  origin that fronts the private storage account, falling back to `downloadUrl`
-  and then the blob endpoint.
+  download SAS (`cw` permissions). `uploadUrl` rehosts the URL on a configured
+  public origin, such as a Front Door route to a private storage account. It
+  falls back to `downloadUrl` and then the blob endpoint.
 - **S3** and **`MemoryStorage`** leave the method undefined — chunked direct
   upload is an Azure capability — and a caller falls back to the proxied upload
   route.

--- a/packages/storage/src/azure.ts
+++ b/packages/storage/src/azure.ts
@@ -13,6 +13,7 @@ import type { StorageConfig } from "./config";
 import { StorageError, StorageKeyNotFoundError } from "./errors";
 import type {
 	PresignDownloadOptions,
+	PresignUploadOptions,
 	StorageBackend,
 	StorageObjectInfo,
 } from "./types";
@@ -73,34 +74,48 @@ function createServiceClient(config: AzureConfig): {
 	return { service: new BlobServiceClient(url, sharedKey), sharedKey };
 }
 
-// Only swap the origin so the signed resource path remains unchanged.
-function buildDownloadUrl(
+// Only swap the origin so the signed resource path remains unchanged. A SAS
+// signs the container and blob names, not the host, so redirecting the request
+// through a different origin — Front Door — leaves the signature valid.
+function buildPresignedUrl(
 	container: ContainerClient,
 	key: string,
-	config: AzureConfig,
 	sas: string,
+	origin: string | undefined,
 ): string {
 	const url = new URL(container.getBlobClient(key).url);
 
-	if (config.downloadUrl) {
-		const origin = new URL(config.downloadUrl);
-		url.protocol = origin.protocol;
-		url.host = origin.host;
+	if (origin) {
+		const override = new URL(origin);
+		url.protocol = override.protocol;
+		url.host = override.host;
 	}
 
 	return `${url.toString()}?${sas}`;
 }
 
-function createPresign(
-	config: AzureConfig,
+// Real Azure is https-only; a plain-http endpoint or public origin — Azurite in
+// development — has to keep http allowed or the SAS refuses it.
+function sasProtocol(...origins: (string | undefined)[]): SASProtocol {
+	return origins.some((origin) => origin?.startsWith("http://"))
+		? SASProtocol.HttpsAndHttp
+		: SASProtocol.Https;
+}
+
+/**
+ * A cached provider of the account's user-delegation key.
+ *
+ * A managed identity has no signing key of its own, so both presigned downloads
+ * and presigned uploads sign through this one delegation key rather than each
+ * requesting its own.
+ */
+function createDelegationKeyProvider(
 	service: BlobServiceClient,
-	container: ContainerClient,
-	sharedKey: StorageSharedKeyCredential | null,
-): StorageBackend["presignDownload"] {
+): () => Promise<UserDelegationKey> {
 	let cached: { key: UserDelegationKey; expiresOn: Date } | null = null;
 	let inflight: Promise<UserDelegationKey> | null = null;
 
-	async function getDelegationKey(): Promise<UserDelegationKey> {
+	return async function getDelegationKey(): Promise<UserDelegationKey> {
 		const now = new Date();
 
 		if (
@@ -130,8 +145,15 @@ function createPresign(
 		}
 
 		return inflight;
-	}
+	};
+}
 
+function createPresignDownload(
+	config: AzureConfig,
+	container: ContainerClient,
+	sharedKey: StorageSharedKeyCredential | null,
+	getDelegationKey: () => Promise<UserDelegationKey>,
+): NonNullable<StorageBackend["presignDownload"]> {
 	return async function presignDownload(
 		key: string,
 		options: PresignDownloadOptions,
@@ -148,13 +170,7 @@ function createPresign(
 			expiresOn,
 			contentDisposition: options.contentDisposition,
 			contentType: options.contentType,
-			// Real Azure is https-only; a plain-http endpoint or download host —
-			// Azurite in development — has to keep http allowed or the SAS refuses it.
-			protocol:
-				config.endpoint?.startsWith("http://") ||
-				config.downloadUrl?.startsWith("http://")
-					? SASProtocol.HttpsAndHttp
-					: SASProtocol.Https,
+			protocol: sasProtocol(config.endpoint, config.downloadUrl),
 		};
 
 		try {
@@ -169,7 +185,54 @@ function createPresign(
 						config.account,
 					).toString();
 
-			return buildDownloadUrl(container, key, config, sas);
+			return buildPresignedUrl(container, key, sas, config.downloadUrl);
+		} catch (error) {
+			throw new StorageError(
+				error instanceof Error ? error.message : String(error),
+			);
+		}
+	};
+}
+
+function createPresignUpload(
+	config: AzureConfig,
+	container: ContainerClient,
+	sharedKey: StorageSharedKeyCredential | null,
+	getDelegationKey: () => Promise<UserDelegationKey>,
+): NonNullable<StorageBackend["presignUpload"]> {
+	// Front Door is the only route to the private storage account, so an upload
+	// URL prefers the Front Door origin, then the download origin, then the raw
+	// blob endpoint for a development backend reachable directly.
+	const origin = config.uploadUrl ?? config.downloadUrl;
+
+	return async function presignUpload(
+		key: string,
+		options: PresignUploadOptions,
+	): Promise<string> {
+		const now = new Date();
+		const startsOn = new Date(now.getTime() - CLOCK_SKEW_MS);
+		const expiresOn = new Date(now.getTime() + options.expiresIn * 1000);
+
+		const values = {
+			containerName: config.container,
+			blobName: key,
+			// Create and write cover staging blocks and committing the block list.
+			permissions: BlobSASPermissions.parse("cw"),
+			startsOn,
+			expiresOn,
+			protocol: sasProtocol(config.endpoint, origin),
+		};
+
+		try {
+			const sas = sharedKey
+				? generateBlobSASQueryParameters(values, sharedKey).toString()
+				: generateBlobSASQueryParameters(
+						values,
+						await getDelegationKey(),
+						config.account,
+					).toString();
+
+			return buildPresignedUrl(container, key, sas, origin);
 		} catch (error) {
 			throw new StorageError(
 				error instanceof Error ? error.message : String(error),
@@ -181,9 +244,22 @@ function createPresign(
 export function createAzureStorage(config: AzureConfig): StorageBackend {
 	const { service, sharedKey } = createServiceClient(config);
 	const container = service.getContainerClient(config.container);
+	const getDelegationKey = createDelegationKeyProvider(service);
 
 	return {
-		presignDownload: createPresign(config, service, container, sharedKey),
+		presignDownload: createPresignDownload(
+			config,
+			container,
+			sharedKey,
+			getDelegationKey,
+		),
+
+		presignUpload: createPresignUpload(
+			config,
+			container,
+			sharedKey,
+			getDelegationKey,
+		),
 
 		async *read(key: string): AsyncIterable<Uint8Array> {
 			let body: NodeJS.ReadableStream | undefined;

--- a/packages/storage/src/config.ts
+++ b/packages/storage/src/config.ts
@@ -23,8 +23,14 @@ export type StorageConfig =
 			accessKey?: string;
 			endpoint?: string;
 			/**
-			 * Public origin that replaces the blob endpoint origin in presigned URLs.
-			 * Unset preserves the blob endpoint origin.
+			 * Public origin that replaces the blob endpoint origin in presigned
+			 * download URLs. Unset preserves the blob endpoint origin.
 			 */
 			downloadUrl?: string;
+			/**
+			 * Public origin that replaces the blob endpoint origin in presigned
+			 * upload URLs — the Front Door route to the private storage account.
+			 * Unset falls back to {@link downloadUrl}, then the blob endpoint origin.
+			 */
+			uploadUrl?: string;
 	  };

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -6,6 +6,7 @@ export * from "./keys";
 export { MemoryStorage } from "./memory";
 export {
 	type PresignDownloadOptions,
+	type PresignUploadOptions,
 	STORAGE_CHUNK_SIZE,
 	type StorageBackend,
 	type StorageObjectInfo,

--- a/packages/storage/src/integration.test.ts
+++ b/packages/storage/src/integration.test.ts
@@ -187,4 +187,31 @@ describe.each(BACKENDS)("$name storage", ({ config }) => {
 		);
 		expect(response.headers.get("content-type")).toBe("application/gzip");
 	});
+
+	it("presigns an upload URL a client stages and commits blocks to", async () => {
+		// Only Azure presigns uploads; S3 leaves it undefined and the client uses
+		// the proxied route instead.
+		if (!storage.presignUpload) {
+			return;
+		}
+
+		const key = `${prefix}chunked.fq`;
+		const url = await storage.presignUpload(key, { expiresIn: 900 });
+		const blockId = btoa("000000");
+
+		const staged = await fetch(
+			`${url}&comp=block&blockid=${encodeURIComponent(blockId)}`,
+			{ method: "PUT", body: "ACGT" },
+		);
+		expect(staged.status).toBe(201);
+
+		const committed = await fetch(`${url}&comp=blocklist`, {
+			method: "PUT",
+			headers: { "content-type": "application/xml" },
+			body: `<?xml version="1.0" encoding="utf-8"?><BlockList><Latest>${blockId}</Latest></BlockList>`,
+		});
+		expect(committed.status).toBe(201);
+
+		expect(await readText(storage, key)).toBe("ACGT");
+	});
 });

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -23,6 +23,16 @@ export type PresignDownloadOptions = {
 	expiresIn: number;
 };
 
+/** The lifetime for a presigned upload URL. */
+export type PresignUploadOptions = {
+	/**
+	 * The URL lifetime in seconds from now. A chunked upload can run for a long
+	 * time over hundreds of block writes, so this is measured in hours rather
+	 * than the minutes a download redirect lives for.
+	 */
+	expiresIn: number;
+};
+
 /**
  * Streaming object storage, backed by S3 or Azure Blob.
  *
@@ -61,4 +71,17 @@ export type StorageBackend = {
 		key: string,
 		options: PresignDownloadOptions,
 	): Promise<string>;
+
+	/**
+	 * Mint a short-lived, write-only URL a client uploads the object at `key`
+	 * to directly, chunk by chunk, instead of streaming the bytes through this
+	 * server. The URL grants only create and write on that one key; the caller
+	 * appends the block-blob query parameters (`comp=block`, `comp=blocklist`)
+	 * itself.
+	 *
+	 * Optional: only the Azure backend implements it — chunked direct upload is
+	 * an Azure Block Blob capability, and `MemoryStorage` and the S3 backend
+	 * leave it undefined. A caller falls back to the proxied upload route.
+	 */
+	presignUpload?(key: string, options: PresignUploadOptions): Promise<string>;
 };


### PR DESCRIPTION
## Summary
- Add a chunked direct-to-blob upload path (Azure Put Block / Put Block List) so large uploads become hundreds of short requests over a presigned write SAS instead of one long proxied stream, avoiding Front Door's idle timeout. The server owns the choice via `initUploadFn` (gated by `VT_UPLOADS_CHUNKED` and backend presign support); the raw `POST /uploads` route stays as the proxied fallback and rollback path.
- Add `StorageBackend.presignUpload` (Azure only, `cw` SAS, `VT_STORAGE_AZURE_UPLOAD_URL` Front Door origin) and the pending-upload lifecycle in `@virtool/data`: reserve → finalize (size read from storage) → cancel, with a stale-reservation sweep folded into the reap task. No schema migration.
- Cover the flow with unit tests (data lifecycle, client block upload, init/finalize/cancel server fns) and a real Azurite integration test of the SAS round-trip; update the storage, data, and web READMEs.

Closes VIR-2920.