### PR TITLE
fix: preserve client error statuses across server functions

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -369,6 +369,28 @@ Expected 4xx outcomes set the response status and throw `ClientError` from
 not set 204, 205, or 304 because TanStack Start serializes an RPC body. Return
 `null` with 200 for deletion instead.
 
+Map domain errors in one plain, module-local
+`function rethrowAsHttp(err: unknown): never` per `functions.ts`. Hand caught
+errors to it, match known error classes with `instanceof`, and end with
+`throw err` so unknown failures retain their identity and cause. Each expected
+4xx branch sets `setResponseStatus(status)` and throws
+`new ClientError(message, status)` with the same status. Preserve feature-specific
+messages and statuses: a missing upload can be a 404 when fetched and a 400
+when selected as an input to another operation.
+
+TanStack Start serializes thrown errors, but its default error serializer keeps
+only the message. `ClientError` and our `serverErrorSerializationAdapter` preserve
+the name and status needed by query handling and Sentry filtering; setting the
+HTTP response status alone does not carry it onto the client-side error. Router
+`notFound()` and raw `Response` values do not replace this contract.
+
+Do not wrap these local mappers in `createServerOnlyFn`: the Start compiler
+removes them and their imports when it removes the handlers that call them.
+Use `createServerOnlyFn` when code remains reachable from the browser graph and
+its body must be stripped, as in the global auth and metrics middleware.
+Keep upstream-service error handling explicit, including its existing reporting
+behavior; a 502 is not an expected client 4xx.
+
 ### Server and client boundaries
 
 `apps/web` type-checks server and browser code as separate projects. Browser

--- a/apps/web/src/server/account/functions.ts
+++ b/apps/web/src/server/account/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { permissionsSchema } from "@virtool/contracts";
 import {
@@ -27,17 +27,13 @@ const updateApiKeySchema = keyIdSchema.extend({
 	permissions: permissionsSchema.partial().default({}),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// ApiKeyNotFoundError import it references — from the client bundle. A plain
-// top-level helper would pin ./data and its postgres transitive dependency in
-// the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof ApiKeyNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("API key not found.");
+		throw new ClientError("API key not found.", 404);
 	}
 	throw err;
-});
+}
 
 export const findApiKeysFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/analyses/functions.ts
+++ b/apps/web/src/server/analyses/functions.ts
@@ -65,9 +65,7 @@ const blastSchema = analysisIdSchema.extend({
 	sequenceIndex: z.number().int().nonnegative(),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// ./data imports it references — from the client bundle.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof AnalysisNotFoundError) {
 		setResponseStatus(404);
 		throw new ClientError("Analysis not found.", 404);
@@ -95,7 +93,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	// HMM annotation — is a data-integrity failure rather than a client mistake,
 	// and surfaces as a 500 that reaches Sentry.
 	throw err;
-});
+}
 
 // The `authenticated()` floor guarantees a signed-in caller; an analysis's own
 // visibility is entirely its parent sample's, so this resolves that sample's

--- a/apps/web/src/server/auth/functions.ts
+++ b/apps/web/src/server/auth/functions.ts
@@ -42,6 +42,30 @@ const createFirstUserSchema = z.object({
 	password: z.string(),
 });
 
+function rethrowAsHttp(err: unknown): never {
+	if (err instanceof InvalidCredentialsError) {
+		setResponseStatus(400);
+		throw new ClientError("Invalid handle or password.", 400);
+	}
+	if (err instanceof PasswordTooShortError) {
+		setResponseStatus(400);
+		throw new ClientError(err.message, 400);
+	}
+	if (err instanceof FirstUserExistsError) {
+		setResponseStatus(409);
+		throw new ClientError("Virtool already has a user.", 409);
+	}
+	if (err instanceof InvalidResetSessionError) {
+		setResponseStatus(400);
+		throw new ClientError("Invalid session", 400);
+	}
+	if (err instanceof PasswordReuseError) {
+		setResponseStatus(400);
+		throw new ClientError("Cannot reuse current password", 400);
+	}
+	throw err;
+}
+
 /** Login server function. Unauthenticated by necessity — this *creates* the session. */
 export const loginFn = createServerFn({ method: "POST" })
 	.middleware([open()])
@@ -63,11 +87,7 @@ export const loginFn = createServerFn({ method: "POST" })
 			setResponseStatus(201);
 			return { reset: false as const };
 		} catch (err) {
-			if (err instanceof InvalidCredentialsError) {
-				setResponseStatus(400);
-				throw new ClientError("Invalid handle or password.");
-			}
-			throw err;
+			rethrowAsHttp(err);
 		}
 	});
 
@@ -94,15 +114,7 @@ export const createFirstUserFn = createServerFn({ method: "POST" })
 			setResponseStatus(201);
 			return user;
 		} catch (err) {
-			if (err instanceof PasswordTooShortError) {
-				setResponseStatus(400);
-				throw new ClientError(err.message);
-			}
-			if (err instanceof FirstUserExistsError) {
-				setResponseStatus(409);
-				throw new ClientError("Virtool already has a user.");
-			}
-			throw err;
+			rethrowAsHttp(err);
 		}
 	});
 
@@ -141,18 +153,6 @@ export const resetPasswordFn = createServerFn({ method: "POST" })
 			setResponseStatus(200);
 			return { login: false as const, reset: false as const };
 		} catch (err) {
-			if (err instanceof PasswordTooShortError) {
-				setResponseStatus(400);
-				throw new ClientError(err.message);
-			}
-			if (err instanceof InvalidResetSessionError) {
-				setResponseStatus(400);
-				throw new ClientError("Invalid session");
-			}
-			if (err instanceof PasswordReuseError) {
-				setResponseStatus(400);
-				throw new ClientError("Cannot reuse current password");
-			}
-			throw err;
+			rethrowAsHttp(err);
 		}
 	});

--- a/apps/web/src/server/banners/functions.ts
+++ b/apps/web/src/server/banners/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { bannerColors } from "@virtool/contracts";
 import {
@@ -35,15 +35,13 @@ const updateBannerSchema = idSchema
 		message: "At least one of `message` or `color` must be provided.",
 	});
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// BannerNotFoundError import it references — from the client bundle.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof BannerNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("Banner not found.");
+		throw new ClientError("Banner not found.", 404);
 	}
 	throw err;
-});
+}
 
 export const findBannerFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/genbank/functions.ts
+++ b/apps/web/src/server/genbank/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import type { Genbank } from "@virtool/contracts";
 import { getSettings } from "@virtool/data/settings/data";
@@ -26,7 +26,7 @@ const accessionSchema = z.object({
 		.regex(/^[A-Za-z0-9._-]+$/),
 });
 
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof NcbiUnreachableError) {
 		setResponseStatus(502);
 		throw new ClientError("Could not reach NCBI.", 502);
@@ -43,7 +43,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	}
 
 	throw err;
-});
+}
 
 /**
  * Find a sequence in GenBank by accession, so that the sequence form can fill

--- a/apps/web/src/server/groups/functions.test.ts
+++ b/apps/web/src/server/groups/functions.test.ts
@@ -8,6 +8,7 @@ import {
 	createTestDatabase,
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
+import * as groupData from "@virtool/data/groups/data";
 import {
 	NO_PERMISSIONS,
 	seedGroup as seedGroupImpl,
@@ -15,6 +16,7 @@ import {
 import { eq } from "drizzle-orm";
 import {
 	afterAll,
+	afterEach,
 	beforeAll,
 	beforeEach,
 	describe,
@@ -85,6 +87,10 @@ beforeEach(async () => {
 	);
 });
 
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 /** Authenticate the next call as a user with the given administrator role. */
 
 function seedGroup(): Promise<number> {
@@ -94,6 +100,49 @@ function seedGroup(): Promise<number> {
 function call(name: string, data?: unknown) {
 	return callServerFn(handlers, name, data);
 }
+
+describe("error mapping", () => {
+	it("carries a missing group's status on the client error", async () => {
+		await signIn(db, getRequest, { administratorRole: null });
+
+		await expect(
+			call("getGroupFn", { groupId: 999_999 }),
+		).rejects.toMatchObject({
+			name: "ClientError",
+			message: "Group not found.",
+			status: 404,
+		});
+		expect(setResponseStatus).toHaveBeenCalledWith(404);
+	});
+
+	it("carries a duplicate group's conflict status on the client error", async () => {
+		await signIn(db, getRequest, { administratorRole: "base" });
+		await call("createGroupFn", { name: "technicians" });
+		setResponseStatus.mockClear();
+
+		await expect(
+			call("createGroupFn", { name: "technicians" }),
+		).rejects.toMatchObject({
+			name: "ClientError",
+			message: "Group name already exists.",
+			status: 409,
+		});
+		expect(setResponseStatus).toHaveBeenCalledWith(409);
+	});
+
+	it.each([
+		new Error("query failed", { cause: new Error("connection lost") }),
+		"failure",
+	])("rethrows an unmapped failure unchanged: %s", async (failure) => {
+		await signIn(db, getRequest, { administratorRole: null });
+		vi.spyOn(groupData, "getGroup").mockRejectedValueOnce(failure);
+
+		await expect(call("getGroupFn", { groupId: 999_999 })).rejects.toBe(
+			failure,
+		);
+		expect(setResponseStatus).not.toHaveBeenCalled();
+	});
+});
 
 describe("createGroup", () => {
 	it("refuses a user with no administrator role", async () => {

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { permissionsSchema } from "@virtool/contracts";
 import {
@@ -38,21 +38,17 @@ const updateGroupSchema = groupIdSchema.extend({
 	permissions: permissionsSchema.partial().optional(),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// GroupNotFoundError / GroupConflictError imports it references — from the
-// client bundle. A plain top-level helper would pin ./data and its postgres
-// transitive dependency in the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof GroupNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("Group not found.");
+		throw new ClientError("Group not found.", 404);
 	}
 	if (err instanceof GroupConflictError) {
 		setResponseStatus(409);
-		throw new ClientError("Group name already exists.");
+		throw new ClientError("Group name already exists.", 409);
 	}
 	throw err;
-});
+}
 
 // Ordinary users need the group list to set sample rights and to pick a primary
 // group, so the reads are open to any signed-in user.

--- a/apps/web/src/server/hmm/functions.test.ts
+++ b/apps/web/src/server/hmm/functions.test.ts
@@ -184,7 +184,11 @@ describe("installHmm", () => {
 		await seedStatus({ updates: [{ ready: false } as HmmUpdate] });
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-		await expect(call("installHmmFn")).rejects.toThrow();
+		await expect(call("installHmmFn")).rejects.toMatchObject({
+			name: "ClientError",
+			message: "Install already in progress.",
+			status: 409,
+		});
 		expect(setResponseStatus).toHaveBeenCalledWith(409);
 		expect(fetchSpy).not.toHaveBeenCalled();
 		expect(await db.select().from(tasks)).toHaveLength(0);
@@ -205,7 +209,11 @@ describe("getHmm", () => {
 	it("responds 404 when the HMM is absent", async () => {
 		await signIn(db, getRequest, { administratorRole: "base" });
 
-		await expect(call("getHmmFn", { hmmId: 5000 })).rejects.toThrow();
+		await expect(call("getHmmFn", { hmmId: 5000 })).rejects.toMatchObject({
+			name: "ClientError",
+			message: "HMM not found.",
+			status: 404,
+		});
 		expect(setResponseStatus).toHaveBeenCalledWith(404);
 	});
 });

--- a/apps/web/src/server/hmm/functions.ts
+++ b/apps/web/src/server/hmm/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import {
 	findHmms,
@@ -10,6 +10,7 @@ import {
 import { z } from "zod";
 import { authenticated, permission } from "../auth/policy";
 import { db } from "../composition";
+import { ClientError } from "../errors";
 import { rowIdSchema } from "../validation";
 import { installUpdate } from "./service";
 
@@ -23,25 +24,21 @@ const hmmIdSchema = z.object({
 	hmmId: rowIdSchema,
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// error-class imports it references — from the client bundle. A plain top-level
-// helper would pin ./data and its postgres transitive dependency in the client
-// graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof HmmNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("HMM not found.");
+		throw new ClientError("HMM not found.", 404);
 	}
 	if (err instanceof HmmInstallConflictError) {
 		setResponseStatus(409);
-		throw new Error("Install already in progress.");
+		throw new ClientError("Install already in progress.", 409);
 	}
 	if (err instanceof HmmReleaseError) {
 		setResponseStatus(502);
 		throw new Error(err.message);
 	}
 	throw err;
-});
+}
 
 export const findHmmsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/indexes/functions.ts
+++ b/apps/web/src/server/indexes/functions.ts
@@ -43,11 +43,7 @@ const findUnbuiltChangesSchema = referenceIdSchema.extend({
 	perPage: perPageSchema,
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip these bodies — and the
-// ./data imports they reference — from the client bundle. A plain top-level
-// helper would pin ./data and its postgres transitive dependency in the client
-// graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof IndexNotFoundError) {
 		setResponseStatus(404);
 		throw new ClientError("Index not found.", 404);
@@ -73,7 +69,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		throw new ClientError(err.message, 400);
 	}
 	throw err;
-});
+}
 
 const authorizeBuild = createServerOnlyFn(
 	async (referenceId: number, userId: number): Promise<void> => {

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import {
 	fromStoredJobClaim,
@@ -41,17 +41,13 @@ const jobIdsSchema = z.object({
 	jobIds: z.array(rowIdSchema).min(1).max(100),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// JobNotFoundError import it references — from the client bundle. A plain
-// top-level helper would pin ./data and its postgres transitive dependency in
-// the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof JobNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("Job not found.");
+		throw new ClientError("Job not found.", 404);
 	}
 	throw err;
-});
+}
 
 /**
  * Narrow a row's `workflow` onto the union the SPA reads.

--- a/apps/web/src/server/labels/functions.ts
+++ b/apps/web/src/server/labels/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import {
 	createLabel,
@@ -42,21 +42,17 @@ const labelIdSchema = z.object({
 
 const findLabelsSchema = z.object({ term: z.string().default("") }).optional();
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// LabelNotFoundError / LabelConflictError imports it references — from the
-// client bundle. A plain top-level helper would pin ./data and its postgres
-// transitive dependency in the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof LabelNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("Label not found.");
+		throw new ClientError("Label not found.", 404);
 	}
 	if (err instanceof LabelConflictError) {
 		setResponseStatus(409);
-		throw new ClientError("Label name already exists.");
+		throw new ClientError("Label name already exists.", 409);
 	}
 	throw err;
-});
+}
 
 export const findLabelsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/otus/functions.ts
+++ b/apps/web/src/server/otus/functions.ts
@@ -81,11 +81,7 @@ const updateSequenceSchema = sequenceIdSchema.extend(
 	SequenceUpdateRequest.shape,
 );
 
-// Wrapped in createServerOnlyFn so the compiler can strip these bodies — and the
-// ./data imports they reference — from the client bundle. A plain top-level
-// helper would pin ./data and its postgres transitive dependency in the client
-// graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (
 		err instanceof OtuNotFoundError ||
 		err instanceof IsolateNotFoundError ||
@@ -111,7 +107,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		throw new ClientError(err.message, 400);
 	}
 	throw err;
-});
+}
 
 const notFound = createServerOnlyFn((message: string): never => {
 	setResponseStatus(404);

--- a/apps/web/src/server/references/functions.ts
+++ b/apps/web/src/server/references/functions.ts
@@ -75,11 +75,7 @@ const addReferenceGroupSchema = referenceGroupSchema.merge(rightsSchema);
 const updateReferenceUserSchema = referenceUserSchema.merge(rightsSchema);
 const updateReferenceGroupSchema = referenceGroupSchema.merge(rightsSchema);
 
-// Wrapped in createServerOnlyFn so the compiler can strip these bodies — and the
-// ./data imports they reference — from the client bundle. A plain top-level
-// helper would pin ./data and its postgres transitive dependency in the client
-// graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof ReferenceNotFoundError) {
 		setResponseStatus(404);
 		throw new ClientError("Reference not found.", 404);
@@ -105,7 +101,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		throw new ClientError(err.message, 400);
 	}
 	throw err;
-});
+}
 
 // The `authenticated()` floor guarantees a signed-in caller; this enforces the
 // per-reference right the operation needs on top of it. A full administrator

--- a/apps/web/src/server/samples/functions.ts
+++ b/apps/web/src/server/samples/functions.ts
@@ -83,11 +83,7 @@ const updateRightsSchema = sampleIdSchema.extend({
 // creation job is finished and will not resume.
 const DELETABLE_JOB_STATES = new Set(["cancelled", "failed", "succeeded"]);
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// ./data imports it references — from the client bundle. A plain top-level
-// helper would pin ./data and its postgres transitive dependency in the client
-// graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof SampleNotFoundError) {
 		setResponseStatus(404);
 		throw new ClientError("Sample not found.", 404);
@@ -115,7 +111,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		throw new ClientError("File is already reserved.", 400);
 	}
 	throw err;
-});
+}
 
 // The `authenticated()` floor guarantees a signed-in caller; this enforces the
 // per-sample right the operation needs on top of it. A lookup for a nonexistent

--- a/apps/web/src/server/subtraction/functions.test.ts
+++ b/apps/web/src/server/subtraction/functions.test.ts
@@ -145,7 +145,11 @@ describe("createSubtraction", () => {
 				nickname: "",
 				uploadId: 999_999,
 			}),
-		).rejects.toThrow("Upload does not exist.");
+		).rejects.toMatchObject({
+			name: "ClientError",
+			message: "Upload does not exist.",
+			status: 400,
+		});
 		expect(setResponseStatus).toHaveBeenCalledWith(400);
 	});
 });
@@ -156,7 +160,11 @@ describe("getSubtraction", () => {
 
 		await expect(
 			call("getSubtractionFn", { subtractionId: 999_999 }),
-		).rejects.toThrow("Subtraction not found.");
+		).rejects.toMatchObject({
+			name: "ClientError",
+			message: "Subtraction not found.",
+			status: 404,
+		});
 		expect(setResponseStatus).toHaveBeenCalledWith(404);
 	});
 });

--- a/apps/web/src/server/subtraction/functions.ts
+++ b/apps/web/src/server/subtraction/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import {
 	createSubtraction,
@@ -13,6 +13,7 @@ import {
 import { z } from "zod";
 import { authenticated, permission } from "../auth/policy";
 import { db, storage } from "../composition";
+import { ClientError } from "../errors";
 import { logger } from "../logger";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 
@@ -37,20 +38,17 @@ const updateSubtractionSchema = subtractionIdSchema.extend({
 	nickname: z.string().trim().optional(),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// error imports it references — from the client bundle. A plain top-level helper
-// would pin ./data and its postgres transitive dependency in the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof SubtractionNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Subtraction not found.");
+		throw new ClientError("Subtraction not found.", 404);
 	}
 	if (err instanceof SubtractionUploadNotFoundError) {
 		setResponseStatus(400);
-		throw new Error("Upload does not exist.");
+		throw new ClientError("Upload does not exist.", 400);
 	}
 	throw err;
-});
+}
 
 export const findSubtractionsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/tasks/functions.ts
+++ b/apps/web/src/server/tasks/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { getTask, getTasks, TaskNotFoundError } from "@virtool/data/tasks/data";
 import { z } from "zod";
@@ -18,17 +18,13 @@ const taskIdsSchema = z.object({
 	taskIds: z.array(rowIdSchema).min(1).max(100),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// TaskNotFoundError import it references — from the client bundle. A plain
-// top-level helper would pin ./data and its postgres transitive dependency in
-// the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof TaskNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("Task not found.");
+		throw new ClientError("Task not found.", 404);
 	}
 	throw err;
-});
+}
 
 export const getTasksFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import {
 	SORT_DIRECTIONS,
@@ -43,29 +43,25 @@ const uploadIdSchema = z.object({
 	id: rowIdSchema,
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// UploadNotFoundError / UploadReservedError imports it references — from the
-// client bundle. A plain top-level helper would pin ./data and its postgres
-// transitive dependency in the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof UploadNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("Upload not found.");
+		throw new ClientError("Upload not found.", 404);
 	}
 	if (err instanceof UploadReservedError) {
 		setResponseStatus(409);
-		throw new ClientError("Upload is reserved and in use.");
+		throw new ClientError("Upload is reserved and in use.", 409);
 	}
 	if (err instanceof UploadIncompleteError) {
 		setResponseStatus(409);
-		throw new ClientError("Upload is not complete.");
+		throw new ClientError("Upload is not complete.", 409);
 	}
 	if (err instanceof UploadSizeMismatchError) {
 		setResponseStatus(409);
-		throw new ClientError("Upload size does not match the declared size.");
+		throw new ClientError("Upload size does not match the declared size.", 409);
 	}
 	throw err;
-});
+}
 
 export const findUploadsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -1,4 +1,4 @@
-import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import {
 	ADMINISTRATOR_ROLE_NAMES,
@@ -100,7 +100,7 @@ const changePasswordSchema = z.object({
 function checkEmail(email: string): void {
 	if (email !== "" && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
 		setResponseStatus(400);
-		throw new ClientError("The format of the email is invalid");
+		throw new ClientError("The format of the email is invalid", 400);
 	}
 }
 
@@ -108,37 +108,33 @@ const setAdministratorRoleSchema = userIdSchema.extend({
 	role: administratorRoleSchema.nullable(),
 });
 
-// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
-// domain-error imports it references — from the client bundle. A plain
-// top-level helper would pin ./data and its postgres transitive dependency in
-// the client graph.
-const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+function rethrowAsHttp(err: unknown): never {
 	if (err instanceof PasswordTooShortError) {
 		setResponseStatus(400);
-		throw new ClientError(err.message);
+		throw new ClientError(err.message, 400);
 	}
 	if (err instanceof InvalidPasswordError) {
 		setResponseStatus(400);
-		throw new ClientError("Invalid credentials");
+		throw new ClientError("Invalid credentials", 400);
 	}
 	if (err instanceof UserNotFoundError) {
 		setResponseStatus(404);
-		throw new ClientError("User not found.");
+		throw new ClientError("User not found.", 404);
 	}
 	if (err instanceof UserConflictError) {
 		setResponseStatus(409);
-		throw new ClientError("User already exists.");
+		throw new ClientError("User already exists.", 409);
 	}
 	if (err instanceof GroupMembershipError) {
 		setResponseStatus(400);
-		throw new ClientError("User is not a member of group.");
+		throw new ClientError("User is not a member of group.", 400);
 	}
 	if (err instanceof PendingAccountError) {
 		setResponseStatus(409);
-		throw new ClientError("User has not completed account setup.");
+		throw new ClientError("User has not completed account setup.", 409);
 	}
 	throw err;
-});
+}
 
 export const listAdministratorRolesFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("base")])
@@ -314,7 +310,7 @@ export const setAdministratorRoleFn = createServerFn({ method: "POST" })
 	.handler(async ({ context, data }) => {
 		if (context.session.userId === data.userId) {
 			setResponseStatus(400);
-			throw new ClientError("Cannot change own role");
+			throw new ClientError("Cannot change own role", 400);
 		}
 
 		try {


### PR DESCRIPTION
## Summary

- Preserve client error statuses so missing resources and other expected failures remain recognizable by query handling and Sentry filtering.
- Standardize domain error mapping on plain local helpers, remove unnecessary server-only wrappers, and document the convention while preserving existing messages and upstream failure behavior.
- Verified 474 tests, the production web build, lint, typechecking, and knip; browser bundles contain no persistence dependencies.
