### PR TITLE
feat: create samples in bulk from uploaded reads

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -694,7 +694,7 @@ probes.
 | `VT_STORAGE_AZURE_UPLOAD_URL` | URL origin | Unset | Rehost presigned Azure uploads on a public origin, such as a Front Door route to a private storage account. Falls back to `VT_STORAGE_AZURE_DOWNLOAD_URL`, then the Azure Blob endpoint. |
 | `VT_STORAGE_DOWNLOAD_MODE` | `stream` \| `redirect` | `stream` | Serve file downloads by streaming the bytes through this server, or by 302-redirecting to a short-lived presigned storage URL. `redirect` falls back to streaming when the backend cannot presign. |
 | `VT_UPLOADS_CHUNKED` | `0` \| `1` \| `true` \| `false` \| `yes` \| `no` | Unset (`false`) | Enable direct-to-blob chunked uploads when the storage backend can presign them. Unset or disable it to use the proxied upload route. |
-| `VT_UPLOADS_CHUNKED_CONCURRENCY` | Positive integer | `8` | Set how many blocks a chunked upload PUTs at once. Raise it to lift throughput on a high-latency upload path. |
+| `VT_UPLOADS_CHUNKED_CONCURRENCY` | Positive integer | `8` | Set how many block PUTs a browser runs at once across all active uploads. Raise it to lift throughput on a high-latency upload path. |
 
 The build and test tooling reads one additional variable. It is not a runtime
 server setting and has no `_FILE` variant.

--- a/apps/web/src/samples/__tests__/queries.test.tsx
+++ b/apps/web/src/samples/__tests__/queries.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import { useCreateSample } from "../queries";
 
 describe("useCreateSample()", () => {
-	it("invalidates the reads selector on success so reserved files leave it", async () => {
+	it("invalidates every upload list on success so reserved files leave them", async () => {
 		const queryClient = new QueryClient();
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -38,7 +38,7 @@ describe("useCreateSample()", () => {
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		expect(invalidateQueries).toHaveBeenCalledWith({
-			queryKey: [...fileQueryKeys.infiniteLists(), "reads"],
+			queryKey: fileQueryKeys.lists(),
 		});
 	});
 });

--- a/apps/web/src/samples/components/Create/BulkRename.tsx
+++ b/apps/web/src/samples/components/Create/BulkRename.tsx
@@ -1,11 +1,11 @@
 import { pluralize } from "@app/format";
 import { BoxGroupSection } from "@base/Box";
-import Button from "@base/Button";
+import Button, { ButtonToggle } from "@base/Button";
 import { InputSimple } from "@base/Input";
 import Popover from "@base/Popover";
 import Tooltip from "@base/Tooltip";
-import { Info, ReplaceAll } from "lucide-react";
-import { useState } from "react";
+import { Info, Regex, ReplaceAll } from "lucide-react";
+import { useId, useState } from "react";
 
 type BulkRenameProps = {
 	names: string[];
@@ -15,24 +15,23 @@ type BulkRenameProps = {
 export default function BulkRename({ names, onRename }: BulkRenameProps) {
 	const [match, setMatch] = useState("");
 	const [replacement, setReplacement] = useState("");
-	const pattern = new RegExp(
-		match
-			.split(/\*+/)
-			.map((text) => text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-			.join(".*"),
-		"g",
-	);
-	const renamed = names.map((name) =>
-		match
-			? name.replace(pattern, (matched) => (matched ? replacement : ""))
-			: name,
-	);
+	const [isRegex, setIsRegex] = useState(false);
+	const errorId = useId();
+	const { pattern, error } = getPattern(match, isRegex);
+	const renamed = names.map((name) => {
+		if (!match || !pattern) {
+			return name;
+		}
+		return isRegex
+			? name.replace(pattern, replacement)
+			: name.replace(pattern, (matched) => (matched ? replacement : ""));
+	});
 	const changedCount = renamed.filter(
 		(name, index) => name !== names[index],
 	).length;
 
 	return (
-		<BoxGroupSection className="flex h-14 items-center gap-2 bg-gray-50 py-0 text-sm text-gray-600">
+		<BoxGroupSection className="flex min-h-14 flex-wrap items-center gap-2 bg-gray-50 py-2 text-sm text-gray-600">
 			<span className="mr-2 shrink-0 font-medium" aria-live="polite">
 				{pluralize(names.length, "sample")}
 			</span>
@@ -42,6 +41,8 @@ export default function BulkRename({ names, onRename }: BulkRenameProps) {
 			>
 				<InputSimple
 					aria-label="Match text"
+					aria-invalid={Boolean(error)}
+					aria-describedby={error ? errorId : undefined}
 					className="h-9 w-50 min-w-0 max-w-50 rounded-r-none focus-visible:z-10"
 					placeholder="Match"
 					value={match}
@@ -54,6 +55,16 @@ export default function BulkRename({ names, onRename }: BulkRenameProps) {
 					value={replacement}
 					onChange={(event) => setReplacement(event.target.value)}
 				/>
+				<Tooltip tip="Use regular expression">
+					<ButtonToggle
+						aria-label="Use regular expression"
+						pressed={isRegex}
+						onPressedChange={setIsRegex}
+						className="relative -ml-px h-9 min-h-9 w-9 shrink-0 justify-center rounded-none border border-gray-300 bg-white px-0 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:z-10 focus-visible:ring-offset-0"
+					>
+						<Regex aria-hidden="true" size={16} />
+					</ButtonToggle>
+				</Tooltip>
 				<Tooltip tip="Replace all">
 					<Button
 						size="small"
@@ -82,9 +93,30 @@ export default function BulkRename({ names, onRename }: BulkRenameProps) {
 				<p className="p-3 text-sm text-gray-600">
 					Replace matching text in all sample names. Matching is case-sensitive.
 					Use * for any number of characters. Leave the replacement empty to
-					delete matches.
+					delete matches. Enable regular expressions to use patterns such as
+					^sample_ or (.*)_batch. Enter patterns without slash delimiters. Use
+					$1, $2, and so on in the replacement for captured groups.
 				</p>
 			</Popover>
+			{error && (
+				<p id={errorId} role="alert" className="w-full text-red-600">
+					{error}
+				</p>
+			)}
 		</BoxGroupSection>
 	);
+}
+
+function getPattern(match: string, isRegex: boolean) {
+	try {
+		const source = isRegex
+			? match
+			: match
+					.split(/\*+/)
+					.map((text) => text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+					.join(".*");
+		return { pattern: new RegExp(source, "g"), error: null };
+	} catch {
+		return { pattern: null, error: "Enter a valid regular expression." };
+	}
 }

--- a/apps/web/src/samples/components/Create/BulkRename.tsx
+++ b/apps/web/src/samples/components/Create/BulkRename.tsx
@@ -1,6 +1,11 @@
+import { pluralize } from "@app/format";
+import { BoxGroupSection } from "@base/Box";
 import Button from "@base/Button";
-import { InputLabel, InputSimple } from "@base/Input";
-import { useId, useState } from "react";
+import { InputSimple } from "@base/Input";
+import Popover from "@base/Popover";
+import Tooltip from "@base/Tooltip";
+import { Info, ReplaceAll } from "lucide-react";
+import { useState } from "react";
 
 type BulkRenameProps = {
 	names: string[];
@@ -8,7 +13,6 @@ type BulkRenameProps = {
 };
 
 export default function BulkRename({ names, onRename }: BulkRenameProps) {
-	const id = useId();
 	const [match, setMatch] = useState("");
 	const [replacement, setReplacement] = useState("");
 	const pattern = new RegExp(
@@ -28,41 +32,59 @@ export default function BulkRename({ names, onRename }: BulkRenameProps) {
 	).length;
 
 	return (
-		<fieldset className="mb-4 rounded-lg border border-gray-300 p-4">
-			<legend className="px-1 font-medium">Bulk rename</legend>
-			<p id={`${id}-help`} className="mb-3 text-sm text-gray-500">
-				Match text is case-sensitive. Use * for any number of characters. Leave
-				the replacement empty to delete matches from all names.
-			</p>
-			<div className="flex flex-wrap items-end gap-3">
-				<div className="min-w-0 flex-1">
-					<InputLabel htmlFor={`${id}-match`}>Match text</InputLabel>
-					<InputSimple
-						id={`${id}-match`}
-						aria-describedby={`${id}-help`}
-						value={match}
-						onChange={(event) => setMatch(event.target.value)}
-					/>
-				</div>
-				<div className="min-w-0 flex-1">
-					<InputLabel htmlFor={`${id}-replacement`}>Replace with</InputLabel>
-					<InputSimple
-						id={`${id}-replacement`}
-						value={replacement}
-						onChange={(event) => setReplacement(event.target.value)}
-					/>
-				</div>
-				<Button
-					type="button"
-					disabled={changedCount === 0}
-					onClick={() => onRename(renamed)}
-				>
-					Apply rename
-				</Button>
-			</div>
-			<p className="mt-3 text-sm text-gray-500" aria-live="polite">
-				{changedCount} {changedCount === 1 ? "name" : "names"} will change.
-			</p>
-		</fieldset>
+		<BoxGroupSection className="flex h-14 items-center gap-2 bg-gray-50 py-0 text-sm text-gray-600">
+			<span className="mr-2 shrink-0 font-medium" aria-live="polite">
+				{pluralize(names.length, "sample")}
+			</span>
+			<fieldset
+				aria-label="Bulk rename"
+				className="ml-auto flex min-w-0 items-center rounded shadow-xs"
+			>
+				<InputSimple
+					aria-label="Match text"
+					className="h-9 w-50 min-w-0 max-w-50 rounded-r-none focus-visible:z-10"
+					placeholder="Match"
+					value={match}
+					onChange={(event) => setMatch(event.target.value)}
+				/>
+				<InputSimple
+					aria-label="Replacement"
+					className="-ml-px h-9 w-50 min-w-0 max-w-50 rounded-none focus-visible:z-10"
+					placeholder="Replacement"
+					value={replacement}
+					onChange={(event) => setReplacement(event.target.value)}
+				/>
+				<Tooltip tip="Replace all">
+					<Button
+						size="small"
+						aria-label="Replace all"
+						className="relative -ml-px h-9 w-9 shrink-0 justify-center px-0 rounded-l-none rounded-r border border-gray-300 bg-white hover:bg-gray-100 focus-visible:z-10 focus-visible:ring-offset-0 disabled:cursor-default disabled:opacity-100 disabled:text-gray-400 disabled:hover:bg-white disabled:hover:text-gray-400 disabled:active:brightness-100"
+						disabled={changedCount === 0}
+						onClick={() => onRename(renamed)}
+					>
+						<ReplaceAll aria-hidden="true" size={16} />
+					</Button>
+				</Tooltip>
+			</fieldset>
+			<Popover
+				align="end"
+				alignOffset={0}
+				trigger={
+					<button
+						type="button"
+						aria-label="Bulk rename help"
+						className="shrink-0 cursor-pointer rounded p-1 text-gray-500 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-blue-500"
+					>
+						<Info aria-hidden="true" size={16} />
+					</button>
+				}
+			>
+				<p className="p-3 text-sm text-gray-600">
+					Replace matching text in all sample names. Matching is case-sensitive.
+					Use * for any number of characters. Leave the replacement empty to
+					delete matches.
+				</p>
+			</Popover>
+		</BoxGroupSection>
 	);
 }

--- a/apps/web/src/samples/components/Create/BulkRename.tsx
+++ b/apps/web/src/samples/components/Create/BulkRename.tsx
@@ -1,0 +1,68 @@
+import Button from "@base/Button";
+import { InputLabel, InputSimple } from "@base/Input";
+import { useId, useState } from "react";
+
+type BulkRenameProps = {
+	names: string[];
+	onRename: (names: string[]) => void;
+};
+
+export default function BulkRename({ names, onRename }: BulkRenameProps) {
+	const id = useId();
+	const [match, setMatch] = useState("");
+	const [replacement, setReplacement] = useState("");
+	const pattern = new RegExp(
+		match
+			.split(/\*+/)
+			.map((text) => text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+			.join(".*"),
+		"g",
+	);
+	const renamed = names.map((name) =>
+		match
+			? name.replace(pattern, (matched) => (matched ? replacement : ""))
+			: name,
+	);
+	const changedCount = renamed.filter(
+		(name, index) => name !== names[index],
+	).length;
+
+	return (
+		<fieldset className="mb-4 rounded-lg border border-gray-300 p-4">
+			<legend className="px-1 font-medium">Bulk rename</legend>
+			<p id={`${id}-help`} className="mb-3 text-sm text-gray-500">
+				Match text is case-sensitive. Use * for any number of characters. Leave
+				the replacement empty to delete matches from all names.
+			</p>
+			<div className="flex flex-wrap items-end gap-3">
+				<div className="min-w-0 flex-1">
+					<InputLabel htmlFor={`${id}-match`}>Match text</InputLabel>
+					<InputSimple
+						id={`${id}-match`}
+						aria-describedby={`${id}-help`}
+						value={match}
+						onChange={(event) => setMatch(event.target.value)}
+					/>
+				</div>
+				<div className="min-w-0 flex-1">
+					<InputLabel htmlFor={`${id}-replacement`}>Replace with</InputLabel>
+					<InputSimple
+						id={`${id}-replacement`}
+						value={replacement}
+						onChange={(event) => setReplacement(event.target.value)}
+					/>
+				</div>
+				<Button
+					type="button"
+					disabled={changedCount === 0}
+					onClick={() => onRename(renamed)}
+				>
+					Apply rename
+				</Button>
+			</div>
+			<p className="mt-3 text-sm text-gray-500" aria-live="polite">
+				{changedCount} {changedCount === 1 ? "name" : "names"} will change.
+			</p>
+		</fieldset>
+	);
+}

--- a/apps/web/src/samples/components/Create/BulkRename.tsx
+++ b/apps/web/src/samples/components/Create/BulkRename.tsx
@@ -5,17 +5,33 @@ import { InputSimple } from "@base/Input";
 import Popover from "@base/Popover";
 import Tooltip from "@base/Tooltip";
 import { Info, Regex, ReplaceAll } from "lucide-react";
-import { useId, useState } from "react";
+import { useId } from "react";
 
 type BulkRenameProps = {
+	canUndo: boolean;
+	isRegex: boolean;
+	match: string;
 	names: string[];
 	onRename: (names: string[]) => void;
+	onRegexChange: (isRegex: boolean) => void;
+	onMatchChange: (match: string) => void;
+	onReplacementChange: (replacement: string) => void;
+	onUndo: () => void;
+	replacement: string;
 };
 
-export default function BulkRename({ names, onRename }: BulkRenameProps) {
-	const [match, setMatch] = useState("");
-	const [replacement, setReplacement] = useState("");
-	const [isRegex, setIsRegex] = useState(false);
+export default function BulkRename({
+	canUndo,
+	isRegex,
+	match,
+	names,
+	onMatchChange,
+	onRegexChange,
+	onRename,
+	onReplacementChange,
+	onUndo,
+	replacement,
+}: BulkRenameProps) {
 	const errorId = useId();
 	const { pattern, error } = getPattern(match, isRegex);
 	const renamed = names.map((name) => {
@@ -46,37 +62,43 @@ export default function BulkRename({ names, onRename }: BulkRenameProps) {
 					className="h-9 w-50 min-w-0 max-w-50 rounded-r-none focus-visible:z-10"
 					placeholder="Match"
 					value={match}
-					onChange={(event) => setMatch(event.target.value)}
+					onChange={(event) => onMatchChange(event.target.value)}
 				/>
 				<InputSimple
 					aria-label="Replacement"
 					className="-ml-px h-9 w-50 min-w-0 max-w-50 rounded-none focus-visible:z-10"
 					placeholder="Replacement"
 					value={replacement}
-					onChange={(event) => setReplacement(event.target.value)}
+					onChange={(event) => onReplacementChange(event.target.value)}
 				/>
 				<Tooltip tip="Use regular expression">
 					<ButtonToggle
 						aria-label="Use regular expression"
 						pressed={isRegex}
-						onPressedChange={setIsRegex}
+						onPressedChange={onRegexChange}
 						className="relative -ml-px h-9 min-h-9 w-9 shrink-0 justify-center rounded-none border border-gray-300 bg-white px-0 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:z-10 focus-visible:ring-offset-0"
 					>
 						<Regex aria-hidden="true" size={16} />
 					</ButtonToggle>
 				</Tooltip>
-				<Tooltip tip="Replace all">
+				<Tooltip tip={`Replace in ${pluralize(changedCount, "name")}`}>
 					<Button
 						size="small"
-						aria-label="Replace all"
-						className="relative -ml-px h-9 w-9 shrink-0 justify-center px-0 rounded-l-none rounded-r border border-gray-300 bg-white hover:bg-gray-100 focus-visible:z-10 focus-visible:ring-offset-0 disabled:cursor-default disabled:opacity-100 disabled:text-gray-400 disabled:hover:bg-white disabled:hover:text-gray-400 disabled:active:brightness-100"
+						aria-label={`Replace in ${pluralize(changedCount, "name")}`}
+						className="relative -ml-px h-9 shrink-0 justify-center rounded-l-none rounded-r border border-gray-300 bg-white hover:bg-gray-100 focus-visible:z-10 focus-visible:ring-offset-0 disabled:cursor-default disabled:opacity-100 disabled:text-gray-400 disabled:hover:bg-white disabled:hover:text-gray-400 disabled:active:brightness-100"
 						disabled={changedCount === 0}
 						onClick={() => onRename(renamed)}
 					>
 						<ReplaceAll aria-hidden="true" size={16} />
+						{changedCount > 0 && pluralize(changedCount, "name")}
 					</Button>
 				</Tooltip>
 			</fieldset>
+			{canUndo && (
+				<Button size="small" onClick={onUndo}>
+					Undo rename
+				</Button>
+			)}
 			<Popover
 				align="end"
 				alignOffset={0}

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -1,10 +1,5 @@
 import { useFetchAccount } from "@account/account";
 import Button from "@base/Button";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@base/Collapsible";
 import { ContainerNarrow } from "@base/Container";
 import CreatedCount from "@base/CreatedCount";
 import {
@@ -29,34 +24,20 @@ import type { Label } from "@virtool/contracts";
 import { WandSparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import DefaultSubtractionSelector from "./DefaultSubtractionSelector";
-import LabelSelector from "./LabelSelector";
-import LibraryTypeSelector from "./LibraryTypeSelector";
 import ReadSelector from "./ReadSelector";
-import SampleUserGroup from "./SampleUserGroup";
+import SampleSettingsFields from "./SampleSettingsFields";
+import { type SampleSettingsValues, sampleSettingsDefaults } from "./settings";
 
 type FormValues = {
+	settings: SampleSettingsValues;
 	name: string;
-	isolate: string;
-	host: string;
-	locale: string;
-	libraryType: string;
 	readFiles: number[];
-	group: string;
-	labels: number[];
-	subtractionIds: number[];
 };
 
 const emptyValues: FormValues = {
+	settings: sampleSettingsDefaults,
 	name: "",
-	isolate: "",
-	host: "",
-	locale: "",
-	libraryType: "normal",
 	readFiles: [],
-	group: "",
-	labels: [],
-	subtractionIds: [],
 };
 
 type CreateSampleProps = {
@@ -99,12 +80,11 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 	});
 	const mutation = useCreateSample();
 
-	const [showMetadata, setShowMetadata] = useState(false);
 	const [createMore, setCreateMore] = useState(false);
 	const [createdCount, setCreatedCount] = useState(0);
 
 	useEffect(() => {
-		setValue("group", String(account?.primaryGroup?.id ?? ""));
+		setValue("settings.group", String(account?.primaryGroup?.id ?? ""));
 	}, [account, setValue]);
 
 	const reads = readsResponse?.pages.flatMap((page) => page.items) ?? [];
@@ -137,7 +117,10 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 	function clearForm() {
 		reset({
 			...emptyValues,
-			group: String(account?.primaryGroup?.id ?? ""),
+			settings: {
+				...sampleSettingsDefaults,
+				group: String(account?.primaryGroup?.id ?? ""),
+			},
 		});
 	}
 
@@ -147,18 +130,24 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 	}
 
 	function onSubmit(values: FormValues) {
-		mutation.mutate(getCreateSampleRequest(values, values.readFiles), {
-			onSuccess: () => {
-				clearForm();
+		mutation.mutate(
+			getCreateSampleRequest(
+				{ ...values.settings, name: values.name },
+				values.readFiles,
+			),
+			{
+				onSuccess: () => {
+					clearForm();
 
-				if (createMore) {
-					setCreatedCount((count) => count + 1);
-					return;
-				}
+					if (createMore) {
+						setCreatedCount((count) => count + 1);
+						return;
+					}
 
-				navigate({ to: "/samples" });
+					navigate({ to: "/samples" });
+				},
 			},
-		});
+		);
 	}
 
 	return (
@@ -203,69 +192,16 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 
 						<Controller
 							control={control}
-							render={({ field: { onChange, value } }) => (
-								<SampleUserGroup
-									selected={value}
+							name="settings"
+							render={({ field }) => (
+								<SampleSettingsFields
 									groups={groups}
-									onChange={onChange}
-								/>
-							)}
-							name="group"
-						/>
-
-						<Collapsible
-							className="mb-4"
-							open={showMetadata}
-							onOpenChange={setShowMetadata}
-						>
-							<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
-							<CollapsibleContent className="grid grid-cols-2 gap-x-4 pt-4">
-								<InputGroup>
-									<InputLabel htmlFor="locale">Locale</InputLabel>
-									<InputSimple id="locale" {...register("locale")} />
-								</InputGroup>
-
-								<InputGroup>
-									<InputLabel htmlFor="isolate">Isolate</InputLabel>
-									<InputSimple id="isolate" {...register("isolate")} />
-								</InputGroup>
-
-								<InputGroup>
-									<InputLabel htmlFor="host">Host</InputLabel>
-									<InputSimple id="host" {...register("host")} />
-								</InputGroup>
-							</CollapsibleContent>
-						</Collapsible>
-
-						<Controller
-							control={control}
-							render={({ field: { onChange, value } }) => (
-								<LibraryTypeSelector libraryType={value} onSelect={onChange} />
-							)}
-							name="libraryType"
-						/>
-
-						<Controller
-							control={control}
-							render={({ field: { onChange, value } }) => (
-								<LabelSelector
 									labels={labels}
-									selected={value}
-									onChange={onChange}
+									value={field.value}
+									onChange={field.onChange}
+									metadataColumns={2}
 								/>
 							)}
-							name="labels"
-						/>
-
-						<Controller
-							control={control}
-							render={({ field: { onChange, value } }) => (
-								<DefaultSubtractionSelector
-									selected={value}
-									onChange={onChange}
-								/>
-							)}
-							name="subtractionIds"
 						/>
 
 						<Controller

--- a/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
+++ b/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
@@ -1,10 +1,5 @@
 import { useFetchAccount } from "@account/account";
 import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@base/Collapsible";
-import {
 	Dialog,
 	DialogContent,
 	DialogFooter,
@@ -24,12 +19,10 @@ import type { Label, Upload } from "@virtool/contracts";
 import { CirclePlus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import DefaultSubtractionSelector from "./DefaultSubtractionSelector";
-import LabelSelector from "./LabelSelector";
-import LibraryTypeSelector from "./LibraryTypeSelector";
 import ReadPairBadge from "./ReadPairBadge";
 import ReadSlot from "./ReadSlot";
-import SampleUserGroup from "./SampleUserGroup";
+import SampleSettingsFields from "./SampleSettingsFields";
+import { type SampleSettingsValues, sampleSettingsDefaults } from "./settings";
 
 type ReadFilesProps = {
 	/** The read files the sample will be created from, in [LEFT, RIGHT] order */
@@ -62,14 +55,8 @@ function ReadFiles({ reads }: ReadFilesProps) {
 }
 
 type FormValues = {
+	settings: SampleSettingsValues;
 	name: string;
-	isolate: string;
-	host: string;
-	locale: string;
-	libraryType: string;
-	group: string;
-	labels: number[];
-	subtractionIds: number[];
 };
 
 type CreateSampleFromFileFormProps = {
@@ -107,29 +94,21 @@ function CreateSampleFromFileForm({
 		setValue,
 	} = useForm<FormValues>({
 		defaultValues: {
+			settings: sampleSettingsDefaults,
 			name: getSampleNameFromReads(reads),
-			isolate: "",
-			host: "",
-			locale: "",
-			libraryType: "normal",
-			group: "",
-			labels: [],
-			subtractionIds: [],
 		},
 	});
 
 	const mutation = useCreateSample();
 
-	const [showMetadata, setShowMetadata] = useState(false);
-
 	useEffect(() => {
-		setValue("group", String(account?.primaryGroup?.id ?? ""));
+		setValue("settings.group", String(account?.primaryGroup?.id ?? ""));
 	}, [account, setValue]);
 
 	function onSubmit(values: FormValues) {
 		mutation.mutate(
 			getCreateSampleRequest(
-				values,
+				{ ...values.settings, name: values.name },
 				reads.map((read) => read.id),
 			),
 			{ onSuccess: onClose },
@@ -166,69 +145,15 @@ function CreateSampleFromFileForm({
 
 					<Controller
 						control={control}
-						render={({ field: { onChange, value } }) => (
-							<SampleUserGroup
-								selected={value}
+						name="settings"
+						render={({ field }) => (
+							<SampleSettingsFields
 								groups={groups}
-								onChange={onChange}
-							/>
-						)}
-						name="group"
-					/>
-
-					<Collapsible
-						className="mb-4"
-						open={showMetadata}
-						onOpenChange={setShowMetadata}
-					>
-						<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
-						<CollapsibleContent className="grid grid-cols-3 gap-x-4 pt-4">
-							<InputGroup>
-								<InputLabel htmlFor="locale">Locale</InputLabel>
-								<InputSimple id="locale" {...register("locale")} />
-							</InputGroup>
-
-							<InputGroup>
-								<InputLabel htmlFor="isolate">Isolate</InputLabel>
-								<InputSimple id="isolate" {...register("isolate")} />
-							</InputGroup>
-
-							<InputGroup>
-								<InputLabel htmlFor="host">Host</InputLabel>
-								<InputSimple id="host" {...register("host")} />
-							</InputGroup>
-						</CollapsibleContent>
-					</Collapsible>
-
-					<Controller
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<LibraryTypeSelector libraryType={value} onSelect={onChange} />
-						)}
-						name="libraryType"
-					/>
-
-					<Controller
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<LabelSelector
 								labels={labels}
-								selected={value}
-								onChange={onChange}
+								value={field.value}
+								onChange={field.onChange}
 							/>
 						)}
-						name="labels"
-					/>
-
-					<Controller
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<DefaultSubtractionSelector
-								selected={value}
-								onChange={onChange}
-							/>
-						)}
-						name="subtractionIds"
 					/>
 
 					<DialogFooter>

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -12,7 +12,12 @@ import {
 	DialogTrigger,
 } from "@base/Dialog";
 import { IconButton } from "@base/Icon";
-import { InputError, InputSimple } from "@base/Input";
+import {
+	InputContainer,
+	InputError,
+	InputIconButton,
+	InputSimple,
+} from "@base/Input";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
@@ -26,9 +31,10 @@ import {
 	getReadRowReads,
 } from "@uploads/pairing";
 import type { Label, Upload } from "@virtool/contracts";
-import { AlertCircle, X } from "lucide-react";
-import { useEffect, useState } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { AlertCircle, PencilOff, X } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import { Controller, useFieldArray, useForm, useWatch } from "react-hook-form";
+import BulkRename from "./BulkRename";
 import ReadPairBadge from "./ReadPairBadge";
 import SampleSettingsFields from "./SampleSettingsFields";
 import { type SampleSettingsValues, sampleSettingsDefaults } from "./settings";
@@ -116,6 +122,26 @@ function CreateSamplesForm({
 		name: "samples",
 	});
 
+	const nameErrorPrefix = useId();
+	const samples = useWatch({ control, name: "samples" });
+	const nameCounts = new Map<string, number>();
+	for (const sample of samples) {
+		const name = sample.name.trim();
+		nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+	}
+	const hasDuplicates = samples.some(
+		(sample) => (nameCounts.get(sample.name.trim()) ?? 0) > 1,
+	);
+
+	function renameSamples(names: string[]) {
+		for (const [index, name] of names.entries()) {
+			setValue(`samples.${index}.name`, name, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+		}
+	}
+
 	const mutation = useCreateSamples();
 
 	const [failedCount, setFailedCount] = useState(0);
@@ -125,6 +151,14 @@ function CreateSamplesForm({
 	}, [account, setValue]);
 
 	function onSubmit(values: FormValues) {
+		const names = values.samples.map((sample) => sample.name.trim());
+		if (
+			new Set(names).size !== names.length ||
+			!names.length ||
+			mutation.isPending
+		) {
+			return;
+		}
 		const requests = values.samples.map((sample) =>
 			getCreateSampleRequest(
 				{ ...values.settings, name: sample.name },
@@ -187,6 +221,13 @@ function CreateSamplesForm({
 
 			<div className="flex flex-col gap-6 lg:flex-row">
 				<div className="min-w-0 flex-1">
+					<BulkRename
+						names={samples.map((sample) => sample.name)}
+						onRename={renameSamples}
+					/>
+					<p className="mb-3 font-medium" aria-live="polite">
+						{pluralize(fields.length, "sample")}
+					</p>
 					<BoxGroup className="max-h-192 overflow-y-auto">
 						<BoxGroupTable className="table-fixed" variant="data">
 							<caption className="sr-only">Samples</caption>
@@ -200,19 +241,43 @@ function CreateSamplesForm({
 							</TableHead>
 							<tbody>
 								{fields.map((field, index) => {
-									const error = errors.samples?.[index]?.name;
+									const isDuplicate =
+										(nameCounts.get(samples[index]?.name.trim() ?? "") ?? 0) >
+										1;
+									const error = isDuplicate
+										? "Duplicate sample name"
+										: errors.samples?.[index]?.name?.message;
+									const initialName = getSampleNameFromReads(field.reads);
+									const errorId = `${nameErrorPrefix}-${index}`;
 
 									return (
 										<tr key={field.id}>
 											<td>
-												<InputSimple
-													aria-invalid={Boolean(error) || undefined}
-													aria-label={`Name for ${field.reads[0]?.name}`}
-													{...register(`samples.${index}.name`, {
-														required: "Required Field",
-													})}
-												/>
-												<InputError>{error?.message}</InputError>
+												<InputContainer align="right" className="items-center">
+													<InputSimple
+														aria-describedby={error ? errorId : undefined}
+														aria-invalid={Boolean(error) || undefined}
+														aria-label={`Name for ${field.reads[0]?.name}`}
+														{...register(`samples.${index}.name`, {
+															validate: (name) =>
+																Boolean(name.trim()) || "Required Field",
+														})}
+													/>
+													{samples[index]?.name !== initialName && (
+														<InputIconButton
+															IconComponent={PencilOff}
+															ariaLabel={`Reset name for ${field.reads[0]?.name}`}
+															tip="Reset name"
+															onClick={() =>
+																setValue(`samples.${index}.name`, initialName, {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																})
+															}
+														/>
+													)}
+												</InputContainer>
+												<InputError id={errorId}>{error}</InputError>
 											</td>
 											<td>
 												<div className="flex flex-col gap-1">
@@ -263,7 +328,9 @@ function CreateSamplesForm({
 			</div>
 
 			<DialogFooter>
-				<SaveButton disabled={fields.length === 0} />
+				<SaveButton
+					disabled={fields.length === 0 || hasDuplicates || mutation.isPending}
+				/>
 			</DialogFooter>
 		</form>
 	);

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -32,7 +32,7 @@ import {
 } from "@uploads/pairing";
 import type { Label, Upload } from "@virtool/contracts";
 import { AlertCircle, PencilOff, X } from "lucide-react";
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Controller, useFieldArray, useForm, useWatch } from "react-hook-form";
 import BulkRename from "./BulkRename";
 import ReadPairBadge from "./ReadPairBadge";
@@ -73,26 +73,39 @@ function buildSampleRows(selected: Upload[]): SampleRow[] {
 	});
 }
 
-type CreateSamplesFormProps = {
+type CreateSamplesFromFilesProps = {
 	/** All labels available for selection */
 	labels: Label[];
 
-	/** Closes the dialog */
-	onClose: () => void;
-
-	/** Drops the created files from the selection they were made from */
-	onCreated: () => void;
+	/** Drops the files reserved by created samples from the selection */
+	onCreated: (uploads: Upload[]) => void;
 
 	/** The selected read files the batch is built from */
 	selected: Upload[];
 };
 
-function CreateSamplesForm({
+/**
+ * Creates a sample from every selected read file in the file manager. Detected
+ * mate pairs become one paired sample, and every other field is shared across
+ * the batch.
+ */
+export default function CreateSamplesFromFiles({
 	labels,
-	onClose,
 	onCreated,
 	selected,
-}: CreateSamplesFormProps) {
+}: CreateSamplesFromFilesProps) {
+	const [open, setOpen] = useState(false);
+	const [hasDraft, setHasDraft] = useState(false);
+	const [failedCount, setFailedCount] = useState(0);
+	const [match, setMatch] = useState("");
+	const [replacement, setReplacement] = useState("");
+	const [isRegex, setIsRegex] = useState(false);
+	const [undoNames, setUndoNames] = useState<string[] | null>(null);
+	const [showMetadata, setShowMetadata] = useState(false);
+	const initialRows = buildSampleRows(selected);
+	const previousSelectedKeys = useRef(
+		new Set(initialRows.map((sample) => sample.key)),
+	);
 	const {
 		data: groups,
 		isError: isErrorGroups,
@@ -106,15 +119,18 @@ function CreateSamplesForm({
 
 	const {
 		control,
-		formState: { errors },
+		formState: { errors, isDirty },
+		getValues,
 		handleSubmit,
 		register,
+		reset,
 		setValue,
 	} = useForm<FormValues>({
 		defaultValues: {
 			settings: sampleSettingsDefaults,
-			samples: buildSampleRows(selected),
+			samples: initialRows,
 		},
+		mode: "onChange",
 	});
 
 	const { fields, remove, replace } = useFieldArray({
@@ -134,6 +150,7 @@ function CreateSamplesForm({
 	);
 
 	function renameSamples(names: string[]) {
+		setUndoNames(samples.map((sample) => sample.name));
 		for (const [index, name] of names.entries()) {
 			setValue(`samples.${index}.name`, name, {
 				shouldDirty: true,
@@ -142,13 +159,49 @@ function CreateSamplesForm({
 		}
 	}
 
-	const mutation = useCreateSamples();
+	function undoRename() {
+		if (!undoNames) {
+			return;
+		}
 
-	const [failedCount, setFailedCount] = useState(0);
+		for (const [index, name] of undoNames.entries()) {
+			setValue(`samples.${index}.name`, name, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+		}
+		setUndoNames(null);
+	}
+
+	const mutation = useCreateSamples();
 
 	useEffect(() => {
 		setValue("settings.group", String(account?.primaryGroup?.id ?? ""));
 	}, [account, setValue]);
+
+	useEffect(() => {
+		const selectedRows = buildSampleRows(selected);
+		const selectedKeys = new Set(selectedRows.map((sample) => sample.key));
+		const currentRows = getValues("samples");
+		const retainedRows = currentRows.filter((sample) =>
+			selectedKeys.has(sample.key),
+		);
+		const addedRows = selectedRows.filter(
+			(sample) => !previousSelectedKeys.current.has(sample.key),
+		);
+
+		if (retainedRows.length !== currentRows.length || addedRows.length > 0) {
+			const nextRows = [...retainedRows, ...addedRows];
+			if (hasDraft) {
+				replace(nextRows);
+			} else {
+				reset({ settings: getValues("settings"), samples: nextRows });
+			}
+			setUndoNames(null);
+		}
+
+		previousSelectedKeys.current = selectedKeys;
+	}, [getValues, hasDraft, replace, reset, selected]);
 
 	function onSubmit(values: FormValues) {
 		const names = values.samples.map((sample) => sample.name.trim());
@@ -168,219 +221,283 @@ function CreateSamplesForm({
 
 		mutation.mutate(requests, {
 			onSuccess: ({ created, failed }) => {
-				if (created.length) {
-					onCreated();
-				}
-
-				if (!failed.length) {
-					onClose();
-					return;
-				}
-
-				// The created samples reserved their reads, so only the failed rows
-				// can still be submitted. Keeping them on screen lets the user fix
-				// and retry without reselecting anything.
 				const failedKeys = new Set(
 					failed.map(({ request }) => request.files.join()),
 				);
+				const failedRows = values.samples.filter((sample) =>
+					failedKeys.has(sample.reads.map((read) => read.id).join()),
+				);
+				const createdUploads = values.samples
+					.filter((sample) => !failedRows.includes(sample))
+					.flatMap((sample) => sample.reads);
+
+				if (created.length) {
+					onCreated(createdUploads);
+				}
+
+				if (!failed.length) {
+					reset({
+						settings: {
+							...sampleSettingsDefaults,
+							group: String(account?.primaryGroup?.id ?? ""),
+						},
+						samples: [],
+					});
+					setFailedCount(0);
+					setMatch("");
+					setReplacement("");
+					setIsRegex(false);
+					setUndoNames(null);
+					setShowMetadata(false);
+					setHasDraft(false);
+					setOpen(false);
+					return;
+				}
 
 				setFailedCount(failed.length);
-				replace(
-					values.samples.filter((sample) =>
-						failedKeys.has(sample.reads.map((read) => read.id).join()),
-					),
-				);
+				replace(failedRows);
+				setUndoNames(null);
 			},
 		});
 	}
 
-	if ((isErrorGroups && !groups) || (isErrorAccount && !account)) {
-		return <QueryError noun="the sample form" />;
+	function handleOpenChange(nextOpen: boolean) {
+		if (!nextOpen && mutation.isPending) {
+			return;
+		}
+
+		setOpen(nextOpen);
+		if (nextOpen) {
+			setHasDraft(true);
+		}
 	}
 
-	if (isPendingGroups || isPendingAccount || !groups) {
-		return <LoadingPlaceholder className="mt-9" />;
+	function resetDraft() {
+		reset({
+			settings: {
+				...sampleSettingsDefaults,
+				group: String(account?.primaryGroup?.id ?? ""),
+			},
+			samples: buildSampleRows(selected),
+		});
+		setFailedCount(0);
+		setMatch("");
+		setReplacement("");
+		setIsRegex(false);
+		setUndoNames(null);
+		setShowMetadata(false);
+	}
+
+	const hasEmptyNames = samples.some((sample) => !sample.name.trim());
+	const hasLoadError =
+		(isErrorGroups && !groups) || (isErrorAccount && !account);
+
+	if (selected.length === 0 && !hasDraft) {
+		return null;
 	}
 
 	return (
-		<form onSubmit={handleSubmit(onSubmit)}>
-			{failedCount > 0 && (
-				<Alert color="red" icon={AlertCircle}>
-					<span>
-						<strong>
-							{pluralize(failedCount, "sample")} could not be created.
-						</strong>
-						<span> The others were created and have left the list.</span>
-					</span>
-				</Alert>
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			{(selected.length > 0 || hasDraft) && (
+				<Button as={DialogTrigger} color="blue" size="small">
+					Create Samples
+				</Button>
 			)}
-
-			<InputError className="text-left">
-				{mutation.isError && mutation.error.message}
-			</InputError>
-
-			<div className="flex flex-col gap-6 lg:flex-row">
-				<div className="min-w-0 flex-1">
-					<BoxGroup className="flex max-h-192 flex-col">
-						<BulkRename
-							names={samples.map((sample) => sample.name)}
-							onRename={renameSamples}
-						/>
-						<div className="min-h-0 overflow-y-auto">
-							<BoxGroupTable className="table-fixed" variant="data">
-								<caption className="sr-only">Samples</caption>
-								<TableHead className="sticky top-0 z-10">
-									<th scope="col">Name</th>
-									<th scope="col">Read Files</th>
-									<th className="w-28" scope="col">
-										Pairing
-									</th>
-									<TableActionsHead className="w-14" />
-								</TableHead>
-								<tbody>
-									{fields.map((field, index) => {
-										const isDuplicate =
-											(nameCounts.get(samples[index]?.name.trim() ?? "") ?? 0) >
-											1;
-										const error = isDuplicate
-											? "Duplicate sample name"
-											: errors.samples?.[index]?.name?.message;
-										const initialName = getSampleNameFromReads(field.reads);
-										const errorId = `${nameErrorPrefix}-${index}`;
-
-										return (
-											<tr key={field.id}>
-												<td>
-													<InputContainer
-														align="right"
-														className="items-center"
-													>
-														<InputSimple
-															aria-describedby={error ? errorId : undefined}
-															aria-invalid={Boolean(error) || undefined}
-															aria-label={`Name for ${field.reads[0]?.name}`}
-															{...register(`samples.${index}.name`, {
-																validate: (name) =>
-																	Boolean(name.trim()) || "Required Field",
-															})}
-														/>
-														{samples[index]?.name !== initialName && (
-															<InputIconButton
-																IconComponent={PencilOff}
-																ariaLabel={`Reset name for ${field.reads[0]?.name}`}
-																tip="Reset name"
-																onClick={() =>
-																	setValue(
-																		`samples.${index}.name`,
-																		initialName,
-																		{
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		},
-																	)
-																}
-															/>
-														)}
-													</InputContainer>
-													<InputError id={errorId}>{error}</InputError>
-												</td>
-												<td>
-													<div className="flex flex-col gap-1">
-														{field.reads.map((read) => (
-															<span
-																className="break-all font-mono text-xs text-gray-500"
-																key={read.id}
-															>
-																{read.name}
-															</span>
-														))}
-													</div>
-												</td>
-												<td>
-													<ReadPairBadge count={field.reads.length} />
-												</td>
-												<TableActionsCell>
-													<IconButton
-														ariaLabel={`Remove ${field.reads[0]?.name}`}
-														color="gray"
-														IconComponent={X}
-														onClick={() => remove(index)}
-														tip="remove"
-													/>
-												</TableActionsCell>
-											</tr>
-										);
-									})}
-								</tbody>
-							</BoxGroupTable>
-						</div>
-					</BoxGroup>
-				</div>
-				<div className="w-full min-w-0 lg:w-80 lg:shrink-0">
-					<p className="mb-4 text-sm text-gray-500">Applies to every sample.</p>
-					<Controller
-						control={control}
-						name="settings"
-						render={({ field }) => (
-							<SampleSettingsFields
-								groups={groups}
-								labels={labels}
-								value={field.value}
-								onChange={field.onChange}
-							/>
-						)}
-					/>
-				</div>
-			</div>
-
-			<DialogFooter>
-				<SaveButton
-					disabled={fields.length === 0 || hasDuplicates || mutation.isPending}
-				/>
-			</DialogFooter>
-		</form>
-	);
-}
-
-type CreateSamplesFromFilesProps = {
-	/** All labels available for selection */
-	labels: Label[];
-
-	/** Drops the created files from the selection they were made from */
-	onCreated: () => void;
-
-	/** The selected read files the batch is built from */
-	selected: Upload[];
-};
-
-/**
- * Creates a sample from every selected read file in the file manager. Detected
- * mate pairs become one paired sample, and every other field is shared across
- * the batch.
- */
-export default function CreateSamplesFromFiles({
-	labels,
-	onCreated,
-	selected,
-}: CreateSamplesFromFilesProps) {
-	const [open, setOpen] = useState(false);
-
-	return (
-		<Dialog open={open} onOpenChange={setOpen}>
-			<Button as={DialogTrigger} color="blue" size="small">
-				Create Samples
-			</Button>
 			<DialogContent className="w-11/12 max-w-7xl">
 				<DialogTitle>Create Samples</DialogTitle>
 				<DialogDescription>
-					Create samples from the selected read files.
+					Review names and settings for {pluralize(fields.length, "sample")}.
 				</DialogDescription>
-				<CreateSamplesForm
-					labels={labels}
-					onClose={() => setOpen(false)}
-					onCreated={onCreated}
-					selected={selected}
-				/>
+				{hasLoadError ? (
+					<QueryError noun="the sample form" />
+				) : isPendingGroups || isPendingAccount || !groups ? (
+					<LoadingPlaceholder className="mt-9" />
+				) : (
+					<form onSubmit={handleSubmit(onSubmit)}>
+						{failedCount > 0 && (
+							<Alert color="red" icon={AlertCircle}>
+								<span>
+									<strong>
+										{pluralize(failedCount, "sample")} could not be created.
+									</strong>
+									<span> The others were created and have left the list.</span>
+								</span>
+							</Alert>
+						)}
+
+						<InputError className="text-left">
+							{mutation.isError && mutation.error.message}
+						</InputError>
+
+						<div className="flex flex-col gap-6 lg:flex-row">
+							<div className="min-w-0 flex-1">
+								<BoxGroup className="flex max-h-192 flex-col">
+									<BulkRename
+										canUndo={Boolean(undoNames)}
+										isRegex={isRegex}
+										match={match}
+										names={samples.map((sample) => sample.name)}
+										onMatchChange={setMatch}
+										onRename={renameSamples}
+										onRegexChange={setIsRegex}
+										onReplacementChange={setReplacement}
+										onUndo={undoRename}
+										replacement={replacement}
+									/>
+									<div className="min-h-0 overflow-y-auto">
+										<BoxGroupTable className="table-fixed" variant="data">
+											<caption className="sr-only">Samples</caption>
+											<TableHead className="sticky top-0 z-10">
+												<th scope="col">Name</th>
+												<th scope="col">Read Files</th>
+												<th className="w-28" scope="col">
+													Pairing
+												</th>
+												<TableActionsHead className="w-14" />
+											</TableHead>
+											<tbody>
+												{fields.map((field, index) => {
+													const isDuplicate =
+														(nameCounts.get(
+															samples[index]?.name.trim() ?? "",
+														) ?? 0) > 1;
+													const error = isDuplicate
+														? "Duplicate sample name"
+														: errors.samples?.[index]?.name?.message;
+													const initialName = getSampleNameFromReads(
+														field.reads,
+													);
+													const errorId = `${nameErrorPrefix}-${index}`;
+
+													return (
+														<tr key={field.id}>
+															<td>
+																<InputContainer
+																	align="right"
+																	className="items-center"
+																>
+																	<InputSimple
+																		aria-describedby={
+																			error ? errorId : undefined
+																		}
+																		aria-invalid={Boolean(error) || undefined}
+																		aria-label={`Name for ${field.reads[0]?.name}`}
+																		{...register(`samples.${index}.name`, {
+																			onChange: () => setUndoNames(null),
+																			validate: (name) =>
+																				Boolean(name.trim()) ||
+																				"Required Field",
+																		})}
+																	/>
+																	{samples[index]?.name !== initialName && (
+																		<InputIconButton
+																			IconComponent={PencilOff}
+																			ariaLabel={`Reset name for ${field.reads[0]?.name}`}
+																			tip="Reset name"
+																			onClick={() => {
+																				setValue(
+																					`samples.${index}.name`,
+																					initialName,
+																					{
+																						shouldDirty: true,
+																						shouldValidate: true,
+																					},
+																				);
+																				setUndoNames(null);
+																			}}
+																		/>
+																	)}
+																</InputContainer>
+																<InputError id={errorId}>{error}</InputError>
+															</td>
+															<td>
+																<div className="flex flex-col gap-1">
+																	{field.reads.map((read) => (
+																		<span
+																			className="break-all font-mono text-xs text-gray-500"
+																			key={read.id}
+																		>
+																			{read.name}
+																		</span>
+																	))}
+																</div>
+															</td>
+															<td>
+																<ReadPairBadge count={field.reads.length} />
+															</td>
+															<TableActionsCell>
+																<IconButton
+																	ariaLabel={`Remove ${field.reads[0]?.name}`}
+																	color="gray"
+																	IconComponent={X}
+																	onClick={() => {
+																		remove(index);
+																		setUndoNames(null);
+																	}}
+																	tip="remove"
+																/>
+															</TableActionsCell>
+														</tr>
+													);
+												})}
+											</tbody>
+										</BoxGroupTable>
+									</div>
+								</BoxGroup>
+							</div>
+							<div className="w-full min-w-0 lg:w-80 lg:shrink-0">
+								<p className="mb-4 text-sm text-gray-500">
+									Applies to every sample.
+								</p>
+								<Controller
+									control={control}
+									name="settings"
+									render={({ field }) => (
+										<SampleSettingsFields
+											groups={groups}
+											labels={labels}
+											onShowMetadataChange={setShowMetadata}
+											showMetadata={showMetadata}
+											value={field.value}
+											onChange={field.onChange}
+										/>
+									)}
+								/>
+							</div>
+						</div>
+
+						<DialogFooter className="gap-2">
+							{isDirty && (
+								<Button
+									className="mr-auto"
+									disabled={mutation.isPending}
+									onClick={resetDraft}
+								>
+									Reset
+								</Button>
+							)}
+							<Button
+								disabled={mutation.isPending}
+								onClick={() => handleOpenChange(false)}
+							>
+								Close
+							</Button>
+							<SaveButton
+								altText={
+									mutation.isPending
+										? `Creating ${pluralize(fields.length, "sample")}…`
+										: `Create ${pluralize(fields.length, "sample")}`
+								}
+								disabled={
+									fields.length === 0 ||
+									hasDuplicates ||
+									hasEmptyNames ||
+									mutation.isPending
+								}
+							/>
+						</DialogFooter>
+					</form>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -96,6 +96,7 @@ export default function CreateSamplesFromFiles({
 }: CreateSamplesFromFilesProps) {
 	const [open, setOpen] = useState(false);
 	const [hasDraft, setHasDraft] = useState(false);
+	const [createdCount, setCreatedCount] = useState(0);
 	const [failedCount, setFailedCount] = useState(0);
 	const [match, setMatch] = useState("");
 	const [replacement, setReplacement] = useState("");
@@ -255,6 +256,7 @@ export default function CreateSamplesFromFiles({
 				}
 
 				setFailedCount(failed.length);
+				setCreatedCount(created.length);
 				replace(failedRows);
 				setUndoNames(null);
 			},
@@ -281,6 +283,7 @@ export default function CreateSamplesFromFiles({
 			samples: buildSampleRows(selected),
 		});
 		setFailedCount(0);
+		setCreatedCount(0);
 		setMatch("");
 		setReplacement("");
 		setIsRegex(false);
@@ -320,7 +323,12 @@ export default function CreateSamplesFromFiles({
 									<strong>
 										{pluralize(failedCount, "sample")} could not be created.
 									</strong>
-									<span> The others were created and have left the list.</span>
+									{createdCount > 0 && (
+										<span>
+											{" "}
+											The others were created and have left the list.
+										</span>
+									)}
 								</span>
 							</Alert>
 						)}

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -221,90 +221,99 @@ function CreateSamplesForm({
 
 			<div className="flex flex-col gap-6 lg:flex-row">
 				<div className="min-w-0 flex-1">
-					<BoxGroup className="max-h-192 overflow-y-auto">
+					<BoxGroup className="flex max-h-192 flex-col">
 						<BulkRename
 							names={samples.map((sample) => sample.name)}
 							onRename={renameSamples}
 						/>
-						<BoxGroupTable className="table-fixed" variant="data">
-							<caption className="sr-only">Samples</caption>
-							<TableHead className="sticky top-0 z-10">
-								<th scope="col">Name</th>
-								<th scope="col">Read Files</th>
-								<th className="w-28" scope="col">
-									Pairing
-								</th>
-								<TableActionsHead className="w-14" />
-							</TableHead>
-							<tbody>
-								{fields.map((field, index) => {
-									const isDuplicate =
-										(nameCounts.get(samples[index]?.name.trim() ?? "") ?? 0) >
-										1;
-									const error = isDuplicate
-										? "Duplicate sample name"
-										: errors.samples?.[index]?.name?.message;
-									const initialName = getSampleNameFromReads(field.reads);
-									const errorId = `${nameErrorPrefix}-${index}`;
+						<div className="min-h-0 overflow-y-auto">
+							<BoxGroupTable className="table-fixed" variant="data">
+								<caption className="sr-only">Samples</caption>
+								<TableHead className="sticky top-0 z-10">
+									<th scope="col">Name</th>
+									<th scope="col">Read Files</th>
+									<th className="w-28" scope="col">
+										Pairing
+									</th>
+									<TableActionsHead className="w-14" />
+								</TableHead>
+								<tbody>
+									{fields.map((field, index) => {
+										const isDuplicate =
+											(nameCounts.get(samples[index]?.name.trim() ?? "") ?? 0) >
+											1;
+										const error = isDuplicate
+											? "Duplicate sample name"
+											: errors.samples?.[index]?.name?.message;
+										const initialName = getSampleNameFromReads(field.reads);
+										const errorId = `${nameErrorPrefix}-${index}`;
 
-									return (
-										<tr key={field.id}>
-											<td>
-												<InputContainer align="right" className="items-center">
-													<InputSimple
-														aria-describedby={error ? errorId : undefined}
-														aria-invalid={Boolean(error) || undefined}
-														aria-label={`Name for ${field.reads[0]?.name}`}
-														{...register(`samples.${index}.name`, {
-															validate: (name) =>
-																Boolean(name.trim()) || "Required Field",
-														})}
-													/>
-													{samples[index]?.name !== initialName && (
-														<InputIconButton
-															IconComponent={PencilOff}
-															ariaLabel={`Reset name for ${field.reads[0]?.name}`}
-															tip="Reset name"
-															onClick={() =>
-																setValue(`samples.${index}.name`, initialName, {
-																	shouldDirty: true,
-																	shouldValidate: true,
-																})
-															}
+										return (
+											<tr key={field.id}>
+												<td>
+													<InputContainer
+														align="right"
+														className="items-center"
+													>
+														<InputSimple
+															aria-describedby={error ? errorId : undefined}
+															aria-invalid={Boolean(error) || undefined}
+															aria-label={`Name for ${field.reads[0]?.name}`}
+															{...register(`samples.${index}.name`, {
+																validate: (name) =>
+																	Boolean(name.trim()) || "Required Field",
+															})}
 														/>
-													)}
-												</InputContainer>
-												<InputError id={errorId}>{error}</InputError>
-											</td>
-											<td>
-												<div className="flex flex-col gap-1">
-													{field.reads.map((read) => (
-														<span
-															className="break-all font-mono text-xs text-gray-500"
-															key={read.id}
-														>
-															{read.name}
-														</span>
-													))}
-												</div>
-											</td>
-											<td>
-												<ReadPairBadge count={field.reads.length} />
-											</td>
-											<TableActionsCell>
-												<IconButton
-													ariaLabel={`Remove ${field.reads[0]?.name}`}
-													color="gray"
-													IconComponent={X}
-													onClick={() => remove(index)}
-													tip="remove"
-												/>
-											</TableActionsCell>
-										</tr>
-									);
-								})}
-							</tbody>
-						</BoxGroupTable>
+														{samples[index]?.name !== initialName && (
+															<InputIconButton
+																IconComponent={PencilOff}
+																ariaLabel={`Reset name for ${field.reads[0]?.name}`}
+																tip="Reset name"
+																onClick={() =>
+																	setValue(
+																		`samples.${index}.name`,
+																		initialName,
+																		{
+																			shouldDirty: true,
+																			shouldValidate: true,
+																		},
+																	)
+																}
+															/>
+														)}
+													</InputContainer>
+													<InputError id={errorId}>{error}</InputError>
+												</td>
+												<td>
+													<div className="flex flex-col gap-1">
+														{field.reads.map((read) => (
+															<span
+																className="break-all font-mono text-xs text-gray-500"
+																key={read.id}
+															>
+																{read.name}
+															</span>
+														))}
+													</div>
+												</td>
+												<td>
+													<ReadPairBadge count={field.reads.length} />
+												</td>
+												<TableActionsCell>
+													<IconButton
+														ariaLabel={`Remove ${field.reads[0]?.name}`}
+														color="gray"
+														IconComponent={X}
+														onClick={() => remove(index)}
+														tip="remove"
+													/>
+												</TableActionsCell>
+											</tr>
+										);
+									})}
+								</tbody>
+							</BoxGroupTable>
+						</div>
 					</BoxGroup>
 				</div>
 				<div className="w-full min-w-0 lg:w-80 lg:shrink-0">

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -4,11 +4,6 @@ import Alert from "@base/Alert";
 import { BoxGroup, BoxGroupTable } from "@base/Box";
 import Button from "@base/Button";
 import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@base/Collapsible";
-import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
@@ -17,7 +12,7 @@ import {
 	DialogTrigger,
 } from "@base/Dialog";
 import { IconButton } from "@base/Icon";
-import { InputError, InputGroup, InputLabel, InputSimple } from "@base/Input";
+import { InputError, InputSimple } from "@base/Input";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
@@ -34,11 +29,9 @@ import type { Label, Upload } from "@virtool/contracts";
 import { AlertCircle, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import DefaultSubtractionSelector from "./DefaultSubtractionSelector";
-import LabelSelector from "./LabelSelector";
-import LibraryTypeSelector from "./LibraryTypeSelector";
 import ReadPairBadge from "./ReadPairBadge";
-import SampleUserGroup from "./SampleUserGroup";
+import SampleSettingsFields from "./SampleSettingsFields";
+import { type SampleSettingsValues, sampleSettingsDefaults } from "./settings";
 
 /** One sample in the batch: its name and the reads it is created from. */
 type SampleRow = {
@@ -52,14 +45,8 @@ type SampleRow = {
 };
 
 type FormValues = {
-	group: string;
-	host: string;
-	isolate: string;
-	labels: number[];
-	libraryType: string;
-	locale: string;
+	settings: SampleSettingsValues;
 	samples: SampleRow[];
-	subtractionIds: number[];
 };
 
 /**
@@ -119,14 +106,8 @@ function CreateSamplesForm({
 		setValue,
 	} = useForm<FormValues>({
 		defaultValues: {
-			group: "",
-			host: "",
-			isolate: "",
-			labels: [],
-			libraryType: "normal",
-			locale: "",
+			settings: sampleSettingsDefaults,
 			samples: buildSampleRows(selected),
-			subtractionIds: [],
 		},
 	});
 
@@ -137,26 +118,16 @@ function CreateSamplesForm({
 
 	const mutation = useCreateSamples();
 
-	const [showMetadata, setShowMetadata] = useState(false);
 	const [failedCount, setFailedCount] = useState(0);
 
 	useEffect(() => {
-		setValue("group", String(account?.primaryGroup?.id ?? ""));
+		setValue("settings.group", String(account?.primaryGroup?.id ?? ""));
 	}, [account, setValue]);
 
 	function onSubmit(values: FormValues) {
 		const requests = values.samples.map((sample) =>
 			getCreateSampleRequest(
-				{
-					group: values.group,
-					host: values.host,
-					isolate: values.isolate,
-					labels: values.labels,
-					libraryType: values.libraryType,
-					locale: values.locale,
-					name: sample.name,
-					subtractionIds: values.subtractionIds,
-				},
+				{ ...values.settings, name: sample.name },
 				sample.reads.map((read) => read.id),
 			),
 		);
@@ -278,69 +249,15 @@ function CreateSamplesForm({
 					<p className="mb-4 text-sm text-gray-500">Applies to every sample.</p>
 					<Controller
 						control={control}
-						render={({ field: { onChange, value } }) => (
-							<SampleUserGroup
-								selected={value}
+						name="settings"
+						render={({ field }) => (
+							<SampleSettingsFields
 								groups={groups}
-								onChange={onChange}
-							/>
-						)}
-						name="group"
-					/>
-
-					<Collapsible
-						className="mb-4"
-						open={showMetadata}
-						onOpenChange={setShowMetadata}
-					>
-						<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
-						<CollapsibleContent className="grid grid-cols-3 gap-x-4 pt-4">
-							<InputGroup>
-								<InputLabel htmlFor="locale">Locale</InputLabel>
-								<InputSimple id="locale" {...register("locale")} />
-							</InputGroup>
-
-							<InputGroup>
-								<InputLabel htmlFor="isolate">Isolate</InputLabel>
-								<InputSimple id="isolate" {...register("isolate")} />
-							</InputGroup>
-
-							<InputGroup>
-								<InputLabel htmlFor="host">Host</InputLabel>
-								<InputSimple id="host" {...register("host")} />
-							</InputGroup>
-						</CollapsibleContent>
-					</Collapsible>
-
-					<Controller
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<LibraryTypeSelector libraryType={value} onSelect={onChange} />
-						)}
-						name="libraryType"
-					/>
-
-					<Controller
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<LabelSelector
 								labels={labels}
-								selected={value}
-								onChange={onChange}
+								value={field.value}
+								onChange={field.onChange}
 							/>
 						)}
-						name="labels"
-					/>
-
-					<Controller
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<DefaultSubtractionSelector
-								selected={value}
-								onChange={onChange}
-							/>
-						)}
-						name="subtractionIds"
 					/>
 				</div>
 			</div>

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -216,7 +216,7 @@ function CreateSamplesForm({
 
 			<div className="flex flex-col gap-6 lg:flex-row">
 				<div className="min-w-0 flex-1">
-					<BoxGroup className="max-h-[60vh] overflow-y-auto">
+					<BoxGroup className="max-h-192 overflow-y-auto">
 						<BoxGroupTable className="table-fixed" variant="data">
 							<caption className="sr-only">Samples</caption>
 							<TableHead className="sticky top-0 z-10">

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -16,13 +16,12 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@base/Dialog";
-import Icon, { IconButton } from "@base/Icon";
+import { IconButton } from "@base/Icon";
 import { InputError, InputGroup, InputLabel, InputSimple } from "@base/Input";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
 import { TableActionsCell, TableActionsHead, TableHead } from "@base/Table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@base/Tabs";
 import { useListGroups } from "@groups/queries";
 import { useCreateSamples } from "@samples/queries";
 import { getCreateSampleRequest, getSampleNameFromReads } from "@samples/utils";
@@ -32,7 +31,7 @@ import {
 	getReadRowReads,
 } from "@uploads/pairing";
 import type { Label, Upload } from "@virtool/contracts";
-import { AlertCircle, CirclePlus, X } from "lucide-react";
+import { AlertCircle, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import DefaultSubtractionSelector from "./DefaultSubtractionSelector";
@@ -138,7 +137,6 @@ function CreateSamplesForm({
 
 	const mutation = useCreateSamples();
 
-	const [tab, setTab] = useState("samples");
 	const [showMetadata, setShowMetadata] = useState(false);
 	const [failedCount, setFailedCount] = useState(0);
 
@@ -182,7 +180,6 @@ function CreateSamplesForm({
 				);
 
 				setFailedCount(failed.length);
-				setTab("samples");
 				replace(
 					values.samples.filter((sample) =>
 						failedKeys.has(sample.reads.map((read) => read.id).join()),
@@ -201,7 +198,7 @@ function CreateSamplesForm({
 	}
 
 	return (
-		<form onSubmit={handleSubmit(onSubmit, () => setTab("samples"))}>
+		<form onSubmit={handleSubmit(onSubmit)}>
 			{failedCount > 0 && (
 				<Alert color="red" icon={AlertCircle}>
 					<span>
@@ -217,20 +214,12 @@ function CreateSamplesForm({
 				{mutation.isError && mutation.error.message}
 			</InputError>
 
-			<Tabs value={tab} onValueChange={setTab}>
-				<TabsList aria-label="Sample creation" className="mb-4">
-					<TabsTrigger value="samples">Samples</TabsTrigger>
-					<TabsTrigger value="settings">Settings</TabsTrigger>
-				</TabsList>
-				<TabsContent
-					value="samples"
-					forceMount
-					className="data-[state=inactive]:hidden"
-				>
-					<BoxGroup className="overflow-x-auto">
-						<BoxGroupTable className="table-fixed min-w-128" variant="data">
+			<div className="flex flex-col gap-6 lg:flex-row">
+				<div className="min-w-0 flex-1">
+					<BoxGroup className="max-h-[60vh] overflow-y-auto">
+						<BoxGroupTable className="table-fixed" variant="data">
 							<caption className="sr-only">Samples</caption>
-							<TableHead>
+							<TableHead className="sticky top-0 z-10">
 								<th scope="col">Name</th>
 								<th scope="col">Read Files</th>
 								<th className="w-28" scope="col">
@@ -284,12 +273,8 @@ function CreateSamplesForm({
 							</tbody>
 						</BoxGroupTable>
 					</BoxGroup>
-				</TabsContent>
-				<TabsContent
-					value="settings"
-					forceMount
-					className="data-[state=inactive]:hidden"
-				>
+				</div>
+				<div className="w-full min-w-0 lg:w-80 lg:shrink-0">
 					<p className="mb-4 text-sm text-gray-500">Applies to every sample.</p>
 					<Controller
 						control={control}
@@ -357,8 +342,8 @@ function CreateSamplesForm({
 						)}
 						name="subtractionIds"
 					/>
-				</TabsContent>
-			</Tabs>
+				</div>
+			</div>
 
 			<DialogFooter>
 				<SaveButton disabled={fields.length === 0} />
@@ -393,9 +378,9 @@ export default function CreateSamplesFromFiles({
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<Button as={DialogTrigger} color="blue" size="small">
-				<Icon icon={CirclePlus} /> Create Samples
+				Create Samples
 			</Button>
-			<DialogContent size="lg">
+			<DialogContent className="w-11/12 max-w-7xl">
 				<DialogTitle>Create Samples</DialogTitle>
 				<DialogDescription>
 					Create samples from the selected read files.

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -1,0 +1,370 @@
+import { useFetchAccount } from "@account/account";
+import { pluralize } from "@app/format";
+import Alert from "@base/Alert";
+import Button from "@base/Button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@base/Collapsible";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogTitle,
+	DialogTrigger,
+} from "@base/Dialog";
+import Icon, { IconButton } from "@base/Icon";
+import { InputError, InputGroup, InputLabel, InputSimple } from "@base/Input";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
+import SaveButton from "@base/SaveButton";
+import { useListGroups } from "@groups/queries";
+import { useCreateSamples } from "@samples/queries";
+import { getCreateSampleRequest, getSampleNameFromReads } from "@samples/utils";
+import {
+	buildReadRows,
+	getReadRowKey,
+	getReadRowReads,
+} from "@uploads/pairing";
+import type { Label, Upload } from "@virtool/contracts";
+import { AlertCircle, CirclePlus, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
+import DefaultSubtractionSelector from "./DefaultSubtractionSelector";
+import LabelSelector from "./LabelSelector";
+import LibraryTypeSelector from "./LibraryTypeSelector";
+import ReadPairBadge from "./ReadPairBadge";
+import SampleUserGroup from "./SampleUserGroup";
+
+/** One sample in the batch: its name and the reads it is created from. */
+type SampleRow = {
+	/** A stable key for the row, from the read row it was built from */
+	key: string;
+
+	name: string;
+
+	/** The read files the sample will be created from, in [LEFT, RIGHT] order */
+	reads: Upload[];
+};
+
+type FormValues = {
+	group: string;
+	host: string;
+	isolate: string;
+	labels: number[];
+	libraryType: string;
+	locale: string;
+	samples: SampleRow[];
+	subtractionIds: number[];
+};
+
+/**
+ * Groups the selected read files into one row per sample, collapsing detected
+ * mate pairs. A file whose mate isn't selected becomes an unpaired sample.
+ *
+ * @param selected - the selected read files
+ */
+function buildSampleRows(selected: Upload[]): SampleRow[] {
+	return buildReadRows(selected).map((row) => {
+		const reads = getReadRowReads(row);
+
+		return {
+			key: getReadRowKey(row),
+			name: getSampleNameFromReads(reads),
+			reads,
+		};
+	});
+}
+
+type CreateSamplesFormProps = {
+	/** All labels available for selection */
+	labels: Label[];
+
+	/** Closes the dialog */
+	onClose: () => void;
+
+	/** Drops the created files from the selection they were made from */
+	onCreated: () => void;
+
+	/** The selected read files the batch is built from */
+	selected: Upload[];
+};
+
+function CreateSamplesForm({
+	labels,
+	onClose,
+	onCreated,
+	selected,
+}: CreateSamplesFormProps) {
+	const {
+		data: groups,
+		isError: isErrorGroups,
+		isPending: isPendingGroups,
+	} = useListGroups();
+	const {
+		data: account,
+		isError: isErrorAccount,
+		isPending: isPendingAccount,
+	} = useFetchAccount();
+
+	const {
+		control,
+		formState: { errors },
+		handleSubmit,
+		register,
+		setValue,
+	} = useForm<FormValues>({
+		defaultValues: {
+			group: "",
+			host: "",
+			isolate: "",
+			labels: [],
+			libraryType: "normal",
+			locale: "",
+			samples: buildSampleRows(selected),
+			subtractionIds: [],
+		},
+	});
+
+	const { fields, remove, replace } = useFieldArray({
+		control,
+		name: "samples",
+	});
+
+	const mutation = useCreateSamples();
+
+	const [showMetadata, setShowMetadata] = useState(false);
+	const [failedCount, setFailedCount] = useState(0);
+
+	useEffect(() => {
+		setValue("group", String(account?.primaryGroup?.id ?? ""));
+	}, [account, setValue]);
+
+	function onSubmit(values: FormValues) {
+		const requests = values.samples.map((sample) =>
+			getCreateSampleRequest(
+				{
+					group: values.group,
+					host: values.host,
+					isolate: values.isolate,
+					labels: values.labels,
+					libraryType: values.libraryType,
+					locale: values.locale,
+					name: sample.name,
+					subtractionIds: values.subtractionIds,
+				},
+				sample.reads.map((read) => read.id),
+			),
+		);
+
+		mutation.mutate(requests, {
+			onSuccess: ({ created, failed }) => {
+				if (created.length) {
+					onCreated();
+				}
+
+				if (!failed.length) {
+					onClose();
+					return;
+				}
+
+				// The created samples reserved their reads, so only the failed rows
+				// can still be submitted. Keeping them on screen lets the user fix
+				// and retry without reselecting anything.
+				const failedKeys = new Set(
+					failed.map(({ request }) => request.files.join()),
+				);
+
+				setFailedCount(failed.length);
+				replace(
+					values.samples.filter((sample) =>
+						failedKeys.has(sample.reads.map((read) => read.id).join()),
+					),
+				);
+			},
+		});
+	}
+
+	if ((isErrorGroups && !groups) || (isErrorAccount && !account)) {
+		return <QueryError noun="the sample form" />;
+	}
+
+	if (isPendingGroups || isPendingAccount || !groups) {
+		return <LoadingPlaceholder className="mt-9" />;
+	}
+
+	return (
+		<form onSubmit={handleSubmit(onSubmit)}>
+			{failedCount > 0 && (
+				<Alert color="red" icon={AlertCircle}>
+					<span>
+						<strong>
+							{pluralize(failedCount, "sample")} could not be created.
+						</strong>
+						<span> The others were created and have left the list.</span>
+					</span>
+				</Alert>
+			)}
+
+			<InputError className="text-left">
+				{mutation.isError && mutation.error.message}
+			</InputError>
+
+			<InputGroup>
+				<InputLabel>Samples</InputLabel>
+				<ul className="flex flex-col gap-2">
+					{fields.map((field, index) => {
+						const error = errors.samples?.[index]?.name;
+
+						return (
+							<li
+								className="flex items-start gap-3 rounded-md border border-gray-300 p-3"
+								key={field.id}
+							>
+								<div className="flex-1 min-w-0">
+									<InputSimple
+										aria-invalid={Boolean(error) || undefined}
+										aria-label={`Name for ${field.reads[0]?.name}`}
+										{...register(`samples.${index}.name`, {
+											required: "Required Field",
+										})}
+									/>
+									<InputError>{error?.message}</InputError>
+								</div>
+								<div className="flex flex-col items-end gap-1 min-w-0">
+									<ReadPairBadge count={field.reads.length} />
+									{field.reads.map((read) => (
+										<span
+											className="truncate font-mono text-xs text-gray-500"
+											key={read.id}
+										>
+											{read.name}
+										</span>
+									))}
+								</div>
+								<IconButton
+									ariaLabel={`Remove ${field.reads[0]?.name}`}
+									color="gray"
+									IconComponent={X}
+									onClick={() => remove(index)}
+									tip="remove"
+								/>
+							</li>
+						);
+					})}
+				</ul>
+			</InputGroup>
+
+			<Controller
+				control={control}
+				render={({ field: { onChange, value } }) => (
+					<SampleUserGroup
+						selected={value}
+						groups={groups}
+						onChange={onChange}
+					/>
+				)}
+				name="group"
+			/>
+
+			<Collapsible
+				className="mb-4"
+				open={showMetadata}
+				onOpenChange={setShowMetadata}
+			>
+				<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
+				<CollapsibleContent className="grid grid-cols-3 gap-x-4 pt-4">
+					<InputGroup>
+						<InputLabel htmlFor="locale">Locale</InputLabel>
+						<InputSimple id="locale" {...register("locale")} />
+					</InputGroup>
+
+					<InputGroup>
+						<InputLabel htmlFor="isolate">Isolate</InputLabel>
+						<InputSimple id="isolate" {...register("isolate")} />
+					</InputGroup>
+
+					<InputGroup>
+						<InputLabel htmlFor="host">Host</InputLabel>
+						<InputSimple id="host" {...register("host")} />
+					</InputGroup>
+				</CollapsibleContent>
+			</Collapsible>
+
+			<Controller
+				control={control}
+				render={({ field: { onChange, value } }) => (
+					<LibraryTypeSelector libraryType={value} onSelect={onChange} />
+				)}
+				name="libraryType"
+			/>
+
+			<Controller
+				control={control}
+				render={({ field: { onChange, value } }) => (
+					<LabelSelector labels={labels} selected={value} onChange={onChange} />
+				)}
+				name="labels"
+			/>
+
+			<Controller
+				control={control}
+				render={({ field: { onChange, value } }) => (
+					<DefaultSubtractionSelector selected={value} onChange={onChange} />
+				)}
+				name="subtractionIds"
+			/>
+
+			<DialogFooter>
+				<SaveButton disabled={fields.length === 0} />
+			</DialogFooter>
+		</form>
+	);
+}
+
+type CreateSamplesFromFilesProps = {
+	/** All labels available for selection */
+	labels: Label[];
+
+	/** Drops the created files from the selection they were made from */
+	onCreated: () => void;
+
+	/** The selected read files the batch is built from */
+	selected: Upload[];
+};
+
+/**
+ * Creates a sample from every selected read file in the file manager. Detected
+ * mate pairs become one paired sample, and every other field is shared across
+ * the batch.
+ */
+export default function CreateSamplesFromFiles({
+	labels,
+	onCreated,
+	selected,
+}: CreateSamplesFromFilesProps) {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<Button as={DialogTrigger} color="blue" size="small">
+				<Icon icon={CirclePlus} /> Create Samples
+			</Button>
+			<DialogContent size="lg">
+				<DialogTitle>Create Samples</DialogTitle>
+				<DialogDescription>
+					One sample is created for each row. Detected mate pairs are already
+					paired, and the fields below apply to every sample in the batch.
+				</DialogDescription>
+				<CreateSamplesForm
+					labels={labels}
+					onClose={() => setOpen(false)}
+					onCreated={onCreated}
+					selected={selected}
+				/>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -1,6 +1,7 @@
 import { useFetchAccount } from "@account/account";
 import { pluralize } from "@app/format";
 import Alert from "@base/Alert";
+import { BoxGroup, BoxGroupTable } from "@base/Box";
 import Button from "@base/Button";
 import {
 	Collapsible,
@@ -20,6 +21,8 @@ import { InputError, InputGroup, InputLabel, InputSimple } from "@base/Input";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
+import { TableActionsCell, TableActionsHead, TableHead } from "@base/Table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@base/Tabs";
 import { useListGroups } from "@groups/queries";
 import { useCreateSamples } from "@samples/queries";
 import { getCreateSampleRequest, getSampleNameFromReads } from "@samples/utils";
@@ -135,6 +138,7 @@ function CreateSamplesForm({
 
 	const mutation = useCreateSamples();
 
+	const [tab, setTab] = useState("samples");
 	const [showMetadata, setShowMetadata] = useState(false);
 	const [failedCount, setFailedCount] = useState(0);
 
@@ -178,6 +182,7 @@ function CreateSamplesForm({
 				);
 
 				setFailedCount(failed.length);
+				setTab("samples");
 				replace(
 					values.samples.filter((sample) =>
 						failedKeys.has(sample.reads.map((read) => read.id).join()),
@@ -196,7 +201,7 @@ function CreateSamplesForm({
 	}
 
 	return (
-		<form onSubmit={handleSubmit(onSubmit)}>
+		<form onSubmit={handleSubmit(onSubmit, () => setTab("samples"))}>
 			{failedCount > 0 && (
 				<Alert color="red" icon={AlertCircle}>
 					<span>
@@ -212,110 +217,148 @@ function CreateSamplesForm({
 				{mutation.isError && mutation.error.message}
 			</InputError>
 
-			<InputGroup>
-				<InputLabel>Samples</InputLabel>
-				<ul className="flex flex-col gap-2">
-					{fields.map((field, index) => {
-						const error = errors.samples?.[index]?.name;
+			<Tabs value={tab} onValueChange={setTab}>
+				<TabsList aria-label="Sample creation" className="mb-4">
+					<TabsTrigger value="samples">Samples</TabsTrigger>
+					<TabsTrigger value="settings">Settings</TabsTrigger>
+				</TabsList>
+				<TabsContent
+					value="samples"
+					forceMount
+					className="data-[state=inactive]:hidden"
+				>
+					<BoxGroup className="overflow-x-auto">
+						<BoxGroupTable className="table-fixed min-w-128" variant="data">
+							<caption className="sr-only">Samples</caption>
+							<TableHead>
+								<th scope="col">Name</th>
+								<th scope="col">Read Files</th>
+								<th className="w-28" scope="col">
+									Pairing
+								</th>
+								<TableActionsHead className="w-14" />
+							</TableHead>
+							<tbody>
+								{fields.map((field, index) => {
+									const error = errors.samples?.[index]?.name;
 
-						return (
-							<li
-								className="flex items-start gap-3 rounded-md border border-gray-300 p-3"
-								key={field.id}
-							>
-								<div className="flex-1 min-w-0">
-									<InputSimple
-										aria-invalid={Boolean(error) || undefined}
-										aria-label={`Name for ${field.reads[0]?.name}`}
-										{...register(`samples.${index}.name`, {
-											required: "Required Field",
-										})}
-									/>
-									<InputError>{error?.message}</InputError>
-								</div>
-								<div className="flex flex-col items-end gap-1 min-w-0">
-									<ReadPairBadge count={field.reads.length} />
-									{field.reads.map((read) => (
-										<span
-											className="truncate font-mono text-xs text-gray-500"
-											key={read.id}
-										>
-											{read.name}
-										</span>
-									))}
-								</div>
-								<IconButton
-									ariaLabel={`Remove ${field.reads[0]?.name}`}
-									color="gray"
-									IconComponent={X}
-									onClick={() => remove(index)}
-									tip="remove"
-								/>
-							</li>
-						);
-					})}
-				</ul>
-			</InputGroup>
-
-			<Controller
-				control={control}
-				render={({ field: { onChange, value } }) => (
-					<SampleUserGroup
-						selected={value}
-						groups={groups}
-						onChange={onChange}
+									return (
+										<tr key={field.id}>
+											<td>
+												<InputSimple
+													aria-invalid={Boolean(error) || undefined}
+													aria-label={`Name for ${field.reads[0]?.name}`}
+													{...register(`samples.${index}.name`, {
+														required: "Required Field",
+													})}
+												/>
+												<InputError>{error?.message}</InputError>
+											</td>
+											<td>
+												<div className="flex flex-col gap-1">
+													{field.reads.map((read) => (
+														<span
+															className="break-all font-mono text-xs text-gray-500"
+															key={read.id}
+														>
+															{read.name}
+														</span>
+													))}
+												</div>
+											</td>
+											<td>
+												<ReadPairBadge count={field.reads.length} />
+											</td>
+											<TableActionsCell>
+												<IconButton
+													ariaLabel={`Remove ${field.reads[0]?.name}`}
+													color="gray"
+													IconComponent={X}
+													onClick={() => remove(index)}
+													tip="remove"
+												/>
+											</TableActionsCell>
+										</tr>
+									);
+								})}
+							</tbody>
+						</BoxGroupTable>
+					</BoxGroup>
+				</TabsContent>
+				<TabsContent
+					value="settings"
+					forceMount
+					className="data-[state=inactive]:hidden"
+				>
+					<p className="mb-4 text-sm text-gray-500">Applies to every sample.</p>
+					<Controller
+						control={control}
+						render={({ field: { onChange, value } }) => (
+							<SampleUserGroup
+								selected={value}
+								groups={groups}
+								onChange={onChange}
+							/>
+						)}
+						name="group"
 					/>
-				)}
-				name="group"
-			/>
 
-			<Collapsible
-				className="mb-4"
-				open={showMetadata}
-				onOpenChange={setShowMetadata}
-			>
-				<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
-				<CollapsibleContent className="grid grid-cols-3 gap-x-4 pt-4">
-					<InputGroup>
-						<InputLabel htmlFor="locale">Locale</InputLabel>
-						<InputSimple id="locale" {...register("locale")} />
-					</InputGroup>
+					<Collapsible
+						className="mb-4"
+						open={showMetadata}
+						onOpenChange={setShowMetadata}
+					>
+						<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
+						<CollapsibleContent className="grid grid-cols-3 gap-x-4 pt-4">
+							<InputGroup>
+								<InputLabel htmlFor="locale">Locale</InputLabel>
+								<InputSimple id="locale" {...register("locale")} />
+							</InputGroup>
 
-					<InputGroup>
-						<InputLabel htmlFor="isolate">Isolate</InputLabel>
-						<InputSimple id="isolate" {...register("isolate")} />
-					</InputGroup>
+							<InputGroup>
+								<InputLabel htmlFor="isolate">Isolate</InputLabel>
+								<InputSimple id="isolate" {...register("isolate")} />
+							</InputGroup>
 
-					<InputGroup>
-						<InputLabel htmlFor="host">Host</InputLabel>
-						<InputSimple id="host" {...register("host")} />
-					</InputGroup>
-				</CollapsibleContent>
-			</Collapsible>
+							<InputGroup>
+								<InputLabel htmlFor="host">Host</InputLabel>
+								<InputSimple id="host" {...register("host")} />
+							</InputGroup>
+						</CollapsibleContent>
+					</Collapsible>
 
-			<Controller
-				control={control}
-				render={({ field: { onChange, value } }) => (
-					<LibraryTypeSelector libraryType={value} onSelect={onChange} />
-				)}
-				name="libraryType"
-			/>
+					<Controller
+						control={control}
+						render={({ field: { onChange, value } }) => (
+							<LibraryTypeSelector libraryType={value} onSelect={onChange} />
+						)}
+						name="libraryType"
+					/>
 
-			<Controller
-				control={control}
-				render={({ field: { onChange, value } }) => (
-					<LabelSelector labels={labels} selected={value} onChange={onChange} />
-				)}
-				name="labels"
-			/>
+					<Controller
+						control={control}
+						render={({ field: { onChange, value } }) => (
+							<LabelSelector
+								labels={labels}
+								selected={value}
+								onChange={onChange}
+							/>
+						)}
+						name="labels"
+					/>
 
-			<Controller
-				control={control}
-				render={({ field: { onChange, value } }) => (
-					<DefaultSubtractionSelector selected={value} onChange={onChange} />
-				)}
-				name="subtractionIds"
-			/>
+					<Controller
+						control={control}
+						render={({ field: { onChange, value } }) => (
+							<DefaultSubtractionSelector
+								selected={value}
+								onChange={onChange}
+							/>
+						)}
+						name="subtractionIds"
+					/>
+				</TabsContent>
+			</Tabs>
 
 			<DialogFooter>
 				<SaveButton disabled={fields.length === 0} />
@@ -355,8 +398,7 @@ export default function CreateSamplesFromFiles({
 			<DialogContent size="lg">
 				<DialogTitle>Create Samples</DialogTitle>
 				<DialogDescription>
-					One sample is created for each row. Detected mate pairs are already
-					paired, and the fields below apply to every sample in the batch.
+					Create samples from the selected read files.
 				</DialogDescription>
 				<CreateSamplesForm
 					labels={labels}

--- a/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
+++ b/apps/web/src/samples/components/Create/CreateSamplesFromFiles.tsx
@@ -221,14 +221,11 @@ function CreateSamplesForm({
 
 			<div className="flex flex-col gap-6 lg:flex-row">
 				<div className="min-w-0 flex-1">
-					<BulkRename
-						names={samples.map((sample) => sample.name)}
-						onRename={renameSamples}
-					/>
-					<p className="mb-3 font-medium" aria-live="polite">
-						{pluralize(fields.length, "sample")}
-					</p>
 					<BoxGroup className="max-h-192 overflow-y-auto">
+						<BulkRename
+							names={samples.map((sample) => sample.name)}
+							onRename={renameSamples}
+						/>
 						<BoxGroupTable className="table-fixed" variant="data">
 							<caption className="sr-only">Samples</caption>
 							<TableHead className="sticky top-0 z-10">

--- a/apps/web/src/samples/components/Create/LibraryTypeSelector.tsx
+++ b/apps/web/src/samples/components/Create/LibraryTypeSelector.tsx
@@ -1,4 +1,6 @@
-import { SelectBox, SelectBoxItem } from "@base/Select";
+import { InputGroup, InputLabel } from "@base/Input";
+import Select, { SelectButton, SelectContent, SelectItem } from "@base/Select";
+import { ChevronDown } from "lucide-react";
 
 type LibraryTypeSelectorProps = {
 	libraryType: string;
@@ -13,20 +15,25 @@ export default function LibraryTypeSelector({
 	onSelect,
 }: LibraryTypeSelectorProps) {
 	return (
-		<SelectBox
-			className="grid-cols-2 mb-6"
-			label="Library Type"
-			onValueChange={onSelect}
-			value={libraryType}
-		>
-			<SelectBoxItem value="normal">
-				<div>Normal</div>
-				<span>Search against whole genome references using normal reads.</span>
-			</SelectBoxItem>
-			<SelectBoxItem value="srna">
-				<div>sRNA</div>
-				<span>Search against whole genome references using sRNA reads</span>
-			</SelectBoxItem>
-		</SelectBox>
+		<InputGroup className="mb-6">
+			<InputLabel htmlFor="libraryType">Library Type</InputLabel>
+			<Select value={libraryType} onValueChange={onSelect}>
+				<SelectButton className="w-full" icon={ChevronDown} id="libraryType" />
+				<SelectContent>
+					<SelectItem
+						description="Search against whole genome references using normal reads."
+						value="normal"
+					>
+						Normal
+					</SelectItem>
+					<SelectItem
+						description="Search against whole genome references using sRNA reads."
+						value="srna"
+					>
+						sRNA
+					</SelectItem>
+				</SelectContent>
+			</Select>
+		</InputGroup>
 	);
 }

--- a/apps/web/src/samples/components/Create/SampleSettingsFields.tsx
+++ b/apps/web/src/samples/components/Create/SampleSettingsFields.tsx
@@ -1,0 +1,104 @@
+import { cn } from "@app/cn";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@base/Collapsible";
+import { InputGroup, InputLabel, InputSimple } from "@base/Input";
+import type { GroupMinimal, Label } from "@virtool/contracts";
+import { useState } from "react";
+import DefaultSubtractionSelector from "./DefaultSubtractionSelector";
+import LabelSelector from "./LabelSelector";
+import LibraryTypeSelector from "./LibraryTypeSelector";
+import SampleUserGroup from "./SampleUserGroup";
+import type { SampleSettingsValues } from "./settings";
+
+type SampleSettingsFieldsProps = {
+	groups: GroupMinimal[];
+	labels: Label[];
+	metadataColumns?: 2 | 3;
+	value: SampleSettingsValues;
+	onChange: (value: SampleSettingsValues) => void;
+};
+
+export default function SampleSettingsFields({
+	groups,
+	labels,
+	metadataColumns = 3,
+	value,
+	onChange,
+}: SampleSettingsFieldsProps) {
+	const [showMetadata, setShowMetadata] = useState(false);
+	return (
+		<>
+			<SampleUserGroup
+				selected={value.group}
+				groups={groups}
+				onChange={(next) => onChange({ ...value, group: next })}
+			/>
+
+			<Collapsible
+				className="mb-4"
+				open={showMetadata}
+				onOpenChange={setShowMetadata}
+			>
+				<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
+				<CollapsibleContent
+					className={cn(
+						"grid gap-x-4 pt-4",
+						metadataColumns === 2 ? "grid-cols-2" : "grid-cols-3",
+					)}
+				>
+					<InputGroup>
+						<InputLabel htmlFor="locale">Locale</InputLabel>
+						<InputSimple
+							id="locale"
+							value={value.locale}
+							onChange={(event) =>
+								onChange({ ...value, locale: event.target.value })
+							}
+						/>
+					</InputGroup>
+
+					<InputGroup>
+						<InputLabel htmlFor="isolate">Isolate</InputLabel>
+						<InputSimple
+							id="isolate"
+							value={value.isolate}
+							onChange={(event) =>
+								onChange({ ...value, isolate: event.target.value })
+							}
+						/>
+					</InputGroup>
+
+					<InputGroup>
+						<InputLabel htmlFor="host">Host</InputLabel>
+						<InputSimple
+							id="host"
+							value={value.host}
+							onChange={(event) =>
+								onChange({ ...value, host: event.target.value })
+							}
+						/>
+					</InputGroup>
+				</CollapsibleContent>
+			</Collapsible>
+
+			<LibraryTypeSelector
+				libraryType={value.libraryType}
+				onSelect={(next) => onChange({ ...value, libraryType: next })}
+			/>
+
+			<LabelSelector
+				labels={labels}
+				selected={value.labels}
+				onChange={(next) => onChange({ ...value, labels: next })}
+			/>
+
+			<DefaultSubtractionSelector
+				selected={value.subtractionIds}
+				onChange={(next) => onChange({ ...value, subtractionIds: next })}
+			/>
+		</>
+	);
+}

--- a/apps/web/src/samples/components/Create/SampleSettingsFields.tsx
+++ b/apps/web/src/samples/components/Create/SampleSettingsFields.tsx
@@ -17,6 +17,8 @@ type SampleSettingsFieldsProps = {
 	groups: GroupMinimal[];
 	labels: Label[];
 	metadataColumns?: 2 | 3;
+	onShowMetadataChange?: (showMetadata: boolean) => void;
+	showMetadata?: boolean;
 	value: SampleSettingsValues;
 	onChange: (value: SampleSettingsValues) => void;
 };
@@ -25,10 +27,15 @@ export default function SampleSettingsFields({
 	groups,
 	labels,
 	metadataColumns = 3,
+	onShowMetadataChange,
+	showMetadata,
 	value,
 	onChange,
 }: SampleSettingsFieldsProps) {
-	const [showMetadata, setShowMetadata] = useState(false);
+	const [internalShowMetadata, setInternalShowMetadata] = useState(false);
+	const isShowingMetadata = showMetadata ?? internalShowMetadata;
+	const handleShowMetadataChange =
+		onShowMetadataChange ?? setInternalShowMetadata;
 	return (
 		<>
 			<SampleUserGroup
@@ -39,8 +46,8 @@ export default function SampleSettingsFields({
 
 			<Collapsible
 				className="mb-4"
-				open={showMetadata}
-				onOpenChange={setShowMetadata}
+				open={isShowingMetadata}
+				onOpenChange={handleShowMetadataChange}
 			>
 				<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
 				<CollapsibleContent

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -156,7 +156,10 @@ describe("<CreateSample>", () => {
 		await userEvent.type(await screen.findByLabelText("Isolate"), "Clone AB");
 		await userEvent.type(screen.getByLabelText("Host"), "Apple");
 		await userEvent.type(screen.getByLabelText("Locale"), "Earth");
-		await userEvent.click(screen.getByText("Normal"));
+		await userEvent.click(
+			screen.getByRole("combobox", { name: "Library Type" }),
+		);
+		await userEvent.click(screen.getByRole("option", { name: /^sRNA/ }));
 
 		// Select Files
 		await setReadSelectorMode("Manual");
@@ -189,7 +192,7 @@ describe("<CreateSample>", () => {
 					isolate: "Clone AB",
 					host: "Apple",
 					locale: "Earth",
-					libraryType: "normal",
+					libraryType: "srna",
 					files: [firstFile.id, secondFile.id],
 					labels: [firstLabel.id],
 					subtractions: [subtractionShortlist.id],

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -1,0 +1,268 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createFakeAccount } from "@tests/fake/account";
+import { createFakeFile } from "@tests/fake/files";
+import { createFakeLabel } from "@tests/fake/labels";
+import { createFakeSubtractionNested } from "@tests/fake/subtractions";
+import { mockListGroups } from "@tests/server-fn/groups";
+import {
+	mockCreateSample,
+	sampleServerFnMocks,
+} from "@tests/server-fn/samples";
+import { mockListSubtractionsShortlist } from "@tests/server-fn/subtractions";
+import { mockGetAccount } from "@tests/server-fn/users";
+import { renderWithRouter } from "@tests/setup";
+import type { Upload } from "@virtool/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CreateSamplesFromFiles from "../CreateSamplesFromFiles";
+
+describe("<CreateSamplesFromFiles>", () => {
+	const label = createFakeLabel();
+	const labels = [label];
+	const subtractionShortlist = createFakeSubtractionNested();
+
+	beforeEach(() => {
+		mockGetAccount(createFakeAccount({ primaryGroup: null }));
+		mockListGroups([]);
+		mockListSubtractionsShortlist([subtractionShortlist]);
+	});
+
+	async function renderDialog(selected: Upload[], onCreated = vi.fn()) {
+		await renderWithRouter(
+			<CreateSamplesFromFiles
+				labels={labels}
+				onCreated={onCreated}
+				selected={selected}
+			/>,
+		);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "Create Samples" }),
+		);
+
+		expect(
+			await screen.findByRole("heading", { name: "Create Samples" }),
+		).toBeInTheDocument();
+
+		return onCreated;
+	}
+
+	async function submitForm() {
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+	}
+
+	it("should make one row per selected file, prefilled with its name", async () => {
+		const first = createFakeFile({ name: "sample_one.fastq.gz" });
+		const second = createFakeFile({ name: "sample_two.fastq.gz" });
+
+		await renderDialog([first, second]);
+
+		expect(
+			await screen.findByRole("textbox", {
+				name: "Name for sample_one.fastq.gz",
+			}),
+		).toHaveValue("sample_one");
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_two.fastq.gz" }),
+		).toHaveValue("sample_two");
+		expect(screen.getAllByText("Unpaired")).toHaveLength(2);
+	});
+
+	it("should collapse a detected mate pair into one paired row", async () => {
+		const left = createFakeFile({ name: "sample_one_R1.fastq.gz" });
+		const right = createFakeFile({ name: "sample_one_R2.fastq.gz" });
+		const lone = createFakeFile({ name: "sample_two.fastq.gz" });
+
+		const createSample = mockCreateSample();
+
+		await renderDialog([left, right, lone]);
+
+		expect(
+			await screen.findByRole("textbox", {
+				name: "Name for sample_one_R1.fastq.gz",
+			}),
+		).toHaveValue("sample_one");
+		expect(screen.getByText("Paired")).toBeInTheDocument();
+		expect(screen.getByText("Unpaired")).toBeInTheDocument();
+
+		await submitForm();
+
+		await waitFor(() => expect(createSample).toHaveBeenCalledTimes(2));
+
+		expect(createSample).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				name: "sample_one",
+				files: [left.id, right.id],
+			}),
+		});
+		expect(createSample).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				name: "sample_two",
+				files: [lone.id],
+			}),
+		});
+	});
+
+	it("should create a sample whose mate isn't selected as unpaired", async () => {
+		const left = createFakeFile({ name: "sample_one_R1.fastq.gz" });
+
+		const createSample = mockCreateSample();
+
+		await renderDialog([left]);
+
+		expect(await screen.findByText("Unpaired")).toBeInTheDocument();
+
+		await submitForm();
+
+		await waitFor(() =>
+			expect(createSample).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					name: "sample_one_R1",
+					files: [left.id],
+				}),
+			}),
+		);
+	});
+
+	it("should apply the shared fields to every sample in the batch", async () => {
+		const first = createFakeFile({ name: "sample_one.fastq.gz" });
+		const second = createFakeFile({ name: "sample_two.fastq.gz" });
+
+		const createSample = mockCreateSample();
+
+		await renderDialog([first, second]);
+
+		await userEvent.click(
+			await screen.findByRole("button", { name: "Show Metadata Fields" }),
+		);
+		await userEvent.type(await screen.findByLabelText("Isolate"), "Clone AB");
+		await userEvent.type(screen.getByLabelText("Host"), "Apple");
+		await userEvent.type(screen.getByLabelText("Locale"), "Earth");
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "Toggle Labels menu" }),
+		);
+		await userEvent.click(screen.getByRole("option", { name: label.name }));
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "Toggle Default Subtractions menu" }),
+		);
+		await userEvent.click(
+			screen.getByRole("option", { name: subtractionShortlist.name }),
+		);
+
+		await submitForm();
+
+		await waitFor(() => expect(createSample).toHaveBeenCalledTimes(2));
+
+		for (const name of ["sample_one", "sample_two"]) {
+			expect(createSample).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					name,
+					isolate: "Clone AB",
+					host: "Apple",
+					locale: "Earth",
+					labels: [label.id],
+					subtractions: [subtractionShortlist.id],
+				}),
+			});
+		}
+	});
+
+	it("should submit an edited name", async () => {
+		const file = createFakeFile({ name: "sample_one.fastq.gz" });
+
+		const createSample = mockCreateSample();
+
+		await renderDialog([file]);
+
+		const field = await screen.findByRole("textbox", {
+			name: "Name for sample_one.fastq.gz",
+		});
+		await userEvent.clear(field);
+		await userEvent.type(field, "Sample A");
+
+		await submitForm();
+
+		await waitFor(() =>
+			expect(createSample).toHaveBeenCalledWith({
+				data: expect.objectContaining({ name: "Sample A", files: [file.id] }),
+			}),
+		);
+	});
+
+	it("should not create a sample for a removed row", async () => {
+		const first = createFakeFile({ name: "sample_one.fastq.gz" });
+		const second = createFakeFile({ name: "sample_two.fastq.gz" });
+
+		const createSample = mockCreateSample();
+
+		await renderDialog([first, second]);
+
+		await userEvent.click(
+			await screen.findByRole("button", { name: "Remove sample_one.fastq.gz" }),
+		);
+
+		expect(
+			screen.queryByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).not.toBeInTheDocument();
+
+		await submitForm();
+
+		await waitFor(() => expect(createSample).toHaveBeenCalledTimes(1));
+		expect(createSample).toHaveBeenCalledWith({
+			data: expect.objectContaining({ name: "sample_two" }),
+		});
+	});
+
+	it("should require a name for every row", async () => {
+		const file = createFakeFile({ name: "sample_one.fastq.gz" });
+
+		const createSample = mockCreateSample();
+
+		await renderDialog([file]);
+
+		await userEvent.clear(
+			await screen.findByRole("textbox", {
+				name: "Name for sample_one.fastq.gz",
+			}),
+		);
+
+		await submitForm();
+
+		expect(await screen.findByText("Required Field")).toBeInTheDocument();
+		expect(createSample).not.toHaveBeenCalled();
+	});
+
+	it("should keep only the failed rows when part of the batch fails", async () => {
+		const first = createFakeFile({ name: "sample_one.fastq.gz" });
+		const second = createFakeFile({ name: "sample_two.fastq.gz" });
+
+		sampleServerFnMocks.createSampleFn.mockImplementation(
+			async ({ data }: { data: { files: number[] } }) => {
+				if (data.files[0] === second.id) {
+					throw new Error("Name is already in use");
+				}
+				return {};
+			},
+		);
+
+		const onCreated = await renderDialog([first, second]);
+
+		await submitForm();
+
+		expect(
+			await screen.findByText("1 sample could not be created."),
+		).toBeInTheDocument();
+
+		// The created sample's reads are reserved, so its row is gone and the
+		// selection it came from was cleared.
+		expect(onCreated).toHaveBeenCalled();
+		expect(
+			screen.queryByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_two.fastq.gz" }),
+		).toHaveValue("sample_two");
+	});
+});

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -650,6 +650,9 @@ describe("<CreateSamplesFromFiles>", () => {
 		expect(
 			await screen.findByText("1 sample could not be created."),
 		).toBeInTheDocument();
+		expect(
+			screen.getByText("The others were created and have left the list."),
+		).toBeInTheDocument();
 
 		// The created sample's reads are reserved, so its row and only its files
 		// leave the draft selection.
@@ -660,5 +663,22 @@ describe("<CreateSamplesFromFiles>", () => {
 		expect(
 			screen.getByRole("textbox", { name: "Name for sample_two.fastq.gz" }),
 		).toHaveValue("sample_two");
+	});
+
+	it("should not claim any samples were created when the entire batch fails", async () => {
+		const file = createFakeFile({ name: "sample_one.fastq.gz" });
+		sampleServerFnMocks.createSampleFn.mockRejectedValue(
+			new Error("Name is already in use"),
+		);
+
+		await renderDialog([file]);
+		await submitForm();
+
+		expect(
+			await screen.findByText("1 sample could not be created."),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("The others were created and have left the list."),
+		).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -132,8 +132,9 @@ describe("<CreateSamplesFromFiles>", () => {
 
 		await renderDialog([first, second]);
 
+		await userEvent.click(await screen.findByRole("tab", { name: "Settings" }));
 		await userEvent.click(
-			await screen.findByRole("button", { name: "Show Metadata Fields" }),
+			screen.getByRole("button", { name: "Show Metadata Fields" }),
 		);
 		await userEvent.type(await screen.findByLabelText("Isolate"), "Clone AB");
 		await userEvent.type(screen.getByLabelText("Host"), "Apple");
@@ -181,6 +182,11 @@ describe("<CreateSamplesFromFiles>", () => {
 		});
 		await userEvent.clear(field);
 		await userEvent.type(field, "Sample A");
+		await userEvent.click(screen.getByRole("tab", { name: "Settings" }));
+		await userEvent.click(screen.getByRole("tab", { name: "Samples" }));
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).toHaveValue("Sample A");
 
 		await submitForm();
 
@@ -228,8 +234,13 @@ describe("<CreateSamplesFromFiles>", () => {
 			}),
 		);
 
+		await userEvent.click(screen.getByRole("tab", { name: "Settings" }));
 		await submitForm();
 
+		expect(screen.getByRole("tab", { name: "Samples" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
 		expect(await screen.findByText("Required Field")).toBeInTheDocument();
 		expect(createSample).not.toHaveBeenCalled();
 	});

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -48,7 +48,9 @@ describe("<CreateSamplesFromFiles>", () => {
 	}
 
 	async function submitForm() {
-		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+		await userEvent.click(
+			screen.getByRole("button", { name: /^Create \d+ samples?$/ }),
+		);
 	}
 
 	it("should make one row per selected file, prefilled with its name", async () => {
@@ -67,6 +69,77 @@ describe("<CreateSamplesFromFiles>", () => {
 		).toHaveValue("sample_two");
 		expect(screen.getAllByText("Unpaired")).toHaveLength(2);
 		expect(screen.getByText("2 samples")).toBeInTheDocument();
+	});
+
+	it("should preserve the draft when the dialog closes and reopens", async () => {
+		await renderDialog([createFakeFile({ name: "sample_one.fastq.gz" })]);
+
+		const name = screen.getByRole("textbox", {
+			name: "Name for sample_one.fastq.gz",
+		});
+		await userEvent.clear(name);
+		await userEvent.type(name, "Edited sample");
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Match text" }),
+			"sample",
+		);
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Replacement" }),
+			"specimen",
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: "Show Metadata Fields" }),
+		);
+
+		await userEvent.keyboard("{Escape}");
+
+		expect(
+			screen.queryByRole("heading", { name: "Create Samples" }),
+		).not.toBeInTheDocument();
+		await userEvent.click(
+			screen.getByRole("button", { name: "Create Samples" }),
+		);
+
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample_one.fastq.gz",
+			}),
+		).toHaveValue("Edited sample");
+		expect(screen.getByRole("textbox", { name: "Match text" })).toHaveValue(
+			"sample",
+		);
+		expect(screen.getByRole("textbox", { name: "Replacement" })).toHaveValue(
+			"specimen",
+		);
+		expect(screen.getByLabelText("Host")).toBeVisible();
+	});
+
+	it("should stay open while samples are being created", async () => {
+		let resolveCreate: ((value: object) => void) | undefined;
+		sampleServerFnMocks.createSampleFn.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCreate = resolve;
+				}),
+		);
+		await renderDialog([createFakeFile({ name: "sample_one.fastq.gz" })]);
+
+		await submitForm();
+
+		expect(
+			screen.getByRole("button", { name: "Creating 1 sample…" }),
+		).toBeDisabled();
+		await userEvent.keyboard("{Escape}");
+		expect(
+			screen.getByRole("heading", { name: "Create Samples" }),
+		).toBeInTheDocument();
+
+		resolveCreate?.({});
+		await waitFor(() =>
+			expect(
+				screen.queryByRole("heading", { name: "Create Samples" }),
+			).not.toBeInTheDocument(),
+		);
 	});
 
 	it("should scroll the rows without scrolling the bulk rename controls", async () => {
@@ -253,7 +326,9 @@ describe("<CreateSamplesFromFiles>", () => {
 		expect(firstName).toHaveAttribute("aria-invalid", "true");
 		expect(secondName).toHaveAttribute("aria-invalid", "true");
 		expect(screen.getAllByText("Duplicate sample name")).toHaveLength(2);
-		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: /^Create \d+ samples?$/ }),
+		).toBeDisabled();
 		await submitForm();
 		expect(createSample).not.toHaveBeenCalled();
 
@@ -263,7 +338,9 @@ describe("<CreateSamplesFromFiles>", () => {
 		expect(screen.queryByText("Duplicate sample name")).not.toBeInTheDocument();
 		expect(firstName).not.toHaveAttribute("aria-invalid", "true");
 		expect(secondName).not.toHaveAttribute("aria-invalid", "true");
-		expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+		expect(
+			screen.getByRole("button", { name: /^Create \d+ samples?$/ }),
+		).toBeEnabled();
 
 		await submitForm();
 		await waitFor(() => expect(createSample).toHaveBeenCalledTimes(2));
@@ -277,7 +354,9 @@ describe("<CreateSamplesFromFiles>", () => {
 
 		expect(screen.getByText("2 samples")).toBeInTheDocument();
 		expect(screen.getAllByText("Duplicate sample name")).toHaveLength(2);
-		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: /^Create \d+ samples?$/ }),
+		).toBeDisabled();
 
 		await userEvent.click(
 			screen.getByRole("button", { name: "Remove sample.fastq.gz" }),
@@ -285,7 +364,9 @@ describe("<CreateSamplesFromFiles>", () => {
 
 		expect(screen.getByText("1 sample")).toBeInTheDocument();
 		expect(screen.queryByText("Duplicate sample name")).not.toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+		expect(
+			screen.getByRole("button", { name: /^Create \d+ samples?$/ }),
+		).toBeEnabled();
 	});
 
 	it("should reset an edited name to its own initial value after removing another row", async () => {
@@ -335,7 +416,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Match text" }),
 			"_batch*_end",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
+		await userEvent.click(
+			screen.getByRole("button", { name: /^Replace in \d+ names?$/ }),
+		);
 
 		expect(
 			screen.getByRole("textbox", {
@@ -348,7 +431,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			}),
 		).toHaveValue("sample");
 		expect(screen.getAllByText("Duplicate sample name")).toHaveLength(2);
-		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: /^Create \d+ samples?$/ }),
+		).toBeDisabled();
 	});
 
 	it("should replace all literal matches with literal replacement text", async () => {
@@ -365,7 +450,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Replacement" }),
 			"$&",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
+		await userEvent.click(
+			screen.getByRole("button", { name: /^Replace in \d+ names?$/ }),
+		);
 
 		expect(
 			screen.getByRole("textbox", {
@@ -377,6 +464,32 @@ describe("<CreateSamplesFromFiles>", () => {
 				name: "Name for sample.A+.fastq.gz",
 			}),
 		).toHaveValue("sample.A+");
+	});
+
+	it("should undo the last bulk rename", async () => {
+		await renderDialog([
+			createFakeFile({ name: "sample_one.fastq.gz" }),
+			createFakeFile({ name: "sample_two.fastq.gz" }),
+		]);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Match text" }),
+			"sample_",
+		);
+		await userEvent.click(
+			screen.getByRole("button", { name: "Replace in 2 names" }),
+		);
+
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).toHaveValue("one");
+		await userEvent.click(screen.getByRole("button", { name: "Undo rename" }));
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).toHaveValue("sample_one");
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_two.fastq.gz" }),
+		).toHaveValue("sample_two");
 	});
 
 	it.each([
@@ -403,7 +516,7 @@ describe("<CreateSamplesFromFiles>", () => {
 				);
 			}
 			await userEvent.click(
-				screen.getByRole("button", { name: "Replace all" }),
+				screen.getByRole("button", { name: /^Replace in \d+ names?$/ }),
 			);
 
 			expect(
@@ -418,7 +531,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			name: "Use regular expression",
 		});
 		const match = screen.getByRole("textbox", { name: "Match text" });
-		const replace = screen.getByRole("button", { name: "Replace all" });
+		const replace = screen.getByRole("button", {
+			name: /^Replace in \d+ names?$/,
+		});
 
 		await userEvent.click(toggle);
 		expect(replace).toBeDisabled();
@@ -461,7 +576,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Replacement" }),
 			"renamed",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
+		await userEvent.click(
+			screen.getByRole("button", { name: /^Replace in \d+ names?$/ }),
+		);
 
 		expect(
 			screen.getByRole("textbox", {
@@ -478,7 +595,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Match text" }),
 			"*",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
+		await userEvent.click(
+			screen.getByRole("button", { name: /^Replace in \d+ names?$/ }),
+		);
 
 		expect(
 			screen.getByRole("textbox", {
@@ -532,9 +651,9 @@ describe("<CreateSamplesFromFiles>", () => {
 			await screen.findByText("1 sample could not be created."),
 		).toBeInTheDocument();
 
-		// The created sample's reads are reserved, so its row is gone and the
-		// selection it came from was cleared.
-		expect(onCreated).toHaveBeenCalled();
+		// The created sample's reads are reserved, so its row and only its files
+		// leave the draft selection.
+		expect(onCreated).toHaveBeenCalledWith([first]);
 		expect(
 			screen.queryByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
 		).not.toBeInTheDocument();

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -66,6 +66,7 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Name for sample_two.fastq.gz" }),
 		).toHaveValue("sample_two");
 		expect(screen.getAllByText("Unpaired")).toHaveLength(2);
+		expect(screen.getByText("2 samples")).toBeInTheDocument();
 	});
 
 	it("should collapse a detected mate pair into one paired row", async () => {
@@ -216,6 +217,193 @@ describe("<CreateSamplesFromFiles>", () => {
 		expect(createSample).toHaveBeenCalledWith({
 			data: expect.objectContaining({ name: "sample_two" }),
 		});
+	});
+
+	it("should highlight trimmed duplicate names and allow submission after editing", async () => {
+		const first = createFakeFile({ name: "sample_one.fastq.gz" });
+		const second = createFakeFile({ name: "sample_two.fastq.gz" });
+		const createSample = mockCreateSample();
+
+		await renderDialog([first, second]);
+
+		const firstName = screen.getByRole("textbox", {
+			name: "Name for sample_one.fastq.gz",
+		});
+		const secondName = screen.getByRole("textbox", {
+			name: "Name for sample_two.fastq.gz",
+		});
+		await userEvent.clear(secondName);
+		await userEvent.type(secondName, " sample_one ");
+
+		expect(firstName).toHaveAttribute("aria-invalid", "true");
+		expect(secondName).toHaveAttribute("aria-invalid", "true");
+		expect(screen.getAllByText("Duplicate sample name")).toHaveLength(2);
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		await submitForm();
+		expect(createSample).not.toHaveBeenCalled();
+
+		await userEvent.clear(secondName);
+		await userEvent.type(secondName, "unique");
+
+		expect(screen.queryByText("Duplicate sample name")).not.toBeInTheDocument();
+		expect(firstName).not.toHaveAttribute("aria-invalid", "true");
+		expect(secondName).not.toHaveAttribute("aria-invalid", "true");
+		expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+
+		await submitForm();
+		await waitFor(() => expect(createSample).toHaveBeenCalledTimes(2));
+	});
+
+	it("should clear duplicate errors and update the count when a row is removed", async () => {
+		await renderDialog([
+			createFakeFile({ name: "sample.fastq.gz" }),
+			createFakeFile({ name: "sample.fq.gz" }),
+		]);
+
+		expect(screen.getByText("2 samples")).toBeInTheDocument();
+		expect(screen.getAllByText("Duplicate sample name")).toHaveLength(2);
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "Remove sample.fastq.gz" }),
+		);
+
+		expect(screen.getByText("1 sample")).toBeInTheDocument();
+		expect(screen.queryByText("Duplicate sample name")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+	});
+
+	it("should reset an edited name to its own initial value after removing another row", async () => {
+		await renderDialog([
+			createFakeFile({ name: "sample_one.fastq.gz" }),
+			createFakeFile({ name: "sample_two.fastq.gz" }),
+		]);
+
+		expect(
+			screen.queryByRole("button", {
+				name: "Reset name for sample_two.fastq.gz",
+			}),
+		).not.toBeInTheDocument();
+		const name = screen.getByRole("textbox", {
+			name: "Name for sample_two.fastq.gz",
+		});
+		await userEvent.clear(name);
+		await userEvent.type(name, "Edited");
+		await userEvent.click(
+			screen.getByRole("button", { name: "Remove sample_one.fastq.gz" }),
+		);
+		await userEvent.click(
+			screen.getByRole("button", {
+				name: "Reset name for sample_two.fastq.gz",
+			}),
+		);
+
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample_two.fastq.gz",
+			}),
+		).toHaveValue("sample_two");
+		expect(
+			screen.queryByRole("button", {
+				name: "Reset name for sample_two.fastq.gz",
+			}),
+		).not.toBeInTheDocument();
+	});
+
+	it("should delete wildcard matches from every name and guard the resulting duplicates", async () => {
+		await renderDialog([
+			createFakeFile({ name: "sample_batch-one_end.fastq.gz" }),
+			createFakeFile({ name: "sample_batch_end.fastq.gz" }),
+		]);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Match text" }),
+			"_batch*_end",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample_batch-one_end.fastq.gz",
+			}),
+		).toHaveValue("sample");
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample_batch_end.fastq.gz",
+			}),
+		).toHaveValue("sample");
+		expect(screen.getAllByText("Duplicate sample name")).toHaveLength(2);
+		expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+	});
+
+	it("should replace all literal matches with literal replacement text", async () => {
+		await renderDialog([
+			createFakeFile({ name: "sample.a+.a+.fastq.gz" }),
+			createFakeFile({ name: "sample.A+.fastq.gz" }),
+		]);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Match text" }),
+			".a+",
+		);
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Replace with" }),
+			"$&",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample.a+.a+.fastq.gz",
+			}),
+		).toHaveValue("sample$&$&");
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample.A+.fastq.gz",
+			}),
+		).toHaveValue("sample.A+");
+	});
+
+	it("should replace the whole name once with a standalone wildcard", async () => {
+		await renderDialog([createFakeFile({ name: "sample_one.fastq.gz" })]);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Match text" }),
+			"*",
+		);
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Replace with" }),
+			"renamed",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample_one.fastq.gz",
+			}),
+		).toHaveValue("renamed");
+	});
+
+	it("should require a name after deleting it with a standalone wildcard", async () => {
+		const createSample = mockCreateSample();
+		await renderDialog([createFakeFile({ name: "sample_one.fastq.gz" })]);
+
+		await userEvent.type(
+			screen.getByRole("textbox", { name: "Match text" }),
+			"*",
+		);
+		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+
+		expect(
+			screen.getByRole("textbox", {
+				name: "Name for sample_one.fastq.gz",
+			}),
+		).toHaveValue("");
+		expect(await screen.findByText("Required Field")).toBeInTheDocument();
+
+		await submitForm();
+
+		expect(createSample).not.toHaveBeenCalled();
 	});
 
 	it("should require a name for every row", async () => {

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -320,7 +320,7 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Match text" }),
 			"_batch*_end",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
 
 		expect(
 			screen.getByRole("textbox", {
@@ -347,10 +347,10 @@ describe("<CreateSamplesFromFiles>", () => {
 			".a+",
 		);
 		await userEvent.type(
-			screen.getByRole("textbox", { name: "Replace with" }),
+			screen.getByRole("textbox", { name: "Replacement" }),
 			"$&",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
 
 		expect(
 			screen.getByRole("textbox", {
@@ -372,10 +372,10 @@ describe("<CreateSamplesFromFiles>", () => {
 			"*",
 		);
 		await userEvent.type(
-			screen.getByRole("textbox", { name: "Replace with" }),
+			screen.getByRole("textbox", { name: "Replacement" }),
 			"renamed",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
 
 		expect(
 			screen.getByRole("textbox", {
@@ -392,7 +392,7 @@ describe("<CreateSamplesFromFiles>", () => {
 			screen.getByRole("textbox", { name: "Match text" }),
 			"*",
 		);
-		await userEvent.click(screen.getByRole("button", { name: "Apply rename" }));
+		await userEvent.click(screen.getByRole("button", { name: "Replace all" }));
 
 		expect(
 			screen.getByRole("textbox", {

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -132,9 +132,8 @@ describe("<CreateSamplesFromFiles>", () => {
 
 		await renderDialog([first, second]);
 
-		await userEvent.click(await screen.findByRole("tab", { name: "Settings" }));
 		await userEvent.click(
-			screen.getByRole("button", { name: "Show Metadata Fields" }),
+			await screen.findByRole("button", { name: "Show Metadata Fields" }),
 		);
 		await userEvent.type(await screen.findByLabelText("Isolate"), "Clone AB");
 		await userEvent.type(screen.getByLabelText("Host"), "Apple");
@@ -182,8 +181,6 @@ describe("<CreateSamplesFromFiles>", () => {
 		});
 		await userEvent.clear(field);
 		await userEvent.type(field, "Sample A");
-		await userEvent.click(screen.getByRole("tab", { name: "Settings" }));
-		await userEvent.click(screen.getByRole("tab", { name: "Samples" }));
 		expect(
 			screen.getByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
 		).toHaveValue("Sample A");
@@ -234,13 +231,8 @@ describe("<CreateSamplesFromFiles>", () => {
 			}),
 		);
 
-		await userEvent.click(screen.getByRole("tab", { name: "Settings" }));
 		await submitForm();
 
-		expect(screen.getByRole("tab", { name: "Samples" })).toHaveAttribute(
-			"aria-selected",
-			"true",
-		);
 		expect(await screen.findByText("Required Field")).toBeInTheDocument();
 		expect(createSample).not.toHaveBeenCalled();
 	});

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -364,6 +364,77 @@ describe("<CreateSamplesFromFiles>", () => {
 		).toHaveValue("sample.A+");
 	});
 
+	it.each([
+		["(sample)_(\\d+)", "$2-$1", "12-sample_34"],
+		["\\d+", "batch", "sample_batch_batch"],
+		["^sample_", "", "12_34"],
+		["$", "_end", "sample_12_34_end"],
+	])(
+		"should replace regex %s with %s",
+		async (pattern, replacement, expected) => {
+			await renderDialog([createFakeFile({ name: "sample_12_34.fastq.gz" })]);
+
+			await userEvent.click(
+				screen.getByRole("button", { name: "Use regular expression" }),
+			);
+			await userEvent.type(
+				screen.getByRole("textbox", { name: "Match text" }),
+				pattern,
+			);
+			if (replacement) {
+				await userEvent.type(
+					screen.getByRole("textbox", { name: "Replacement" }),
+					replacement,
+				);
+			}
+			await userEvent.click(
+				screen.getByRole("button", { name: "Replace all" }),
+			);
+
+			expect(
+				screen.getByRole("textbox", { name: "Name for sample_12_34.fastq.gz" }),
+			).toHaveValue(expected);
+		},
+	);
+
+	it("should block invalid regex and recover when corrected or disabled", async () => {
+		await renderDialog([createFakeFile({ name: "sample_one.fastq.gz" })]);
+		const toggle = screen.getByRole("button", {
+			name: "Use regular expression",
+		});
+		const match = screen.getByRole("textbox", { name: "Match text" });
+		const replace = screen.getByRole("button", { name: "Replace all" });
+
+		await userEvent.click(toggle);
+		expect(replace).toBeDisabled();
+		await userEvent.type(match, "(");
+		expect(match).toHaveAccessibleDescription(
+			"Enter a valid regular expression.",
+		);
+		expect(match).toHaveAttribute("aria-invalid", "true");
+		expect(replace).toBeDisabled();
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).toHaveValue("sample_one");
+
+		await userEvent.click(toggle);
+		expect(
+			screen.queryByText("Enter a valid regular expression."),
+		).not.toBeInTheDocument();
+		expect(match).toHaveAttribute("aria-invalid", "false");
+		await userEvent.click(toggle);
+		await userEvent.clear(match);
+		await userEvent.type(match, "^sample_");
+		expect(
+			screen.queryByText("Enter a valid regular expression."),
+		).not.toBeInTheDocument();
+		expect(replace).toBeEnabled();
+		await userEvent.click(replace);
+		expect(
+			screen.getByRole("textbox", { name: "Name for sample_one.fastq.gz" }),
+		).toHaveValue("one");
+	});
+
 	it("should replace the whole name once with a standalone wildcard", async () => {
 		await renderDialog([createFakeFile({ name: "sample_one.fastq.gz" })]);
 

--- a/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSamplesFromFiles.test.tsx
@@ -69,6 +69,21 @@ describe("<CreateSamplesFromFiles>", () => {
 		expect(screen.getByText("2 samples")).toBeInTheDocument();
 	});
 
+	it("should scroll the rows without scrolling the bulk rename controls", async () => {
+		await renderDialog([
+			createFakeFile({ name: "sample_one.fastq.gz" }),
+			createFakeFile({ name: "sample_two.fastq.gz" }),
+		]);
+
+		const table = screen.getByRole("table", { name: "Samples" });
+		const scrollContainer = table.parentElement;
+		const bulkRename = screen.getByRole("group", { name: "Bulk rename" });
+
+		expect(scrollContainer).toHaveClass("overflow-y-auto");
+		expect(scrollContainer).not.toContainElement(bulkRename);
+		expect(table.querySelector("thead")).toHaveClass("sticky", "top-0");
+	});
+
 	it("should collapse a detected mate pair into one paired row", async () => {
 		const left = createFakeFile({ name: "sample_one_R1.fastq.gz" });
 		const right = createFakeFile({ name: "sample_one_R2.fastq.gz" });

--- a/apps/web/src/samples/components/Create/__tests__/LibraryTypeSelector.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/LibraryTypeSelector.test.tsx
@@ -11,7 +11,8 @@ describe("<LibraryTypeSelector>", () => {
 			<LibraryTypeSelector libraryType="normal" onSelect={onSelect} />,
 		);
 
-		await userEvent.click(screen.getByRole("radio", { name: /sRNA/i }));
+		await userEvent.click(screen.getByRole("combobox"));
+		await userEvent.click(screen.getByRole("option", { name: /sRNA/i }));
 		expect(onSelect).toHaveBeenCalledWith("srna");
 	});
 
@@ -20,13 +21,6 @@ describe("<LibraryTypeSelector>", () => {
 			<LibraryTypeSelector libraryType="normal" onSelect={vi.fn()} />,
 		);
 
-		expect(screen.getByRole("radio", { name: /Normal/i })).toHaveAttribute(
-			"data-state",
-			"on",
-		);
-		expect(screen.getByRole("radio", { name: /sRNA/i })).toHaveAttribute(
-			"data-state",
-			"off",
-		);
+		expect(screen.getByRole("combobox")).toHaveTextContent("Normal");
 	});
 });

--- a/apps/web/src/samples/components/Create/settings.ts
+++ b/apps/web/src/samples/components/Create/settings.ts
@@ -1,0 +1,16 @@
+import type { CreateSampleFormValues } from "@samples/utils";
+
+/** The settings shared by every sample creation form. */
+export type SampleSettingsValues = Required<
+	Omit<CreateSampleFormValues, "name">
+>;
+
+export const sampleSettingsDefaults: SampleSettingsValues = {
+	group: "",
+	host: "",
+	isolate: "",
+	labels: [],
+	libraryType: "normal",
+	locale: "",
+	subtractionIds: [],
+};

--- a/apps/web/src/samples/components/SampleFileManager.tsx
+++ b/apps/web/src/samples/components/SampleFileManager.tsx
@@ -3,6 +3,7 @@ import { ContainerNarrow } from "@base/Container";
 import { FileManager } from "@uploads/components/FileManager";
 import type { Label, SortDirection, UploadSortField } from "@virtool/contracts";
 import CreateSampleFromFile from "./Create/CreateSampleFromFile";
+import CreateSamplesFromFiles from "./Create/CreateSamplesFromFiles";
 
 type SampleFileManagerProps = {
 	direction: SortDirection;
@@ -43,6 +44,17 @@ export default function SampleFileManager({
 									labels={labels}
 									upload={upload}
 									uploads={uploads}
+								/>
+							)
+						: undefined
+				}
+				renderSelectionAction={
+					canCreate
+						? (selected, clear) => (
+								<CreateSamplesFromFiles
+									labels={labels}
+									onCreated={clear}
+									selected={selected}
 								/>
 							)
 						: undefined

--- a/apps/web/src/samples/components/SampleFileManager.tsx
+++ b/apps/web/src/samples/components/SampleFileManager.tsx
@@ -50,10 +50,10 @@ export default function SampleFileManager({
 				}
 				renderSelectionAction={
 					canCreate
-						? (selected, clear) => (
+						? (selected, _clear, remove) => (
 								<CreateSamplesFromFiles
 									labels={labels}
-									onCreated={clear}
+									onCreated={remove}
 									selected={selected}
 								/>
 							)

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -268,11 +268,76 @@ export function useCreateSample() {
 			}) as Promise<Sample>,
 		onSuccess: () => {
 			// The created sample reserves its read files, so the server stops
-			// returning them. Only the reads selector shows them — an infinite
-			// list — so refetch just that, not every upload type and page.
-			queryClient.invalidateQueries({
-				queryKey: [...fileQueryKeys.infiniteLists(), "reads"],
+			// returning them. `lists()` is a prefix of `infiniteLists()`, so this
+			// refreshes both the paginated file manager and the reads selector.
+			queryClient.invalidateQueries({ queryKey: fileQueryKeys.lists() });
+		},
+	});
+}
+
+/** The outcome of creating a batch of samples. */
+export type CreateSamplesResult = {
+	/** The samples that were created. */
+	created: Sample[];
+
+	/** The requests that failed, each with the error that rejected it. */
+	failed: { error: Error; request: CreateSampleRequest }[];
+};
+
+/**
+ * Initializes a mutator for creating several samples at once.
+ *
+ * Every request is attempted, so one rejection doesn't strand the rest. The
+ * mutation resolves with both outcomes rather than rejecting, letting the
+ * caller keep the failed requests on screen while the created ones leave.
+ */
+export function useCreateSamples() {
+	const queryClient = useQueryClient();
+
+	return useMutation<CreateSamplesResult, Error, CreateSampleRequest[]>({
+		mutationFn: async (requests) => {
+			const results = await Promise.allSettled(
+				requests.map(
+					(request) =>
+						createSampleFn({
+							data: {
+								...request,
+								libraryType: request.libraryType as LibraryType,
+							},
+						}) as Promise<Sample>,
+				),
+			);
+
+			const created: Sample[] = [];
+			const failed: CreateSamplesResult["failed"] = [];
+
+			results.forEach((result, index) => {
+				const request = requests[index];
+
+				if (request === undefined) {
+					return;
+				}
+
+				if (result.status === "fulfilled") {
+					created.push(result.value);
+				} else {
+					failed.push({
+						error:
+							result.reason instanceof Error
+								? result.reason
+								: new Error(String(result.reason)),
+						request,
+					});
+				}
 			});
+
+			return { created, failed };
+		},
+		// Settled, not success: a partial failure still reserved the read files of
+		// the samples that were created, so the lists have to be refreshed either
+		// way.
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: fileQueryKeys.lists() });
 		},
 	});
 }

--- a/apps/web/src/uploads/__tests__/chunkedUpload.test.ts
+++ b/apps/web/src/uploads/__tests__/chunkedUpload.test.ts
@@ -8,6 +8,9 @@ let statusFor: (url: string) => number;
 
 // Every request the run made, in creation order.
 let requests: MockXhr[];
+let settleBlocksAutomatically: boolean;
+let activeBlocks: number;
+let maxActiveBlocks: number;
 
 // A mock XHR that settles itself on the next microtask, so the concurrent block
 // uploads run to completion without a test driving each one by hand.
@@ -20,6 +23,7 @@ class MockXhr {
 	aborted = false;
 	upload = new EventTarget();
 	private events = new EventTarget();
+	private settled = false;
 
 	constructor() {
 		requests.push(this);
@@ -34,12 +38,15 @@ class MockXhr {
 
 	send(body: unknown): void {
 		this.body = body;
-		queueMicrotask(() => {
-			if (this.aborted) {
+		if (this.url.includes("comp=block&")) {
+			activeBlocks++;
+			maxActiveBlocks = Math.max(maxActiveBlocks, activeBlocks);
+			if (!settleBlocksAutomatically) {
 				return;
 			}
-			this.status = statusFor(this.url);
-			this.events.dispatchEvent(new Event("load"));
+		}
+		queueMicrotask(() => {
+			this.respond();
 		});
 	}
 
@@ -48,8 +55,27 @@ class MockXhr {
 	}
 
 	abort(): void {
+		if (this.settled) {
+			return;
+		}
 		this.aborted = true;
+		this.settled = true;
+		if (this.url.includes("comp=block&")) {
+			activeBlocks--;
+		}
 		this.events.dispatchEvent(new Event("abort"));
+	}
+
+	respond(): void {
+		if (this.aborted || this.settled) {
+			return;
+		}
+		this.settled = true;
+		if (this.url.includes("comp=block&")) {
+			activeBlocks--;
+		}
+		this.status = statusFor(this.url);
+		this.events.dispatchEvent(new Event("load"));
 	}
 }
 
@@ -73,6 +99,9 @@ function blockListRequest(): MockXhr | undefined {
 
 beforeEach(() => {
 	requests = [];
+	settleBlocksAutomatically = true;
+	activeBlocks = 0;
+	maxActiveBlocks = 0;
 	statusFor = () => 201;
 	vi.stubGlobal("XMLHttpRequest", function XMLHttpRequestStub() {
 		return new MockXhr();
@@ -118,6 +147,44 @@ describe("uploadBlocks", () => {
 		expect(blockListRequest()?.body).toBe(
 			'<?xml version="1.0" encoding="utf-8"?><BlockList></BlockList>',
 		);
+	});
+
+	it("limits block requests across simultaneous uploads", async () => {
+		settleBlocksAutomatically = false;
+		uploadServerFnMocks.finalizeChunkedUploadFn.mockImplementation(
+			async ({ data }) => ({ id: data.id }),
+		);
+
+		const first = uploadBlocks(
+			init({ uploadId: 7, url: "https://fd/c/first?sig=x" }),
+			new File(["01234567890123456789"], "first.fq.gz"),
+		);
+		const second = uploadBlocks(
+			init({ uploadId: 8, url: "https://fd/c/second?sig=x" }),
+			new File(["01234567890123456789"], "second.fq.gz"),
+		);
+
+		await vi.waitFor(() => expect(blockRequests()).toHaveLength(4));
+
+		while (blockRequests().length < 10) {
+			const requestCount = blockRequests().length;
+			for (const request of blockRequests()) {
+				request.respond();
+			}
+			await vi.waitFor(() =>
+				expect(blockRequests().length).toBeGreaterThan(requestCount),
+			);
+		}
+
+		for (const request of blockRequests()) {
+			request.respond();
+		}
+
+		await expect(Promise.all([first, second])).resolves.toEqual([
+			{ id: 7 },
+			{ id: 8 },
+		]);
+		expect(maxActiveBlocks).toBe(4);
 	});
 
 	it("cancels the reservation and rejects when a block fails", async () => {

--- a/apps/web/src/uploads/chunkedUpload.ts
+++ b/apps/web/src/uploads/chunkedUpload.ts
@@ -25,12 +25,84 @@ export type ChunkedInit = {
 	uploadId: number;
 	url: string;
 	blockSize: number;
-	/** How many blocks are PUT at once. */
+	/** How many block PUTs this browser may run at once across all uploads. */
 	concurrency: number;
 };
 
 /** How many times a single block PUT is retried before the upload fails. */
 const BLOCK_MAX_ATTEMPTS = 3;
+
+type BlockWaiter = {
+	limit: number;
+	reject: (reason: DOMException) => void;
+	resolve: (release: () => void) => void;
+	signal: AbortSignal | undefined;
+};
+
+let activeBlockRequests = 0;
+const blockWaiters: BlockWaiter[] = [];
+
+/** Start queued block requests while the shared browser-wide limit allows it. */
+function startBlockRequests(): void {
+	while (
+		blockWaiters.length > 0 &&
+		activeBlockRequests < (blockWaiters[0]?.limit ?? 0)
+	) {
+		const waiter = blockWaiters.shift();
+		if (!waiter) {
+			return;
+		}
+
+		if (waiter.signal?.aborted) {
+			waiter.reject(new DOMException("Upload aborted.", "AbortError"));
+			continue;
+		}
+
+		activeBlockRequests++;
+		let released = false;
+		waiter.resolve(() => {
+			if (released) {
+				return;
+			}
+			released = true;
+			activeBlockRequests--;
+			startBlockRequests();
+		});
+	}
+}
+
+/** Wait for one slot in the block-request pool shared by every upload. */
+function acquireBlockRequest(
+	limit: number,
+	signal: AbortSignal | undefined,
+): Promise<() => void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("Upload aborted.", "AbortError"));
+			return;
+		}
+
+		const waiter: BlockWaiter = { limit, reject, resolve, signal };
+
+		function onAbort() {
+			const index = blockWaiters.indexOf(waiter);
+			if (index === -1) {
+				return;
+			}
+			blockWaiters.splice(index, 1);
+			reject(new DOMException("Upload aborted.", "AbortError"));
+			startBlockRequests();
+		}
+
+		signal?.addEventListener("abort", onAbort, { once: true });
+		waiter.resolve = (release) => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve(release);
+		};
+		blockWaiters.push(waiter);
+		startBlockRequests();
+	});
+}
 
 /**
  * The block id for the block at `index`.
@@ -250,6 +322,7 @@ async function stageBlocks(
 			const start = index * blockSize;
 			const body = file.slice(start, Math.min(start + blockSize, file.size));
 
+			const release = await acquireBlockRequest(concurrency, controller.signal);
 			try {
 				await putBlock(
 					url,
@@ -261,6 +334,8 @@ async function stageBlocks(
 			} catch (error) {
 				controller.abort();
 				throw error;
+			} finally {
+				release();
 			}
 		}
 	}

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -4,7 +4,6 @@ import { byteSize, pluralize } from "@app/format";
 import Alert from "@base/Alert";
 import { BoxGroup, BoxGroupTable } from "@base/Box";
 import Button from "@base/Button";
-import Icon from "@base/Icon";
 import ListEmpty from "@base/ListEmpty";
 import ListHeader from "@base/ListHeader";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
@@ -20,7 +19,7 @@ import type {
 	UploadType,
 } from "@virtool/contracts";
 import { capitalize } from "es-toolkit";
-import { AlertCircle, FileUp, Trash } from "lucide-react";
+import { AlertCircle, FileUp } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { useState } from "react";
 import type { Accept } from "react-dropzone";
@@ -217,7 +216,7 @@ export function FileManager({
 									{renderSelectionAction?.(selection.selected, selection.clear)}
 									{canDelete && (
 										<Button color="red" size="small" onClick={handleDelete}>
-											<Icon icon={Trash} /> Delete
+											Delete
 										</Button>
 									)}
 								</>

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -52,6 +52,11 @@ export type FileManagerProps = {
 	   files listed with it. */
 	renderItemAction?: (upload: Upload, uploads: Upload[]) => ReactNode;
 
+	/* Renders a control acting on the whole selection, shown in the list header
+	   while at least one file is selected. Providing it makes the list
+	   selectable even when the account can't delete files. */
+	renderSelectionAction?: (selected: Upload[], clear: () => void) => ReactNode;
+
 	setPage?: (page: number) => void;
 
 	setSort?: (sort: UploadSortField, direction: SortDirection) => void;
@@ -68,6 +73,7 @@ export function FileManager({
 	page = 1,
 	regex,
 	renderItemAction,
+	renderSelectionAction,
 	setPage = () => {},
 	setSort = () => {},
 	sort,
@@ -113,6 +119,7 @@ export function FileManager({
 		account,
 		"remove_file",
 	);
+	const canSelect = canDelete || Boolean(renderSelectionAction);
 
 	const title = `${fileType === "reads" ? "Read" : capitalize(fileType)} Files`;
 
@@ -205,10 +212,15 @@ export function FileManager({
 									: pluralize(files.foundCount, "file")
 							}
 						>
-							{canDelete && selection.selected.length > 0 && (
-								<Button color="red" size="small" onClick={handleDelete}>
-									<Icon icon={Trash} /> Delete
-								</Button>
+							{selection.selected.length > 0 && (
+								<>
+									{renderSelectionAction?.(selection.selected, selection.clear)}
+									{canDelete && (
+										<Button color="red" size="small" onClick={handleDelete}>
+											<Icon icon={Trash} /> Delete
+										</Button>
+									)}
+								</>
 							)}
 						</ListHeader>
 						<BoxGroupTable className="table-fixed" variant="data">
@@ -217,7 +229,7 @@ export function FileManager({
 								checked={selection.getVisibleState(files.items)}
 								direction={direction}
 								onSelectAll={
-									canDelete
+									canSelect
 										? () => selection.toggleVisible(files.items)
 										: undefined
 								}
@@ -233,7 +245,7 @@ export function FileManager({
 										checked={selection.isSelected(item)}
 										key={item.id}
 										onSelect={
-											canDelete
+											canSelect
 												? (event: MouseEvent<HTMLButtonElement>) =>
 														selection.select(item, {
 															shiftKey: event.shiftKey,

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -51,10 +51,13 @@ export type FileManagerProps = {
 	   files listed with it. */
 	renderItemAction?: (upload: Upload, uploads: Upload[]) => ReactNode;
 
-	/* Renders a control acting on the whole selection, shown in the list header
-	   while at least one file is selected. Providing it makes the list
-	   selectable even when the account can't delete files. */
-	renderSelectionAction?: (selected: Upload[], clear: () => void) => ReactNode;
+	/* Renders a control acting on the whole selection. The renderer stays mounted
+	   while the list is mounted so it can preserve an in-progress action. */
+	renderSelectionAction?: (
+		selected: Upload[],
+		clear: () => void,
+		remove: (uploads: Upload[]) => void,
+	) => ReactNode;
 
 	setPage?: (page: number) => void;
 
@@ -144,6 +147,13 @@ export function FileManager({
 		selection.clear();
 	}
 
+	function removeFromSelection(uploads: Upload[]) {
+		const removedIds = new Set(uploads.map((upload) => upload.id));
+		selection.setSelected((selected) =>
+			selected.filter((upload) => !removedIds.has(upload.id)),
+		);
+	}
+
 	function handleSort(field: UploadSortField) {
 		setSort(field, nextSortDirection(field, sort, direction));
 	}
@@ -211,15 +221,15 @@ export function FileManager({
 									: pluralize(files.foundCount, "file")
 							}
 						>
-							{selection.selected.length > 0 && (
-								<>
-									{renderSelectionAction?.(selection.selected, selection.clear)}
-									{canDelete && (
-										<Button color="red" size="small" onClick={handleDelete}>
-											Delete
-										</Button>
-									)}
-								</>
+							{renderSelectionAction?.(
+								selection.selected,
+								selection.clear,
+								removeFromSelection,
+							)}
+							{selection.selected.length > 0 && canDelete && (
+								<Button color="red" size="small" onClick={handleDelete}>
+									Delete
+								</Button>
 							)}
 						</ListHeader>
 						<BoxGroupTable className="table-fixed" variant="data">

--- a/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
@@ -6,10 +6,40 @@ import { mockFindUploads, uploadServerFnMocks } from "@tests/server-fn/uploads";
 import { mockGetAccount } from "@tests/server-fn/users";
 import { renderWithRouter } from "@tests/setup";
 import { upload } from "@uploads/uploader";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileManager, type FileManagerProps } from "../FileManager";
 
 vi.mock("@uploads/uploader");
+
+type PersistentSelectionActionProps = {
+	clear: () => void;
+	selectedCount: number;
+};
+
+function PersistentSelectionAction({
+	clear,
+	selectedCount,
+}: PersistentSelectionActionProps) {
+	const [draft, setDraft] = useState("");
+
+	if (selectedCount === 0 && !draft) {
+		return null;
+	}
+
+	return (
+		<>
+			<input
+				aria-label="Draft name"
+				value={draft}
+				onChange={(event) => setDraft(event.target.value)}
+			/>
+			<button onClick={clear} type="button">
+				Clear selection
+			</button>
+		</>
+	);
+}
 
 describe("<FileManager>", () => {
 	let props: FileManagerProps;
@@ -303,6 +333,72 @@ describe("<FileManager>", () => {
 
 			expect(screen.getByText("2 files")).toBeInTheDocument();
 			expect(screen.queryByText("2 selected")).not.toBeInTheDocument();
+		});
+
+		it("should keep a selection action mounted after its selection is cleared", async () => {
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			mockFindUploads([createFakeFile({ name: "one.fq.gz" })]);
+
+			await renderWithRouter(
+				<FileManager
+					{...props}
+					renderSelectionAction={(selected, clear) => (
+						<PersistentSelectionAction
+							clear={clear}
+							selectedCount={selected.length}
+						/>
+					)}
+				/>,
+				path,
+			);
+
+			await userEvent.click(
+				await screen.findByRole("checkbox", { name: "Select one.fq.gz" }),
+			);
+			await userEvent.type(screen.getByLabelText("Draft name"), "My draft");
+			await userEvent.click(
+				screen.getByRole("button", { name: "Clear selection" }),
+			);
+
+			expect(screen.getByLabelText("Draft name")).toHaveValue("My draft");
+			expect(screen.getByText("1 file")).toBeInTheDocument();
+		});
+
+		it("should let a selection action remove only completed items", async () => {
+			const first = createFakeFile({ name: "one.fq.gz" });
+			const second = createFakeFile({ name: "two.fq.gz" });
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			mockFindUploads([first, second]);
+
+			await renderWithRouter(
+				<FileManager
+					{...props}
+					renderSelectionAction={(selected, _clear, remove) =>
+						selected.length > 1 ? (
+							<button onClick={() => remove([first])} type="button">
+								Remove completed
+							</button>
+						) : null
+					}
+				/>,
+				path,
+			);
+
+			const firstCheckbox = await screen.findByRole("checkbox", {
+				name: "Select one.fq.gz",
+			});
+			const secondCheckbox = screen.getByRole("checkbox", {
+				name: "Select two.fq.gz",
+			});
+			await userEvent.click(firstCheckbox);
+			await userEvent.click(secondCheckbox);
+			await userEvent.click(
+				screen.getByRole("button", { name: "Remove completed" }),
+			);
+
+			expect(firstCheckbox).not.toBeChecked();
+			expect(secondCheckbox).toBeChecked();
+			expect(screen.getByText("1 selected")).toBeInTheDocument();
 		});
 
 		it("should delete every selected file", async () => {

--- a/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
@@ -212,6 +212,99 @@ describe("<FileManager>", () => {
 	});
 
 	describe("selection", () => {
+		const noDeletePermissions = {
+			cancel_job: false,
+			create_ref: false,
+			create_sample: true,
+			modify_hmm: false,
+			modify_subtraction: false,
+			remove_file: false,
+			remove_job: false,
+			upload_file: true,
+		};
+
+		it("should hide the checkboxes when the account can neither delete nor act on a selection", async () => {
+			mockGetAccount(
+				createFakeAccount({
+					administratorRole: null,
+					permissions: noDeletePermissions,
+				}),
+			);
+			mockFindUploads([createFakeFile({ name: "one.fq.gz" })]);
+
+			await renderWithRouter(<FileManager {...props} />, path);
+
+			expect(await screen.findByText("one.fq.gz")).toBeInTheDocument();
+			expect(
+				screen.queryByRole("checkbox", { name: "Select one.fq.gz" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("should show the checkboxes for a selection action even when the account can't delete", async () => {
+			mockGetAccount(
+				createFakeAccount({
+					administratorRole: null,
+					permissions: noDeletePermissions,
+				}),
+			);
+			mockFindUploads([createFakeFile({ name: "one.fq.gz" })]);
+
+			await renderWithRouter(
+				<FileManager
+					{...props}
+					renderSelectionAction={(selected) => (
+						<button type="button">Create {selected.length}</button>
+					)}
+				/>,
+				path,
+			);
+
+			await userEvent.click(
+				await screen.findByRole("checkbox", { name: "Select one.fq.gz" }),
+			);
+
+			expect(
+				screen.getByRole("button", { name: "Create 1" }),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Delete" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("should pass the selection and a way to clear it to the selection action", async () => {
+			const first = createFakeFile({ name: "one.fq.gz" });
+			const second = createFakeFile({ name: "two.fq.gz" });
+
+			mockGetAccount(createFakeAccount({ administratorRole: "full" }));
+			mockFindUploads([first, second]);
+
+			await renderWithRouter(
+				<FileManager
+					{...props}
+					renderSelectionAction={(selected, clear) => (
+						<button onClick={clear} type="button">
+							Create {selected.map((item) => item.name).join(", ")}
+						</button>
+					)}
+				/>,
+				path,
+			);
+
+			await userEvent.click(
+				await screen.findByRole("checkbox", { name: "Select one.fq.gz" }),
+			);
+			await userEvent.click(
+				screen.getByRole("checkbox", { name: "Select two.fq.gz" }),
+			);
+
+			await userEvent.click(
+				screen.getByRole("button", { name: "Create one.fq.gz, two.fq.gz" }),
+			);
+
+			expect(screen.getByText("2 files")).toBeInTheDocument();
+			expect(screen.queryByText("2 selected")).not.toBeInTheDocument();
+		});
+
 		it("should delete every selected file", async () => {
 			const first = createFakeFile({ name: "one.fq.gz" });
 			const second = createFakeFile({ name: "two.fq.gz" });

--- a/dev/README.md
+++ b/dev/README.md
@@ -193,6 +193,54 @@ attachment. Resume restores a missing default bridge before starting the inner
 daemon, preserving the host-gateway route to the shared services. It does not
 disconnect shared-service networks or reset their volumes.
 
+### Shared-service recovery
+
+Run `coasts up` when an instance is running but cannot reach Postgres or
+Azurite. The controller checks shared-service registrations and actual host
+containers, starts stopped shared containers, and probes the proxy addresses
+from the effective Compose configuration. If a proxy is unreachable, it stops
+and resumes the Coast through its lifecycle, then checks the proxies again
+before proceeding. This preserves the instance's data identity and URL. A
+second failed proxy check stops startup with a routing error.
+
+Missing registrations or host containers stop startup with an explicit error.
+The controller never automatically recreates shared storage. In Coasts 0.1.53,
+`shared-services start` starts an existing registered container; it cannot
+recreate a removed service. `shared-services rm` deletes the service's named
+volumes as well as its container and registration. Do not use it to repair
+connectivity. That release's documentation mentions **Refresh Shared Services**,
+but its UI does not implement the operation.
+
+To deliberately provision a missing shared service, use a temporary, unassigned
+Coast from the primary worktree. Choose an unused temporary instance name:
+
+```bash
+coast run repair-shared-services
+coast rm repair-shared-services
+```
+
+With this project's `autostart = false`, provisioning creates the missing shared
+containers and registrations without initializing application data. Removing
+this unmanaged temporary Coast preserves shared services. Existing named volumes
+are reused; absent volumes are created empty. Then run `coasts up` from the
+affected worktree to initialize its database, apply migrations, and check
+application readiness. Keep using `coasts remove` for managed instances.
+
+The relevant pinned implementations are
+[shared-service provisioning](https://github.com/coast-guard/coasts/blob/v0.1.53/coast-daemon/src/handlers/run/shared_services_setup.rs),
+[proxy restoration during start](https://github.com/coast-guard/coasts/blob/v0.1.53/coast-daemon/src/handlers/start.rs),
+and [shared-service lifecycle commands](https://github.com/coast-guard/coasts/blob/v0.1.53/coast-daemon/src/handlers/shared.rs).
+
+Live validation on 2026-09-10 provisioned a fresh shared Postgres through a
+temporary Coast and restored the existing instance with Coast stop/start.
+Database initialization, migrations, storage initialization, and application
+readiness succeeded. Killing the verified Postgres proxy listener and removing
+its alias from `docker0` reproduced an unreachable database while the outer
+container remained running. `coasts up` repaired it in 36.60 seconds. A normal
+stop/resume took 2.20/28.13 seconds. Both preserved a test database row, the
+instance data ID, and the HTTPS URL; the test table and temporary Coast were
+removed. These are single observations, not benchmarks.
+
 ### Builds, dependencies, and rollout
 
 The removal hook calls the controller in the primary worktree. Keep that

--- a/dev/scripts/coast.py
+++ b/dev/scripts/coast.py
@@ -228,6 +228,56 @@ class Coast:
         return run(["docker", "inspect", "--format", "{{.State.Running}}",
                     f"{self.project}-coasts-{name}"], self.root) == "true"
 
+    def shared_services(self):
+        return tomllib.loads((self.root / "Coastfile").read_text()).get("shared_services", {})
+
+    def check_shared_services(self):
+        configured = self.shared_services()
+        if not configured:
+            return
+        registered = {service["name"] for service in self.api(
+            "/shared/ls?" + urllib.parse.urlencode({"project": self.project}))["services"]}
+        missing = configured.keys() - registered
+        if missing:
+            raise RuntimeError(f"Shared services are not registered in Coast: {', '.join(sorted(missing))}. Restore them through Coast provisioning before retrying; `shared-services start` cannot recreate them. See dev/README.md#shared-service-recovery.")
+        for service in configured:
+            container = f"{self.project}-shared-services-{service}"
+            inspected = subprocess.run(["docker", "inspect", "--format", "{{.State.Running}}", container],
+                                       text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if inspected.returncode:
+                raise RuntimeError(f"Cannot inspect shared service {service!r}: {inspected.stderr.strip()}. Restore the shared container before retrying. See dev/README.md#shared-service-recovery.")
+            if inspected.stdout.strip() != "true":
+                self.command("shared-services", "start", service)
+                if run(["docker", "inspect", "--format", "{{.State.Running}}", container], self.root) != "true":
+                    raise RuntimeError(f"Shared service {service!r} did not start; inspect its Docker logs before retrying")
+
+    def has_shared_service_proxies(self, name):
+        configured = self.shared_services()
+        if not configured:
+            return True
+        configuration = json.loads(run([self.binary, "--project", self.project, "docker", "--root", name,
+                                        "compose", "config", "--format", "json"], self.root))
+        targets = set()
+        for service, settings in configured.items():
+            addresses = set()
+            for inner in configuration["services"].values():
+                hosts = inner.get("extra_hosts", [])
+                if isinstance(hosts, list):
+                    hosts = dict(host.split("=" if "=" in host else ":", 1) for host in hosts)
+                if service in hosts:
+                    addresses.add(hosts[service])
+            if not addresses:
+                return False
+            for port in settings.get("ports", []):
+                targets.update((address, str(port).split(":")[-1]) for address in addresses)
+        if not targets:
+            return True
+        script = "\n".join(shlex.join(["nc", "-z", "-w", "2", address, port])
+                           for address, port in sorted(targets))
+        result = subprocess.run(["docker", "exec", f"{self.project}-coasts-{name}", "sh", "-ec", script],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return result.returncode == 0
+
     def check_resume_ports(self, name):
         for mapping in self.ports(name):
             port = mapping["dynamic_port"]
@@ -424,10 +474,13 @@ class Lifecycle:
         record["config_hash"] = config_hash
         self.save(key, record)
         instance = instances.get(record["name"])
+        if instance is not None:
+            self.coast.check_shared_services()
         if (instance and instance["status"] in ("running", "checked_out")
                 and instance.get("worktree") == (branch if worktree != primary else None)
                 and not changed_identity and not rebuild
-                and record.get("build_hash") == source_hash and self.coast.ready(record)):
+                and record.get("build_hash") == source_hash and self.coast.ready(record)
+                and self.coast.has_shared_service_proxies(record["name"])):
             self.coast.check_worktree(record)
             record["state"] = "ready"
             record.pop("error", None)
@@ -445,8 +498,16 @@ class Lifecycle:
             record["provisioned"] = True
             record["image_hash"] = build_hash
             self.save(key, record)
+            self.coast.check_shared_services()
         if instance["status"] == "stopped" or not self.coast.is_running(record["name"]):
             self.coast.resume(record["name"], instance["status"])
+            instance = self.coast.instances()[record["name"]]
+        if not self.coast.has_shared_service_proxies(record["name"]):
+            self.coast.command("stop", record["name"])
+            self.coast.resume(record["name"], "stopped")
+            instance = self.coast.instances()[record["name"]]
+            if not self.coast.has_shared_service_proxies(record["name"]):
+                raise RuntimeError("Coast restarted but shared-service proxies are still unreachable; inspect Coast's shared-service proxy logs before retrying")
         ports = self.coast.ports(record["name"])
         port = next(port["dynamic_port"] for port in ports if port["logical_name"] == "https")
         record["url"] = f"https://{record['hostname']}:{port}"

--- a/dev/scripts/test_coast.py
+++ b/dev/scripts/test_coast.py
@@ -25,6 +25,8 @@ class FakeCoast:
         self.fail_start = False
         self.fail_stop = False
         self.fail_assign = False
+        self.proxies_running = True
+        self.shared_services_missing = False
 
     def instances(self):
         return self.items.copy()
@@ -40,6 +42,14 @@ class FakeCoast:
 
     def resume(self, name, status):
         self.command("start", name)
+        self.proxies_running = True
+
+    def check_shared_services(self):
+        if self.shared_services_missing:
+            raise RuntimeError("Shared services are not registered in Coast")
+
+    def has_shared_service_proxies(self, name):
+        return self.proxies_running
 
     def clear_url(self, record):
         self.events.append(("clear_url", record["name"]))
@@ -137,6 +147,105 @@ class LifecycleTests(unittest.TestCase):
             second = self.ensure()
         resume.assert_called_once_with(first["name"], "running")
         self.assertEqual(second["data_id"], first["data_id"])
+
+    def test_running_instance_with_missing_proxies_restarts_without_recreating_data(self):
+        first = self.ensure()
+        self.backend.events.clear()
+        self.backend.proxies_running = False
+        second = self.ensure()
+        self.assertEqual(second["data_id"], first["data_id"])
+        self.assertEqual(second["url"], first["url"])
+        self.assertIn(first["data_id"], self.backend.databases)
+        self.assertIn(first["data_id"], self.backend.blobs)
+        self.assertEqual(self.backend.events[:2], [("stop", first["name"]), ("start", first["name"])])
+        self.assertFalse(any(event[0] in ("run", "rm", "rebuild", "configure", "delete_data")
+                             for event in self.backend.events))
+
+    def test_missing_shared_service_blocks_existing_instance_without_mutations(self):
+        first = self.ensure()
+        self.backend.events.clear()
+        self.backend.shared_services_missing = True
+        with self.assertRaisesRegex(RuntimeError, "not registered"):
+            self.ensure()
+        self.assertFalse(self.backend.events)
+        self.assertIn(first["data_id"], self.backend.databases)
+
+    def test_idle_primary_with_missing_proxies_is_started_once(self):
+        record = self.ensure(worktree=self.root)
+        self.backend.events.clear()
+        self.backend.items[record["name"]]["status"] = "idle"
+        self.backend.proxies_running = False
+        self.ensure(worktree=self.root)
+        self.assertEqual(self.backend.events.count(("start", record["name"])), 1)
+
+    def test_failed_proxy_repair_stops_before_compose_startup(self):
+        first = self.ensure()
+        self.backend.events.clear()
+        with patch.object(self.backend, "has_shared_service_proxies", return_value=False):
+            with self.assertRaisesRegex(RuntimeError, "proxies are still unreachable"):
+                self.ensure()
+        self.assertEqual(self.backend.events, [("stop", first["name"]), ("start", first["name"])])
+
+    def test_missing_shared_registration_fails_before_docker_commands(self):
+        backend = coast.Coast(self.root, "virtool")
+        with patch.object(backend, "shared_services", return_value={"postgres": {}}), \
+                patch.object(backend, "api", return_value={"services": []}), \
+                patch.object(coast.subprocess, "run") as command:
+            with self.assertRaisesRegex(RuntimeError, "not registered.*postgres"):
+                backend.check_shared_services()
+        command.assert_not_called()
+
+    def test_missing_shared_container_is_not_recreated(self):
+        backend = coast.Coast(self.root, "virtool")
+        missing = subprocess.CompletedProcess([], 1, stdout="", stderr="No such container")
+        with patch.object(backend, "shared_services", return_value={"postgres": {}}), \
+                patch.object(backend, "api", return_value={"services": [{"name": "postgres"}]}), \
+                patch.object(coast.subprocess, "run", return_value=missing), \
+                patch.object(backend, "command") as command:
+            with self.assertRaisesRegex(RuntimeError, "Cannot inspect shared service.*postgres"):
+                backend.check_shared_services()
+        command.assert_not_called()
+
+    def test_stopped_shared_service_is_started_and_checked(self):
+        backend = coast.Coast(self.root, "virtool")
+        stopped = subprocess.CompletedProcess([], 0, stdout="false\n", stderr="")
+        for running in ("true", "false"):
+            with self.subTest(running=running), \
+                    patch.object(backend, "shared_services", return_value={"postgres": {}}), \
+                    patch.object(backend, "api", return_value={"services": [{"name": "postgres"}]}), \
+                    patch.object(coast.subprocess, "run", return_value=stopped), \
+                    patch.object(coast, "run", return_value=running), \
+                    patch.object(backend, "command") as command:
+                if running == "true":
+                    backend.check_shared_services()
+                else:
+                    with self.assertRaisesRegex(RuntimeError, "did not start"):
+                        backend.check_shared_services()
+                command.assert_called_once_with("shared-services", "start", "postgres")
+
+    def test_proxy_probe_uses_effective_addresses_and_container_ports(self):
+        backend = coast.Coast(self.root, "virtool")
+        shared = {"postgres": {"ports": ["15432:5432"]}, "azurite": {"ports": ["11000:10000"]}}
+        hosts = ["postgres=172.18.255.253", "azurite:172.18.255.254"]
+        configuration = {"services": {"database-init": {"extra_hosts": hosts}}}
+        for exit_code in (0, 1):
+            with self.subTest(exit_code=exit_code), \
+                    patch.object(backend, "shared_services", return_value=shared), \
+                    patch.object(coast, "run", return_value=json.dumps(configuration)), \
+                    patch.object(coast.subprocess, "run", return_value=subprocess.CompletedProcess([], exit_code)) as probe:
+                self.assertEqual(backend.has_shared_service_proxies("secondary"), exit_code == 0)
+                self.assertEqual(probe.call_args.args[0], [
+                    "docker", "exec", "virtool-coasts-secondary", "sh", "-ec",
+                    "nc -z -w 2 172.18.255.253 5432\nnc -z -w 2 172.18.255.254 10000",
+                ])
+
+    def test_missing_proxy_host_mapping_is_unhealthy(self):
+        backend = coast.Coast(self.root, "virtool")
+        with patch.object(backend, "shared_services", return_value={"postgres": {"ports": [5432]}}), \
+                patch.object(coast, "run", return_value='{"services": {"database-init": {}}}'), \
+                patch.object(coast.subprocess, "run") as probe:
+            self.assertFalse(backend.has_shared_service_proxies("secondary"))
+        probe.assert_not_called()
 
     def test_resume_clears_previous_boot_proxy_pids_before_coast_start(self):
         backend = coast.Coast(self.root, "virtool")

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -39,7 +39,8 @@ proxy in the path trips and no bytes pass through the server.
 
 ## Testing
 
-The `unit` Vitest project covers behavior testable with `MemoryStorage`. The
+The `unit` Vitest project covers `MemoryStorage` and Azure URL signing without
+network requests. The
 `integration` project exercises the S3 and Azure backends against real Garage
 and Azurite containers and runs in the shared `Data & Storage / Test` CI job.
 Place tests beside their source as `*.test.ts`.

--- a/packages/storage/src/azure.test.ts
+++ b/packages/storage/src/azure.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createAzureStorage } from "./azure";
+
+describe("presigned Azure origins", () => {
+	const endpoint = "http://azurite:10000/devstoreaccount1";
+
+	it.each([
+		[undefined, "http://azurite:10000"],
+		["https://virtool.local", "https://virtool.local"],
+		["https://virtool.local:8443", "https://virtool.local:8443"],
+	])("rehosts uploads and downloads on %s", async (origin, expected) => {
+		const storage = createAzureStorage({
+			kind: "azure",
+			account: "devstoreaccount1",
+			container: "virtool",
+			accessKey: Buffer.from("test-key").toString("base64"),
+			endpoint,
+			uploadUrl: origin,
+			downloadUrl: origin,
+		});
+
+		if (!storage.presignUpload || !storage.presignDownload) {
+			throw new Error("Azure storage must support presigning");
+		}
+
+		const urls = await Promise.all([
+			storage.presignUpload("uploads/test.fastq", { expiresIn: 900 }),
+			storage.presignDownload("uploads/test.fastq", {
+				expiresIn: 900,
+				contentDisposition: "attachment",
+				contentType: "application/octet-stream",
+			}),
+		]);
+
+		for (const value of urls) {
+			const url = new URL(value);
+			expect(url.origin).toBe(expected);
+			expect(url.pathname).toBe("/devstoreaccount1/virtool/uploads/test.fastq");
+			expect(url.searchParams.get("sig")).toBeTruthy();
+		}
+	});
+});

--- a/packages/storage/src/azure.ts
+++ b/packages/storage/src/azure.ts
@@ -89,6 +89,7 @@ function buildPresignedUrl(
 		const override = new URL(origin);
 		url.protocol = override.protocol;
 		url.host = override.host;
+		url.port = override.port;
 	}
 
 	return `${url.toString()}?${sas}`;


### PR DESCRIPTION
## Summary
- create samples in bulk from selected uploaded reads with automatic pair detection and shared sample settings
- support generated-name editing, wildcard or regex bulk replacement, duplicate validation, partial-failure recovery, and persistent table controls
- harden upload and development infrastructure with bounded chunk concurrency, public Azure URLs, and Coast service recovery