### PR TITLE
fix: preserve dev data on teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ then run these commands from the repository root:
 mise run init          # one-time cluster setup
 mise run up            # bring up this worktree and start Tilt
 mise run up:minikube   # start Minikube only
-mise run down          # delete this worktree's namespace and data
-mise run wipe          # delete this worktree's StatefulSets and PVCs
+mise run down           # tear down workloads, keeping data
+mise run destroy        # delete the namespace, workloads, and data
+mise run wipe           # wipe this worktree's data
 ```
 
 Set `WT` to use a short, memorable namespace slug:

--- a/dev/README.md
+++ b/dev/README.md
@@ -60,7 +60,8 @@ dev/
     ensure-minikube.sh    Start the cluster if it is not already running
     init.sh               One-time cluster-wide setup: addons, KEDA, certificate
     up.sh                 Bring up this worktree's instance and start Tilt
-    down.sh               Delete this worktree's namespace
+    down.sh               Tear down workloads while retaining data
+    destroy.sh            Delete this worktree's namespace and data
     wipe.sh               Delete this worktree's StatefulSets and their PVCs
     lib.sh                Shared helper: derive the worktree namespace slug
 ```
@@ -149,6 +150,12 @@ which leaves room for any one workflow — or both small ones — to schedule.
 Requests are dev-sized reservations and limits carry the headroom, so a
 workflow's `VT_PROC` and `VT_MEM` track its **limits**; raising either without
 the other is an OOMKill rather than a faster run.
+
+## Lifecycle commands
+
+`mise run down` tears down the worktree's workloads while retaining its
+namespace and Postgres/Azurite PVCs. `mise run destroy` deletes the namespace,
+which also deletes all workloads and data; use it when deleting the worktree.
 
 ## Wiping data
 

--- a/dev/scripts/destroy.sh
+++ b/dev/scripts/destroy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Delete this worktree's namespace and everything in it, including its data.
+# Other worktrees and shared cluster resources are untouched.
+
+set -e
+
+source "$(dirname "$0")/lib.sh"
+
+require_minikube_context
+
+NS=$(wt_slug "$1")
+echo "Destroying worktree instance in namespace '$NS'..."
+
+kubectl delete namespace "$NS" --ignore-not-found
+
+echo "Done. Other worktrees are unaffected."

--- a/dev/scripts/down.sh
+++ b/dev/scripts/down.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# Tear down this worktree's dev instance. Deletes the namespace and everything
-# in it, including the Postgres and Azurite data. Other worktrees, KEDA, the
-# ingress controller and the shared certificate are untouched. Pass a slug or
-# set `WT` to target a namespace other than this worktree's default.
+# Tear down this worktree's workloads while retaining its Postgres and Azurite
+# PVCs. Other worktrees and shared cluster resources are untouched. Pass a slug
+# or set `WT` to target a namespace other than this worktree's default.
 
 set -e
 
@@ -12,8 +11,8 @@ source "$(dirname "$0")/lib.sh"
 require_minikube_context
 
 NS=$(wt_slug "$1")
-echo "Tearing down worktree instance in namespace '$NS'..."
+echo "Tearing down workloads in namespace '$NS'..."
 
-kubectl delete namespace "$NS" --ignore-not-found
+kubectl -n "$NS" delete all,scaledjob,ingress,configmap --all --ignore-not-found
 
-echo "Done. Other worktrees are unaffected."
+echo "Done. Data PVCs and the namespace were retained."

--- a/mise.toml
+++ b/mise.toml
@@ -12,11 +12,16 @@ raw_args = true
 run = "bash dev/scripts/up.sh"
 
 [tasks.down]
-description = "Delete this worktree's namespace and data"
+description = "Tear down this worktree's workloads and keep its data"
 raw_args = true
 run = "bash dev/scripts/down.sh"
 
+[tasks.destroy]
+description = "Delete this worktree's namespace, workloads, and data"
+raw_args = true
+run = "bash dev/scripts/destroy.sh"
+
 [tasks.wipe]
-description = "Delete this worktree's StatefulSets and PVCs"
+description = "Wipe this worktree's data"
 raw_args = true
 run = "bash dev/scripts/wipe.sh"


### PR DESCRIPTION
## Summary
- Keep worktree data when taking down workloads at the end of the day.
- Add separate destroy and wipe lifecycle commands for explicit data removal.