### PR TITLE
ci: merge data and storage test jobs into one

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -522,11 +522,12 @@ jobs:
             # Its own job rather than part of Packages / Test: data starts a
             # Postgres testcontainer and storage starts Garage and Azurite,
             # and pulling those images does not belong in the fast package
-            # loop. The two persistence packages share one job because their
-            # testcontainer pulls run concurrently and neither fills the job's
+            # loop. The two persistence packages share one job, run with
+            # --parallel so their testcontainer pulls overlap despite the
+            # data-on-storage dependency, and neither fills the job's
             # wall-clock budget.
             - name: Test
-              run: pnpm --filter @virtool/data --filter @virtool/storage test
+              run: pnpm --parallel --filter @virtool/data --filter @virtool/storage test
               env:
                   TZ: UTC
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -319,7 +319,7 @@ jobs:
             - name: Setup
               uses: ./.github/actions/setup
             # Its own job rather than part of Packages / Test, for the same
-            # reason as Data / Test: the job guard and the task probes are tested
+            # reason as Data & Storage / Test: the job guard and the task probes are tested
             # against a real Postgres testcontainer, and pulling that image does
             # not belong in the fast package loop.
             - name: Test
@@ -502,15 +502,16 @@ jobs:
               uses: ./.github/actions/setup
             # Exclusions rather than an inclusion list, so a new workspace that
             # declares `test` is covered without editing this job. The four
-            # excluded here have their own jobs.
+            # excluded here run in dedicated jobs: web, internal, and the two
+            # persistence packages that share Data & Storage / Test.
             - name: Test
               run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" --filter "!@virtool/internal" test
 
     # -------------------------------------------------------------------------
-    # Data (packages/data)
+    # Data and Storage (packages/data, packages/storage)
     # -------------------------------------------------------------------------
-    data-test:
-        name: Data / Test
+    data-storage-test:
+        name: Data & Storage / Test
         runs-on: ubuntu-24.04
         timeout-minutes: 15
         steps:
@@ -518,31 +519,16 @@ jobs:
               uses: actions/checkout@v7
             - name: Setup
               uses: ./.github/actions/setup
-            # Its own job rather than part of Packages / Test, for the same
-            # reason as Storage / Test: it starts a Postgres testcontainer, and
-            # pulling that image does not belong in the fast package loop.
+            # Its own job rather than part of Packages / Test: data starts a
+            # Postgres testcontainer and storage starts Garage and Azurite,
+            # and pulling those images does not belong in the fast package
+            # loop. The two persistence packages share one job because their
+            # testcontainer pulls run concurrently and neither fills the job's
+            # wall-clock budget.
             - name: Test
-              run: pnpm --filter @virtool/data test
+              run: pnpm --filter @virtool/data --filter @virtool/storage test
               env:
                   TZ: UTC
-
-    # -------------------------------------------------------------------------
-    # Storage (packages/storage)
-    # -------------------------------------------------------------------------
-    storage-test:
-        name: Storage / Test
-        runs-on: ubuntu-24.04
-        timeout-minutes: 15
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v7
-            - name: Setup
-              uses: ./.github/actions/setup
-            # Its own job rather than part of Packages / Test: the integration
-            # project starts Garage and Azurite in testcontainers, and pulling
-            # those images does not belong in the fast package loop.
-            - name: Test
-              run: pnpm --filter @virtool/storage test
 
     # -------------------------------------------------------------------------
     # Release
@@ -557,13 +543,12 @@ jobs:
                 build-nuvs,
                 build-pathoscope,
                 checks,
-                data-test,
+                data-storage-test,
                 internal-test,
                 packages-test,
                 pathoscope-test,
                 quality-test,
                 site-build,
-                storage-test,
                 web-test,
                 web-test-a11y,
                 web-test-server,

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -240,9 +240,9 @@ shutdown contracts are documented in
 Tests run as one Node Vitest project against a Postgres testcontainer. The
 project owns the shared container definition in `src/db/test/globalSetup.ts`;
 the web server project and `@virtool/internal` import that
-setup rather than defining another container. The project has its own CI job
-and is excluded from `Packages / Test`. Place tests beside their source as
-`*.test.ts`.
+setup rather than defining another container. The project runs in the shared
+`Data & Storage / Test` CI job and is excluded from `Packages / Test`. Place
+tests beside their source as `*.test.ts`.
 
 Call `createTestDatabase()` from `@virtool/data/db/test/fixtures` once per test
 file and drop it in `afterAll`. It creates an isolated database, applies the
@@ -252,7 +252,7 @@ both `emit` and `createEmitter` so fixture setup can still install the emitter.
 
 The shared container uses `withReuse()` and deliberately has no teardown, so
 local suites reuse it. Remove it with `docker rm -f` when it is no longer
-wanted; separate CI jobs still start separate containers.
+wanted; each CI job still starts its own containers.
 
 ## Commands
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -41,8 +41,8 @@ proxy in the path trips and no bytes pass through the server.
 
 The `unit` Vitest project covers behavior testable with `MemoryStorage`. The
 `integration` project exercises the S3 and Azure backends against real Garage
-and Azurite containers and has its own CI job. Place tests beside their source
-as `*.test.ts`.
+and Azurite containers and runs in the shared `Data & Storage / Test` CI job.
+Place tests beside their source as `*.test.ts`.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Merge the `Data / Test` and `Storage / Test` CI jobs into a single `Data & Storage / Test` job that runs both package filters under `TZ=UTC`, since both are persistence packages whose testcontainer pulls run concurrently and neither fills the job's wall-clock budget.
- Update the `release-tag` `needs:` list and the `Packages / Test` and `Internal / Test` comments to match, cutting the PR check count by one.