### PR TITLE
fix: surface GitHub HTTP status when release fetch fails

### DIFF
--- a/apps/site/src/utils/releases.ts
+++ b/apps/site/src/utils/releases.ts
@@ -47,14 +47,18 @@ async function fetchRepoReleases(repo: string): Promise<Array<object>> {
   let allReleases = [];
   let page = 1;
 
+  const headers = new Headers();
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.set("Authorization", `Bearer ${process.env.GITHUB_TOKEN}`);
+  } else {
+    console.warn(
+      "GITHUB_TOKEN is not set; fetching releases unauthenticated (60 requests/hour/IP). Set it to avoid rate-limit build failures.",
+    );
+  }
+
   while (true) {
     const url = `https://api.github.com/repos/virtool/${repo}/releases?per_page=100&page=${page}`;
-
-    const headers = new Headers();
-
-    if (process.env.GITHUB_TOKEN) {
-      headers.set("Authorization", `Bearer ${process.env.GITHUB_TOKEN}`);
-    }
 
     const response = await fetch(url, {
       headers,

--- a/apps/site/src/utils/releases.ts
+++ b/apps/site/src/utils/releases.ts
@@ -61,7 +61,9 @@ async function fetchRepoReleases(repo: string): Promise<Array<object>> {
     });
 
     if (!response.ok) {
-      throw new Error("Failed to fetch releases from GitHub");
+      throw new Error(
+        `Failed to fetch releases for ${repo} from GitHub (page ${page}): ${response.status} ${response.statusText}`,
+      );
     }
 
     const releases = await response.json();


### PR DESCRIPTION
## Summary
- The Astro site build fetches GitHub release data at build time; when the request fails it threw a generic `Failed to fetch releases from GitHub`, hiding whether the cause was a bad token (401), rate limit (403), or GitHub outage (5xx).
- The error now includes the repo, page, and HTTP status/statusText so intermittent build failures are self-diagnosing (VIR-3045).