### PR TITLE
chore: support per-worktree dev instances via namespace isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Virtool
+
+## Development
+
+The local Kubernetes development environment uses Tilt on Minikube. Install
+the tools listed in [the dev cluster documentation](dev/README.md#requirements),
+then run these commands from the repository root:
+
+```shell
+mise run init          # one-time cluster setup
+mise run up            # bring up this worktree and start Tilt
+mise run up:minikube   # start Minikube only
+mise run down          # delete this worktree's namespace and data
+mise run wipe          # delete this worktree's StatefulSets and PVCs
+```
+
+Set `WT` to use a short, memorable namespace slug:
+
+```shell
+WT=vir3044 mise run up
+```
+
+Arguments after `up` are passed to Tilt, so live-edit targets can be combined:
+
+```shell
+mise run up --web --internal
+```
+
+See [the dev cluster documentation](dev/README.md) for the architecture,
+worktree isolation, manifests, live editing, and data-wiping details.

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,34 @@
 local(['bash', 'dev/scripts/ensure-minikube.sh'], quiet=False)
 
+# Each worktree runs its own dev instance in its own Kubernetes namespace. `WT`
+# names that namespace and `dev/scripts/up.sh` sets it before `tilt up`. Every
+# object this Tiltfile applies goes into that namespace, and the ingress host is
+# derived from it, so two worktrees never collide. KEDA, ingress-nginx and the
+# wildcard TLS certificate are cluster-wide singletons that
+# `dev/scripts/init.sh` installs once.
+WT = os.getenv('WT', '')
+if not WT:
+    fail('WT is not set. Start the dev instance with `bash dev/scripts/up.sh`.')
+
+MINIKUBE_IP = str(local('minikube ip', quiet=True)).strip()
+HOST = WT + '.' + MINIKUBE_IP + '.nip.io'
+
+load('ext://namespace', 'namespace_create', 'namespace_inject')
+load('ext://uibutton', 'cmd_button', 'location')
+
+# Rewrite the shared manifests for this worktree: put every object in the `WT`
+# namespace, repoint the hard-coded `default` service FQDNs at it, and swap the
+# `virtool.local` ingress host for the worktree's nip.io host. The manifests
+# keep `default` and `virtool.local` as literals so each stays valid on its own
+# under `kubectl apply -f`.
+def scoped(objects):
+    text = str(objects)
+    text = text.replace('default.svc.cluster.local', WT + '.svc.cluster.local')
+    text = text.replace('virtool.local', HOST)
+    return namespace_inject(blob(text), WT)
+
+namespace_create(WT)
+
 # Every live-edit target is a bool flag named after its Dockerfile stage, e.g.
 # `tilt up -- --web --internal`. The web target is listed apart because it
 # alone runs a dev server rather than the built artifact, so it needs an
@@ -34,40 +63,27 @@ for target, image in WORKFLOW_TARGETS:
 
 cfg = config.parse()
 
-load('ext://helm_resource', 'helm_resource', 'helm_repo')
-load('ext://uibutton', 'cmd_button', 'location')
-
 cmd_button('wipe',
-    argv=['bash', 'dev/scripts/wipe.sh'],
+    argv=['bash', 'dev/scripts/wipe.sh', WT],
     icon_name="delete_forever",
     location=location.NAV,
     text='Wipe',
     requires_confirmation=True,
 )
 
-helm_repo('kedacore', 'https://kedacore.github.io/charts', labels=['k8s'])
-
-helm_resource(
-    'keda',
-    'kedacore/keda',
-    labels=['k8s'],
-    resource_deps=['kedacore'],
-    flags=['--version=2.20.2']
-)
-
-k8s_yaml('dev/manifests/data/azurite.yaml')
-k8s_yaml('dev/manifests/data/postgres.yaml')
+k8s_yaml(scoped(read_file('dev/manifests/data/azurite.yaml')))
+k8s_yaml(scoped(read_file('dev/manifests/data/postgres.yaml')))
 
 k8s_resource("azurite", labels=['data'])
 k8s_resource("postgres", labels=['data'])
 
-k8s_yaml('dev/manifests/config.yaml')
-k8s_yaml('dev/manifests/ingress.yaml')
+k8s_yaml(scoped(read_file('dev/manifests/config.yaml')))
+k8s_yaml(scoped(read_file('dev/manifests/ingress.yaml')))
 
 # The migration Job runs the internal image's `migrate` subcommand. It stays a
 # separate Job so the long-lived processes only start after schema changes have
 # been applied.
-k8s_yaml('dev/manifests/migration.yaml')
+k8s_yaml(scoped(read_file('dev/manifests/migration.yaml')))
 
 # Anything in the build context that no sync below covers forces a full image
 # rebuild, which replaces the pod and costs a cold start. These paths are all
@@ -120,8 +136,8 @@ for target, image in SERVICE_TARGETS:
     if cfg.get(target, False):
         docker_build(image, '.', target=target, ignore=ui_monorepo_ignore)
 
-k8s_yaml(kustomize('dev/manifests/web'))
-k8s_yaml(kustomize('dev/manifests/virtool'))
+k8s_yaml(scoped(kustomize('dev/manifests/web')))
+k8s_yaml(scoped(kustomize('dev/manifests/virtool')))
 
 k8s_resource(
     labels=['data'],
@@ -129,10 +145,12 @@ k8s_resource(
     objects=['virtool-env:configmap'],
 )
 
+# Host port 0 lets Tilt pick a free local port, so concurrent worktrees never
+# fight over one. The bound port shows in the Tilt UI.
 k8s_resource(
     'virtool-jobs-api',
     labels=['virtool'],
-    port_forwards=["9960:9950"],
+    port_forwards=[port_forward(0, 9950)],
     new_name="jobs-api",
     resource_deps=["config", "migration"],
     trigger_mode=TRIGGER_MODE_MANUAL
@@ -157,7 +175,7 @@ k8s_resource(
     'virtool-tasks',
     labels=['virtool'],
     new_name="tasks",
-    port_forwards=["9970:9900"],
+    port_forwards=[port_forward(0, 9900)],
     resource_deps=["config", "migration"],
     trigger_mode=TRIGGER_MODE_MANUAL
 )
@@ -166,7 +184,7 @@ k8s_resource(
     'virtool-web',
     labels=['virtool'],
     new_name="web",
-    port_forwards=[9900],
+    port_forwards=[port_forward(0, 9900)],
     resource_deps=["config", "postgres"]
 )
 
@@ -176,7 +194,7 @@ k8s_kind(
     image_json_path='{.spec.jobTargetRef.template.spec.containers[0].image}'
 )
 
-k8s_yaml(kustomize('dev/manifests/workflows'))
+k8s_yaml(scoped(kustomize('dev/manifests/workflows')))
 
 for target, image in WORKFLOW_TARGETS:
     if cfg.get(target, False):
@@ -186,6 +204,6 @@ for target, image in WORKFLOW_TARGETS:
         'virtool-workflow-' + target,
         labels=["workflows"],
         new_name=target,
-        resource_deps=['config', 'keda', 'jobs-api'],
+        resource_deps=['config', 'jobs-api'],
         trigger_mode=TRIGGER_MODE_MANUAL
     )

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -871,5 +871,5 @@ Follow [the development guide](../../dev/README.md) to set up Tilt and Minikube,
 then start the web app's live-edit target from the repository root:
 
 ```shell
-tilt up -- --web
+bash dev/scripts/up.sh --web
 ```

--- a/dev/README.md
+++ b/dev/README.md
@@ -27,7 +27,7 @@ wildcard `*.<minikube-ip>.nip.io` certificate covers every worktree.
 
 ## Requirements
 
-Docker Engine, Helm, `kubectl`, `mkcert`, Minikube and Tilt.
+Docker Engine, Helm, `kubectl`, `mkcert`, Minikube, Tilt and mise.
 
 ## Stack
 
@@ -45,6 +45,7 @@ Docker Engine, Helm, `kubectl`, `mkcert`, Minikube and Tilt.
 
 ```
 Tiltfile                  at the repo root: resources, buttons, live-edit flags
+mise.toml                 at the repo root: convenient tasks for the dev scripts
 dev/
   manifests/              Kustomize manifests for every cluster resource
     config.yaml           the Postgres and Azurite env every service shares
@@ -65,49 +66,10 @@ dev/
 
 ## Getting started
 
-1. Run the one-time cluster setup:
-
-   ```shell
-   bash dev/scripts/init.sh
-   ```
-
-   This starts Minikube, enables the `metrics-server` and `ingress` addons,
-   installs KEDA, and issues a wildcard mkcert certificate for
-   `*.<minikube-ip>.nip.io` that it installs as the ingress controller's
-   default. It touches no worktree data and is safe to re-run — re-run it after
-   a `minikube delete` to refresh the certificate against the new IP.
-
-   Run `mkcert -install` once beforehand so the certificate is trusted.
-
-2. Bring up this worktree's instance:
-
-   ```shell
-   bash dev/scripts/up.sh
-   ```
-
-   This creates the namespace, installs the shared certificate into it, and
-   starts Tilt on an automatically chosen UI port. The namespace defaults to the
-   worktree directory name; set `WT` for a short, memorable slug:
-
-   ```shell
-   WT=vir3044 bash dev/scripts/up.sh
-   ```
-
-   The instance is then at `https://<WT>.<minikube-ip>.nip.io` — the Tilt UI
-   prints the exact host.
-
-3. Tear the instance down when you are done:
-
-   ```shell
-   bash dev/scripts/down.sh
-   ```
-
-   This deletes the namespace and its data. Other worktrees, KEDA, the ingress
-   controller and the certificate are untouched.
-
-The `Tiltfile` calls `dev/scripts/ensure-minikube.sh` as it loads, so `up.sh`
-starts a stopped cluster on its own. Run `tilt down` (or `down.sh`) before
-`minikube stop` so the cluster stops cleanly.
+See the root README for the development commands. The `Tiltfile` calls
+`dev/scripts/ensure-minikube.sh` as it loads, so bringing up an instance also
+starts a stopped Minikube cluster. Run `tilt down` before `minikube stop` so the
+cluster stops cleanly.
 
 ## Live editing
 
@@ -122,8 +84,6 @@ stage named after the target. Pass a flag through `up.sh` to turn one on:
 | `--create-subtraction` | `ghcr.io/virtool/create-subtraction` | `create-subtraction` |
 | `--nuvs` | `ghcr.io/virtool/nuvs` | `nuvs` |
 | `--pathoscope` | `ghcr.io/virtool/pathoscope` | `pathoscope` |
-
-Flags combine: `bash dev/scripts/up.sh --web --internal`.
 
 `--web` runs Vite in the pod and syncs `apps/web/src` and `packages` into it,
 so an edit shows up without a rebuild. The rest rebuild the image on change,

--- a/dev/README.md
+++ b/dev/README.md
@@ -8,19 +8,38 @@ The `Tiltfile` is at the **repo root**, where `tilt up` looks for it; this
 directory holds everything it reads. Run every command below from the repo
 root.
 
+## Per-worktree isolation
+
+Each git worktree runs its own dev instance in its own Kubernetes namespace, so
+parallel branches never collide over ports, data or images on one Minikube
+cluster. The `WT` environment variable names the namespace; `up.sh` sets it and
+the `Tiltfile` reads it. The 8 CPU / 16 GB node cannot fit two full clusters,
+so a few resources are shared singletons rather than per-worktree:
+
+| Scope | What |
+| --- | --- |
+| Cluster-wide, set up once by `init.sh` | Minikube, metrics-server, ingress-nginx, KEDA, the wildcard TLS certificate |
+| Per worktree, brought up by `up.sh` | The namespace and everything in it — web, jobs-api, tasks, migration, workflows, Postgres, Azurite |
+
+Each worktree is reachable at `https://<WT>.<minikube-ip>.nip.io`. nip.io
+resolves that host to the Minikube IP with no `/etc/hosts` entry, and the
+wildcard `*.<minikube-ip>.nip.io` certificate covers every worktree.
+
 ## Requirements
 
 Docker Engine, Helm, `kubectl`, `mkcert`, Minikube and Tilt.
 
 ## Stack
 
-- **Tilt** — orchestrates the cluster; the root `Tiltfile` is the entry point
-- **Minikube** — the cluster itself
-- **KEDA** — scales workflow pods off a `metrics-api` trigger pointing at
-  `jobs-api`'s `/jobs/counts`
-- **PostgreSQL** — persisted across `tilt up` / `tilt down` by a PVC
-- **Azurite** — Azure Blob Storage emulator, on the well-known dev account
-  `devstoreaccount1`, persisting blobs at `/data` by a PVC
+- **Tilt** — orchestrates one namespace per worktree; the root `Tiltfile` is the
+  entry point
+- **Minikube** — the shared cluster
+- **KEDA** — scales workflow pods off a `metrics-api` trigger pointing at the
+  worktree's `jobs-api` `/jobs/counts`; installed once, cluster-wide
+- **PostgreSQL** — one per worktree, persisted across `tilt up` / `tilt down` by
+  a PVC
+- **Azurite** — Azure Blob Storage emulator, one per worktree, on the well-known
+  dev account `devstoreaccount1`, persisting blobs at `/data` by a PVC
 
 ## Layout
 
@@ -37,42 +56,63 @@ dev/
     workflows/            a ScaledJob per workflow
   scripts/
     ensure-minikube.sh    Start the cluster if it is not already running
-    init.sh               Create or reset the cluster
-    wipe.sh               Delete the StatefulSets and their PVCs
+    init.sh               One-time cluster-wide setup: addons, KEDA, certificate
+    up.sh                 Bring up this worktree's instance and start Tilt
+    down.sh               Delete this worktree's namespace
+    wipe.sh               Delete this worktree's StatefulSets and their PVCs
+    lib.sh                Shared helper: derive the worktree namespace slug
 ```
 
 ## Getting started
 
-1. Create the cluster:
+1. Run the one-time cluster setup:
 
    ```shell
    bash dev/scripts/init.sh
    ```
 
-   This deletes any existing cluster, creates one with preset resource limits,
-   enables the `ingress` and `metrics-server` addons, issues an mkcert
-   certificate for `virtool.local` and installs it as the ingress controller's
-   default, and writes the cluster IP to `/etc/hosts` — which needs `sudo`.
+   This starts Minikube, enables the `metrics-server` and `ingress` addons,
+   installs KEDA, and issues a wildcard mkcert certificate for
+   `*.<minikube-ip>.nip.io` that it installs as the ingress controller's
+   default. It touches no worktree data and is safe to re-run — re-run it after
+   a `minikube delete` to refresh the certificate against the new IP.
 
    Run `mkcert -install` once beforehand so the certificate is trusted.
 
-2. Start Tilt:
+2. Bring up this worktree's instance:
 
    ```shell
-   tilt up
+   bash dev/scripts/up.sh
    ```
 
-   Virtool is then at <https://virtool.local>.
+   This creates the namespace, installs the shared certificate into it, and
+   starts Tilt on an automatically chosen UI port. The namespace defaults to the
+   worktree directory name; set `WT` for a short, memorable slug:
 
-`tilt down` brings the resources back down; run it before `minikube stop` or
-the cluster does not stop cleanly. The `Tiltfile` calls
-`dev/scripts/ensure-minikube.sh` as it loads, so `tilt up` starts a stopped cluster
-on its own.
+   ```shell
+   WT=vir3044 bash dev/scripts/up.sh
+   ```
+
+   The instance is then at `https://<WT>.<minikube-ip>.nip.io` — the Tilt UI
+   prints the exact host.
+
+3. Tear the instance down when you are done:
+
+   ```shell
+   bash dev/scripts/down.sh
+   ```
+
+   This deletes the namespace and its data. Other worktrees, KEDA, the ingress
+   controller and the certificate are untouched.
+
+The `Tiltfile` calls `dev/scripts/ensure-minikube.sh` as it loads, so `up.sh`
+starts a stopped cluster on its own. Run `tilt down` (or `down.sh`) before
+`minikube stop` so the cluster stops cleanly.
 
 ## Live editing
 
 Every live-edit target builds from this repository's root `Dockerfile`, at the
-stage named after the target. Pass a flag to turn one on:
+stage named after the target. Pass a flag through `up.sh` to turn one on:
 
 | Flag | Image | Dockerfile stage |
 | --- | --- | --- |
@@ -83,7 +123,7 @@ stage named after the target. Pass a flag to turn one on:
 | `--nuvs` | `ghcr.io/virtool/nuvs` | `nuvs` |
 | `--pathoscope` | `ghcr.io/virtool/pathoscope` | `pathoscope` |
 
-Flags combine: `tilt up -- --web --internal`.
+Flags combine: `bash dev/scripts/up.sh --web --internal`.
 
 `--web` runs Vite in the pod and syncs `apps/web/src` and `packages` into it,
 so an edit shows up without a rebuild. The rest rebuild the image on change,
@@ -104,6 +144,21 @@ the newest release each time it starts and no tag is ever committed. The
 migration Job runs `ghcr.io/virtool/internal`'s `migrate` subcommand and follows
 the same tag or local Tilt build as the `jobs-api` and `tasks` Deployments,
 which run the same image.
+
+Worktrees share one Minikube Docker daemon but do not collide over images: Tilt
+tags each build with a content hash, so two worktrees building the same image
+name get distinct tags that coexist, and each injects its own tag into its own
+namespace.
+
+## Namespacing
+
+The manifests hard-code the `default` namespace in service FQDNs and
+`virtool.local` as the ingress host, so each file stays valid on its own under
+`kubectl apply -f`. The `Tiltfile` rewrites both for the worktree as it loads:
+`*.default.svc.cluster.local` becomes `*.<WT>.svc.cluster.local`, `virtool.local`
+becomes the worktree's nip.io host, and every object is placed in the `WT`
+namespace. The KEDA operator runs cluster-wide and resolves each workflow's
+trigger URL by its fully-qualified `<WT>` service name.
 
 ## Labels
 
@@ -135,10 +190,11 @@ the other is an OOMKill rather than a faster run.
 
 ## Wiping data
 
-`dev/scripts/wipe.sh` deletes the `postgres` and `azurite` StatefulSets and their
-PVCs; Tilt recreates them on the next trigger. It refuses to run unless
-`kubectl`'s current context is `minikube`. Run it directly or click **Wipe** in
-the Tilt UI.
+`dev/scripts/wipe.sh` deletes the `postgres` and `azurite` StatefulSets and
+their PVCs in one worktree's namespace; Tilt recreates them on the next
+trigger. It targets the namespace named by `WT` (or its first argument) and
+refuses to run unless `kubectl`'s current context is `minikube`. Run it directly
+or click **Wipe** in the Tilt UI, which passes the worktree namespace for you.
 
 ## Why none of this is linted or bundled
 

--- a/dev/scripts/down.sh
+++ b/dev/scripts/down.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Tear down this worktree's dev instance. Deletes the namespace and everything
+# in it, including the Postgres and Azurite data. Other worktrees, KEDA, the
+# ingress controller and the shared certificate are untouched. Pass a slug or
+# set `WT` to target a namespace other than this worktree's default.
+
+set -e
+
+source "$(dirname "$0")/lib.sh"
+
+NS=$(wt_slug "$1")
+echo "Tearing down worktree instance in namespace '$NS'..."
+
+kubectl delete namespace "$NS" --ignore-not-found
+
+echo "Done. Other worktrees are unaffected."

--- a/dev/scripts/down.sh
+++ b/dev/scripts/down.sh
@@ -9,6 +9,8 @@ set -e
 
 source "$(dirname "$0")/lib.sh"
 
+require_minikube_context
+
 NS=$(wt_slug "$1")
 echo "Tearing down worktree instance in namespace '$NS'..."
 

--- a/dev/scripts/init.sh
+++ b/dev/scripts/init.sh
@@ -1,39 +1,55 @@
 #!/bin/bash
 
+# One-time, cluster-wide setup shared by every worktree. It starts Minikube,
+# installs the singletons — metrics-server, the ingress addon and KEDA — and
+# issues one wildcard `*.<minikube-ip>.nip.io` certificate that every
+# worktree's ingress reuses. Per-worktree bring-up is `dev/scripts/up.sh`.
+#
+# Safe to re-run. It does not delete the cluster or any data; run
+# `minikube delete` by hand for a clean slate. Re-run it after a cluster
+# recreate to refresh the certificate against the new Minikube IP.
+
 set -e
 
-echo "Deleting any existing Minikube cluster..."
-minikube delete --purge=true
+CERT_STORE="${XDG_DATA_HOME:-$HOME/.local/share}/virtool-dev"
 
-echo "Starting Minikube for first time..."
-minikube start --cpus 8 --memory 16000
+echo "Starting Minikube..."
+if ! minikube status >/dev/null 2>&1; then
+    minikube start --cpus 8 --memory 16000
+fi
 
-echo "Enabling Minikube addons..."
+echo "Enabling metrics-server addon..."
 minikube addons enable metrics-server
 
-echo "Generating TLS certificate for virtool.local..."
-CERT_DIR=$(mktemp -d)
-mkcert -key-file "$CERT_DIR/key.pem" -cert-file "$CERT_DIR/cert.pem" virtool.local
+echo "Installing KEDA..."
+helm repo add kedacore https://kedacore.github.io/charts >/dev/null
+helm repo update kedacore >/dev/null
+helm upgrade --install keda kedacore/keda \
+    --namespace keda \
+    --create-namespace \
+    --version 2.20.2
 
-echo "Creating TLS secrets..."
+MINIKUBE_IP=$(minikube ip)
+
+echo "Generating wildcard TLS certificate for *.${MINIKUBE_IP}.nip.io..."
+echo "Run 'mkcert -install' once beforehand so the certificate is trusted."
+mkdir -p "$CERT_STORE"
+mkcert \
+    -key-file "$CERT_STORE/key.pem" \
+    -cert-file "$CERT_STORE/cert.pem" \
+    "*.${MINIKUBE_IP}.nip.io"
+
+echo "Installing the certificate as the ingress controller's default..."
 kubectl -n kube-system create secret tls mkcert \
-    --key "$CERT_DIR/key.pem" \
-    --cert "$CERT_DIR/cert.pem"
-kubectl create secret tls mkcert \
-    --key "$CERT_DIR/key.pem" \
-    --cert "$CERT_DIR/cert.pem"
+    --key "$CERT_STORE/key.pem" \
+    --cert "$CERT_STORE/cert.pem" \
+    --dry-run=client -o yaml | kubectl apply -f -
 
-echo "Cleaning up temporary certificate files..."
-rm -rf "$CERT_DIR"
-
-echo "Configuring ingress addon to use custom certificate..."
-minikube addons configure ingress <<< "kube-system/mkcert"
+echo "Configuring ingress addon to use the certificate..."
+# The second line answers the "overwrite existing cert? [y/n]" prompt that
+# minikube adds only when a custom cert is already set; on a first run there is
+# no such prompt and the extra line is harmlessly ignored.
+printf 'kube-system/mkcert\ny\n' | minikube addons configure ingress
 minikube addons enable ingress
 
-echo "Verifying ingress configuration..."
-kubectl -n ingress-nginx get deployment ingress-nginx-controller -o yaml | grep "kube-system"
-
-echo "Configuring /etc/hosts..."
-MINIKUBE_IP=$(minikube ip)
-sudo sed -i '/virtool.local/d' /etc/hosts
-echo -e "$MINIKUBE_IP\tvirtool.local" | sudo tee -a /etc/hosts
+echo "Done. Start a worktree instance with: bash dev/scripts/up.sh"

--- a/dev/scripts/init.sh
+++ b/dev/scripts/init.sh
@@ -34,6 +34,7 @@ MINIKUBE_IP=$(minikube ip)
 echo "Generating wildcard TLS certificate for *.${MINIKUBE_IP}.nip.io..."
 echo "Run 'mkcert -install' once beforehand so the certificate is trusted."
 mkdir -p "$CERT_STORE"
+rm -f "$CERT_STORE/key.pem" "$CERT_STORE/cert.pem"
 mkcert \
     -key-file "$CERT_STORE/key.pem" \
     -cert-file "$CERT_STORE/cert.pem" \

--- a/dev/scripts/lib.sh
+++ b/dev/scripts/lib.sh
@@ -2,11 +2,24 @@
 
 # Shared helpers for the per-worktree dev scripts.
 
+# Namespaces holding shared, cluster-wide resources. A worktree slug must never
+# resolve to one of these, or bring-up and teardown would clobber resources
+# every worktree depends on.
+WT_RESERVED_NAMESPACES=(
+    default
+    ingress-nginx
+    keda
+    kube-node-lease
+    kube-public
+    kube-system
+)
+
 # Print the namespace slug for this worktree. Source order: an explicit
 # argument, then `$WT`, then the worktree directory name. The result is a valid
 # DNS-1123 label — lowercased, non-alphanumerics collapsed to hyphens, trimmed
 # to 63 characters with no leading or trailing hyphen. Set `WT` to a short,
-# memorable slug; the directory-name fallback can be long and truncated.
+# memorable slug; the directory-name fallback can be long and truncated. Exits
+# non-zero if the slug is empty or names a reserved shared namespace.
 wt_slug() {
     local raw="${1:-${WT:-}}"
     if [[ -z "$raw" ]]; then
@@ -14,5 +27,32 @@ wt_slug() {
     fi
     raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g')
     raw=${raw:0:63}
-    printf '%s' "$raw" | sed -E 's/^-+//; s/-+$//'
+    raw=$(printf '%s' "$raw" | sed -E 's/^-+//; s/-+$//')
+
+    if [[ -z "$raw" ]]; then
+        echo "Worktree slug is empty after normalization. Set WT to a value with alphanumeric characters." >&2
+        return 1
+    fi
+
+    local reserved
+    for reserved in "${WT_RESERVED_NAMESPACES[@]}"; do
+        if [[ "$raw" == "$reserved" ]]; then
+            echo "Worktree slug '$raw' is a reserved shared namespace. Set WT to a different slug." >&2
+            return 1
+        fi
+    done
+
+    printf '%s' "$raw"
+}
+
+# Exit non-zero unless the current kubectl context is Minikube. Guards
+# destructive operations from running against another cluster.
+require_minikube_context() {
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || true)
+    if [[ "$current_context" != "minikube" ]]; then
+        echo "Refusing to run: kubectl current-context is '${current_context:-<none>}', expected 'minikube'." >&2
+        echo "Switch contexts with: kubectl config use-context minikube" >&2
+        return 1
+    fi
 }

--- a/dev/scripts/lib.sh
+++ b/dev/scripts/lib.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Shared helpers for the per-worktree dev scripts.
+
+# Print the namespace slug for this worktree. Source order: an explicit
+# argument, then `$WT`, then the worktree directory name. The result is a valid
+# DNS-1123 label — lowercased, non-alphanumerics collapsed to hyphens, trimmed
+# to 63 characters with no leading or trailing hyphen. Set `WT` to a short,
+# memorable slug; the directory-name fallback can be long and truncated.
+wt_slug() {
+    local raw="${1:-${WT:-}}"
+    if [[ -z "$raw" ]]; then
+        raw=$(basename "$(git rev-parse --show-toplevel)")
+    fi
+    raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g')
+    raw=${raw:0:63}
+    printf '%s' "$raw" | sed -E 's/^-+//; s/-+$//'
+}

--- a/dev/scripts/up.sh
+++ b/dev/scripts/up.sh
@@ -12,8 +12,8 @@ source "$(dirname "$0")/lib.sh"
 
 CERT_STORE="${XDG_DATA_HOME:-$HOME/.local/share}/virtool-dev"
 
-if [[ ! -f "$CERT_STORE/cert.pem" ]]; then
-    echo "No wildcard certificate found. Run 'bash dev/scripts/init.sh' first."
+if [[ ! -f "$CERT_STORE/cert.pem" || ! -f "$CERT_STORE/key.pem" ]]; then
+    echo "No wildcard certificate and key found. Run 'bash dev/scripts/init.sh' first."
     exit 1
 fi
 

--- a/dev/scripts/up.sh
+++ b/dev/scripts/up.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Bring up this worktree's dev instance in its own namespace. Creates the
+# namespace, installs the shared wildcard certificate into it, then starts
+# Tilt. Set `WT` to name the namespace, or let it default to the worktree
+# directory name. Extra arguments pass through as Tilt live-edit flags, e.g.
+# `bash dev/scripts/up.sh --web --internal`.
+
+set -e
+
+source "$(dirname "$0")/lib.sh"
+
+CERT_STORE="${XDG_DATA_HOME:-$HOME/.local/share}/virtool-dev"
+
+if [[ ! -f "$CERT_STORE/cert.pem" ]]; then
+    echo "No wildcard certificate found. Run 'bash dev/scripts/init.sh' first."
+    exit 1
+fi
+
+NS=$(wt_slug)
+echo "Bringing up worktree instance in namespace '$NS'..."
+
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret tls mkcert \
+    --cert "$CERT_STORE/cert.pem" \
+    --key "$CERT_STORE/key.pem" \
+    -n "$NS" --dry-run=client -o yaml | kubectl apply -f -
+
+exec env WT="$NS" tilt up --port 0 -- "$@"

--- a/dev/scripts/wipe.sh
+++ b/dev/scripts/wipe.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source "$(dirname "$0")/lib.sh"
+
 current_context=$(kubectl config current-context 2>/dev/null || true)
 if [[ "$current_context" != "minikube" ]]; then
     echo "Refusing to wipe: kubectl current-context is '${current_context:-<none>}', expected 'minikube'."
@@ -13,11 +15,13 @@ if ! minikube status >/dev/null 2>&1; then
     exit 1
 fi
 
-echo "Deleting StatefulSets..."
-kubectl delete statefulset azurite postgres --ignore-not-found
+NS=$(wt_slug "$1")
 
-echo "Deleting PVCs..."
-kubectl delete pvc \
+echo "Deleting StatefulSets in namespace '$NS'..."
+kubectl -n "$NS" delete statefulset azurite postgres --ignore-not-found
+
+echo "Deleting PVCs in namespace '$NS'..."
+kubectl -n "$NS" delete pvc \
     data-azurite-0 \
     data-postgres-0 \
     --ignore-not-found

--- a/dev/scripts/wipe.sh
+++ b/dev/scripts/wipe.sh
@@ -3,12 +3,7 @@ set -e
 
 source "$(dirname "$0")/lib.sh"
 
-current_context=$(kubectl config current-context 2>/dev/null || true)
-if [[ "$current_context" != "minikube" ]]; then
-    echo "Refusing to wipe: kubectl current-context is '${current_context:-<none>}', expected 'minikube'."
-    echo "Switch contexts with: kubectl config use-context minikube"
-    exit 1
-fi
+require_minikube_context
 
 if ! minikube status >/dev/null 2>&1; then
     echo "Refusing to wipe: Minikube is not running."

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,22 @@
+[tasks.init]
+description = "Set up the shared Minikube services and certificate"
+run = "bash dev/scripts/init.sh"
+
+[tasks."up:minikube"]
+description = "Start Minikube if it is not already running"
+run = "bash dev/scripts/ensure-minikube.sh"
+
+[tasks.up]
+description = "Bring up this worktree's instance and start Tilt"
+raw_args = true
+run = "bash dev/scripts/up.sh"
+
+[tasks.down]
+description = "Delete this worktree's namespace and data"
+raw_args = true
+run = "bash dev/scripts/down.sh"
+
+[tasks.wipe]
+description = "Delete this worktree's StatefulSets and PVCs"
+raw_args = true
+run = "bash dev/scripts/wipe.sh"


### PR DESCRIPTION
## Summary
- Give each git worktree its own Tilt/Minikube dev instance in its own Kubernetes namespace (keyed on `WT`), so parallel branches never collide over ports, data, or images on one cluster.
- Split setup into a one-time cluster-wide `init.sh` (Minikube, addons, KEDA, one wildcard `*.<ip>.nip.io` cert) and per-worktree `up.sh`/`down.sh`; the Tiltfile injects the namespace and rewrites `default` service FQDNs and the `virtool.local` ingress host to the worktree's nip.io host.
- Make KEDA and the ingress cert cluster-wide singletons, run Postgres/Azurite per namespace, auto-assign Tilt port-forwards, and update the dev docs.