### PR TITLE
fix: reduce layout shifts in the quick analyze dialog

### DIFF
--- a/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
@@ -1,9 +1,7 @@
 import { Dialog, DialogTitle } from "@base/Dialog";
 import type { HmmSearchResult } from "@virtool/contracts";
-import HmmAlert from "../HmmAlert";
+import CreateAnalysisBody from "./CreateAnalysisBody";
 import CreateAnalysisDialogContent from "./CreateAnalysisDialogContent";
-import CreateAnalysisForm from "./CreateAnalysisForm";
-import { getCompatibleWorkflows } from "./workflows";
 
 type CreateAnalysisProps = {
 	/** The HMM search results */
@@ -26,15 +24,12 @@ export default function CreateAnalysis({
 	setOpen,
 	sampleId,
 }: CreateAnalysisProps) {
-	const compatibleWorkflows = getCompatibleWorkflows(Boolean(hmms.totalCount));
-
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<CreateAnalysisDialogContent>
 				<DialogTitle>Analyze</DialogTitle>
-				<HmmAlert installed={Boolean(hmms.status.task?.complete)} />
-				<CreateAnalysisForm
-					compatibleWorkflows={compatibleWorkflows}
+				<CreateAnalysisBody
+					hmms={hmms}
 					onClose={() => setOpen(false)}
 					sampleCount={1}
 					sampleIds={[sampleId]}

--- a/apps/web/src/analyses/components/Create/CreateAnalysisBody.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisBody.tsx
@@ -1,0 +1,54 @@
+import { useCreateAnalysisOptions } from "@analyses/hooks";
+import QueryError from "@base/QueryError";
+import type { HmmSearchResult } from "@virtool/contracts";
+import HmmAlert from "../HmmAlert";
+import CreateAnalysisForm from "./CreateAnalysisForm";
+import CreateAnalysisPlaceholder from "./CreateAnalysisPlaceholder";
+import { getCompatibleWorkflows } from "./workflows";
+
+type CreateAnalysisBodyProps = {
+	/** The HMM search results, or `undefined` while loading */
+	hmms: HmmSearchResult | undefined;
+
+	onClose: () => void;
+
+	sampleCount: number;
+
+	sampleIds: number[];
+};
+
+/**
+ * Show the form once HMMs and analysis options are ready to limit dialog resizing.
+ */
+export default function CreateAnalysisBody({
+	hmms,
+	onClose,
+	sampleCount,
+	sampleIds,
+}: CreateAnalysisBodyProps) {
+	const { defaultSubtractions, indexes, subtractions, isError, isPending } =
+		useCreateAnalysisOptions(sampleIds);
+
+	if (isError) {
+		return <QueryError noun="analysis options" />;
+	}
+
+	if (isPending || !hmms) {
+		return <CreateAnalysisPlaceholder />;
+	}
+
+	return (
+		<>
+			<HmmAlert installed={Boolean(hmms.status.task?.complete)} />
+			<CreateAnalysisForm
+				compatibleWorkflows={getCompatibleWorkflows(hmms.totalCount > 0)}
+				defaultSubtractions={defaultSubtractions}
+				indexes={indexes}
+				onClose={onClose}
+				sampleCount={sampleCount}
+				sampleIds={sampleIds}
+				subtractions={subtractions}
+			/>
+		</>
+	);
+}

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -1,13 +1,12 @@
-import { useCompatibleIndexes, useSubtractionOptions } from "@analyses/hooks";
 import { useCreateAnalysis } from "@analyses/queries";
 import Button from "@base/Button";
 import CreatedCount from "@base/CreatedCount";
 import { DialogFooter } from "@base/Dialog";
 import { InputError } from "@base/Input";
-import QueryError from "@base/QueryError";
 import Switch from "@base/Switch";
 import SubtractionSelector from "@subtraction/components/SubtractionSelector";
-import type { AnalysisWorkflow } from "@virtool/contracts";
+import type { SubtractionOption } from "@subtraction/types";
+import type { AnalysisWorkflow, IndexMinimal } from "@virtool/contracts";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { CreateAnalysisSummary } from "./CreateAnalysisSummary";
@@ -25,6 +24,11 @@ type CreateAnalysisFormProps = {
 	/** The workflows compatible with the selected sample(s) */
 	compatibleWorkflows: workflow[];
 
+	/** The subtractions selected when the form opens */
+	defaultSubtractions: SubtractionOption[];
+
+	indexes: IndexMinimal[];
+
 	/** Closes the enclosing dialog. */
 	onClose: () => void;
 
@@ -33,6 +37,8 @@ type CreateAnalysisFormProps = {
 
 	/** The ids of the samples being analyzed */
 	sampleIds: number[];
+
+	subtractions: SubtractionOption[];
 };
 
 /**
@@ -42,23 +48,13 @@ type CreateAnalysisFormProps = {
  */
 export default function CreateAnalysisForm({
 	compatibleWorkflows,
+	defaultSubtractions,
+	indexes,
 	onClose,
 	sampleCount,
 	sampleIds,
+	subtractions,
 }: CreateAnalysisFormProps) {
-	const {
-		indexes,
-		isPending: isPendingIndexes,
-		isError: isErrorIndexes,
-	} = useCompatibleIndexes();
-
-	const {
-		defaultSubtractions,
-		subtractions,
-		isPending: isPendingSubtractions,
-		isError: isErrorSubtractions,
-	} = useSubtractionOptions(sampleIds);
-
 	const createAnalysis = useCreateAnalysis();
 
 	const defaultValues = {
@@ -77,14 +73,6 @@ export default function CreateAnalysisForm({
 
 	const [createMore, setCreateMore] = useState(false);
 	const [createdCount, setCreatedCount] = useState(0);
-
-	if (isErrorIndexes || isErrorSubtractions) {
-		return <QueryError noun="analysis options" />;
-	}
-
-	if (isPendingIndexes || isPendingSubtractions) {
-		return null;
-	}
 
 	async function onSubmit(values: CreateAnalysisFormValues) {
 		const { indexId, subtractionIds, workflow } = values;

--- a/apps/web/src/analyses/components/Create/CreateAnalysisPlaceholder.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisPlaceholder.tsx
@@ -1,0 +1,12 @@
+import Loader from "@base/Loader";
+
+/**
+ * Approximate the loaded form's height to limit dialog resizing during loading.
+ */
+export default function CreateAnalysisPlaceholder() {
+	return (
+		<div className="flex h-[23rem] items-center justify-center">
+			<Loader />
+		</div>
+	);
+}

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -2,11 +2,45 @@ import { Dialog, DialogTitle } from "@base/Dialog";
 import QueryError from "@base/QueryError";
 import { useListHmms } from "@hmm/queries";
 import type { SampleMinimal } from "@virtool/contracts";
-import HmmAlert from "../HmmAlert";
+import CreateAnalysisBody from "./CreateAnalysisBody";
 import CreateAnalysisDialogContent from "./CreateAnalysisDialogContent";
-import CreateAnalysisForm from "./CreateAnalysisForm";
 import { SelectedSamples } from "./SelectedSamples";
-import { getCompatibleWorkflows } from "./workflows";
+
+type QuickAnalyzeContentProps = {
+	fromSelection: boolean;
+	onClose: () => void;
+	samples: SampleMinimal[];
+};
+
+/**
+ * Keep data requests inside the dialog content so they start together on open.
+ */
+function QuickAnalyzeContent({
+	fromSelection,
+	onClose,
+	samples,
+}: QuickAnalyzeContentProps) {
+	const { data: hmms, isError } = useListHmms(1, 1, "");
+
+	const sampleIds = samples.map((sample) => sample.id);
+
+	return (
+		<>
+			<DialogTitle>Quick Analyze</DialogTitle>
+			<SelectedSamples fromSelection={fromSelection} samples={samples} />
+			{isError && !hmms ? (
+				<QueryError noun="HMMs" />
+			) : (
+				<CreateAnalysisBody
+					hmms={hmms}
+					onClose={onClose}
+					sampleCount={sampleIds.length}
+					sampleIds={sampleIds}
+				/>
+			)}
+		</>
+	);
+}
 
 type QuickAnalyzeProps = {
 	/** Whether the samples came from the list selection rather than a single sample */
@@ -28,40 +62,13 @@ export default function QuickAnalyze({
 	samples,
 	setOpen,
 }: QuickAnalyzeProps) {
-	const { data: hmms, isPending, isError } = useListHmms(1, 1, "");
-
-	if (isError && !hmms) {
-		return (
-			<Dialog open={open} onOpenChange={setOpen}>
-				<CreateAnalysisDialogContent>
-					<DialogTitle>Quick Analyze</DialogTitle>
-					<QueryError noun="HMMs" />
-				</CreateAnalysisDialogContent>
-			</Dialog>
-		);
-	}
-
-	if (isPending) {
-		return null;
-	}
-
-	const compatibleWorkflows = getCompatibleWorkflows(hmms.totalCount > 0);
-
-	const sampleIds = samples.map((sample) => sample.id);
-
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<CreateAnalysisDialogContent>
-				<DialogTitle>Quick Analyze</DialogTitle>
-				<HmmAlert installed={Boolean(hmms.status.task?.complete)} />
-
-				<SelectedSamples fromSelection={fromSelection} samples={samples} />
-
-				<CreateAnalysisForm
-					compatibleWorkflows={compatibleWorkflows}
+				<QuickAnalyzeContent
+					fromSelection={fromSelection}
 					onClose={() => setOpen(false)}
-					sampleCount={sampleIds.length}
-					sampleIds={sampleIds}
+					samples={samples}
 				/>
 			</CreateAnalysisDialogContent>
 		</Dialog>

--- a/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
@@ -4,9 +4,6 @@ import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
 import { createFakeIndexMinimal } from "@tests/fake/indexes";
 import { createFakeSample } from "@tests/fake/samples";
 import { mockCreateAnalysis } from "@tests/server-fn/analyses";
-import { mockListReadyIndexes } from "@tests/server-fn/indexes";
-import { mockGetSample } from "@tests/server-fn/samples";
-import { mockListSubtractionsShortlist } from "@tests/server-fn/subtractions";
 import { renderWithRouter } from "@tests/setup";
 import { describe, expect, it, vi } from "vitest";
 import CreateAnalysisForm from "../CreateAnalysisForm";
@@ -21,16 +18,15 @@ async function renderForm(indexId?: number) {
 		reference: { id: 1, name: "Plant Viruses" },
 	});
 
-	mockListReadyIndexes([index]);
-	mockListSubtractionsShortlist([]);
-	mockGetSample(sample);
-
 	await renderWithRouter(
 		<CreateAnalysisForm
 			compatibleWorkflows={getCompatibleWorkflows(false)}
+			defaultSubtractions={[]}
+			indexes={[index]}
 			onClose={onClose}
 			sampleCount={1}
 			sampleIds={[sample.id]}
+			subtractions={[]}
 		/>,
 	);
 

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -148,7 +148,7 @@ type UseCompatibleIndexesResult = {
 	isError: boolean;
 };
 
-export function useCompatibleIndexes(): UseCompatibleIndexesResult {
+function useCompatibleIndexes(): UseCompatibleIndexesResult {
 	const { data, isPending, isError } = useListReadyIndexes(false);
 
 	const indexes = Object.values(
@@ -178,7 +178,7 @@ type UseSubtractionOptionsResult = {
  *
  * @param sampleIds
  */
-export function useSubtractionOptions(
+function useSubtractionOptions(
 	sampleIds: number[],
 ): UseSubtractionOptionsResult {
 	const {
@@ -241,5 +241,41 @@ export function useSubtractionOptions(
 		subtractions,
 		isPending: false,
 		isError: false,
+	};
+}
+
+type UseCreateAnalysisOptionsResult = {
+	defaultSubtractions: SubtractionOption[];
+	indexes: IndexMinimal[];
+	subtractions: SubtractionOption[];
+	isError: boolean;
+	isPending: boolean;
+};
+
+/**
+ * Load indexes and subtractions together so the form can appear all at once.
+ */
+export function useCreateAnalysisOptions(
+	sampleIds: number[],
+): UseCreateAnalysisOptionsResult {
+	const {
+		indexes,
+		isPending: isPendingIndexes,
+		isError: isErrorIndexes,
+	} = useCompatibleIndexes();
+
+	const {
+		defaultSubtractions,
+		subtractions,
+		isPending: isPendingSubtractions,
+		isError: isErrorSubtractions,
+	} = useSubtractionOptions(sampleIds);
+
+	return {
+		defaultSubtractions,
+		indexes,
+		subtractions,
+		isError: isErrorIndexes || isErrorSubtractions,
+		isPending: isPendingIndexes || isPendingSubtractions,
 	};
 }

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -157,7 +157,7 @@ function useCompatibleIndexes(): UseCompatibleIndexesResult {
 		.map((group) => maxBy(group, (item) => Number(item.version)))
 		.filter((index): index is IndexMinimal => index !== undefined);
 
-	return { indexes, isPending, isError };
+	return { indexes, isPending, isError: isError && data === undefined };
 }
 
 type UseSubtractionOptionsResult = {
@@ -195,7 +195,10 @@ function useSubtractionOptions(
 		isError: isErrorSample,
 	} = useFetchSample(sampleId);
 
-	if (isErrorSample || isErrorSubtractionShortlist) {
+	if (
+		(isErrorSample && !sample) ||
+		(isErrorSubtractionShortlist && !subtractionShortlist)
+	) {
 		return {
 			defaultSubtractions: [],
 			subtractions: [],


### PR DESCRIPTION
## Summary
- Reduce layout shifts in Quick Analyze by starting HMM and analysis-option requests together and reserving space while they load.
- Share loading and error handling with the single-sample analysis dialog, and initialize the form after its options are ready.
- Verified with lint, typecheck, knip, and all three CreateAnalysisForm tests.
