### PR TITLE
fix: sync handle input via form values instead of manual reset

### DIFF
--- a/apps/web/src/users/components/Handle.tsx
+++ b/apps/web/src/users/components/Handle.tsx
@@ -8,7 +8,6 @@ import {
 import SaveButton from "@base/SaveButton";
 import SectionHeader from "@base/SectionHeader";
 import { useUpdateUser } from "@users/queries";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 type HandleProps = {
@@ -31,14 +30,7 @@ export default function Handle({ id, handle }: HandleProps) {
 		formState: { errors },
 		handleSubmit,
 		register,
-		reset,
-	} = useForm<FormValues>({ defaultValues: { handle } });
-
-	// Keep the input in sync when the handle prop changes after a successful
-	// update and refetch.
-	useEffect(() => {
-		reset({ handle });
-	}, [handle, reset]);
+	} = useForm<FormValues>({ values: { handle } });
 
 	return (
 		<section>

--- a/apps/web/src/users/components/__tests__/UserDetail.test.tsx
+++ b/apps/web/src/users/components/__tests__/UserDetail.test.tsx
@@ -220,7 +220,11 @@ describe("<UserDetail />", () => {
 			const form = input.closest("form") as HTMLElement;
 			await userEvent.click(within(form).getByRole("button", { name: "Save" }));
 
-			await waitFor(() => expect(updateUser).toHaveBeenCalled());
+			await waitFor(() =>
+				expect(updateUser).toHaveBeenCalledWith({
+					data: { userId: user.id, handle: "new_handle" },
+				}),
+			);
 		});
 
 		it("should show a conflict error when the handle is taken", async () => {


### PR DESCRIPTION
## Summary
- Sync the handle input with `useForm`'s `values` option instead of a manual `useEffect` + `reset` call
- Update the save test to assert `updateUser` is called with the expected payload rather than just checking it was called