### PR TITLE
chore: tear down tilt namespaces on worktree removal, add status task

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,4 +1,10 @@
 pre-start = "pnpm install"
 
+# Tear down this worktree's Tilt namespace before the worktree itself is
+# removed, so a leftover namespace does not linger on the shared Minikube
+# cluster. `|| true` keeps a stopped cluster or missing namespace from
+# blocking removal, since teardown here is best-effort cleanup.
+pre-remove = "mise run down || true"
+
 [list]
 url = "http://localhost:{{ branch | hash_port }}"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -4,7 +4,7 @@ pre-start = "pnpm install"
 # removed, so a leftover namespace does not linger on the shared Minikube
 # cluster. `|| true` keeps a stopped cluster or missing namespace from
 # blocking removal, since teardown here is best-effort cleanup.
-pre-remove = "mise run down || true"
+pre-remove = "mise run destroy || true"
 
 [list]
 url = "http://localhost:{{ branch | hash_port }}"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ config.json
 .cache
 .DS_store
 .TILT_PORT
+.WT
 env
 tags
 .vscode

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ mise run up:minikube   # start Minikube only
 mise run down           # tear down workloads, keeping data
 mise run destroy        # delete the namespace, workloads, and data
 mise run wipe           # wipe this worktree's data
+mise run tilt           # show Minikube, Tilt, and worktree namespace status
 ```
 
 Set `WT` to use a short, memorable namespace slug:

--- a/dev/README.md
+++ b/dev/README.md
@@ -63,6 +63,7 @@ dev/
     down.sh               Tear down workloads while retaining data
     destroy.sh            Delete this worktree's namespace and data
     wipe.sh               Delete this worktree's StatefulSets and their PVCs
+    status.sh             Report Minikube, Tilt, and worktree namespace status
     lib.sh                Shared helper: derive the worktree namespace slug
 ```
 

--- a/dev/scripts/lib.sh
+++ b/dev/scripts/lib.sh
@@ -15,15 +15,22 @@ WT_RESERVED_NAMESPACES=(
 )
 
 # Print the namespace slug for this worktree. Source order: an explicit
-# argument, then `$WT`, then the worktree directory name. The result is a valid
-# DNS-1123 label — lowercased, non-alphanumerics collapsed to hyphens, trimmed
-# to 63 characters with no leading or trailing hyphen. Set `WT` to a short,
-# memorable slug; the directory-name fallback can be long and truncated. Exits
-# non-zero if the slug is empty or names a reserved shared namespace.
+# argument, then `$WT`, then the slug pinned in `.WT` by a prior `up.sh` run,
+# then the worktree directory name. The result is a valid DNS-1123 label —
+# lowercased, non-alphanumerics collapsed to hyphens, trimmed to 63 characters
+# with no leading or trailing hyphen. Set `WT` to a short, memorable slug; the
+# directory-name fallback can be long and truncated. Exits non-zero if the
+# slug is empty or names a reserved shared namespace.
 wt_slug() {
     local raw="${1:-${WT:-}}"
     if [[ -z "$raw" ]]; then
-        raw=$(basename "$(git rev-parse --show-toplevel)")
+        local repo_root
+        repo_root=$(git rev-parse --show-toplevel)
+        if [[ -f "$repo_root/.WT" ]]; then
+            raw=$(tr -d '[:space:]' < "$repo_root/.WT")
+        else
+            raw=$(basename "$repo_root")
+        fi
     fi
     raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g')
     raw=${raw:0:63}

--- a/dev/scripts/status.sh
+++ b/dev/scripts/status.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
 # Report the shared dev cluster's status: whether Minikube is running, and
-# for each worktree's namespace, whether it exists in the cluster and
-# whether its Tilt server is running.
+# for every worktree slug found either as a git worktree or as a namespace
+# in the cluster, whether each side still exists and whether its Tilt server
+# is running. A namespace with no matching worktree means removal never
+# tore it down, whether by `wt remove` failing its pre-remove hook or by a
+# worktree that predates that hook.
 
 set -e
+
+source "$(dirname "$0")/lib.sh"
 
 if command -v ss >/dev/null; then
     is_port_listening() {
@@ -30,6 +35,18 @@ slug_for() {
     printf '%s' "$raw" | sed -E 's/^-+//; s/-+$//'
 }
 
+is_reserved_namespace() {
+    local candidate="$1"
+    local reserved
+
+    for reserved in "${WT_RESERVED_NAMESPACES[@]}"; do
+        if [[ "$candidate" == "$reserved" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 if minikube status >/dev/null 2>&1; then
     MINIKUBE_STATUS="up"
 else
@@ -38,34 +55,63 @@ fi
 echo "Minikube: $MINIKUBE_STATUS"
 echo
 
-NAMESPACES=""
+declare -A WORKTREE_FOR_SLUG
+while IFS= read -r worktree; do
+    WORKTREE_FOR_SLUG[$(slug_for "$worktree")]="$worktree"
+done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+
+declare -A NAMESPACE_EXISTS
 if [[ "$MINIKUBE_STATUS" == "up" && "$(kubectl config current-context 2>/dev/null)" == "minikube" ]]; then
-    NAMESPACES=" $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}') "
+    while IFS= read -r namespace; do
+        is_reserved_namespace "$namespace" || NAMESPACE_EXISTS[$namespace]=1
+    done < <(kubectl get namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 fi
 
-{
-    printf 'NAMESPACE\tIN TILT\tTILT SERVER\n'
-    while IFS= read -r worktree; do
-        slug=$(slug_for "$worktree")
+SLUGS=$( { printf '%s\n' "${!WORKTREE_FOR_SLUG[@]}"; printf '%s\n' "${!NAMESPACE_EXISTS[@]}"; } | sort -u)
 
-        if [[ "$NAMESPACES" == *" $slug "* ]]; then
+{
+    printf 'SLUG\tWORKTREE\tNAMESPACE\tTILT SERVER\n'
+    while IFS= read -r slug; do
+        [[ -z "$slug" ]] && continue
+
+        worktree="${WORKTREE_FOR_SLUG[$slug]:-}"
+        if [[ -n "${NAMESPACE_EXISTS[$slug]:-}" ]]; then
             ns_state="exists"
         else
             ns_state="missing"
         fi
 
-        port_file="$worktree/.TILT_PORT"
-        if [[ -f "$port_file" ]]; then
-            port=$(tr -d '[:space:]' < "$port_file")
-            if is_port_listening "$port"; then
-                tilt_state="up (port $port)"
-            else
-                tilt_state="down (port $port)"
-            fi
+        if [[ -n "$worktree" ]]; then
+            wt_state="exists"
         else
-            tilt_state="never started"
+            wt_state="removed"
         fi
 
-        printf '%s\t%s\t%s\n' "$slug" "$ns_state" "$tilt_state"
-    done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+        tilt_state="n/a"
+        if [[ -n "$worktree" ]]; then
+            port_file="$worktree/.TILT_PORT"
+            if [[ -f "$port_file" ]]; then
+                port=$(tr -d '[:space:]' < "$port_file")
+                if is_port_listening "$port"; then
+                    tilt_state="up (port $port)"
+                else
+                    tilt_state="down (port $port)"
+                fi
+            else
+                tilt_state="never started"
+            fi
+        fi
+
+        printf '%s\t%s\t%s\t%s\n' "$slug" "$wt_state" "$ns_state" "$tilt_state"
+    done <<< "$SLUGS"
 } | column -t -s $'\t'
+
+if [[ "$MINIKUBE_STATUS" == "up" ]]; then
+    for slug in "${!NAMESPACE_EXISTS[@]}"; do
+        if [[ -z "${WORKTREE_FOR_SLUG[$slug]:-}" ]]; then
+            echo
+            echo "Orphaned namespace(s) with no matching worktree: run 'mise run destroy' with WT set to reclaim them."
+            break
+        fi
+    done
+fi

--- a/dev/scripts/status.sh
+++ b/dev/scripts/status.sh
@@ -43,27 +43,29 @@ if [[ "$MINIKUBE_STATUS" == "up" && "$(kubectl config current-context 2>/dev/nul
     NAMESPACES=" $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}') "
 fi
 
-printf '%-25s %-10s %s\n' "NAMESPACE" "IN TILT" "TILT SERVER"
-while IFS= read -r worktree; do
-    slug=$(slug_for "$worktree")
+{
+    printf 'NAMESPACE\tIN TILT\tTILT SERVER\n'
+    while IFS= read -r worktree; do
+        slug=$(slug_for "$worktree")
 
-    if [[ "$NAMESPACES" == *" $slug "* ]]; then
-        ns_state="exists"
-    else
-        ns_state="missing"
-    fi
-
-    port_file="$worktree/.TILT_PORT"
-    if [[ -f "$port_file" ]]; then
-        port=$(tr -d '[:space:]' < "$port_file")
-        if is_port_listening "$port"; then
-            tilt_state="up (port $port)"
+        if [[ "$NAMESPACES" == *" $slug "* ]]; then
+            ns_state="exists"
         else
-            tilt_state="down (port $port)"
+            ns_state="missing"
         fi
-    else
-        tilt_state="never started"
-    fi
 
-    printf '%-25s %-10s %s\n' "$slug" "$ns_state" "$tilt_state"
-done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+        port_file="$worktree/.TILT_PORT"
+        if [[ -f "$port_file" ]]; then
+            port=$(tr -d '[:space:]' < "$port_file")
+            if is_port_listening "$port"; then
+                tilt_state="up (port $port)"
+            else
+                tilt_state="down (port $port)"
+            fi
+        else
+            tilt_state="never started"
+        fi
+
+        printf '%s\t%s\t%s\n' "$slug" "$ns_state" "$tilt_state"
+    done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+} | column -t -s $'\t'

--- a/dev/scripts/status.sh
+++ b/dev/scripts/status.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Report the shared dev cluster's status: whether Minikube is running,
-# whether each worktree's Tilt server is running, and which worktrees have a
-# namespace in the cluster.
+# Report the shared dev cluster's status: whether Minikube is running, and
+# for each worktree's namespace, whether it exists in the cluster and
+# whether its Tilt server is running.
 
 set -e
 
@@ -43,7 +43,7 @@ if [[ "$MINIKUBE_STATUS" == "up" && "$(kubectl config current-context 2>/dev/nul
     NAMESPACES=" $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}') "
 fi
 
-printf '%-25s %-25s %-10s %s\n' "WORKTREE" "NAMESPACE" "IN TILT" "TILT SERVER"
+printf '%-25s %-10s %s\n' "NAMESPACE" "IN TILT" "TILT SERVER"
 while IFS= read -r worktree; do
     slug=$(slug_for "$worktree")
 
@@ -65,5 +65,5 @@ while IFS= read -r worktree; do
         tilt_state="never started"
     fi
 
-    printf '%-25s %-25s %-10s %s\n' "$(basename "$worktree")" "$slug" "$ns_state" "$tilt_state"
+    printf '%-25s %-10s %s\n' "$slug" "$ns_state" "$tilt_state"
 done < <(git worktree list --porcelain | sed -n 's/^worktree //p')

--- a/dev/scripts/status.sh
+++ b/dev/scripts/status.sh
@@ -5,7 +5,9 @@
 # in the cluster, whether each side still exists and whether its Tilt server
 # is running. A namespace with no matching worktree means removal never
 # tore it down, whether by `wt remove` failing its pre-remove hook or by a
-# worktree that predates that hook.
+# worktree that predates that hook. Namespace state prints "unknown" rather
+# than "missing" when Minikube is down or the current kubectl context is not
+# `minikube`, since the cluster was never queried.
 
 set -e
 
@@ -26,9 +28,14 @@ else
     exit 1
 fi
 
-# Mirrors the default slug in lib.sh's wt_slug, but a worktree brought up
-# with a custom WT will show under its directory name here instead.
+# Mirrors lib.sh's wt_slug default: the slug pinned in the worktree's .WT by
+# a prior `up.sh` run, falling back to the directory name.
 slug_for() {
+    if [[ -f "$1/.WT" ]]; then
+        tr -d '[:space:]' < "$1/.WT"
+        return
+    fi
+
     local raw
     raw=$(basename "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g')
     raw=${raw:0:63}
@@ -61,7 +68,9 @@ while IFS= read -r worktree; do
 done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
 
 declare -A NAMESPACE_EXISTS
+NAMESPACES_QUERIED=0
 if [[ "$MINIKUBE_STATUS" == "up" && "$(kubectl config current-context 2>/dev/null)" == "minikube" ]]; then
+    NAMESPACES_QUERIED=1
     while IFS= read -r namespace; do
         is_reserved_namespace "$namespace" || NAMESPACE_EXISTS[$namespace]=1
     done < <(kubectl get namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
@@ -75,7 +84,9 @@ SLUGS=$( { printf '%s\n' "${!WORKTREE_FOR_SLUG[@]}"; printf '%s\n' "${!NAMESPACE
         [[ -z "$slug" ]] && continue
 
         worktree="${WORKTREE_FOR_SLUG[$slug]:-}"
-        if [[ -n "${NAMESPACE_EXISTS[$slug]:-}" ]]; then
+        if [[ "$NAMESPACES_QUERIED" == 0 ]]; then
+            ns_state="unknown"
+        elif [[ -n "${NAMESPACE_EXISTS[$slug]:-}" ]]; then
             ns_state="exists"
         else
             ns_state="missing"
@@ -104,7 +115,7 @@ SLUGS=$( { printf '%s\n' "${!WORKTREE_FOR_SLUG[@]}"; printf '%s\n' "${!NAMESPACE
 
         printf '%s\t%s\t%s\t%s\n' "$slug" "$wt_state" "$ns_state" "$tilt_state"
     done <<< "$SLUGS"
-} | column -t -s $'\t'
+} | if command -v column >/dev/null; then column -t -s $'\t'; else cat; fi
 
 if [[ "$MINIKUBE_STATUS" == "up" ]]; then
     for slug in "${!NAMESPACE_EXISTS[@]}"; do

--- a/dev/scripts/status.sh
+++ b/dev/scripts/status.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Report the shared dev cluster's status: whether Minikube is running,
+# whether each worktree's Tilt server is running, and which worktrees have a
+# namespace in the cluster.
+
+set -e
+
+if command -v ss >/dev/null; then
+    is_port_listening() {
+        local port="$1"
+
+        ss -H -ltn | awk -v port=":$port" 'substr($4, length($4) - length(port) + 1) == port { found = 1 } END { exit found ? 0 : 1 }'
+    }
+elif command -v lsof >/dev/null; then
+    is_port_listening() {
+        lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+    }
+else
+    echo "Cannot check Tilt ports: 'ss' or 'lsof' is required." >&2
+    exit 1
+fi
+
+# Mirrors the default slug in lib.sh's wt_slug, but a worktree brought up
+# with a custom WT will show under its directory name here instead.
+slug_for() {
+    local raw
+    raw=$(basename "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g')
+    raw=${raw:0:63}
+    printf '%s' "$raw" | sed -E 's/^-+//; s/-+$//'
+}
+
+if minikube status >/dev/null 2>&1; then
+    MINIKUBE_STATUS="up"
+else
+    MINIKUBE_STATUS="down"
+fi
+echo "Minikube: $MINIKUBE_STATUS"
+echo
+
+NAMESPACES=""
+if [[ "$MINIKUBE_STATUS" == "up" && "$(kubectl config current-context 2>/dev/null)" == "minikube" ]]; then
+    NAMESPACES=" $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}') "
+fi
+
+printf '%-25s %-25s %-10s %s\n' "WORKTREE" "NAMESPACE" "IN TILT" "TILT SERVER"
+while IFS= read -r worktree; do
+    slug=$(slug_for "$worktree")
+
+    if [[ "$NAMESPACES" == *" $slug "* ]]; then
+        ns_state="exists"
+    else
+        ns_state="missing"
+    fi
+
+    port_file="$worktree/.TILT_PORT"
+    if [[ -f "$port_file" ]]; then
+        port=$(tr -d '[:space:]' < "$port_file")
+        if is_port_listening "$port"; then
+            tilt_state="up (port $port)"
+        else
+            tilt_state="down (port $port)"
+        fi
+    else
+        tilt_state="never started"
+    fi
+
+    printf '%-25s %-25s %-10s %s\n' "$(basename "$worktree")" "$slug" "$ns_state" "$tilt_state"
+done < <(git worktree list --porcelain | sed -n 's/^worktree //p')

--- a/dev/scripts/up.sh
+++ b/dev/scripts/up.sh
@@ -22,6 +22,7 @@ if [[ ! -f "$CERT_STORE/cert.pem" || ! -f "$CERT_STORE/key.pem" ]]; then
 fi
 
 NS=$(wt_slug)
+printf '%s\n' "$NS" > "$REPO_ROOT/.WT"
 echo "Bringing up worktree instance in namespace '$NS'..."
 
 MINIKUBE_IP=$(minikube ip)

--- a/mise.toml
+++ b/mise.toml
@@ -25,3 +25,7 @@ run = "bash dev/scripts/destroy.sh"
 description = "Wipe this worktree's data"
 raw_args = true
 run = "bash dev/scripts/wipe.sh"
+
+[tasks.tilt]
+description = "Show Minikube, Tilt, and worktree namespace status"
+run = "bash dev/scripts/status.sh"


### PR DESCRIPTION
## Summary
- Add a `pre-remove` worktrunk hook that runs `mise run down` before a worktree is deleted, so its Tilt namespace doesn't linger on the shared Minikube cluster.
- Add a `mise run tilt` task (`dev/scripts/status.sh`) that reports Minikube status and, for every worktree slug found either as a git worktree or as a cluster namespace, whether each side still exists and whether its Tilt server is running — surfacing orphaned namespaces left behind by worktrees removed before this hook existed.