### PR TITLE
fix: discard queued email when delivery is disabled

### DIFF
--- a/apps/internal/README.md
+++ b/apps/internal/README.md
@@ -233,7 +233,10 @@ a rate has a prior sample and a failure series at zero reads as evidence.
 `virtool_email_accepted_age_seconds` is deliberately unlabelled, because
 splitting it by template would thin the samples behind every quantile.
 `virtool_email_availability` is one-hot, so
-`virtool_email_availability{state="ready"} == 1` is directly alertable.
+`virtool_email_availability{state="ready"} == 1` is directly alertable. The
+`disabled` state still delivers: switching sending off stops new mail entering
+the outbox, and `deliver_email` drains what was already queued, so the outbox
+gauge falls to zero instead of holding until sending returns.
 
 The probe listener (`run`) accepts only `GET`. `/health/live` returns a static
 success and never checks Postgres — a database outage must not restart every pod

--- a/apps/internal/src/run/tasks/deliver-email.test.ts
+++ b/apps/internal/src/run/tasks/deliver-email.test.ts
@@ -12,7 +12,10 @@ import {
 	createTestDatabase,
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
-import { enqueueEmail } from "@virtool/data/email/outbox";
+import {
+	type EnqueueEmailInput,
+	enqueueEmail,
+} from "@virtool/data/email/outbox";
 import {
 	EMAIL_DELIVERY_DEADLINE_SECONDS,
 	EMAIL_MAX_ATTEMPTS,
@@ -261,15 +264,33 @@ const template = {
 	verifyUrl: "https://virtool.example/verify?token=abc",
 } as const;
 
+/** Enqueue a fixture message, failing the test if it was discarded. */
+async function queue(
+	overrides: Partial<EnqueueEmailInput> = {},
+): Promise<{ created: boolean; outboxId: number }> {
+	const result = await enqueueEmail(db, {
+		idempotencyKey: "email_verification/1/1",
+		recipient: "someone@example.com",
+		template,
+		...overrides,
+	});
+
+	if (result.status !== "queued") {
+		throw new Error("expected the message to be queued");
+	}
+
+	return result;
+}
+
+async function disableSending(): Promise<void> {
+	await db.update(settings).set({ emailEnabled: false });
+}
+
 describe("deliverEmailTask", () => {
 	it("sends a due row and records provider acceptance", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "email_verification/1/1",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue();
 
 		const fetchMock = stubSend(jsonResponse(200, { id: "msg_1" }));
 
@@ -291,13 +312,24 @@ describe("deliverEmailTask", () => {
 		expect(recorded.acceptedAges).toHaveLength(1);
 	});
 
-	it("leaves rows queued and sends nothing while delivery is disabled", async () => {
+	it("drains the backlog while sending is disabled", async () => {
+		await seedEmailSettings();
+
+		const { outboxId } = await queue({ idempotencyKey: "a" });
+
+		await disableSending();
+
+		const fetchMock = stubSend(jsonResponse(200, { id: "msg_1" }));
+
+		await runDrain();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect((await readOutboxRow(outboxId)).status).toBe("accepted");
+		expect(recorded.availabilities).toEqual(["disabled"]);
+	});
+
+	it("sends nothing while disabled once the backlog is empty", async () => {
 		await seedEmailSettings({ enabled: false });
-		await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
 
 		const fetchMock = stubSend();
 
@@ -305,7 +337,6 @@ describe("deliverEmailTask", () => {
 
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(recorded.availabilities).toEqual(["disabled"]);
-		expect(recorded.outboxSets).toBe(1);
 	});
 
 	it("reports unconfigured and sends nothing without a stored key", async () => {
@@ -323,11 +354,7 @@ describe("deliverEmailTask", () => {
 		await seedEmailSettings();
 		ctx = { ...ctx, keyring: keys() };
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		const fetchMock = stubSend();
 
@@ -345,11 +372,7 @@ describe("deliverEmailTask", () => {
 	it("schedules a retry for a retryable provider failure", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		stubSend(providerError(500, "internal_server_error"));
 
@@ -369,11 +392,7 @@ describe("deliverEmailTask", () => {
 	it("fails a row terminally on a permanent provider rejection", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		stubSend(providerError(422, "validation_error"));
 
@@ -389,11 +408,7 @@ describe("deliverEmailTask", () => {
 	it("fails a row terminally once its attempts are exhausted", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		await db
 			.update(emailOutbox)
@@ -414,11 +429,7 @@ describe("deliverEmailTask", () => {
 	it("fails a row terminally once its delivery deadline has passed", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		await ageRow(outboxId, EMAIL_DELIVERY_DEADLINE_SECONDS + 3600);
 
@@ -437,11 +448,7 @@ describe("deliverEmailTask", () => {
 	it("fails a rate-limited row past its deadline instead of waiting out the quota", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		await ageRow(outboxId, EMAIL_DELIVERY_DEADLINE_SECONDS + 3600);
 
@@ -456,11 +463,7 @@ describe("deliverEmailTask", () => {
 	it("keeps retrying a rate-limited row inside its deadline", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		await ageRow(outboxId, EMAIL_DELIVERY_DEADLINE_SECONDS - 3600);
 
@@ -480,11 +483,7 @@ describe("deliverEmailTask", () => {
 	it("clamps a long provider retry-after to the remaining deadline", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "a" });
 
 		const remainingSeconds = 600;
 
@@ -505,16 +504,8 @@ describe("deliverEmailTask", () => {
 	it("stops the drain and releases the rows when the stored key is empty", async () => {
 		await seedEmailSettings({ apiKey: "" });
 
-		const first = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
-		await enqueueEmail(db, {
-			idempotencyKey: "b",
-			recipient: "someone@example.com",
-			template,
-		});
+		const first = await queue({ idempotencyKey: "a" });
+		await queue({ idempotencyKey: "b" });
 
 		const fetchMock = stubSend(jsonResponse(200, { id: "msg_1" }));
 
@@ -537,16 +528,8 @@ describe("deliverEmailTask", () => {
 	it("stops the drain and releases the row when the provider rejects the API key", async () => {
 		await seedEmailSettings();
 
-		const first = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
-		await enqueueEmail(db, {
-			idempotencyKey: "b",
-			recipient: "someone@example.com",
-			template,
-		});
+		const first = await queue({ idempotencyKey: "a" });
+		await queue({ idempotencyKey: "b" });
 
 		const fetchMock = stubSend(providerError(401, "invalid_api_key"));
 
@@ -570,16 +553,8 @@ describe("deliverEmailTask", () => {
 	it("stops the drain after a rate limit, leaving the rest for the next run", async () => {
 		await seedEmailSettings();
 
-		const first = await enqueueEmail(db, {
-			idempotencyKey: "a",
-			recipient: "someone@example.com",
-			template,
-		});
-		await enqueueEmail(db, {
-			idempotencyKey: "b",
-			recipient: "someone@example.com",
-			template,
-		});
+		const first = await queue({ idempotencyKey: "a" });
+		await queue({ idempotencyKey: "b" });
 
 		const fetchMock = stubSend(providerError(429, "rate_limit_exceeded"));
 
@@ -600,11 +575,7 @@ describe("deliverEmailTask", () => {
 	it("fails queued rows with unsupported template versions", async () => {
 		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "unsupported-version",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "unsupported-version" });
 
 		await db
 			.update(emailOutbox)
@@ -627,11 +598,7 @@ describe("deliverEmailTask", () => {
 		await seedEmailSettings();
 
 		for (let i = 0; i < 3; i++) {
-			await enqueueEmail(db, {
-				idempotencyKey: `key/${i}`,
-				recipient: "someone@example.com",
-				template,
-			});
+			await queue({ idempotencyKey: `key/${i}` });
 		}
 
 		const fetchMock = stubSend(jsonResponse(200, { id: "msg" }));
@@ -663,11 +630,7 @@ describe("deliverEmailTask", () => {
 		await seedEmailSettings();
 
 		for (let i = 0; i < CLAIM_BATCH_SIZE + 1; i++) {
-			await enqueueEmail(db, {
-				idempotencyKey: `budget/${i}`,
-				recipient: "someone@example.com",
-				template,
-			});
+			await queue({ idempotencyKey: `budget/${i}` });
 		}
 
 		const clock = stubElapsed();
@@ -705,13 +668,9 @@ describe("deliverEmailTask", () => {
 	});
 
 	it("prunes terminal rows past retention", async () => {
-		await seedEmailSettings({ enabled: false });
+		await seedEmailSettings();
 
-		const { outboxId } = await enqueueEmail(db, {
-			idempotencyKey: "old",
-			recipient: "someone@example.com",
-			template,
-		});
+		const { outboxId } = await queue({ idempotencyKey: "old" });
 
 		await db
 			.update(emailOutbox)

--- a/apps/internal/src/run/tasks/deliver-email.ts
+++ b/apps/internal/src/run/tasks/deliver-email.ts
@@ -282,7 +282,10 @@ export const deliverEmailTask = defineTask<typeof payload, TaskContext>({
 				);
 			}
 
-			if (availability !== "ready" || state.apiKey === null) {
+			// Delivery turns on the resolved configuration, not on `enabled`. That
+			// flag gates intake, so this task drains what was queued before sending
+			// was switched off.
+			if (state.availability !== "ready" || state.apiKey === null) {
 				ctx.metrics.setEmailOutbox(await countEmailOutbox(ctx.db));
 
 				return;

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -548,8 +548,9 @@ The section is four independent forms, so no action can submit another's
 values:
 
 - **Send email** switches delivery on and off on its own. Turning it off keeps
-  the stored key and every other setting; it only stops queued mail from being
-  sent. Turning it on needs a configuration the server has already resolved.
+  the stored key and every other setting; it stops new mail entering the outbox,
+  and mail queued before the switch is still sent. Turning it on needs a
+  configuration the server has already resolved.
 - **Sender identity** saves the sender name, the sender address, and an optional
   reply-to address. An empty reply-to sends replies to the sender address. The
   server validates authoritatively and the fields re-render from its response.
@@ -575,7 +576,8 @@ Four status states render distinctly:
 | Configuration Error | The stored key cannot be decrypted with the encryption key this instance is running with. |
 
 The **Sending** control is separate from the status presentation. Disabling it
-preserves the configuration but stops queued mail from being sent.
+preserves the configuration and discards new mail rather than holding it. The
+backlog queued before the switch still goes out.
 
 A configuration error is never reported as a missing key. The stored value is
 intact and is not changed, so the fix is the encryption key rather than the API

--- a/apps/web/src/administration/components/email/EmailDelivery.tsx
+++ b/apps/web/src/administration/components/email/EmailDelivery.tsx
@@ -43,7 +43,7 @@ export default function EmailDelivery() {
 			<section>
 				<SectionHeader level={3}>
 					<h3>Sending</h3>
-					<p>Choose whether queued email is sent.</p>
+					<p>Choose whether this instance accepts email for delivery.</p>
 				</SectionHeader>
 				<BoxGroup>
 					<EmailDeliverySending settings={data} />

--- a/apps/web/src/administration/components/email/EmailDeliverySending.tsx
+++ b/apps/web/src/administration/components/email/EmailDeliverySending.tsx
@@ -4,7 +4,7 @@ import Switch from "@base/Switch";
 import type { EmailSettings } from "@virtool/contracts";
 import { getEmailErrorMessage } from "./errors";
 
-/** Control whether queued email is sent. */
+/** Control whether this instance accepts new email for delivery. */
 export default function EmailDeliverySending({
 	settings,
 }: {
@@ -23,7 +23,8 @@ export default function EmailDeliverySending({
 				<div>
 					<p className="font-semibold">Enable</p>
 					<p className="text-gray-600 text-sm">
-						Turn on this setting to send email.
+						Turn this setting off and new email is discarded rather than held.
+						Email already queued still goes out.
 					</p>
 					{mutation.isError ? (
 						<p className="text-red-600 text-sm" role="alert">

--- a/apps/web/src/administration/components/email/EmailDeliverySending.tsx
+++ b/apps/web/src/administration/components/email/EmailDeliverySending.tsx
@@ -22,7 +22,9 @@ export default function EmailDeliverySending({
 			<div className="flex items-center justify-between gap-5">
 				<div>
 					<p className="font-semibold">Enable</p>
-					<p className="text-gray-600 text-sm">New email is not sent when disabled.</p>
+					<p className="text-gray-600 text-sm">
+						New email is not sent when disabled.
+					</p>
 					{mutation.isError ? (
 						<p className="text-red-600 text-sm" role="alert">
 							{getEmailErrorMessage(mutation.error)}

--- a/apps/web/src/administration/components/email/EmailDeliverySending.tsx
+++ b/apps/web/src/administration/components/email/EmailDeliverySending.tsx
@@ -22,10 +22,7 @@ export default function EmailDeliverySending({
 			<div className="flex items-center justify-between gap-5">
 				<div>
 					<p className="font-semibold">Enable</p>
-					<p className="text-gray-600 text-sm">
-						Turn this setting off and new email is discarded rather than held.
-						Email already queued still goes out.
-					</p>
+					<p className="text-gray-600 text-sm">New email is not sent when disabled.</p>
 					{mutation.isError ? (
 						<p className="text-red-600 text-sm" role="alert">
 							{getEmailErrorMessage(mutation.error)}

--- a/apps/web/src/administration/components/email/EmailDeliveryStatus.tsx
+++ b/apps/web/src/administration/components/email/EmailDeliveryStatus.tsx
@@ -68,10 +68,7 @@ function Detail({ settings }: { settings: EmailSettings }) {
 			return settings.enabled ? (
 				<p>Email is configured and sending is enabled.</p>
 			) : (
-				<p>
-					Email is configured, but sending is turned off. New email is
-					discarded, not held for later. Anything already queued still goes out.
-				</p>
+				<p>Email is configured, but sending is turned off.</p>
 			);
 
 		case "unconfigured":

--- a/apps/web/src/administration/components/email/EmailDeliveryStatus.tsx
+++ b/apps/web/src/administration/components/email/EmailDeliveryStatus.tsx
@@ -68,7 +68,10 @@ function Detail({ settings }: { settings: EmailSettings }) {
 			return settings.enabled ? (
 				<p>Email is configured and sending is enabled.</p>
 			) : (
-				<p>Email is configured, but sending is turned off.</p>
+				<p>
+					Email is configured, but sending is turned off. New email is
+					discarded, not held for later. Anything already queued still goes out.
+				</p>
 			);
 
 		case "unconfigured":

--- a/apps/web/src/administration/components/email/__tests__/EmailDelivery.test.tsx
+++ b/apps/web/src/administration/components/email/__tests__/EmailDelivery.test.tsx
@@ -51,10 +51,12 @@ describe("<EmailDelivery>", () => {
 
 			renderWithProviders(<EmailDelivery />);
 
-			expect(await findStatus()).toHaveTextContent("Disabled");
-			expect(
-				screen.getByText("Turn on this setting to send email."),
-			).toBeVisible();
+			const status = await findStatus();
+
+			expect(status).toHaveTextContent("Disabled");
+			expect(status).toHaveTextContent(
+				"New email is discarded, not held for later.",
+			);
 		});
 
 		it("names the fields an unconfigured instance is missing", async () => {

--- a/apps/web/src/administration/components/email/__tests__/EmailDelivery.test.tsx
+++ b/apps/web/src/administration/components/email/__tests__/EmailDelivery.test.tsx
@@ -51,12 +51,8 @@ describe("<EmailDelivery>", () => {
 
 			renderWithProviders(<EmailDelivery />);
 
-			const status = await findStatus();
-
-			expect(status).toHaveTextContent("Disabled");
-			expect(status).toHaveTextContent(
-				"New email is discarded, not held for later.",
-			);
+			expect(await findStatus()).toHaveTextContent("Disabled");
+			expect(screen.getByText(/new email is not sent/i)).toBeVisible();
 		});
 
 		it("names the fields an unconfigured instance is missing", async () => {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -221,8 +221,12 @@ templates, retries, and the Resend integration. The periodic `deliver_email`
 task in `apps/internal` performs delivery.
 
 Disabled, unconfigured, or invalid email configuration does not prevent the
-services from running. Only `ready` permits delivery. Provider acceptance is
-not proof of mailbox delivery.
+services from running. Only a `ready` configuration permits delivery. Provider
+acceptance is not proof of mailbox delivery.
+
+The `enabled` flag gates intake, not delivery. While sending is off,
+`enqueueEmail` writes no row and answers `{ status: "discarded" }`, and
+`deliver_email` drains whatever was queued before the switch.
 
 The Resend API key is encrypted under the environment-owned encryption key
 documented in [docs/env.md](../../docs/env.md#encryption-key). Neither the
@@ -234,6 +238,9 @@ Features enqueue mail through `enqueueEmail(db, input)` in
 - Pass an `EmailTemplate` and a stable domain idempotency key, never HTML.
 - Use a transaction when domain state and its email must commit together.
 - Keep provider errors, retries, and the Resend SDK behind the email package.
+- Handle `{ status: "discarded" }`. It is an ordinary outcome, not an error:
+  a flow that depends on the email must offer the user another route rather
+  than fail.
 
 A failing row is retried with jittered exponential backoff, or on the
 provider's `Retry-After` when it sends one. Retries stop at the delivery

--- a/packages/data/src/email/outbox.test.ts
+++ b/packages/data/src/email/outbox.test.ts
@@ -1,8 +1,10 @@
 import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import type { Db } from "../db/pg";
+import type { Db, DbOrTx } from "../db/pg";
 import { type EmailOutboxRow, emailOutbox } from "../db/schema/emailOutbox";
+import { settings } from "../db/schema/settings";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { seedSettings } from "../settings/test/fixtures";
 import {
 	claimDueEmails,
 	countEmailOutbox,
@@ -29,7 +31,13 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	await db.delete(emailOutbox);
+	await db.delete(settings);
+	await seedSettings(db, { emailEnabled: true });
 });
+
+async function disableSending(): Promise<void> {
+	await db.update(settings).set({ emailEnabled: false });
+}
 
 function input(overrides: Partial<EnqueueEmailInput> = {}): EnqueueEmailInput {
 	return {
@@ -42,6 +50,20 @@ function input(overrides: Partial<EnqueueEmailInput> = {}): EnqueueEmailInput {
 		},
 		...overrides,
 	};
+}
+
+/** Enqueue a fixture message, failing the test if it was discarded. */
+async function queue(
+	overrides: Partial<EnqueueEmailInput> = {},
+	on: DbOrTx = db,
+): Promise<{ created: boolean; outboxId: number }> {
+	const result = await enqueueEmail(on, input(overrides));
+
+	if (result.status !== "queued") {
+		throw new Error("expected the message to be queued");
+	}
+
+	return result;
 }
 
 async function readRow(outboxId: number): Promise<EmailOutboxRow> {
@@ -63,7 +85,15 @@ describe("enqueueEmail", () => {
 	it("creates a queued row with the template and version", async () => {
 		const result = await enqueueEmail(db, input());
 
-		expect(result.created).toBe(true);
+		expect(result).toEqual({
+			status: "queued",
+			created: true,
+			outboxId: expect.any(Number),
+		});
+
+		if (result.status !== "queued") {
+			throw new Error("expected the message to be queued");
+		}
 
 		const row = await readRow(result.outboxId);
 
@@ -74,22 +104,24 @@ describe("enqueueEmail", () => {
 	});
 
 	it("returns the existing row for a duplicate idempotency key", async () => {
-		const first = await enqueueEmail(db, input());
+		const first = await queue();
 		const second = await enqueueEmail(
 			db,
 			input({ recipient: "other@example.com" }),
 		);
 
-		expect(second).toEqual({ created: false, outboxId: first.outboxId });
+		expect(second).toEqual({
+			status: "queued",
+			created: false,
+			outboxId: first.outboxId,
+		});
 		expect(
 			await db.select({ id: emailOutbox.id }).from(emailOutbox),
 		).toHaveLength(1);
 	});
 
 	it("resolves concurrent duplicate enqueues to one row", async () => {
-		const results = await Promise.all(
-			Array.from({ length: 8 }, () => enqueueEmail(db, input())),
-		);
+		const results = await Promise.all(Array.from({ length: 8 }, () => queue()));
 
 		const ids = new Set(results.map((result) => result.outboxId));
 
@@ -100,7 +132,7 @@ describe("enqueueEmail", () => {
 	it("participates in a caller's transaction", async () => {
 		await db
 			.transaction(async (tx) => {
-				await enqueueEmail(tx, input());
+				await queue({}, tx);
 				throw new Error("roll it back");
 			})
 			.catch(() => {});
@@ -113,15 +145,65 @@ describe("enqueueEmail", () => {
 	it("honors notBefore", async () => {
 		const future = new Date(Date.now() + 60 * 60 * 1000);
 
-		await enqueueEmail(db, input({ notBefore: future }));
+		await queue({ notBefore: future });
 
 		expect(await claimDueEmails(db, claimOptions)).toEqual([]);
+	});
+
+	it("discards the message while sending is disabled", async () => {
+		await disableSending();
+
+		expect(await enqueueEmail(db, input())).toEqual({ status: "discarded" });
+		expect(
+			await db.select({ id: emailOutbox.id }).from(emailOutbox),
+		).toHaveLength(0);
+	});
+
+	it("discards the message when no settings row exists", async () => {
+		await db.delete(settings);
+
+		expect(await enqueueEmail(db, input())).toEqual({ status: "discarded" });
+		expect(
+			await db.select({ id: emailOutbox.id }).from(emailOutbox),
+		).toHaveLength(0);
+	});
+
+	it("discards inside a caller's transaction without failing it", async () => {
+		await disableSending();
+
+		const result = await db.transaction((tx) => enqueueEmail(tx, input()));
+
+		expect(result).toEqual({ status: "discarded" });
+	});
+
+	it("leaves rows queued before sending was disabled alone", async () => {
+		const { outboxId } = await queue();
+
+		await disableSending();
+
+		expect(await enqueueEmail(db, input({ idempotencyKey: "other" }))).toEqual({
+			status: "discarded",
+		});
+		expect((await readRow(outboxId)).status).toBe("queued");
+	});
+
+	it("queues again once sending is re-enabled", async () => {
+		await disableSending();
+
+		expect(await enqueueEmail(db, input())).toEqual({ status: "discarded" });
+
+		await db.update(settings).set({ emailEnabled: true });
+
+		const result = await queue();
+
+		expect(result.created).toBe(true);
+		expect((await readRow(result.outboxId)).status).toBe("queued");
 	});
 });
 
 describe("claimDueEmails", () => {
 	it("claims a due row, incrementing its attempt count", async () => {
-		const { outboxId } = await enqueueEmail(db, input());
+		const { outboxId } = await queue();
 
 		const claimed = await claimDueEmails(db, claimOptions);
 
@@ -136,7 +218,7 @@ describe("claimDueEmails", () => {
 	});
 
 	it("does not hand a live claim to a second claimer", async () => {
-		await enqueueEmail(db, input());
+		await queue();
 
 		await claimDueEmails(db, claimOptions);
 
@@ -146,7 +228,7 @@ describe("claimDueEmails", () => {
 	});
 
 	it("reclaims a row whose claim expired", async () => {
-		const { outboxId } = await enqueueEmail(db, input());
+		const { outboxId } = await queue();
 
 		await claimDueEmails(db, { ...claimOptions, leaseSeconds: 1 });
 
@@ -168,7 +250,7 @@ describe("claimDueEmails", () => {
 
 	it("bounds the batch and takes the oldest-due rows first", async () => {
 		for (let i = 0; i < 5; i++) {
-			await enqueueEmail(db, input({ idempotencyKey: `key/${i}` }));
+			await queue({ idempotencyKey: `key/${i}` });
 		}
 
 		const claimed = await claimDueEmails(db, { ...claimOptions, limit: 3 });
@@ -182,7 +264,7 @@ describe("claimDueEmails", () => {
 	});
 
 	it("ignores terminal rows", async () => {
-		const { outboxId } = await enqueueEmail(db, input());
+		const { outboxId } = await queue();
 		const [claimed] = await claimDueEmails(db, claimOptions);
 
 		if (!claimed) {
@@ -199,7 +281,7 @@ describe("claimDueEmails", () => {
 
 describe("fenced result writes", () => {
 	async function claimOne(): Promise<number> {
-		const { outboxId } = await enqueueEmail(db, input());
+		const { outboxId } = await queue();
 		const claimed = await claimDueEmails(db, claimOptions);
 
 		expect(claimed).toHaveLength(1);
@@ -304,10 +386,10 @@ describe("fenced result writes", () => {
 
 describe("countEmailOutbox", () => {
 	it("splits rows into queued, in-flight, accepted, and failed", async () => {
-		await enqueueEmail(db, input({ idempotencyKey: "a" }));
-		await enqueueEmail(db, input({ idempotencyKey: "b" }));
-		await enqueueEmail(db, input({ idempotencyKey: "c" }));
-		await enqueueEmail(db, input({ idempotencyKey: "d" }));
+		await queue({ idempotencyKey: "a" });
+		await queue({ idempotencyKey: "b" });
+		await queue({ idempotencyKey: "c" });
+		await queue({ idempotencyKey: "d" });
 
 		const claimed = await claimDueEmails(db, { ...claimOptions, limit: 2 });
 
@@ -333,7 +415,7 @@ describe("countEmailOutbox", () => {
 	});
 
 	it("counts a live claim as in flight", async () => {
-		await enqueueEmail(db, input());
+		await queue();
 		await claimDueEmails(db, claimOptions);
 
 		await expect(countEmailOutbox(db)).resolves.toEqual({
@@ -354,10 +436,7 @@ describe("pruneEmailOutbox", () => {
 			status: "accepted" | "failed",
 			ageSeconds: number,
 		): Promise<number> {
-			const { outboxId } = await enqueueEmail(
-				db,
-				input({ idempotencyKey: key }),
-			);
+			const { outboxId } = await queue({ idempotencyKey: key });
 
 			await db
 				.update(emailOutbox)
@@ -374,10 +453,9 @@ describe("pruneEmailOutbox", () => {
 		const freshAccepted = await seedTerminal("fresh-accepted", "accepted", 60);
 		await seedTerminal("old-failed", "failed", 10_000);
 		const agingFailed = await seedTerminal("aging-failed", "failed", 7000);
-		const { outboxId: queued } = await enqueueEmail(
-			db,
-			input({ idempotencyKey: "still-queued" }),
-		);
+		const { outboxId: queued } = await queue({
+			idempotencyKey: "still-queued",
+		});
 
 		await expect(pruneEmailOutbox(db, retention)).resolves.toBe(2);
 

--- a/packages/data/src/email/outbox.ts
+++ b/packages/data/src/email/outbox.ts
@@ -14,6 +14,7 @@ import type { Db, DbOrTx } from "../db/pg";
 import { takeFirst, takeFirstOrThrow } from "../db/rows";
 import { emailOutbox } from "../db/schema/emailOutbox";
 import { nowUtc, secondsAgo } from "../db/time";
+import { isEmailEnabled } from "./settings";
 import { EMAIL_TEMPLATE_VERSION } from "./templates";
 
 /** What {@link enqueueEmail} needs to queue one logical message. */
@@ -29,17 +30,27 @@ export type EnqueueEmailInput = {
 	template: EmailTemplate;
 };
 
-/** What {@link enqueueEmail} returns: the row's identity and whether it is new. */
-export type EnqueueEmailResult = {
-	created: boolean;
-	outboxId: number;
-};
+/** What {@link enqueueEmail} returns: a queued row's identity, or a discard. */
+export type EnqueueEmailResult =
+	| { status: "queued"; created: boolean; outboxId: number }
+	| { status: "discarded" };
 
-/** Queue one message, returning the existing row for a duplicate key. */
+/**
+ * Queue one message, returning the existing row for a duplicate key.
+ *
+ * While sending is switched off the message is discarded and no row is
+ * written. Holding it instead would let an administrator re-enable delivery
+ * days later and send an authentication link nobody is waiting for. Discarding
+ * is an ordinary outcome, not a failure.
+ */
 export async function enqueueEmail(
 	db: DbOrTx,
 	input: EnqueueEmailInput,
 ): Promise<EnqueueEmailResult> {
+	if (!(await isEmailEnabled(db))) {
+		return { status: "discarded" };
+	}
+
 	const inserted = takeFirst(
 		await db
 			.insert(emailOutbox)
@@ -58,7 +69,7 @@ export async function enqueueEmail(
 	);
 
 	if (inserted) {
-		return { created: true, outboxId: inserted.id };
+		return { status: "queued", created: true, outboxId: inserted.id };
 	}
 
 	const existing = takeFirstOrThrow(
@@ -68,7 +79,7 @@ export async function enqueueEmail(
 			.where(eq(emailOutbox.idempotency_key, input.idempotencyKey)),
 	);
 
-	return { created: false, outboxId: existing.id };
+	return { status: "queued", created: false, outboxId: existing.id };
 }
 
 /** A row handed to the delivery loop by {@link claimDueEmails}. */

--- a/packages/data/src/email/settings.test.ts
+++ b/packages/data/src/email/settings.test.ts
@@ -14,6 +14,7 @@ import {
 	clearEmailApiKey,
 	EmailConfigurationError,
 	getEmailSettings,
+	isEmailEnabled,
 	resolveEmailDelivery,
 	setEmailApiKey,
 	updateEmailDelivery,
@@ -254,5 +255,29 @@ describe("setEmailApiKey and clearEmailApiKey", () => {
 
 		expect(cleared.apiKeyEnvelope).toBeNull();
 		expect(cleared.enabled).toBe(false);
+	});
+});
+
+describe("isEmailEnabled", () => {
+	it("is false when no settings row exists", async () => {
+		await expect(isEmailEnabled(db)).resolves.toBe(false);
+	});
+
+	it("is false while sending is switched off", async () => {
+		await seedSettings(db, { emailEnabled: false });
+
+		await expect(isEmailEnabled(db)).resolves.toBe(false);
+	});
+
+	it("is true while sending is switched on", async () => {
+		await seedSettings(db, { emailEnabled: true });
+
+		await expect(isEmailEnabled(db)).resolves.toBe(true);
+	});
+
+	it("does not seed the settings row", async () => {
+		await isEmailEnabled(db);
+
+		expect(await db.select().from(settings)).toHaveLength(0);
 	});
 });

--- a/packages/data/src/email/settings.ts
+++ b/packages/data/src/email/settings.ts
@@ -1,8 +1,8 @@
 import type { EmailAvailability } from "@virtool/contracts";
 import { eq } from "drizzle-orm";
 import type { EncryptedValue, Keyring } from "../crypto/keyring";
-import type { Db } from "../db/pg";
-import { takeFirstOrThrow } from "../db/rows";
+import type { Db, DbOrTx } from "../db/pg";
+import { takeFirst, takeFirstOrThrow } from "../db/rows";
 import { settings as settingsTable } from "../db/schema/settings";
 import { AppError } from "../errors";
 import { getSettings, type Settings } from "../settings/data";
@@ -43,6 +43,28 @@ function toEmailDeliverySettings(settings: Settings): EmailDeliverySettings {
 /** Read the stored email delivery configuration, seeding defaults if absent. */
 export async function getEmailSettings(db: Db): Promise<EmailDeliverySettings> {
 	return toEmailDeliverySettings(await getSettings(db));
+}
+
+/**
+ * Whether new mail may enter the outbox.
+ *
+ * This reads the one flag rather than the whole row, and seeds nothing, so it
+ * can run inside a caller's transaction. A database with no settings row has
+ * never been configured, so the answer is `false`.
+ *
+ * The flag alone decides intake: {@link updateEmailDelivery} refuses to set it
+ * while the configuration does not resolve, and {@link clearEmailApiKey} turns
+ * it off, so `true` already implies a stored key and a sender address.
+ */
+export async function isEmailEnabled(db: DbOrTx): Promise<boolean> {
+	const row = takeFirst(
+		await db
+			.select({ enabled: settingsTable.emailEnabled })
+			.from(settingsTable)
+			.where(eq(settingsTable.id, SETTINGS_ID)),
+	);
+
+	return row?.enabled ?? false;
 }
 
 /** Resolve stored delivery settings against the process keyring. */


### PR DESCRIPTION
## Summary
- `enqueueEmail` now checks the `enabled` flag and discards the message instead of writing an outbox row while delivery is switched off, returning `{ status: "discarded" }`
- `deliver_email` still drains whatever was already queued before sending was disabled, keying off the resolved `availability` rather than `enabled`
- Updates docs and the administration UI/tests to match