### PR TITLE
feat: support per-worktree dev instances in tilt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config.json
 *.log*
 .cache
 .DS_store
+.TILT_PORT
 env
 tags
 .vscode

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,6 +10,7 @@ WT = os.getenv('WT', '')
 if not WT:
     fail('WT is not set. Start the dev instance with `bash dev/scripts/up.sh`.')
 
+WORKTREE_NAME = str(local('git rev-parse --show-toplevel', quiet=True)).strip().rsplit('/', 1)[-1][:32]
 MINIKUBE_IP = str(local('minikube ip', quiet=True)).strip()
 HOST = WT + '.' + MINIKUBE_IP + '.nip.io'
 
@@ -69,6 +70,13 @@ cmd_button('wipe',
     location=location.NAV,
     text='Wipe',
     requires_confirmation=True,
+)
+
+cmd_button('worktree',
+    argv=['true'],
+    icon_name='account_tree',
+    location=location.NAV,
+    text=WORKTREE_NAME,
 )
 
 k8s_yaml(scoped(read_file('dev/manifests/data/azurite.yaml')))

--- a/Tiltfile
+++ b/Tiltfile
@@ -145,8 +145,9 @@ k8s_resource(
     objects=['virtool-env:configmap'],
 )
 
-# Host port 0 lets Tilt pick a free local port, so concurrent worktrees never
-# fight over one. The bound port shows in the Tilt UI.
+# The Tilt UI port is pinned per worktree by dev/scripts/up.sh. Kubernetes
+# resource forwards remain dynamically allocated so concurrent instances do
+# not fight over local service ports.
 k8s_resource(
     'virtool-jobs-api',
     labels=['virtool'],

--- a/Tiltfile
+++ b/Tiltfile
@@ -73,7 +73,7 @@ cmd_button('wipe',
 )
 
 cmd_button('worktree',
-    argv=['true'],
+    argv=['bash', 'dev/scripts/open.sh', 'https://' + HOST],
     icon_name='account_tree',
     location=location.NAV,
     text=WORKTREE_NAME,

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -171,7 +171,10 @@ export default defineConfig(({ command, mode }) => ({
 		],
 	},
 	server: {
-		allowedHosts: ["virtool.local"],
+		allowedHosts: [
+			"virtool.local",
+			process.env.VT_DEV_SERVER_ALLOWED_HOST,
+		].filter(Boolean),
 		warmup: {
 			// Pre-transform the app shell so the first navigation is warm. The `!`
 			// patterns keep the globs off `__tests__` files — those import

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -3,10 +3,15 @@ import babel from "@rolldown/plugin-babel";
 import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import { resolveFileBacked } from "@virtool/contracts/env";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { nitro } from "nitro/vite";
 import { defineConfig } from "vite";
 import pkg from "./package.json" with { type: "json" };
+
+const { VT_DEV_SERVER_ALLOWED_HOST } = resolveFileBacked([
+	"VT_DEV_SERVER_ALLOWED_HOST",
+]);
 
 export default defineConfig(({ command, mode }) => ({
 	build: {
@@ -171,10 +176,7 @@ export default defineConfig(({ command, mode }) => ({
 		],
 	},
 	server: {
-		allowedHosts: [
-			"virtool.local",
-			process.env.VT_DEV_SERVER_ALLOWED_HOST,
-		].filter(Boolean),
+		allowedHosts: ["virtool.local", VT_DEV_SERVER_ALLOWED_HOST].filter(Boolean),
 		warmup: {
 			// Pre-transform the app shell so the first navigation is warm. The `!`
 			// patterns keep the globs off `__tests__` files — those import

--- a/dev/README.md
+++ b/dev/README.md
@@ -69,7 +69,8 @@ dev/
 See the root README for the development commands. The `Tiltfile` calls
 `dev/scripts/ensure-minikube.sh` as it loads, so bringing up an instance also
 starts a stopped Minikube cluster. Run `tilt down` before `minikube stop` so the
-cluster stops cleanly.
+cluster stops cleanly. `mise up` prints the instance URL; in terminals that
+support OSC 8 it is clickable.
 
 ## Live editing
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -27,7 +27,8 @@ wildcard `*.<minikube-ip>.nip.io` certificate covers every worktree.
 
 ## Requirements
 
-Docker Engine, Helm, `kubectl`, `mkcert`, Minikube, Tilt and mise.
+Docker Engine, Helm, `kubectl`, `mkcert`, Minikube, Tilt, mise and either
+`ss` or `lsof` to check which Tilt ports are free.
 
 ## Stack
 

--- a/dev/manifests/config.yaml
+++ b/dev/manifests/config.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/component: config
     app.kubernetes.io/part-of: virtool
 data:
+  VT_DEV_SERVER_ALLOWED_HOST: "virtool.local"
   VT_POSTGRES_URL: "postgres://virtool:virtool@postgres.default.svc.cluster.local:5432/virtool"
   VT_STORAGE_BACKEND: "azure"
   VT_STORAGE_AZURE_ACCOUNT: "devstoreaccount1"

--- a/dev/scripts/open.sh
+++ b/dev/scripts/open.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Open a URL in the default browser. Used by the Tilt 'worktree' nav button.
+set -e
+
+URL="$1"
+
+if command -v xdg-open >/dev/null; then
+    xdg-open "$URL" >/dev/null 2>&1 &
+elif command -v open >/dev/null; then
+    open "$URL"
+else
+    echo "No browser opener found (tried xdg-open, open)." >&2
+    exit 1
+fi

--- a/dev/scripts/up.sh
+++ b/dev/scripts/up.sh
@@ -12,6 +12,7 @@ source "$(dirname "$0")/lib.sh"
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 TILT_PORT_FILE="$REPO_ROOT/.TILT_PORT"
+TILT_PORT_LOCK="$(git rev-parse --path-format=absolute --git-common-dir)/virtool-tilt-port.lock"
 
 CERT_STORE="${XDG_DATA_HOME:-$HOME/.local/share}/virtool-dev"
 
@@ -34,16 +35,22 @@ kubectl create secret tls mkcert \
     --key "$CERT_STORE/key.pem" \
     -n "$NS" --dry-run=client -o yaml | kubectl apply -f -
 
-if ! command -v ss >/dev/null; then
-    echo "Cannot choose a Tilt port: 'ss' is required to check listening ports." >&2
+if command -v ss >/dev/null; then
+    is_tilt_port_available() {
+        local port="$1"
+
+        ! ss -H -ltn | awk -v port=":$port" 'substr($4, length($4) - length(port) + 1) == port { found = 1 } END { exit found ? 0 : 1 }'
+    }
+elif command -v lsof >/dev/null; then
+    is_tilt_port_available() {
+        local port="$1"
+
+        ! lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    }
+else
+    echo "Cannot choose a Tilt port: 'ss' or 'lsof' is required to check listening ports." >&2
     exit 1
 fi
-
-is_tilt_port_available() {
-    local port="$1"
-
-    ! ss -H -ltn | awk -v port=":$port" 'substr($4, length($4) - length(port) + 1) == port { found = 1 } END { exit found ? 0 : 1 }'
-}
 
 is_tilt_port_reserved() {
     local candidate="$1"
@@ -82,6 +89,28 @@ find_tilt_port() {
     return 1
 }
 
+release_tilt_port_lock() {
+    rmdir "$TILT_PORT_LOCK" 2>/dev/null || true
+}
+
+# Selecting a port and writing it to `.TILT_PORT` must be atomic across
+# worktrees. Without the lock, two concurrent `up.sh` runs can both see the same
+# port free and pin it, which leaves each worktree permanently reserved by the
+# other. `mkdir` is the portable atomic test-and-set; the lock lives in the
+# common git directory, which every worktree shares.
+for attempt in {1..100}; do
+    if mkdir "$TILT_PORT_LOCK" 2>/dev/null; then
+        trap release_tilt_port_lock EXIT
+        break
+    fi
+    if [[ "$attempt" == 100 ]]; then
+        echo "Timed out waiting for the Tilt port lock at '$TILT_PORT_LOCK'." >&2
+        echo "Remove it if no other 'up.sh' is running." >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+
 if [[ -f "$TILT_PORT_FILE" ]]; then
     TILT_PORT=$(tr -d '[:space:]' < "$TILT_PORT_FILE")
     if [[ ! "$TILT_PORT" =~ ^[0-9]+$ || "$TILT_PORT" -lt 10350 || "$TILT_PORT" -gt 10370 ]]; then
@@ -103,6 +132,10 @@ else
     printf '%s\n' "$TILT_PORT" > "$TILT_PORT_FILE"
     echo "Pinned Tilt port $TILT_PORT in $TILT_PORT_FILE."
 fi
+
+# `exec` below replaces this process, so the EXIT trap never fires.
+trap - EXIT
+release_tilt_port_lock
 
 echo "Starting Tilt on port $TILT_PORT..."
 exec env WT="$NS" tilt up --port "$TILT_PORT" -- "$@"

--- a/dev/scripts/up.sh
+++ b/dev/scripts/up.sh
@@ -20,6 +20,10 @@ fi
 NS=$(wt_slug)
 echo "Bringing up worktree instance in namespace '$NS'..."
 
+MINIKUBE_IP=$(minikube ip)
+DEV_URL="https://${NS}.${MINIKUBE_IP}.nip.io"
+printf 'Dev URL: \033]8;;%s\033\\%s\033]8;;\033\\\n' "$DEV_URL" "$DEV_URL"
+
 kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
 
 kubectl create secret tls mkcert \

--- a/dev/scripts/up.sh
+++ b/dev/scripts/up.sh
@@ -10,6 +10,9 @@ set -e
 
 source "$(dirname "$0")/lib.sh"
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TILT_PORT_FILE="$REPO_ROOT/.TILT_PORT"
+
 CERT_STORE="${XDG_DATA_HOME:-$HOME/.local/share}/virtool-dev"
 
 if [[ ! -f "$CERT_STORE/cert.pem" || ! -f "$CERT_STORE/key.pem" ]]; then
@@ -31,4 +34,75 @@ kubectl create secret tls mkcert \
     --key "$CERT_STORE/key.pem" \
     -n "$NS" --dry-run=client -o yaml | kubectl apply -f -
 
-exec env WT="$NS" tilt up --port 0 -- "$@"
+if ! command -v ss >/dev/null; then
+    echo "Cannot choose a Tilt port: 'ss' is required to check listening ports." >&2
+    exit 1
+fi
+
+is_tilt_port_available() {
+    local port="$1"
+
+    ! ss -H -ltn | awk -v port=":$port" 'substr($4, length($4) - length(port) + 1) == port { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+is_tilt_port_reserved() {
+    local candidate="$1"
+    local worktree
+    local port_file
+    local reserved_port
+
+    while IFS= read -r worktree; do
+        port_file="$worktree/.TILT_PORT"
+        if [[ -f "$port_file" ]]; then
+            reserved_port=$(tr -d '[:space:]' < "$port_file")
+            if [[ "$reserved_port" == "$candidate" && "$port_file" != "$TILT_PORT_FILE" ]]; then
+                return 0
+            fi
+        fi
+    done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+
+    return 1
+}
+
+find_tilt_port() {
+    local candidate
+    local offset
+    local start
+
+    start=$((RANDOM % 21))
+    for ((offset = 0; offset < 21; offset++)); do
+        candidate=$((10350 + (start + offset) % 21))
+        if is_tilt_port_available "$candidate" && ! is_tilt_port_reserved "$candidate"; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "No available Tilt port found in the range 10350-10370." >&2
+    return 1
+}
+
+if [[ -f "$TILT_PORT_FILE" ]]; then
+    TILT_PORT=$(tr -d '[:space:]' < "$TILT_PORT_FILE")
+    if [[ ! "$TILT_PORT" =~ ^[0-9]+$ || "$TILT_PORT" -lt 10350 || "$TILT_PORT" -gt 10370 ]]; then
+        echo "Invalid Tilt port in '$TILT_PORT_FILE': '$TILT_PORT'. Use a port from 10350-10370." >&2
+        exit 1
+    fi
+    if ! is_tilt_port_available "$TILT_PORT"; then
+        echo "Pinned Tilt port $TILT_PORT from '$TILT_PORT_FILE' is already in use." >&2
+        echo "Stop the existing Tilt instance or edit '$TILT_PORT_FILE' to an unused port from 10350-10370." >&2
+        exit 1
+    fi
+    if is_tilt_port_reserved "$TILT_PORT"; then
+        echo "Pinned Tilt port $TILT_PORT from '$TILT_PORT_FILE' is reserved by another worktree." >&2
+        echo "Edit '$TILT_PORT_FILE' to an unused port from 10350-10370." >&2
+        exit 1
+    fi
+else
+    TILT_PORT=$(find_tilt_port)
+    printf '%s\n' "$TILT_PORT" > "$TILT_PORT_FILE"
+    echo "Pinned Tilt port $TILT_PORT in $TILT_PORT_FILE."
+fi
+
+echo "Starting Tilt on port $TILT_PORT..."
+exec env WT="$NS" tilt up --port "$TILT_PORT" -- "$@"


### PR DESCRIPTION
## Summary
- Reserve a Tilt port per worktree so multiple worktrees can run `tilt up` concurrently without colliding
- Allow the worktree's nip.io host in the Vite dev server config
- Show the current worktree's name in the Tilt nav, with a button that opens its instance URL in the browser