### PR TITLE
feat: add pending-account and restricted-setup state

### DIFF
--- a/apps/internal/src/run/spawner.test.ts
+++ b/apps/internal/src/run/spawner.test.ts
@@ -84,10 +84,10 @@ function build(
 
 describe("PERIODIC_TASKS", () => {
 	/**
-	 * Pinning the list means adding an eighth type breaks a test, and so stays a
+	 * Pinning the list means adding a ninth type breaks a test, and so stays a
 	 * deliberate act rather than a line someone appends.
 	 */
-	it("registers exactly the seven periodic names", () => {
+	it("registers exactly the eight periodic names", () => {
 		expect(PERIODIC_TASKS.map(({ type }) => type).toSorted()).toEqual(
 			[...PeriodicTaskName.options].toSorted(),
 		);
@@ -126,6 +126,7 @@ describe("PERIODIC_TASKS", () => {
 			timeout_jobs: 600,
 			evict_caches_lru: 3600,
 			cleanup_sessions: 3600,
+			cleanup_setup_state: 3600,
 			reap_orphaned_uploads: 86400,
 		});
 	});

--- a/apps/internal/src/run/tasks/cleanup-setup-state.test.ts
+++ b/apps/internal/src/run/tasks/cleanup-setup-state.test.ts
@@ -1,0 +1,110 @@
+import {
+	seedSetupSession,
+	seedSetupToken,
+	seedUser,
+} from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { setupSessions, setupTokens } from "@virtool/data/db/schema/setup";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { createLogger, type Logger } from "@virtool/logger";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runTask } from "../framework/run";
+import {
+	claimTask,
+	createTaskTestContext,
+	readTaskRow,
+} from "../testing/tasks";
+import { cleanupSetupStateTask } from "./cleanup-setup-state";
+import type { TaskContext } from "./registry";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let ctx: TaskContext;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(setupSessions);
+	await db.delete(setupTokens);
+	await db.delete(users);
+	await db.delete(tasks);
+
+	ctx = createTaskTestContext({ db });
+});
+
+function minutesFromNow(minutes: number): Date {
+	return new Date(Date.now() + minutes * 60 * 1000);
+}
+
+async function run() {
+	const task = await claimTask(db, cleanupSetupStateTask);
+
+	const outcome = await runTask({
+		db,
+		def: cleanupSetupStateTask,
+		task,
+		ctx,
+		logger,
+		signal: new AbortController().signal,
+	});
+
+	return { outcome, row: await readTaskRow(db, task.id) };
+}
+
+describe("cleanupSetupStateTask", () => {
+	it("deletes the expired tokens and sessions and completes", async () => {
+		const userId = await seedUser(db);
+
+		await seedSetupToken(db, userId, "email_remediation", {
+			expiresAt: minutesFromNow(-30),
+		});
+		await seedSetupToken(db, userId, "account_completion", {
+			expiresAt: minutesFromNow(30),
+		});
+		await seedSetupSession(db, userId, "totp_enrollment", {
+			expiresAt: minutesFromNow(-1),
+		});
+
+		const { outcome, row } = await run();
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(row).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+			step: "cleanup_expired_setup_state",
+		});
+
+		expect(await db.select().from(setupTokens)).toHaveLength(1);
+		expect(await db.select().from(setupSessions)).toHaveLength(0);
+	});
+
+	// Idempotent as a reclaim requires: a re-run deletes whatever is expired
+	// when it runs, which is nothing if the first attempt got there.
+	it("completes without deleting when nothing has expired", async () => {
+		const userId = await seedUser(db);
+		await seedSetupToken(db, userId, "account_completion", {
+			expiresAt: minutesFromNow(30),
+		});
+
+		const { outcome, row } = await run();
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(row).toMatchObject({ complete: true, error: null, progress: 100 });
+		expect(await db.select().from(setupTokens)).toHaveLength(1);
+	});
+});

--- a/apps/internal/src/run/tasks/cleanup-setup-state.ts
+++ b/apps/internal/src/run/tasks/cleanup-setup-state.ts
@@ -1,0 +1,37 @@
+import { deleteExpiredSetupState } from "@virtool/data/auth/setup";
+import { z } from "zod";
+import { defineTask } from "../framework/define";
+import type { TaskContext } from "./registry";
+
+/**
+ * `cleanup_setup_state` carries nothing.
+ */
+const payload = z.object({});
+
+/**
+ * Delete expired setup tokens and restricted setup sessions.
+ *
+ * Kept apart from `cleanup_sessions` rather than folded into it. The two sweep
+ * different tables on different lifetimes, and a single task that failed
+ * part-way would leave whichever half ran second permanently unswept while
+ * reporting the same one failure.
+ *
+ * It is idempotent as a reclaim requires: a re-run deletes whatever is expired
+ * when it runs, which is nothing if the first attempt got there.
+ */
+export const cleanupSetupStateTask = defineTask<typeof payload, TaskContext>({
+	type: "cleanup_setup_state",
+	payload,
+	steps: ["cleanup_expired_setup_state"],
+	async run({ ctx, helpers, logger, signal }) {
+		await helpers.runStep("cleanup_expired_setup_state", async () => {
+			const { tokens, sessions } = await deleteExpiredSetupState(ctx.db, {
+				signal,
+			});
+
+			if (tokens > 0 || sessions > 0) {
+				logger.info({ sessions, tokens }, "cleaned up expired setup state");
+			}
+		});
+	},
+});

--- a/apps/internal/src/run/tasks/periodic.ts
+++ b/apps/internal/src/run/tasks/periodic.ts
@@ -44,7 +44,7 @@ export const SPAWN_TICK_INTERVAL_MS = 30_000;
  * type rather than a backlog, which is what makes the mistake survivable rather
  * than invisible.
  *
- * A test pins this list to exactly these seven, so an eighth is a deliberate
+ * A test pins this list to exactly these eight, so a ninth is a deliberate
  * act.
  *
  * The order is the order each tick walks.
@@ -76,5 +76,14 @@ export const PERIODIC_TASKS: PeriodicTaskRegistration[] = [
 	 * accumulation makes each run a larger delete for no benefit.
 	 */
 	{ type: "cleanup_sessions", intervalSeconds: 3600 },
+	/*
+	 * Hourly, for the same reasons `cleanup_sessions` is. Correctness never
+	 * waits on it either: `consumeSetupToken` and `verifySetupSession` both
+	 * refuse an expired row on sight, so a row lingering between sweeps is
+	 * inert. A restricted setup session lives 30 minutes and a setup link 72
+	 * hours, so hourly keeps the shorter of the two from outliving its expiry
+	 * by much.
+	 */
+	{ type: "cleanup_setup_state", intervalSeconds: 3600 },
 	{ type: "reap_orphaned_uploads", intervalSeconds: 86_400 },
 ];

--- a/apps/internal/src/run/tasks/registry.ts
+++ b/apps/internal/src/run/tasks/registry.ts
@@ -4,6 +4,7 @@ import type { StorageBackend } from "@virtool/storage";
 import type { CompleteTaskRegistry } from "../framework/define";
 import type { Metrics } from "../metrics/registry";
 import { cleanupSessionsTask } from "./cleanup-sessions";
+import { cleanupSetupStateTask } from "./cleanup-setup-state";
 import { cloneReferenceTask } from "./clone-reference";
 import { createIndexTask } from "./create-index";
 import { deliverEmailTask } from "./deliver-email";
@@ -45,6 +46,7 @@ export type TaskContext = {
  */
 export const taskRegistry: CompleteTaskRegistry<TaskContext> = {
 	cleanup_sessions: cleanupSessionsTask,
+	cleanup_setup_state: cleanupSetupStateTask,
 	clone_reference: cloneReferenceTask,
 	create_index: createIndexTask,
 	deliver_email: deliverEmailTask,

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -396,9 +396,10 @@ by rewriting the response body, because doing so buffers the HTML stream.
 ### Authorization and raw routes
 
 Every exported server function declares exactly one policy from
-`@server/auth/policy`: `open()`, `authenticated()`, `adminRole(role)`, or
-`permission(name)`. Read the resolved session from `context.session`; do not
-perform a second session lookup. Row-dependent authorization remains in the
+`@server/auth/policy`: `open()`, `authenticated()`, `adminRole(role)`,
+`permission(name)`, or `setupOnly(purpose)`. Read the resolved session from
+`context.session` — or the restricted credential from `context.restricted` —
+and do not perform a second lookup. Row-dependent authorization remains in the
 handler. Register each new `functions.ts` module in
 `server/__tests__/authorization.test.ts`.
 
@@ -425,9 +426,11 @@ global CSRF middleware in `start.ts` is likewise scoped to
 own origin check against `VT_PUBLIC_ORIGIN`, which
 `@server/auth/betterAuth.test.ts` pins.
 
-Two Virtool states still gate every Better Auth sign-in. A `session.create`
-database hook refuses a user who is not `active` — with the same 401 a wrong
-password gets — and refuses one carrying `force_reset` with a 403, so the
+Three Virtool states still gate every Better Auth sign-in. A `session.create`
+database hook refuses a user who is not `active`, and one whose
+`lifecycle_state` is still `pending` — both with the same 401 a wrong password
+gets, because neither a switched-off account nor an outstanding invitation is
+public information — and refuses one carrying `force_reset` with a 403, so the
 password, passkey and two-factor endpoints are no looser than `login()` in
 `@server/auth/core`. `/sign-in/email` is answered 404 by a `before` hook:
 `emailAndPassword` is enabled only for its bcrypt hashing, and `users.email`
@@ -458,6 +461,55 @@ rather than recorded as ready; `cancelChunkedUploadFn` drops an abandoned or
 rejected reservation. Otherwise it returns `proxied` and the client streams
 through the raw `/uploads` route, which stays the fallback and the rollback path
 — disable the flag to revert.
+
+### The setup boundary
+
+Some accounts are neither anonymous nor fully authenticated: an
+administrator-created account that has not been claimed, an active legacy
+account with no usable unique email, and a user under a `required` MFA policy
+who has not enrolled. Each holds a **restricted setup credential** that
+completes exactly one named transition and reaches nothing else.
+
+The credential is its own cookie pair, `setup_session_id` and
+`setup_session_token`, deliberately not the session pair. `@virtool/data` owns
+the rows and the purposes; this app owns the transport and the boundary.
+
+- `@server/auth/restricted` is the **one** authority for what a restricted
+  caller is. `resolveRestrictedSetup` turns the cookies into a credential
+  carrying a user id, a non-secret session id, one purpose and an expiry —
+  no roles, no permissions, no API-key cap. A second reader would be a second
+  chance to widen it.
+- The **global authentication middleware** enforces the restriction, before
+  any policy runs. An application session wins outright; only then is the
+  restricted credential considered, and a restricted caller is refused
+  anything absent from `@server/auth/setupExceptions` with a 403
+  `SetupRequiredError` naming the purpose. That error crosses the boundary
+  through `serverErrorSerializationAdapter`, and is what tells the router
+  which setup surface the caller belongs on — it carries no token and no
+  authorization data.
+- `setupOnly(purpose)` is the other half. The middleware decides whether a
+  restricted caller may reach a function at all; the policy decides whether
+  the purpose they hold is the one it completes, and refuses an ordinary
+  authenticated caller too.
+- A function listed in `setupExceptions` must declare `setupOnly()` and vice
+  versa. `authorization.test.ts` pins both directions, and separately proves
+  every ordinary server function refuses a restricted principal on its own.
+
+`setupExceptions` is currently empty: the setup surfaces themselves belong to
+the invitation, recovery and required-MFA work, so a restricted principal
+reaches nothing yet.
+
+Raw routes reject restricted principals and always will:
+`requireAuthenticatedRequest` reads the session cookies or an `Authorization`
+header and never the setup pair, so SSE, uploads, downloads and streamed files
+answer a restricted holder the same 401 they answer anyone else. API-key Basic
+authentication is untouched — a restricted credential can never mint, accept
+or inherit a key, and `verifyApiKey` refuses a key whose owner has not
+completed setup.
+
+`logout` is the abandon path. It deletes the restricted session and clears its
+cookies alongside the application pair, so there is one way to end a browser's
+authority rather than one per kind.
 
 ### Server push
 

--- a/apps/web/src/app/queryErrors.ts
+++ b/apps/web/src/app/queryErrors.ts
@@ -2,6 +2,7 @@ import { endSession } from "@app/session";
 import * as Sentry from "@sentry/tanstackstart-react";
 import {
 	FORBIDDEN_ERROR_NAME,
+	SETUP_REQUIRED_ERROR_NAME,
 	UNAUTHORIZED_ERROR_NAME,
 } from "@virtool/contracts";
 
@@ -72,7 +73,10 @@ function reportContractDrift(error: Error): void {
 // ShallowErrorPlugin, so a 401 is matched by name here.
 //
 // A 403 is deliberately not handled: the session is valid, the user just lacks
-// the role, so bouncing them to the login wall would be wrong.
+// the role, so bouncing them to the login wall would be wrong. Nor is a
+// `SetupRequiredError`, for a stronger version of the same reason — the caller
+// holds a live setup credential, and ending their session would take it with
+// it and strand them part-way through a flow.
 export function handleQueryError(error: Error): void {
 	if (error.name === UNAUTHORIZED_ERROR_NAME) {
 		endSession();
@@ -102,7 +106,8 @@ export function shouldRetryQuery(
 	// /login.
 	if (
 		error.name === UNAUTHORIZED_ERROR_NAME ||
-		error.name === FORBIDDEN_ERROR_NAME
+		error.name === FORBIDDEN_ERROR_NAME ||
+		error.name === SETUP_REQUIRED_ERROR_NAME
 	) {
 		return false;
 	}

--- a/apps/web/src/app/serverErrors.ts
+++ b/apps/web/src/app/serverErrors.ts
@@ -2,12 +2,15 @@ import { createSerializationAdapter } from "@tanstack/react-router";
 import {
 	CLIENT_ERROR_NAME,
 	FORBIDDEN_ERROR_NAME,
+	SETUP_REQUIRED_ERROR_NAME,
+	type SetupPurpose,
 	UNAUTHORIZED_ERROR_NAME,
 } from "@virtool/contracts";
 
 const SERVER_ERROR_NAMES = new Set<string>([
 	UNAUTHORIZED_ERROR_NAME,
 	FORBIDDEN_ERROR_NAME,
+	SETUP_REQUIRED_ERROR_NAME,
 	CLIENT_ERROR_NAME,
 ]);
 
@@ -16,6 +19,12 @@ type SerializedServerError = {
 	name: string;
 	message: string;
 	status?: number;
+	/**
+	 * Which setup flow the caller has to complete. Carried only by a
+	 * `SetupRequiredError`, and the whole of what it says — no token, no session
+	 * and nothing about what the holder may do.
+	 */
+	purpose?: SetupPurpose;
 };
 
 /**
@@ -28,7 +37,9 @@ type SerializedServerError = {
  * field the query retry guard and `handleQueryError` use to recognize
  * a 401/403 — without it, an auth failure is retried ~4× with backoff before
  * the guard can bounce to the login wall. It erases a `ClientError`'s `status`
- * too, which is what a route loader reads to turn a 404 into `notFound()`.
+ * too, which is what a route loader reads to turn a 404 into `notFound()`, and
+ * a `SetupRequiredError`'s `purpose`, which is the only thing telling the
+ * router which setup surface a restricted caller belongs on.
  * Registered adapters run before the default plugins, so this one
  * re-serializes our own errors with those fields intact and rebuilds them
  * client-side. Everything else still falls through to `ShallowErrorPlugin`
@@ -45,12 +56,16 @@ export const serverErrorSerializationAdapter = createSerializationAdapter<
 		name: error.name,
 		message: error.message,
 		status: (error as { status?: number }).status,
+		purpose: (error as { purpose?: SetupPurpose }).purpose,
 	}),
-	fromSerializable: ({ name, message, status }) => {
+	fromSerializable: ({ name, message, status, purpose }) => {
 		const error = new Error(message);
 		error.name = name;
 		if (status !== undefined) {
 			Object.assign(error, { status });
+		}
+		if (purpose !== undefined) {
+			Object.assign(error, { purpose });
 		}
 		return error;
 	},

--- a/apps/web/src/server/__tests__/authorization.test.ts
+++ b/apps/web/src/server/__tests__/authorization.test.ts
@@ -48,6 +48,11 @@ vi.mock("@virtool/data/events/emit", () => ({
 
 const { UnauthorizedError } = await import("../auth/middleware");
 const { authenticationExceptions } = await import("../auth/exceptions");
+const { setupEndpoints } = await import("../auth/setupExceptions");
+const { seedSetupSession, seedUser } = await import(
+	"@virtool/data/auth/test/fixtures"
+);
+const { setupSessionCookie } = await import("../auth/test/fixtures");
 
 /**
  * Every module that defines server functions, paired with the split module
@@ -217,8 +222,12 @@ beforeEach(() => {
 });
 
 const openUrls = new Set(authenticationExceptions.map((fn) => fn.url));
+const setupUrls = new Set(setupEndpoints.map(({ fn }) => fn.url));
 
-/** Every exported server function, paired with whether it is declared open. */
+/**
+ * Every exported server function, paired with which of the three reaches it:
+ * anyone, an application session, or a restricted setup principal.
+ */
 const endpoints = MODULES.flatMap(({ fns, handlers, path }) =>
 	Object.entries(fns as Record<string, unknown>).flatMap((entry) => {
 		const [name, value] = entry;
@@ -230,7 +239,15 @@ const endpoints = MODULES.flatMap(({ fns, handlers, path }) =>
 			return [];
 		}
 
-		return [{ handlers, isOpen: openUrls.has(url), name, path }];
+		return [
+			{
+				handlers,
+				isOpen: openUrls.has(url),
+				isSetup: setupUrls.has(url),
+				name,
+				path,
+			},
+		];
 	}),
 );
 
@@ -292,6 +309,86 @@ describe("the open endpoints are reachable without a session", () => {
 	it.each(open.map((endpoint) => [endpoint.name, endpoint] as const))(
 		"%s is not refused for want of a session",
 		async (_name, endpoint) => {
+			const error = await callServerFn(
+				endpoint.handlers,
+				endpoint.name,
+				undefined,
+			).then(
+				() => null,
+				(err: unknown) => err,
+			);
+
+			expect(error).not.toBeInstanceOf(UnauthorizedError);
+		},
+	);
+});
+
+/**
+ * Point the request at a restricted setup credential and nothing else.
+ *
+ * A restricted caller holds neither half of the session cookie pair, which is
+ * why every policy below refuses them without knowing the concept exists.
+ */
+let restrictedUsers = 0;
+
+async function restrictNextCall(): Promise<void> {
+	// A distinct handle per call: `users.handle` is unique case-insensitively
+	// and this runs once per endpoint.
+	restrictedUsers += 1;
+	const userId = await seedUser(db, {
+		handle: `pending${restrictedUsers}`,
+		lifecycleState: "pending",
+	});
+	const session = await seedSetupSession(db, userId, "account_completion");
+
+	getRequest.mockReturnValue(
+		new Request("https://virtool.test/_serverFn/test", {
+			headers: { cookie: setupSessionCookie(session) },
+		}),
+	);
+}
+
+// The other half of the setup boundary. The global middleware refuses a
+// restricted caller anything outside `setupEndpoints` before a policy runs;
+// this proves each policy refuses them on its own too, so the two are not one
+// mistake away from an in-progress setup becoming an ordinary session.
+describe("every server function refuses a restricted setup principal", () => {
+	const guarded = endpoints.filter(
+		(endpoint) => !endpoint.isOpen && !endpoint.isSetup,
+	);
+
+	it.each(guarded.map((endpoint) => [endpoint.name, endpoint] as const))(
+		"%s rejects a restricted caller",
+		async (_name, endpoint) => {
+			await restrictNextCall();
+
+			await expect(
+				callServerFn(endpoint.handlers, endpoint.name, undefined),
+			).rejects.toBeInstanceOf(UnauthorizedError);
+		},
+	);
+});
+
+describe("the setup endpoints are the only ones a restricted caller reaches", () => {
+	const setup = endpoints.filter((endpoint) => endpoint.isSetup);
+
+	// A url in `setupEndpoints` that matches no exported server function is a
+	// stale entry widening the allowlist for nothing.
+	//
+	// The other direction needs no assertion of its own: a function declaring
+	// `setupOnly()` but left out of the list would not refuse the restricted
+	// caller above, and fails there by name.
+	it("resolves every declared entry to an exported server function", () => {
+		expect(setup).toHaveLength(setupEndpoints.length);
+	});
+
+	// They may fail on validation or on missing data — they must not fail for
+	// want of a credential they were never going to be given.
+	it.each(setup.map((endpoint) => [endpoint.name, endpoint] as const))(
+		"%s is not refused for want of an application session",
+		async (_name, endpoint) => {
+			await restrictNextCall();
+
 			const error = await callServerFn(
 				endpoint.handlers,
 				endpoint.name,

--- a/apps/web/src/server/auth/betterAuth.test.ts
+++ b/apps/web/src/server/auth/betterAuth.test.ts
@@ -1,3 +1,4 @@
+import type { AccountLifecycleState } from "@virtool/contracts";
 import type { Db } from "@virtool/data/db/pg";
 import { authAccounts, authSessions } from "@virtool/data/db/schema/auth";
 import { users } from "@virtool/data/db/schema/users";
@@ -67,8 +68,16 @@ function post(path: string, body: unknown, origin = ORIGIN): Request {
  */
 async function seedMigratedUser(
 	hash = LEGACY_HASH,
-	state: { active?: boolean; forceReset?: boolean } = {},
+	state: {
+		active?: boolean;
+		forceReset?: boolean;
+		lifecycleState?: AccountLifecycleState;
+	} = {},
 ): Promise<number> {
+	// A pending row carries no legacy password — `pending_has_no_password`
+	// refuses the pair — so the credential exists only on the Better Auth side,
+	// which is the state a half-finished completion would leave behind.
+	const pending = state.lifecycleState === "pending";
 	const [user] = await db
 		.insert(users)
 		.values({
@@ -77,11 +86,12 @@ async function seedMigratedUser(
 			displayUsername: "Alice",
 			name: "Alice",
 			email: "alice@virtool.test",
-			password: Buffer.from(hash, "utf8"),
+			password: pending ? null : Buffer.from(hash, "utf8"),
 			lastPasswordChange: new Date(),
 			settings: {},
 			active: state.active ?? true,
 			forceReset: state.forceReset ?? false,
+			lifecycleState: state.lifecycleState ?? "normal",
 		})
 		.returning({ id: users.id });
 
@@ -246,6 +256,23 @@ describe("the mounted handler", () => {
 describe("virtool account state", () => {
 	it("refuses a deactivated user with the wrong-password response", async () => {
 		await seedMigratedUser(LEGACY_HASH, { active: false });
+
+		const response = await auth.handler(
+			post("/sign-in/username", {
+				username: "alice",
+				password: LEGACY_PASSWORD,
+			}),
+		);
+
+		expect(response.status).toBe(401);
+		expect(await db.select().from(authSessions)).toHaveLength(0);
+	});
+
+	// A completion transaction moves the account out of `pending` before its
+	// caller mints any session, so an ordinary session can only ever be issued
+	// to an account that is already eligible for one.
+	it("refuses an account that has not completed setup", async () => {
+		await seedMigratedUser(LEGACY_HASH, { lifecycleState: "pending" });
 
 		const response = await auth.handler(
 			post("/sign-in/username", {

--- a/apps/web/src/server/auth/betterAuth.ts
+++ b/apps/web/src/server/auth/betterAuth.ts
@@ -142,23 +142,34 @@ export function createAuth({
 		databaseHooks: {
 			session: {
 				create: {
-					// Better Auth answers *who*, so the two Virtool states that gate a
+					// Better Auth answers *who*, so the Virtool states that gate a
 					// sign-in are enforced at the one point every password, passkey and
 					// two-factor path has to pass through. `login()` in `./core` refuses
-					// the same pair; without this the Better Auth endpoints would be the
+					// the same set; without this the Better Auth endpoints would be the
 					// looser of the two doors on the same accounts.
 					//
 					// A deactivated user gets the same 401 the wrong password gets: that
 					// an account exists but is switched off is not something an
-					// unauthenticated caller should be able to read off the response.
+					// unauthenticated caller should be able to read off the response. An
+					// account that has not completed setup gets it too, and for the same
+					// reason — an outstanding invitation is not public information.
+					//
+					// This is also what keeps a setup flow from short-circuiting itself.
+					// A completion transaction moves the account out of `pending` before
+					// its caller mints any session, so an ordinary session can only ever
+					// be issued to an account that is already eligible for one.
 					before: async (session) => {
 						const [user] = await db
-							.select({ active: users.active, forceReset: users.forceReset })
+							.select({
+								active: users.active,
+								forceReset: users.forceReset,
+								lifecycleState: users.lifecycleState,
+							})
 							.from(users)
 							.where(eq(users.id, Number(session.userId)))
 							.limit(1);
 
-						if (!user?.active) {
+						if (!user?.active || user.lifecycleState !== "normal") {
 							throw new APIError("UNAUTHORIZED", {
 								message: "Invalid credentials",
 								code: "INVALID_CREDENTIALS",

--- a/apps/web/src/server/auth/cookies.test.ts
+++ b/apps/web/src/server/auth/cookies.test.ts
@@ -10,13 +10,21 @@ vi.mock("@tanstack/react-start/server", () => ({
 	setCookie,
 }));
 
-const { realCookies, SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import(
-	"./cookies"
-);
+const {
+	realCookies,
+	SESSION_ID_COOKIE,
+	SESSION_TOKEN_COOKIE,
+	SETUP_SESSION_ID_COOKIE,
+	SETUP_SESSION_TOKEN_COOKIE,
+} = await import("./cookies");
 
 // The max-age set on both cookies. A mismatch would let the session id and
 // session token cookies expire on different schedules.
 const MAX_AGE_SECONDS = 2_600_000;
+
+// The setup pair's, deliberately much shorter: a setup credential is finished
+// with the moment its flow is.
+const SETUP_MAX_AGE_SECONDS = 3_600;
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -103,5 +111,75 @@ describe("realCookies", () => {
 		expect(deleteCookie).toHaveBeenCalledWith(SESSION_TOKEN_COOKIE, {
 			path: "/",
 		});
+	});
+
+	it("reads the setup session cookies", () => {
+		getCookie.mockReturnValue("setup_abc");
+
+		expect(realCookies.getSetupSessionId()).toBe("setup_abc");
+		expect(getCookie).toHaveBeenCalledWith(SETUP_SESSION_ID_COOKIE);
+
+		expect(realCookies.getSetupSessionToken()).toBe("setup_abc");
+		expect(getCookie).toHaveBeenCalledWith(SETUP_SESSION_TOKEN_COOKIE);
+	});
+
+	// Both halves together: a setup session is worthless without either, and
+	// there is no flow that sets one alone.
+	it("writes both setup cookies with the short max-age", () => {
+		realCookies.setSetupSession("setup_abc", "token_abc");
+
+		expect(setCookie).toHaveBeenNthCalledWith(
+			1,
+			SETUP_SESSION_ID_COOKIE,
+			"setup_abc",
+			{
+				httpOnly: true,
+				maxAge: SETUP_MAX_AGE_SECONDS,
+				path: "/",
+				sameSite: "lax",
+				secure: false,
+			},
+		);
+		expect(setCookie).toHaveBeenNthCalledWith(
+			2,
+			SETUP_SESSION_TOKEN_COOKIE,
+			"token_abc",
+			expect.objectContaining({ maxAge: SETUP_MAX_AGE_SECONDS }),
+		);
+	});
+
+	it("marks the setup cookies secure in production", () => {
+		vi.stubEnv("NODE_ENV", "production");
+
+		realCookies.setSetupSession("setup_abc", "token_abc");
+
+		expect(setCookie).toHaveBeenNthCalledWith(
+			1,
+			SETUP_SESSION_ID_COOKIE,
+			"setup_abc",
+			expect.objectContaining({ secure: true }),
+		);
+	});
+
+	it("clears both setup cookies from the root path", () => {
+		realCookies.clearSetup();
+
+		expect(deleteCookie).toHaveBeenCalledTimes(2);
+		expect(deleteCookie).toHaveBeenCalledWith(SETUP_SESSION_ID_COOKIE, {
+			path: "/",
+		});
+		expect(deleteCookie).toHaveBeenCalledWith(SETUP_SESSION_TOKEN_COOKIE, {
+			path: "/",
+		});
+	});
+
+	// The two credentials must not be one rename away from clearing each other.
+	it("does not touch the setup cookies when clearing the session pair", () => {
+		realCookies.clear();
+
+		expect(deleteCookie).not.toHaveBeenCalledWith(
+			SETUP_SESSION_ID_COOKIE,
+			expect.anything(),
+		);
 	});
 });

--- a/apps/web/src/server/auth/cookies.ts
+++ b/apps/web/src/server/auth/cookies.ts
@@ -25,21 +25,52 @@ export const SESSION_ID_COOKIE = "session_id";
 export const SESSION_TOKEN_COOKIE = "session_token";
 
 /**
- * The `max_age` set on both cookies, regardless of the row's actual
+ * The opaque identifier of a restricted setup session. Names the row and
+ * nothing more: it is safe to log and to attribute an error to, and proves
+ * nothing on its own.
+ *
+ * Deliberately not `session_id`. A restricted setup credential is not an
+ * application session, and sharing the cookie name with one would make the two
+ * indistinguishable to every reader — including the ones whose whole job is to
+ * tell them apart.
+ */
+export const SETUP_SESSION_ID_COOKIE = "setup_session_id";
+
+/**
+ * Proves the paired `setup_session_id` belongs to a live restricted setup
+ * session. Only its hash is stored, so the client is the only holder of the
+ * value. It authorizes exactly one setup purpose and reaches nothing else.
+ */
+export const SETUP_SESSION_TOKEN_COOKIE = "setup_session_token";
+
+/**
+ * The `max_age` set on both session cookies, regardless of the row's actual
  * `expires_at`. The browser keeps the cookie alive for ~30 days; the DB
  * row's `expires_at` is the real authority.
  */
 const MAX_AGE_SECONDS = 2_600_000;
 
+/**
+ * The `max_age` set on the setup cookies.
+ *
+ * Deliberately short, unlike the session pair's. A setup credential is
+ * finished with the moment its flow is, and a stale one left in the browser
+ * would be presented on every later request and refused — which is the state
+ * that looks to a user like being stuck. The row's `expires_at` is still the
+ * real authority; this only keeps the browser from holding the pair long after
+ * it can be of any use.
+ */
+const SETUP_MAX_AGE_SECONDS = 3_600;
+
 type Bool = boolean;
 
-function cookieOptions(secure: Bool) {
+function cookieOptions(secure: Bool, maxAge: number = MAX_AGE_SECONDS) {
 	return {
 		httpOnly: true,
 		secure,
 		sameSite: "lax" as const,
 		path: "/",
-		maxAge: MAX_AGE_SECONDS,
+		maxAge,
 	};
 }
 
@@ -47,13 +78,17 @@ function isSecure(): boolean {
 	return process.env.NODE_ENV === "production";
 }
 
-/** Read/write/clear access to the pair of session cookies. */
+/** Read/write/clear access to the session and setup cookies. */
 export type CookieAdapter = {
 	getSessionId(): string | undefined;
 	getSessionToken(): string | undefined;
 	setSessionId(sessionId: string): void;
 	setSessionToken(token: string): void;
 	clear(): void;
+	getSetupSessionId(): string | undefined;
+	getSetupSessionToken(): string | undefined;
+	setSetupSession(sessionId: string, token: string): void;
+	clearSetup(): void;
 };
 
 /* Each method is wrapped in createServerOnlyFn so the references to
@@ -72,5 +107,30 @@ export const realCookies: CookieAdapter = {
 	clear: createServerOnlyFn(() => {
 		deleteCookie(SESSION_ID_COOKIE, { path: "/" });
 		deleteCookie(SESSION_TOKEN_COOKIE, { path: "/" });
+	}),
+	getSetupSessionId: createServerOnlyFn(() =>
+		getCookie(SETUP_SESSION_ID_COOKIE),
+	),
+	getSetupSessionToken: createServerOnlyFn(() =>
+		getCookie(SETUP_SESSION_TOKEN_COOKIE),
+	),
+	/* Both halves together, because a setup session is worthless without either
+	   and there is no flow that sets one alone — unlike the authenticated pair,
+	   where a forced reset deliberately sets `session_id` by itself. */
+	setSetupSession: createServerOnlyFn((sessionId: string, token: string) => {
+		setCookie(
+			SETUP_SESSION_ID_COOKIE,
+			sessionId,
+			cookieOptions(isSecure(), SETUP_MAX_AGE_SECONDS),
+		);
+		setCookie(
+			SETUP_SESSION_TOKEN_COOKIE,
+			token,
+			cookieOptions(isSecure(), SETUP_MAX_AGE_SECONDS),
+		);
+	}),
+	clearSetup: createServerOnlyFn(() => {
+		deleteCookie(SETUP_SESSION_ID_COOKIE, { path: "/" });
+		deleteCookie(SETUP_SESSION_TOKEN_COOKIE, { path: "/" });
 	}),
 };

--- a/apps/web/src/server/auth/core.test.ts
+++ b/apps/web/src/server/auth/core.test.ts
@@ -1,8 +1,13 @@
 import { hashPassword, verifyPassword } from "@virtool/data/auth/password";
 import * as sessionModule from "@virtool/data/auth/session";
-import { seedSession, seedUser } from "@virtool/data/auth/test/fixtures";
+import {
+	seedSession,
+	seedSetupSession,
+	seedUser,
+} from "@virtool/data/auth/test/fixtures";
 import type { Db } from "@virtool/data/db/pg";
 import { sessions } from "@virtool/data/db/schema/sessions";
+import { setupSessions } from "@virtool/data/db/schema/setup";
 import { users } from "@virtool/data/db/schema/users";
 import {
 	createTestDatabase,
@@ -54,12 +59,16 @@ const NEW_PASSWORD = "new-password";
 type FakeCookies = CookieAdapter & {
 	sessionId: string | undefined;
 	token: string | undefined;
+	setupSessionId: string | undefined;
+	setupToken: string | undefined;
 };
 
 function fakeCookies(sessionId?: string): FakeCookies {
 	return {
 		sessionId,
 		token: undefined,
+		setupSessionId: undefined,
+		setupToken: undefined,
 		getSessionId() {
 			return this.sessionId;
 		},
@@ -75,6 +84,20 @@ function fakeCookies(sessionId?: string): FakeCookies {
 		clear() {
 			this.sessionId = undefined;
 			this.token = undefined;
+		},
+		getSetupSessionId() {
+			return this.setupSessionId;
+		},
+		getSetupSessionToken() {
+			return this.setupToken;
+		},
+		setSetupSession(sessionId: string, token: string) {
+			this.setupSessionId = sessionId;
+			this.setupToken = token;
+		},
+		clearSetup() {
+			this.setupSessionId = undefined;
+			this.setupToken = undefined;
 		},
 	};
 }
@@ -94,6 +117,7 @@ afterAll(async () => {
 beforeEach(async () => {
 	vi.mocked(createAuthenticatedSession).mockClear();
 	await db.delete(sessions);
+	await db.delete(setupSessions);
 	await db.delete(users);
 });
 
@@ -335,6 +359,24 @@ describe("createFirstUser", () => {
 });
 
 describe("login", () => {
+	// That an invitation is outstanding is not something an unauthenticated
+	// caller should be able to read off a login response, so a pending account
+	// gets exactly the answer a wrong password gets.
+	it("refuses a pending account as a bad credential", async () => {
+		await seedUser(db, { handle: "alice", lifecycleState: "pending" });
+		const cookies = fakeCookies();
+
+		await expect(
+			login(db, cookies, {
+				handle: "alice",
+				password: OLD_PASSWORD,
+				remember: false,
+				ip: "127.0.0.1",
+			}),
+		).rejects.toBeInstanceOf(InvalidCredentialsError);
+		expect(cookies.sessionId).toBeUndefined();
+	});
+
 	it("authenticates a valid credential and sets both cookies", async () => {
 		const userId = await seedUser(db, {
 			handle: "alice",
@@ -479,5 +521,20 @@ describe("logout", () => {
 		await logout(db, cookies);
 
 		expect(cookies.sessionId).toBeUndefined();
+	});
+
+	// Logout is the abandon path for a setup flow, so it has to end a
+	// restricted credential as thoroughly as it ends an ordinary session.
+	it("invalidates a restricted setup session and clears its cookies", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const setup = await seedSetupSession(db, userId, "account_completion");
+		const cookies = fakeCookies();
+		cookies.setSetupSession(setup.sessionId, setup.token);
+
+		await logout(db, cookies);
+
+		expect(await db.select().from(setupSessions)).toHaveLength(0);
+		expect(cookies.setupSessionId).toBeUndefined();
+		expect(cookies.setupToken).toBeUndefined();
 	});
 });

--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 import type { User } from "@virtool/contracts";
+import { updateAuthPassword } from "@virtool/data/auth/identity";
 import { hashPassword, verifyPassword } from "@virtool/data/auth/password";
 import {
 	consumeResetSession,
@@ -338,6 +339,8 @@ export async function resetPassword(
 					lastPasswordChange: new Date(),
 				})
 				.where(eq(users.id, userId));
+
+			await updateAuthPassword(tx, userId, newHash);
 
 			return createAuthenticatedSession(tx, {
 				userId,

--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -8,6 +8,7 @@ import {
 	invalidateSession,
 	invalidateUserSessions,
 } from "@virtool/data/auth/session";
+import { invalidateSetupSession } from "@virtool/data/auth/setup";
 import type { Db } from "@virtool/data/db/pg";
 import { sessions } from "@virtool/data/db/schema/sessions";
 import { users } from "@virtool/data/db/schema/users";
@@ -152,7 +153,12 @@ export async function login(
 		.where(sql`lower(${users.handle}) = ${handle}`)
 		.limit(1);
 
-	if (!user?.active) {
+	// An account that has not completed setup is refused here too, and with the
+	// same answer. It has no password to verify against — the two conditions
+	// cannot come apart, which `pending_has_no_password` is what holds — and
+	// that an invitation is outstanding is not something an unauthenticated
+	// caller should be able to read off a login response.
+	if (!user?.active || user.lifecycleState !== "normal" || !user.password) {
 		await verifyPassword(input.password, TIMING_DUMMY_HASH);
 		throw new InvalidCredentialsError();
 	}
@@ -183,17 +189,31 @@ export async function login(
 }
 
 /**
- * Delete the session named by the `session_id` cookie and clear both cookies.
+ * Delete the session named by the `session_id` cookie, delete the restricted
+ * setup session named by the `setup_session_id` cookie, and clear every one of
+ * those cookies.
  *
  * Safe to call with no session, or with a stale one: the cookies are cleared
  * either way, which is why `logoutFn` is exempt from authentication.
+ *
+ * This is also the abandon path for a setup flow. A holder who walks away from
+ * an invitation or an enrollment has to be able to drop the credential, and
+ * doing it here means there is one way to end a browser's authority rather
+ * than one per kind.
  */
 export async function logout(db: Db, cookies: CookieAdapter): Promise<void> {
 	const sessionId = cookies.getSessionId();
 	if (sessionId) {
 		await invalidateSession(db, sessionId);
 	}
+
+	const setupSessionId = cookies.getSetupSessionId();
+	if (setupSessionId) {
+		await invalidateSetupSession(db, setupSessionId);
+	}
+
 	cookies.clear();
+	cookies.clearSetup();
 }
 
 /** Inputs to complete a forced-reset password change. */
@@ -275,7 +295,10 @@ export async function resetPassword(
 		.where(eq(users.id, userId))
 		.limit(1);
 
-	if (!user) {
+	// A null password means the account never completed setup, so there is no
+	// forced reset to be part-way through. Nothing can mint a reset session for
+	// one — `login` refuses it before that — so this is a floor.
+	if (!user?.password) {
 		throw new InvalidResetSessionError();
 	}
 

--- a/apps/web/src/server/auth/middleware.test.ts
+++ b/apps/web/src/server/auth/middleware.test.ts
@@ -1,7 +1,11 @@
-import { emptyPermissions } from "@virtool/contracts";
+import {
+	emptyPermissions,
+	SETUP_REQUIRED_ERROR_NAME,
+} from "@virtool/contracts";
 import type { Db } from "@virtool/data/db/pg";
 import { apiKeys } from "@virtool/data/db/schema/apiKeys";
 import { sessions } from "@virtool/data/db/schema/sessions";
+import { setupSessions } from "@virtool/data/db/schema/setup";
 import { users } from "@virtool/data/db/schema/users";
 import {
 	createTestDatabase,
@@ -16,6 +20,7 @@ import {
 	it,
 	vi,
 } from "vitest";
+import type { SetupEndpoint } from "./setupExceptions";
 
 const getRequest = vi.fn();
 const setResponseStatus = vi.fn();
@@ -60,10 +65,11 @@ const { createFirstUserFn, loginFn, logoutFn, resetPasswordFn } = await import(
 );
 const { getPasswordPolicyFn } = await import("../settings/functions");
 const { getRootFn } = await import("../root/functions");
-const { seedApiKey, seedSession, seedUser } = await import(
+const { seedApiKey, seedSession, seedSetupSession, seedUser } = await import(
 	"@virtool/data/auth/test/fixtures"
 );
-const { basicAuthHeader, sessionCookie } = await import("./test/fixtures");
+const { basicAuthHeader, restrictTo, sessionCookie, setupSessionCookie } =
+	await import("./test/fixtures");
 
 let database: TestDatabase;
 
@@ -80,6 +86,7 @@ beforeEach(async () => {
 	vi.clearAllMocks();
 	await db.delete(apiKeys);
 	await db.delete(sessions);
+	await db.delete(setupSessions);
 	await db.delete(users);
 });
 
@@ -89,8 +96,14 @@ type ServerHandler = (options: {
 	serverFnMeta: { id: string };
 }) => Promise<unknown>;
 
-function serverHandler(exceptions: ReadonlyArray<{ url: string }>) {
-	const middleware = createAuthenticationMiddleware(async () => exceptions);
+function serverHandler(
+	exceptions: ReadonlyArray<{ url: string }>,
+	setup: ReadonlyArray<SetupEndpoint> = [],
+) {
+	const middleware = createAuthenticationMiddleware(
+		async () => exceptions,
+		async () => setup,
+	);
 	return (middleware as unknown as { options: { server: ServerHandler } })
 		.options.server;
 }
@@ -168,7 +181,9 @@ describe("createAuthenticationMiddleware", () => {
 			serverFnMeta: metaFor(get()),
 		});
 
-		expect(next).toHaveBeenCalledWith({ context: { session: null } });
+		expect(next).toHaveBeenCalledWith({
+			context: { session: null, restricted: null },
+		});
 		expect(setUser).not.toHaveBeenCalled();
 	});
 
@@ -185,7 +200,9 @@ describe("createAuthenticationMiddleware", () => {
 			serverFnMeta: metaFor(getRootFn),
 		});
 
-		expect(next).toHaveBeenCalledWith({ context: { session: null } });
+		expect(next).toHaveBeenCalledWith({
+			context: { session: null, restricted: null },
+		});
 	});
 
 	it("rejects an unauthenticated call to a fn that is not excepted", async () => {
@@ -217,7 +234,9 @@ describe("createAuthenticationMiddleware", () => {
 			serverFnMeta: { id: "somethingElse" },
 		});
 
-		expect(next).toHaveBeenCalledWith({ context: { session: { userId } } });
+		expect(next).toHaveBeenCalledWith({
+			context: { session: { userId }, restricted: null },
+		});
 	});
 
 	it("ties the acting user to the sentry scope", async () => {
@@ -274,6 +293,140 @@ describe("createAuthenticationMiddleware", () => {
 				next: vi.fn(),
 				serverFnMeta: { id: `${metaFor(loginFn).id}Extra` },
 			}),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+	});
+});
+
+describe("the setup boundary", () => {
+	// This is the whole restriction. A restricted caller is refused at the door,
+	// before the function's own policy could resolve them as an ordinary user,
+	// and the refusal names the flow they belong on rather than the login wall.
+	it("refuses a restricted caller an ordinary fn, naming the purpose", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		await restrictTo(db, getRequest, userId, "account_completion");
+		const next = vi.fn();
+
+		const error = await serverHandler(authenticationExceptions)({
+			next,
+			serverFnMeta: { id: "somethingElse" },
+		}).then(
+			() => null,
+			(err: unknown) => err,
+		);
+
+		expect((error as Error).name).toBe(SETUP_REQUIRED_ERROR_NAME);
+		expect((error as { purpose?: string }).purpose).toBe("account_completion");
+		expect(setResponseStatus).toHaveBeenCalledWith(403);
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("lets a restricted caller reach an allowlisted fn", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const session = await restrictTo(
+			db,
+			getRequest,
+			userId,
+			"account_completion",
+		);
+		const next = vi.fn().mockResolvedValue("result");
+
+		await serverHandler(authenticationExceptions, [
+			{
+				fn: { url: "/_serverFn/completeSetup" },
+				purpose: "account_completion",
+			},
+		])({ next, serverFnMeta: { id: "completeSetup" } });
+
+		expect(next).toHaveBeenCalledWith({
+			context: {
+				session: null,
+				restricted: {
+					userId,
+					sessionId: session.sessionId,
+					purpose: "account_completion",
+					expiresAt: expect.any(Date),
+				},
+			},
+		});
+	});
+
+	// Only the user id, never the session secret.
+	it("attributes a restricted caller by user id alone", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		await restrictTo(db, getRequest, userId, "account_completion");
+
+		await serverHandler(authenticationExceptions)({
+			next: vi.fn(),
+			serverFnMeta: { id: "somethingElse" },
+		}).catch(() => null);
+
+		expect(setUser).toHaveBeenCalledWith({ id: userId });
+	});
+
+	// An application session and a leftover setup cookie describe an ordinary
+	// user, and the session is the half that says so.
+	it("prefers an application session over a setup credential", async () => {
+		const userId = await seedUser(db);
+		const session = await seedSession(db, userId);
+		const setup = await seedSetupSession(db, userId, "totp_enrollment");
+
+		getRequest.mockReturnValue(
+			new Request("https://virtool.test/_serverFn/somethingElse", {
+				headers: {
+					cookie: `${sessionCookie(session)}; ${setupSessionCookie(setup)}`,
+				},
+			}),
+		);
+		const next = vi.fn().mockResolvedValue("result");
+
+		await serverHandler(authenticationExceptions)({
+			next,
+			serverFnMeta: { id: "somethingElse" },
+		});
+
+		expect(next).toHaveBeenCalledWith({
+			context: { session: { userId }, restricted: null },
+		});
+	});
+
+	it("refuses an expired restricted credential as anonymous", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const setup = await seedSetupSession(db, userId, "account_completion", {
+			expiresAt: new Date(Date.now() - 1_000),
+		});
+
+		getRequest.mockReturnValue(
+			requestFor("/_serverFn/somethingElse", setupSessionCookie(setup)),
+		);
+
+		await expect(
+			serverHandler(authenticationExceptions)({
+				next: vi.fn(),
+				serverFnMeta: { id: "somethingElse" },
+			}),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+	});
+
+	// Deactivation is authoritative, and a setup credential must not be the
+	// looser of the two doors.
+	it("refuses a restricted credential once its user is deactivated", async () => {
+		const userId = await seedUser(db, {
+			active: false,
+			lifecycleState: "pending",
+		});
+		const setup = await seedSetupSession(db, userId, "account_completion");
+
+		getRequest.mockReturnValue(
+			requestFor("/_serverFn/somethingElse", setupSessionCookie(setup)),
+		);
+
+		await expect(
+			serverHandler(authenticationExceptions, [
+				{
+					fn: { url: "/_serverFn/completeSetup" },
+					purpose: "account_completion",
+				},
+			])({ next: vi.fn(), serverFnMeta: { id: "completeSetup" } }),
 		).rejects.toBeInstanceOf(UnauthorizedError);
 	});
 });
@@ -338,6 +491,48 @@ describe("requireAuthenticatedRequest", () => {
 
 		const result = await requireAuthenticatedRequest(
 			authorizedRequestFor("/uploads", basicAuthHeader("alice", "wrong")),
+		);
+
+		expect((result as Response).status).toBe(401);
+	});
+
+	// SSE, uploads, downloads and every streamed file go through here, and a
+	// restricted setup credential must reach none of them.
+	it("returns a 401 for a restricted setup credential", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const setup = await seedSetupSession(db, userId, "account_completion");
+
+		const result = await requireAuthenticatedRequest(
+			requestFor("/events", setupSessionCookie(setup)),
+		);
+
+		expect((result as Response).status).toBe(401);
+	});
+
+	// The restriction must not become a way to reach the key path either.
+	it("returns a 401 for a restricted credential presented with an api key header", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const setup = await seedSetupSession(db, userId, "account_completion");
+
+		const request = new Request("https://virtool.test/uploads", {
+			headers: {
+				authorization: basicAuthHeader("alice", "wrong"),
+				cookie: setupSessionCookie(setup),
+			},
+		});
+
+		expect(
+			((await requireAuthenticatedRequest(request)) as Response).status,
+		).toBe(401);
+	});
+
+	it("returns a 401 for an api key belonging to a pending account", async () => {
+		const userId = await seedUser(db, { handle: "ada" });
+		const key = await seedApiKey(db, userId, { upload_file: true });
+		await db.update(users).set({ lifecycleState: "pending", password: null });
+
+		const result = await requireAuthenticatedRequest(
+			authorizedRequestFor("/uploads", basicAuthHeader("ada", key)),
 		);
 
 		expect((result as Response).status).toBe(401);

--- a/apps/web/src/server/auth/middleware.ts
+++ b/apps/web/src/server/auth/middleware.ts
@@ -5,11 +5,13 @@ import {
 	type AdministratorRoleName,
 	FORBIDDEN_ERROR_NAME,
 	hasSufficientAdminRole,
+	type RestrictedSetup,
 	UNAUTHORIZED_ERROR_NAME,
 } from "@virtool/contracts";
 import { users } from "@virtool/data/db/schema/users";
 import { eq } from "drizzle-orm";
 import { db } from "../composition";
+import { resolveRestrictedSetup, SetupRequiredError } from "./restricted";
 import {
 	type AuthenticatedSession,
 	parseBasicAuthHeader,
@@ -75,6 +77,12 @@ export const requireAdminRole = createServerOnlyFn(
  * Handlers do **not** call this. They read `context.session`, which their policy
  * put there; calling this in a handler buys a second Postgres lookup for a
  * session that has already been resolved.
+ *
+ * A restricted setup credential resolves to nothing here, because it is not an
+ * application session: `verifyRequest` reads only the authenticated cookie
+ * pair, and a restricted holder carries neither half of it. That is what makes
+ * every ordinary policy refuse a restricted caller without knowing the concept
+ * exists.
  */
 // createServerOnlyFn keeps the getRequest / db / verifyRequest references
 // behind a server boundary so import-protection doesn't pin
@@ -90,6 +98,13 @@ export const requireSession = createServerOnlyFn(
 	},
 );
 
+// The non-throwing half of `requireSession`, for the global middleware, which
+// has a second credential to consider before it can answer 401.
+const resolveSessionOrNull = createServerOnlyFn(
+	async (): Promise<AuthenticatedSession | null> =>
+		verifyRequest(db, getRequest()),
+);
+
 /**
  * Resolve the identity behind a raw `Request` (used by `createFileRoute`
  * handlers outside the server-function async-local context). Returns a 401
@@ -102,7 +117,12 @@ export const requireSession = createServerOnlyFn(
  *
  * An `Authorization` header commits the request to the key path — a malformed
  * one is a 401 rather than a silent fall back to whatever cookies happen to be
- * attached.
+ * attached. A restricted setup credential in the cookies does not change that
+ * and never could: neither branch here reads the setup cookies, so a
+ * restricted holder gets the same 401 an anonymous caller gets from SSE,
+ * uploads, downloads and every streamed file. `middleware.test.ts` pins it,
+ * because "it happens not to look" is only a guarantee while nobody adds a
+ * third branch.
  */
 export const requireAuthenticatedRequest = createServerOnlyFn(
 	async (request: Request): Promise<AuthenticatedSession | Response> => {
@@ -153,6 +173,32 @@ const loadAuthenticationExceptions = createServerOnlyFn(
 );
 
 /**
+ * What the global middleware hands downstream: exactly one resolved credential,
+ * or neither for a function exempt from authentication.
+ *
+ * Both fields are always present, so a policy reads the one it cares about
+ * without having to know which branch produced the context.
+ */
+export type AuthContext = {
+	session: AuthenticatedSession | null;
+	restricted: RestrictedSetup | null;
+};
+
+/** Resolves the server functions a restricted setup principal may call. */
+export type LoadSetupEndpoints = () => Promise<
+	ReadonlyArray<{ fn: { url: string } }>
+>;
+
+// Loaded the same way, and lazily for the same reason, as the authentication
+// exceptions above.
+const loadSetupEndpoints = createServerOnlyFn(
+	async (): Promise<ReadonlyArray<{ fn: { url: string } }>> => {
+		const { setupEndpoints } = await import("./setupExceptions");
+		return setupEndpoints;
+	},
+);
+
+/**
  * Build the global server-function middleware that enforces authentication on
  * every server function except those in `./exceptions`. Resolved sessions are
  * exposed to downstream handlers as `context.session`.
@@ -176,28 +222,74 @@ const loadAuthenticationExceptions = createServerOnlyFn(
 // function on both paths.
 export function createAuthenticationMiddleware(
 	loadExceptions: LoadAuthenticationExceptions = loadAuthenticationExceptions,
+	loadSetup: LoadSetupEndpoints = loadSetupEndpoints,
 ) {
 	// Resolved on the first call and cached: the ids never change.
 	let exceptionIds: Set<string> | null = null;
+	let setupIds: Set<string> | null = null;
 
 	return createMiddleware({ type: "function" }).server(
 		async ({ next, serverFnMeta }) => {
 			exceptionIds ??= new Set(
 				(await loadExceptions()).map((fn) => serverFnIdFromUrl(fn.url)),
 			);
+			setupIds ??= new Set(
+				(await loadSetup()).map(({ fn }) => serverFnIdFromUrl(fn.url)),
+			);
 
-			const session: AuthenticatedSession | null = exceptionIds.has(
-				serverFnMeta.id,
-			)
-				? null
-				: await requireSession();
-			// Attach the user to the request's isolation scope so errors and logs
-			// from this handler are tied to the acting user. Id-only here — the
-			// handle isn't on the session and isn't worth a per-request lookup.
-			if (session) {
-				Sentry.setUser({ id: session.userId });
-			}
-			return next({ context: { session } });
+			const context: AuthContext = exceptionIds.has(serverFnMeta.id)
+				? { session: null, restricted: null }
+				: await resolvePrincipal(setupIds, serverFnMeta.id);
+
+			return next({ context });
 		},
 	);
 }
+
+/**
+ * Resolve the one credential a request carries, or refuse it.
+ *
+ * The order is the whole of the setup restriction. An application session
+ * wins outright — a holder of both is an ordinary user with a stale setup
+ * cookie left over, and the session is what describes them. Only then is the
+ * restricted credential considered, and a restricted caller is refused
+ * anything outside the allowlist *here*, before the function's own
+ * `authenticated()`, `adminRole()` or `permission()` policy gets a chance to
+ * resolve them as an ordinary user.
+ *
+ * The refusal is a 403 carrying the purpose rather than a 401, because the
+ * caller has a credential — it just does not reach this. That is what tells
+ * the router which setup surface they belong on, and it says nothing about
+ * tokens, sessions or what the holder may do.
+ */
+const resolvePrincipal = createServerOnlyFn(
+	async (setupIds: Set<string>, serverFnId: string): Promise<AuthContext> => {
+		const session = await resolveSessionOrNull();
+
+		if (session) {
+			// Attach the user to the request's isolation scope so errors and logs
+			// from this handler are tied to the acting user. Id-only here — the
+			// handle isn't on the session and isn't worth a per-request lookup.
+			Sentry.setUser({ id: session.userId });
+			return { session, restricted: null };
+		}
+
+		const restricted = await resolveRestrictedSetup(getRequest());
+
+		if (!restricted) {
+			setResponseStatus(401);
+			throw new UnauthorizedError();
+		}
+
+		// The user id, and nothing else. A restricted principal has no role to
+		// attribute and its secret half must not reach a log.
+		Sentry.setUser({ id: restricted.userId });
+
+		if (!setupIds.has(serverFnId)) {
+			setResponseStatus(403);
+			throw new SetupRequiredError(restricted.purpose);
+		}
+
+		return { session: null, restricted };
+	},
+);

--- a/apps/web/src/server/auth/policy.ts
+++ b/apps/web/src/server/auth/policy.ts
@@ -1,16 +1,23 @@
 import { createMiddleware, createServerOnlyFn } from "@tanstack/react-start";
-import { setResponseStatus } from "@tanstack/react-start/server";
+import { getRequest, setResponseStatus } from "@tanstack/react-start/server";
 import {
 	AdministratorPermissions,
 	type AdministratorRoleName,
 	hasSufficientAdminRole,
 	type Permission,
+	type RestrictedSetup,
+	type SetupPurpose,
 } from "@virtool/contracts";
 import { groups, userGroups } from "@virtool/data/db/schema/groups";
 import { users } from "@virtool/data/db/schema/users";
 import { eq } from "drizzle-orm";
 import { db } from "../composition";
-import { ForbiddenError, requireSession } from "./middleware";
+import {
+	ForbiddenError,
+	requireSession,
+	UnauthorizedError,
+} from "./middleware";
+import { resolveRestrictedSetup } from "./restricted";
 import type { AuthenticatedSession } from "./verify";
 
 // Every server function declares one of the policies below with `.middleware()`.
@@ -29,7 +36,10 @@ import type { AuthenticatedSession } from "./verify";
 
 // The global authentication middleware has already resolved the session and put
 // it here. Reusing it keeps an authenticated call to a single session lookup.
-type UpstreamContext = { session?: AuthenticatedSession | null };
+type UpstreamContext = {
+	session?: AuthenticatedSession | null;
+	restricted?: RestrictedSetup | null;
+};
 
 // Absent only in tests, which run a handler without the global middleware.
 const resolveSession = createServerOnlyFn(
@@ -42,6 +52,25 @@ const forbid = createServerOnlyFn((): never => {
 	setResponseStatus(403);
 	throw new ForbiddenError();
 });
+
+// Absent only in tests, which run a handler without the global middleware.
+//
+// 401, not 403: with no restricted credential resolved there is no caller to
+// forbid, and this is the answer every other policy gives an anonymous call.
+const resolveRestricted = createServerOnlyFn(
+	async (context: unknown): Promise<RestrictedSetup> => {
+		const restricted =
+			(context as UpstreamContext).restricted ??
+			(await resolveRestrictedSetup(getRequest()));
+
+		if (!restricted) {
+			setResponseStatus(401);
+			throw new UnauthorizedError();
+		}
+
+		return restricted;
+	},
+);
 
 /**
  * Whether the user holds `name` — through the union of their groups'
@@ -161,6 +190,40 @@ export function permission(name: Permission) {
 			}
 
 			return next({ context: { session } });
+		},
+	);
+}
+
+/**
+ * Callable only by a restricted setup principal whose credential is for
+ * `purpose`, and by nobody else.
+ *
+ * The counterpart to the global middleware's allowlist, and both are required.
+ * The middleware decides whether a restricted caller may reach this function
+ * at all; this decides whether the purpose they hold is the one the function
+ * completes, so an `email_remediation` credential cannot be spent on a TOTP
+ * enrollment endpoint.
+ *
+ * An ordinary authenticated user is refused too. Reaching a setup surface
+ * means a transition is outstanding, and for a user who has completed setup
+ * none is — offering them one would be offering a second way to change a
+ * credential they can already change through their account.
+ *
+ * A function declaring this must appear in `./setupExceptions`, and one that
+ * appears there must declare it. `authorization.test.ts` pins both directions.
+ *
+ * @public
+ */
+export function setupOnly(purpose: SetupPurpose) {
+	return createMiddleware({ type: "function" }).server(
+		async ({ context, next }) => {
+			const restricted = await resolveRestricted(context);
+
+			if (restricted.purpose !== purpose) {
+				forbid();
+			}
+
+			return next({ context: { restricted } });
 		},
 	);
 }

--- a/apps/web/src/server/auth/restricted.test.ts
+++ b/apps/web/src/server/auth/restricted.test.ts
@@ -1,0 +1,203 @@
+import {
+	SETUP_REQUIRED_ERROR_NAME,
+	type SetupPurpose,
+} from "@virtool/contracts";
+import type { Db } from "@virtool/data/db/pg";
+import { setupSessions } from "@virtool/data/db/schema/setup";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+const getRequest = vi.fn();
+const setResponseStatus = vi.fn();
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest,
+	setCookie: vi.fn(),
+	setResponseStatus,
+}));
+
+let db: Db;
+vi.mock("../composition", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const { resolveRestrictedSetup, SetupRequiredError } = await import(
+	"./restricted"
+);
+const { setupOnly } = await import("./policy");
+const { UnauthorizedError, ForbiddenError } = await import("./middleware");
+const { seedSetupSession, seedUser } = await import(
+	"@virtool/data/auth/test/fixtures"
+);
+const { sessionCookie, setupSessionCookie } = await import("./test/fixtures");
+const { seedSession } = await import("@virtool/data/auth/test/fixtures");
+
+let database: TestDatabase;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(setupSessions);
+	await db.delete(users);
+});
+
+function requestWith(cookie?: string): Request {
+	return new Request("https://virtool.test/_serverFn/test", {
+		headers: cookie ? { cookie } : undefined,
+	});
+}
+
+/** The policy's server handler, which `createMiddleware` stores verbatim. */
+type ServerHandler = (options: {
+	context: unknown;
+	next: (options?: unknown) => Promise<unknown>;
+}) => Promise<unknown>;
+
+function handlerFor(purpose: SetupPurpose) {
+	const middleware = setupOnly(purpose);
+	return (middleware as unknown as { options: { server: ServerHandler } })
+		.options.server;
+}
+
+describe("SetupRequiredError", () => {
+	it("carries the purpose and the shared name, and nothing else", () => {
+		const error = new SetupRequiredError("email_remediation");
+
+		expect(error.name).toBe(SETUP_REQUIRED_ERROR_NAME);
+		expect(error.purpose).toBe("email_remediation");
+		// Enumerable, so the serialization adapter can read it off across the
+		// server-function boundary; nothing else is added.
+		expect(Object.keys(error).toSorted()).toEqual(["name", "purpose"]);
+	});
+});
+
+describe("resolveRestrictedSetup", () => {
+	it("resolves the credential the setup cookies carry", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const session = await seedSetupSession(db, userId, "account_completion");
+
+		expect(
+			await resolveRestrictedSetup(requestWith(setupSessionCookie(session))),
+		).toEqual({
+			userId,
+			sessionId: session.sessionId,
+			purpose: "account_completion",
+			expiresAt: expect.any(Date),
+		});
+	});
+
+	it("returns null with no cookies at all", async () => {
+		expect(await resolveRestrictedSetup(requestWith())).toBeNull();
+	});
+
+	// The two credentials are separate pairs, so neither can be mistaken for
+	// the other however the boundary is later rearranged.
+	it("returns null for an application session's cookies", async () => {
+		const userId = await seedUser(db);
+		const session = await seedSession(db, userId);
+
+		expect(
+			await resolveRestrictedSetup(requestWith(sessionCookie(session))),
+		).toBeNull();
+	});
+});
+
+describe("setupOnly", () => {
+	it("passes a matching restricted credential through", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const session = await seedSetupSession(db, userId, "account_completion");
+		const next = vi.fn().mockResolvedValue("result");
+
+		getRequest.mockReturnValue(requestWith(setupSessionCookie(session)));
+
+		await handlerFor("account_completion")({ context: {}, next });
+
+		expect(next).toHaveBeenCalledWith({
+			context: {
+				restricted: {
+					userId,
+					sessionId: session.sessionId,
+					purpose: "account_completion",
+					expiresAt: expect.any(Date),
+				},
+			},
+		});
+	});
+
+	// A credential for one transition must not be spendable on another.
+	it("refuses a credential for a different purpose", async () => {
+		const userId = await seedUser(db);
+		const session = await seedSetupSession(db, userId, "email_remediation");
+		const next = vi.fn();
+
+		getRequest.mockReturnValue(requestWith(setupSessionCookie(session)));
+
+		await expect(
+			handlerFor("totp_enrollment")({ context: {}, next }),
+		).rejects.toBeInstanceOf(ForbiddenError);
+		expect(setResponseStatus).toHaveBeenCalledWith(403);
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("refuses an anonymous caller with a 401", async () => {
+		getRequest.mockReturnValue(requestWith());
+
+		await expect(
+			handlerFor("account_completion")({ context: {}, next: vi.fn() }),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+		expect(setResponseStatus).toHaveBeenCalledWith(401);
+	});
+
+	// A user who has completed setup has no transition outstanding, so a setup
+	// surface is not theirs to reach.
+	it("refuses an ordinary authenticated caller", async () => {
+		const userId = await seedUser(db);
+		const session = await seedSession(db, userId);
+
+		getRequest.mockReturnValue(requestWith(sessionCookie(session)));
+
+		await expect(
+			handlerFor("account_completion")({ context: {}, next: vi.fn() }),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+	});
+
+	it("reuses the credential the global middleware already resolved", async () => {
+		const next = vi.fn().mockResolvedValue("result");
+		const restricted = {
+			userId: 7,
+			sessionId: "setup_upstream",
+			purpose: "totp_enrollment" as const,
+			expiresAt: new Date(Date.now() + 60_000),
+		};
+
+		await handlerFor("totp_enrollment")({ context: { restricted }, next });
+
+		expect(next).toHaveBeenCalledWith({ context: { restricted } });
+		expect(getRequest).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/server/auth/restricted.ts
+++ b/apps/web/src/server/auth/restricted.ts
@@ -1,0 +1,61 @@
+import { createServerOnlyFn } from "@tanstack/react-start";
+import {
+	type RestrictedSetup,
+	SETUP_REQUIRED_ERROR_NAME,
+	type SetupPurpose,
+} from "@virtool/contracts";
+import { verifySetupSession } from "@virtool/data/auth/setup";
+import { db } from "../composition";
+import { SETUP_SESSION_ID_COOKIE, SETUP_SESSION_TOKEN_COOKIE } from "./cookies";
+import { parseCookieHeader } from "./verify";
+
+/**
+ * Thrown when a request carries a restricted setup credential and asks for
+ * anything outside that credential's one purpose.
+ *
+ * Distinct from `UnauthorizedError` because the caller is not anonymous:
+ * sending them to the login wall would strand them, and retrying would fail
+ * the same way. `purpose` is the whole of what it adds — enough for the router
+ * to pick the right setup surface, and nothing about tokens, sessions or what
+ * the holder may do.
+ */
+export class SetupRequiredError extends Error {
+	declare readonly purpose: SetupPurpose;
+
+	constructor(purpose: SetupPurpose) {
+		super("Account setup required");
+		this.name = SETUP_REQUIRED_ERROR_NAME;
+		Object.defineProperty(this, "purpose", {
+			value: purpose,
+			enumerable: true,
+		});
+	}
+}
+
+/**
+ * Resolve the restricted setup credential behind a raw `Request`, or `null`.
+ *
+ * **The one authority for what a restricted caller is.** The global
+ * authentication middleware calls this, the setup-only policy reads what it
+ * produced, and nothing else re-derives it — a second reader would be a second
+ * chance to widen it.
+ *
+ * `null` for every failure, including a missing cookie pair, so the boundary
+ * answers one refusal without saying which check failed. `verifySetupSession`
+ * re-reads `users.active` on the way, so deactivation revokes a restricted
+ * session as immediately as it revokes an ordinary one.
+ */
+// createServerOnlyFn keeps the db and @virtool/data references behind a server
+// boundary, so import protection does not pin them in the client graph through
+// the middleware that calls this.
+export const resolveRestrictedSetup = createServerOnlyFn(
+	async (request: Request): Promise<RestrictedSetup | null> => {
+		const cookies = parseCookieHeader(request.headers.get("cookie"));
+
+		return verifySetupSession(
+			db,
+			cookies[SETUP_SESSION_ID_COOKIE],
+			cookies[SETUP_SESSION_TOKEN_COOKIE],
+		);
+	},
+);

--- a/apps/web/src/server/auth/setupExceptions.ts
+++ b/apps/web/src/server/auth/setupExceptions.ts
@@ -1,0 +1,32 @@
+import type { SetupPurpose } from "@virtool/contracts";
+
+/** A server function a restricted setup principal may call, and for what. */
+export type SetupEndpoint = {
+	fn: { url: string };
+	purpose: SetupPurpose;
+};
+
+/**
+ * Every server function reachable by a restricted setup principal, and the one
+ * purpose each answers.
+ *
+ * The allowlist half of the setup boundary. The global authentication
+ * middleware refuses a restricted caller anything absent from here *before*
+ * the function's own policy runs, so a setup function left out of this list is
+ * unreachable rather than open — the same failure direction
+ * `./exceptions` has.
+ *
+ * A function listed here must also declare `setupOnly()` with the matching
+ * purpose, and one declaring `setupOnly()` must appear here.
+ * `authorization.test.ts` pins both directions, so the two cannot drift.
+ *
+ * **It is deliberately empty.** The setup surfaces themselves — invitation and
+ * bootstrap completion, account recovery, required-TOTP enrollment — are the
+ * dependent issues' work. This issue builds the boundary they are declared
+ * against, and an empty allowlist means a restricted principal currently
+ * reaches nothing at all, which is the right default for a door with no rooms
+ * behind it yet.
+ *
+ * @public
+ */
+export const setupEndpoints: ReadonlyArray<SetupEndpoint> = [];

--- a/apps/web/src/server/auth/test/fixtures.ts
+++ b/apps/web/src/server/auth/test/fixtures.ts
@@ -1,12 +1,20 @@
+import type { SetupPurpose } from "@virtool/contracts";
 import {
 	type SeededSession,
+	type SeededSetupSession,
 	type SeedUserOptions,
 	seedSession,
+	seedSetupSession,
 	seedUser,
 } from "@virtool/data/auth/test/fixtures";
 import type { Db } from "@virtool/data/db/pg";
 import type { Mock } from "vitest";
-import { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } from "../cookies";
+import {
+	SESSION_ID_COOKIE,
+	SESSION_TOKEN_COOKIE,
+	SETUP_SESSION_ID_COOKIE,
+	SETUP_SESSION_TOKEN_COOKIE,
+} from "../cookies";
 
 /**
  * Encode a seeded session as the `Cookie` header value that authenticates it.
@@ -62,4 +70,43 @@ export async function signIn(
 /** Encode `handle` and `key` as an HTTP Basic `Authorization` header value. */
 export function basicAuthHeader(handle: string, key: string): string {
 	return `Basic ${Buffer.from(`${handle}:${key}`, "utf8").toString("base64")}`;
+}
+
+/**
+ * Encode a seeded restricted setup session as the `Cookie` header value that
+ * presents it.
+ *
+ * Deliberately a different pair from {@link sessionCookie}: a restricted
+ * credential is not an application session, and a test that could substitute
+ * one for the other would prove nothing about the boundary between them.
+ */
+export function setupSessionCookie({
+	sessionId,
+	token,
+}: Pick<SeededSetupSession, "sessionId" | "token">): string {
+	return `${SETUP_SESSION_ID_COOKIE}=${sessionId}; ${SETUP_SESSION_TOKEN_COOKIE}=${token}`;
+}
+
+/**
+ * Open a restricted setup session for an already-seeded user and point
+ * `getRequest` at a request carrying its cookies.
+ *
+ * The caller is then a restricted principal: it holds a credential for exactly
+ * `purpose` and no application session at all.
+ */
+export async function restrictTo(
+	db: Db,
+	getRequest: Mock,
+	userId: number,
+	purpose: SetupPurpose,
+): Promise<SeededSetupSession> {
+	const session = await seedSetupSession(db, userId, purpose);
+
+	getRequest.mockReturnValue(
+		new Request("https://virtool.test/_serverFn/test", {
+			headers: { cookie: setupSessionCookie(session) },
+		}),
+	);
+
+	return session;
 }

--- a/apps/web/src/server/auth/verify.test.ts
+++ b/apps/web/src/server/auth/verify.test.ts
@@ -62,6 +62,15 @@ describe("verifyAuthenticatedSession", () => {
 		expect(await verifyAuthenticatedSession(db, sessionId, token)).toBeNull();
 	});
 
+	// An account that has not completed setup is not an application principal,
+	// whatever session row happens to name it.
+	it("rejects a session whose user is still pending", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { sessionId, token } = await seedSession(db, userId);
+
+		expect(await verifyAuthenticatedSession(db, sessionId, token)).toBeNull();
+	});
+
 	it("rejects a session deactivated after it was issued", async () => {
 		const userId = await seedUser(db);
 		const { sessionId, token } = await seedSession(db, userId);
@@ -293,6 +302,16 @@ describe("verifyApiKey", () => {
 			userId,
 			keyPermissions: { ...emptyPermissions(), upload_file: true },
 		});
+	});
+
+	// A restricted setup credential must never turn into a machine one.
+	it("rejects a key whose owner is still pending", async () => {
+		const userId = await seedUser(db);
+		const key = await seedApiKey(db, userId);
+
+		await db.update(users).set({ lifecycleState: "pending", password: null });
+
+		expect(await verifyApiKey(db, "alice", key)).toBeNull();
 	});
 
 	it("rejects an unknown handle", async () => {

--- a/apps/web/src/server/auth/verify.ts
+++ b/apps/web/src/server/auth/verify.ts
@@ -23,8 +23,9 @@ export type AuthenticatedSession = {
 /**
  * Resolve an authenticated session from cookie values. Returns `null` for any
  * non-fatal failure (missing cookies, unknown session, wrong type, expired,
- * deactivated user, or token mismatch) so callers can respond with a single 401
- * without leaking which check failed.
+ * deactivated user, an account that has not completed setup, or token
+ * mismatch) so callers can respond with a single 401 without leaking which
+ * check failed.
  */
 export async function verifyAuthenticatedSession(
 	db: Db,
@@ -40,6 +41,10 @@ export async function verifyAuthenticatedSession(
 	// checked on every request rather than trusted at login — such a session must
 	// stop verifying the moment the user goes inactive. The inner join only drops
 	// anonymous sessions, which carry no user_id and are rejected anyway.
+	//
+	// `lifecycle_state` is read for the same reason: an account that has not
+	// completed setup is not an application principal, whatever session row
+	// happens to name it.
 	const [row] = await db
 		.select({
 			userId: sessions.userId,
@@ -47,6 +52,7 @@ export async function verifyAuthenticatedSession(
 			tokenHash: sessions.tokenHash,
 			expiresAt: sessions.expiresAt,
 			active: users.active,
+			lifecycleState: users.lifecycleState,
 		})
 		.from(sessions)
 		.innerJoin(users, eq(users.id, sessions.userId))
@@ -57,7 +63,8 @@ export async function verifyAuthenticatedSession(
 		row?.sessionType !== "authenticated" ||
 		!row.tokenHash ||
 		row.userId === null ||
-		!row.active
+		!row.active ||
+		row.lifecycleState !== "normal"
 	) {
 		return null;
 	}
@@ -146,8 +153,9 @@ export function parseBasicAuthHeader(header: string): BasicCredentials | null {
 
 /**
  * Resolve an identity from a user handle and a raw API key. Returns `null` for
- * any failure — unknown handle, deactivated user, or a key that is not that
- * user's — so callers answer a single 401 without saying which check failed.
+ * any failure — unknown handle, deactivated user, an account that has not
+ * completed setup, or a key that is not that user's — so callers answer a
+ * single 401 without saying which check failed.
  *
  * Handles are matched case-insensitively, as they are at login. Only the key's
  * SHA-256 is stored, so the lookup hashes the supplied secret and matches on
@@ -175,6 +183,7 @@ export async function verifyApiKey(
 		.select({
 			userId: users.id,
 			active: users.active,
+			lifecycleState: users.lifecycleState,
 			permissions: apiKeys.permissions,
 		})
 		.from(users)
@@ -187,7 +196,10 @@ export async function verifyApiKey(
 		)
 		.limit(1);
 
-	if (!row?.active) {
+	// A pending account has no keys to find, so this is a floor rather than a
+	// live case: a restricted setup credential must never turn into a machine
+	// one, and the rule belongs where it can be read off the code.
+	if (!row?.active || row.lifecycleState !== "normal") {
 		return null;
 	}
 

--- a/apps/web/src/server/sentryFilters.ts
+++ b/apps/web/src/server/sentryFilters.ts
@@ -2,12 +2,14 @@ import type { ErrorEvent, EventHint } from "@sentry/tanstackstart-react";
 import {
 	CLIENT_ERROR_NAME,
 	FORBIDDEN_ERROR_NAME,
+	SETUP_REQUIRED_ERROR_NAME,
 	UNAUTHORIZED_ERROR_NAME,
 } from "@virtool/contracts";
 
 const EXPECTED_CLIENT_ERROR_NAMES = new Set<string>([
 	UNAUTHORIZED_ERROR_NAME,
 	FORBIDDEN_ERROR_NAME,
+	SETUP_REQUIRED_ERROR_NAME,
 	CLIENT_ERROR_NAME,
 ]);
 
@@ -16,8 +18,9 @@ const EXPECTED_CLIENT_ERROR_NAMES = new Set<string>([
  * reported.
  *
  * Three kinds slip through here, all routine rather than incidents: the auth
- * middleware's 401/403 rejections (`UnauthorizedError` / `ForbiddenError`),
- * whose name the client's retry guard reads to bounce to the login wall; the
+ * middleware's 401/403 rejections (`UnauthorizedError` / `ForbiddenError` /
+ * `SetupRequiredError`), whose name the client's retry guard reads to bounce
+ * to the login wall or a setup surface; the
  * handlers' deliberate 4xx `ClientError`s — a bad login, a missing record, a
  * name conflict — which the client renders as a message; and a request whose
  * client went away before its response finished. Reporting any of them only

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -15,6 +15,7 @@ import {
 	InvalidPasswordError,
 	listAdministratorRoles,
 	listUsers,
+	PendingAccountError,
 	setAdministratorRole,
 	UserConflictError,
 	UserNotFoundError,
@@ -132,6 +133,10 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		setResponseStatus(400);
 		throw new ClientError("User is not a member of group.");
 	}
+	if (err instanceof PendingAccountError) {
+		setResponseStatus(409);
+		throw new ClientError("User has not completed account setup.");
+	}
 	throw err;
 });
 
@@ -155,6 +160,11 @@ export const findUsersFn = createServerFn({ method: "GET" })
 			perPage: data?.perPage ?? 25,
 			administrator: data?.administrator,
 			active: data?.active ?? true,
+			// The one caller that asks for pending accounts. An administrator has
+			// to see the invitation they issued in order to re-issue or revoke it,
+			// and `findUsers` defaults to hiding them so nothing else has to
+			// remember to.
+			lifecycleState: "any",
 		});
 	});
 

--- a/apps/web/src/tests/fake/user.ts
+++ b/apps/web/src/tests/fake/user.ts
@@ -37,6 +37,7 @@ export function createFakeUser(overrides?: Partial<User>): User {
 		forceReset: false,
 		groups,
 		lastPasswordChange: faker.date.past(),
+		lifecycleState: "normal",
 		permissions: createFakePermissions(permissions),
 		primaryGroup:
 			primaryGroup === undefined ? (groups[0] ?? null) : primaryGroup,

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -11,3 +11,14 @@ export const UNAUTHORIZED_ERROR_NAME = "UnauthorizedError";
  * lacks the required administrator role.
  */
 export const FORBIDDEN_ERROR_NAME = "ForbiddenError";
+
+/**
+ * Name of the error the server auth middleware throws when a request carries a
+ * restricted setup credential and asks for something outside that credential's
+ * one purpose.
+ *
+ * A distinct name because a restricted caller is not anonymous — retrying the
+ * request or sending them to the login wall is the wrong answer, and both are
+ * what the 401 name already means to the client.
+ */
+export const SETUP_REQUIRED_ERROR_NAME = "SetupRequiredError";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -24,6 +24,7 @@ export * from "./samples";
 export * from "./search";
 export * from "./sessions";
 export * from "./settings";
+export * from "./setup";
 export * from "./sse";
 export * from "./subtractions";
 export * from "./tasks";

--- a/packages/contracts/src/setup.ts
+++ b/packages/contracts/src/setup.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+/**
+ * Where a Virtool human account sits between creation and ordinary use.
+ *
+ * `users.lifecycle_state` is a `text` column closed by the
+ * `lifecycle_state_valid` CHECK constraint; this is the one declaration of
+ * what that constraint admits, imported by the schema mirror rather than
+ * restated there.
+ *
+ * This is not `users.active`. Activation stays the administrator's switch and
+ * remains authoritative: a deactivated account cannot be used whatever its
+ * lifecycle state, and completing setup never activates anyone.
+ *
+ * `pending` means the account exists — handle, administrator role and group
+ * memberships are all assigned — but has no credential and cannot be used as
+ * an application account. `normal` means it can.
+ */
+export const AccountLifecycleState = z.enum(["pending", "normal"]);
+
+export type AccountLifecycleState = z.infer<typeof AccountLifecycleState>;
+
+/**
+ * The one transition a setup credential authorizes.
+ *
+ * A setup token and a restricted setup session each carry exactly one of
+ * these, and each is refused for any other. `setup_tokens.purpose` and
+ * `setup_sessions.purpose` are `text` columns closed by CHECK constraints;
+ * this is the one declaration of what they admit.
+ *
+ * `account_completion` covers both an administrator's invitation and the
+ * first-instance bootstrap: an account that exists but has no credential yet.
+ * `email_remediation` covers an active legacy account with no usable unique
+ * email. `totp_enrollment` covers a user who has authenticated under a
+ * `required` MFA policy but has not enrolled.
+ */
+export const SetupPurpose = z.enum([
+	"account_completion",
+	"email_remediation",
+	"totp_enrollment",
+]);
+
+export type SetupPurpose = z.infer<typeof SetupPurpose>;
+
+/**
+ * What a restricted setup session proves, and the whole of it.
+ *
+ * Deliberately not a principal. It carries no roles, no group permissions, no
+ * administrator capability and no API-key permission cap, because a caller
+ * holding one may complete `purpose` and do nothing else. The web
+ * authentication boundary maps this into its own principal union; it must not
+ * widen it on the way.
+ *
+ * `sessionId` is the non-secret half of the credential — safe to log and to
+ * attribute an error to. The secret that proves the session is never part of
+ * this shape.
+ */
+export type RestrictedSetup = {
+	/** The Virtool user completing setup. */
+	userId: number;
+
+	/** The session's stable, non-secret identifier, for attribution. */
+	sessionId: string;
+
+	/** The only transition this session may complete. */
+	purpose: SetupPurpose;
+
+	/** When the session stops being valid. The server row is authoritative. */
+	expiresAt: Date;
+};
+
+/**
+ * What the server answers a caller whose credential reaches only a setup
+ * surface.
+ *
+ * A restricted caller is neither anonymous nor an ordinary authenticated user,
+ * so neither a 401 nor a bare 403 tells the router where to send them. This
+ * carries the purpose and nothing else — no bearer token, no session secret,
+ * and no statement about whether any given setup token exists.
+ */
+export type SetupRequired = {
+	purpose: SetupPurpose;
+};

--- a/packages/contracts/src/tasks.ts
+++ b/packages/contracts/src/tasks.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
  */
 export const PeriodicTaskName = z.enum([
 	"cleanup_sessions",
+	"cleanup_setup_state",
 	"deliver_email",
 	"evict_caches_lru",
 	"reap_orphaned_uploads",

--- a/packages/contracts/src/users.ts
+++ b/packages/contracts/src/users.ts
@@ -3,6 +3,7 @@ import type { AdministratorRoleName } from "./administrators";
 import type { GroupMinimal } from "./groups";
 import type { Permissions } from "./permissions";
 import type { SearchResult } from "./search";
+import type { AccountLifecycleState } from "./setup";
 
 /** A user reduced to the fields shown alongside another resource. */
 export const UserNested = z.object({
@@ -31,6 +32,15 @@ export type User = UserNested & {
 
 	/** When they last changed their password */
 	lastPasswordChange: Date;
+
+	/**
+	 * Whether the account is usable as an application account yet.
+	 *
+	 * Separate from {@link User.active}: a `pending` account has a handle, a
+	 * role and group memberships but no credential, and a deactivated account
+	 * is unusable whatever this says.
+	 */
+	lifecycleState: AccountLifecycleState;
 
 	/** What they may do, their groups' grants folded in */
 	permissions: Permissions;

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -216,7 +216,64 @@ looks fields up by property — so `userId` and `credentialID` keep their exact
 spelling while their columns stay snake_case.
 
 `users.email` is deliberately not unique, though Better Auth declares it so.
-Legacy rows share an empty email, and normalizing them is separate work.
+Legacy rows share an empty email, and normalizing them is separate work. Until
+that lands, `src/auth/lifecycle.ts` holds uniqueness for the addresses it
+establishes with a transaction-scoped advisory lock on the normalized address
+rather than an index.
+
+### Account lifecycle and setup state
+
+`users.lifecycle_state` is the persisted half of the account lifecycle:
+`pending` for an account that exists but holds no credential, `normal` for one
+that can be used. It is **not** `users.active`. Activation remains the
+administrator's switch and stays authoritative — a deactivated account is
+unusable whatever its lifecycle state, and completing setup never activates
+anyone.
+
+A pending account keeps its handle, administrator role and group memberships,
+so an administrator states who a person is and what they may do at the moment
+of invitation. What it does not have is a credential: `users.password` is null,
+which the `pending_has_no_password` constraint holds, and `createPendingUser`
+is the only thing that writes the state.
+
+Every reader that assumes an account is usable checks the state, not just
+`active`: `listUsers`, `findUsers` (which defaults to `normal` and takes
+`lifecycleState: "any"` for the administration views), and the app's session
+and API-key resolution.
+
+`setup_tokens` and `setup_sessions` carry the two setup credentials, and
+`src/auth/setup.ts` owns both:
+
+- A **setup token** is the bearer secret in an invitation, bootstrap or
+  remediation link. Only its SHA-256 is stored; the plaintext is returned to
+  the issuing caller once and is never readable back. It is purpose-bound,
+  expiring, single-use — `consumeSetupToken` is one conditional `UPDATE ...
+  RETURNING`, so concurrent submissions of one token produce exactly one
+  winner — and superseded when a replacement is issued.
+- A **restricted setup session** is what a holder gets in exchange: a
+  non-secret `session_id` for attribution plus a secret whose digest is
+  stored, bound to one purpose and expiring. `verifySetupSession` re-reads
+  `users.active` on every request, so deactivation revokes it at once. It is
+  never an application session, which is why it is a table of its own rather
+  than another `sessions.session_type`.
+
+`src/auth/lifecycle.ts` holds one transactional completion primitive per
+purpose. Each spends the token, writes the credential and identity state,
+moves the account, and revokes every setup credential the user held — in one
+transaction, so a failure rolls the whole transition back and a spent token
+never outlives the change it paid for. None of them mints a session; which
+session a completed holder gets is the calling flow's decision, and cookies
+belong to `apps/web`.
+
+Credential state is written on both sides during the Better Auth migration:
+`users.password` for the boundary `apps/web`'s `login()` still reads, and
+`auth_accounts.password` plus `users.username`/`display_username` for Better
+Auth. An account credentialed against only one of them cannot sign in under
+the other.
+
+Expiry cleanup is the internal runner's `cleanup_setup_state` periodic task.
+Nothing waits on it — both readers refuse an expired row on sight — so there
+are no request-path scans.
 
 ## Outbound requests
 

--- a/packages/data/drizzle/0021_add_setup_state.sql
+++ b/packages/data/drizzle/0021_add_setup_state.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "setup_sessions" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "setup_sessions_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"session_id" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"user_id" integer NOT NULL,
+	"purpose" text NOT NULL,
+	"ip" text NOT NULL,
+	"created_at" timestamp DEFAULT timezone('utc', now()) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	CONSTRAINT "setup_sessions_session_id_key" UNIQUE("session_id"),
+	CONSTRAINT "setup_sessions_purpose_valid" CHECK (purpose in ('account_completion', 'email_remediation', 'totp_enrollment'))
+);
+--> statement-breakpoint
+CREATE TABLE "setup_tokens" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "setup_tokens_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" integer NOT NULL,
+	"purpose" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"created_at" timestamp DEFAULT timezone('utc', now()) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"consumed_at" timestamp,
+	CONSTRAINT "setup_tokens_token_hash_key" UNIQUE("token_hash"),
+	CONSTRAINT "setup_tokens_purpose_valid" CHECK (purpose in ('account_completion', 'email_remediation', 'totp_enrollment'))
+);
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "password" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "lifecycle_state" text DEFAULT 'normal' NOT NULL;--> statement-breakpoint
+ALTER TABLE "setup_sessions" ADD CONSTRAINT "setup_sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "setup_tokens" ADD CONSTRAINT "setup_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_setup_sessions_expires_at" ON "setup_sessions" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "idx_setup_sessions_user_id" ON "setup_sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_setup_tokens_expires_at" ON "setup_tokens" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "idx_setup_tokens_user_id_purpose" ON "setup_tokens" USING btree ("user_id","purpose");--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "lifecycle_state_valid" CHECK ("users"."lifecycle_state" in ('pending', 'normal'));--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "pending_has_no_password" CHECK ("users"."lifecycle_state" <> 'pending' or "users"."password" is null);

--- a/packages/data/drizzle/meta/0021_snapshot.json
+++ b/packages/data/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,5302 @@
+{
+  "id": "c88e6d8f-2b97-40ee-ad51-0b4304001fd8",
+  "prevId": "69af3c5a-6387-40d0-94b3-bc382515d11c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analyses_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_version": {
+          "name": "workflow_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_analyses_sample_id_workflow": {
+          "name": "ix_analyses_sample_id_workflow",
+          "columns": [
+            {
+              "expression": "sample_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analyses_sample_id_fkey": {
+          "name": "analyses_sample_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_index_id_fkey": {
+          "name": "analyses_index_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_user_id_fkey": {
+          "name": "analyses_user_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_job_id_fkey": {
+          "name": "analyses_job_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analyses_legacy_id_key": {
+          "name": "analyses_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_files": {
+      "name": "analysis_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_files_analysis_id_fkey": {
+          "name": "analysis_files_analysis_id_fkey",
+          "tableFrom": "analysis_files",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_files_name_on_disk_key": {
+          "name": "analysis_files_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_analysis_files_storage_key": {
+          "name": "uq_analysis_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_analysis_files_format": {
+          "name": "ck_analysis_files_format",
+          "value": "\"analysis_files\".\"format\" in ('sam', 'bam', 'fasta', 'fastq', 'csv', 'tsv', 'json')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_subtractions": {
+      "name": "analysis_subtractions",
+      "schema": "",
+      "columns": {
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_analysis_subtractions_subtraction_id": {
+          "name": "ix_analysis_subtractions_subtraction_id",
+          "columns": [
+            {
+              "expression": "subtraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_subtractions_analysis_id_fkey": {
+          "name": "analysis_subtractions_analysis_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_subtractions_subtraction_id_fkey": {
+          "name": "analysis_subtractions_subtraction_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analysis_subtractions_pkey": {
+          "name": "analysis_subtractions_pkey",
+          "columns": [
+            "analysis_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nuvs_blast": {
+      "name": "nuvs_blast",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "nuvs_blast_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rid": {
+          "name": "rid",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nuvs_blast_analysis_id_fkey": {
+          "name": "nuvs_blast_analysis_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nuvs_blast_task_id_fkey": {
+          "name": "nuvs_blast_task_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nuvs_blast_analysis_id_sequence_index_key": {
+          "name": "nuvs_blast_analysis_id_sequence_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_id",
+            "sequence_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "api_keys_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "hashed": {
+          "name": "hashed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key": {
+          "name": "api_keys_hashed_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "auth_accounts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_auth_accounts_user_id": {
+          "name": "idx_auth_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_fkey": {
+          "name": "auth_accounts_user_id_fkey",
+          "tableFrom": "auth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_accounts_provider_id_account_id_key": {
+          "name": "auth_accounts_provider_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_passkeys": {
+      "name": "auth_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "auth_passkeys_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_auth_passkeys_credential_id": {
+          "name": "idx_auth_passkeys_credential_id",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_passkeys_user_id": {
+          "name": "idx_auth_passkeys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_passkeys_user_id_fkey": {
+          "name": "auth_passkeys_user_id_fkey",
+          "tableFrom": "auth_passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "auth_sessions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_auth_sessions_user_id": {
+          "name": "idx_auth_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_fkey": {
+          "name": "auth_sessions_user_id_fkey",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_token_key": {
+          "name": "auth_sessions_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_two_factors": {
+      "name": "auth_two_factors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "auth_two_factors_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_auth_two_factors_secret": {
+          "name": "idx_auth_two_factors_secret",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_two_factors_user_id": {
+          "name": "idx_auth_two_factors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_two_factors_user_id_fkey": {
+          "name": "auth_two_factors_user_id_fkey",
+          "tableFrom": "auth_two_factors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "auth_verifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_auth_verifications_identifier": {
+          "name": "idx_auth_verifications_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banners": {
+      "name": "banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "banners_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banners_one_active": {
+          "name": "banners_one_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"banners\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banners_user_id_fkey": {
+          "name": "banners_user_id_fkey",
+          "tableFrom": "banners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_banners_color": {
+          "name": "ck_banners_color",
+          "value": "\"banners\".\"color\" in ('red', 'yellow', 'blue', 'purple', 'orange', 'grey')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.caches": {
+      "name": "caches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "caches_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_caches_last_accessed_at_id": {
+          "name": "ix_caches_last_accessed_at_id",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cache_key": {
+          "name": "cache_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "caches_storage_key_key": {
+          "name": "caches_storage_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_outbox_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_email_outbox_due": {
+          "name": "idx_email_outbox_due",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_outbox\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_outbox_terminal": {
+          "name": "idx_email_outbox_terminal",
+          "columns": [
+            {
+              "expression": "terminal_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_outbox\".\"status\" in ('accepted', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_email_outbox_idempotency_key": {
+          "name": "uq_email_outbox_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_email_outbox_status": {
+          "name": "ck_email_outbox_status",
+          "value": "\"email_outbox\".\"status\" in ('queued', 'accepted', 'failed')"
+        },
+        "ck_email_outbox_attempt_count": {
+          "name": "ck_email_outbox_attempt_count",
+          "value": "\"email_outbox\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_name_unique": {
+          "name": "groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "groups_legacy_id_key": {
+          "name": "groups_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "primary_group_unique": {
+          "name": "primary_group_unique",
+          "columns": [
+            {
+              "expression": "primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_group_id_fkey": {
+          "name": "user_groups_group_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_user_id_fkey": {
+          "name": "user_groups_user_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_pkey": {
+          "name": "user_groups_pkey",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history": {
+      "name": "legacy_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu": {
+          "name": "otu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_name": {
+          "name": "otu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_version": {
+          "name": "otu_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_history_index_id": {
+          "name": "ix_legacy_history_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_otu_otu_version": {
+          "name": "ix_legacy_history_otu_otu_version",
+          "columns": [
+            {
+              "expression": "otu",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "otu_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_reference_id": {
+          "name": "ix_legacy_history_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_user_id": {
+          "name": "ix_legacy_history_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_history_user_id_fkey": {
+          "name": "legacy_history_user_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_reference_id_fkey": {
+          "name": "legacy_history_reference_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_index_id_fkey": {
+          "name": "legacy_history_index_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_history_legacy_id_key": {
+          "name": "legacy_history_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history_diff": {
+      "name": "legacy_history_diff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_history_diff_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_history_diff_history_id_fkey": {
+          "name": "legacy_history_diff_history_id_fkey",
+          "tableFrom": "legacy_history_diff",
+          "tableTo": "legacy_history",
+          "columnsFrom": [
+            "history_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "history_diffs_pkey": {
+          "name": "history_diffs_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "history_diffs_change_id_key": {
+          "name": "history_diffs_change_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_id"
+          ]
+        },
+        "legacy_history_diff_history_id_key": {
+          "name": "legacy_history_diff_history_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "history_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmms": {
+      "name": "hmms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hmms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster": {
+          "name": "cluster",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_entropy": {
+          "name": "mean_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_entropy": {
+          "name": "total_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "names": {
+          "name": "names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "families": {
+          "name": "families",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genera": {
+          "name": "genera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmms_legacy_id_key": {
+          "name": "hmms_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_hmm_status": {
+      "name": "legacy_hmm_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed": {
+          "name": "installed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updates": {
+          "name": "updates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_hmm_status_task_id_fkey": {
+          "name": "legacy_hmm_status_task_id_fkey",
+          "tableFrom": "legacy_hmm_status",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_legacy_hmm_status_singleton": {
+          "name": "ck_legacy_hmm_status_singleton",
+          "value": "\"legacy_hmm_status\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.index_files": {
+      "name": "index_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "index_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "index_files_index_id_fkey": {
+          "name": "index_files_index_id_fkey",
+          "tableFrom": "index_files",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_index_files_storage_key": {
+          "name": "uq_index_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "index_files_index_id_name_key": {
+          "name": "index_files_index_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_index_files_type": {
+          "name": "ck_index_files_type",
+          "value": "\"index_files\".\"type\" in ('json', 'fasta', 'bowtie2', 'sqlite')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.indexes": {
+      "name": "indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "indexes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otus_json_storage_key": {
+          "name": "otus_json_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "indexes_reference_id_fkey": {
+          "name": "indexes_reference_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_user_id_fkey": {
+          "name": "indexes_user_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_job_id_fkey": {
+          "name": "indexes_job_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_task_id_fkey": {
+          "name": "indexes_task_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "indexes_legacy_id_key": {
+          "name": "indexes_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "uq_indexes_otus_json_storage_key": {
+          "name": "uq_indexes_otus_json_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "otus_json_storage_key"
+          ]
+        },
+        "uq_indexes_reference_id_version": {
+          "name": "uq_indexes_reference_id_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_indexes_job_or_task": {
+          "name": "ck_indexes_job_or_task",
+          "value": "num_nonnulls(\"indexes\".\"job_id\", \"indexes\".\"task_id\") <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "acquired": {
+          "name": "acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claim": {
+          "name": "claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinged_at": {
+          "name": "pinged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_jobs_state_created_at": {
+          "name": "ix_jobs_state_created_at",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_user_id_state": {
+          "name": "ix_jobs_user_id_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_workflow_state": {
+          "name": "ix_jobs_workflow_state",
+          "columns": [
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_active": {
+          "name": "idx_jobs_active",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"state\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_user_id_fkey": {
+          "name": "jobs_user_id_fkey",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_legacy_id_key": {
+          "name": "jobs_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_jobs_state": {
+          "name": "ck_jobs_state",
+          "value": "\"jobs\".\"state\" in ('pending', 'running', 'cancelled', 'failed', 'succeeded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "labels_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_name_key": {
+          "name": "labels_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_otus": {
+      "name": "legacy_otus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_indexed_version": {
+          "name": "last_indexed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_legacy_otus_reference_id": {
+          "name": "ix_legacy_otus_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_otus_name_lower": {
+          "name": "legacy_otus_name_lower",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_otus_reference_id_fkey": {
+          "name": "legacy_otus_reference_id_fkey",
+          "tableFrom": "legacy_otus",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sequences": {
+      "name": "legacy_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_id": {
+          "name": "otu_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate_id": {
+          "name": "isolate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_sequences_otu_id": {
+          "name": "ix_legacy_sequences_otu_id",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_sequences_otu_id_position": {
+          "name": "ix_legacy_sequences_otu_id_position",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_sequences_otu_id_fkey": {
+          "name": "legacy_sequences_otu_id_fkey",
+          "tableFrom": "legacy_sequences",
+          "tableTo": "legacy_otus",
+          "columnsFrom": [
+            "otu_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_groups": {
+      "name": "legacy_reference_groups",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_groups_reference_id_fkey": {
+          "name": "legacy_reference_groups_reference_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_groups_group_id_fkey": {
+          "name": "legacy_reference_groups_group_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_groups_pkey": {
+          "name": "legacy_reference_groups_pkey",
+          "columns": [
+            "reference_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_users": {
+      "name": "legacy_reference_users",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_users_reference_id_fkey": {
+          "name": "legacy_reference_users_reference_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_users_user_id_fkey": {
+          "name": "legacy_reference_users_user_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_users_pkey": {
+          "name": "legacy_reference_users_pkey",
+          "columns": [
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_references": {
+      "name": "legacy_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_references_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organism": {
+          "name": "organism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restrict_source_types": {
+          "name": "restrict_source_types",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_types": {
+          "name": "source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloned_from_id": {
+          "name": "cloned_from_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_references_user_id_fkey": {
+          "name": "legacy_references_user_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_upload_id_fkey": {
+          "name": "legacy_references_upload_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_cloned_from_id_fkey": {
+          "name": "legacy_references_cloned_from_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "cloned_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_task_id_fkey": {
+          "name": "legacy_references_task_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_references_legacy_id_key": {
+          "name": "legacy_references_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_labels": {
+      "name": "legacy_sample_labels",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_labels_sample_id_fkey": {
+          "name": "legacy_sample_labels_sample_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_labels_label_id_fkey": {
+          "name": "legacy_sample_labels_label_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_labels_pkey": {
+          "name": "legacy_sample_labels_pkey",
+          "columns": [
+            "sample_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_subtractions": {
+      "name": "legacy_sample_subtractions",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_subtractions_sample_id_fkey": {
+          "name": "legacy_sample_subtractions_sample_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_subtractions_subtraction_id_fkey": {
+          "name": "legacy_sample_subtractions_subtraction_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_subtractions_pkey": {
+          "name": "legacy_sample_subtractions_pkey",
+          "columns": [
+            "sample_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_samples": {
+      "name": "legacy_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_samples_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate": {
+          "name": "isolate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_type": {
+          "name": "library_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paired": {
+          "name": "paired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold": {
+          "name": "hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_read": {
+          "name": "all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_write": {
+          "name": "all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_read": {
+          "name": "group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_write": {
+          "name": "group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_samples_all_read": {
+          "name": "ix_legacy_samples_all_read",
+          "columns": [
+            {
+              "expression": "all_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"all_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_id": {
+          "name": "ix_legacy_samples_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_read": {
+          "name": "ix_legacy_samples_group_read",
+          "columns": [
+            {
+              "expression": "group_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"group_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_user_id_created_at": {
+          "name": "ix_legacy_samples_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_samples_group_id_fkey": {
+          "name": "legacy_samples_group_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_user_id_fkey": {
+          "name": "legacy_samples_user_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_job_id_fkey": {
+          "name": "legacy_samples_job_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_samples_legacy_id_key": {
+          "name": "legacy_samples_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "legacy_samples_job_id_key": {
+          "name": "legacy_samples_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_reads": {
+      "name": "sample_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sample_reads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload": {
+          "name": "upload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_reads_sample_id_fkey": {
+          "name": "sample_reads_sample_id_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_reads_upload_fkey": {
+          "name": "sample_reads_upload_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_sample_reads_storage_key": {
+          "name": "uq_sample_reads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "sample_reads_sample_id_name_key": {
+          "name": "sample_reads_sample_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample_id",
+            "name"
+          ]
+        },
+        "sample_reads_sample_name_key": {
+          "name": "sample_reads_sample_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_uploads": {
+      "name": "sample_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sample_uploads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_uploads_sample_id_fkey": {
+          "name": "sample_uploads_sample_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_uploads_upload_id_fkey": {
+          "name": "sample_uploads_upload_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sample_uploads_upload_id_key": {
+          "name": "sample_uploads_upload_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sessions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_code": {
+          "name": "reset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_remember": {
+          "name": "reset_remember",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_session_id": {
+          "name": "idx_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_type": {
+          "name": "idx_sessions_type",
+          "columns": [
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_fkey": {
+          "name": "sessions_user_id_fkey",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_type_valid": {
+          "name": "session_type_valid",
+          "value": "\"sessions\".\"session_type\" in ('anonymous', 'authenticated', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cache_storage_budget": {
+          "name": "cache_storage_budget",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_source_types": {
+          "name": "default_source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_api_key": {
+          "name": "email_api_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_reply_to_address": {
+          "name": "email_reply_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_sender_address": {
+          "name": "email_sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_sender_name": {
+          "name": "email_sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_sentry": {
+          "name": "enable_sentry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimum_password_length": {
+          "name": "minimum_password_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ncbi_api_key": {
+          "name": "ncbi_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_read": {
+          "name": "sample_all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_write": {
+          "name": "sample_all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group": {
+          "name": "sample_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_read": {
+          "name": "sample_group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_write": {
+          "name": "sample_group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_settings_singleton": {
+          "name": "ck_settings_singleton",
+          "value": "\"settings\".\"id\" = 1"
+        },
+        "ck_settings_cache_storage_budget": {
+          "name": "ck_settings_cache_storage_budget",
+          "value": "\"settings\".\"cache_storage_budget\" > 0"
+        },
+        "ck_settings_sample_group": {
+          "name": "ck_settings_sample_group",
+          "value": "\"settings\".\"sample_group\" in ('none', 'force_choice', 'users_primary_group')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.setup_sessions": {
+      "name": "setup_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_sessions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc', now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_setup_sessions_expires_at": {
+          "name": "idx_setup_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_setup_sessions_user_id": {
+          "name": "idx_setup_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setup_sessions_user_id_fkey": {
+          "name": "setup_sessions_user_id_fkey",
+          "tableFrom": "setup_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_sessions_session_id_key": {
+          "name": "setup_sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "setup_sessions_purpose_valid": {
+          "name": "setup_sessions_purpose_valid",
+          "value": "purpose in ('account_completion', 'email_remediation', 'totp_enrollment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.setup_tokens": {
+      "name": "setup_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "setup_tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc', now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_setup_tokens_expires_at": {
+          "name": "idx_setup_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_setup_tokens_user_id_purpose": {
+          "name": "idx_setup_tokens_user_id_purpose",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setup_tokens_user_id_fkey": {
+          "name": "setup_tokens_user_id_fkey",
+          "tableFrom": "setup_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "setup_tokens_token_hash_key": {
+          "name": "setup_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "setup_tokens_purpose_valid": {
+          "name": "setup_tokens_purpose_valid",
+          "value": "purpose in ('account_completion', 'email_remediation', 'totp_enrollment')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtraction_files": {
+      "name": "subtraction_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subtraction_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtraction_files_subtraction_id_fkey": {
+          "name": "subtraction_files_subtraction_id_fkey",
+          "tableFrom": "subtraction_files",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_subtraction_files_storage_key": {
+          "name": "uq_subtraction_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "subtraction_files_subtraction_id_name_key": {
+          "name": "subtraction_files_subtraction_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subtraction_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_subtraction_files_type": {
+          "name": "ck_subtraction_files_type",
+          "value": "\"subtraction_files\".\"type\" in ('fasta', 'bowtie2')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtractions": {
+      "name": "subtractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subtractions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gc": {
+          "name": "gc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtractions_user_id_fkey": {
+          "name": "subtractions_user_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_job_id_fkey": {
+          "name": "subtractions_job_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_upload_id_fkey": {
+          "name": "subtractions_upload_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtractions_legacy_id_key": {
+          "name": "subtractions_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "subtractions_job_id_key": {
+          "name": "subtractions_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tasks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_active": {
+          "name": "idx_tasks_active",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"complete\" = false and \"tasks\".\"error\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_unacquired": {
+          "name": "idx_tasks_unacquired",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"acquired_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "uploads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed": {
+          "name": "removed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_size": {
+          "name": "expected_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploads_user_id_fkey": {
+          "name": "uploads_user_id_fkey",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uploads_name_on_disk_key": {
+          "name": "uploads_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_uploads_storage_key": {
+          "name": "uq_uploads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_uploads_type": {
+          "name": "ck_uploads_type",
+          "value": "\"uploads\".\"type\" in ('reference', 'reads', 'subtraction')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrator_role": {
+          "name": "administrator_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc', now())"
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "force_reset": {
+          "name": "force_reset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "password": {
+          "name": "password",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "timezone('utc', now())"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_handle_lower_unique": {
+          "name": "users_handle_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_legacy_id_key": {
+          "name": "users_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "users_username_key": {
+          "name": "users_username_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "administrator_role_valid": {
+          "name": "administrator_role_valid",
+          "value": "\"users\".\"administrator_role\" in ('full', 'settings', 'users', 'base')"
+        },
+        "lifecycle_state_valid": {
+          "name": "lifecycle_state_valid",
+          "value": "\"users\".\"lifecycle_state\" in ('pending', 'normal')"
+        },
+        "pending_has_no_password": {
+          "name": "pending_has_no_password",
+          "value": "\"users\".\"lifecycle_state\" <> 'pending' or \"users\".\"password\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_views": {
+      "name": "analysis_views",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_analysis_views_user_id_viewed_at": {
+          "name": "ix_analysis_views_user_id_viewed_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_views_user_id_fkey": {
+          "name": "analysis_views_user_id_fkey",
+          "tableFrom": "analysis_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_views_analysis_id_fkey": {
+          "name": "analysis_views_analysis_id_fkey",
+          "tableFrom": "analysis_views",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analysis_views_pkey": {
+          "name": "analysis_views_pkey",
+          "columns": [
+            "user_id",
+            "analysis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_views": {
+      "name": "sample_views",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_sample_views_user_id_viewed_at": {
+          "name": "ix_sample_views_user_id_viewed_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sample_views_user_id_fkey": {
+          "name": "sample_views_user_id_fkey",
+          "tableFrom": "sample_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sample_views_sample_id_fkey": {
+          "name": "sample_views_sample_id_fkey",
+          "tableFrom": "sample_views",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sample_views_pkey": {
+          "name": "sample_views_pkey",
+          "columns": [
+            "user_id",
+            "sample_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/data/drizzle/meta/_journal.json
+++ b/packages/data/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1788382353037,
       "tag": "0020_add_better_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1788450372090,
+      "tag": "0021_add_setup_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/data/src/auth/identity.ts
+++ b/packages/data/src/auth/identity.ts
@@ -1,0 +1,42 @@
+import { and, eq, sql } from "drizzle-orm";
+
+import type { DbOrTx } from "../db/pg";
+import { authAccounts } from "../db/schema/auth";
+import { users } from "../db/schema/users";
+
+/** The Better Auth provider used for Virtool handle-and-password identities. */
+export const CREDENTIAL_PROVIDER_ID = "credential";
+
+/** Keep the Better Auth password copy synchronized with the legacy credential. */
+export async function updateAuthPassword(
+	db: DbOrTx,
+	userId: number,
+	password: Buffer,
+): Promise<void> {
+	await db
+		.update(authAccounts)
+		.set({ password: password.toString("utf8"), updatedAt: new Date() })
+		.where(
+			and(
+				eq(authAccounts.userId, userId),
+				eq(authAccounts.providerId, CREDENTIAL_PROVIDER_ID),
+			),
+		);
+}
+
+/** Keep Better Auth's username fields synchronized with the Virtool handle. */
+export async function updateAuthUsername(
+	db: DbOrTx,
+	userId: number,
+	handle: string,
+): Promise<void> {
+	await db
+		.update(users)
+		.set({ username: handle.toLowerCase(), displayUsername: handle })
+		.where(
+			and(
+				eq(users.id, userId),
+				sql`exists (select 1 from ${authAccounts} where ${authAccounts.userId} = ${userId} and ${authAccounts.providerId} = ${CREDENTIAL_PROVIDER_ID})`,
+			),
+		);
+}

--- a/packages/data/src/auth/lifecycle.test.ts
+++ b/packages/data/src/auth/lifecycle.test.ts
@@ -1,0 +1,375 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Db } from "../db/pg";
+import { authAccounts, authTwoFactors } from "../db/schema/auth";
+import { setupSessions, setupTokens } from "../db/schema/setup";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import {
+	completeAccountSetup,
+	completeEmailRemediation,
+	completeTotpEnrollment,
+	EmailInUseError,
+	normalizeEmail,
+	SetupNotEligibleError,
+	TotpNotEnrolledError,
+} from "./lifecycle";
+import { hashPassword, verifyPassword } from "./password";
+import { SetupCredentialError } from "./setup";
+import { seedSetupSession, seedSetupToken, seedUser } from "./test/fixtures";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeEach(async () => {
+	database ??= await createTestDatabase();
+	db = database.db;
+	await db.delete(setupSessions);
+	await db.delete(setupTokens);
+	await db.delete(authAccounts);
+	await db.delete(authTwoFactors);
+	await db.delete(users);
+}, 60_000);
+
+async function readUser(userId: number) {
+	const [row] = await db.select().from(users).where(eq(users.id, userId));
+	if (!row) {
+		throw new Error("user missing");
+	}
+	return row;
+}
+
+describe("normalizeEmail", () => {
+	it.each([
+		["  Ada@Example.com ", "ada@example.com"],
+		["ADA@EXAMPLE.COM", "ada@example.com"],
+		["", ""],
+	])("folds %j to %j", (input, expected) => {
+		expect(normalizeEmail(input)).toBe(expected);
+	});
+});
+
+describe("completeAccountSetup", () => {
+	it("credentials a pending account and moves it to normal", async () => {
+		const userId = await seedUser(db, {
+			handle: "Ada",
+			lifecycleState: "pending",
+		});
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		const user = await completeAccountSetup(db, {
+			token,
+			password: "a-good-password",
+			email: "Ada@Example.com",
+		});
+
+		expect(user.lifecycleState).toBe("normal");
+
+		const row = await readUser(userId);
+		expect(row.email).toBe("ada@example.com");
+		expect(row.emailVerified).toBe(true);
+		expect(row.username).toBe("ada");
+		expect(row.displayUsername).toBe("Ada");
+		expect(row.password).not.toBeNull();
+		expect(
+			await verifyPassword("a-good-password", row.password as Buffer),
+		).toBe(true);
+	});
+
+	it("writes one Better Auth credential identity", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await completeAccountSetup(db, {
+			token,
+			password: "a-good-password",
+			email: "ada@example.com",
+		});
+
+		const accounts = await db.select().from(authAccounts);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]?.providerId).toBe("credential");
+		expect(accounts[0]?.accountId).toBe(String(userId));
+		expect(accounts[0]?.password).not.toBeNull();
+	});
+
+	it("revokes every setup credential the account held", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+		await seedSetupSession(db, userId, "account_completion");
+
+		await completeAccountSetup(db, {
+			token,
+			password: "a-good-password",
+			email: "ada@example.com",
+		});
+
+		expect(await db.select().from(setupSessions)).toHaveLength(0);
+		const remaining = await db.select().from(setupTokens);
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0]?.consumedAt).toBeInstanceOf(Date);
+	});
+
+	it("refuses a token for the wrong purpose", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "email_remediation");
+
+		await expect(
+			completeAccountSetup(db, {
+				token,
+				password: "a-good-password",
+				email: "ada@example.com",
+			}),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+	});
+
+	it("refuses an account that is not pending", async () => {
+		const userId = await seedUser(db);
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await expect(
+			completeAccountSetup(db, {
+				token,
+				password: "a-good-password",
+				email: "ada@example.com",
+			}),
+		).rejects.toBeInstanceOf(SetupNotEligibleError);
+	});
+
+	it("refuses a deactivated account", async () => {
+		const userId = await seedUser(db, {
+			active: false,
+			lifecycleState: "pending",
+		});
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await expect(
+			completeAccountSetup(db, {
+				token,
+				password: "a-good-password",
+				email: "ada@example.com",
+			}),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+	});
+
+	it("refuses an address another account already holds", async () => {
+		await seedUser(db, { handle: "bob", email: "ada@example.com" });
+		const userId = await seedUser(db, {
+			handle: "ada",
+			lifecycleState: "pending",
+		});
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await expect(
+			completeAccountSetup(db, {
+				token,
+				password: "a-good-password",
+				email: "ADA@example.com",
+			}),
+		).rejects.toBeInstanceOf(EmailInUseError);
+	});
+
+	// The rollback is what makes a failed completion retryable. A spent token
+	// against an unchanged account is a link the holder can never use again.
+	it("rolls the whole transition back when it fails", async () => {
+		await seedUser(db, { handle: "bob", email: "ada@example.com" });
+		const userId = await seedUser(db, {
+			handle: "ada",
+			lifecycleState: "pending",
+		});
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await expect(
+			completeAccountSetup(db, {
+				token,
+				password: "a-good-password",
+				email: "ada@example.com",
+			}),
+		).rejects.toBeInstanceOf(EmailInUseError);
+
+		const row = await readUser(userId);
+		expect(row.lifecycleState).toBe("pending");
+		expect(row.password).toBeNull();
+		expect(await db.select().from(authAccounts)).toHaveLength(0);
+
+		const [tokenRow] = await db.select().from(setupTokens);
+		expect(tokenRow?.consumedAt).toBeNull();
+	});
+
+	it("cannot be replayed after it commits", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await completeAccountSetup(db, {
+			token,
+			password: "a-good-password",
+			email: "ada@example.com",
+		});
+
+		await expect(
+			completeAccountSetup(db, {
+				token,
+				password: "another-password",
+				email: "ada@example.com",
+			}),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+
+		expect(await db.select().from(authAccounts)).toHaveLength(1);
+	});
+
+	it("gives exactly one winner under concurrent completion", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		const other = database.connect();
+
+		try {
+			const results = await Promise.allSettled([
+				completeAccountSetup(db, {
+					token,
+					password: "a-good-password",
+					email: "ada@example.com",
+				}),
+				completeAccountSetup(other.db, {
+					token,
+					password: "a-good-password",
+					email: "ada@example.com",
+				}),
+			]);
+
+			expect(
+				results.filter((result) => result.status === "fulfilled"),
+			).toHaveLength(1);
+			expect(await db.select().from(authAccounts)).toHaveLength(1);
+		} finally {
+			await other.close();
+		}
+	});
+});
+
+describe("completeEmailRemediation", () => {
+	it("claims the address and derives an identity from the legacy hash", async () => {
+		const password = await hashPassword("legacy-password");
+		const userId = await seedUser(db, { handle: "Ada", password });
+		const { token } = await seedSetupToken(db, userId, "email_remediation");
+
+		await completeEmailRemediation(db, {
+			token,
+			email: " Ada@Example.com ",
+		});
+
+		const row = await readUser(userId);
+		expect(row.email).toBe("ada@example.com");
+		expect(row.emailVerified).toBe(true);
+		expect(row.username).toBe("ada");
+
+		const [account] = await db.select().from(authAccounts);
+		expect(account?.password).toBe(password.toString("utf8"));
+	});
+
+	it("refuses a pending account", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "email_remediation");
+
+		await expect(
+			completeEmailRemediation(db, { token, email: "ada@example.com" }),
+		).rejects.toBeInstanceOf(SetupNotEligibleError);
+	});
+
+	it("refuses an empty address", async () => {
+		const userId = await seedUser(db);
+		const { token } = await seedSetupToken(db, userId, "email_remediation");
+
+		await expect(
+			completeEmailRemediation(db, { token, email: "   " }),
+		).rejects.toBeInstanceOf(EmailInUseError);
+	});
+
+	it("refuses an address another account already holds", async () => {
+		await seedUser(db, { handle: "bob", email: "ada@example.com" });
+		const userId = await seedUser(db, { handle: "ada" });
+		const { token } = await seedSetupToken(db, userId, "email_remediation");
+
+		await expect(
+			completeEmailRemediation(db, { token, email: "ada@example.com" }),
+		).rejects.toBeInstanceOf(EmailInUseError);
+	});
+
+	it("is idempotent against a retry with the same address", async () => {
+		const userId = await seedUser(db);
+		const first = await seedSetupToken(db, userId, "email_remediation");
+		await completeEmailRemediation(db, {
+			token: first.token,
+			email: "ada@example.com",
+		});
+
+		const second = await seedSetupToken(db, userId, "email_remediation");
+		await completeEmailRemediation(db, {
+			token: second.token,
+			email: "ada@example.com",
+		});
+
+		expect(await db.select().from(authAccounts)).toHaveLength(1);
+	});
+});
+
+describe("completeTotpEnrollment", () => {
+	async function seedTwoFactor(userId: number, verified: boolean) {
+		await db.insert(authTwoFactors).values({
+			backupCodes: "encrypted",
+			secret: "secret",
+			userId,
+			verified,
+		});
+	}
+
+	it("releases the restriction once a verified enrollment exists", async () => {
+		const userId = await seedUser(db);
+		await seedTwoFactor(userId, true);
+		await seedSetupSession(db, userId, "totp_enrollment");
+
+		const user = await completeTotpEnrollment(db, { userId });
+
+		expect(user.id).toBe(userId);
+		expect((await readUser(userId)).twoFactorEnabled).toBe(true);
+		expect(await db.select().from(setupSessions)).toHaveLength(0);
+	});
+
+	it("refuses an unverified enrollment and keeps the restriction", async () => {
+		const userId = await seedUser(db);
+		await seedTwoFactor(userId, false);
+		await seedSetupSession(db, userId, "totp_enrollment");
+
+		await expect(completeTotpEnrollment(db, { userId })).rejects.toBeInstanceOf(
+			TotpNotEnrolledError,
+		);
+
+		expect(await db.select().from(setupSessions)).toHaveLength(1);
+	});
+
+	it("refuses when nothing was enrolled at all", async () => {
+		const userId = await seedUser(db);
+
+		await expect(completeTotpEnrollment(db, { userId })).rejects.toBeInstanceOf(
+			TotpNotEnrolledError,
+		);
+	});
+
+	it("refuses a deactivated user", async () => {
+		const userId = await seedUser(db, { active: false });
+		await seedTwoFactor(userId, true);
+
+		await expect(completeTotpEnrollment(db, { userId })).rejects.toBeInstanceOf(
+			TotpNotEnrolledError,
+		);
+	});
+
+	it("refuses a pending account", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		await seedTwoFactor(userId, true);
+
+		await expect(completeTotpEnrollment(db, { userId })).rejects.toBeInstanceOf(
+			TotpNotEnrolledError,
+		);
+	});
+});

--- a/packages/data/src/auth/lifecycle.ts
+++ b/packages/data/src/auth/lifecycle.ts
@@ -1,0 +1,358 @@
+import type { User } from "@virtool/contracts";
+import { and, eq, sql } from "drizzle-orm";
+
+import type { Db, DbOrTx } from "../db/pg";
+import { authAccounts, authTwoFactors } from "../db/schema/auth";
+import { users } from "../db/schema/users";
+import { AppError } from "../errors";
+import { emit } from "../events/emit";
+import { getUser } from "../users/data";
+import { hashPassword } from "./password";
+import {
+	consumeSetupToken,
+	invalidateUserSetupSessions,
+	SetupCredentialError,
+	supersedeSetupTokens,
+} from "./setup";
+
+/**
+ * The Better Auth provider a Virtool handle-and-password identity is held
+ * under.
+ *
+ * Better Auth resolves a credential by `(providerId, accountId)`, and
+ * `accountId` is the Virtool user id, so a user has at most one of these — a
+ * rule the `auth_accounts_provider_id_account_id_key` constraint holds.
+ */
+const CREDENTIAL_PROVIDER_ID = "credential";
+
+/** Thrown when a completion is aimed at an account that is not eligible. */
+export class SetupNotEligibleError extends AppError {}
+
+/** Thrown when the address a completion would establish is already in use. */
+export class EmailInUseError extends AppError {}
+
+/** Thrown when TOTP enrollment has not actually happened. */
+export class TotpNotEnrolledError extends AppError {}
+
+/**
+ * Fold an address to the one form it is compared and stored in.
+ *
+ * Lower-cased and trimmed, because a person who typed `Ada@Example.com` and a
+ * person who typed `ada@example.com` are one person as far as recovery mail is
+ * concerned.
+ */
+export function normalizeEmail(email: string): string {
+	return email.trim().toLowerCase();
+}
+
+/**
+ * Claim `email` for `userId`, or throw {@link EmailInUseError}.
+ *
+ * **`users.email` carries no unique constraint and cannot yet.** Legacy rows
+ * share an empty address and duplicate real ones exist, so an index would fail
+ * to build against a production database. Until those are resolved, the rule
+ * is held here.
+ *
+ * A `SELECT` alone would not hold it: two transactions claiming one address
+ * would both find it free and both commit. So the claim runs under a
+ * transaction-scoped advisory lock keyed on the normalized address, which is
+ * what makes exactly one of them the winner. `hashtext` is applied in
+ * Postgres, so the key is derived the same way every session derives it.
+ */
+async function claimEmail(
+	tx: DbOrTx,
+	userId: number,
+	email: string,
+): Promise<void> {
+	await tx.execute(
+		sql`select pg_advisory_xact_lock(hashtext(${`account_email:${email}`}))`,
+	);
+
+	const taken = await tx
+		.select({ id: users.id })
+		.from(users)
+		.where(
+			and(sql`lower(${users.email}) = ${email}`, sql`${users.id} <> ${userId}`),
+		)
+		.limit(1);
+
+	if (taken.length > 0) {
+		throw new EmailInUseError();
+	}
+}
+
+/**
+ * Give a user the Better Auth credential identity that lets the interactive
+ * endpoints authenticate them.
+ *
+ * Three things together make an identity: the `auth_accounts` row holding the
+ * password, and the `username`/`display_username` pair the `username` plugin
+ * matches a sign-in against. Without the pair the row exists but no sign-in
+ * resolves to it.
+ *
+ * `onConflictDoNothing` rather than an insert: a completion retried after its
+ * transaction already committed must not mint a second identity, and the
+ * `(provider_id, account_id)` constraint is what it lands on.
+ *
+ * `username` is the lower-cased handle and `display_username` the handle as
+ * typed, which is the split the plugin draws and the same one
+ * `users_handle_lower_unique` already holds.
+ */
+async function establishAuthIdentity(
+	tx: DbOrTx,
+	userId: number,
+	handle: string,
+	passwordHash: string,
+): Promise<void> {
+	const now = new Date();
+
+	await tx
+		.insert(authAccounts)
+		.values({
+			accountId: String(userId),
+			providerId: CREDENTIAL_PROVIDER_ID,
+			userId,
+			password: passwordHash,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.onConflictDoNothing({
+			target: [authAccounts.providerId, authAccounts.accountId],
+		});
+
+	await tx
+		.update(users)
+		.set({ username: handle.toLowerCase(), displayUsername: handle })
+		.where(eq(users.id, userId));
+}
+
+/** What {@link completeAccountSetup} accepts. */
+export type CompleteAccountSetupInput = {
+	/** The plaintext setup token from the invitation or bootstrap link. */
+	token: string;
+	/** The password the holder chose. Never one an administrator picked. */
+	password: string;
+	/** The address the holder confirmed. */
+	email: string;
+};
+
+/**
+ * Turn a pending account into a usable one, authorized by an
+ * `account_completion` setup token.
+ *
+ * Everything happens in one transaction: the token is spent, the address is
+ * claimed, the credential is written on both sides of the migration, the
+ * account leaves `pending`, and every setup credential the user holds is
+ * revoked. A failure anywhere rolls the whole transition back, so a spent
+ * token never outlives the account change it paid for.
+ *
+ * The password is written twice on purpose. `users.password` is what
+ * `login()` in the web app still reads, and `auth_accounts.password` is what
+ * Better Auth reads; both boundaries are live during the migration, and an
+ * account completed against only one of them cannot sign in at all under the
+ * other. Both hold the same bcrypt hash at the same cost, because
+ * `@virtool/data/auth/password` is the one place that cost is stated and
+ * Better Auth is configured to use it.
+ *
+ * No session is minted here. Which session a completed holder gets is the
+ * calling flow's decision, and the web app owns cookies.
+ */
+export async function completeAccountSetup(
+	db: Db,
+	{ token, password, email }: CompleteAccountSetupInput,
+): Promise<User> {
+	const normalized = normalizeEmail(email);
+
+	// Hashing is CPU-bound and slow by design, so it happens before the
+	// transaction opens rather than holding one idle for the duration.
+	const hashed = await hashPassword(password);
+
+	const userId = await db.transaction(async (tx) => {
+		const consumed = await consumeSetupToken(tx, token, "account_completion");
+
+		const [row] = await tx
+			.select({
+				handle: users.handle,
+				lifecycleState: users.lifecycleState,
+			})
+			.from(users)
+			.where(eq(users.id, consumed.userId))
+			.limit(1);
+
+		if (!row) {
+			throw new SetupCredentialError();
+		}
+
+		if (row.lifecycleState !== "pending") {
+			throw new SetupNotEligibleError();
+		}
+
+		await claimEmail(tx, consumed.userId, normalized);
+
+		await tx
+			.update(users)
+			.set({
+				password: hashed,
+				email: normalized,
+				emailVerified: true,
+				forceReset: false,
+				lastPasswordChange: new Date(),
+				lifecycleState: "normal",
+			})
+			.where(eq(users.id, consumed.userId));
+
+		await establishAuthIdentity(
+			tx,
+			consumed.userId,
+			row.handle,
+			hashed.toString("utf8"),
+		);
+
+		// The token just spent is gone, but a second outstanding link for the
+		// same purpose would still work. Completion has to close every door it
+		// opened, not just the one it came through.
+		await supersedeSetupTokens(tx, consumed.userId, "account_completion");
+		await invalidateUserSetupSessions(tx, consumed.userId);
+
+		return consumed.userId;
+	});
+
+	// An administrator watching the user list sees the account leave pending.
+	await emit("users", userId, "update");
+
+	return getUser(db, userId);
+}
+
+/** What {@link completeEmailRemediation} accepts. */
+export type CompleteEmailRemediationInput = {
+	/** The plaintext setup token from the remediation link. */
+	token: string;
+	/** The address the holder confirmed. */
+	email: string;
+};
+
+/**
+ * Give an active legacy account a usable unique address and a Better Auth
+ * identity, authorized by an `email_remediation` setup token.
+ *
+ * Bounded to an eligible account: `normal`, active, and still carrying the
+ * legacy `users.password` hash this identity is derived from. A pending
+ * account is not remediated — it has no credential to carry over — and an
+ * account that already has an identity has nothing to remediate.
+ *
+ * The existing password hash moves across rather than being re-derived: the
+ * holder is proving control of an address, not setting a new credential, and
+ * asking them for their password again would make this a reset.
+ */
+export async function completeEmailRemediation(
+	db: Db,
+	{ token, email }: CompleteEmailRemediationInput,
+): Promise<User> {
+	const normalized = normalizeEmail(email);
+
+	if (!normalized) {
+		throw new EmailInUseError();
+	}
+
+	const userId = await db.transaction(async (tx) => {
+		const consumed = await consumeSetupToken(tx, token, "email_remediation");
+
+		const [row] = await tx
+			.select({
+				handle: users.handle,
+				lifecycleState: users.lifecycleState,
+				password: users.password,
+			})
+			.from(users)
+			.where(eq(users.id, consumed.userId))
+			.limit(1);
+
+		if (!row) {
+			throw new SetupCredentialError();
+		}
+
+		if (row.lifecycleState !== "normal" || row.password === null) {
+			throw new SetupNotEligibleError();
+		}
+
+		await claimEmail(tx, consumed.userId, normalized);
+
+		await tx
+			.update(users)
+			.set({ email: normalized, emailVerified: true })
+			.where(eq(users.id, consumed.userId));
+
+		await establishAuthIdentity(
+			tx,
+			consumed.userId,
+			row.handle,
+			row.password.toString("utf8"),
+		);
+
+		await supersedeSetupTokens(tx, consumed.userId, "email_remediation");
+		await invalidateUserSetupSessions(tx, consumed.userId);
+
+		return consumed.userId;
+	});
+
+	await emit("users", userId, "update");
+
+	return getUser(db, userId);
+}
+
+/** What {@link completeTotpEnrollment} accepts. */
+export type CompleteTotpEnrollmentInput = {
+	/** The user the restricted session names. */
+	userId: number;
+};
+
+/**
+ * Release a user from required-MFA restriction, once they have actually
+ * enrolled.
+ *
+ * This confirms rather than performs: Better Auth's two-factor endpoints write
+ * `auth_two_factors` and set `users.two_factor_enabled`, and only a *verified*
+ * row counts — an enrollment that minted a secret but never had a code checked
+ * against it is not enrollment.
+ *
+ * The check and the revocation are one transaction, so a caller cannot lose
+ * the restriction against an enrollment that then rolls back.
+ *
+ * There is no setup token. The holder of a required-MFA restriction got it by
+ * authenticating, not by following a link, so there is nothing to spend.
+ */
+export async function completeTotpEnrollment(
+	db: Db,
+	{ userId }: CompleteTotpEnrollmentInput,
+): Promise<User> {
+	await db.transaction(async (tx) => {
+		const [row] = await tx
+			.select({ id: authTwoFactors.id })
+			.from(authTwoFactors)
+			.innerJoin(users, eq(users.id, authTwoFactors.userId))
+			.where(
+				and(
+					eq(authTwoFactors.userId, userId),
+					eq(authTwoFactors.verified, true),
+					eq(users.active, true),
+					eq(users.lifecycleState, "normal"),
+				),
+			)
+			.limit(1);
+
+		if (!row) {
+			throw new TotpNotEnrolledError();
+		}
+
+		await tx
+			.update(users)
+			.set({ twoFactorEnabled: true })
+			.where(eq(users.id, userId));
+
+		await invalidateUserSetupSessions(tx, userId);
+	});
+
+	await emit("users", userId, "update");
+
+	return getUser(db, userId);
+}

--- a/packages/data/src/auth/lifecycle.ts
+++ b/packages/data/src/auth/lifecycle.ts
@@ -7,6 +7,7 @@ import { users } from "../db/schema/users";
 import { AppError } from "../errors";
 import { emit } from "../events/emit";
 import { getUser } from "../users/data";
+import { CREDENTIAL_PROVIDER_ID, updateAuthUsername } from "./identity";
 import { hashPassword } from "./password";
 import {
 	consumeSetupToken,
@@ -14,16 +15,6 @@ import {
 	SetupCredentialError,
 	supersedeSetupTokens,
 } from "./setup";
-
-/**
- * The Better Auth provider a Virtool handle-and-password identity is held
- * under.
- *
- * Better Auth resolves a credential by `(providerId, accountId)`, and
- * `accountId` is the Virtool user id, so a user has at most one of these — a
- * rule the `auth_accounts_provider_id_account_id_key` constraint holds.
- */
-const CREDENTIAL_PROVIDER_ID = "credential";
 
 /** Thrown when a completion is aimed at an account that is not eligible. */
 export class SetupNotEligibleError extends AppError {}
@@ -120,10 +111,7 @@ async function establishAuthIdentity(
 			target: [authAccounts.providerId, authAccounts.accountId],
 		});
 
-	await tx
-		.update(users)
-		.set({ username: handle.toLowerCase(), displayUsername: handle })
-		.where(eq(users.id, userId));
+	await updateAuthUsername(tx, userId, handle);
 }
 
 /** What {@link completeAccountSetup} accepts. */

--- a/packages/data/src/auth/setup.test.ts
+++ b/packages/data/src/auth/setup.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Db } from "../db/pg";
+import { setupSessions, setupTokens } from "../db/schema/setup";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import {
+	consumeSetupToken,
+	createSetupSession,
+	deleteExpiredSetupState,
+	invalidateSetupSession,
+	invalidateUserSetupSessions,
+	issueSetupToken,
+	SetupCredentialError,
+	supersedeSetupTokens,
+	verifySetupSession,
+} from "./setup";
+import { seedSetupSession, seedSetupToken, seedUser } from "./test/fixtures";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeEach(async () => {
+	database ??= await createTestDatabase();
+	db = database.db;
+	await db.delete(setupSessions);
+	await db.delete(setupTokens);
+	await db.delete(users);
+}, 60_000);
+
+describe("issueSetupToken", () => {
+	it("returns the plaintext once and stores only its digest", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+
+		const issued = await issueSetupToken(db, {
+			userId,
+			purpose: "account_completion",
+		});
+
+		expect(issued.token).toMatch(/^[0-9a-f]{64}$/);
+		expect(issued.userId).toBe(userId);
+		expect(issued.purpose).toBe("account_completion");
+
+		const rows = await db.select().from(setupTokens);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.tokenHash).not.toBe(issued.token);
+		expect(rows[0]?.consumedAt).toBeNull();
+	});
+
+	it("supersedes an outstanding token for the same purpose", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const first = await issueSetupToken(db, {
+			userId,
+			purpose: "account_completion",
+		});
+
+		await issueSetupToken(db, { userId, purpose: "account_completion" });
+
+		await expect(
+			consumeSetupToken(db, first.token, "account_completion"),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+		expect(await db.select().from(setupTokens)).toHaveLength(1);
+	});
+
+	it("leaves a token for a different purpose alone", async () => {
+		const userId = await seedUser(db);
+		const remediation = await issueSetupToken(db, {
+			userId,
+			purpose: "email_remediation",
+		});
+
+		await issueSetupToken(db, { userId, purpose: "totp_enrollment" });
+
+		await expect(
+			consumeSetupToken(db, remediation.token, "email_remediation"),
+		).resolves.toEqual({ userId, purpose: "email_remediation" });
+	});
+});
+
+describe("consumeSetupToken", () => {
+	it("spends a live token and records the consumption", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await expect(
+			consumeSetupToken(db, token, "account_completion"),
+		).resolves.toEqual({ userId, purpose: "account_completion" });
+
+		const [row] = await db.select().from(setupTokens);
+		expect(row?.consumedAt).toBeInstanceOf(Date);
+	});
+
+	it("refuses a second use", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await consumeSetupToken(db, token, "account_completion");
+
+		await expect(
+			consumeSetupToken(db, token, "account_completion"),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+	});
+
+	it("refuses an unknown token", async () => {
+		await expect(
+			consumeSetupToken(db, "0".repeat(64), "account_completion"),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+	});
+
+	it("refuses an expired token", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion", {
+			expiresAt: new Date(Date.now() - 1_000),
+		});
+
+		await expect(
+			consumeSetupToken(db, token, "account_completion"),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+	});
+
+	it("refuses a token presented for the wrong purpose", async () => {
+		const userId = await seedUser(db);
+		const { token } = await seedSetupToken(db, userId, "email_remediation");
+
+		await expect(
+			consumeSetupToken(db, token, "totp_enrollment"),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+
+		const [row] = await db.select().from(setupTokens);
+		expect(row?.consumedAt).toBeNull();
+	});
+
+	it("refuses a token whose user has been deactivated", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		await db.update(users).set({ active: false });
+
+		await expect(
+			consumeSetupToken(db, token, "account_completion"),
+		).rejects.toBeInstanceOf(SetupCredentialError);
+	});
+
+	/*
+	 The fixture pool is max: 1, so two awaits a test starts together reach
+	 Postgres one after the other. A second connection is what makes the two
+	 transactions genuinely contend for the row.
+	*/
+	it("gives exactly one winner under concurrent submission", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const { token } = await seedSetupToken(db, userId, "account_completion");
+
+		const other = database.connect();
+
+		try {
+			const results = await Promise.allSettled([
+				db.transaction((tx) =>
+					consumeSetupToken(tx, token, "account_completion"),
+				),
+				other.db.transaction((tx) =>
+					consumeSetupToken(tx, token, "account_completion"),
+				),
+			]);
+
+			expect(
+				results.filter((result) => result.status === "fulfilled"),
+			).toHaveLength(1);
+			expect(
+				results.filter((result) => result.status === "rejected"),
+			).toHaveLength(1);
+		} finally {
+			await other.close();
+		}
+	});
+});
+
+describe("supersedeSetupTokens", () => {
+	it("removes only the unspent tokens for that purpose", async () => {
+		const userId = await seedUser(db);
+		await seedSetupToken(db, userId, "email_remediation");
+		await seedSetupToken(db, userId, "email_remediation", {
+			consumedAt: new Date(),
+		});
+		await seedSetupToken(db, userId, "totp_enrollment");
+
+		expect(await supersedeSetupTokens(db, userId, "email_remediation")).toBe(1);
+		expect(await db.select().from(setupTokens)).toHaveLength(2);
+	});
+});
+
+describe("createSetupSession", () => {
+	it("returns a non-secret id and a secret, storing only the digest", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+
+		const created = await createSetupSession(db, {
+			userId,
+			purpose: "account_completion",
+			ip: "127.0.0.1",
+		});
+
+		expect(created.sessionId).toMatch(/^setup_[0-9a-f]{48}$/);
+		expect(created.row.tokenHash).not.toBe(created.token);
+		expect(created.row.purpose).toBe("account_completion");
+	});
+
+	it("replaces any restricted session the user already holds", async () => {
+		const userId = await seedUser(db);
+		const first = await seedSetupSession(db, userId, "email_remediation");
+
+		await createSetupSession(db, {
+			userId,
+			purpose: "totp_enrollment",
+			ip: "127.0.0.1",
+		});
+
+		expect(
+			await verifySetupSession(db, first.sessionId, first.token),
+		).toBeNull();
+		expect(await db.select().from(setupSessions)).toHaveLength(1);
+	});
+});
+
+describe("verifySetupSession", () => {
+	it("resolves the user, session id, purpose and expiry, and nothing else", async () => {
+		const userId = await seedUser(db, { lifecycleState: "pending" });
+		const seeded = await seedSetupSession(db, userId, "account_completion");
+
+		const resolved = await verifySetupSession(
+			db,
+			seeded.sessionId,
+			seeded.token,
+		);
+
+		expect(Object.keys(resolved ?? {}).toSorted()).toEqual([
+			"expiresAt",
+			"purpose",
+			"sessionId",
+			"userId",
+		]);
+		expect(resolved?.userId).toBe(userId);
+		expect(resolved?.purpose).toBe("account_completion");
+	});
+
+	it.each([
+		["no session id", undefined, "token"],
+		["no token", "setup_x", undefined],
+	])("returns null with %s", async (_name, sessionId, token) => {
+		expect(await verifySetupSession(db, sessionId, token)).toBeNull();
+	});
+
+	it("returns null for an unknown session", async () => {
+		expect(
+			await verifySetupSession(db, "setup_unknown", "0".repeat(64)),
+		).toBeNull();
+	});
+
+	it("returns null when the secret does not match", async () => {
+		const userId = await seedUser(db);
+		const seeded = await seedSetupSession(db, userId, "totp_enrollment");
+
+		expect(
+			await verifySetupSession(db, seeded.sessionId, "0".repeat(64)),
+		).toBeNull();
+	});
+
+	it("returns null once expired", async () => {
+		const userId = await seedUser(db);
+		const seeded = await seedSetupSession(db, userId, "totp_enrollment", {
+			expiresAt: new Date(Date.now() - 1_000),
+		});
+
+		expect(
+			await verifySetupSession(db, seeded.sessionId, seeded.token),
+		).toBeNull();
+	});
+
+	it("returns null once the user is deactivated", async () => {
+		const userId = await seedUser(db);
+		const seeded = await seedSetupSession(db, userId, "totp_enrollment");
+
+		await db.update(users).set({ active: false });
+
+		expect(
+			await verifySetupSession(db, seeded.sessionId, seeded.token),
+		).toBeNull();
+	});
+});
+
+describe("invalidateSetupSession", () => {
+	it("deletes the named session and leaves the rest", async () => {
+		const first = await seedUser(db, { handle: "alice" });
+		const second = await seedUser(db, { handle: "bob" });
+		const seeded = await seedSetupSession(db, first, "totp_enrollment");
+		await seedSetupSession(db, second, "totp_enrollment");
+
+		await invalidateSetupSession(db, seeded.sessionId);
+
+		expect(await db.select().from(setupSessions)).toHaveLength(1);
+	});
+});
+
+describe("invalidateUserSetupSessions", () => {
+	it("deletes every session the user holds", async () => {
+		const first = await seedUser(db, { handle: "alice" });
+		const second = await seedUser(db, { handle: "bob" });
+		await seedSetupSession(db, first, "totp_enrollment");
+		await seedSetupSession(db, second, "totp_enrollment");
+
+		await invalidateUserSetupSessions(db, first);
+
+		const rows = await db.select().from(setupSessions);
+		expect(rows.map((row) => row.userId)).toEqual([second]);
+	});
+});
+
+describe("deleteExpiredSetupState", () => {
+	it("removes expired rows from both tables and keeps live ones", async () => {
+		const userId = await seedUser(db);
+		const past = new Date(Date.now() - 60_000);
+
+		await seedSetupToken(db, userId, "email_remediation", { expiresAt: past });
+		await seedSetupToken(db, userId, "totp_enrollment", {
+			expiresAt: past,
+			consumedAt: new Date(),
+		});
+		await seedSetupToken(db, userId, "account_completion");
+		await seedSetupSession(db, userId, "totp_enrollment", { expiresAt: past });
+
+		expect(await deleteExpiredSetupState(db)).toEqual({
+			tokens: 2,
+			sessions: 1,
+		});
+		expect(await db.select().from(setupTokens)).toHaveLength(1);
+		expect(await db.select().from(setupSessions)).toHaveLength(0);
+	});
+
+	it("sweeps in more than one batch", async () => {
+		const userId = await seedUser(db);
+		const past = new Date(Date.now() - 60_000);
+
+		for (const purpose of ["email_remediation", "totp_enrollment"] as const) {
+			await seedSetupToken(db, userId, purpose, { expiresAt: past });
+		}
+
+		expect(await deleteExpiredSetupState(db, { batchSize: 1 })).toEqual({
+			tokens: 2,
+			sessions: 0,
+		});
+	});
+
+	it("rejects a batch size that is not a positive integer", async () => {
+		await expect(
+			deleteExpiredSetupState(db, { batchSize: 0 }),
+		).rejects.toBeInstanceOf(RangeError);
+	});
+});

--- a/packages/data/src/auth/setup.ts
+++ b/packages/data/src/auth/setup.ts
@@ -1,0 +1,408 @@
+import { randomBytes } from "node:crypto";
+
+import type { RestrictedSetup, SetupPurpose } from "@virtool/contracts";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import type { Db, DbOrTx } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import {
+	type SetupSessionRow,
+	setupSessions,
+	setupTokens,
+} from "../db/schema/setup";
+import { users } from "../db/schema/users";
+import { nowUtc } from "../db/time";
+import { AppError } from "../errors";
+import { hashToken } from "./tokens";
+
+/** How long a setup link stays usable. */
+const SETUP_TOKEN_LIFETIME_MS = 72 * 60 * 60 * 1000;
+
+/** How long a restricted setup session stays usable. */
+const SETUP_SESSION_LIFETIME_MS = 30 * 60 * 1000;
+
+/** The prefix every restricted setup session id carries. */
+const SETUP_SESSION_ID_PREFIX = "setup_";
+
+/**
+ * Thrown when a setup token cannot be used.
+ *
+ * Deliberately carries no reason. Unknown, expired, already spent, presented
+ * for the wrong purpose, and belonging to a deactivated account are one
+ * answer, because telling them apart tells the holder whether a given token
+ * exists.
+ */
+export class SetupCredentialError extends AppError {}
+
+/** What {@link issueSetupToken} accepts. */
+export type IssueSetupTokenInput = {
+	userId: number;
+	purpose: SetupPurpose;
+	/** Defaults to {@link SETUP_TOKEN_LIFETIME_MS}. */
+	lifetimeMs?: number;
+};
+
+/**
+ * A freshly issued setup token: the plaintext to put in a link, and the
+ * non-secret facts a caller may show or store.
+ *
+ * `token` is the only time the plaintext exists outside the holder's link. It
+ * is not written to the row, not logged, and not readable back.
+ */
+export type IssuedSetupToken = {
+	token: string;
+	userId: number;
+	purpose: SetupPurpose;
+	expiresAt: Date;
+};
+
+/**
+ * Issue a setup token, superseding any the user already holds for the same
+ * purpose.
+ *
+ * Superseding is what makes "send a new link" safe: the previous link stops
+ * working the moment the replacement is minted, so a forwarded or intercepted
+ * older mail is inert. Consumed rows are left alone — they are the record that
+ * the transition already happened, and cleanup removes them once they expire.
+ *
+ * Both statements run in one transaction, so a caller can never end up with
+ * two live tokens for a purpose.
+ */
+export async function issueSetupToken(
+	db: Db,
+	{
+		userId,
+		purpose,
+		lifetimeMs = SETUP_TOKEN_LIFETIME_MS,
+	}: IssueSetupTokenInput,
+): Promise<IssuedSetupToken> {
+	const token = randomBytes(32).toString("hex");
+	const expiresAt = new Date(Date.now() + lifetimeMs);
+
+	await db.transaction(async (tx) => {
+		await supersedeSetupTokens(tx, userId, purpose);
+
+		await tx.insert(setupTokens).values({
+			userId,
+			purpose,
+			tokenHash: hashToken(token),
+			expiresAt,
+		});
+	});
+
+	return { token, userId, purpose, expiresAt };
+}
+
+/**
+ * Delete every unspent setup token a user holds for `purpose`, and report how
+ * many went.
+ *
+ * Deleted rather than flagged: a superseded link and an unknown one have to be
+ * indistinguishable to whoever submits them, and the simplest way to say
+ * nothing is to have nothing to say.
+ */
+export async function supersedeSetupTokens(
+	db: DbOrTx,
+	userId: number,
+	purpose: SetupPurpose,
+): Promise<number> {
+	const deleted = await db
+		.delete(setupTokens)
+		.where(
+			and(
+				eq(setupTokens.userId, userId),
+				eq(setupTokens.purpose, purpose),
+				isNull(setupTokens.consumedAt),
+			),
+		)
+		.returning({ id: setupTokens.id });
+
+	return deleted.length;
+}
+
+/** The user a consumed setup token names. */
+export type ConsumedSetupToken = {
+	userId: number;
+	purpose: SetupPurpose;
+};
+
+/**
+ * Spend a setup token for `purpose`, or throw {@link SetupCredentialError}.
+ *
+ * **Call this inside the transaction that performs the transition it
+ * authorizes.** The consumption and the transition are one unit: a token spent
+ * against a transition that then rolls back is a link the holder can no longer
+ * use for an account that never changed.
+ *
+ * Consumption is a single conditional `UPDATE ... RETURNING`, so two
+ * submissions of one token serialize on the row and exactly one sees a row
+ * come back. The loser is told the same thing every other refusal says.
+ *
+ * The expiry test uses Postgres's clock rather than a `Date` bound from here:
+ * `expires_at` is `timestamp without time zone` holding naive UTC, and a
+ * JavaScript `Date` compared against it casts through the session `TimeZone`,
+ * which this pool leaves unset.
+ *
+ * `users.active` is re-read here rather than trusted from issuance.
+ * Deactivation is authoritative and immediate — an administrator who switches
+ * an account off has revoked its setup link too.
+ */
+export async function consumeSetupToken(
+	db: DbOrTx,
+	token: string,
+	purpose: SetupPurpose,
+): Promise<ConsumedSetupToken> {
+	const [row] = await db
+		.update(setupTokens)
+		.set({ consumedAt: sql`${nowUtc()}` })
+		.where(
+			and(
+				eq(setupTokens.tokenHash, hashToken(token)),
+				eq(setupTokens.purpose, purpose),
+				isNull(setupTokens.consumedAt),
+				sql`${setupTokens.expiresAt} > ${nowUtc()}`,
+				sql`exists (select 1 from ${users} where ${users.id} = ${setupTokens.userId} and ${users.active})`,
+			),
+		)
+		.returning({ userId: setupTokens.userId, purpose: setupTokens.purpose });
+
+	if (!row) {
+		throw new SetupCredentialError();
+	}
+
+	return row;
+}
+
+/** What {@link createSetupSession} accepts. */
+export type CreateSetupSessionInput = {
+	userId: number;
+	purpose: SetupPurpose;
+	ip: string;
+	/** Defaults to {@link SETUP_SESSION_LIFETIME_MS}. */
+	lifetimeMs?: number;
+};
+
+/** A restricted setup session, and the secret the browser must send back. */
+export type CreatedSetupSession = {
+	/** The non-secret identifier, for attribution. */
+	sessionId: string;
+	/** The secret half. Only its digest is stored. */
+	token: string;
+	row: SetupSessionRow;
+};
+
+/**
+ * Mint a restricted setup session for one purpose.
+ *
+ * Two values rather than one, mirroring the authenticated pair: `sessionId`
+ * names the session in a log or a Sentry scope and proves nothing, and `token`
+ * is the secret that does. Nothing but this function ever holds the plaintext.
+ *
+ * Every restricted session the user already holds goes first. A holder may be
+ * part-way through exactly one setup at a time, and abandoning one flow has to
+ * close it rather than leave a second door open.
+ */
+export async function createSetupSession(
+	db: Db,
+	{
+		userId,
+		purpose,
+		ip,
+		lifetimeMs = SETUP_SESSION_LIFETIME_MS,
+	}: CreateSetupSessionInput,
+): Promise<CreatedSetupSession> {
+	const sessionId = SETUP_SESSION_ID_PREFIX + randomBytes(24).toString("hex");
+	const token = randomBytes(32).toString("hex");
+	const expiresAt = new Date(Date.now() + lifetimeMs);
+
+	const row = await db.transaction(async (tx) => {
+		await invalidateUserSetupSessions(tx, userId);
+
+		return takeFirstOrThrow(
+			await tx
+				.insert(setupSessions)
+				.values({
+					sessionId,
+					tokenHash: hashToken(token),
+					userId,
+					purpose,
+					ip,
+					expiresAt,
+				})
+				.returning(),
+		);
+	});
+
+	return { sessionId, token, row };
+}
+
+/**
+ * Resolve a restricted setup session from its cookie pair, or `null`.
+ *
+ * `null` for every non-fatal failure — missing values, unknown session,
+ * expired, deactivated user, digest mismatch — so the boundary answers one
+ * refusal without saying which check failed.
+ *
+ * What comes back is deliberately the whole of what the credential proves:
+ * a user, a session id, one purpose and an expiry. No role, no group
+ * permission and no API-key cap, because a restricted caller has none.
+ *
+ * The user's `active` flag is re-read on every request for the same reason the
+ * authenticated path re-reads it: deactivation has to take effect at once, and
+ * a setup credential must never be the looser door.
+ */
+export async function verifySetupSession(
+	db: Db,
+	sessionId: string | undefined,
+	token: string | undefined,
+): Promise<RestrictedSetup | null> {
+	if (!sessionId || !token) {
+		return null;
+	}
+
+	const [row] = await db
+		.select({
+			userId: setupSessions.userId,
+			purpose: setupSessions.purpose,
+			tokenHash: setupSessions.tokenHash,
+			expiresAt: setupSessions.expiresAt,
+			active: users.active,
+		})
+		.from(setupSessions)
+		.innerJoin(users, eq(users.id, setupSessions.userId))
+		.where(
+			and(
+				eq(setupSessions.sessionId, sessionId),
+				eq(setupSessions.tokenHash, hashToken(token)),
+			),
+		)
+		.limit(1);
+
+	if (!row?.active || row.expiresAt.getTime() <= Date.now()) {
+		return null;
+	}
+
+	return {
+		userId: row.userId,
+		sessionId,
+		purpose: row.purpose,
+		expiresAt: row.expiresAt,
+	};
+}
+
+/** Delete one restricted setup session, by its non-secret identifier. */
+export async function invalidateSetupSession(
+	db: DbOrTx,
+	sessionId: string,
+): Promise<void> {
+	await db.delete(setupSessions).where(eq(setupSessions.sessionId, sessionId));
+}
+
+/**
+ * Delete every restricted setup session a user holds.
+ *
+ * Called when a setup transition commits and when one is abandoned, so a
+ * completed or dropped flow leaves no credential behind.
+ */
+export async function invalidateUserSetupSessions(
+	db: DbOrTx,
+	userId: number,
+): Promise<void> {
+	await db.delete(setupSessions).where(eq(setupSessions.userId, userId));
+}
+
+/**
+ * How many expired setup rows one statement removes.
+ *
+ * The same bound the session sweep uses, and for the same reason: short enough
+ * that nothing waiting on a row waits long, large enough that the loop is not
+ * itself the cost.
+ */
+const SETUP_CLEANUP_BATCH_SIZE = 2_000;
+
+/** What the setup sweeps accept. */
+export type DeleteExpiredSetupOptions = {
+	/** Rows removed per statement. Defaults to {@link SETUP_CLEANUP_BATCH_SIZE}. */
+	batchSize?: number;
+	/** Aborts the loop between batches. Committed batches stand. */
+	signal?: AbortSignal;
+};
+
+/** How many rows each sweep removed. */
+export type DeleteExpiredSetupResult = {
+	tokens: number;
+	sessions: number;
+};
+
+/**
+ * Delete every expired `setup_tokens` and `setup_sessions` row, and report how
+ * many of each went.
+ *
+ * Batched, each batch its own transaction, and bounded by Postgres's clock —
+ * the same shape as `deleteExpiredSessions`, for the same reasons, which are
+ * written out in full there.
+ *
+ * Nothing waits on this. `consumeSetupToken` and `verifySetupSession` both
+ * refuse an expired row on sight, so a row lingering between sweeps is inert
+ * and a late sweep is harmless. That is what keeps the work on the runner's
+ * schedule instead of in the request path.
+ *
+ * An expired *consumed* token goes too. Its only remaining job was to make a
+ * replayed link fail the same way an unknown one does, and past its expiry the
+ * expiry check does that on its own.
+ */
+export async function deleteExpiredSetupState(
+	db: DbOrTx,
+	{
+		batchSize = SETUP_CLEANUP_BATCH_SIZE,
+		signal,
+	}: DeleteExpiredSetupOptions = {},
+): Promise<DeleteExpiredSetupResult> {
+	if (!Number.isInteger(batchSize) || batchSize < 1) {
+		throw new RangeError(
+			`batchSize must be a positive integer, got ${batchSize}`,
+		);
+	}
+
+	return {
+		tokens: await sweep(db, setupTokens, batchSize, signal),
+		sessions: await sweep(db, setupSessions, batchSize, signal),
+	};
+}
+
+/*
+ The expiry test is repeated on the outer `delete`, where it looks redundant
+ against the subquery that already applied it. Under Read Committed a row
+ updated by a transaction that commits mid-statement is re-checked against the
+ outer `where` alone — the subquery is not re-run — so a predicate naming only
+ the id would pass on a row whose `expires_at` has since moved forward.
+*/
+async function sweep(
+	db: DbOrTx,
+	table: typeof setupTokens | typeof setupSessions,
+	batchSize: number,
+	signal: AbortSignal | undefined,
+): Promise<number> {
+	let total = 0;
+
+	for (;;) {
+		signal?.throwIfAborted();
+
+		const deleted = await db
+			.delete(table)
+			.where(
+				sql`${table.expiresAt} < ${nowUtc()} and ${table.id} in (
+					select id from ${table}
+					where expires_at < ${nowUtc()}
+					limit ${batchSize}
+				)`,
+			)
+			.returning({ id: table.id });
+
+		total += deleted.length;
+
+		if (deleted.length < batchSize) {
+			return total;
+		}
+	}
+}

--- a/packages/data/src/auth/setup.ts
+++ b/packages/data/src/auth/setup.ts
@@ -80,6 +80,7 @@ export async function issueSetupToken(
 	const expiresAt = new Date(Date.now() + lifetimeMs);
 
 	await db.transaction(async (tx) => {
+		await lockUserSetupCredentials(tx, userId);
 		await supersedeSetupTokens(tx, userId, purpose);
 
 		await tx.insert(setupTokens).values({
@@ -118,6 +119,14 @@ export async function supersedeSetupTokens(
 		.returning({ id: setupTokens.id });
 
 	return deleted.length;
+}
+
+/** Delete every setup token held by a user. */
+export async function invalidateUserSetupTokens(
+	db: DbOrTx,
+	userId: number,
+): Promise<void> {
+	await db.delete(setupTokens).where(eq(setupTokens.userId, userId));
 }
 
 /** The user a consumed setup token names. */
@@ -216,6 +225,7 @@ export async function createSetupSession(
 	const expiresAt = new Date(Date.now() + lifetimeMs);
 
 	const row = await db.transaction(async (tx) => {
+		await lockUserSetupCredentials(tx, userId);
 		await invalidateUserSetupSessions(tx, userId);
 
 		return takeFirstOrThrow(
@@ -234,6 +244,16 @@ export async function createSetupSession(
 	});
 
 	return { sessionId, token, row };
+}
+
+/** Serialize replacement or revocation of a user's setup credentials. */
+export async function lockUserSetupCredentials(
+	db: DbOrTx,
+	userId: number,
+): Promise<void> {
+	await db.execute(
+		sql`select pg_advisory_xact_lock(hashtext(${`setup:${userId}`}))`,
+	);
 }
 
 /**

--- a/packages/data/src/auth/test/fixtures.ts
+++ b/packages/data/src/auth/test/fixtures.ts
@@ -1,14 +1,17 @@
 import { randomBytes } from "node:crypto";
 
 import {
+	type AccountLifecycleState,
 	type AdministratorRoleName,
 	emptyPermissions,
 	type Permissions,
+	type SetupPurpose,
 } from "@virtool/contracts";
 
 import type { Db } from "../../db/pg";
 import { apiKeys } from "../../db/schema/apiKeys";
 import { sessions } from "../../db/schema/sessions";
+import { setupSessions, setupTokens } from "../../db/schema/setup";
 import { users } from "../../db/schema/users";
 import { hashToken, newSessionId, newSessionToken } from "../tokens";
 
@@ -19,7 +22,8 @@ export type SeedUserOptions = {
 	email?: string;
 	forceReset?: boolean;
 	handle?: string;
-	password?: Buffer;
+	lifecycleState?: AccountLifecycleState;
+	password?: Buffer | null;
 	settings?: Record<string, unknown>;
 };
 
@@ -40,6 +44,10 @@ export type SeededSession = {
  * `password` defaults to a placeholder that is not a real bcrypt hash. A test
  * that exercises a code path which verifies the stored password must pass a
  * hash from `hashPassword`.
+ *
+ * `lifecycleState: "pending"` forces `password` to null, because the
+ * `pending_has_no_password` constraint refuses the pair — a pending account is
+ * one that has no credential at all.
  */
 export async function seedUser(
 	db: Db,
@@ -49,6 +57,7 @@ export async function seedUser(
 		email = "",
 		forceReset = false,
 		handle = "alice",
+		lifecycleState = "normal",
 		password = Buffer.from("not-a-real-hash"),
 		settings = {},
 	}: SeedUserOptions = {},
@@ -62,7 +71,8 @@ export async function seedUser(
 			forceReset,
 			handle,
 			lastPasswordChange: new Date(),
-			password,
+			lifecycleState,
+			password: lifecycleState === "pending" ? null : password,
 			settings,
 		})
 		.returning({ id: users.id });
@@ -132,4 +142,68 @@ export async function seedApiKey(
 	});
 
 	return key;
+}
+
+/** A seeded setup token and the plaintext that spends it. */
+export type SeededSetupToken = {
+	token: string;
+	userId: number;
+};
+
+/**
+ * Insert a setup token for `userId`. Only its digest is stored, so the
+ * plaintext is returned — it is the only way a caller can spend it afterwards.
+ */
+export async function seedSetupToken(
+	db: Db,
+	userId: number,
+	purpose: SetupPurpose,
+	{
+		expiresAt = new Date(Date.now() + 60_000),
+		consumedAt = null,
+	}: { expiresAt?: Date; consumedAt?: Date | null } = {},
+): Promise<SeededSetupToken> {
+	const token = randomBytes(32).toString("hex");
+
+	await db.insert(setupTokens).values({
+		consumedAt,
+		expiresAt,
+		purpose,
+		tokenHash: hashToken(token),
+		userId,
+	});
+
+	return { token, userId };
+}
+
+/** A seeded restricted setup session and the secret that proves it. */
+export type SeededSetupSession = {
+	sessionId: string;
+	token: string;
+	userId: number;
+};
+
+/**
+ * Insert a restricted setup session for `userId`. Only the secret's digest is
+ * stored, so the plaintext is returned.
+ */
+export async function seedSetupSession(
+	db: Db,
+	userId: number,
+	purpose: SetupPurpose,
+	{ expiresAt = new Date(Date.now() + 60_000) }: { expiresAt?: Date } = {},
+): Promise<SeededSetupSession> {
+	const sessionId = `setup_${randomBytes(24).toString("hex")}`;
+	const token = randomBytes(32).toString("hex");
+
+	await db.insert(setupSessions).values({
+		expiresAt,
+		ip: "127.0.0.1",
+		purpose,
+		sessionId,
+		tokenHash: hashToken(token),
+		userId,
+	});
+
+	return { sessionId, token, userId };
 }

--- a/packages/data/src/db/schema/foreignKeys.test.ts
+++ b/packages/data/src/db/schema/foreignKeys.test.ts
@@ -41,7 +41,7 @@ describe("foreign key constraint names", () => {
 	});
 
 	it("covers every foreign key in the mirror", () => {
-		expect(found).toHaveLength(59);
+		expect(found).toHaveLength(61);
 	});
 
 	it.each(found)("names $expected", ({ actual, expected }) => {

--- a/packages/data/src/db/schema/index.ts
+++ b/packages/data/src/db/schema/index.ts
@@ -20,6 +20,7 @@ export * from "./references";
 export * from "./samples";
 export * from "./sessions";
 export * from "./settings";
+export * from "./setup";
 export * from "./subtractions";
 export * from "./tasks";
 export * from "./uploads";

--- a/packages/data/src/db/schema/setup.ts
+++ b/packages/data/src/db/schema/setup.ts
@@ -1,0 +1,118 @@
+// Schema for the account-setup tables.
+//
+// Two separate credentials, because they answer different questions. A
+// `setup_tokens` row is the bearer secret in a link an administrator copies or
+// an email carries: it proves the holder was sent the link, and it is spent
+// once. A `setup_sessions` row is the restricted browser credential the holder
+// gets in exchange: it proves an in-progress setup for one named purpose and
+// nothing else.
+//
+// Neither is the legacy `sessions` table and neither is `auth_sessions`. A
+// restricted setup credential must not be an ordinary application session —
+// the whole point is that it reaches only its own setup surface — so it is
+// held apart rather than added as another `session_type`.
+
+import type { SetupPurpose } from "@virtool/contracts";
+import { type SQL, sql } from "drizzle-orm";
+import {
+	check,
+	foreignKey,
+	index,
+	integer,
+	pgTable,
+	text,
+	timestamp,
+	unique,
+} from "drizzle-orm/pg-core";
+
+import { users } from "./users";
+
+/**
+ * The SQL fragment closing a `purpose` column to the shared union.
+ *
+ * Written once because both tables carry the same column and the two must not
+ * be able to disagree about what a purpose is.
+ */
+function purposeCheck(): SQL {
+	return sql.raw(
+		"purpose in ('account_completion', 'email_remediation', 'totp_enrollment')",
+	);
+}
+
+export const setupTokens = pgTable(
+	"setup_tokens",
+	{
+		id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+		userId: integer("user_id").notNull(),
+		purpose: text("purpose").$type<SetupPurpose>().notNull(),
+		/**
+		 * SHA-256 of the plaintext token, the only form it is ever stored in.
+		 * The plaintext is returned to the issuing caller once and never again.
+		 */
+		tokenHash: text("token_hash").notNull(),
+		createdAt: timestamp("created_at")
+			.notNull()
+			.default(sql`timezone('utc', now())`),
+		expiresAt: timestamp("expires_at").notNull(),
+		/** When this token was spent. Null while it is still usable. */
+		consumedAt: timestamp("consumed_at"),
+	},
+	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "setup_tokens_user_id_fkey",
+		}).onDelete("cascade"),
+		// The digest is what a submission is looked up by, so it is unique and
+		// indexed by the same constraint. A collision would be two users sharing
+		// one link.
+		unique("setup_tokens_token_hash_key").on(table.tokenHash),
+		// The expiry sweep's index. It is the only query that scans the table
+		// without a digest.
+		index("idx_setup_tokens_expires_at").on(table.expiresAt),
+		// Issuing a replacement supersedes the outstanding tokens for the same
+		// user and purpose, which is the only lookup by user.
+		index("idx_setup_tokens_user_id_purpose").on(table.userId, table.purpose),
+		check("setup_tokens_purpose_valid", purposeCheck()),
+	],
+);
+
+/** A row from the `setup_tokens` table. */
+export type SetupTokenRow = typeof setupTokens.$inferSelect;
+
+export const setupSessions = pgTable(
+	"setup_sessions",
+	{
+		id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+		/**
+		 * The stable, non-secret identifier. Safe to log and to attribute an
+		 * error to; it proves nothing on its own.
+		 */
+		sessionId: text("session_id").notNull(),
+		/** SHA-256 of the secret half of the credential. */
+		tokenHash: text("token_hash").notNull(),
+		userId: integer("user_id").notNull(),
+		purpose: text("purpose").$type<SetupPurpose>().notNull(),
+		ip: text("ip").notNull(),
+		createdAt: timestamp("created_at")
+			.notNull()
+			.default(sql`timezone('utc', now())`),
+		expiresAt: timestamp("expires_at").notNull(),
+	},
+	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "setup_sessions_user_id_fkey",
+		}).onDelete("cascade"),
+		unique("setup_sessions_session_id_key").on(table.sessionId),
+		index("idx_setup_sessions_expires_at").on(table.expiresAt),
+		// Completing or abandoning setup revokes every restricted session the
+		// user holds, so the whole set has to be reachable by user.
+		index("idx_setup_sessions_user_id").on(table.userId),
+		check("setup_sessions_purpose_valid", purposeCheck()),
+	],
+);
+
+/** A row from the `setup_sessions` table. */
+export type SetupSessionRow = typeof setupSessions.$inferSelect;

--- a/packages/data/src/db/schema/users.ts
+++ b/packages/data/src/db/schema/users.ts
@@ -1,6 +1,9 @@
 // Schema for the `users` table.
 
-import type { AdministratorRoleName } from "@virtool/contracts";
+import type {
+	AccountLifecycleState,
+	AdministratorRoleName,
+} from "@virtool/contracts";
 import { sql } from "drizzle-orm";
 import {
 	boolean,
@@ -46,8 +49,18 @@ export const users = pgTable(
 		image: text("image"),
 		lastPasswordChange: timestamp("last_password_change").notNull(),
 		legacyId: text("legacy_id"),
+		// A real database default rather than a `$defaultFn`, because the
+		// migration that adds the column has to backfill every existing row and
+		// because an account is pending only when something says so.
+		lifecycleState: text("lifecycle_state")
+			.$type<AccountLifecycleState>()
+			.notNull()
+			.default("normal"),
 		name: text("name").notNull().default(""),
-		password: bytea("password").notNull(),
+		// Null while an account is pending: it exists, but nothing can sign in
+		// as it yet. Every reader treats null as "no credential" and answers the
+		// same way it answers a wrong password.
+		password: bytea("password"),
 		settings: jsonb("settings").$type<Record<string, unknown>>().notNull(),
 		twoFactorEnabled: boolean("two_factor_enabled"),
 		updatedAt: timestamp("updated_at")
@@ -62,6 +75,22 @@ export const users = pgTable(
 		check(
 			"administrator_role_valid",
 			sql`${table.administratorRole} in ('full', 'settings', 'users', 'base')`,
+		),
+		check(
+			"lifecycle_state_valid",
+			sql`${table.lifecycleState} in ('pending', 'normal')`,
+		),
+		// A pending account holds no credential. Stated as a database rule
+		// because a pending row carrying a password is a row that can sign in
+		// before it has completed setup.
+		//
+		// One-directional on purpose: a `normal` account has a password today,
+		// but once Better Auth owns credentials outright `users.password` becomes
+		// dead weight for accounts that never had a legacy one, and this must not
+		// stand in the way of clearing it.
+		check(
+			"pending_has_no_password",
+			sql`${table.lifecycleState} <> 'pending' or ${table.password} is null`,
 		),
 	],
 );

--- a/packages/data/src/users/data.test.ts
+++ b/packages/data/src/users/data.test.ts
@@ -12,6 +12,7 @@ import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import { addToGroup, seedGroup } from "../groups/test/fixtures";
 import {
 	changePassword,
+	createPendingUser,
 	createUser,
 	findUsers,
 	GroupMembershipError,
@@ -22,6 +23,7 @@ import {
 	InvalidPasswordError,
 	listAdministratorRoles,
 	listUsers,
+	PendingAccountError,
 	setAdministratorRole,
 	UserConflictError,
 	UserNotFoundError,
@@ -479,9 +481,39 @@ describe("listUsers", () => {
 
 		expect(result.map((user) => user.handle)).toEqual(["alice", "Charlie"]);
 	});
+
+	// This answers "who can something be assigned to", and an account that
+	// cannot sign in yet is not an answer to it.
+	it("leaves out a pending account", async () => {
+		await seedUser(db, { handle: "alice" });
+		await seedUser(db, { handle: "bob", lifecycleState: "pending" });
+
+		expect((await listUsers(db)).map((user) => user.handle)).toEqual(["alice"]);
+	});
 });
 
 describe("findUsers", () => {
+	// Default-deny: a caller that has not thought about pending accounts does
+	// not publish them, and the administration views opt in explicitly.
+	it("hides pending accounts unless asked for them", async () => {
+		await seedUser(db, { handle: "alice" });
+		await seedUser(db, { handle: "bob", lifecycleState: "pending" });
+
+		expect((await findUsers(db, {})).items.map((user) => user.handle)).toEqual([
+			"alice",
+		]);
+		expect(
+			(await findUsers(db, { lifecycleState: "any" })).items
+				.map((user) => user.handle)
+				.toSorted(),
+		).toEqual(["alice", "bob"]);
+		expect(
+			(await findUsers(db, { lifecycleState: "pending" })).items.map(
+				(user) => user.handle,
+			),
+		).toEqual(["bob"]);
+	});
+
 	it("filters by handle substring", async () => {
 		await seedUser(db, { handle: "alice" });
 		await seedUser(db, { handle: "malice" });
@@ -561,6 +593,44 @@ describe("getUser", () => {
 
 	it("throws when the user does not exist", async () => {
 		await expect(getUser(db, 404)).rejects.toBeInstanceOf(UserNotFoundError);
+	});
+});
+
+describe("createPendingUser", () => {
+	it("creates an account with no credential and pending lifecycle", async () => {
+		const group = await seedGroup(db, { name: "researchers" });
+
+		const user = await createPendingUser(db, {
+			handle: "alice",
+			administratorRole: "users",
+			groups: [group],
+		});
+
+		expect(user).toMatchObject({
+			handle: "alice",
+			administratorRole: "users",
+			active: true,
+			forceReset: false,
+			lifecycleState: "pending",
+		});
+		expect(user.groups.map((entry) => entry.name)).toEqual(["researchers"]);
+
+		const [row] = await db.select().from(users).where(eq(users.id, user.id));
+		expect(row?.password).toBeNull();
+		expect(row?.settings).toEqual({
+			skip_quick_analyze_dialog: true,
+			show_ids: true,
+			show_versions: true,
+			quick_analyze_workflow: "pathoscope",
+		});
+	});
+
+	it("rejects a duplicate handle", async () => {
+		await seedUser(db, { handle: "alice" });
+
+		await expect(
+			createPendingUser(db, { handle: "Alice" }),
+		).rejects.toBeInstanceOf(UserConflictError);
 	});
 });
 
@@ -655,5 +725,50 @@ describe("listAdministratorRoles", () => {
 			"users",
 			"base",
 		]);
+	});
+});
+
+describe("updateUser on a pending account", () => {
+	// Setting a password here would complete the setup without the token that
+	// authorizes the transition.
+	it("refuses to set a password", async () => {
+		const user = await createPendingUser(db, { handle: "alice" });
+
+		await expect(
+			updateUser(db, user.id, { password: "a-real-password" }),
+		).rejects.toBeInstanceOf(PendingAccountError);
+
+		const [row] = await db.select().from(users).where(eq(users.id, user.id));
+		expect(row?.password).toBeNull();
+		expect(row?.lifecycleState).toBe("pending");
+	});
+
+	it("still assigns a handle, a role and groups", async () => {
+		const user = await createPendingUser(db, { handle: "alice" });
+		const group = await seedGroup(db, { name: "researchers" });
+
+		const updated = await updateUser(db, user.id, {
+			handle: "ada",
+			groups: [group],
+		});
+
+		expect(updated.handle).toBe("ada");
+		expect(updated.groups.map((entry) => entry.name)).toEqual(["researchers"]);
+		expect(updated.lifecycleState).toBe("pending");
+	});
+});
+
+describe("changePassword on a pending account", () => {
+	it("reports a bad credential rather than a lifecycle state", async () => {
+		const user = await createPendingUser(db, { handle: "alice" });
+
+		await expect(
+			changePassword(db, {
+				userId: user.id,
+				oldPassword: "anything",
+				password: "a-real-password",
+				ip: "127.0.0.1",
+			}),
+		).rejects.toBeInstanceOf(InvalidPasswordError);
 	});
 });

--- a/packages/data/src/users/data.ts
+++ b/packages/data/src/users/data.ts
@@ -1,5 +1,6 @@
 import {
 	type Account,
+	type AccountLifecycleState,
 	type AccountSettings,
 	type AdministratorRoleName,
 	emptyPermissions,
@@ -96,6 +97,15 @@ export type FindUsersFilters = {
 	perPage?: number;
 	administrator?: boolean;
 	active?: boolean;
+	/**
+	 * Which lifecycle states to return. Defaults to `"normal"`, so a caller
+	 * that has not thought about pending accounts does not publish them.
+	 *
+	 * `"any"` is for the user administration views, which are the one place a
+	 * pending account has to be visible — an administrator needs to see the
+	 * invitation they issued and to be able to re-issue it.
+	 */
+	lifecycleState?: AccountLifecycleState | "any";
 };
 
 /** Values accepted when creating a user. */
@@ -104,6 +114,13 @@ export type CreateUserValues = {
 	password: string;
 	forceReset: boolean;
 	administratorRole?: AdministratorRoleName | null;
+};
+
+/** Values accepted when creating a pending user. */
+export type CreatePendingUserValues = {
+	handle: string;
+	administratorRole?: AdministratorRoleName | null;
+	groups?: number[];
 };
 
 /** Partial values accepted when updating a user. */
@@ -152,6 +169,12 @@ export class UserConflictError extends AppError {}
 
 /** Thrown when a primary group is set to a group the user does not belong to. */
 export class GroupMembershipError extends AppError {}
+
+/**
+ * Thrown when an operation that assumes a usable account is aimed at one that
+ * has not completed setup.
+ */
+export class PendingAccountError extends AppError {}
 
 // The settings every newly created account starts with, and the fallback for
 // any key a stored blob is missing.
@@ -263,6 +286,7 @@ function buildUser(row: UserRow, memberships: GroupMembershipRow[]): User {
 		forceReset: row.forceReset,
 		groups,
 		lastPasswordChange: row.lastPasswordChange,
+		lifecycleState: row.lifecycleState,
 		permissions: mergePermissions(
 			memberships.map((membership) => membership.permissions),
 		),
@@ -299,12 +323,19 @@ export async function getUserCount(db: Db): Promise<number> {
 	return row?.value ?? 0;
 }
 
-/** List every active user, for populating selectors and filters. */
+/**
+ * List every usable user, for populating selectors and filters.
+ *
+ * Pending accounts are left out. This answers "who can something be assigned
+ * to", and an account that cannot sign in yet is not an answer to that.
+ */
 export async function listUsers(db: Db): Promise<UserNested[]> {
 	return db
 		.select({ id: usersTable.id, handle: usersTable.handle })
 		.from(usersTable)
-		.where(eq(usersTable.active, true))
+		.where(
+			and(eq(usersTable.active, true), eq(usersTable.lifecycleState, "normal")),
+		)
 		.orderBy(asc(sql`lower(${usersTable.handle})`));
 }
 
@@ -318,9 +349,13 @@ export async function findUsers(
 		perPage = 25,
 		administrator,
 		active = true,
+		lifecycleState = "normal",
 	} = filters;
 
 	const conditions = [eq(usersTable.active, active)];
+	if (lifecycleState !== "any") {
+		conditions.push(eq(usersTable.lifecycleState, lifecycleState));
+	}
 	if (administrator === true) {
 		conditions.push(isNotNull(usersTable.administratorRole));
 	}
@@ -444,7 +479,16 @@ export async function changePassword(
 		throw new UserNotFoundError();
 	}
 
-	if (!(await verifyPassword(oldPassword, existing.password))) {
+	// A pending account has no password to verify against and no session to
+	// have reached this from. Reported as a bad credential rather than as a
+	// lifecycle state, which is all the caller of a password form needs.
+	if (existing.password === null) {
+		throw new InvalidPasswordError();
+	}
+
+	const currentPassword = existing.password;
+
+	if (!(await verifyPassword(oldPassword, currentPassword))) {
 		throw new InvalidPasswordError();
 	}
 
@@ -477,7 +521,7 @@ export async function changePassword(
 			.where(
 				and(
 					eq(usersTable.id, userId),
-					eq(usersTable.password, existing.password),
+					eq(usersTable.password, currentPassword),
 				),
 			)
 			.returning({ id: usersTable.id });
@@ -511,6 +555,69 @@ export async function getAdministratorRole(
 		.limit(1);
 
 	return row?.administratorRole ?? null;
+}
+
+/**
+ * Create an account that exists but cannot yet be signed in as.
+ *
+ * The handle, the administrator role and the group memberships are all set
+ * here, so an administrator states who the person is and what they may do at
+ * the moment of invitation rather than after they accept. What is missing is
+ * the credential: `password` stays null and `lifecycle_state` is `pending`,
+ * which the `pending_has_no_password` constraint holds together.
+ *
+ * No password is generated and none is transmitted. Completing the account is
+ * `completeAccountSetup`'s job, authorized by a setup token.
+ *
+ * `active` is left at its default of true. Activation is the administrator's
+ * separate switch, and a pending account is already unusable — conflating the
+ * two would make deactivating an invited user indistinguishable from never
+ * having invited them.
+ */
+export async function createPendingUser(
+	db: Db,
+	values: CreatePendingUserValues,
+): Promise<User> {
+	const groupIds = Array.from(new Set(values.groups ?? []));
+
+	try {
+		const userId = await db.transaction(async (tx) => {
+			const row = takeFirstOrThrow(
+				await tx
+					.insert(usersTable)
+					.values({
+						handle: values.handle,
+						lifecycleState: "pending",
+						administratorRole: values.administratorRole ?? null,
+						lastPasswordChange: new Date(),
+						legacyId: null,
+						settings: toStoredAccountSettings(DEFAULT_USER_SETTINGS),
+					})
+					.returning({ id: usersTable.id }),
+			);
+
+			if (groupIds.length > 0) {
+				await tx.insert(userGroupsTable).values(
+					groupIds.map((groupId) => ({
+						userId: row.id,
+						groupId,
+						primary: false,
+					})),
+				);
+			}
+
+			return row.id;
+		});
+
+		await emit("users", userId, "create");
+
+		return getUser(db, userId);
+	} catch (error) {
+		if (isUniqueViolation(error)) {
+			throw new UserConflictError();
+		}
+		throw error;
+	}
 }
 
 export async function createUser(
@@ -552,13 +659,25 @@ export async function updateUser(
 	values: UserUpdateValues,
 ): Promise<User> {
 	const [existing] = await db
-		.select({ id: usersTable.id })
+		.select({
+			id: usersTable.id,
+			lifecycleState: usersTable.lifecycleState,
+		})
 		.from(usersTable)
 		.where(eq(usersTable.id, userId))
 		.limit(1);
 
 	if (!existing) {
 		throw new UserNotFoundError();
+	}
+
+	// Setting a password on a pending account would complete its setup without
+	// the token that authorizes the transition, and leave a `pending` row
+	// carrying a credential the `pending_has_no_password` constraint forbids.
+	// Refused here so the caller gets a stated reason rather than a check
+	// violation.
+	if (values.password !== undefined && existing.lifecycleState === "pending") {
+		throw new PendingAccountError();
 	}
 
 	// Changing credentials or activation revokes every existing session for the

--- a/packages/data/src/users/data.ts
+++ b/packages/data/src/users/data.ts
@@ -23,11 +23,17 @@ import {
 	sql,
 } from "drizzle-orm";
 import type { PostgresError } from "postgres";
+import { updateAuthPassword, updateAuthUsername } from "../auth/identity";
 import { hashPassword, verifyPassword } from "../auth/password";
 import {
 	createAuthenticatedSession,
 	invalidateUserSessions,
 } from "../auth/session";
+import {
+	invalidateUserSetupSessions,
+	invalidateUserSetupTokens,
+	lockUserSetupCredentials,
+} from "../auth/setup";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import {
@@ -530,6 +536,8 @@ export async function changePassword(
 			throw new InvalidPasswordError();
 		}
 
+		await updateAuthPassword(tx, userId, hashed);
+
 		await invalidateUserSessions(tx, userId);
 
 		return createAuthenticatedSession(tx, { userId, ip, remember: false });
@@ -715,8 +723,22 @@ export async function updateUser(
 			}
 		}
 
+		if (values.password !== undefined && patch.password) {
+			await updateAuthPassword(tx, userId, patch.password);
+		}
+
+		if (values.handle !== undefined) {
+			await updateAuthUsername(tx, userId, values.handle);
+		}
+
 		if (revokeSessions) {
 			await invalidateUserSessions(tx, userId);
+		}
+
+		if (values.active === false) {
+			await lockUserSetupCredentials(tx, userId);
+			await invalidateUserSetupTokens(tx, userId);
+			await invalidateUserSetupSessions(tx, userId);
 		}
 
 		if (values.groups !== undefined) {


### PR DESCRIPTION
## Summary

- Adds `users.lifecycle_state` (`pending` | `normal`) as an explicit account lifecycle, kept separate from `users.active`, which stays the administrator's authoritative switch. `users.password` becomes nullable, because a pending account genuinely holds no credential — a NOT NULL column filled with an unusable blob is the implicit special case this replaces. Pending accounts are excluded from selectors, session resolution, API-key resolution and Better Auth sign-in, but stay visible to the administration views.
- Adds `setup_tokens` and `setup_sessions`: digest-only, purpose-bound, expiring credentials, single-use or revocable. Token consumption is one conditional `UPDATE ... RETURNING`, so concurrent submissions produce exactly one winner, and each of the three completion primitives spends the token, writes the credential and identity state, moves the account and revokes every setup credential in one transaction. Expiry cleanup is a new `cleanup_setup_state` periodic task rather than any request-path scan.
- Adds the restricted setup boundary in `apps/web`: a separate cookie pair, one authority for resolving a restricted principal, a `setupOnly(purpose)` policy, and enforcement in the global middleware *before* any policy runs — a restricted caller gets a 403 naming the setup flow instead of the login wall. `setupExceptions` is empty until the invitation, recovery and MFA surfaces land, so a restricted principal currently reaches nothing. Raw routes, SSE, uploads, downloads and API-key Basic authentication are unchanged and reject it.

## Notes for review

- Completion writes the credential on both sides (`users.password` and `auth_accounts.password` + `username`/`display_username`). The Better Auth foundation is configuration only so far — nothing yet writes `auth_accounts` — and the legacy cookie pair is still the live boundary, so an account credentialed against one side alone could not sign in at all until VIR-3097. The primitives mint no session; that stays with the calling flow.
- Email uniqueness is held by a transaction-scoped advisory lock on the normalized address, not an index: production has duplicate non-empty `users.email` values, so a partial unique index would fail to build. Documented in `packages/data/README.md`.

Closes VIR-3092.