### PR TITLE
feat: make chunked upload block concurrency tunable

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -413,10 +413,9 @@ route. `initUploadFn` owns the choice so the client never carries the flag:
 with `VT_UPLOADS_CHUNKED` enabled and an Azure backend that can presign, it
 reserves the upload — recording the file size the client declares at init — and
 returns a write SAS the client PUTs blocks to (`@uploads/chunkedUpload`), then
-commits with a Put Block List and calls `finalizeChunkedUploadFn`. Blocks start
-at 4 MiB and grow in 4 MiB increments when necessary to keep the upload within
-Azure's 50,000-block limit. Finalize records the stored object's size only when
-it matches the declared size, so an empty or partial block list is rejected
+commits with a Put Block List and calls `finalizeChunkedUploadFn`. Finalize
+records the stored object's size only when it matches the declared size, so an
+empty or partial block list is rejected
 rather than recorded as ready; `cancelChunkedUploadFn` drops an abandoned or
 rejected reservation. Otherwise it returns `proxied` and the client streams
 through the raw `/uploads` route, which stays the fallback and the rollback path
@@ -523,6 +522,7 @@ whitespace is trimmed, and an empty value is treated as unset.
 | `VT_STORAGE_AZURE_UPLOAD_URL` | URL origin | Unset | Rehost presigned Azure uploads on a public origin, such as a Front Door route to a private storage account. Falls back to `VT_STORAGE_AZURE_DOWNLOAD_URL`, then the Azure Blob endpoint. |
 | `VT_STORAGE_DOWNLOAD_MODE` | `stream` \| `redirect` | `stream` | Serve file downloads by streaming the bytes through this server, or by 302-redirecting to a short-lived presigned storage URL. `redirect` falls back to streaming when the backend cannot presign. |
 | `VT_UPLOADS_CHUNKED` | `0` \| `1` \| `true` \| `false` \| `yes` \| `no` | Unset (`false`) | Enable direct-to-blob chunked uploads when the storage backend can presign them. Unset or disable it to use the proxied upload route. |
+| `VT_UPLOADS_CHUNKED_CONCURRENCY` | Positive integer | `8` | Set how many blocks a chunked upload PUTs at once. Raise it to lift throughput on a high-latency upload path. |
 
 The build and test tooling reads one additional variable. It is not a runtime
 server setting and has no `_FILE` variant.

--- a/apps/web/src/server/__tests__/config.test.ts
+++ b/apps/web/src/server/__tests__/config.test.ts
@@ -221,6 +221,39 @@ describe("parseServerConfig", () => {
 		});
 	});
 
+	describe("chunked uploads", () => {
+		it("defaults the concurrency when unset", () => {
+			expect(parseServerConfig(minimalS3).uploadsChunkedConcurrency).toBe(8);
+		});
+
+		it("treats a blank concurrency as unset", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_UPLOADS_CHUNKED_CONCURRENCY: "",
+			} as NodeJS.ProcessEnv);
+
+			expect(config.uploadsChunkedConcurrency).toBe(8);
+		});
+
+		it("reads the concurrency from the environment", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_UPLOADS_CHUNKED_CONCURRENCY: "12",
+			} as NodeJS.ProcessEnv);
+
+			expect(config.uploadsChunkedConcurrency).toBe(12);
+		});
+
+		it("rejects a non-positive concurrency", () => {
+			expect(() =>
+				parseServerConfig({
+					...minimalS3,
+					VT_UPLOADS_CHUNKED_CONCURRENCY: "0",
+				} as NodeJS.ProcessEnv),
+			).toThrow(/VT_UPLOADS_CHUNKED_CONCURRENCY/);
+		});
+	});
+
 	describe("file-backed values", () => {
 		let directory: string;
 

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -5,6 +5,9 @@ import { z } from "zod";
 /** postgres-js pool size when `VT_POSTGRES_POOL_MAX` is unset. */
 const DEFAULT_POSTGRES_POOL_MAX = 10;
 
+/** How many blocks a chunked upload PUTs at once when unconfigured. */
+const DEFAULT_UPLOADS_CHUNKED_CONCURRENCY = 8;
+
 /** Server-side configuration parsed from process.env. */
 export type ServerConfig = {
 	postgresUrl: string;
@@ -35,6 +38,12 @@ export type ServerConfig = {
 	 * rollback path.
 	 */
 	uploadsChunked: boolean;
+	/**
+	 * How many blocks a chunked upload PUTs at once. Higher values raise
+	 * throughput on a high-latency path at the cost of more concurrent requests.
+	 * The server passes it to the client at upload init.
+	 */
+	uploadsChunkedConcurrency: number;
 };
 
 const ServerEnv = z.object({
@@ -100,6 +109,12 @@ const ServerEnv = z.object({
 				(value) => value === "1" || value === "true" || value === "yes",
 			),
 	),
+	// How many blocks a chunked upload PUTs at once. Unset — or empty, which
+	// deployment tooling injects — applies the default.
+	VT_UPLOADS_CHUNKED_CONCURRENCY: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.coerce.number().int().positive().optional(),
+	),
 });
 
 type StorageEnv = z.infer<typeof ServerEnv>;
@@ -112,6 +127,8 @@ const ServerEnvSchema = ServerEnv.transform((raw, ctx) => ({
 	storage: buildStorage(raw, ctx),
 	downloadMode: raw.VT_STORAGE_DOWNLOAD_MODE,
 	uploadsChunked: raw.VT_UPLOADS_CHUNKED,
+	uploadsChunkedConcurrency:
+		raw.VT_UPLOADS_CHUNKED_CONCURRENCY ?? DEFAULT_UPLOADS_CHUNKED_CONCURRENCY,
 }));
 
 // Unset and empty are the same thing for storage variables. Deployment tooling

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -64,7 +64,10 @@ const presignUpload = vi.fn();
 	presignUpload;
 
 // Mutable so a test can flip the chunked-upload flag; reset in `beforeEach`.
-const testConfig = { uploadsChunked: false };
+const testConfig = {
+	uploadsChunked: false,
+	uploadsChunkedConcurrency: 8,
+};
 
 const handlers = (await import(
 	"./functions.ts?tss-serverfn-split"
@@ -275,11 +278,18 @@ describe("initUpload", () => {
 			name: "reads.fq.gz",
 			type: "reads",
 			size: 4096,
-		})) as { mode: string; uploadId: number; url: string; blockSize: number };
+		})) as {
+			mode: string;
+			uploadId: number;
+			url: string;
+			blockSize: number;
+			concurrency: number;
+		};
 
 		expect(result.mode).toBe("chunked");
 		expect(result.url).toBe("https://fd/c/blob?sig=x");
-		expect(result.blockSize).toBe(4 * 1024 * 1024);
+		expect(result.blockSize).toBe(16 * 1024 * 1024);
+		expect(result.concurrency).toBe(8);
 
 		const [row] = await db
 			.select()
@@ -302,10 +312,10 @@ describe("initUpload", () => {
 		const result = (await call("initUploadFn", {
 			name: "reads.fq.gz",
 			type: "reads",
-			size: 4 * 1024 * 1024 * 50_000 + 1,
+			size: 16 * 1024 * 1024 * 50_000 + 1,
 		})) as { blockSize: number };
 
-		expect(result.blockSize).toBe(8 * 1024 * 1024);
+		expect(result.blockSize).toBe(32 * 1024 * 1024);
 	});
 
 	it("rejects files larger than Azure's maximum block blob size", async () => {

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -16,7 +16,6 @@ import {
 	UploadReservedError,
 	UploadSizeMismatchError,
 } from "@virtool/data/uploads/data";
-import { STORAGE_CHUNK_SIZE } from "@virtool/storage";
 import { z } from "zod";
 import { authenticated, permission } from "../auth/policy";
 import { db, storage } from "../composition";
@@ -32,6 +31,11 @@ const UPLOAD_SAS_TTL_SECONDS = 6 * 60 * 60;
 const AZURE_MAX_BLOCK_COUNT = 50_000;
 const AZURE_MAX_BLOCK_SIZE = 4_000 * 1024 * 1024;
 const AZURE_MAX_BLOB_SIZE = AZURE_MAX_BLOCK_COUNT * AZURE_MAX_BLOCK_SIZE;
+
+// The smallest block a chunked upload cuts a file into. Larger blocks mean
+// fewer requests per file; the block only grows past this floor for a file too
+// large to fit in the block-count limit at this size (~781 GiB and up).
+const MIN_UPLOAD_BLOCK_SIZE = 16 * 1024 * 1024;
 
 // The upload endpoint itself is not a server function — it streams a multi-GB
 // request body and is posted to with XMLHttpRequest so the client can report
@@ -115,8 +119,8 @@ const initUploadSchema = z.object({
 function getUploadBlockSize(size: number): number {
 	const minimumBlockSize = Math.ceil(size / AZURE_MAX_BLOCK_COUNT);
 	return Math.max(
-		STORAGE_CHUNK_SIZE,
-		Math.ceil(minimumBlockSize / STORAGE_CHUNK_SIZE) * STORAGE_CHUNK_SIZE,
+		MIN_UPLOAD_BLOCK_SIZE,
+		Math.ceil(minimumBlockSize / MIN_UPLOAD_BLOCK_SIZE) * MIN_UPLOAD_BLOCK_SIZE,
 	);
 }
 
@@ -130,8 +134,9 @@ function getUploadBlockSize(size: number): number {
  * it returns `proxied` and the client falls back to the `POST /uploads` route.
  * A `proxied` result reserves nothing — that route creates its own row.
  *
- * `blockSize` is the block size the client cuts the file into. After committing
- * the block list the client calls {@link finalizeChunkedUploadFn}.
+ * `blockSize` is the block size the client cuts the file into and `concurrency`
+ * is how many blocks it PUTs at once, the latter from configuration. After
+ * committing the block list the client calls {@link finalizeChunkedUploadFn}.
  */
 export const initUploadFn = createServerFn({ method: "POST" })
 	.middleware([permission("upload_file")])
@@ -175,6 +180,7 @@ export const initUploadFn = createServerFn({ method: "POST" })
 			uploadId: upload.id,
 			url,
 			blockSize: getUploadBlockSize(data.size),
+			concurrency: config.uploadsChunkedConcurrency,
 		};
 	});
 

--- a/apps/web/src/uploads/__tests__/chunkedUpload.test.ts
+++ b/apps/web/src/uploads/__tests__/chunkedUpload.test.ts
@@ -58,6 +58,7 @@ function init(overrides: Partial<ChunkedInit> = {}): ChunkedInit {
 		uploadId: 7,
 		url: "https://fd/c/blob?sig=x",
 		blockSize: 4,
+		concurrency: 4,
 		...overrides,
 	};
 }

--- a/apps/web/src/uploads/chunkedUpload.ts
+++ b/apps/web/src/uploads/chunkedUpload.ts
@@ -26,10 +26,9 @@ export type ChunkedInit = {
 	uploadId: number;
 	url: string;
 	blockSize: number;
+	/** How many blocks are PUT at once. */
+	concurrency: number;
 };
-
-/** How many blocks are PUT at once. */
-const BLOCK_CONCURRENCY = 4;
 
 /** How many times a single block PUT is retried before the upload fails. */
 const BLOCK_MAX_ATTEMPTS = 3;
@@ -185,14 +184,15 @@ function putBlockList(
 }
 
 /**
- * Stage every block, PUTting up to {@link BLOCK_CONCURRENCY} at once and summing
- * their progress across the whole file.
+ * Stage every block, PUTting up to `concurrency` at once and summing their
+ * progress across the whole file.
  */
 async function stageBlocks(
 	url: string,
 	file: File,
 	blockSize: number,
 	blockCount: number,
+	concurrency: number,
 	onProgress: ((progress: UploadProgress) => void) | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<void> {
@@ -268,7 +268,7 @@ async function stageBlocks(
 
 	try {
 		await Promise.all(
-			Array.from({ length: Math.min(BLOCK_CONCURRENCY, blockCount) }, worker),
+			Array.from({ length: Math.min(concurrency, blockCount) }, worker),
 		);
 	} finally {
 		signal?.removeEventListener("abort", onExternalAbort);
@@ -288,12 +288,20 @@ export async function uploadBlocks(
 	onProgress?: (progress: UploadProgress) => void,
 	signal?: AbortSignal,
 ): Promise<Upload> {
-	const { uploadId, url, blockSize } = init;
+	const { uploadId, url, blockSize, concurrency } = init;
 
 	try {
 		const blockCount = Math.ceil(file.size / blockSize);
 
-		await stageBlocks(url, file, blockSize, blockCount, onProgress, signal);
+		await stageBlocks(
+			url,
+			file,
+			blockSize,
+			blockCount,
+			concurrency,
+			onProgress,
+			signal,
+		);
 		await putBlockList(url, blockCount, file.type, signal);
 
 		// The server marks the row ready and cannot un-mark it, so once finalize is


### PR DESCRIPTION
## Summary
- Add `VT_UPLOADS_CHUNKED_CONCURRENCY` (default 8) so the number of blocks a chunked upload PUTs at once is deployment-tunable, and pass it to the client at upload init instead of the hardcoded 4.
- Raise the minimum upload block size to 16 MiB (was tied to `STORAGE_CHUNK_SIZE`), cutting large files into fewer, larger blocks for higher throughput on high-latency paths.