### PR TITLE
fix: keep installed HMM record when a later install fails

### DIFF
--- a/apps/internal/src/run/tasks/install-hmms.test.ts
+++ b/apps/internal/src/run/tasks/install-hmms.test.ts
@@ -409,7 +409,7 @@ describe("installHmmsTask", () => {
 });
 
 describe("installHmmsTask cleanup", () => {
-	it("clears the status when the task fails", async () => {
+	it("clears the in-flight update when the task fails", async () => {
 		await seedPendingStatus();
 		stubFetch(Buffer.from("<html>nope</html>"), { status: 500 });
 
@@ -418,7 +418,27 @@ describe("installHmmsTask cleanup", () => {
 		const status = await readStatus();
 
 		expect(status?.updates).toEqual([]);
-		expect(status?.installed).toBeNull();
+		expect(status?.task_id).toBeNull();
+	});
+
+	it("keeps a previous good install when the task fails", async () => {
+		await seedPendingStatus();
+
+		const installed = { ready: true } as unknown as HmmUpdate;
+
+		await db
+			.update(legacyHmmStatus)
+			.set({ installed })
+			.where(eq(legacyHmmStatus.id, HMM_STATUS_ID));
+
+		stubFetch(Buffer.from("<html>nope</html>"), { status: 500 });
+
+		expect((await run(await claimInstall())).status).toBe("failed");
+
+		const status = await readStatus();
+
+		expect(status?.installed).toEqual(installed);
+		expect(status?.updates).toEqual([]);
 	});
 
 	/*

--- a/packages/data/src/hmm/data.ts
+++ b/packages/data/src/hmm/data.ts
@@ -716,20 +716,21 @@ export async function writeHmmAnnotations(
 }
 
 /**
- * Clear the status singleton's install record.
+ * Clear the status singleton's in-flight install record.
  *
  * Run when an install **fails**. It is also the only thing that unwedges the
  * install button afterwards, because `isInstallInProgress` reads the pending
- * entry this removes.
+ * `updates` entry this removes.
  *
- * **It clears `installed` unconditionally**, so a failed install of release N
- * erases the record of a good N-1 whose rows and profiles are untouched. Left
- * that way deliberately; any repair has to keep making `isInstallInProgress`
- * false, which is what unwedges the install button.
+ * **`installed` is left untouched.** It is only ever written inside the
+ * committed install transaction, so it always names the last install that
+ * actually landed — a failed install of release N does not touch the rows or
+ * profiles of a good N-1, and must not erase its record. Clearing `task_id` and
+ * `updates` is enough to make `isInstallInProgress` false and free the button.
  */
 export async function cleanHmmStatus(db: DbOrTx): Promise<void> {
 	await db
 		.update(legacyHmmStatus)
-		.set({ installed: null, task_id: null, updates: [] })
+		.set({ task_id: null, updates: [] })
 		.where(eq(legacyHmmStatus.id, HMM_STATUS_ID));
 }

--- a/packages/data/src/hmm/data.ts
+++ b/packages/data/src/hmm/data.ts
@@ -722,15 +722,26 @@ export async function writeHmmAnnotations(
  * install button afterwards, because `isInstallInProgress` reads the pending
  * `updates` entry this removes.
  *
- * **`installed` is left untouched.** It is only ever written inside the
- * committed install transaction, so it always names the last install that
- * actually landed — a failed install of release N does not touch the rows or
- * profiles of a good N-1, and must not erase its record. Clearing `task_id` and
- * `updates` is enough to make `isInstallInProgress` false and free the button.
+ * **Only the pending (`ready: false`) updates are dropped; `installed` and any
+ * committed (`ready: true`) markers stay.** `installed` and the ready marker are
+ * both written only inside the committed install transaction, so they name an
+ * install that actually landed — a pre-commit failure of release N leaves a
+ * good N-1's rows and profiles untouched and must not erase its record. Keeping
+ * the ready marker also lets a retry short-circuit in {@link installHmms} and
+ * rebuild the annotations blob, the recovery path for an install whose
+ * post-commit blob write failed. Removing the pending entry is enough to make
+ * `isInstallInProgress` false and free the button.
  */
 export async function cleanHmmStatus(db: DbOrTx): Promise<void> {
+	const [row] = await db
+		.select({ updates: legacyHmmStatus.updates })
+		.from(legacyHmmStatus)
+		.where(eq(legacyHmmStatus.id, HMM_STATUS_ID));
+
+	const updates = (row?.updates ?? []).filter((update) => update.ready);
+
 	await db
 		.update(legacyHmmStatus)
-		.set({ task_id: null, updates: [] })
+		.set({ task_id: null, updates })
 		.where(eq(legacyHmmStatus.id, HMM_STATUS_ID));
 }

--- a/packages/data/src/hmm/install.test.ts
+++ b/packages/data/src/hmm/install.test.ts
@@ -565,4 +565,23 @@ describe("cleanHmmStatus", () => {
 		expect(status?.task_id).toBeNull();
 		expect(status?.updates).toEqual([]);
 	});
+
+	it("keeps a committed update so a retry can rebuild the annotations blob", async () => {
+		await seedPendingStatus();
+
+		const pending = (await readStatus())?.updates[0] as HmmUpdate;
+		const committed = { ...pending, id: 1111, ready: true };
+
+		await db
+			.update(legacyHmmStatus)
+			.set({ updates: [committed, pending] })
+			.where(eq(legacyHmmStatus.id, HMM_STATUS_ID));
+
+		await cleanHmmStatus(db);
+
+		const status = await readStatus();
+
+		// The committed marker stays; only the failed pending one is dropped.
+		expect(status?.updates).toEqual([committed]);
+	});
 });

--- a/packages/data/src/hmm/install.test.ts
+++ b/packages/data/src/hmm/install.test.ts
@@ -534,22 +534,35 @@ describe("writeHmmAnnotations", () => {
 });
 
 describe("cleanHmmStatus", () => {
-	it("clears the install record", async () => {
+	it("clears the in-flight install record", async () => {
 		await seedPendingStatus();
+
+		await cleanHmmStatus(db);
+
+		const status = await readStatus();
+
+		expect(status?.task_id).toBeNull();
+		expect(status?.updates).toEqual([]);
+		// The release itself survives, so the install button still has one to offer.
+		expect(status?.release?.id).toBe(RELEASE_ID);
+	});
+
+	it("preserves the previous good install when a later one fails", async () => {
+		await seedPendingStatus();
+
+		const installed = { ready: true } as unknown as HmmUpdate;
 
 		await db
 			.update(legacyHmmStatus)
-			.set({ installed: { ready: true } as unknown as HmmUpdate })
+			.set({ installed })
 			.where(eq(legacyHmmStatus.id, HMM_STATUS_ID));
 
 		await cleanHmmStatus(db);
 
 		const status = await readStatus();
 
-		expect(status?.installed).toBeNull();
+		expect(status?.installed).toEqual(installed);
 		expect(status?.task_id).toBeNull();
 		expect(status?.updates).toEqual([]);
-		// The release itself survives, so the install button still has one to offer.
-		expect(status?.release?.id).toBe(RELEASE_ID);
 	});
 });


### PR DESCRIPTION
## Summary
- `cleanHmmStatus` no longer clears the `installed` field on a failed install, so a failed install of release N no longer erases the record of a good N-1 whose rows and profiles are untouched (VIR-2996).
- It still clears `task_id` and `updates`, which is all that is needed to make `isInstallInProgress` false and free the install button.
- Added tests in `@virtool/data` and `@virtool/internal` covering that a previous good install survives a later failed one.