### PR TITLE
ci: give nuvs a dedicated test job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,13 +22,11 @@ jobs:
     # -------------------------------------------------------------------------
     # Change detection
     # -------------------------------------------------------------------------
-    # Only the workflow-image jobs are filtered. They are the expensive
-    # outliers: a libclang-dev install and a cargo build for pathoscope, a
-    # from-source SPAdes compile for nuvs, and a from-source bowtie2, HMMER and
-    # samtools build for both, all carrying long timeouts, on every PR including
-    # ones confined to apps/web. Everything else in this file is cheap enough
-    # that gating it would cost more in review attention than it saves in runner
-    # minutes.
+    # Filtering is reserved for expensive jobs — libclang and cargo, SPAdes,
+    # bowtie2, HMMER, samtools — that would otherwise run on every PR, even ones
+    # confined to apps/web. NuVs / Test is the one cheap exception, filtered
+    # only for parity with pathoscope-test and quality-test. Everything else
+    # stays unfiltered; gating it would cost more review attention than it saves.
     #
     # The filter step is skipped on `push`, so this job needs no checkout and no
     # base-ref handling for that event: dorny/paths-filter reads the changed
@@ -41,6 +39,7 @@ jobs:
         permissions:
             pull-requests: read
         outputs:
+            nuvs-app: ${{ steps.filter.outputs.nuvs-app }}
             nuvs-image: ${{ steps.filter.outputs.nuvs-image }}
             pathoscope-crate: ${{ steps.filter.outputs.pathoscope-crate }}
             pathoscope-image: ${{ steps.filter.outputs.pathoscope-image }}
@@ -82,6 +81,27 @@ jobs:
                   # a rule that excluded the crate would fail the build on main
                   # with nothing having caught it on the PR.
                   filters: |
+                      # Gates NuVs / Test. Narrower than nuvs-image: no
+                      # Dockerfile or .dockerignore, and only the packages nuvs
+                      # imports — so no data, ncbi or service.
+                      nuvs-app:
+                        - '.github/workflows/ci.yaml'
+                        - 'apps/nuvs/**'
+                        - 'packages/archive/**'
+                        - 'packages/bio/**'
+                        - 'packages/contracts/**'
+                        - 'packages/logger/**'
+                        - 'packages/sentry/**'
+                        - 'packages/sqlite/**'
+                        - 'packages/storage/**'
+                        - 'packages/workflow/**'
+                        - 'packages/tsconfig.base.json'
+                        - 'apps/tsconfig.node.json'
+                        - 'apps/*/package.json'
+                        - 'packages/*/package.json'
+                        - 'package.json'
+                        - 'pnpm-workspace.yaml'
+                        - 'pnpm-lock.yaml'
                       nuvs-image:
                         - '.github/workflows/ci.yaml'
                         - 'apps/nuvs/**'
@@ -360,6 +380,27 @@ jobs:
                   cache-from: type=gha,scope=nuvs
                   cache-to: type=gha,mode=max,scope=nuvs
 
+    # Split out of Packages / Test for a per-app job and path filtering, like
+    # pathoscope-test and quality-test. Mocked vitest, no real tools, so just
+    # the setup action.
+    nuvs-test:
+        name: NuVs / Test
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        needs: [changes]
+        # See the note on build-pathoscope: filtered on pull requests,
+        # unconditional on push so the release-tag gate stays complete.
+        if: github.event_name == 'push' || needs.changes.outputs.nuvs-app == 'true'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+            - name: Setup
+              uses: ./.github/actions/setup
+            - name: Test
+              run: pnpm --filter @virtool/nuvs test
+              env:
+                  TZ: UTC
+
     # -------------------------------------------------------------------------
     # Pathoscope (apps/pathoscope, packages/pathoscope-core)
     # -------------------------------------------------------------------------
@@ -501,11 +542,11 @@ jobs:
             - name: Setup
               uses: ./.github/actions/setup
             # Exclusions rather than an inclusion list, so a new workspace that
-            # declares `test` is covered without editing this job. The four
-            # excluded here run in dedicated jobs: web, internal, and the two
-            # persistence packages that share Data & Storage / Test.
+            # declares `test` is covered without editing this job. The five
+            # excluded here run in dedicated jobs: web, internal, nuvs, and the
+            # two persistence packages that share Data & Storage / Test.
             - name: Test
-              run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" --filter "!@virtool/internal" test
+              run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" --filter "!@virtool/internal" --filter "!@virtool/nuvs" test
 
     # -------------------------------------------------------------------------
     # Data and Storage (packages/data, packages/storage)
@@ -546,6 +587,7 @@ jobs:
                 checks,
                 data-storage-test,
                 internal-test,
+                nuvs-test,
                 packages-test,
                 pathoscope-test,
                 quality-test,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,9 +70,11 @@ jobs:
                   # not, and one shared filter would rebuild each image for the
                   # other's inputs.
                   #
-                  # This file is in all three so that a change to the jobs
-                  # themselves is still gated by them. None uses
-                  # ./.github/actions/setup, so that action is not.
+                  # This file is in every filter so that a change to the jobs
+                  # themselves is still gated by them. The image and crate
+                  # filters build via Docker and do not use
+                  # ./.github/actions/setup, so that action is not in them;
+                  # nuvs-app runs it and so carries it and .nvmrc.
                   #
                   # `.dockerignore` is in the image filter: build-pathoscope
                   # builds with `context: .`, so a rule there decides what the
@@ -86,6 +88,8 @@ jobs:
                       # imports — so no data, ncbi or service.
                       nuvs-app:
                         - '.github/workflows/ci.yaml'
+                        - '.github/actions/setup/**'
+                        - '.nvmrc'
                         - 'apps/nuvs/**'
                         - 'packages/archive/**'
                         - 'packages/bio/**'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,8 +40,8 @@ docker build --target pathoscope .
 
 ## Path-filtered jobs
 
-Most CI jobs run for every pull request. Four expensive jobs use the `changes`
-job in `.github/workflows/ci.yaml` to run only when their inputs change:
+Most CI jobs run for every pull request. Five jobs use the `changes` job in
+`.github/workflows/ci.yaml` to run only when their inputs change:
 
 | Filter | Job | Inputs |
 | --- | --- | --- |
@@ -49,13 +49,18 @@ job in `.github/workflows/ci.yaml` to run only when their inputs change:
 | `quality-crate` | `quality-test` | The quality-statistics Rust crate |
 | `pathoscope-image` | `build-pathoscope` | The Pathoscope app, its Rust crate, and everything copied into its image |
 | `nuvs-image` | `build-nuvs` | The Nuvs app and everything copied into its image |
+| `nuvs-app` | `nuvs-test` | The Nuvs app and the workspace packages it imports |
 
-Keep a separate filter for each job. The crate jobs run Cargo and do not read
-TypeScript sources. The image jobs bundle different apps and have different
-Docker build inputs: Pathoscope copies `packages/pathoscope-core`, while Nuvs
-does not. Combining the filters would run the libclang-and-Cargo job for
-unrelated workspace changes and rebuild each image for inputs used only by the
-other image.
+The first four are expensive outliers — libclang, Cargo, and from-source
+bioinformatics compiles that would otherwise run on every PR. `nuvs-test` is
+cheap mocked vitest, filtered only for parity with the other workflow apps.
+
+Keep a separate filter for each job. The crate jobs run Cargo, not TypeScript.
+The image jobs copy different packages: Pathoscope copies
+`packages/pathoscope-core`; Nuvs does not. `nuvs-app` is narrower than
+`nuvs-image` — no `Dockerfile` or `.dockerignore`, and only the packages Nuvs
+imports (so no `data`, `ncbi`, or `service`). Sharing one filter would rebuild
+each image, and rerun Cargo, for inputs it does not use.
 
 Extend a filter in the same change that gives its job a new input. Every path a
 workflow image's Dockerfile stages `COPY` must appear under that image's


### PR DESCRIPTION
## Summary
- Add a `NuVs / Test` job running `apps/nuvs`'s vitest suite on its own, split out of the catch-all `packages-test` so it shows in the per-app job list and gates `release-tag`.
- Gate it on a new `nuvs-app` change filter — narrower than `nuvs-image` (no `Dockerfile`/`.dockerignore`, only the packages nuvs imports), matching the `pathoscope-test`/`quality-test` pattern.
- Update `docs/ci.md` and the in-file comments for the new filter and job.