### PR TITLE
fix: show only relevant users in analysis filters

### DIFF
--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -15,7 +15,7 @@ import type { AnalysisSortField, AnalysisWorkflow } from "@virtool/contracts";
 import { xor } from "es-toolkit/array";
 import { Microscope, SearchX } from "lucide-react";
 import { useState } from "react";
-import { useListAnalyses } from "../queries";
+import { useListAnalyses, useListAnalysisUsers } from "../queries";
 import AnalysisItem from "./AnalysisItem";
 import AnalysisTableHead from "./AnalysisTableHead";
 import CreateAnalysis from "./Create/CreateAnalysis";
@@ -79,6 +79,11 @@ export default function AnalysesList({
 		isError: isErrorSample,
 	} = useFetchSample(sampleId);
 	const { hasPermission: canCreate } = useCheckCanEditSample(sampleId);
+	const {
+		data: analysisUsers,
+		isError: isErrorAnalysisUsers,
+		isPending: isPendingAnalysisUsers,
+	} = useListAnalysisUsers(sampleId, workflows);
 
 	if (
 		(isErrorAnalyses && !analyses) ||
@@ -129,6 +134,8 @@ export default function AnalysesList({
 			/>
 			<div className="mb-3 flex min-h-9 flex-wrap items-center gap-4">
 				<FilterBar
+					isUsersError={isErrorAnalysisUsers}
+					isUsersPending={isPendingAnalysisUsers}
 					onClearUsers={() => setSearch({ page: 1, users: [] })}
 					onClearWorkflows={() => setSearch({ page: 1, workflows: [] })}
 					onToggleUser={(userId) =>
@@ -139,6 +146,7 @@ export default function AnalysesList({
 					}
 					selectedUsers={users}
 					selectedWorkflows={workflows}
+					users={analysisUsers}
 				/>
 				<span className="text-sm font-medium text-gray-600">
 					Showing {analyses.foundCount} of{" "}

--- a/apps/web/src/analyses/components/Filter/FilterBar.tsx
+++ b/apps/web/src/analyses/components/Filter/FilterBar.tsx
@@ -5,11 +5,17 @@ import {
 	FilterGroup,
 } from "@base/Filter";
 import UserFilterGroup from "@users/components/UserFilterGroup";
-import type { AnalysisWorkflow } from "@virtool/contracts";
+import type { AnalysisWorkflow, UserNested } from "@virtool/contracts";
 import { Workflow } from "lucide-react";
 import WorkflowFilterMenu from "./WorkflowFilterMenu";
 
 type FilterBarProps = {
+	/** Whether loading the available users failed. */
+	isUsersError: boolean;
+
+	/** Whether the available users are loading. */
+	isUsersPending: boolean;
+
 	/** Deselects every user. */
 	onClearUsers: () => void;
 
@@ -27,6 +33,9 @@ type FilterBarProps = {
 
 	/** The selected workflows. */
 	selectedWorkflows: AnalysisWorkflow[];
+
+	/** The users who own analyses matching the current list context. */
+	users?: UserNested[];
 };
 
 /**
@@ -34,12 +43,15 @@ type FilterBarProps = {
  * filters
  */
 export default function FilterBar({
+	isUsersError,
+	isUsersPending,
 	onClearUsers,
 	onClearWorkflows,
 	onToggleUser,
 	onToggleWorkflow,
 	selectedUsers,
 	selectedWorkflows,
+	users,
 }: FilterBarProps) {
 	return (
 		<BaseFilterBar label="Filters">
@@ -65,9 +77,12 @@ export default function FilterBar({
 				))}
 			</FilterGroup>
 			<UserFilterGroup
+				isError={isUsersError}
+				isPending={isUsersPending}
 				onClear={onClearUsers}
 				onToggle={onToggleUser}
 				selected={selectedUsers}
+				users={users}
 			/>
 		</BaseFilterBar>
 	);

--- a/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
@@ -7,10 +7,13 @@ import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
 import { createFakeHmmSearchResults } from "@tests/fake/hmm";
 import { createFakeSample } from "@tests/fake/samples";
 import { createFakeUserNested } from "@tests/fake/user";
-import { mockFindAnalyses } from "@tests/server-fn/analyses";
+import {
+	mockFindAnalyses,
+	mockListAnalysisUsers,
+} from "@tests/server-fn/analyses";
 import { mockFindHmms } from "@tests/server-fn/hmm";
 import { mockGetSample } from "@tests/server-fn/samples";
-import { mockGetAccount, mockListUsers } from "@tests/server-fn/users";
+import { mockGetAccount } from "@tests/server-fn/users";
 import { at, MemoryRouter, renderWithProviders } from "@tests/setup";
 import type { AnalysisMinimal, AnalysisSortField } from "@virtool/contracts";
 import { useState } from "react";
@@ -296,7 +299,7 @@ describe("<AnalysesList /> filtering", () => {
 		mockGetAccount(createFakeAccount({ administratorRole: "full" }));
 		mockGetSample(sample);
 		mockFindHmms(createFakeHmmSearchResults());
-		mockListUsers(users);
+		mockListAnalysisUsers(users);
 		mockFindAnalyses([
 			createFakeAnalysisMinimal({
 				sample: { id: sample.id, name: sample.name },
@@ -382,6 +385,17 @@ describe("<AnalysesList /> filtering", () => {
 		await waitFor(() => {
 			expect(findAnalyses).toHaveBeenCalledWith({
 				data: expect.objectContaining({ userIds: [at(users, 0).id] }),
+			});
+		});
+	});
+
+	it("requests user options for the sample and workflow filters", async () => {
+		const listAnalysisUsers = mockListAnalysisUsers(users);
+		renderList({ workflows: ["pathoscope"] });
+
+		await waitFor(() => {
+			expect(listAnalysisUsers).toHaveBeenCalledWith({
+				data: { sampleId: sample.id, workflows: ["pathoscope"] },
 			});
 		});
 	});

--- a/apps/web/src/analyses/keys.ts
+++ b/apps/web/src/analyses/keys.ts
@@ -6,8 +6,8 @@ const keys = createQueryKeys("analyses");
 export const analysesQueryKeys = {
 	...keys,
 	/** Users available for an analysis list's user filter. */
-	users: (filters: readonly QueryKeyFilter[]) =>
-		[...keys.lists(), ...filters, "users"] as const,
+	users: (filters: readonly QueryKeyFilter[] = []) =>
+		[...keys.lists(), "users", ...filters] as const,
 	// An analysis's results are fetched apart from the analysis itself, so they
 	// need a key of their own. Derived from `detail` so that anything
 	// invalidating one analysis — an SSE frame, a mutation — invalidates its

--- a/apps/web/src/analyses/keys.ts
+++ b/apps/web/src/analyses/keys.ts
@@ -1,10 +1,13 @@
-import { createQueryKeys } from "@app/queryKeys";
+import { createQueryKeys, type QueryKeyFilter } from "@app/queryKeys";
 
 const keys = createQueryKeys("analyses");
 
 /** Query keys for analyses. */
 export const analysesQueryKeys = {
 	...keys,
+	/** Users available for an analysis list's user filter. */
+	users: (filters: readonly QueryKeyFilter[]) =>
+		[...keys.lists(), ...filters, "users"] as const,
 	// An analysis's results are fetched apart from the analysis itself, so they
 	// need a key of their own. Derived from `detail` so that anything
 	// invalidating one analysis — an SSE frame, a mutation — invalidates its

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -8,6 +8,7 @@ import {
 	findRecentlyViewedAnalysesFn,
 	getAnalysisFn,
 	getAnalysisResultsFn,
+	listAnalysisUsersFn,
 	recordAnalysisViewFn,
 } from "@server/analyses/functions";
 import {
@@ -25,6 +26,7 @@ import type {
 	AnalysisSortField,
 	AnalysisWorkflow,
 	SortDirection,
+	UserNested,
 } from "@virtool/contracts";
 import { useEffect } from "react";
 
@@ -81,6 +83,19 @@ export function useListAnalyses({
 				data: { sampleId, page, perPage, sort, direction, userIds, workflows },
 			}),
 		placeholderData: keepPreviousData,
+	});
+}
+
+/**
+ * Fetch the users who own an analysis matching the sample and workflow scope.
+ */
+export function useListAnalysisUsers(
+	sampleId: number,
+	workflows: AnalysisWorkflow[],
+) {
+	return useQuery<UserNested[]>({
+		queryKey: analysesQueryKeys.users([sampleId, workflows]),
+		queryFn: () => listAnalysisUsersFn({ data: { sampleId, workflows } }),
 	});
 }
 

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -87,10 +87,6 @@ describe("reactQueryHandler", () => {
 				queryKey: samplesQueryKeys.lists(),
 			},
 			{
-				message: { domain: "users", operation: "update", id: 7 },
-				queryKey: userQueryKeys.detail(7),
-			},
-			{
 				message: { domain: "users", operation: "delete", id: 7 },
 				queryKey: userQueryKeys.lists(),
 			},
@@ -242,9 +238,11 @@ describe("reactQueryHandler", () => {
 		}
 	});
 
-	it("marks only the matching user detail stale on update", () => {
+	it("marks the matching user detail and analysis user options stale on update", () => {
 		queryClient.setQueryData(userQueryKeys.detail(7), { id: 7 });
 		queryClient.setQueryData(userQueryKeys.detail(8), { id: 8 });
+		const analysisUsers = analysesQueryKeys.users([1, ["pathoscope"]]);
+		queryClient.setQueryData(analysisUsers, []);
 
 		reactQueryHandler(queryClient)({
 			domain: "users",
@@ -258,6 +256,7 @@ describe("reactQueryHandler", () => {
 		expect(
 			queryClient.getQueryState(userQueryKeys.detail(8))?.isInvalidated,
 		).toBe(false);
+		expect(queryClient.getQueryState(analysisUsers)?.isInvalidated).toBe(true);
 	});
 
 	// Every on-screen job holds its own detail query, so invalidating the frame's

--- a/apps/web/src/app/sse/reactQueryHandler.ts
+++ b/apps/web/src/app/sse/reactQueryHandler.ts
@@ -129,5 +129,11 @@ export function reactQueryHandler(queryClient: QueryClient) {
 		queryClient.invalidateQueries({
 			queryKey: selectQueryKey(domain, message.operation, message.id),
 		});
+
+		if (message.domain === "users" && message.operation === "update") {
+			queryClient.invalidateQueries({
+				queryKey: analysesQueryKeys.users(),
+			});
+		}
 	};
 }

--- a/apps/web/src/samples/components/Filter/FilterBar.tsx
+++ b/apps/web/src/samples/components/Filter/FilterBar.tsx
@@ -13,6 +13,7 @@ import {
 	parseWorkflowFilters,
 } from "@samples/utils";
 import UserFilterGroup from "@users/components/UserFilterGroup";
+import { useListUsers } from "@users/queries";
 import type { GroupMinimal, Label } from "@virtool/contracts";
 import { CalendarDays, Search, Tag, Users, Workflow } from "lucide-react";
 import { lazy, Suspense } from "react";
@@ -105,6 +106,11 @@ export default function FilterBar({
 }: FilterBarProps) {
 	const selected = labels.filter((label) => selectedLabels.includes(label.id));
 	const workflows = parseWorkflowFilters(selectedWorkflows);
+	const {
+		data: users,
+		isError: isUsersError,
+		isPending: isUsersPending,
+	} = useListUsers();
 
 	return (
 		<BaseFilterBar className="mb-3" label="Filters">
@@ -196,9 +202,12 @@ export default function FilterBar({
 				)}
 			</FilterGroup>
 			<UserFilterGroup
+				isError={isUsersError}
+				isPending={isUsersPending}
 				onClear={onClearUsers}
 				onToggle={onToggleUser}
 				selected={selectedUsers}
+				users={users}
 			/>
 			<FilterGroup
 				icon={<Users size={14} />}

--- a/apps/web/src/server/analyses/functions.test.ts
+++ b/apps/web/src/server/analyses/functions.test.ts
@@ -219,6 +219,38 @@ function call(name: string, data?: unknown) {
 	return callServerFn(handlers, name, data);
 }
 
+describe("listAnalysisUsers", () => {
+	it("lists users with analyses matching the sample and workflow scope", async () => {
+		await signInAsNewUser();
+		const matchingUser = await seedUser(db, { handle: "matching" });
+		const otherUser = await seedUser(db, { handle: "other" });
+		const sampleId = await seedSample({ all_read: true });
+
+		await seedAnalysis({
+			sample_id: sampleId,
+			user_id: matchingUser,
+			workflow: "pathoscope",
+		});
+		await seedAnalysis({
+			sample_id: sampleId,
+			user_id: ownerId,
+			workflow: "nuvs",
+		});
+		await seedAnalysis({
+			sample_id: await seedSample({ all_read: true }),
+			user_id: otherUser,
+			workflow: "pathoscope",
+		});
+
+		expect(
+			await call("listAnalysisUsersFn", {
+				sampleId,
+				workflows: ["pathoscope"],
+			}),
+		).toEqual([{ id: matchingUser, handle: "matching" }]);
+	});
+});
+
 describe("getAnalysis", () => {
 	it("returns 404 for an analysis that does not exist", async () => {
 		await signInAsNewUser();

--- a/apps/web/src/server/analyses/functions.ts
+++ b/apps/web/src/server/analyses/functions.ts
@@ -21,6 +21,7 @@ import {
 	getAnalysis,
 	getAnalysisResults,
 	getAnalysisSampleRights,
+	listAnalysisUsers,
 	recordAnalysisView,
 } from "@virtool/data/analyses/data";
 import {
@@ -52,6 +53,11 @@ const findAnalysesSchema = z.object({
 	// applied only once a column is named.
 	sort: z.enum(ANALYSIS_SORT_FIELDS).optional(),
 	direction: z.enum(SORT_DIRECTIONS).default("descending"),
+});
+
+const listAnalysisUsersSchema = z.object({
+	sampleId: rowIdSchema,
+	workflows: z.array(AnalysisWorkflow).max(100).default([]),
 });
 
 const createAnalysisSchema = z.object({
@@ -142,6 +148,19 @@ export const findAnalysesFn = createServerFn({ method: "POST" })
 				userIds: data.userIds,
 				workflows: data.workflows,
 			},
+			actor,
+		);
+	});
+
+export const listAnalysisUsersFn = createServerFn({ method: "POST" })
+	.middleware([authenticated()])
+	.validator(listAnalysisUsersSchema)
+	.handler(async ({ context, data }) => {
+		const actor = await resolveSampleActor(db, context.session.userId);
+
+		return listAnalysisUsers(
+			db,
+			{ sampleId: data.sampleId, workflows: data.workflows },
 			actor,
 		);
 	});

--- a/apps/web/src/tests/server-fn/analyses.ts
+++ b/apps/web/src/tests/server-fn/analyses.ts
@@ -11,11 +11,20 @@ export const analysisServerFnMocks = {
 	findRecentlyViewedAnalysesFn: vi.fn(),
 	getAnalysisFn: vi.fn(),
 	getAnalysisResultsFn: vi.fn(),
+	listAnalysisUsersFn: vi.fn(),
 	recordAnalysisViewFn: vi.fn(),
 	createAnalysisFn: vi.fn(),
 	deleteAnalysisFn: vi.fn(),
 	blastNuvsFn: vi.fn(),
 };
+
+/** Sets up listAnalysisUsers to resolve with the given users. */
+export function mockListAnalysisUsers(
+	users: Array<{ handle: string; id: number }>,
+): Mock {
+	analysisServerFnMocks.listAnalysisUsersFn.mockResolvedValue(users);
+	return analysisServerFnMocks.listAnalysisUsersFn;
+}
 
 /**
  * Sets up findAnalyses to resolve with a single page of the given analyses.

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -154,6 +154,7 @@ beforeEach(() => {
 		analysisServerFnMocks.findRecentlyViewedAnalysesFn,
 		analysisServerFnMocks.getAnalysisFn,
 		analysisServerFnMocks.getAnalysisResultsFn,
+		analysisServerFnMocks.listAnalysisUsersFn,
 		settingsServerFnMocks.getSettingsFn,
 		emailServerFnMocks.getEmailSettingsFn,
 		...Object.values(indexServerFnMocks),

--- a/apps/web/src/users/__tests__/queries.test.tsx
+++ b/apps/web/src/users/__tests__/queries.test.tsx
@@ -1,0 +1,36 @@
+import { analysesQueryKeys } from "@analyses/keys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createFakeUser } from "@tests/fake/user";
+import { mockUpdateUser } from "@tests/server-fn/users";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { useUpdateUser } from "../queries";
+
+describe("useUpdateUser()", () => {
+	it("invalidates analysis user options after updating a user", async () => {
+		const queryClient = new QueryClient();
+		const analysisUsers = analysesQueryKeys.users([1, ["pathoscope"]]);
+		queryClient.setQueryData(analysisUsers, []);
+		const user = createFakeUser();
+		mockUpdateUser(user.id, 200, { handle: "new_handle" }, user);
+
+		function wrapper({ children }: { children: ReactNode }) {
+			return (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+		}
+
+		const { result } = renderHook(() => useUpdateUser(), { wrapper });
+		result.current.mutate({
+			userId: user.id,
+			update: { handle: "new_handle" },
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(queryClient.getQueryState(analysisUsers)?.isInvalidated).toBe(true);
+	});
+});

--- a/apps/web/src/users/components/UserFilterGroup.tsx
+++ b/apps/web/src/users/components/UserFilterGroup.tsx
@@ -1,9 +1,15 @@
 import { FilterChip, FilterGroup } from "@base/Filter";
-import { useListUsers } from "@users/queries";
+import type { UserNested } from "@virtool/contracts";
 import { Users } from "lucide-react";
 import UserFilterMenu from "./UserFilterMenu";
 
 type UserFilterGroupProps = {
+	/** Whether loading the available users failed. */
+	isError: boolean;
+
+	/** Whether the available users are loading. */
+	isPending: boolean;
+
 	/** Deselects every user. */
 	onClear: () => void;
 
@@ -12,20 +18,22 @@ type UserFilterGroupProps = {
 
 	/** The ids of the selected users. */
 	selected: number[];
+
+	/** The users available in the current list context. */
+	users?: UserNested[];
 };
 
 /**
  * The users filter of a list view, with a chip for each selected user
  */
 export default function UserFilterGroup({
+	isError,
+	isPending,
 	onClear,
 	onToggle,
 	selected,
+	users,
 }: UserFilterGroupProps) {
-	// Shares a query key with the menu's own list, so this resolves from the cache
-	// rather than issuing a second request.
-	const { data: users, isPending } = useListUsers();
-
 	const handlesById = new Map(users?.map((user) => [user.id, user.handle]));
 
 	return (
@@ -33,9 +41,12 @@ export default function UserFilterGroup({
 			icon={<Users size={14} />}
 			menu={
 				<UserFilterMenu
+					isError={isError}
+					isPending={isPending}
 					onClear={onClear}
 					onToggle={onToggle}
 					selected={selected}
+					users={users}
 				/>
 			}
 			title="Users"

--- a/apps/web/src/users/components/UserFilterMenu.tsx
+++ b/apps/web/src/users/components/UserFilterMenu.tsx
@@ -3,11 +3,16 @@ import { DropdownMenuSeparator } from "@base/Dropdown";
 import { FilterMenuCheckboxItem, FilterMenuContent } from "@base/Filter";
 import Input from "@base/Input";
 import QueryError from "@base/QueryError";
-import { useListUsers } from "@users/queries";
 import type { UserNested } from "@virtool/contracts";
 import { useState } from "react";
 
 type UserFilterMenuProps = {
+	/** Whether loading the available users failed. */
+	isError: boolean;
+
+	/** Whether the available users are loading. */
+	isPending: boolean;
+
 	/** Deselects every user. */
 	onClear: () => void;
 
@@ -16,17 +21,22 @@ type UserFilterMenuProps = {
 
 	/** The ids of the selected users. */
 	selected: number[];
+
+	/** The users available in the current list context. */
+	users?: UserNested[];
 };
 
 /**
  * A dropdown menu for selecting the users a list is filtered by
  */
 export default function UserFilterMenu({
+	isError,
+	isPending,
 	onClear,
 	onToggle,
 	selected,
+	users,
 }: UserFilterMenuProps) {
-	const { data: users, isError, isPending } = useListUsers();
 	const { data: account } = useFetchAccount();
 	const [term, setTerm] = useState("");
 

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -1,3 +1,4 @@
+import { analysesQueryKeys } from "@analyses/keys";
 import {
 	createUserFn,
 	findUsersFn,
@@ -178,6 +179,9 @@ export function useUpdateUser() {
 				queryClient.setQueryData(userQueryKeys.detail(result.id), result);
 			}
 			queryClient.invalidateQueries({ queryKey: userQueryKeys.lists() });
+			queryClient.invalidateQueries({
+				queryKey: analysesQueryKeys.users(),
+			});
 		},
 	});
 }

--- a/packages/data/src/analyses/data.test.ts
+++ b/packages/data/src/analyses/data.test.ts
@@ -39,6 +39,7 @@ import {
 	findRecentlyViewedAnalyses,
 	getAnalysis,
 	getAnalysisResults,
+	listAnalysisUsers,
 	recordAnalysisView,
 } from "./data";
 
@@ -212,6 +213,62 @@ async function storedKeys(storage: StorageBackend): Promise<Set<string>> {
 const adminActor: SampleActor = { userId: 999, groupIds: [], isAdmin: true };
 
 const page = { page: 1, perPage: 25 };
+
+describe("listAnalysisUsers", () => {
+	it("lists distinct active users with analyses in the sample and workflow scope", async () => {
+		const sampleId = await seedSample();
+		const abe = await seedUser(db, { handle: "abe" });
+		const zoe = await seedUser(db, { handle: "zoe" });
+		const inactive = await seedUser(db, { active: false, handle: "inactive" });
+
+		await seedAnalysis({ sample_id: sampleId, user_id: zoe, workflow: "nuvs" });
+		await seedAnalysis({ sample_id: sampleId, user_id: abe, workflow: "nuvs" });
+		await seedAnalysis({ sample_id: sampleId, user_id: abe, workflow: "nuvs" });
+		await seedAnalysis({
+			sample_id: sampleId,
+			user_id: inactive,
+			workflow: "nuvs",
+		});
+		await seedAnalysis({
+			sample_id: sampleId,
+			user_id: ownerId,
+			workflow: "pathoscope",
+		});
+		await seedAnalysisOnNewSample({ user_id: ownerId, workflow: "nuvs" });
+
+		expect(
+			await listAnalysisUsers(
+				db,
+				{ sampleId, workflows: ["nuvs"] },
+				adminActor,
+			),
+		).toEqual([
+			{ id: abe, handle: "abe" },
+			{ id: zoe, handle: "zoe" },
+		]);
+	});
+
+	it("only lists users with analyses the caller may read", async () => {
+		const caller = await seedUser(db, { handle: "caller" });
+		const visible = await seedUser(db, { handle: "visible" });
+		const hidden = await seedUser(db, { handle: "hidden" });
+
+		await seedAnalysis({
+			sample_id: await seedSample({ all_read: true }),
+			user_id: visible,
+		});
+		await seedAnalysis({
+			sample_id: await seedSample({ all_read: false }),
+			user_id: hidden,
+		});
+
+		const actor = await resolveSampleActor(db, caller);
+
+		expect(await listAnalysisUsers(db, {}, actor)).toEqual([
+			{ id: visible, handle: "visible" },
+		]);
+	});
+});
 
 describe("findAnalyses", () => {
 	it("scopes a non-admin to analyses on samples they may read", async () => {

--- a/packages/data/src/analyses/data.ts
+++ b/packages/data/src/analyses/data.ts
@@ -58,6 +58,12 @@ export type FindAnalysesOptions = {
 	workflows?: AnalysisWorkflow[];
 };
 
+/** The scope and non-user filters used to list analysis owners. */
+export type ListAnalysisUsersOptions = Pick<
+	FindAnalysesOptions,
+	"sampleId" | "workflows"
+>;
+
 /** The fields an analysis is created from, plus the user starting it. */
 export type CreateAnalysisValues = {
 	sampleId: number;
@@ -307,6 +313,40 @@ function analysisReadableFilter(db: Db, actor: SampleActor): SQL | undefined {
 		analyses.sample_id,
 		db.select({ id: legacySamples.id }).from(legacySamples).where(readable),
 	);
+}
+
+/**
+ * List active users who own at least one analysis in the readable filter scope.
+ */
+export async function listAnalysisUsers(
+	db: Db,
+	options: ListAnalysisUsersOptions,
+	actor: SampleActor,
+): Promise<UserNested[]> {
+	const readable = analysisReadableFilter(db, actor);
+	const sample =
+		options.sampleId === undefined
+			? undefined
+			: eq(analyses.sample_id, options.sampleId);
+	const workflow = options.workflows?.length
+		? inArray(analyses.workflow, options.workflows)
+		: undefined;
+
+	return db
+		.select({ id: users.id, handle: users.handle })
+		.from(users)
+		.innerJoin(analyses, eq(analyses.user_id, users.id))
+		.where(
+			and(
+				eq(users.active, true),
+				eq(users.lifecycleState, "normal"),
+				readable,
+				sample,
+				workflow,
+			),
+		)
+		.groupBy(users.id, users.handle)
+		.orderBy(asc(sql`lower(${users.handle})`));
 }
 
 const SORT_COLUMNS = {


### PR DESCRIPTION
## Summary
- limit analysis user filter options to active users with analyses matching the readable sample and workflow context
- preserve the shared sample filter behavior and cover the new data, server, and client paths